### PR TITLE
[API] Improve migration process when updating from from sources

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -2,7 +2,7 @@
 # Copyright (C) 2015-2020, Wazuh Inc.
 # May 3, 2017
 #
-# Syntax: make [ all | install]
+# Syntax: make [ all | backup | install | restore | service ]
 
 OSSEC_GROUP       = ossec
 PREFIX            = /var/ossec
@@ -16,14 +16,15 @@ INSTALL_CONFIG_FILE   = install -o root -g ${OSSEC_GROUP} -m 0660
 PYTHON_BIN     = $(PREFIX)/framework/python/bin/python3
 
 
-.PHONY: all install service
+.PHONY: all backup install restore service
 
-all: install service
+all: backup install restore service
+
+backup:
+	# Backup previous configuration
+	. ../api/service/inst-api-functions.sh; backup_old_api ${REVISION}
 
 install:
-    # Backup previous configuration
-	. ../api/service/inst-api-functions.sh; backup_old_api
-
     # Copy files and create folders
 	$(INSTALL_DIR) $(PREFIX)/api
 	$(INSTALL_RW_DIR) $(PREFIX)/api/configuration
@@ -43,9 +44,10 @@ install:
     # Install scripts/%.py on $(PREFIX)/bin/%
 	$(foreach script,$(wildcard scripts/*),$(INSTALL_EXEC) wrappers/generic_wrapper.sh $(patsubst scripts/%.py,$(PREFIX)/bin/%,$(script));)
 
-    # Restore old API config
-	. ../api/service/inst-api-functions.sh; restore_old_api
+restore:
+	# Restore old API config
+	. ../api/service/inst-api-functions.sh; restore_old_api ${REVISION}
 
-    # Install daemon
 service:
+    # Install daemon
 	WAZUH_PATH=$(PREFIX) $(PREFIX)/api/service/install_daemon.sh

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -102,6 +102,8 @@ def fill_dict(default: Dict, config: Dict) -> Dict:
             raise APIError(2000, details=', '.join(config.keys() - default.keys()))
 
     for k, val in filter(lambda x: isinstance(x[1], dict), config.items()):
+        for item, value in config[k].items():
+            config[k][item] = default[k][item] if value is "" else config[k][item]
         config[k] = {**default[k], **config[k]}
 
     return {**default, **config}

--- a/api/service/inst-api-functions.sh
+++ b/api/service/inst-api-functions.sh
@@ -9,50 +9,123 @@
 # Foundation.
 
 
+API_PATH=${PREFIX}/api
+API_PATH_BACKUP=${PREFIX}/~api
 
 
 backup_old_api() {
 
-    API_PATH=${PREFIX}/api
-    API_PATH_BACKUP=${PREFIX}/~api
-
-    # do backup only if config.js file exists
-    if [ -f ${API_PATH}/configuration/config.js ]; then
-
-        if [ -e ${API_PATH_BACKUP} ]; then
-            rm -rf ${API_PATH_BACKUP}
-        else
-            ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${API_PATH_BACKUP}
-            chown root:ossec ${API_PATH_BACKUP}
-        fi
-
-        ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${API_PATH_BACKUP}/configuration
-        cp -rLfp ${API_PATH}/configuration/config.js ${API_PATH_BACKUP}/configuration/config.js
-
-        if [ -d ${API_PATH}/configuration/ssl ]; then
-            ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${API_PATH_BACKUP}/configuration/ssl
-            cp -rLfp ${API_PATH}/configuration/ssl/* ${API_PATH_BACKUP}/configuration/ssl
-        fi
-
-        # remove old API directory
-        rm -rf ${API_PATH}
-
+    if [ $# -ne 1 ]; then
+        echo "Backup_old_api requires the REVISION of the existing API"
+        exit 1
     fi
 
+    # remove backup folder and its contents if exists
+    if [ -e "${API_PATH_BACKUP}" ]; then
+        rm -rf "${API_PATH_BACKUP}"
+    fi
+
+    # check current REVISION and perform the applicable backup
+    if [ "$1" -ge 40000 ]; then
+        backup_old_api_4x
+    else
+        # stop api process if its still running
+        OLD_API_PID=$(pgrep -f "${API_PATH}/app.js")
+        if [ -n "$OLD_API_PID" ]; then
+            echo "killing old api process: ${OLD_API_PID}"
+            kill -9 "${OLD_API_PID}"
+        fi
+    fi
+
+    # remove old API directory
+    rm -rf "${API_PATH}"
 }
+
+
+backup_old_api_4x() {
+
+    # backup files only if configuration folder exists and its not empty
+    if [ -d "${API_PATH}"/configuration ]; then
+        if [ -n "$(ls -A "${API_PATH}"/configuration)" ]; then
+
+            install -o root -g ossec -m 0770 -d "${API_PATH_BACKUP}"/configuration
+
+            # backup API yaml if exists
+            if [ -e "${API_PATH}"/configuration/api.yaml ]; then
+                cp -rLfp "${API_PATH}"/configuration/api.yaml "${API_PATH_BACKUP}"/configuration/
+            fi
+
+            # backup security files if the folder exists and its not empty
+            if [ -d "${API_PATH}"/configuration/security ]; then
+                if [ -n "$(ls -A "${API_PATH}"/configuration/security)" ]; then
+                    install -o root -g ossec -m 0770 -d "${API_PATH_BACKUP}"/configuration/security
+                    cp -rLfp "${API_PATH}"/configuration/security/* "${API_PATH_BACKUP}"/configuration/security
+                fi
+            fi
+
+            # backup ssl files if the folder exists and its not empty
+            if [ -d "${API_PATH}"/configuration/ssl ]; then
+                if [ -n "$(ls -A "${API_PATH}"/configuration/ssl)" ]; then
+                    install -o root -g ossec -m 0770 -d "${API_PATH_BACKUP}"/configuration/ssl
+                    cp -rLfp "${API_PATH}"/configuration/ssl/* "${API_PATH_BACKUP}"/configuration/ssl
+                fi
+            fi
+        fi
+    fi
+}
+
 
 restore_old_api() {
 
-    API_PATH=${PREFIX}/api
-    API_PATH_BACKUP=${PREFIX}/~api
+    if [ $# -ne 1 ]; then
+        echo "restore_old_api requires the REVISION of the existing API"
+        exit 1
+    fi
 
-    if [ -r ${API_PATH_BACKUP}/configuration/config.js ]; then
-        # execute migration.py
-        ${PREFIX}/framework/python/bin/python3 ../api/migration.py
-        if [ ! -d ${API_PATH}/configuration/ssl ]; then
-            ${INSTALL} -d -m 0770 -o root -g ${OSSEC_GROUP} ${API_PATH}/configuration/ssl
+    # check current REVISION and perform the applicable restore
+    if [ "$1" -ge 40000 ]; then
+        restore_old_api_4x
+    fi
+
+    # remove the old api backup
+    rm -rf "${API_PATH_BACKUP}"
+}
+
+
+
+restore_old_api_4x() {
+
+    # create configuration folder if it does not exists in the new api
+    if [ ! -d "${API_PATH}"/configuration ]; then
+        install -o root -g ossec -m 0770 -d "${API_PATH}"/configuration
+    fi
+
+    # create security folder if it does not exists in the new api
+    if [ ! -d "${API_PATH}"/configuration/security ]; then
+        install -o root -g ossec -m 0770 -d "${API_PATH}"/configuration/security
+    fi
+
+    # create ssl folder if it does not exists in the new api
+    if [ ! -d "${API_PATH}"/configuration/ssl ]; then
+        install -o root -g ossec -m 0770 -d "${API_PATH}"/configuration/ssl
+    fi
+
+    # Copy API yaml if exists
+    if [ -e "${API_PATH_BACKUP}"/configuration/api.yaml ]; then
+        cp -rLfp "${API_PATH_BACKUP}"/configuration/api.yaml "${API_PATH}"/configuration/
+    fi
+
+    # Copy security folder if exists and its not empty
+    if [ -d "${API_PATH_BACKUP}"/configuration/security ]; then
+        if [ -n "$(ls -A "${API_PATH_BACKUP}"/configuration/security)" ]; then
+            cp -rLfp "${API_PATH_BACKUP}"/configuration/security/* "${API_PATH}"/configuration/security
         fi
-        cp -rLfp ${API_PATH_BACKUP}/configuration/ssl/* ${API_PATH}/configuration/ssl
-        rm -rf ${API_PATH_BACKUP}
+    fi
+
+    # Copy ssl folder if exists and its not empty
+    if [ -d "${API_PATH_BACKUP}"/configuration/ssl ]; then
+        if [ -n "$(ls -A "${API_PATH_BACKUP}"/configuration/ssl)" ]; then
+            cp -rLfp "${API_PATH_BACKUP}"/configuration/ssl/* "${API_PATH}"/configuration/ssl
+        fi
     fi
 }

--- a/api/service/inst-api-functions.sh
+++ b/api/service/inst-api-functions.sh
@@ -13,6 +13,24 @@ API_PATH=${PREFIX}/api
 API_PATH_BACKUP=${PREFIX}/~api
 
 
+
+stop_api_3x(){
+    # stop api process if its still running
+    OLD_API_PID=$(pgrep -f "${API_PATH}/app.js")
+    if [ -n "$OLD_API_PID" ]; then
+        echo "killing old api process: ${OLD_API_PID}"
+        kill -9 "${OLD_API_PID}"
+    fi
+}
+
+
+
+stop_api_4x() {
+    "${PREFIX}"/bin/wazuh-apid stop
+}
+
+
+
 backup_old_api() {
 
     if [ $# -ne 1 ]; then
@@ -27,19 +45,16 @@ backup_old_api() {
 
     # check current REVISION and perform the applicable backup
     if [ "$1" -ge 40000 ]; then
+        stop_api_4x
         backup_old_api_4x
     else
-        # stop api process if its still running
-        OLD_API_PID=$(pgrep -f "${API_PATH}/app.js")
-        if [ -n "$OLD_API_PID" ]; then
-            echo "killing old api process: ${OLD_API_PID}"
-            kill -9 "${OLD_API_PID}"
-        fi
+        stop_api_3x
     fi
 
     # remove old API directory
     rm -rf "${API_PATH}"
 }
+
 
 
 backup_old_api_4x() {
@@ -73,6 +88,7 @@ backup_old_api_4x() {
         fi
     fi
 }
+
 
 
 restore_old_api() {

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -929,8 +929,18 @@ InstallLocal()
 
     ${MAKEBIN} --quiet -C ../framework install PREFIX=${PREFIX} USE_FRAMEWORK_LIB=${LIB_FLAG}
 
+    ### Backup old API
+    if [ "X${update_only}" = "Xyes" ]; then
+      ${MAKEBIN} --quiet -C ../api backup PREFIX=${PREFIX} REVISION=${REVISION}
+    fi
+
     ### Install API
     ${MAKEBIN} --quiet -C ../api install PREFIX=${PREFIX}
+
+    ### restore old API
+    if [ "X${update_only}" = "Xyes" ]; then
+      ${MAKEBIN} --quiet -C ../api restore PREFIX=${PREFIX} REVISION=${REVISION}
+    fi
 
     ### Install API service
     if [ "X${INSTALL_API_DAEMON}" = "X" ] || [ "X${INSTALL_API_DAEMON}" = "Xy" ]; then

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -86,17 +86,17 @@ UpdateStartOSSEC()
    if [ `stat /proc/1/exe 2> /dev/null | grep "systemd" | wc -l` -ne 0 ]; then
        systemctl start wazuh-$TYPE
        if [ "X$TYPE" = "Xmanager" ]; then
-         systemctl start wazuh-api
+         systemctl restart wazuh-api
        fi
    elif [ `stat /proc/1/exe 2> /dev/null | grep "init.d" | wc -l` -ne 0 ]; then
        service wazuh-$TYPE start
        if [ "X$TYPE" = "Xmanager" ]; then
-         service wazuh-api start
+         service wazuh-api restart
        fi
    else
        $DIRECTORY/bin/ossec-control start
        if [ "X$TYPE" = "Xmanager" ]; then
-         $DIRECTORY/bin/wazuh-apid start
+         $DIRECTORY/bin/wazuh-apid restart
        fi
    fi
 }


### PR DESCRIPTION
# Description

This PR improves the process in charge of updating the API from 4.x to 4.y when installing Wazuh from sources. This works in a similar way as the proposed solution in PR #4966 but only applies if the API version is 4.0 or higher. 

No migration will be performed when updating from 3.x to 4.0. It also ensures the old api node process will be killed when updating from 3.x to 4.x.

Additionally, this also fixes the problem detected in https://github.com/wazuh/wazuh-api/issues/494 regarding the node version.

### How it works

When the API is updated from **4.x** to **4.y** (for example from **4.0** to **4.1**) the `api.yaml` file and the contents of `api/configuration/security/` and `api/configuration/ssl/` are saved.

If the user is updating from **3.x** to **4.y** no files will be saved (as no migration is plan to be performed for that particular case) but the new script will ensure the old api process will be killed.

### Changes made

The following changes has been applied:

- `api/Makefile`: Extracted restore and backup API logic from the `install` target. Created new `backup` and `restore` targets used only when performing an update instead of a clean installation. 

- `configuration.py`: The `fill_dict` function has been improved to not only check when a field is missing but also when the field is present but its empty. In those cases the default value will be used.

- `inst-api-functions.sh`: backup and restore functions has been redone and now they receive a parameter for the current `REVISION` value. With this parameter we will know from which Major release we are updating, which files to save and which additional actions needs to be taken.

- `inst-functions.sh`: Updated to use the new `backup` and `restore` targets for the Makefile and also to provide the required `REVISION` parameter.

- `update.sh`: When the API is updated now we will use `restart` instead of `start` to avoid any unwanted behaviour.


## Tests performed

After the changes were made the following tests were performed:
- Migrating from 3.13.1 to 4.0 with a custom api.yaml
- Migrating from 3.13.1 to 4.0 with the default api.yaml
- Migrating from 4.0 to a fake 4.1 version with a custom api.yaml
- Migrating from 4.0 to a fake 4.1 version with the default api.yaml

In every scenario the API was working as expected (with HTTPS enabled and disabled) and the files were migrated as the should.

