### PR TITLE
Remove "V4" version string from our endpoints

### DIFF
--- a/api/api/spec/changes.md
+++ b/api/api/spec/changes.md
@@ -1,5 +1,4 @@
 ## General
-* Removed "v4" version string from the endpoingts (removed from the tests, spec.yaml, common.yaml and conftest.py). Changes on wazuh-apid.py in order to make aiohttp do it without error.
 * Date type use a standard format ISO-8601 defined by date-time format.
 * Deleted all return parameters **path**, new API don't show any absolute path in responses.
 * Changed search negation from `!` to `-`.

--- a/api/api/spec/changes.md
+++ b/api/api/spec/changes.md
@@ -1,4 +1,5 @@
 ## General
+* Removed "v4" version string from the endpoingts (removed from the tests, spec.yaml, common.yaml and conftest.py). Changes on wazuh-apid.py in order to make aiohttp do it without error.
 * Date type use a standard format ISO-8601 defined by date-time format.
 * Deleted all return parameters **path**, new API don't show any absolute path in responses.
 * Changed search negation from `!` to `-`.

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -15,7 +15,7 @@ info:
     url: 'https://github.com/wazuh/wazuh/blob/master/LICENSE'
 
 servers:
-  - url: '{protocol}://{host}:{port}/v4'
+  - url: '{protocol}://{host}:{port}'
     variables:
       protocol:
         default: https

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -113,7 +113,8 @@ def start(foreground, root, config_file):
     app = connexion.AioHttpApp(__name__, host=api_conf['host'],
                                port=api_conf['port'],
                                specification_dir=os.path.join(api_path[0], 'spec'),
-                               options={"swagger_ui": False, 'uri_parser_class': APIUriParser}
+                               options={"swagger_ui": False, 'uri_parser_class': APIUriParser},
+                               only_one_api=True
                                )
     app.add_api('spec.yaml',
                 arguments={'title': 'Wazuh API',

--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -11,7 +11,6 @@ variables:
   port: 55000
   user: testing
   pass: wazuh
-  version: v4
   login_endpoint: /security/user/authenticate
 
   # delays

--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -15,7 +15,7 @@ current_path = os.path.dirname(os.path.abspath(__file__))
 
 with open('common.yaml', 'r') as stream:
     common = yaml.safe_load(stream)['variables']
-login_url = f"{common['protocol']}://{common['host']}:{common['port']}/{common['version']}{common['login_endpoint']}"
+login_url = f"{common['protocol']}://{common['host']}:{common['port']}/{common['login_endpoint']}"
 basic_auth = f"{common['user']}:{common['pass']}".encode()
 login_headers = {'Content-Type': 'application/json',
                  'Authorization': f'Basic {b64encode(basic_auth).decode()}'}

--- a/api/test/integration/test_active-response_endpoints.tavern.yaml
+++ b/api/test/integration/test_active-response_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Runs an Active Response command on a specified agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -32,7 +32,7 @@ stages:
   - name: Send a message to an agent (Status=Active)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -56,7 +56,7 @@ stages:
   - name: Send a message to a list of agents (Status=Active)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -83,7 +83,7 @@ stages:
   - name: Try to send a message to an agent (status=disconnected/never_connected)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -109,7 +109,7 @@ stages:
   - name: Try to send a message to an unexisting agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -135,7 +135,7 @@ stages:
   - name: Try to send a message to an agent, without body
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -147,7 +147,7 @@ stages:
   - name: Try to send a message to an agent, malformed body
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -163,7 +163,7 @@ stages:
   - name: Send a message to one agent (Active response disabled)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -196,7 +196,7 @@ stages:
     delay_before: !float "{active_reponse_delay}"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -228,7 +228,7 @@ stages:
   - name: Try to send a message to all agents, malformed body
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_agents_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_DELETE_endpoints.tavern.yaml
@@ -10,7 +10,7 @@ stages:
   - name: Try to remove agent 000 (manager) from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/000/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -23,7 +23,7 @@ stages:
   - name: Try to remove non existing agent from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/999/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/999/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -36,7 +36,7 @@ stages:
   - name: Try to remove wrong agent_id from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/wrong_id/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/wrong_id/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -50,7 +50,7 @@ stages:
   - name: Try to remove agent 001 from a wrong_group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/group/wrong_group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/wrong_group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -63,7 +63,7 @@ stages:
   - name: Try to remove agent 001 from a group where it is not assigned (group2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/group/group2"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group2"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -76,7 +76,7 @@ stages:
   - name: Try to remove agent 004 (only assigned to default) from group default
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/004/group/default"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/004/group/default"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -89,7 +89,7 @@ stages:
   - name: Remove agent 001 from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -103,7 +103,7 @@ stages:
   - name: Remove agent 002 from default
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/002/group/default"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/002/group/default"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -117,7 +117,7 @@ stages:
   - name: Remove agent 002 from group2 when it is the only group assigned
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/002/group/group2"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/002/group/group2"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -136,7 +136,7 @@ stages:
   - name: Try to remove agent 000 (manager) from all groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/000/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -149,7 +149,7 @@ stages:
   - name: Try to remove non existing agent from all groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/999/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/999/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -160,7 +160,7 @@ stages:
   - name: Try to remove wrong agent_id from all groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/bad_id/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/bad_id/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -173,7 +173,7 @@ stages:
   - name: Remove agent 005 from all groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/005/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/005/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -191,7 +191,7 @@ stages:
   - name: Remove agent 008 from group1 and group2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/008/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -216,7 +216,7 @@ stages:
   - name: Try to remove agents from non existing group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -232,7 +232,7 @@ stages:
   - name: Try to remove agents 000 and 002(not assigned to group1) from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -260,7 +260,7 @@ stages:
   - name: Try to remove agents 998 and 999 from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -286,7 +286,7 @@ stages:
   - name: Remove agents 006 and 010 from group2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -307,7 +307,7 @@ stages:
   - name: Remove all agents from group2 (008)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -327,7 +327,7 @@ stages:
   - name: Remove all agents from group2 (invalid list_agents)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -341,7 +341,7 @@ stages:
   - name: Remove all agents from group2 (invalid list_agents)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -359,7 +359,7 @@ stages:
   - name: Try to delete non existing group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -384,7 +384,7 @@ stages:
   - name: Try to delete default group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -408,7 +408,7 @@ stages:
   - name: Delete group3
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -431,7 +431,7 @@ stages:
   - name: Delete group3
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -447,7 +447,7 @@ stages:
   - name: Try to delete non existing groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -472,7 +472,7 @@ stages:
   - name: Delete groups group1 and default
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -500,7 +500,7 @@ stages:
   - name: Delete all groups (group2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -525,7 +525,7 @@ stages:
   - name: Try to delete agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -546,7 +546,7 @@ stages:
   - name: Try to delete non existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -569,7 +569,7 @@ stages:
   - name: Try to delete agent using wrong agent_id format
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -584,7 +584,7 @@ stages:
   - name: Delete an agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -604,7 +604,7 @@ stages:
   - name: Delete an agent using purge
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -625,7 +625,7 @@ stages:
   - name: Delete an agent using purge
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -644,7 +644,7 @@ stages:
   - name: Try to delete agent with a wrong list_agents
     request: &delete_agents
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -845,7 +845,7 @@ stages:
   - name: Delete all agents (001,002,003,005)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_agents_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_GET_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
  - name: Get all agents
    request: &get_agents
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -820,7 +820,7 @@ stages:
  - name: Basic response agent
    request: &get_agent
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -858,7 +858,7 @@ stages:
  - name: Try to show not existing agent
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -881,7 +881,7 @@ stages:
  - name: Try show not existing agent by name
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -967,7 +967,7 @@ stages:
  - name: Request-Agent-Client
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/agent/client"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/client"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -987,7 +987,7 @@ stages:
  - name: Request-Agent-Buffer
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/agent/buffer"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/buffer"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1003,7 +1003,7 @@ stages:
  - name: Request-Agent-Labels
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/agent/labels"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/labels"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1016,7 +1016,7 @@ stages:
  - name: Request-Agent-Internal
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/agent/internal"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/internal"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1053,7 +1053,7 @@ stages:
  - name: Request-Agentless-Agentless
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/agentless/agentless"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/agentless/agentless"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1072,7 +1072,7 @@ stages:
  - name: Request-Analysis-Global
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/analysis/global"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/global"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1100,7 +1100,7 @@ stages:
  - name: Request-Analysis-Active-response
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/analysis/active_response"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/active_response"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1113,7 +1113,7 @@ stages:
  - name: Request-Analysis-Alerts
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/analysis/alerts"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/alerts"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1128,7 +1128,7 @@ stages:
  - name: Request-Analysis-Command
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/analysis/command"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/command"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1141,7 +1141,7 @@ stages:
  - name: Request-Analysis-Internal
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/analysis/internal"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/internal"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1168,7 +1168,7 @@ stages:
  - name: Request-Auth-Auth
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/auth/auth"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/auth/auth"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1194,7 +1194,7 @@ stages:
  - name: Request-Com-Active-response (Manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/com/active-response"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/com/active-response"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1209,7 +1209,7 @@ stages:
  - name: Request-Com-Active-response (Agent)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/com/active-response"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/com/active-response"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1225,7 +1225,7 @@ stages:
  - name: Request-Com-Internal (Manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/com/internal"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/com/internal"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1241,7 +1241,7 @@ stages:
  - name: Request-Com-Internal (Agent)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/com/internal"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/com/internal"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1257,7 +1257,7 @@ stages:
  - name: Request-Com-Cluster (Manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/com/cluster"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/com/cluster"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1278,7 +1278,7 @@ stages:
  - name: Request-Csyslog-Csyslog
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/csyslog/csyslog"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/csyslog/csyslog"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1296,7 +1296,7 @@ stages:
  - name: Request-Integrator-Integration
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/integrator/integration"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/integrator/integration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1315,7 +1315,7 @@ stages:
  - name: Request-Logcollector-Localfile (Manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/logcollector/localfile"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/logcollector/localfile"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1328,7 +1328,7 @@ stages:
  - name: Request-Logcollector-Localfile (Agent)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/logcollector/localfile"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/logcollector/localfile"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1341,7 +1341,7 @@ stages:
  - name: Request-Logcollector-Socker (Manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/logcollector/socket"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/logcollector/socket"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1351,7 +1351,7 @@ stages:
  - name: Request-Logcollector-Socker (Agent)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/logcollector/socket"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/logcollector/socket"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1361,7 +1361,7 @@ stages:
  - name: Request-Logcollector-Internal (Manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/logcollector/internal"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/logcollector/internal"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1390,7 +1390,7 @@ stages:
  - name: Request-Logcollector-Internal (Agent)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/logcollector/internal"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/logcollector/internal"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1419,7 +1419,7 @@ stages:
  - name: Request-Mail-Global
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/mail/global"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/mail/global"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1437,7 +1437,7 @@ stages:
  - name: Request-Mail-Alerts
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/mail/alerts"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/mail/alerts"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1450,7 +1450,7 @@ stages:
  - name: Request-Mail-Internal
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/mail/internal"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/mail/internal"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1466,7 +1466,7 @@ stages:
  - name: Request-Monitor-Internal
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/monitor/internal"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/monitor/internal"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1488,7 +1488,7 @@ stages:
  - name: Request-Request-Remote
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/request/remote"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/request/remote"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1506,7 +1506,7 @@ stages:
  - name: Request-Request-Internal
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/request/internal"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/request/internal"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1539,7 +1539,7 @@ stages:
  - name: Request-Syscheck-Syscheck (Manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/syscheck/syscheck"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/syscheck/syscheck"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1560,7 +1560,7 @@ stages:
  - name: Request-Syscheck-Syscheck (Agent)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/syscheck/syscheck"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/syscheck/syscheck"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1581,7 +1581,7 @@ stages:
  - name: Request-Syscheck-Rootcheck (Manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/syscheck/rootcheck"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/syscheck/rootcheck"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1608,7 +1608,7 @@ stages:
  - name: Request-Syscheck-Rootcheck (Agent)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/syscheck/rootcheck"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/syscheck/rootcheck"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1635,7 +1635,7 @@ stages:
  - name: Request-Syscheck-Internal (Manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/syscheck/internal"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/syscheck/internal"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1657,7 +1657,7 @@ stages:
  - name: Request-Syscheck-Internal (Agent)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/syscheck/internal"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/syscheck/internal"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1680,7 +1680,7 @@ stages:
  - name: Request-Wmodules-Wmodules (Manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/config/wmodules/wmodules"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/wmodules/wmodules"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1693,7 +1693,7 @@ stages:
  - name: Request-Wmodules-Wmodules (Agent)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/wmodules/wmodules"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/wmodules/wmodules"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1706,7 +1706,7 @@ stages:
  - name: Try to show config of a non existing agent
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/999/config/mail/global"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/999/config/mail/global"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1718,7 +1718,7 @@ stages:
  - name: Try to show config of an invalid agent
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/wrong_name/config/mail/global"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/wrong_name/config/mail/global"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1730,7 +1730,7 @@ stages:
  - name: Request Error
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/mail/global"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/mail/global"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1742,7 +1742,7 @@ stages:
  - name: Request Error Component Parameter
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/wrong_component/global"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/wrong_component/global"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1754,7 +1754,7 @@ stages:
  - name: Request Error Configuration Parameter
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/mail/wrong_configuration"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/mail/wrong_configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1766,7 +1766,7 @@ stages:
  - name: Request Error Component and Configuration Parameters
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/config/wrong_component/wrong_configuration"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/wrong_component/wrong_configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1783,7 +1783,7 @@ stages:
  - name: Try to get sync of agent 000 (manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/group/is_sync"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/group/is_sync"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1803,7 +1803,7 @@ stages:
  - name: Try to get sync of a non existing agent
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/999/group/is_sync"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/999/group/is_sync"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1823,7 +1823,7 @@ stages:
  - name: Try get sync agent by name
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/bad_id/group/is_sync"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/bad_id/group/is_sync"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1835,7 +1835,7 @@ stages:
  - name: Get agent sync
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/group/is_sync"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/is_sync"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1858,7 +1858,7 @@ stages:
  - name: Try get key agent 000 (manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/key"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/key"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1878,7 +1878,7 @@ stages:
  - name: Try get key not existing agent
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/999/key"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/999/key"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1898,7 +1898,7 @@ stages:
  - name: Try get key agent by name
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/bad_id/key"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/bad_id/key"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1910,7 +1910,7 @@ stages:
  - name: Get agent key
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/key"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/key"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -1932,7 +1932,7 @@ stages:
  - name: Basic response agents groups
    request: &get_agents_groups
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+     url: "{protocol:s}://{host:s}:{port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -2187,7 +2187,7 @@ stages:
  - name: Try get all agents in one group
    request: &groups_id_request
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group3/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -2289,7 +2289,7 @@ stages:
  - name: Params, bad group name
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/wrong_group/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -2301,7 +2301,7 @@ stages:
  - name: Params, invalid group name (not alphanumeric)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/wrong_%_group/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_%_group/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -2600,7 +2600,7 @@ stages:
  - name: Try get the configuration of a group
    request: &groups_id_config_request
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/default/configuration"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/default/configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -2618,7 +2618,7 @@ stages:
  - name: Try get the configuration of a bad group
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/wrong_group/configuration"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -2630,7 +2630,7 @@ stages:
  - name: Try get the configuration of a bad group (not alphanumeric)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/wrong_%group/configuration"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_%group/configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -2727,7 +2727,7 @@ stages:
  - name: Try get the files of a group
    request: &groups_id_files_request
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/default/files"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/default/files"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -2840,7 +2840,7 @@ stages:
  - name: Try get the files of a bad group name
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/wrong_group/files"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/files"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -2862,7 +2862,7 @@ stages:
  - name: Try get the files of a bad group name (no alphanumeric)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/wrong_%_group/files"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_%_group/files"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -2989,7 +2989,7 @@ stages:
  - name: Try get one file of a group
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/default/files/agent.conf/json"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf/json"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3001,7 +3001,7 @@ stages:
  - name: Try get one file of a group, bad group
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/wrong_group/files/agent.conf/json"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/files/agent.conf/json"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3011,7 +3011,7 @@ stages:
  - name: Try get one file of a group, bad group (not aplhanumeric)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/wrong_%_group/files/agent.conf/json"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_%_group/files/agent.conf/json"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3028,7 +3028,7 @@ stages:
  - name: Try get one file of a group
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/default/files/agent.conf/xml"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf/xml"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3041,7 +3041,7 @@ stages:
  - name: Try get one file of a group, bad group
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/wrong_group/files/agent.conf/xml"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/files/agent.conf/xml"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3051,7 +3051,7 @@ stages:
  - name: Try get one file of a group, bad group (not aplhanumeric)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/wrong_%_group/files/agent.conf/xml"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_%_group/files/agent.conf/xml"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3068,7 +3068,7 @@ stages:
  - name: Basic response agents name
    request: &get_agents_by_name
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3088,7 +3088,7 @@ stages:
  - name: Error agent name
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents?name=wrong_agent"
+     url: "{protocol:s}://{host:s}:{port:d}/agents?name=wrong_agent"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3152,7 +3152,7 @@ stages:
  - name: Get the agents without group
    request: &no_group_request
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/no_group"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/no_group"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3357,7 +3357,7 @@ stages:
  - name: Get the agents without group, sort
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/no_group"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/no_group"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3371,7 +3371,7 @@ stages:
  - name: Select
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/no_group"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/no_group"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3390,7 +3390,7 @@ stages:
  - name: Get the outdated agents
    request: &agents_outdated_request
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/outdated"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/outdated"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3562,7 +3562,7 @@ stages:
  - name: Returns all the different combinations that agents have for the selected fields. It also indicates the total number of agents that have each combination.
    request: &distinct_request
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/stats/distinct"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/stats/distinct"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3638,7 +3638,7 @@ stages:
  - name: Get the different combinations for os.platform, search
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/stats/distinct"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/stats/distinct"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3660,7 +3660,7 @@ stages:
  - name: Invalid select
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/stats/distinct"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/stats/distinct"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3878,7 +3878,7 @@ stages:
  - name: Get the different combinations for all fields
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/stats/distinct"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/stats/distinct"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3901,7 +3901,7 @@ stages:
  - name: Get the agents status summary
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/summary/status"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/summary/status"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3923,7 +3923,7 @@ stages:
  - name: Get the summary/os of all agents
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/summary/os"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/summary/os"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3945,7 +3945,7 @@ stages:
  - name: Try get upgrade result agent 000 (manager)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/upgrade_result?wait_for_complete=true"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/000/upgrade_result?wait_for_complete=true"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3957,7 +3957,7 @@ stages:
  - name: Try get upgrade result not existing agent
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/999/upgrade_result?wait_for_complete=true"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/999/upgrade_result?wait_for_complete=true"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3967,7 +3967,7 @@ stages:
  - name: Try get upgrade result agent by name
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/bad_id/upgrade_result?wait_for_complete=true"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/bad_id/upgrade_result?wait_for_complete=true"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3979,7 +3979,7 @@ stages:
  - name: Get agent upgrade result not upgrade
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/upgrade_result?wait_for_complete=true"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/upgrade_result?wait_for_complete=true"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -3994,7 +3994,7 @@ stages:
  - name: Upgrade an agent
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/upgrade?wait_for_complete=true"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/upgrade?wait_for_complete=true"
      method: PUT
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -4013,7 +4013,7 @@ stages:
  - name: Get agent upgrade result
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/upgrade_result?wait_for_complete=true"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/upgrade_result?wait_for_complete=true"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_agents_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_POST_endpoints.tavern.yaml
@@ -10,7 +10,7 @@ stages:
   - name: Try to create a new agent without body
     request: &agent_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -169,7 +169,7 @@ stages:
   - name: Create a group called group4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -185,7 +185,7 @@ stages:
   - name: Try to create a group that already exists
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -200,7 +200,7 @@ stages:
   - name: Try to create a group with an invalid name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -220,7 +220,7 @@ stages:
   - name: Try to create a new agent without body
     request: &agent_insert_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/insert"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/insert"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -421,7 +421,7 @@ stages:
   - name: Create new agent specifying its name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/insert/quick"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/insert/quick"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -439,7 +439,7 @@ stages:
   - name: Try to create agent with an invalid name (invalid_character)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/insert/quick"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/insert/quick"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -454,7 +454,7 @@ stages:
   - name: Try to create an already existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/insert/quick"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/insert/quick"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_agents_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_PUT_endpoints.tavern.yaml
@@ -10,7 +10,7 @@ stages:
   - name: Try to assign all agents to a non existing group
     request: &put_agents_group
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -39,7 +39,7 @@ stages:
   - name: Try to assign all agents to an invalid group id
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -54,7 +54,7 @@ stages:
   - name: Try to assign non existing agents to group default
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -79,7 +79,7 @@ stages:
   - name: Try to assign 000 and a non existing agent to group default
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -107,7 +107,7 @@ stages:
   - name: Try to assign agents 001 and 002 to group default where they already belong
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -132,7 +132,7 @@ stages:
   - name: Assign agents 003, 004 and 005 to group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -158,7 +158,7 @@ stages:
   - name: Assign all agents to group2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -180,7 +180,7 @@ stages:
   - name: Assign all agents to group2 with force_single_group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -214,7 +214,7 @@ stages:
   - name: Update group2 configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group2/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/group2/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -228,7 +228,7 @@ stages:
   - name: Try to update configuration of a non existing group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/wrong_group/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -242,7 +242,7 @@ stages:
   - name: Try to update configuration using an empty file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -256,7 +256,7 @@ stages:
   - name: Try to update configuration using an invalid configuration file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -272,7 +272,7 @@ stages:
   - name: Try to update configuration using a wrong configuration file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -293,7 +293,7 @@ stages:
   - name: Restart all agents from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group/group1/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/group1/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -307,7 +307,7 @@ stages:
   - name: Restart all agents from group2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group/group2/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/group2/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -339,7 +339,7 @@ stages:
   - name: Restart all agents from a group which does not exist
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group/not_exists/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/not_exists/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -356,7 +356,7 @@ stages:
   - name: Try to restart agent with wrong_id
     request: &agent_restart_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -438,7 +438,7 @@ stages:
   - name: Try to restart all agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -469,7 +469,7 @@ stages:
   - name: Assign agent 001 to group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group1"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -485,7 +485,7 @@ stages:
   - name: Try to assign an agent with an invalid id
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/wrong_id/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/wrong_id/group/group1"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -498,7 +498,7 @@ stages:
   - name: Try to assign a non existing agent to group3
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/999/group/group3"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/999/group/group3"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -519,7 +519,7 @@ stages:
   - name: Assign agent 001 to group3 with force_single_group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/group/group3?force_single_group=true"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group3?force_single_group=true"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -542,7 +542,7 @@ stages:
   - name: Try to restart agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/000/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -563,7 +563,7 @@ stages:
   - name: Try to restart a not existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/999/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/999/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -584,7 +584,7 @@ stages:
   - name: Try to restart an agent with an invalid id
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/wrong_id/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/wrong_id/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -597,7 +597,7 @@ stages:
   - name: Restart an agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/002/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/002/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -617,7 +617,7 @@ stages:
   - name: Get agents belonging to a node
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -634,7 +634,7 @@ stages:
   - name: Restart all agents belonging to a node (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/node/worker1/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/node/worker1/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -648,7 +648,7 @@ stages:
   - name: Restart all agents belonging to a node (it does not exist)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/node/notexists/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/node/notexists/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -672,7 +672,7 @@ stages:
   - name: Try to upgrade a not existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/999/upgrade"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/999/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -685,7 +685,7 @@ stages:
   - name: Try to upgrade agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/upgrade"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/000/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -698,7 +698,7 @@ stages:
   - name: Try to upgrade an agent using an invalid id
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/wrong_id/upgrade"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/wrong_id/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -711,7 +711,7 @@ stages:
   - name: Upgrade an agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/upgrade"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -730,7 +730,7 @@ stages:
   - name: Try to upgrade an agent that is updated to the latest version
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/upgrade"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -745,7 +745,7 @@ stages:
   - name: Downgrade agent to an specific version using force
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/003/upgrade"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/003/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -761,7 +761,7 @@ stages:
   - name: Upgrade an agent using http
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/004/upgrade"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/004/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -780,7 +780,7 @@ stages:
   - name: Upgrade an agent using wkp repo
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/005/upgrade"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/005/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -804,7 +804,7 @@ stages:
   - name: Try to customly upgrade a non existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/999/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/999/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -818,7 +818,7 @@ stages:
   - name: Try to customly upgrade agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/000/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/000/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -834,7 +834,7 @@ stages:
   - name: Try to customly upgrade an agent using an invalid id
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/wrong_id/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/wrong_id/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -850,7 +850,7 @@ stages:
   - name: Try to customly upgrade an agent without parameters
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/006/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/006/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -863,7 +863,7 @@ stages:
   - name: Try to customly upgrade an agent with an invalid installer
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/003/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/003/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -879,7 +879,7 @@ stages:
   - name: Customly upgrade agent 007 selecting installer
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/007/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/007/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -895,7 +895,7 @@ stages:
   - name: Customly upgrade agent 008 using default installer
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/008/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/008/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -909,7 +909,7 @@ stages:
   - name: Get agent 007 upgrade result
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/007/upgrade_result"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/007/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -921,7 +921,7 @@ stages:
   - name: Get agent 008 upgrade result
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/008/upgrade_result"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/008/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_ciscat_endpoints.tavern.yaml
+++ b/api/test/integration/test_ciscat_endpoints.tavern.yaml
@@ -11,7 +11,7 @@ stages:
     request: &get_ciscat_results_001
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/ciscat/001/results"
+      url: "{protocol:s}://{host:s}:{port:d}/ciscat/001/results"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -250,7 +250,7 @@ stages:
     request: &get_ciscat_results_002
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/ciscat/002/results"
+      url: "{protocol:s}://{host:s}:{port:d}/ciscat/002/results"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -472,7 +472,7 @@ stages:
     request: &get_ciscat_results_003
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/ciscat/003/results"
+      url: "{protocol:s}://{host:s}:{port:d}/ciscat/003/results"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Get cluster config
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/local/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -39,7 +39,7 @@ stages:
   - name: Get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -71,7 +71,7 @@ stages:
   - name: Get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -112,7 +112,7 @@ stages:
   - name: Get cluster node
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/local/info"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -136,7 +136,7 @@ stages:
   - name: Get cluster nodes
     request: &get_cluster_nodes
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -411,7 +411,7 @@ stages:
   - name: Get cluster {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -447,7 +447,7 @@ stages:
   - name: Get cluster nodes with select
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -470,7 +470,7 @@ stages:
   - name: Get cluster status
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/status"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -489,7 +489,7 @@ stages:
   - name: Request {master-node}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -525,7 +525,7 @@ stages:
   - name: Request (worker)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -556,7 +556,7 @@ stages:
   - name: Filters -> section=alerts (master-node)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -578,7 +578,7 @@ stages:
   - name: Filters -> section=syscheck (master)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -606,7 +606,7 @@ stages:
   - name: Filters -> section=syscollector (master)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -634,7 +634,7 @@ stages:
   - name: Filters -> section=alerts (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -655,7 +655,7 @@ stages:
   - name: Filters -> section=syscheck (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -683,7 +683,7 @@ stages:
   - name: Filters -> section=syscollector (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -716,7 +716,7 @@ stages:
   - name: Request cluster validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -739,7 +739,7 @@ stages:
   - name: Upload corrupted configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "{corrupted_rules_file}"
       headers:
@@ -753,7 +753,7 @@ stages:
   - name: Request validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -778,7 +778,7 @@ stages:
   - name: Delete rules file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -790,7 +790,7 @@ stages:
   - name: Request cluster validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -812,7 +812,7 @@ stages:
   - name: Request cluster validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -837,7 +837,7 @@ stages:
   - name: Try to show the config of analisys/global through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -869,7 +869,7 @@ stages:
   - name: Try to show the config of analysis/active_response through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/analysis/active_response"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/analysis/active_response"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -886,7 +886,7 @@ stages:
   - name: Try to show the config of analysis/alerts through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/configuration/analysis/alerts"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/alerts"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -904,7 +904,7 @@ stages:
 
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/analysis/command"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/analysis/command"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -921,7 +921,7 @@ stages:
   - name: Try to show the config of authd/authd in the manager through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/auth/auth"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/auth/auth"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -950,7 +950,7 @@ stages:
   - name: Try to show the config of com/internal in the manager through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/com/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/com/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -970,7 +970,7 @@ stages:
   - name: Try to show the config of csyslog/csyslog in the manager through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/csyslog/csyslog"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/csyslog/csyslog"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -992,7 +992,7 @@ stages:
   - name: Try to show the config of integrator/integration in the manager through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/integrator/integration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/integrator/integration"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1009,7 +1009,7 @@ stages:
   - name: Try to show the config of analysis/internal through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/configuration/analysis/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1040,7 +1040,7 @@ stages:
   - name: Try to show the config of logcollector/localfile in the manager trough a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/logcollector/localfile"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/logcollector/localfile"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1057,7 +1057,7 @@ stages:
   - name: Try to show the config of logcollector/socket in the manager trough a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/logcollector/socket"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/logcollector/socket"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1073,7 +1073,7 @@ stages:
   - name: Try to show the config of logcollector/internal in the manager trough a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/logcollector/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/logcollector/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1106,7 +1106,7 @@ stages:
   - name: Try to show the config of mail/global in the manager trough a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/mail/global"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/mail/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1127,7 +1127,7 @@ stages:
   - name: Try to show the config of mail/alerts in the manager trough a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/mail/alerts"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/mail/alerts"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1147,7 +1147,7 @@ stages:
   - name: Try to show the config of mail/internal in the manager trough a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/mail/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/mail/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1167,7 +1167,7 @@ stages:
   - name: Try to show the config of monitor/internal in the manager trough a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/monitor/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/monitor/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1193,7 +1193,7 @@ stages:
   - name: Try to show the config of request/remote in the manager trough a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/request/remote"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/request/remote"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1215,7 +1215,7 @@ stages:
   - name: Try to show the config of request/internal in the manager trough a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/request/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/request/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1255,7 +1255,7 @@ stages:
   - name: Try to show the config of syscheck/syscheck in the manager trough a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/syscheck/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/syscheck/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1273,7 +1273,7 @@ stages:
   - name: Try to show the config of syscheck/rootcheck in the manager trough a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/syscheck/rootcheck"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/syscheck/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1305,7 +1305,7 @@ stages:
   - name: Try to show the config of syscheck/internal in the manager through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/syscheck/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/syscheck/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1331,7 +1331,7 @@ stages:
   - name: Try to show the config of wmodules/wmodules in the manager trough a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration/wmodules/wmodules"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/wmodules/wmodules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1361,7 +1361,7 @@ stages:
   - name: Get ossec.conf {node_id}
     request: &get_cluster_files
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1461,7 +1461,7 @@ stages:
   - name: Delete rules file
     request: &delete_cluster_files
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1562,7 +1562,7 @@ stages:
   - name: Get ossec.conf {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1579,7 +1579,7 @@ stages:
   - name: Upload ossec.conf {node_id}
     request: &upload_cluster_files
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/files"
       method: PUT
       data: "{ossec_conf}"
       headers:
@@ -1837,7 +1837,7 @@ stages:
   - name: Upload rules to unexisting node (overwrite=false) {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/unexisting-node/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/unexisting-node/files"
       method: PUT
       data: "{new_rules:s}"
       headers:
@@ -1862,7 +1862,7 @@ stages:
   - name: Upload decoder to unexisting node
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/unexisting-node/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/unexisting-node/files"
       method: PUT
       data: "{new_decoder:s}"
       headers:
@@ -1877,7 +1877,7 @@ stages:
   - name: Upload CDB list to unexisting node
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/unexisting-node/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/unexisting-node/files"
       method: PUT
       data: "{new_cdb_list:s}"
       headers:
@@ -1905,7 +1905,7 @@ stages:
   - name: Request {node_id} 0
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/info"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1943,7 +1943,7 @@ stages:
   - name: Request {node_id} 1
     request: &get_cluster_logs
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2157,7 +2157,7 @@ stages:
   - name: Request {node_id} 2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/logs/summary"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2206,7 +2206,7 @@ stages:
   - name: Cluster stats {node_id} today
     request: &get_cluster_stats
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2245,7 +2245,7 @@ stages:
   - name: unexisting_node stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/unexisting_node/stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/unexisting_node/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2268,7 +2268,7 @@ stages:
   - name: Analysisd stats {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/stats/analysisd"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/stats/analysisd"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2339,7 +2339,7 @@ stages:
   - name: Hourly node stats {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/stats/hourly"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/stats/hourly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2366,7 +2366,7 @@ stages:
   - name: Remoted stats {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/stats/remoted"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/stats/remoted"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2399,7 +2399,7 @@ stages:
   - name: Weekly node stats {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/stats/weekly"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/stats/weekly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2445,7 +2445,7 @@ stages:
   - name: Request {node_id} 3
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/{node_id}/status"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2484,7 +2484,7 @@ stages:
   - name: Get API configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2537,7 +2537,7 @@ stages:
   - name: Get API configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2567,7 +2567,7 @@ stages:
   - name: Modify API configuration (some fields)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -2588,7 +2588,7 @@ stages:
   - name: Modify API configuration (all allowed fields)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -2619,7 +2619,7 @@ stages:
   - name: Modify API configuration (forbidden field)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -2633,7 +2633,7 @@ stages:
   - name: Get API configuration that was set above
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2670,7 +2670,7 @@ stages:
   - name: Restore API configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2689,7 +2689,7 @@ stages:
   - name: Get API default configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2721,7 +2721,7 @@ stages:
   - name: Restore API configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2738,7 +2738,7 @@ stages:
   - name: Get API default configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2768,7 +2768,7 @@ stages:
   - name: Restart cluster
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2789,7 +2789,7 @@ stages:
   - name: Restart cluster
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoders_endpoints.tavern.yaml
@@ -11,7 +11,7 @@ stages:
     request: &get_decoders
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -350,7 +350,7 @@ stages:
     request: &get_decoders_with_name
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -522,7 +522,7 @@ stages:
     request: &get_decoders_files
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -758,7 +758,7 @@ stages:
     request: &get_decoders_parents
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/parents"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/parents"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -930,7 +930,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files/0005-wazuh_decoders.xml/download"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml/download"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -943,7 +943,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files/wrongfile/download"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/wrongfile/download"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_default_endpoints.tavern.yaml
+++ b/api/test/integration/test_default_endpoints.tavern.yaml
@@ -11,7 +11,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/"
+      url: "{protocol:s}://{host:s}:{port:d}/"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -40,7 +40,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -67,7 +67,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -103,7 +103,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -130,7 +130,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -168,7 +168,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -199,7 +199,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -231,7 +231,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -262,7 +262,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -305,7 +305,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -336,7 +336,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -367,7 +367,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -398,7 +398,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -438,7 +438,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -469,7 +469,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/packages?wait_for_complete=true"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages?wait_for_complete=true"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -485,7 +485,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -508,7 +508,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -551,7 +551,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -582,7 +582,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -598,7 +598,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -621,7 +621,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -637,7 +637,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_lists_endpoints.tavern.yaml
+++ b/api/test/integration/test_lists_endpoints.tavern.yaml
@@ -11,7 +11,7 @@ stages:
     request: &get_lists
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/lists"
+      url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -236,7 +236,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/lists"
+      url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -249,7 +249,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/lists"
+      url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -273,7 +273,7 @@ stages:
     request: &get_lists_files
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/lists/files"
+      url: "{protocol:s}://{host:s}:{port:d}/lists/files"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -10,7 +10,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/status"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -49,7 +49,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/info"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/info"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -100,7 +100,7 @@ stages:
   - name: Request all sections
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -123,7 +123,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -161,7 +161,7 @@ stages:
   - name: Request section and field (1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -183,7 +183,7 @@ stages:
   - name: Request section and field (2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -205,7 +205,7 @@ stages:
   - name: Request invalid section
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -218,7 +218,7 @@ stages:
   - name: Request invalid field
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -247,7 +247,7 @@ stages:
   - name: Manager stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -259,7 +259,7 @@ stages:
   - name: Manager stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -280,7 +280,7 @@ stages:
   - name: Manager stats with old date
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -300,7 +300,7 @@ stages:
   - name: Hourly stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats/hourly"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/hourly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -319,7 +319,7 @@ stages:
   - name: Weekly stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats/weekly"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/weekly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -357,7 +357,7 @@ stages:
   - name: Analysisd stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats/analysisd"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/analysisd"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -420,7 +420,7 @@ stages:
   - name: Remoted stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats/remoted"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/remoted"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -446,7 +446,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -463,7 +463,7 @@ stages:
   - name: Filters -> limit=4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -490,7 +490,7 @@ stages:
   - name: Filters -> limit=2, sort=-level
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -512,7 +512,7 @@ stages:
   - name: Filters -> offset=3, limit=3
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -535,7 +535,7 @@ stages:
   - name: Filters -> offset=3, level=info, limit=4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -560,7 +560,7 @@ stages:
   - name: Filters -> tag=ossec-analysisd, limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -581,7 +581,7 @@ stages:
   - name: Filters -> tag=ossec-syscheckd, limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -601,7 +601,7 @@ stages:
   - name: Filters by query (tag=ossec-syscheckd, level=info)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -628,7 +628,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs/summary"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -673,7 +673,7 @@ stages:
   - name: Get ossec.conf
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -688,7 +688,7 @@ stages:
   - name: Get local rules
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -703,7 +703,7 @@ stages:
   - name: Get rules from ruleset
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -718,7 +718,7 @@ stages:
   - name: Get local decoder
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -733,7 +733,7 @@ stages:
   - name: Get decoder from ruleset
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -748,7 +748,7 @@ stages:
   - name: Get CDB list
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -763,7 +763,7 @@ stages:
   - name: Get file with wrong path
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -779,7 +779,7 @@ stages:
   - name: Get file with empty path
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -795,7 +795,7 @@ stages:
   - name: Get unexisting rules file with right path
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -810,7 +810,7 @@ stages:
   - name: Get unexisting decoder file with right path
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -825,7 +825,7 @@ stages:
   - name: Get unexisting list file with right path
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -845,7 +845,7 @@ stages:
   - name: Get ossec.conf
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -863,7 +863,7 @@ stages:
   - name: Upload ossec.conf
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "{ossec_conf}"
       headers:
@@ -886,7 +886,7 @@ stages:
   - name: Upload new rules
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "<!-- Local rules -->\n <group name=\"local,\">\n    <!--   NEW RULE    -->\n    <rule id=\"111111\" level=\"5\">\n      <if_sid>5716</if_sid>\n      <srcip>1.1.1.1</srcip>\n      <description>sshd: authentication failed from IP 1.1.1.1.</description>\n      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n    </rule>\n  </group>\n"
       headers:
@@ -908,7 +908,7 @@ stages:
   - name: Upload rules (overwrite=false)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n <rule id=\"111111\" level=\"5\">\n <if_sid>5716</if_sid>\n <srcip>1.1.1.1</srcip>\n  <description>sshd: authentication failed from IP 1.1.1.1.</description>\n <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n </rule>\n </group>\n"
       headers:
@@ -934,7 +934,7 @@ stages:
   - name: Upload rules (overwrite=true)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n <rule id=\"111111\" level=\"5\">\n <if_sid>5716</if_sid>\n <srcip>1.1.1.1</srcip>\n  <description>sshd: authentication failed from IP 1.1.1.1.</description>\n <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n </rule>\n </group>\n"
       headers:
@@ -957,7 +957,7 @@ stages:
   - name: Upload rules with XML syntax error (overwrite=true)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n <rule id=\"111111\" level=\"5\">\n <if_sid>5716\n <srcip>1.1.1.1</srcip>\n  <description>sshd: authentication failed from IP 1.1.1.1.</description>\n <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n </rule>\n </group>\n"
       headers:
@@ -983,7 +983,7 @@ stages:
   - name: Upload new decoder
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "<!-- NEW Local Decoders -->\n <decoder name=\"local_decoder_example\">\n <program_name>NEW DECODER</program_name>\n </decoder>\n"
       headers:
@@ -1005,7 +1005,7 @@ stages:
   - name: Upload decoder (overwrite=false)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "<!-- NEW Local Decoders -->\n <decoder name=\"local_decoder_example\">\n <program_name>NEW DECODER</program_name>\n </decoder>\n"
       headers:
@@ -1031,7 +1031,7 @@ stages:
   - name: Upload decoder (overwrite=true)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "<!-- NEW Local Decoders -->\n <decoder name=\"local_decoder_example\">\n <program_name>NEW DECODER</program_name>\n </decoder>\n"
       headers:
@@ -1054,7 +1054,7 @@ stages:
   - name: Upload decoder with XML syntax error (overwrite=true)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "<!-- NEW Local Decoders -->\n <decoder name=\"local_decoder_example\" NEW DECODER</program_name>\n </decoder>\n"
       headers:
@@ -1080,7 +1080,7 @@ stages:
   - name: Upload new CDB list
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "test-wazuh-w:write\ntest-wazuh-r:read\ntest-wazuh-a:attribute\ntest-wazuh-x:execute\ntest-wazuh-c:command\n"
       headers:
@@ -1102,7 +1102,7 @@ stages:
   - name: Upload CDB list (overwrite=false)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "test-wazuh-w:write\ntest-wazuh-r:read\ntest-wazuh-a:attribute\ntest-wazuh-x:execute\ntest-wazuh-c:command\n"
       headers:
@@ -1128,7 +1128,7 @@ stages:
   - name: Upload CDB list (overwrite=true)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "test-wazuh-w:write\ntest-wazuh-r:read\ntest-wazuh-a:attribute\ntest-wazuh-x:execute\ntest-wazuh-c:command\n"
       headers:
@@ -1151,7 +1151,7 @@ stages:
   - name: Upload CDB list with a syntax error (overwrite=true)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: ":write\ntest-wazuh-r:read\ntest-wazuh-a:attribute\ntest-wazuh-x:execute\ntest-wazuh-c:command\n"
       headers:
@@ -1182,7 +1182,7 @@ stages:
   - name: Delete rules file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1202,7 +1202,7 @@ stages:
   - name: Delete unexisting rules file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1225,7 +1225,7 @@ stages:
   - name: Delete decoder file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1245,7 +1245,7 @@ stages:
   - name: Delete unexisting decoder file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1268,7 +1268,7 @@ stages:
   - name: Delete CDB list file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1288,7 +1288,7 @@ stages:
   - name: Delete unexisting CDB list file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1316,7 +1316,7 @@ stages:
   - name: Request validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/validation"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1341,7 +1341,7 @@ stages:
   - name: Upload corrupted
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n  <rule id=\"111111\" level=\"XXX\">\n      <if_sid>5716</if_sid>\n      <srcip>1.1.1.1</srcip>\n      <description>sshd: authentication failed from IP 1.1.1.1.</description>\n      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n    </rule>\n  </group>\n"
       headers:
@@ -1356,7 +1356,7 @@ stages:
   - name: Request validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/validation"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1381,7 +1381,7 @@ stages:
   - name: Try to show the config of agentless/agentless in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/agentless/agentless"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/agentless/agentless"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1398,7 +1398,7 @@ stages:
   - name: Try to show the config of analysis/global in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1415,7 +1415,7 @@ stages:
   - name: Try to show the config of analysis/active_response in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/analysis/active_response"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/active_response"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1433,7 +1433,7 @@ stages:
   - name: Try to show the config of analysis/alerts in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/analysis/alerts"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/alerts"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1450,7 +1450,7 @@ stages:
   - name: Try to show the config of analysis/command in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/analysis/command"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/command"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1467,7 +1467,7 @@ stages:
   - name: Try to show the config of analysis/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/analysis/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1484,7 +1484,7 @@ stages:
   - name: Try to show the config of auth in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/auth/auth"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/auth/auth"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1501,7 +1501,7 @@ stages:
   - name: Try to show the config of com/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/com/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/com/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1518,7 +1518,7 @@ stages:
   - name: Try to show the config of csyslog/csyslog in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/csyslog/csyslog"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/csyslog/csyslog"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1535,7 +1535,7 @@ stages:
   - name: Try to show the config of integrator/integration in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/integrator/integration"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/integrator/integration"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1552,7 +1552,7 @@ stages:
   - name: Try to show the config of logcollector/localfile in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/logcollector/localfile"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/logcollector/localfile"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1569,7 +1569,7 @@ stages:
   - name: Try to show the config of logcollector/socket in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/logcollector/socket"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/logcollector/socket"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1585,7 +1585,7 @@ stages:
   - name: Try to show the config of logcollector/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/logcollector/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/logcollector/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1602,7 +1602,7 @@ stages:
   - name: Try to show the config of mail/global in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/mail/global"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/mail/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1619,7 +1619,7 @@ stages:
   - name: Try to show the config of mail/alerts in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/mail/alerts"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/mail/alerts"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1636,7 +1636,7 @@ stages:
   - name: Try to show the config of mail/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/mail/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/mail/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1653,7 +1653,7 @@ stages:
   - name: Try to show the config of monitor/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/monitor/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/monitor/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1670,7 +1670,7 @@ stages:
   - name: Try to show the config of request/remote in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/request/remote"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/request/remote"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1687,7 +1687,7 @@ stages:
   - name: Try to show the config of request/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/request/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/request/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1704,7 +1704,7 @@ stages:
   - name: Try to show the config of syscheck/syscheck in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/syscheck/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/syscheck/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1721,7 +1721,7 @@ stages:
   - name: Try to show the config of syscheck/rootcheck in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/syscheck/rootcheck"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/syscheck/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1738,7 +1738,7 @@ stages:
   - name: Try to show the config of syscheck/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/syscheck/internal"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/syscheck/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1755,7 +1755,7 @@ stages:
   - name: Try to show the config of wmodules/wmodules in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/wmodules/wmodules"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/wmodules/wmodules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1778,7 +1778,7 @@ stages:
   - name: Get API configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1831,7 +1831,7 @@ stages:
   - name: Modify API configuration (some fields)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -1852,7 +1852,7 @@ stages:
   - name: Modify API configuration (all allowed fields)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -1880,7 +1880,7 @@ stages:
   - name: Modify API configuration (forbidden field)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -1894,7 +1894,7 @@ stages:
   - name: Get API configuration that were set above
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1942,7 +1942,7 @@ stages:
   - name: Restore API configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1955,7 +1955,7 @@ stages:
   - name: Get API default configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1995,7 +1995,7 @@ stages:
   - name: Restart manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -11,7 +11,7 @@ stages:
     request: &get_mitre
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/mitre"
+      url: "{protocol:s}://{host:s}:{port:d}/mitre"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_overview_endpoints.tavern.yaml
@@ -8,7 +8,7 @@ stages:
  - name: Get full agents overview
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/overview/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/overview/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_active-response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_active-response_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Runs an Active Response command on a specified agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -27,7 +27,7 @@ stages:
   - name: Send a message to an agent (Status=Active) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -50,7 +50,7 @@ stages:
   - name: Send a message to a list of agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -84,7 +84,7 @@ stages:
   - name: Try to send a message to an agent (status=disconnected/never_connected) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -100,7 +100,7 @@ stages:
   - name: Try to send a message to an unexisting agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -133,7 +133,7 @@ stages:
   - name: Runs an Active Response command on all agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agents_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Get all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -31,7 +31,7 @@ stages:
   - name: Get a list of agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -45,7 +45,7 @@ stages:
   - name: Get a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -71,7 +71,7 @@ stages:
   - name: Get a list of agents (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -97,7 +97,7 @@ stages:
   - name: Try to get agent 008 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -109,7 +109,7 @@ stages:
   - name: Get agent 009 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -132,7 +132,7 @@ stages:
   - name: Try tp get Request-Agent-Client for agent 004 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/004/config/agent/client"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/004/config/agent/client"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -143,7 +143,7 @@ stages:
     delay_before: !float "{active_reponse_delay}"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/003/config/agent/client"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/003/config/agent/client"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -168,7 +168,7 @@ stages:
   - name: Try to get sync of agent 008 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/008/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -178,7 +178,7 @@ stages:
   - name: Get agent sync (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/007/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/007/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -201,7 +201,7 @@ stages:
  - name: Try get key agent 006 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/006/key"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/006/key"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -211,7 +211,7 @@ stages:
  - name: Get agent key for 005 (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/005/key"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/005/key"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -233,7 +233,7 @@ stages:
  - name: Get all groups (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+     url: "{protocol:s}://{host:s}:{port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -251,7 +251,7 @@ stages:
  - name: Try to read group1 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+     url: "{protocol:s}://{host:s}:{port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -263,7 +263,7 @@ stages:
  - name: Get a list of groups (Partially allowed, user aware)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+     url: "{protocol:s}://{host:s}:{port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -287,7 +287,7 @@ stages:
  - name: Get a list of groups (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+     url: "{protocol:s}://{host:s}:{port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -312,7 +312,7 @@ stages:
  - name: Try get all agents in one group (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group3/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -335,7 +335,7 @@ stages:
  - name: Try to get the configuration of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/default/configuration"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/default/configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -345,7 +345,7 @@ stages:
  - name: Try get the configuration of a group (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group2/configuration"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group2/configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -366,7 +366,7 @@ stages:
  - name: Try get the files of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group1/files"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group1/files"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -376,7 +376,7 @@ stages:
  - name: Try get the files of a group (Allow)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group3/files"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/files"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -404,7 +404,7 @@ stages:
  - name: Try get one file of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/default/files/agent.conf/json"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf/json"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -414,7 +414,7 @@ stages:
  - name: Try get one file of a group (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group2/files/agent.conf/json"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group2/files/agent.conf/json"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -431,7 +431,7 @@ stages:
  - name: Try get one file of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group1/files/agent.conf/xml"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group1/files/agent.conf/xml"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -441,7 +441,7 @@ stages:
  - name: Try get one file of a group (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group3/files/agent.conf/xml"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/files/agent.conf/xml"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -458,7 +458,7 @@ stages:
  - name: Basic response agents name (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -473,7 +473,7 @@ stages:
  - name: Basic response agents name (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -498,7 +498,7 @@ stages:
  - name: Get the agents without group (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/no_group"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/no_group"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -520,7 +520,7 @@ stages:
  - name: Get the outdated agents (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/outdated"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/outdated"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -545,7 +545,7 @@ stages:
  - name: Get the different combinations for os.platform (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/stats/distinct"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/stats/distinct"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -572,7 +572,7 @@ stages:
  - name: Get the agents status summary (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/summary/status"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/summary/status"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -594,7 +594,7 @@ stages:
  - name: Get the summary/os of all agents (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/summary/os"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/summary/os"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -616,7 +616,7 @@ stages:
  - name: Try get upgrade result agent 002 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/002/upgrade_result?wait_for_complete=true"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/002/upgrade_result?wait_for_complete=true"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -631,7 +631,7 @@ stages:
   - name: Try to remove agent 004 from group2 (Denied group)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/004/group/group2"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/004/group/group2"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -641,7 +641,7 @@ stages:
   - name: Try to remove agent 001 from group1 (Denied agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -651,7 +651,7 @@ stages:
   - name: Try to remove agent 004 from group1 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/004/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/004/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -663,7 +663,7 @@ stages:
   - name: Remove agent 005 from group1 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/005/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/005/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -681,7 +681,7 @@ stages:
   - name: Try to remove agent 008 from all groups (Denied agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/008/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -691,7 +691,7 @@ stages:
   - name: Try to remove agent 009 from group2 (Denied group)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/009/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/009/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -703,7 +703,7 @@ stages:
   - name: Remove agent 009 from all groups Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/009/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/009/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -721,7 +721,7 @@ stages:
   - name: Try to remove agent 005 from a list of groups (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/005/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/005/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -754,7 +754,7 @@ stages:
   - name: Try to remove all agents from group2 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -767,7 +767,7 @@ stages:
   - name: Remove all agents from group1 (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -787,7 +787,7 @@ stages:
   - name: Remove a list of agents from group1 (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -823,7 +823,7 @@ stages:
   - name: Try to delete group1 (Group denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -835,7 +835,7 @@ stages:
   - name: Try to delete group2 (Group modification denied, indirectly denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -858,7 +858,7 @@ stages:
   - name: Try to delete group antonio (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -886,7 +886,7 @@ stages:
   - name: Try to delete all groups (Partially allowed, indirectly denied to delete group2, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -910,7 +910,7 @@ stages:
   - name: Try to delete a list of groups (Partially allowed, indirectly denied to delete group2, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -949,7 +949,7 @@ stages:
   - name: Try to delete agent 003 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -961,7 +961,7 @@ stages:
   - name: Delete agent 002 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -987,7 +987,7 @@ stages:
   - name: Try to delete a list of agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -999,7 +999,7 @@ stages:
   - name: Try to delete a list of agents (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1022,7 +1022,7 @@ stages:
   - name: Try to delete a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1053,7 +1053,7 @@ stages:
   - name: Try to delete all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1080,7 +1080,7 @@ stages:
   - name: Try to create a new agent (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1098,7 +1098,7 @@ stages:
   - name: Try to create a new agent specifying id, ip, key and name (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/insert"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/insert"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1118,7 +1118,7 @@ stages:
   - name: Try to create new agent specifying its name (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/insert/quick"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/insert/quick"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1135,7 +1135,7 @@ stages:
   - name: Try to create a group called group4 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1152,7 +1152,7 @@ stages:
   - name: Try to assign all agents to group2 (Group denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1164,7 +1164,7 @@ stages:
   - name: Try to assign a list of agents to group1 (Agents denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1177,7 +1177,7 @@ stages:
   - name: Try to assign a list of agents to group1 (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1202,7 +1202,7 @@ stages:
   - name: Try to assign all agents to group1 (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1226,7 +1226,7 @@ stages:
   - name: Update group1 configuration (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1239,7 +1239,7 @@ stages:
   - name: Try to update group3 configuration (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group3/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/group3/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1258,7 +1258,7 @@ stages:
   - name: Restart all agents from group1 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group/group1/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/group1/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1272,7 +1272,7 @@ stages:
   - name: Restart all agents from group2 (Only agent 005 will have both permissions -> group:read & agent:restart)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group/group2/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/group2/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1296,7 +1296,7 @@ stages:
   - name: Try to restart agent 001 (Denied)default,group1,group3,pepito
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1308,7 +1308,7 @@ stages:
   - name: Try to restart a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1334,7 +1334,7 @@ stages:
   - name: Try to restart all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1357,7 +1357,7 @@ stages:
   - name: Try to assign agent 003 to group1 (Agent denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/003/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/003/group/group1"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1367,7 +1367,7 @@ stages:
   - name: Try to assign agent 009 to group3 (Group denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/009/group/group3"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/009/group/group3"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1377,7 +1377,7 @@ stages:
   - name: Try to assign agent 005 to group1 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/005/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/005/group/group1"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1402,7 +1402,7 @@ stages:
   - name: Try to restart agent 008 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/008/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/008/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1412,7 +1412,7 @@ stages:
   - name: Restart agent 005 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/005/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/005/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1435,7 +1435,7 @@ stages:
   - name: Try to upgrade agent 004 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/004/upgrade"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/004/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1450,7 +1450,7 @@ stages:
   - name: Try to customly upgrade agent 004 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/004/upgrade_custom?installer=agent_upgrade.py&file_path=/var/ossec"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/004/upgrade_custom?installer=agent_upgrade.py&file_path=/var/ossec"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1465,7 +1465,7 @@ stages:
   - name: Get unknown-node on failed response
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1487,7 +1487,7 @@ stages:
   - name: Restart all agents belonging to master-node (Allow node_id - Could deny agent_id)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/node/master-node/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/node/master-node/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1504,7 +1504,7 @@ stages:
   - name: Restart all agents belonging to worker1 (Allow node_id - Could deny agent_id)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/node/worker1/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/node/worker1/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1521,7 +1521,7 @@ stages:
   - name: Restart all agents belonging to worker2 (Allow node_id - Could deny agent_id)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/node/worker2/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/node/worker2/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_ciscat_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_ciscat_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Get ciscat result for agent 001 (allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/ciscat/001/results"
+      url: "{protocol:s}://{host:s}:{port:d}/ciscat/001/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -25,7 +25,7 @@ stages:
   - name: Get ciscat result for agent 002 (denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/ciscat/002/results"
+      url: "{protocol:s}://{host:s}:{port:d}/ciscat/002/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -37,7 +37,7 @@ stages:
   - name: Get ciscat result for agent 003 (allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/ciscat/003/results"
+      url: "{protocol:s}://{host:s}:{port:d}/ciscat/003/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Get cluster config
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/local/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -26,7 +26,7 @@ stages:
   - name: Get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -55,7 +55,7 @@ stages:
   - name: Get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -83,7 +83,7 @@ stages:
   - name: Get cluster node
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/local/info"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -98,7 +98,7 @@ stages:
   - name: Get cluster nodes
     request: &get_cluster_nodes
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -174,7 +174,7 @@ stages:
   - name: Get cluster {worker2} (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -186,7 +186,7 @@ stages:
   - name: Get cluster {worker2} (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -206,7 +206,7 @@ stages:
   - name: Get cluster {master-node,worker1,worker2} (Allow, Deny, Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -238,7 +238,7 @@ stages:
   - name: Get cluster status
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/status"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -253,7 +253,7 @@ stages:
   - name: Request {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -284,7 +284,7 @@ stages:
   - name: Request (worker1) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -299,7 +299,7 @@ stages:
   - name: Request cluster validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -317,7 +317,7 @@ stages:
   - name: Request cluster validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -348,7 +348,7 @@ stages:
   - name: Try to show the config of analisys/global through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/configuration/analysis/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -358,7 +358,7 @@ stages:
   - name: Try to show the config of analisys/global through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -373,7 +373,7 @@ stages:
   - name: Request {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/info"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -383,7 +383,7 @@ stages:
   - name: Request {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/info"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -398,7 +398,7 @@ stages:
   - name: Request {worker1} (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -408,7 +408,7 @@ stages:
   - name: Request {worker2} (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -423,7 +423,7 @@ stages:
   - name: Request {worker1} (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/logs/summary"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -433,7 +433,7 @@ stages:
   - name: Request {worker2} (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/logs/summary"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -448,7 +448,7 @@ stages:
   - name: Cluster stats {worker2} today (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -458,7 +458,7 @@ stages:
   - name: Cluster stats {worker1} today (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -475,7 +475,7 @@ stages:
   - name: Request {worker1} (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/status"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -485,7 +485,7 @@ stages:
   - name: Request {worker2} (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/status"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -500,7 +500,7 @@ stages:
   - name: Get file {worker1} (Allow) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -514,7 +514,7 @@ stages:
   - name: Get file {worker1} (Allow) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -526,7 +526,7 @@ stages:
   - name: Get file {worker2} (Deny) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -538,7 +538,7 @@ stages:
   - name: Get file {worker2} (Deny) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -555,7 +555,7 @@ stages:
   - name: Get ossec.conf {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -572,7 +572,7 @@ stages:
   - name: Upload ossec.conf {worker1} (Allow) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/files"
       method: PUT
       data: "{ossec_conf}"
       headers:
@@ -587,7 +587,7 @@ stages:
   - name: Upload ossec.conf {worker2} (Deny) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/files"
       method: PUT
       data: "{ossec_conf}"
       headers:
@@ -607,7 +607,7 @@ stages:
   - name: Delete rules file (Deny) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -619,7 +619,7 @@ stages:
   - name: Delete rules file (Allow) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -631,7 +631,7 @@ stages:
   - name: Delete ossec.conf file (Deny) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -648,7 +648,7 @@ stages:
   - name: Request API config (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -676,7 +676,7 @@ stages:
   - name: Modify API configuration (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -702,7 +702,7 @@ stages:
   - name: Restore API config (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -719,7 +719,7 @@ stages:
   - name: Restart cluster
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -731,7 +731,7 @@ stages:
   - name: Restart cluster
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_decoders_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Try to show the decoders of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -42,7 +42,7 @@ stages:
   - name: Try to show the decoders of the system (try q parameter to bypass a denied resource)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -60,7 +60,7 @@ stages:
   - name: Try to show the decoders of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -91,7 +91,7 @@ stages:
   - name: Try to show the decoders files of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -124,7 +124,7 @@ stages:
   - name: Try to show the decoders files of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -152,7 +152,7 @@ stages:
   - name: Try to show the decoders files of the system (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -171,7 +171,7 @@ stages:
   - name: Try to get one decoder file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files/0025-apache_decoders.xml/download"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0025-apache_decoders.xml/download"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -183,7 +183,7 @@ stages:
   - name: Try to get one decoder file (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files/0005-wazuh_decoders.xml/download"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml/download"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -198,7 +198,7 @@ stages:
   - name: Try to show the decoder parents in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/parents"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/parents"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -32,7 +32,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -62,7 +62,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -82,7 +82,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -112,7 +112,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -133,7 +133,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -163,7 +163,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -176,7 +176,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -206,7 +206,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -219,7 +219,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -249,7 +249,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -262,7 +262,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -292,7 +292,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -305,7 +305,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -335,7 +335,7 @@ stages:
   - name:  Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -351,7 +351,7 @@ stages:
   - name:  Request all agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -370,7 +370,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -395,7 +395,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -422,7 +422,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -438,7 +438,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -466,7 +466,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -482,7 +482,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_lists_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_lists_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Try to show the lists of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/lists"
+      url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -31,7 +31,7 @@ stages:
   - name: Try to show an specified filename (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/lists"
+      url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -52,7 +52,7 @@ stages:
   - name: Try to show an specified path (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/lists"
+      url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -71,7 +71,7 @@ stages:
   - name: Try to show the lists files of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/lists/files"
+      url: "{protocol:s}://{host:s}:{port:d}/lists/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Request manager configuration (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -28,7 +28,7 @@ stages:
   - name: Request manager configuration validation (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/validation"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -43,7 +43,7 @@ stages:
   - name: Request manager component configuration (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/agentless/agentless"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/agentless/agentless"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -58,7 +58,7 @@ stages:
   - name: Delete a file (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -70,7 +70,7 @@ stages:
   - name: Delete a file (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -89,7 +89,7 @@ stages:
   - name: Read a file (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -106,7 +106,7 @@ stages:
   - name: Upload a file (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -119,7 +119,7 @@ stages:
   - name: Upload a file (Indirectly denied, can't delete while overwriting)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -148,7 +148,7 @@ stages:
   - name: Request manager info (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/info"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -163,7 +163,7 @@ stages:
   - name: Request manager logs (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -178,7 +178,7 @@ stages:
   - name: Request manager logs summary (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs/summary"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -193,7 +193,7 @@ stages:
   - name: Restart manager (Allowed) (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -209,7 +209,7 @@ stages:
   - name: Request manager stats (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -226,7 +226,7 @@ stages:
   - name: Request manager analysisd stats (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats/analysisd"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/analysisd"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -241,7 +241,7 @@ stages:
   - name: Request manager hourly stats (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats/hourly"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/hourly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -256,7 +256,7 @@ stages:
   - name: Request manager remoted stats (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats/remoted"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/remoted"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -271,7 +271,7 @@ stages:
   - name: Request manager weekly stats (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats/weekly"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/weekly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -286,7 +286,7 @@ stages:
   - name: Request manager status (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/status"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -302,7 +302,7 @@ stages:
   - name: Request API config (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -317,7 +317,7 @@ stages:
   - name: Modify API configuration (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -336,7 +336,7 @@ stages:
   - name: Restore API config (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Request MITRE attacks (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/mitre"
+      url: "{protocol:s}://{host:s}:{port:d}/mitre"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_overview_endpoints.tavern.yaml
@@ -8,7 +8,7 @@ stages:
  - name: Get full agents overview
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/overview/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/overview/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rules_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Try to show the rules of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules"
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -47,7 +47,7 @@ stages:
   - name: Try to show the rules of the system (try q parameter to bypass a denied resource)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules"
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -65,7 +65,7 @@ stages:
   - name: Try to show the rules of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules"
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -98,7 +98,7 @@ stages:
   - name: Try to show the rules files of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -128,7 +128,7 @@ stages:
   - name: Try to show the rules files of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -151,7 +151,7 @@ stages:
   - name: Try to show the rules files of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -177,7 +177,7 @@ stages:
   - name: Try to show the rules files of the system (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -196,7 +196,7 @@ stages:
   - name: Try get one rule file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files/local_rules.xml/download"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files/local_rules.xml/download"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -208,7 +208,7 @@ stages:
   - name: Try get one rule file (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files/0015-ossec_rules.xml/download"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0015-ossec_rules.xml/download"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -223,7 +223,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/groups"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -244,7 +244,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/requirement/pci_dss"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci_dss"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -265,7 +265,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/requirement/mitre"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/mitre"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_black_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_sca_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Request sca for agent 000 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/000"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/000"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -21,7 +21,7 @@ stages:
   - name: Request sca for agent 001 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -33,7 +33,7 @@ stages:
   - name: Request sca for agent 002 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -45,7 +45,7 @@ stages:
   - name: Request sca for agent 003 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -55,7 +55,7 @@ stages:
   - name: Request sca for agent 004 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/004"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/004"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -67,7 +67,7 @@ stages:
   - name: Request sca for agent 005 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/005"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/005"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -82,7 +82,7 @@ stages:
   - name: Request policy checks for 000 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/000/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/000/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -94,7 +94,7 @@ stages:
   - name: Request policy checks for 001 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Get all users in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -48,7 +48,7 @@ stages:
   - name: Get a specified user by its username (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -71,7 +71,7 @@ stages:
   - name: Get a specified user by its username (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -85,7 +85,7 @@ stages:
   - name: Get a list of users by its username (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -118,7 +118,7 @@ stages:
   - name: Get a list of users by its username (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -130,7 +130,7 @@ stages:
   - name: Get a list of users by its username (Both)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -170,7 +170,7 @@ stages:
   - name: Get all roles in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -186,7 +186,7 @@ stages:
   - name: Get a specified role by its id (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -203,7 +203,7 @@ stages:
   - name: Get all policies in the system (All denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -220,7 +220,7 @@ stages:
   - name: Get a specified policy by its id (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -238,7 +238,7 @@ stages:
   - name: Get a specified policy by its id (It doesn't exist but we have all the permissions on the resource policies)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -261,7 +261,7 @@ stages:
   - name: Get a list of policies by its id (Existent and no existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -289,7 +289,7 @@ stages:
   - name: Get current security config (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/config"
+      url: "{protocol:s}://{host:s}:{port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -304,7 +304,7 @@ stages:
   - name: Update default security config (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/config"
+      url: "{protocol:s}://{host:s}:{port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -321,7 +321,7 @@ stages:
   - name: Update one specified user in the system (All allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/105"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/105"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -341,7 +341,7 @@ stages:
   - name: Update one specified user in the system (All allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/103"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/103"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -366,7 +366,7 @@ stages:
   - name: Update one specified role in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/104"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -400,7 +400,7 @@ stages:
   - name: Update one specified role in the system (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/103"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -415,7 +415,7 @@ stages:
   - name: Update one admin role in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/1"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/1"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -446,7 +446,7 @@ stages:
   - name: Update one specified policy in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies/103"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies/103"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -493,7 +493,7 @@ stages:
   - name: Update one specified policy in the system (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -518,7 +518,7 @@ stages:
   - name: Create one specified link between one user and a list of roles (Allow and Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/103/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/103/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -554,7 +554,7 @@ stages:
   - name: Create one specified link between one user and a list of roles (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/102/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/102/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -587,7 +587,7 @@ stages:
   - name: Create one specified user (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -613,7 +613,7 @@ stages:
   - name: Create one specified role (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -628,7 +628,7 @@ stages:
   - name: Create one specified policy (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -652,7 +652,7 @@ stages:
   - name: Delete one specified link between one user and a list of roles (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/104/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/104/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -684,7 +684,7 @@ stages:
   - name: Create one specified link between one role and a list of policies (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/104/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/104/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -725,7 +725,7 @@ stages:
   - name: Delete one specified link between one role and a list of policies (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/104/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/104/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -764,7 +764,7 @@ stages:
   - name: Delete one specified user in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -784,7 +784,7 @@ stages:
   - name: Delete all allowed user in the system (All)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -819,7 +819,7 @@ stages:
   - name: Delete all allowed user in the system (All)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -837,7 +837,7 @@ stages:
   - name: Delete a list of users in the system (Allow and deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -872,7 +872,7 @@ stages:
   - name: Delete one specified role in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -900,7 +900,7 @@ stages:
   - name: Delete all roles in the system (Allow and deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -924,7 +924,7 @@ stages:
     delay_before: 20
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -953,7 +953,7 @@ stages:
   - name: Delete all policies in the system (Allow and deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -976,7 +976,7 @@ stages:
   - name: Revoke all tokens (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/user/revoke"
+      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -986,7 +986,7 @@ stages:
   - name: Revoke all tokens (Invalid token after previous call)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/user/revoke"
+      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT

--- a/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
@@ -10,7 +10,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/000"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/000"
       headers:
         Authorization: "Bearer {test_login_token}"
     response: &permission_denied
@@ -22,7 +22,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/002"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -43,7 +43,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/000/last_scan"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/000/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -53,7 +53,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/002/last_scan"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -76,7 +76,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -102,7 +102,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -126,7 +126,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -143,7 +143,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/002"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -159,7 +159,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/001"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Get os from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/os"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/os"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -40,7 +40,7 @@ stages:
   - name: Get os from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/001/os"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/os"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -57,7 +57,7 @@ stages:
   - name: Get hardware from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/hardware"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/hardware"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -85,7 +85,7 @@ stages:
   - name: Get hardware from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/001/hardware"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/hardware"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -100,7 +100,7 @@ stages:
   - name: Get netaddr from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/netaddr"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netaddr"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -121,7 +121,7 @@ stages:
   - name: Get netaddr from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/001/netaddr"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/netaddr"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -136,7 +136,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/netiface"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netiface"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -168,7 +168,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/001/netiface"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/netiface"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -183,7 +183,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/004/netproto"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/netproto"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -203,7 +203,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/005/netproto"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/netproto"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -218,7 +218,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/004/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/packages"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -248,7 +248,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/005/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/packages"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -263,7 +263,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/ports"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/ports"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -293,7 +293,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/006/ports"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/006/ports"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -308,7 +308,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/processes"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/processes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -356,7 +356,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/006/processes"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/006/processes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -371,7 +371,7 @@ stages:
   - name: Get all hotfixes from an agent (Deny)
     request: &hotfix_request_deny
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/000/hotfixes"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/000/hotfixes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_white_active-response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_active-response_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Runs an Active Response command on a specified agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -33,7 +33,7 @@ stages:
   - name: Send a message to an agent (Status=Active) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -54,7 +54,7 @@ stages:
   - name: Send a message to a list of agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -89,7 +89,7 @@ stages:
   - name: Try to send a message to an agent (status=disconnected/never_connected) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -115,7 +115,7 @@ stages:
   - name: Try to send a message to an unexisting agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -137,7 +137,7 @@ stages:
   - name: Runs an Active Response command on all agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/active-response"
+      url: "{protocol:s}://{host:s}:{port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
@@ -808,6 +808,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         group_id: 'wrong_group'
+        list_agents: 'all'
     response: &resource_not_found_group
       status_code: 404
       json:
@@ -1316,6 +1317,7 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
+    delay_after: !float "{global_db_delay}"
 
 ---
 test_name: PUT /groups/{group_id}/configuration

--- a/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Get all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -32,7 +32,7 @@ stages:
   - name: Get a list of agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -49,7 +49,7 @@ stages:
   - name: Get a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -75,7 +75,7 @@ stages:
   - name: Get a list of agents (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -101,7 +101,7 @@ stages:
   - name: Try to get agent 009 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -113,7 +113,7 @@ stages:
   - name: Get agent 010 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -136,7 +136,7 @@ stages:
   - name: Try tp get Request-Agent-Client for agent 003 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/003/config/agent/client"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/003/config/agent/client"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -147,7 +147,7 @@ stages:
     delay_before: !float "{active_reponse_delay}"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/002/config/agent/client"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/002/config/agent/client"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -172,7 +172,7 @@ stages:
   - name: Try to get sync of agent 011 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/011/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/011/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -182,7 +182,7 @@ stages:
   - name: Get agent sync (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/008/group/is_sync"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -205,7 +205,7 @@ stages:
  - name: Try get key agent 005 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/005/key"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/005/key"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -215,7 +215,7 @@ stages:
  - name: Get agent key for 006 (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/006/key"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/006/key"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -237,7 +237,7 @@ stages:
  - name: Get all groups (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+     url: "{protocol:s}://{host:s}:{port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -256,7 +256,7 @@ stages:
  - name: Try to read group3 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+     url: "{protocol:s}://{host:s}:{port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -268,7 +268,7 @@ stages:
  - name: Get a list of groups (Partially allowed, user aware)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+     url: "{protocol:s}://{host:s}:{port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -292,7 +292,7 @@ stages:
  - name: Get a list of groups (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+     url: "{protocol:s}://{host:s}:{port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -317,7 +317,7 @@ stages:
  - name: Try get all agents in one group (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group2/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group2/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -342,7 +342,7 @@ stages:
  - name: Try to get the configuration of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group3/configuration"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -352,7 +352,7 @@ stages:
  - name: Try get the configuration of a group (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group1/configuration"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -373,7 +373,7 @@ stages:
  - name: Try get the files of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group3/files"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/files"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -383,7 +383,7 @@ stages:
  - name: Try get the files of a group (Allow)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group2/files"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group2/files"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -411,7 +411,7 @@ stages:
  - name: Try get one file of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group3/files/agent.conf/json"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/files/agent.conf/json"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -421,7 +421,7 @@ stages:
  - name: Try get one file of a group (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/default/files/agent.conf/json"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf/json"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -438,7 +438,7 @@ stages:
  - name: Try get one file of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group3/files/agent.conf/xml"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/files/agent.conf/xml"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -448,7 +448,7 @@ stages:
  - name: Try get one file of a group (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group2/files/agent.conf/xml"
+     url: "{protocol:s}://{host:s}:{port:d}/groups/group2/files/agent.conf/xml"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -465,7 +465,7 @@ stages:
  - name: Basic response agents name (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -480,7 +480,7 @@ stages:
  - name: Basic response agents name (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -505,7 +505,7 @@ stages:
  - name: Get the agents without group (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/no_group"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/no_group"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -527,7 +527,7 @@ stages:
  - name: Get the outdated agents (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/outdated"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/outdated"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -552,7 +552,7 @@ stages:
  - name: Get the different combinations for os.platform (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/stats/distinct"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/stats/distinct"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -579,7 +579,7 @@ stages:
  - name: Get the agents status summary (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/summary/status"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/summary/status"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -601,7 +601,7 @@ stages:
  - name: Get the summary/os of all agents (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/summary/os"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/summary/os"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -623,7 +623,7 @@ stages:
  - name: Try get upgrade result agent 001 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/upgrade_result?wait_for_complete=true"
+     url: "{protocol:s}://{host:s}:{port:d}/agents/001/upgrade_result?wait_for_complete=true"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -638,7 +638,7 @@ stages:
   - name: Try to remove agent 001 from group1 (Denied group)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -648,7 +648,7 @@ stages:
   - name: Try to remove agent 004 from group3 (Denied agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/004/group/group3"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/004/group/group3"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -658,7 +658,7 @@ stages:
   - name: Try to remove agent 999 from default (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/999/group/default"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/999/group/default"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -670,7 +670,7 @@ stages:
   - name: Try to remove agent 999 from group1 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/999/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/999/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -680,7 +680,7 @@ stages:
   - name: Try to remove agent 002 from group3 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/002/group/group3"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/002/group/group3"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -692,7 +692,7 @@ stages:
   - name: Remove agent 002 from group2 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/002/group/group2"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/002/group/group2"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -710,7 +710,7 @@ stages:
   - name: Try to remove agent 009 from all groups (Denied agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/009/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/009/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -720,7 +720,7 @@ stages:
   - name: Try to remove agent 001 from group1 (Denied group)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -732,7 +732,7 @@ stages:
   - name: Remove agent 006 from all groups (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/006/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/006/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -751,7 +751,7 @@ stages:
   - name: Try to remove agent 005 from all groups (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/005/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/005/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -769,7 +769,7 @@ stages:
   - name: Try to remove agent 007 from a list of groups (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/007/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/007/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -802,7 +802,7 @@ stages:
   - name: Try to remove all agents from a non existing group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -816,7 +816,7 @@ stages:
   - name: Try to remove all agents from group1 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -829,7 +829,7 @@ stages:
   - name: Remove all agents from group2 (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -850,7 +850,7 @@ stages:
   - name: Remove a list of agents from group3 (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -884,7 +884,7 @@ stages:
   - name: Remove a list of agents from group default (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -911,7 +911,7 @@ stages:
   - name: Try to delete group2 (Group denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -923,7 +923,7 @@ stages:
   - name: Try to delete group1 (Group modification denied, indirectly denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -946,7 +946,7 @@ stages:
   - name: Delete group3
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -973,7 +973,7 @@ stages:
   - name: Try to delete all groups (Partially allowed, indirectly denied to delete group1, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -997,7 +997,7 @@ stages:
   - name: Try to delete a list of groups (Partially allowed, indirectly denied to delete group1, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1038,7 +1038,7 @@ stages:
   - name: Try to delete agent 002 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1050,7 +1050,7 @@ stages:
   - name: Delete agent 001 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1076,7 +1076,7 @@ stages:
   - name: Try to delete a list of agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1088,7 +1088,7 @@ stages:
   - name: Try to delete a list of agents (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1111,7 +1111,7 @@ stages:
   - name: Try to delete a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1138,7 +1138,7 @@ stages:
   - name: Try to delete all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1165,7 +1165,7 @@ stages:
   - name: Try to create a new agent (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1183,7 +1183,7 @@ stages:
   - name: Try to create a new agent specifying id, ip, key and name (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/insert"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/insert"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1203,7 +1203,7 @@ stages:
   - name: Try to create new agent specifying its name (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/insert/quick"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/insert/quick"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1220,7 +1220,7 @@ stages:
   - name: Try to create a group called group4 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1237,7 +1237,7 @@ stages:
   - name: Try to assign all agents to a non existing group (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1249,7 +1249,7 @@ stages:
   - name: Try to assign all agents to group1 (Group denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1261,7 +1261,7 @@ stages:
   - name: Try to assign a list of agents to group2 (Agents denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1274,7 +1274,7 @@ stages:
   - name: Try to assign a list of agents to group2 (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1300,7 +1300,7 @@ stages:
   - name: Try to assign all agents to group2 (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1325,7 +1325,7 @@ stages:
   - name: Update group2 configuration (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group2/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/group2/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1340,7 +1340,7 @@ stages:
   - name: Try to update group1 configuration (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1359,7 +1359,7 @@ stages:
   - name: Restart all agents from group default (Partially allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/group/default/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/group/default/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1390,7 +1390,7 @@ stages:
   - name: Try to restart non existing agent (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1412,7 +1412,7 @@ stages:
   - name: Try to restart agent 010 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1424,7 +1424,7 @@ stages:
   - name: Try to restart a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1457,7 +1457,7 @@ stages:
   - name: Try to restart all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1485,7 +1485,7 @@ stages:
   - name: Try to assign agent 004 to group2 (Agent denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/004/group/group2"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/004/group/group2"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1495,7 +1495,7 @@ stages:
   - name: Try to assign agent 008 to group1 (Group denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/008/group/group1"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group/group1"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1505,7 +1505,7 @@ stages:
   - name: Try to assign agent 008 to group3 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/008/group/group3"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group/group3"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1515,7 +1515,7 @@ stages:
   - name: Try to assign agent 001 to group2 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/group/group2"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group2"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1535,7 +1535,7 @@ stages:
   - name: Assign agent 008 to default (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/008/group/default"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group/default"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1557,7 +1557,7 @@ stages:
   - name: Try to restart agent 001 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/001/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/001/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1577,7 +1577,7 @@ stages:
   - name: Try to restart agent 010 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/010/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/010/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1587,7 +1587,7 @@ stages:
   - name: Restart agent 004 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/004/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/004/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1610,7 +1610,7 @@ stages:
   - name: Try to upgrade agent 004 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/004/upgrade"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/004/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1625,7 +1625,7 @@ stages:
   - name: Try to customly upgrade agent 004 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/004/upgrade_custom?installer=agent_upgrade.py&file_path=/var/ossec"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/004/upgrade_custom?installer=agent_upgrade.py&file_path=/var/ossec"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1640,7 +1640,7 @@ stages:
   - name: Get unknown-node on failed response
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents"
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1657,7 +1657,7 @@ stages:
   - name: Restart all agents belonging to master-node (Deny node_id)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/agents/node/master-node/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/node/master-node/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_ciscat_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_ciscat_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Get ciscat result for agent 001 (allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/ciscat/001/results"
+      url: "{protocol:s}://{host:s}:{port:d}/ciscat/001/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -25,7 +25,7 @@ stages:
   - name: Get ciscat result for agent 002 (allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/ciscat/002/results"
+      url: "{protocol:s}://{host:s}:{port:d}/ciscat/002/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -41,7 +41,7 @@ stages:
   - name: Get ciscat result for agent 003 (denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/ciscat/003/results"
+      url: "{protocol:s}://{host:s}:{port:d}/ciscat/003/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Get cluster config
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/local/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -39,7 +39,7 @@ stages:
   - name: Get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -68,7 +68,7 @@ stages:
   - name: Get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -102,7 +102,7 @@ stages:
   - name: Get cluster node
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/local/info"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -126,7 +126,7 @@ stages:
   - name: Get cluster nodes
     request: &get_cluster_nodes
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -205,7 +205,7 @@ stages:
   - name: Get cluster {worker1} (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -219,7 +219,7 @@ stages:
   - name: Get cluster {worker2} (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -239,7 +239,7 @@ stages:
   - name: Get cluster {master-node,worker1,worker2} (Allow, Deny, Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -270,7 +270,7 @@ stages:
   - name: Get cluster status
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/status"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -289,7 +289,7 @@ stages:
   - name: Request {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -325,7 +325,7 @@ stages:
   - name: Request (worker1) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -335,7 +335,7 @@ stages:
   - name: Filters -> section=alerts (worker2) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -361,7 +361,7 @@ stages:
   - name: Request cluster validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -381,7 +381,7 @@ stages:
   - name: Request cluster validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -410,7 +410,7 @@ stages:
   - name: Try to show the config of analisys/global through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -420,7 +420,7 @@ stages:
   - name: Try to show the config of analisys/global through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/configuration/analysis/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -435,7 +435,7 @@ stages:
   - name: Request {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/info"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -445,7 +445,7 @@ stages:
   - name: Request {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/master-node/info"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -460,7 +460,7 @@ stages:
   - name: Request {worker2} (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -470,7 +470,7 @@ stages:
   - name: Request {worker1} (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -485,7 +485,7 @@ stages:
   - name: Request {worker2} (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/logs/summary"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -495,7 +495,7 @@ stages:
   - name: Request {worker1} (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/logs/summary"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -510,7 +510,7 @@ stages:
   - name: Cluster stats {worker1} today (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -520,7 +520,7 @@ stages:
   - name: Cluster stats {worker2} today (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/stats"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -537,7 +537,7 @@ stages:
   - name: Request {worker2} (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/status"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -547,7 +547,7 @@ stages:
   - name: Request {worker1} (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/status"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -562,7 +562,7 @@ stages:
   - name: Request API config (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -591,7 +591,7 @@ stages:
   - name: Modify API configuration (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -618,7 +618,7 @@ stages:
   - name: Restart cluster
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -642,7 +642,7 @@ stages:
   - name: Restart cluster
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -665,7 +665,7 @@ stages:
   - name: Get ossec.conf {worker2} (Allow) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -679,7 +679,7 @@ stages:
   - name: Get ossec.conf {worker2} (Allow) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -691,7 +691,7 @@ stages:
   - name: Get ossec.conf {worker1} (Deny) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -703,7 +703,7 @@ stages:
   - name: Get ossec.conf {worker1} (Deny) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -720,7 +720,7 @@ stages:
   - name: Get ossec.conf {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -737,7 +737,7 @@ stages:
   - name: Upload ossec.conf {worker2} (Allow) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/files"
       method: PUT
       data: "{ossec_conf}"
       headers:
@@ -752,7 +752,7 @@ stages:
   - name: Upload ossec.conf {worker1} (Deny) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/files"
       method: PUT
       data: "{ossec_conf}"
       headers:
@@ -772,7 +772,7 @@ stages:
   - name: Delete rules file (Deny) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -784,7 +784,7 @@ stages:
   - name: Delete rules file (Allow) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -796,7 +796,7 @@ stages:
   - name: Delete rules file (Deny) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker1/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -808,7 +808,7 @@ stages:
   - name: Delete rules file (Allow) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/worker2/files"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -825,7 +825,7 @@ stages:
   - name: Restore API config (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_decoders_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Try to show the decoders of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -38,7 +38,7 @@ stages:
   - name: Try to show the decoders of the system (try q parameter to bypass a denied resource)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -56,7 +56,7 @@ stages:
   - name: Try to show the decoders of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -91,7 +91,7 @@ stages:
   - name: Try to show the decoders files of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -113,7 +113,7 @@ stages:
   - name: Try to show the decoders files of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -137,7 +137,7 @@ stages:
   - name: Try to show the decoders files of the system (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -159,7 +159,7 @@ stages:
   - name: Try to get one decoder file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files/0005-wazuh_decoders.xml/download"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml/download"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -171,7 +171,7 @@ stages:
   - name: Try to get one decoder file (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/files/0064-cisco-asa_decoders.xml/download"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0064-cisco-asa_decoders.xml/download"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -186,7 +186,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/decoders/parents"
+      url: "{protocol:s}://{host:s}:{port:d}/decoders/parents"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -31,7 +31,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -61,7 +61,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -81,7 +81,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -111,7 +111,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -131,7 +131,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -161,7 +161,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -181,7 +181,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -211,7 +211,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -231,7 +231,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -261,7 +261,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -281,7 +281,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -311,7 +311,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -331,7 +331,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -361,7 +361,7 @@ stages:
   - name:  Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -377,7 +377,7 @@ stages:
   - name:  Request all agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -399,7 +399,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -419,7 +419,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -446,7 +446,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -462,7 +462,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -490,7 +490,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -506,7 +506,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_lists_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_lists_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Try to show the lists of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/lists"
+      url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -31,7 +31,7 @@ stages:
   - name: Try to show an specified filename (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/lists"
+      url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -52,7 +52,7 @@ stages:
   - name: Try to show an specified path (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/lists"
+      url: "{protocol:s}://{host:s}:{port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -74,7 +74,7 @@ stages:
   - name: Try to show the lists files of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/lists/files"
+      url: "{protocol:s}://{host:s}:{port:d}/lists/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Request manager configuration (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -26,7 +26,7 @@ stages:
   - name: Request manager configuration validation (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/validation"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -41,7 +41,7 @@ stages:
   - name: Request manager component configuration (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/configuration/agentless/agentless"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/agentless/agentless"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -56,7 +56,7 @@ stages:
   - name: Delete a file (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -68,7 +68,7 @@ stages:
   - name: Delete a file (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -85,7 +85,7 @@ stages:
   - name: Read a file (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -97,7 +97,7 @@ stages:
   - name: Read a file (Denied, Does not exist)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -114,7 +114,7 @@ stages:
   - name: Upload a file (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/files"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -132,7 +132,7 @@ stages:
   - name: Request manager info (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/info"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -147,7 +147,7 @@ stages:
   - name: Request manager logs (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -162,7 +162,7 @@ stages:
   - name: Request manager logs summary (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/logs/summary"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -177,7 +177,7 @@ stages:
   - name: Request manager stats (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -194,7 +194,7 @@ stages:
   - name: Request manager analysisd stats (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats/analysisd"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/analysisd"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -209,7 +209,7 @@ stages:
   - name: Request manager hourly stats (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats/hourly"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/hourly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -224,7 +224,7 @@ stages:
   - name: Request manager remoted stats (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats/remoted"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/remoted"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -239,7 +239,7 @@ stages:
   - name: Request manager weekly stats (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/stats/weekly"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/weekly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -254,7 +254,7 @@ stages:
   - name: Request manager status (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/status"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -269,7 +269,7 @@ stages:
   - name: Request API config (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -284,7 +284,7 @@ stages:
   - name: Modify API configuration (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -303,7 +303,7 @@ stages:
   - name: Restore API config (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -318,7 +318,7 @@ stages:
   - name: Restart manager (Denied) (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/manager/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Request MITRE attacks (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/mitre"
+      url: "{protocol:s}://{host:s}:{port:d}/mitre"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_overview_endpoints.tavern.yaml
@@ -8,7 +8,7 @@ stages:
  - name: Get full agents overview
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/{version:s}/overview/agents"
+     url: "{protocol:s}://{host:s}:{port:d}/overview/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_rules_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Try to show the rules of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules"
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -47,7 +47,7 @@ stages:
   - name: Try to show the rules of the system (try q parameter to bypass a denied resource)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules"
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -65,7 +65,7 @@ stages:
   - name: Try to show the rules of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules"
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -103,7 +103,7 @@ stages:
   - name: Try to show the rules files of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -125,7 +125,7 @@ stages:
   - name: Try to show the rules files of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -147,7 +147,7 @@ stages:
   - name: Try to show the rules files of the system (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -169,7 +169,7 @@ stages:
   - name: Try get one rule file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files/0015-ossec_rules.xml/download"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0015-ossec_rules.xml/download"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -181,7 +181,7 @@ stages:
   - name: Try get one rule file (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files/0011-ossec_rules.xml/download"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0011-ossec_rules.xml/download"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -196,7 +196,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/groups"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -217,7 +217,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/requirement/pci_dss"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci_dss"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -238,7 +238,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/requirement/mitre"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/mitre"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_white_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_sca_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Request sca for agent 000 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/000"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/000"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -21,7 +21,7 @@ stages:
   - name: Request sca for agent 001 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -36,7 +36,7 @@ stages:
   - name: Request sca for agent 002 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -48,7 +48,7 @@ stages:
   - name: Request sca for agent 003 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -58,7 +58,7 @@ stages:
   - name: Request sca for agent 003 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -68,7 +68,7 @@ stages:
   - name: Request sca for agent 005 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/005"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/005"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -85,7 +85,7 @@ stages:
   - name: Request policy checks for 000 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/000/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/000/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -97,7 +97,7 @@ stages:
   - name: Request policy checks for 001 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Get all users in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -43,7 +43,7 @@ stages:
   - name: Get a specified user by its id (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -67,7 +67,7 @@ stages:
   - name: Get a specified user by its id (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -84,7 +84,7 @@ stages:
   - name: Get a list of users by its id (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -108,7 +108,7 @@ stages:
   - name: Get a list of users by its id (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -120,7 +120,7 @@ stages:
   - name: Get a list of users by its username (Both)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -166,7 +166,7 @@ stages:
   - name: Get all roles in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -380,7 +380,7 @@ stages:
   - name: Get a specified role by its id (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -425,7 +425,7 @@ stages:
   - name: Get a specified role by its id (It doesn't exist but we have all the permissions on the resource roles)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -447,7 +447,7 @@ stages:
   - name: Get a list of roles by its id (Existent and no existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -521,7 +521,7 @@ stages:
   - name: Get all policies in the system (All denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -537,7 +537,7 @@ stages:
   - name: Get a specified policy by its id (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -554,7 +554,7 @@ stages:
   - name: Get current security config (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/config"
+      url: "{protocol:s}://{host:s}:{port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -572,7 +572,7 @@ stages:
   - name: Update default security config (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/config"
+      url: "{protocol:s}://{host:s}:{port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -589,7 +589,7 @@ stages:
   - name: Update one specified user in the system (All denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/105"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/105"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -601,7 +601,7 @@ stages:
   - name: Update one specified user in the system (All denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/1"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/1"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -618,7 +618,7 @@ stages:
   - name: Update one specified role in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/102"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/102"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -651,7 +651,7 @@ stages:
   - name: Update one specified role in the system (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/2"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/2"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -671,7 +671,7 @@ stages:
   - name: Update one specified policy in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -723,7 +723,7 @@ stages:
   - name: Update one specified policy in the system (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies/106"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies/106"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -746,7 +746,7 @@ stages:
   - name: Create one specified link between one user and a list of roles (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/103/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/103/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -758,7 +758,7 @@ stages:
   - name: Create one specified link between one user and a list of roles (Allow and Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/104/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/104/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -775,7 +775,7 @@ stages:
   - name: Create one specified link between one role and a list of policies (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/103/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -807,7 +807,7 @@ stages:
   - name: Create one specified link between one user and a list of roles (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/103/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/103/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -819,7 +819,7 @@ stages:
   - name: Create one specified link between one user and a list of roles (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/104/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/104/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -836,7 +836,7 @@ stages:
   - name: Delete one specified link between one user and a list of roles (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/103/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/103/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -848,7 +848,7 @@ stages:
   - name: Delete one specified link between one user and a list of roles (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/104/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/104/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -865,7 +865,7 @@ stages:
   - name: Delete one specified link between one role and a list of policies (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/11/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/11/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -882,7 +882,7 @@ stages:
   - name: Delete one specified user in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -902,7 +902,7 @@ stages:
   - name: Delete all allowed user in the system (All)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -922,7 +922,7 @@ stages:
   - name: Delete all allowed user in the system (All)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -940,7 +940,7 @@ stages:
   - name: Delete a list of users in the system (Allow and deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -972,7 +972,7 @@ stages:
   - name: Delete all roles in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -990,7 +990,7 @@ stages:
   - name: Delete one specified role in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -1007,7 +1007,7 @@ stages:
   - name: Delete one specified policy in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -1025,7 +1025,7 @@ stages:
   - name: Delete one specified policy in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -1042,7 +1042,7 @@ stages:
   - name: Create one specified user (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -1060,7 +1060,7 @@ stages:
   - name: Create one specified role (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -1087,7 +1087,7 @@ stages:
   - name: Create one specified policy (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -1127,7 +1127,7 @@ stages:
   - name: Revoke all tokens (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/user/revoke"
+      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT

--- a/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
@@ -10,7 +10,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/000"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/000"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -26,7 +26,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/002"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response: &permission_denied
@@ -46,7 +46,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/000/last_scan"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/000/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -64,7 +64,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/002/last_scan"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -79,7 +79,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -95,7 +95,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -118,7 +118,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -135,7 +135,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/001"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -151,7 +151,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/002"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Get os from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/001/os"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/os"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -40,7 +40,7 @@ stages:
   - name: Get os from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/os"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/os"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -60,7 +60,7 @@ stages:
   - name: Get hardware from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/001/hardware"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/hardware"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -88,7 +88,7 @@ stages:
   - name: Get hardware from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/hardware"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/hardware"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -103,7 +103,7 @@ stages:
   - name: Get netaddr from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/001/netaddr"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/netaddr"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -124,7 +124,7 @@ stages:
   - name: Get netaddr from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/netaddr"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netaddr"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -139,7 +139,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/001/netiface"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/netiface"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -171,7 +171,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/netiface"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netiface"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -186,7 +186,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/005/netproto"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/netproto"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -206,7 +206,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/004/netproto"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/netproto"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -221,7 +221,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/005/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/packages"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -251,7 +251,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/004/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/packages"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -266,7 +266,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/006/ports"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/006/ports"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -296,7 +296,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/ports"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/ports"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -311,7 +311,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/006/processes"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/006/processes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -359,7 +359,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/processes"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/processes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -374,7 +374,7 @@ stages:
   - name: Get all hotfixes from an agent (Allow)
     request: &hotfix_request_allow
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/000/hotfixes"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/000/hotfixes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -414,7 +414,7 @@ stages:
   - name: Get all hotfixes from an agent (Deny)
     request: &hotfix_request_deny
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/hotfixes"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/hotfixes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rules_endpoints.tavern.yaml
+++ b/api/test/integration/test_rules_endpoints.tavern.yaml
@@ -9,7 +9,7 @@ stages:
   - name: Try to show the rules of the system
     request: &general_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules"
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -182,7 +182,7 @@ stages:
   - name: Search in rules
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules"
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -282,7 +282,7 @@ stages:
   - name: Try to show the rules of the system with a non-existent state
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules"
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -707,7 +707,7 @@ stages:
   - name: Try to show the rules by requirement pci_dss
     request: &pci_dss_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/requirement/pci_dss"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci_dss"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -812,7 +812,7 @@ stages:
   - name: Try to show the rules by requirement gdpr
     request: &gdpr_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/requirement/gdpr"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/gdpr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -918,7 +918,7 @@ stages:
   - name: Try to show the rules by requirement gpg13
     request: &gpg13_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/requirement/gpg13"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/gpg13"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1033,7 +1033,7 @@ stages:
   - name: Try to show the rules by requirement hipaa
     request: &hipaa_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/requirement/hipaa"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/hipaa"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1118,7 +1118,7 @@ stages:
   - name: Try to show the rules by requirement nist-800-53
     request: &nist-800-53_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/requirement/nist-800-53"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/nist-800-53"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1203,7 +1203,7 @@ stages:
   - name: Try to show the rules by requirement tsc
     request: &tsc_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/requirement/tsc"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/tsc"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1288,7 +1288,7 @@ stages:
   - name: Try to show the rules by requirement mitre
     request: &mitre_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/requirement/mitre"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/mitre"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1373,7 +1373,7 @@ stages:
   - name: Try to show the rules groups
     request: &groups_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/groups"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/groups"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1458,7 +1458,7 @@ stages:
   - name: Get the rules files
     request: &files_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1553,7 +1553,7 @@ stages:
   - name: Download rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules/files/0350-amazon_rules.xml/download"
+      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0350-amazon_rules.xml/download"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1569,7 +1569,7 @@ stages:
   - name: Try to show a rule with a existent id
     request: &id_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules"
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1694,7 +1694,7 @@ stages:
   - name: No rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/rules"
+      url: "{protocol:s}://{host:s}:{port:d}/rules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -8,7 +8,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -20,7 +20,7 @@ stages:
   - name: Parameters -> limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -52,7 +52,7 @@ stages:
   - name: Parameters -> offset=1,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -72,7 +72,7 @@ stages:
   - name: Parameters -> sort=-score,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -93,7 +93,7 @@ stages:
   - name: Parameters -> sort=+score,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -113,7 +113,7 @@ stages:
   - name: Parameters -> search=cis,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -133,7 +133,7 @@ stages:
   - name: Parameters -> q=score>50,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -153,7 +153,7 @@ stages:
   - name: Parameters -> limit=2500
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -165,7 +165,7 @@ stages:
   - name: Parameters -> name=CIS benchmark for Debian/Linux 9 L2,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -186,7 +186,7 @@ stages:
   - name: Parameters -> references=https://www.cisecurity.org/cis-benchmarks/,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -207,7 +207,7 @@ stages:
   - name: Parameters -> description=This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -233,7 +233,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -245,7 +245,7 @@ stages:
   - name: Parameters -> limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -275,7 +275,7 @@ stages:
   - name: Parameters -> limit=4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -295,7 +295,7 @@ stages:
   - name: Parameters -> sort=-id,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -315,7 +315,7 @@ stages:
   - name: Parameters -> search=passwd,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -335,7 +335,7 @@ stages:
   - name: Parameters -> q=id=3098
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -355,7 +355,7 @@ stages:
   - name: Parameters -> result=failed,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -376,7 +376,7 @@ stages:
   - name: Parameters -> file=/etc/shadow,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -397,7 +397,7 @@ stages:
   - name: Parameters -> limit=2500
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -409,7 +409,7 @@ stages:
   - name: Parameters -> title="Ensure shadow group is empty,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -430,7 +430,7 @@ stages:
   - name: Parameters -> title="Ensure address space layout randomization (ASLR) is enabled"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -450,7 +450,7 @@ stages:
   - name: Parameters -> title="non-existent"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -469,7 +469,7 @@ stages:
   - name: Parameters -> description="The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -490,7 +490,7 @@ stages:
   - name: Parameters -> remediation=Remove any legacy + entries from /etc/group if they exist.,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -511,7 +511,7 @@ stages:
   - name: Parameters -> rationale with apostrophe and parenthesis"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -537,7 +537,7 @@ stages:
   - name: Parameters -> rationale with word "count"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -565,7 +565,7 @@ stages:
   - name: Parameters -> rationale with word "offset"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -584,7 +584,7 @@ stages:
   - name: Parameters -> command="dpkg -s libpam-pwquality"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -604,7 +604,7 @@ stages:
   - name: Parameters -> status="Not applicable"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -624,7 +624,7 @@ stages:
   - name: Parameters -> reason="Invalid path or wrong permissions to run command 'ip6tables -L'"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -649,7 +649,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -661,7 +661,7 @@ stages:
   - name: Parameters -> limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -693,7 +693,7 @@ stages:
   - name: Parameters -> offset=1,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -713,7 +713,7 @@ stages:
   - name: Parameters -> sort=-score,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -734,7 +734,7 @@ stages:
   - name: Parameters -> sort=+score,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -754,7 +754,7 @@ stages:
   - name: Parameters -> search=cis,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -774,7 +774,7 @@ stages:
   - name: Parameters -> q=score>50,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -794,7 +794,7 @@ stages:
   - name: Parameters -> limit=2500
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -806,7 +806,7 @@ stages:
   - name: Parameters -> name=CIS benchmark for Debian/Linux 9 L2,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -827,7 +827,7 @@ stages:
   - name: Parameters -> references=https://www.cisecurity.org/cis-benchmarks/,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -848,7 +848,7 @@ stages:
   - name: Parameters -> description=This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -874,7 +874,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -886,7 +886,7 @@ stages:
   - name: Parameters -> limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -916,7 +916,7 @@ stages:
   - name: Parameters -> limit=4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -936,7 +936,7 @@ stages:
   - name: Parameters -> sort=-id,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -956,7 +956,7 @@ stages:
   - name: Parameters -> search=passwd,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -976,7 +976,7 @@ stages:
   - name: Parameters -> q=id=3098
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -996,7 +996,7 @@ stages:
   - name: Parameters -> result=failed,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1017,7 +1017,7 @@ stages:
   - name: Parameters -> file=/etc/shadow,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1038,7 +1038,7 @@ stages:
   - name: Parameters -> limit=2500
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1050,7 +1050,7 @@ stages:
   - name: Parameters -> title="Ensure shadow group is empty,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1071,7 +1071,7 @@ stages:
   - name: Parameters -> remediation=Remove any legacy + entries from /etc/group if they exist.,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1092,7 +1092,7 @@ stages:
   - name: Parameters -> rationale with apostrophe"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1112,7 +1112,7 @@ stages:
   - name: Parameters -> command="systemctl is-enabled autofs"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1132,7 +1132,7 @@ stages:
   - name: Parameters -> status="Not applicable"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1152,7 +1152,7 @@ stages:
   - name: Parameters -> reason="Invalid path or wrong permissions to run command '/sbin/modprobe -n -v freevxfs'"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1177,7 +1177,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1189,7 +1189,7 @@ stages:
   - name: Parameters -> limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1221,7 +1221,7 @@ stages:
   - name: Parameters -> offset=1,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1241,7 +1241,7 @@ stages:
   - name: Parameters -> sort=-score,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1262,7 +1262,7 @@ stages:
   - name: Parameters -> sort=+score,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1282,7 +1282,7 @@ stages:
   - name: Parameters -> search=cis,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1302,7 +1302,7 @@ stages:
   - name: Parameters -> q=score>50,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1322,7 +1322,7 @@ stages:
   - name: Parameters -> q=policy_id~cis_;total_checks>20;total_checks<50
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1341,7 +1341,7 @@ stages:
   - name: Parameters -> limit=2500
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1353,7 +1353,7 @@ stages:
   - name: Parameters -> name=CIS benchmark for Debian/Linux 9 L2,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1374,7 +1374,7 @@ stages:
   - name: Parameters -> references=https://www.cisecurity.org/cis-benchmarks/,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1395,7 +1395,7 @@ stages:
   - name: Parameters -> description=This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1421,7 +1421,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1433,7 +1433,7 @@ stages:
   - name: Parameters -> limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1463,7 +1463,7 @@ stages:
   - name: Parameters -> limit=4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1483,7 +1483,7 @@ stages:
   - name: Parameters -> sort=-id,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1503,7 +1503,7 @@ stages:
   - name: Parameters -> search=passwd,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1523,7 +1523,7 @@ stages:
   - name: Parameters -> q=id=3098
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1543,7 +1543,7 @@ stages:
   - name: Parameters -> q=result=passed;file~/etc/pass;compliance.value=5.4.3;id<5000
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1563,7 +1563,7 @@ stages:
   - name: Parameters -> result=failed,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1584,7 +1584,7 @@ stages:
   - name: Parameters -> file=/etc/shadow,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1605,7 +1605,7 @@ stages:
   - name: Parameters -> limit=2500
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1617,7 +1617,7 @@ stages:
   - name: Parameters -> title="Ensure shadow group is empty,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1638,7 +1638,7 @@ stages:
   - name: Parameters -> remediation=Remove any legacy + entries from /etc/group if they exist.,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1659,7 +1659,7 @@ stages:
   - name: Parameters -> rationale with apostrophe and parenthesis"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1685,7 +1685,7 @@ stages:
   - name: Parameters -> command="dpkg -s libpam-pwquality"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1705,7 +1705,7 @@ stages:
   - name: Parameters -> status="Not applicable"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1725,7 +1725,7 @@ stages:
   - name: Parameters -> reason="Invalid path or wrong permissions to run command 'ip6tables -L'"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/sca/003/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
@@ -10,7 +10,7 @@ stages:
   - name: Try to delete a existent role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -31,7 +31,7 @@ stages:
   - name: Try to delete the admin role of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -53,7 +53,7 @@ stages:
   - name: Try to delete a non-existent role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -73,7 +73,7 @@ stages:
   - name: Try to delete a existent role-policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/103/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -95,7 +95,7 @@ stages:
   - name: Try to delete a non-existent role-policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/999/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -110,7 +110,7 @@ stages:
   - name: Try to delete a non-existent role-policy (role non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/999/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -125,7 +125,7 @@ stages:
   - name: Try to delete a non-existent role-policy (policy non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/3/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/3/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -145,7 +145,7 @@ stages:
   - name: Try to delete a existent user-role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/101/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/101/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -164,7 +164,7 @@ stages:
   - name: Try to delete a non-existent user-role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/987/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/987/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -179,7 +179,7 @@ stages:
   - name: Try to delete a non-existent user-role (role non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/105/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/105/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -199,7 +199,7 @@ stages:
   - name: Try to delete a existent policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -220,7 +220,7 @@ stages:
   - name: Try to delete the admin policy of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -235,7 +235,7 @@ stages:
   - name: Try to delete an inexistent policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -254,7 +254,7 @@ stages:
   - name: Try to delete one existent role and no existent one
     request: &delete_roles_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -304,7 +304,7 @@ stages:
   - name: Try to delete roles (invalid role_ids)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -322,7 +322,7 @@ stages:
   - name: Try to delete two existent policies
     request: &delete_all_policies_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -369,7 +369,7 @@ stages:
   - name: Try to delete policies (invalid policy_ids)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -387,7 +387,7 @@ stages:
     delay_before: 10
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -409,7 +409,7 @@ stages:
   - name: Delete the current user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -431,7 +431,7 @@ stages:
   - name: Delete an admin user (wazuh-wui)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -453,7 +453,7 @@ stages:
   - name: Delete an existent user (with body)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -470,7 +470,7 @@ stages:
   - name: Delete an existent user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -487,7 +487,7 @@ stages:
   - name: Delete all users in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -522,7 +522,7 @@ stages:
   - name: Delete all users in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -540,7 +540,7 @@ stages:
   - name: Change security configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/config"
+      url: "{protocol:s}://{host:s}:{port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -558,7 +558,7 @@ stages:
   - name: Restore default configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/config"
+      url: "{protocol:s}://{host:s}:{port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -573,7 +573,7 @@ stages:
   - name: Get security configuration to check if DELETE method worked correctly
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/config"
+      url: "{protocol:s}://{host:s}:{port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -594,7 +594,7 @@ stages:
     delay_before: 10
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -612,7 +612,7 @@ stages:
   - name: Try to delete all roles
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -10,7 +10,7 @@ stages:
   - name: Try to show the roles of the system
     request: &all_roles_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -142,7 +142,7 @@ stages:
   - name: Search in roles
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -232,7 +232,7 @@ stages:
   - name: Try to show the policies of the system
     request: &all_policies_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -483,7 +483,7 @@ stages:
   - name: Get all users in the system
     request: &all_users_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -531,7 +531,7 @@ stages:
   - name: Get information about the current user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/me"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/me"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -938,7 +938,7 @@ stages:
   - name: Testing RBAC's actions catalog
     request: &rbac_actions_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/actions"
+      url: "{protocol:s}://{host:s}:{port:d}/security/actions"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -988,7 +988,7 @@ stages:
   - name: Testing RBAC's actions catalog
     request: &rbac_resources_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/resources"
+      url: "{protocol:s}://{host:s}:{port:d}/security/resources"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1038,7 +1038,7 @@ stages:
   - name: Get current security configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/config"
+      url: "{protocol:s}://{host:s}:{port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_security_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_POST_endpoints.tavern.yaml
@@ -10,7 +10,7 @@ stages:
   - name: Add a role to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -36,7 +36,7 @@ stages:
   - name: Add a role to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -62,7 +62,7 @@ stages:
   - name: Add a role to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -88,7 +88,7 @@ stages:
   - name: Add an existent role (name) to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -113,7 +113,7 @@ stages:
   - name: Add an existent role (rule) to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -142,7 +142,7 @@ stages:
   - name: Add a policy to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -180,7 +180,7 @@ stages:
   - name: Add a policy to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -216,7 +216,7 @@ stages:
   - name: Add a policy to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -252,7 +252,7 @@ stages:
   - name: Add an existent policy (name) to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -283,7 +283,7 @@ stages:
   - name: Add an existent policy (policy) to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -314,7 +314,7 @@ stages:
   - name: Add an invalid policy to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -345,7 +345,7 @@ stages:
   - name: Add an invalid policy to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -368,7 +368,7 @@ stages:
   - name: Create link role-policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/103/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -385,7 +385,7 @@ stages:
   - name: Create link role-policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/100/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/100/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -402,7 +402,7 @@ stages:
   - name: Create link role-policy (non-existent role)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/999/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -425,7 +425,7 @@ stages:
   - name: Create link role-policy (non-existent policy)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/101/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/101/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -449,7 +449,7 @@ stages:
   - name: Create link role-policy (Both non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/999/policies"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -467,7 +467,7 @@ stages:
   - name: Create a new user (empty body)
     request: &post_users_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -487,7 +487,7 @@ stages:
   - name: Create a new user (secure password)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       json:
@@ -597,7 +597,7 @@ stages:
   - name: Create a new user (secure password)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       json:
@@ -611,7 +611,7 @@ stages:
   - name: Create link user-role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/106/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/106/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -628,7 +628,7 @@ stages:
   - name: Create link user-role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/107/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/107/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -645,7 +645,7 @@ stages:
   - name: Create link user-role (non-existent roles)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/107/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/107/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -669,7 +669,7 @@ stages:
   - name: Create link user-role (valid roles, already linked roles, non-existent roles)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/106/roles"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/106/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -10,7 +10,7 @@ stages:
   - name: Modify a role in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/102"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/102"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -36,7 +36,7 @@ stages:
   - name: Modify a role in the system (without change rule)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/103"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -66,7 +66,7 @@ stages:
   - name: Modify a role in the system (without change name)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/102"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/102"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -91,7 +91,7 @@ stages:
   - name: Modify a non-existent role in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/roles/999"
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -120,7 +120,7 @@ stages:
   - name: Modify a policy in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -156,7 +156,7 @@ stages:
   - name: Modify a policy in the system (without change policy definition)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -184,7 +184,7 @@ stages:
   - name: Modify a policy in the system (without change name)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -219,7 +219,7 @@ stages:
   - name: Modify a non-existent policy in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies/999"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies/999"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -250,7 +250,7 @@ stages:
   - name: Modify a policy in the system, bad policy definition
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -274,7 +274,7 @@ stages:
   - name: Revoke all tokens
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/user/revoke"
+      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -284,7 +284,7 @@ stages:
   - name: Revoke all tokens (Invalid token after previous call)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/user/revoke"
+      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -300,7 +300,7 @@ stages:
     delay_after: 10
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/user/authenticate"
+      url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -315,7 +315,7 @@ stages:
   - name: Update an existent user (empty body)
     request: &put_users_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/103"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/103"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -349,7 +349,7 @@ stages:
   - name: Update an non-existent user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/users/200"
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/200"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -399,7 +399,7 @@ stages:
   - name: Update security configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/config"
+      url: "{protocol:s}://{host:s}:{port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -416,7 +416,7 @@ stages:
   - name: Get security configuration to check if PUT method worked correctly
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/security/config"
+      url: "{protocol:s}://{host:s}:{port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscheck_endpoints.tavern.yaml
@@ -11,7 +11,7 @@ stages:
     request: &get_syscheck_agent
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/000"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/000"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -477,7 +477,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/000/last_scan"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/000/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -500,7 +500,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -519,7 +519,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -555,7 +555,7 @@ stages:
     request: &get_syscheck_agent_002
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/002"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -978,7 +978,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/002/last_scan"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1001,7 +1001,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck/001"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1023,7 +1023,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscheck"
+      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscollector_endpoints.tavern.yaml
@@ -10,7 +10,7 @@ stages:
     request: &os_request_000
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/000/os"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/000/os"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -99,7 +99,7 @@ stages:
   - name: Hardware of an agent
     request: &hardware_request_000
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/000/hardware"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/000/hardware"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -180,7 +180,7 @@ stages:
   - name: Packages of and agent
     request: &packages_request_000
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/000/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/000/packages"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -559,7 +559,7 @@ stages:
   - name: Processes of an agent with limit = 1
     request: &processes_request_000
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/000/processes"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/000/processes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1035,7 +1035,7 @@ stages:
     request: &port_request_000
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/000/ports"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/000/ports"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1283,7 +1283,7 @@ stages:
     request: &netaddr_request_000
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/000/netaddr"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/000/netaddr"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -1653,7 +1653,7 @@ stages:
     request: &netproto_request_000
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/000/netproto"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/000/netproto"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -1967,7 +1967,7 @@ stages:
     request: &netiface_request_000
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/000/netiface"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/000/netiface"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -2603,7 +2603,7 @@ stages:
     request: &os_request
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/os"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/os"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -2688,7 +2688,7 @@ stages:
   - name: Hardware of an agent
     request: &hardware_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/hardware"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/hardware"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -2766,7 +2766,7 @@ stages:
     request: &netaddr_request
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/netaddr"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netaddr"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -3116,7 +3116,7 @@ stages:
     request: &netproto_request
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/netproto"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netproto"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -3443,7 +3443,7 @@ stages:
     request: &netiface_request
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/002/netiface"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netiface"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -4063,7 +4063,7 @@ stages:
     request: &hotfix_request_000
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/{version:s}/syscollector/000/hotfixes"
+      url: "{protocol:s}://{host:s}:{port:d}/syscollector/000/hotfixes"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:


### PR DESCRIPTION
Related issue
#5629 

Hello team,

This PR closes #5629 . In this PR I have removed the "v4" version string from our API. Now, the endpoint urls will have the next format : {protocol}://{host}:{port}/{endpoint}

-I made changes on `changes.md, spec.yaml, common.yaml, wazuh-apid.py, conftest.py` and all the integration tests.
-I tested the API manually (it worked properly) and ran all the integration tests to ensure the changes didn't break anything (all passed).

In the issue related to this PR I commented that with aiohttp we couldn't remove the v4 string because I had the error:
`connexion.exceptions.ConnexionException: aiohttp doesn't allow to set empty base_path ('/'), use non-empty instead, e.g /api`
**Aiohttp** has a parameter which make base_path = '/' posible. This parameter is in the function `connexion.AioHttpApp` which is called in `wazuh-apid.py` (only_one_api=True).