### PR TITLE
Fixed the bug in some cases for inodes modifications

### DIFF
--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -19,7 +19,7 @@ typedef enum fim_event_mode {
 
 typedef enum fdb_stmt {
     FIMDB_STMT_INSERT_DATA,
-    FIMDB_STMT_INSERT_PATH,
+    FIMDB_STMT_REPLACE_PATH,
     FIMDB_STMT_GET_PATH,
     FIMDB_STMT_UPDATE_DATA,
     FIMDB_STMT_UPDATE_PATH,

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -503,7 +503,7 @@ int fim_registry_event(char *key, fim_entry_data *data, int pos) {
 
     if ((saved && data && saved->data && strcmp(saved->data->hash_sha1, data->hash_sha1) != 0)
         || alert_type == FIM_ADD) {
-        if (result = fim_db_insert(syscheck.database, key, data, saved->data, alert_type), result < 0) {
+        if (result = fim_db_insert(syscheck.database, key, data, saved ? saved->data : NULL, alert_type), result < 0) {
             free_entry(saved);
             w_mutex_unlock(&syscheck.fim_entry_mutex);
 
@@ -929,11 +929,11 @@ cJSON * fim_json_event(char * file_name, fim_entry_data * old_data, fim_entry_da
     cJSON_AddNumberToObject(data, "timestamp", new_data->last_event);
 
 #ifndef WIN32
-    if (new_data != NULL) {
-        char** paths = NULL;
+    char** paths = NULL;
 
-        if(paths = fim_db_get_paths_from_inode(syscheck.database, new_data->inode, new_data->dev), paths){
-            if(paths[0] && paths[1]){
+    if (new_data) {
+        if (paths = fim_db_get_paths_from_inode(syscheck.database, new_data->inode, new_data->dev), paths){
+            if (paths[0] && paths[1]) {
                 cJSON *hard_links = cJSON_CreateArray();
                 int i;
                 for(i = 0; paths[i]; i++) {
@@ -949,7 +949,6 @@ cJSON * fim_json_event(char * file_name, fim_entry_data * old_data, fim_entry_da
             os_free(paths);
         }
     }
-
 #endif
 
     cJSON_AddItemToObject(data, "attributes", fim_attributes_json(new_data));

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -355,7 +355,7 @@ int fim_file(char *file, fim_element *item, whodata_evt *w_evt, int report) {
     os_free(diff);
 
     if (json_event) {
-        if (result = fim_db_insert(syscheck.database, file, new, saved ? saved->data : NULL, alert_type), result < 0) {
+        if (result = fim_db_insert(syscheck.database, file, new, saved ? saved->data : NULL), result < 0) {
             free_entry_data(new);
             free_entry(saved);
             w_mutex_unlock(&syscheck.fim_entry_mutex);
@@ -503,7 +503,7 @@ int fim_registry_event(char *key, fim_entry_data *data, int pos) {
 
     if ((saved && data && saved->data && strcmp(saved->data->hash_sha1, data->hash_sha1) != 0)
         || alert_type == FIM_ADD) {
-        if (result = fim_db_insert(syscheck.database, key, data, saved ? saved->data : NULL, alert_type), result < 0) {
+        if (result = fim_db_insert(syscheck.database, key, data, saved ? saved->data : NULL), result < 0) {
             free_entry(saved);
             w_mutex_unlock(&syscheck.fim_entry_mutex);
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -355,7 +355,7 @@ int fim_file(char *file, fim_element *item, whodata_evt *w_evt, int report) {
     os_free(diff);
 
     if (json_event) {
-        if (result = fim_db_insert(syscheck.database, file, new, alert_type), result < 0) {
+        if (result = fim_db_insert(syscheck.database, file, new, saved ? saved->data : NULL, alert_type), result < 0) {
             free_entry_data(new);
             free_entry(saved);
             w_mutex_unlock(&syscheck.fim_entry_mutex);
@@ -503,7 +503,7 @@ int fim_registry_event(char *key, fim_entry_data *data, int pos) {
 
     if ((saved && data && saved->data && strcmp(saved->data->hash_sha1, data->hash_sha1) != 0)
         || alert_type == FIM_ADD) {
-        if (result = fim_db_insert(syscheck.database, key, data, alert_type), result < 0) {
+        if (result = fim_db_insert(syscheck.database, key, data, saved->data, alert_type), result < 0) {
             free_entry(saved);
             w_mutex_unlock(&syscheck.fim_entry_mutex);
 
@@ -929,10 +929,10 @@ cJSON * fim_json_event(char * file_name, fim_entry_data * old_data, fim_entry_da
     cJSON_AddNumberToObject(data, "timestamp", new_data->last_event);
 
 #ifndef WIN32
-    if (old_data != NULL) {
+    if (new_data != NULL) {
         char** paths = NULL;
 
-        if(paths = fim_db_get_paths_from_inode(syscheck.database, old_data->inode, old_data->dev), paths){
+        if(paths = fim_db_get_paths_from_inode(syscheck.database, new_data->inode, new_data->dev), paths){
             if(paths[0] && paths[1]){
                 cJSON *hard_links = cJSON_CreateArray();
                 int i;

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -856,7 +856,7 @@ int fim_db_insert_path(fdb_t *fim_sql, const char *file_path, fim_entry_data *en
     fim_db_bind_replace_path(fim_sql, file_path, inode_id, entry);
 
     if (res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_REPLACE_PATH]), res != SQLITE_DONE) {
-            merror("SQL ERROR: (%d)%s", res, sqlite3_errmsg(fim_sql->db));
+            merror("Step error replacing path '%s': %s", file_path, sqlite3_errmsg(fim_sql->db));
             return FIMDB_ERR;
     }
 
@@ -893,7 +893,7 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *new, fi
             fim_db_bind_delete_data_id(fim_sql, inode_id);
 
             if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_DATA]) != SQLITE_DONE) {
-                merror("Step error deleting data '%s' to insert in new row, the inode has changed: %s", file_path, sqlite3_errmsg(fim_sql->db));
+                merror("Step error deleting data: %s", sqlite3_errmsg(fim_sql->db));
                 return FIMDB_ERR;
             }
             fim_db_force_commit(fim_sql);

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -900,9 +900,6 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *new, fi
         }
     }
 
-    unsigned long inode;
-    int res_inode, res_inode_id;
-
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_DATA_ROW);
     fim_db_bind_get_inode(fim_sql, FIMDB_STMT_GET_DATA_ROW, new->inode, new->dev);
 #else

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -26,7 +26,7 @@ static const char *SQL_STMT[] = {
 #else
     [FIMDB_STMT_INSERT_DATA] = "INSERT INTO entry_data (dev, inode, size, perm, attributes, uid, gid, user_name, group_name, hash_md5, hash_sha1, hash_sha256, mtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
 #endif
-    [FIMDB_STMT_INSERT_PATH] = "INSERT INTO entry_path (path, inode_id, mode, last_event, entry_type, scanned, options, checksum) VALUES (?, ?, ?, ?, ?, ?, ?, ?);",
+    [FIMDB_STMT_REPLACE_PATH] = "INSERT OR REPLACE INTO entry_path (path, inode_id, mode, last_event, entry_type, scanned, options, checksum) VALUES (?, ?, ?, ?, ?, ?, ?, ?);",
     [FIMDB_STMT_GET_PATH] = "SELECT path, inode_id, mode, last_event, entry_type, scanned, options, checksum, dev, inode, size, perm, attributes, uid, gid, user_name, group_name, hash_md5, hash_sha1, hash_sha256, mtime FROM entry_path INNER JOIN entry_data ON path = ? AND entry_data.rowid = entry_path.inode_id;",
     [FIMDB_STMT_UPDATE_DATA] = "UPDATE entry_data SET size = ?, perm = ?, attributes = ?, uid = ?, gid = ?, user_name = ?, group_name = ?, hash_md5 = ?, hash_sha1 = ?, hash_sha256 = ?, mtime = ? WHERE rowid = ?;",
     [FIMDB_STMT_UPDATE_PATH] = "UPDATE entry_path SET inode_id = ?, mode = ?, last_event = ?, entry_type = ?, scanned = ?, options = ?, checksum = ? WHERE path = ?;",
@@ -116,7 +116,7 @@ void fim_db_bind_range(fdb_t *fim_sql, int index, const char *start, const char 
  * @param row_id Row id to be bound.
  * @param entry FIM entry data structure.
  */
-static void fim_db_bind_insert_path(fdb_t *fim_sql, const char *file_path,
+static void fim_db_bind_replace_path(fdb_t *fim_sql, const char *file_path,
                                     int row_id, fim_entry_data *entry);
 
 
@@ -154,19 +154,6 @@ static void fim_db_bind_get_inode(fdb_t *fim_sql, int index,
 static void fim_db_bind_update_data(fdb_t *fim_sql,
                                     fim_entry_data *entry,
                                     int *row_id);
-
-
-/**
- * @brief Binds data into an update entry path statement.
- *
- * @param fim_sql FIM database structure.
- * @param entry FIM entry data structure.
- * @param row_id Row id in entry_data table.
- */
-static void fim_db_bind_update_path(fdb_t *fim_sql,
-                                    const char * file_path,
-                                    fim_entry_data *entry,
-                                    int row_id);
 
 /**
  * @brief Binds data into a delete data id statement.
@@ -700,16 +687,16 @@ void fim_db_bind_insert_data(fdb_t *fim_sql, fim_entry_data *entry) {
 #endif
 }
 
-/* FIMDB_STMT_INSERT_PATH */
-void fim_db_bind_insert_path(fdb_t *fim_sql, const char *file_path, int row_id, fim_entry_data *entry) {
-    sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_INSERT_PATH], 1, file_path, -1, NULL);
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_INSERT_PATH], 2, row_id);
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_INSERT_PATH], 3, entry->mode);
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_INSERT_PATH], 4, entry->last_event);
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_INSERT_PATH], 5, entry->entry_type);
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_INSERT_PATH], 6, entry->scanned);
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_INSERT_PATH], 7, entry->options);
-    sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_INSERT_PATH], 8, entry->checksum, -1, NULL);
+/* FIMDB_STMT_REPLACE_PATH */
+void fim_db_bind_replace_path(fdb_t *fim_sql, const char *file_path, int row_id, fim_entry_data *entry) {
+    sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_REPLACE_PATH], 1, file_path, -1, NULL);
+    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_REPLACE_PATH], 2, row_id);
+    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_REPLACE_PATH], 3, entry->mode);
+    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_REPLACE_PATH], 4, entry->last_event);
+    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_REPLACE_PATH], 5, entry->entry_type);
+    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_REPLACE_PATH], 6, entry->scanned);
+    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_REPLACE_PATH], 7, entry->options);
+    sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_REPLACE_PATH], 8, entry->checksum, -1, NULL);
 }
 
 /* FIMDB_STMT_GET_PATH, FIMDB_STMT_GET_PATH_COUNT, FIMDB_STMT_DELETE_PATH, FIMDB_STMT_GET_DATA_ROW */
@@ -743,18 +730,6 @@ void fim_db_bind_update_data(fdb_t *fim_sql, fim_entry_data *entry, int *row_id)
     sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_UPDATE_DATA], 10, entry->hash_sha256, -1, NULL);
     sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_UPDATE_DATA], 11, entry->mtime);
     sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_UPDATE_DATA], 12, *row_id);
-}
-
-/* FIMDB_STMT_UPDATE_ENTRY_PATH */
-void fim_db_bind_update_path(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry, int row_id) {
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_UPDATE_PATH], 1, row_id);
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_UPDATE_PATH], 2, entry->mode);
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_UPDATE_PATH], 3, entry->last_event);
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_UPDATE_PATH], 4, entry->entry_type);
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_UPDATE_PATH], 5, entry->scanned);
-    sqlite3_bind_int(fim_sql->stmt[FIMDB_STMT_UPDATE_PATH], 6, entry->options);
-    sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_UPDATE_PATH], 7, entry->checksum, -1, NULL);
-    sqlite3_bind_text(fim_sql->stmt[FIMDB_STMT_UPDATE_PATH], 8, file_path, -1, NULL);
 }
 
 /* FIMDB_STMT_DELETE_DATA */
@@ -877,46 +852,24 @@ int fim_db_insert_data(fdb_t *fim_sql, fim_entry_data *entry, int *row_id) {
 int fim_db_insert_path(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry, int inode_id) {
     int res;
 
-    fim_db_clean_stmt(fim_sql, FIMDB_STMT_INSERT_PATH);
+    fim_db_clean_stmt(fim_sql, FIMDB_STMT_REPLACE_PATH);
+    fim_db_bind_replace_path(fim_sql, file_path, inode_id, entry);
 
-    // Insert in inode_path
-    fim_db_bind_insert_path(fim_sql, file_path, inode_id, entry);
-
-    res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_INSERT_PATH]);
-
-    switch (res) {
-    case SQLITE_DONE:
-        break;
-
-    case SQLITE_CONSTRAINT: // If path exist need update
-        fim_db_clean_stmt(fim_sql, FIMDB_STMT_UPDATE_PATH);
-        fim_db_bind_update_path(fim_sql, file_path, entry, inode_id);
-
-        if (res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_UPDATE_PATH]), res != SQLITE_DONE) {
-            merror("Step error updating path '%s': %s", file_path, sqlite3_errmsg(fim_sql->db));
+    if (res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_REPLACE_PATH]), res != SQLITE_DONE) {
+            merror("SQL ERROR: (%d)%s", res, sqlite3_errmsg(fim_sql->db));
             return FIMDB_ERR;
-        }
-        break;
-
-    default:
-        merror("Step error inserting path '%s': %s", file_path, sqlite3_errmsg(fim_sql->db));
-        return FIMDB_ERR;
     }
 
     return FIMDB_OK;
 }
 
-#ifndef WIN32
-int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *new, fim_entry_data *saved, int alert_type) {
-#else
-int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *new, __attribute__((unused)) fim_entry_data *saved, int alert_type) {
-#endif
+int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *new, fim_entry_data *saved) {
     int inode_id;
     int res, res_data, res_path;
     unsigned int nodes_count;
 
-    switch (alert_type) {
-    case FIM_ADD:
+    // Add event
+    if (!saved) {
         if (syscheck.file_limit_enabled) {
             nodes_count = fim_db_get_count_entry_path(syscheck.database);
             if (nodes_count >= syscheck.file_limit) {
@@ -924,58 +877,52 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *new, __
                 return FIMDB_FULL;
             }
         }
-        inode_id = 0;
+    }
+    // Modified event
+#ifndef WIN32
+    else if (new->inode != saved->inode) {
+        fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_PATH_COUNT);
+        fim_db_bind_path(fim_sql, FIMDB_STMT_GET_PATH_COUNT, file_path);
+
+        sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_PATH_COUNT]);
+
+        res = sqlite3_column_int(fim_sql->stmt[FIMDB_STMT_GET_PATH_COUNT], 0);
+        if (res == 1) {
+            // The inode has only one entry, delete the entry data.
+            fim_db_clean_stmt(fim_sql, FIMDB_STMT_DELETE_DATA);
+            fim_db_bind_delete_data_id(fim_sql, inode_id);
+
+            if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_DATA]) != SQLITE_DONE) {
+                merror("Step error deleting data '%s' to insert in new row, the inode has changed: %s", file_path, sqlite3_errmsg(fim_sql->db));
+                return FIMDB_ERR;
+            }
+            fim_db_force_commit(fim_sql);
+        }
+    }
+
+    unsigned long inode;
+    int res_inode, res_inode_id;
+
+    fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_DATA_ROW);
+    fim_db_bind_get_inode(fim_sql, FIMDB_STMT_GET_DATA_ROW, new->inode, new->dev);
+#else
+    fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_DATA_ROW);
+    fim_db_bind_path(fim_sql, FIMDB_STMT_GET_DATA_ROW, file_path);
+#endif
+
+    res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_DATA_ROW]);
+
+    switch(res) {
+    case SQLITE_ROW:
+        inode_id = sqlite3_column_int(fim_sql->stmt[FIMDB_STMT_GET_DATA_ROW], 0);
     break;
 
-    case FIM_MODIFICATION:
-#ifndef WIN32
-        fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_DATA_ROW);
-        fim_db_bind_get_inode(fim_sql, FIMDB_STMT_GET_DATA_ROW, saved->inode, saved->dev);
-        if (res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_DATA_ROW]), res == SQLITE_ROW){
-            if (new->inode != saved->inode) {
-                fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_PATH_COUNT);
-                fim_db_clean_stmt(fim_sql, FIMDB_STMT_DELETE_DATA);
-                fim_db_bind_path(fim_sql, FIMDB_STMT_GET_PATH_COUNT, file_path);
-                sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_PATH_COUNT]);
-
-                res = sqlite3_column_int(fim_sql->stmt[FIMDB_STMT_GET_PATH_COUNT], 0);
-                inode_id = sqlite3_column_int(fim_sql->stmt[FIMDB_STMT_GET_PATH_COUNT], 1);
-
-                if (res == 1) {
-                    // The inode has only one entry, delete the entry data.
-                    fim_db_bind_delete_data_id(fim_sql, inode_id);
-                    if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_DATA]) != SQLITE_DONE) {
-                        merror("Step error deleting data '%s' to insert in new row, the inode has changed: %s", file_path, sqlite3_errmsg(fim_sql->db));
-                        return FIMDB_ERR;
-                    }
-                    fim_db_force_commit(fim_sql);
-                }
-            }
-        } else if (res != SQLITE_DONE) {
-            merror("SQL ERROR: (%d)%s", res, sqlite3_errmsg(fim_sql->db));
-            return FIMDB_ERR;
-        }
-#endif
+    case SQLITE_DONE:
+        inode_id = 0;
     break;
 
     default:
-        merror("Couldn't insert '%s' entry into DB. Invalid event type: %d.", file_path, alert_type);
-        return FIMDB_ERR;
-    }
-
-#ifdef WIN32
-    fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_DATA_ROW);
-    fim_db_bind_path(fim_sql, FIMDB_STMT_GET_DATA_ROW, file_path);
-#else
-    fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_DATA_ROW);
-    fim_db_bind_get_inode(fim_sql, FIMDB_STMT_GET_DATA_ROW, new->inode, new->dev);
-#endif
-    if (res = sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_DATA_ROW]), res == SQLITE_ROW){
-        inode_id = sqlite3_column_int(fim_sql->stmt[FIMDB_STMT_GET_DATA_ROW], 0);
-    } else if (res == SQLITE_DONE) {
-        inode_id = 0;
-    } else {
-        merror("SQL ERROR: (%d)%s", res, sqlite3_errmsg(fim_sql->db));
+        merror("Step error getting data row: %s", sqlite3_errmsg(fim_sql->db));
         return FIMDB_ERR;
     }
 
@@ -984,7 +931,7 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *new, __
 
     fim_db_check_transaction(fim_sql);
 
-    return res_data && res_path;
+    return res_data || res_path;
 }
 
 void fim_db_callback_calculate_checksum(__attribute__((unused)) fdb_t *fim_sql, fim_entry *entry,

--- a/src/syscheckd/fim_db.h
+++ b/src/syscheckd/fim_db.h
@@ -172,7 +172,7 @@ int fim_db_insert_path(fdb_t *fim_sql, const char *file_path, fim_entry_data *en
  * @param alert_type Type of alert: FIM_ADD or FIM_MODIFICATION.
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry, int alert_type);
+int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry, fim_entry_data *saved, int alert_type);
 
 /**
  * @brief Send sync message for all entries.

--- a/src/syscheckd/fim_db.h
+++ b/src/syscheckd/fim_db.h
@@ -168,11 +168,11 @@ int fim_db_insert_path(fdb_t *fim_sql, const char *file_path, fim_entry_data *en
  *
  * @param fim_sql FIM database struct.
  * @param file_path File path.
- * @param entry Entry data to be inserted.
- * @param alert_type Type of alert: FIM_ADD or FIM_MODIFICATION.
+ * @param entry Entry with new data to be inserted.
+ * @param saved Entry with saved data to be inserted.
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry, fim_entry_data *saved, int alert_type);
+int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry, fim_entry_data *saved);
 
 /**
  * @brief Send sync message for all entries.

--- a/src/syscheckd/fim_db.h
+++ b/src/syscheckd/fim_db.h
@@ -168,11 +168,11 @@ int fim_db_insert_path(fdb_t *fim_sql, const char *file_path, fim_entry_data *en
  *
  * @param fim_sql FIM database struct.
  * @param file_path File path.
- * @param entry Entry with new data to be inserted.
- * @param saved Entry with saved data to be inserted.
+ * @param new Entry data to be inserted.
+ * @param saved Entry with existing data.
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry, fim_entry_data *saved);
+int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *new, fim_entry_data *saved);
 
 /**
  * @brief Send sync message for all entries.

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -190,7 +190,7 @@ int __wrap_delete_target_file(const char *path) {
     return mock();
 }
 
-int __wrap_fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry) {
+int __wrap_fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry, fim_entry_data *saved, int alert_type) {
     check_expected_ptr(fim_sql);
     check_expected(file_path);
 
@@ -582,7 +582,7 @@ static void test_fim_json_event(void **state) {
 
     #ifndef TEST_WINAGENT
     expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606060);
+    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606061);
     expect_value(__wrap_fim_db_get_paths_from_inode, dev, 12345678);
     will_return(__wrap_fim_db_get_paths_from_inode, NULL);
     #endif
@@ -645,7 +645,7 @@ static void test_fim_json_event_whodata(void **state) {
 
     #ifndef TEST_WINAGENT
     expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606060);
+    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606061);
     expect_value(__wrap_fim_db_get_paths_from_inode, dev, 12345678);
     will_return(__wrap_fim_db_get_paths_from_inode, NULL);
     #endif
@@ -724,7 +724,7 @@ static void test_fim_json_event_hardlink_one_path(void **state) {
 
     #ifndef TEST_WINAGENT
     expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606060);
+    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606061);
     expect_value(__wrap_fim_db_get_paths_from_inode, dev, 12345678);
     will_return(__wrap_fim_db_get_paths_from_inode, paths);
     #endif
@@ -789,7 +789,7 @@ static void test_fim_json_event_hardlink_two_paths(void **state) {
 
     #ifndef TEST_WINAGENT
     expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606060);
+    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606061);
     expect_value(__wrap_fim_db_get_paths_from_inode, dev, 12345678);
     will_return(__wrap_fim_db_get_paths_from_inode, paths);
     #endif
@@ -1435,6 +1435,13 @@ static void test_fim_file_add(void **state) {
     expect_string(__wrap_fim_db_get_path, file_path, "file");
     will_return(__wrap_fim_db_get_path, NULL);
 
+    #ifndef TEST_WINAGENT
+    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
+    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 1234);
+    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 2345);
+    will_return(__wrap_fim_db_get_paths_from_inode, NULL);
+    #endif
+
     expect_string(__wrap_seechanges_addfile, filename, "file");
     will_return(__wrap_seechanges_addfile, strdup("diff"));
 
@@ -1525,8 +1532,8 @@ static void test_fim_file_modify(void **state) {
 
     #ifndef TEST_WINAGENT
     expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606060);
-    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 12345678);
+    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 1234);
+    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 2345);
     will_return(__wrap_fim_db_get_paths_from_inode, NULL);
     #endif
 
@@ -1654,8 +1661,8 @@ static void test_fim_file_error_on_insert(void **state) {
 
     #ifndef TEST_WINAGENT
     expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606060);
-    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 12345678);
+    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 1234);
+    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 2345);
     will_return(__wrap_fim_db_get_paths_from_inode, NULL);
     #endif
 
@@ -1850,6 +1857,13 @@ static void test_fim_checker_fim_regular(void **state) {
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
 
+    #ifndef TEST_WINAGENT
+    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
+    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 999);
+    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 1);
+    will_return(__wrap_fim_db_get_paths_from_inode, NULL);
+    #endif
+
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, "/media/test.file");
     will_return(__wrap_fim_db_get_path, NULL);
@@ -1888,6 +1902,13 @@ static void test_fim_checker_fim_regular_warning(void **state) {
 
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
+
+    #ifndef TEST_WINAGENT
+    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
+    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 999);
+    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 1);
+    will_return(__wrap_fim_db_get_paths_from_inode, NULL);
+    #endif
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, "/media/test.file");
@@ -2050,6 +2071,13 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
 
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
+
+    #ifndef TEST_WINAGENT
+    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
+    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 999);
+    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 1);
+    will_return(__wrap_fim_db_get_paths_from_inode, NULL);
+    #endif
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, "/test.file");

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -190,7 +190,7 @@ int __wrap_delete_target_file(const char *path) {
     return mock();
 }
 
-int __wrap_fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry, fim_entry_data *saved, int alert_type) {
+int __wrap_fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *entry, fim_entry_data *saved) {
     check_expected_ptr(fim_sql);
     check_expected(file_path);
 

--- a/src/unit_tests/syscheckd/test_fim_db.c
+++ b/src/unit_tests/syscheckd/test_fim_db.c
@@ -544,6 +544,8 @@ static int test_fim_db_setup(void **state) {
     test_data->fim_sql = calloc(1, sizeof(fdb_t));
     test_data->entry = calloc(1, sizeof(fim_entry));
     test_data->entry->data = calloc(1, sizeof(fim_entry_data));
+    test_data->entry->data->inode = 200;
+    test_data->entry->data->dev = 100;
     test_data->entry->path =  strdup("/test/path");
     test_data->fim_sql->transaction.last_commit = 1; //Set a time diferent than 0
     test_data->saved = calloc(1, sizeof(fim_entry_data));
@@ -1040,50 +1042,22 @@ void test_fim_db_insert_path_error(void **state) {
     test_fim_db_insert_data *test_data = *state;
     will_return(__wrap_sqlite3_reset, SQLITE_OK);
     will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_bind_int, 0);
-    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return_count(__wrap_sqlite3_bind_int, 0, 6);
+    will_return_count(__wrap_sqlite3_bind_text, 0, 2);
     will_return(__wrap_sqlite3_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "Step error inserting path '/test/path': ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "Step error replacing path '/test/path': ERROR MESSAGE");
     int ret;
     ret = fim_db_insert_path(test_data->fim_sql, test_data->entry->path, test_data->entry->data, 1);
     assert_int_equal(ret, FIMDB_ERR);
-}
-
-void test_fim_db_insert_path_constraint_error(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_bind_int, 0);
-    will_return_always(__wrap_sqlite3_bind_text, 0);
-    will_return(__wrap_sqlite3_step, SQLITE_CONSTRAINT);
-    will_return(__wrap_sqlite3_step, SQLITE_ERROR);
-    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "Step error updating path '/test/path': ERROR MESSAGE");
-    int ret;
-    ret = fim_db_insert_path(test_data->fim_sql, test_data->entry->path, test_data->entry->data, 1);
-    assert_int_equal(ret, FIMDB_ERR);
-}
-
-void test_fim_db_insert_path_constraint_success(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_bind_int, 0);
-    will_return_always(__wrap_sqlite3_bind_text, 0);
-    will_return(__wrap_sqlite3_step, SQLITE_CONSTRAINT);
-    will_return(__wrap_sqlite3_step, SQLITE_DONE);
-    int ret;
-    ret = fim_db_insert_path(test_data->fim_sql, test_data->entry->path, test_data->entry->data, 1);
-    assert_int_equal(ret, FIMDB_OK);
 }
 
 void test_fim_db_insert_path_success(void **state) {
     test_fim_db_insert_data *test_data = *state;
-    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_bind_int, 0);
-    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return(__wrap_sqlite3_reset, SQLITE_OK);
+    will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    will_return_count(__wrap_sqlite3_bind_int, 0, 6);
+    will_return_count(__wrap_sqlite3_bind_text, 0, 2);
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
     int ret;
     ret = fim_db_insert_path(test_data->fim_sql, test_data->entry->path, test_data->entry->data, 1);
@@ -1092,87 +1066,84 @@ void test_fim_db_insert_path_success(void **state) {
 
 /*-----------------------------------------*/
 /*----------fim_db_insert()----------------*/
-void test_fim_db_insert_error(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-    int ret;
-
-    // Inside fim_clean_stmt
-    {
-        will_return(__wrap_sqlite3_reset, SQLITE_OK);
-        will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    }
-
-    #ifdef TEST_WINAGENT
-    will_return(__wrap_sqlite3_bind_text, 0);
-    #else
-    // Inside fim_db_bind_get_inode
-    {
-        will_return(__wrap_sqlite3_bind_int64, 0);
-        will_return(__wrap_sqlite3_bind_int, 0);
-    }
-    #endif
-
-    will_return(__wrap_sqlite3_step, SQLITE_ERROR);
-    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "Step error getting data row: ERROR MESSAGE");
-
-    ret = fim_db_insert(test_data->fim_sql, test_data->entry->path, test_data->entry->data, test_data->entry->data, FIM_MODIFICATION);
-    assert_int_equal(ret, FIMDB_ERR);
-}
-
-void test_fim_db_insert_invalid_type(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-    int ret;
-
-    expect_string(__wrap__merror, formatted_msg, "Couldn't insert '/test/path' entry into DB. Invalid event type: 1.");
-
-    ret = fim_db_insert(test_data->fim_sql, test_data->entry->path, test_data->entry->data, test_data->entry->data, FIM_DELETE);
-
-    assert_int_equal(ret, FIMDB_ERR);
-}
 
 void test_fim_db_insert_db_full(void **state) {
     test_fim_db_insert_data *test_data = *state;
     int ret;
 
-    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    // Inside fim_db_get_count_entry_path
+    {
+        // Inside fim_db_clean_stmt
+        {
+            will_return(__wrap_sqlite3_reset, SQLITE_OK);
+            will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+        }
+        will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    will_return(__wrap_sqlite3_step, SQLITE_ROW);
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 50000);
+        expect_value(__wrap_sqlite3_column_int, iCol, 0);
+        will_return(__wrap_sqlite3_column_int, 50000);
+    }
 
     expect_string(__wrap__mdebug1, formatted_msg, "Couldn't insert '/test/path' entry into DB. The DB is full, please check your configuration.");
 
     syscheck.database = test_data->fim_sql;
-
-    ret = fim_db_insert(test_data->fim_sql, test_data->entry->path, test_data->entry->data, test_data->entry->data, FIM_ADD);
-
+    ret = fim_db_insert(test_data->fim_sql, test_data->entry->path, test_data->entry->data, NULL);
     syscheck.database = NULL;
-
     assert_int_equal(ret, FIMDB_FULL);
 }
 
 #ifndef TEST_WINAGENT
 void test_fim_db_insert_inode_id_nonull(void **state) {
     test_fim_db_insert_data *test_data = *state;
+    int ret;
 
-    will_return_count(__wrap_sqlite3_reset, SQLITE_OK, 4);
-    will_return_count(__wrap_sqlite3_clear_bindings, SQLITE_OK, 4);
-    will_return_count(__wrap_sqlite3_bind_int64, 0, 2);
-    will_return_count(__wrap_sqlite3_bind_int, 0, 3);
-    will_return(__wrap_sqlite3_bind_text, 0);
+    // Inside fim_db_clean_stmt
+    {
+        will_return(__wrap_sqlite3_reset, SQLITE_OK);
+        will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    }
 
-    will_return_count(__wrap_sqlite3_step, SQLITE_ROW, 2);
+    // Inside fim_db_bind_path
+    {
+        will_return(__wrap_sqlite3_bind_text, 0);
+    }
+
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
-    will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
     expect_value(__wrap_sqlite3_column_int, iCol, 0);
     will_return(__wrap_sqlite3_column_int, 1);
-    expect_value(__wrap_sqlite3_column_int, iCol, 1);
-    will_return(__wrap_sqlite3_column_int, 1);
 
-    wraps_fim_db_check_transaction();
+    // Inside fim_db_clean_stmt
+    {
+        will_return(__wrap_sqlite3_reset, SQLITE_OK);
+        will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    }
+
+    // Inside fim_db_bind_delete_data_id
+    {
+        will_return(__wrap_sqlite3_bind_int, 0);
+    }
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    // Inside fim_db_force_commit
+    {
+        wraps_fim_db_check_transaction();
+    }
+
+    // Inside fim_db_clean_stmt
+    {
+        will_return(__wrap_sqlite3_reset, SQLITE_OK);
+        will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    }
+
+    // Inside fim_db_bind_get_inode
+    {
+        will_return(__wrap_sqlite3_bind_int, 0);
+        will_return(__wrap_sqlite3_bind_int64, 0);
+    }
+
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
     expect_value(__wrap_sqlite3_column_int, iCol, 0);
     will_return(__wrap_sqlite3_column_int, 1);
@@ -1184,20 +1155,61 @@ void test_fim_db_insert_inode_id_nonull(void **state) {
 
     wraps_fim_db_check_transaction();
 
-    int ret;
-    ret = fim_db_insert(test_data->fim_sql, test_data->entry->path, test_data->entry->data, test_data->saved, FIM_MODIFICATION);
-    assert_int_equal(ret, 0);   // Success
+    ret = fim_db_insert(test_data->fim_sql, test_data->entry->path, test_data->entry->data, test_data->saved);
+    assert_int_equal(ret, FIMDB_OK);   // Success
 }
 
 void test_fim_db_insert_inode_id_null(void **state) {
     test_fim_db_insert_data *test_data = *state;
+    int ret;
 
-    will_return_count(__wrap_sqlite3_reset, SQLITE_OK, 2);
-    will_return_count(__wrap_sqlite3_clear_bindings, SQLITE_OK, 2);
-    will_return_count(__wrap_sqlite3_bind_int64, 0, 2);
-    will_return_count(__wrap_sqlite3_bind_int, 0, 2);
+    // Inside fim_db_clean_stmt
+    {
+        will_return(__wrap_sqlite3_reset, SQLITE_OK);
+        will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    }
 
-    will_return_count(__wrap_sqlite3_step, SQLITE_DONE, 2);
+    // Inside fim_db_bind_path
+    {
+        will_return(__wrap_sqlite3_bind_text, 0);
+    }
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    expect_value(__wrap_sqlite3_column_int, iCol, 0);
+    will_return(__wrap_sqlite3_column_int, 1);
+
+    // Inside fim_db_clean_stmt
+    {
+        will_return(__wrap_sqlite3_reset, SQLITE_OK);
+        will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    }
+
+    // Inside fim_db_bind_delete_data_id
+    {
+        will_return(__wrap_sqlite3_bind_int, 0);
+    }
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    // Inside fim_db_force_commit
+    {
+        wraps_fim_db_check_transaction();
+    }
+
+    // Inside fim_db_clean_stmt
+    {
+        will_return(__wrap_sqlite3_reset, SQLITE_OK);
+        will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    }
+
+    // Inside fim_db_bind_get_inode
+    {
+        will_return(__wrap_sqlite3_bind_int, 0);
+        will_return(__wrap_sqlite3_bind_int64, 0);
+    }
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
 
     // Wrap functions for fim_db_insert_data() & fim_db_insert_path()
     int inode_id = 0;
@@ -1206,32 +1218,33 @@ void test_fim_db_insert_inode_id_null(void **state) {
 
     wraps_fim_db_check_transaction();
 
-    int ret;
-    ret = fim_db_insert(test_data->fim_sql, test_data->entry->path, test_data->entry->data, test_data->entry->data, FIM_MODIFICATION);
-    assert_int_equal(ret, 0);   // Success
+    ret = fim_db_insert(test_data->fim_sql, test_data->entry->path, test_data->entry->data, test_data->saved);
+    assert_int_equal(ret, FIMDB_OK);   // Success
 }
 
 void test_fim_db_insert_inode_id_null_error(void **state) {
     test_fim_db_insert_data *test_data = *state;
+    int ret;
+    test_data->entry->data->inode = 100;
 
-    will_return_count(__wrap_sqlite3_reset, SQLITE_OK, 3);
-    will_return_count(__wrap_sqlite3_clear_bindings, SQLITE_OK, 3);
-    will_return(__wrap_sqlite3_bind_int64, 0);
-    will_return_count(__wrap_sqlite3_bind_int, 0, 2);
-    will_return(__wrap_sqlite3_bind_text, 0);
+    // Inside fim_db_clean_stmt
+    {
+        will_return(__wrap_sqlite3_reset, SQLITE_OK);
+        will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+    }
 
-    will_return_count(__wrap_sqlite3_step, SQLITE_ROW, 3);
+    // Inside fim_db_bind_get_inode
+    {
+        will_return(__wrap_sqlite3_bind_int, 0);
+        will_return(__wrap_sqlite3_bind_int64, 0);
+    }
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 1);
-    expect_value(__wrap_sqlite3_column_int, iCol, 1);
-    will_return(__wrap_sqlite3_column_int, 1);
+    will_return(__wrap_sqlite3_step, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "Step error deleting data '/test/path' to insert in new row, the inode has changed: ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "Step error getting data row: ERROR MESSAGE");
 
-    int ret;
-    ret = fim_db_insert(test_data->fim_sql, test_data->entry->path, test_data->entry->data, test_data->saved, FIM_MODIFICATION);
+    ret = fim_db_insert(test_data->fim_sql, test_data->entry->path, test_data->entry->data, test_data->saved);
     assert_int_equal(ret, FIMDB_ERR);
 }
 
@@ -2727,12 +2740,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_fim_db_insert_data_rowid_success, test_fim_db_setup, test_fim_db_teardown),
         // fim_db_insert_path
         cmocka_unit_test_setup_teardown(test_fim_db_insert_path_error, test_fim_db_setup, test_fim_db_teardown),
-        cmocka_unit_test_setup_teardown(test_fim_db_insert_path_constraint_error, test_fim_db_setup, test_fim_db_teardown),
-        cmocka_unit_test_setup_teardown(test_fim_db_insert_path_constraint_success, test_fim_db_setup, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_insert_path_success, test_fim_db_setup, test_fim_db_teardown),
         // fim_db_insert
-        cmocka_unit_test_setup_teardown(test_fim_db_insert_error, test_fim_db_setup, test_fim_db_teardown),
-        cmocka_unit_test_setup_teardown(test_fim_db_insert_invalid_type, test_fim_db_setup, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_insert_db_full, test_fim_db_setup, test_fim_db_teardown),
         #ifndef TEST_WINAGENT
         cmocka_unit_test_setup_teardown(test_fim_db_insert_inode_id_nonull, test_fim_db_setup, test_fim_db_teardown),


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5584|

## Description

Changes in fim_db_insert to fix a bug in inodes modification, now all possible cases are correctly analyzed.
Also the unit tests of this same function have been changed, and some others that were affected


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
