### PR TITLE
Vulnerability-Detector: Deprecate Debian Jessie

### DIFF
--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -16,7 +16,6 @@
     <provider name="debian">
       <enabled>no</enabled>
       <os>stretch</os>
-      <os>jessie</os>
       <os>buster</os>
       <update_interval>1h</update_interval>
     </provider>

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -184,11 +184,10 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
             os_strdup(vu_feed_tag[FEED_STRETCH], upd->version);
             upd->dist_tag_ref = FEED_STRETCH;
             upd->dist_ext = vu_feed_ext[FEED_STRETCH];
-        } else if (!strcmp(version, "8") || strcasestr(version, vu_feed_tag[FEED_JESSIE])) {
-            os_index = CVE_JESSIE;
-            os_strdup(vu_feed_tag[FEED_JESSIE], upd->version);
-            upd->dist_tag_ref = FEED_JESSIE;
-            upd->dist_ext = vu_feed_ext[FEED_JESSIE];
+        } else if (!strcmp(version, "8") || strcasestr(version, "JESSIE")) {
+            mwarn("Debian Jessie is no longer supported.");
+            retval = OS_DEPRECATED;
+            goto end;
         } else if (!strcmp(version, "7") || strcasestr(version, "WHEEZY")) {
             mwarn("Debian Wheezy is no longer supported.");
             retval = OS_DEPRECATED;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -290,7 +290,6 @@ const char *vu_feed_tag[] = {
     "BIONIC",
     "FOCAL",
     // Debian versions
-    "JESSIE",
     "STRETCH",
     "BUSTER",
     // RedHat versions
@@ -336,7 +335,6 @@ const char *vu_feed_ext[] = {
     "Ubuntu Bionic",
     "Ubuntu Focal",
     // Debian versions
-    "Debian Jessie",
     "Debian Stretch",
     "Debian Buster",
     // RedHat versions
@@ -4493,9 +4491,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
             }
             agent_dist = FEED_UBUNTU;
         } else if (strcasestr(os_name, vu_feed_ext[FEED_DEBIAN])) {
-            if (strstr(os_version, "8")) {
-                agent_dist_ver = FEED_JESSIE;
-            } else if (strstr(os_version, "9")) {
+            if (strstr(os_version, "9")) {
                 agent_dist_ver = FEED_STRETCH;
             } else if (strstr(os_version, "10")) {
                 agent_dist_ver = FEED_BUSTER;
@@ -5059,7 +5055,6 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
             product_name = PR_UBUNTU;
             vendor = V_UBUNTU;
         break;
-        case FEED_JESSIE:
         case FEED_STRETCH:
         case FEED_BUSTER:
             product_name = PR_DEBIAN;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -218,7 +218,6 @@ typedef enum vu_feed {
     FEED_BIONIC,
     FEED_FOCAL,
     // Debian versions
-    FEED_JESSIE,
     FEED_STRETCH,
     FEED_BUSTER,
     // RedHat versions
@@ -353,7 +352,6 @@ typedef enum cve_db {
     CVE_XENIAL,
     CVE_BIONIC,
     CVE_FOCAL,
-    CVE_JESSIE,
     CVE_STRETCH,
     CVE_BUSTER,
     CVE_REDHAT5,


### PR DESCRIPTION
|Related issue|
|---|
|#5659|

## Description

This PR removes any references to Debian Jessie, and shows a `warning` message when an agent is detected.

## Logs/Alerts example

`wmodules-vuln-detector.c:188 at wm_vuldet_set_feed_version(): WARNING: Debian Jessie is no longer supported.`

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation

