### PR TITLE
Adding ALB/ELB/NLB access logs to the AWS module

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -34,6 +34,9 @@ static const char *XML_BUCKET_NAME = "name";
 static const char *LEGACY_AWS_ACCOUNT_ALIAS = "LEGACY";
 
 static const char *CLOUDTRAIL_BUCKET_TYPE = "cloudtrail";
+static const char *ALB_BUCKET_TYPE = "alb";
+static const char *ELB_BUCKET_TYPE = "elb";
+static const char *NLB_BUCKET_TYPE = "nlb";
 static const char *CONFIG_BUCKET_TYPE = "config";
 static const char *VPCFLOW_BUCKET_TYPE = "vpcflow";
 static const char *CUSTOM_BUCKET_TYPE = "custom";
@@ -156,12 +159,13 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     if (!strcmp(*nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE) || !strcmp(*nodes[i]->values, CONFIG_BUCKET_TYPE)
                         || !strcmp(*nodes[i]->values, CUSTOM_BUCKET_TYPE) || !strcmp(*nodes[i]->values, GUARDDUTY_BUCKET_TYPE)
                         || !strcmp(*nodes[i]->values, VPCFLOW_BUCKET_TYPE) || !strcmp(*nodes[i]->values, CISCO_UMBRELLA_BUCKET_TYPE)
-                        || !strcmp(*nodes[i]->values, WAF_BUCKET_TYPE)) {
+                        || !strcmp(*nodes[i]->values, WAF_BUCKET_TYPE) || !strcmp(*nodes[i]->values, ALB_BUCKET_TYPE)
+                        || !strcmp(*nodes[i]->values, ELB_BUCKET_TYPE) || !strcmp(*nodes[i]->values, NLB_BUCKET_TYPE)) {
                         os_strdup(*nodes[i]->values, cur_bucket->type);
                     } else {
                         mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s', '%s', '%s', '%s', '%s' or '%s'",
                             *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE, CONFIG_BUCKET_TYPE, GUARDDUTY_BUCKET_TYPE, VPCFLOW_BUCKET_TYPE,
-                            WAF_BUCKET_TYPE, CISCO_UMBRELLA_BUCKET_TYPE, CUSTOM_BUCKET_TYPE);
+                            WAF_BUCKET_TYPE, CISCO_UMBRELLA_BUCKET_TYPE, CUSTOM_BUCKET_TYPE, ALB_BUCKET_TYPE, ELB_BUCKET_TYPE, NLB_BUCKET_TYPE);
                         OS_ClearNode(children);
                         return OS_INVALID;
                     }

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2026,6 +2026,65 @@ class AWSWAFBucket(AWSCustomBucket):
         return json.loads(json.dumps(content))
 
 
+class AWSALBBucket(AWSCustomBucket):
+
+    def __init__(self, **kwargs):
+        db_table_name = 'alb'
+        AWSCustomBucket.__init__(self, db_table_name, **kwargs)
+
+    def load_information_from_file(self, log_key):
+        """Load data from a ALB access log file."""
+        content = []
+        with self.decompress_file(log_key=log_key) as f:
+            fieldnames = (
+                "type", "time", "elb", "client_port", "target_port", "request_processing_time", "target_processing_time", "response_processing_time", "elb_status_code", "target_status_code",
+                "received_bytes", "sent_bytes", "request", "user_agent", "ssl_cipher", "ssl_protocol", "target_group_arn", "trace_id", "domain_name", "chosen_cert_arn",
+                "matched_rule_priority", "request_creation_time", "action_executed", "redirect_url", "error_reason", "target_port_list", "target_status_code_list")
+            tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
+            return [dict(x, source='alb') for x in tsv_file]
+
+        return json.loads(json.dumps(content))
+
+
+class AWSELBBucket(AWSCustomBucket):
+
+    def __init__(self, **kwargs):
+        db_table_name = 'elb'
+        AWSCustomBucket.__init__(self, db_table_name, **kwargs)
+
+    def load_information_from_file(self, log_key):
+        """Load data from a ELB access log file."""
+        content = []
+        with self.decompress_file(log_key=log_key) as f:
+            fieldnames = (
+                "time", "elb", "client_port", "backend_port", "request_processing_time", "backend_processing_time", "response_processing_time",
+                "elb_status_code", "backend_status_code", "received_bytes", "sent_bytes", "request", "user_agent", "ssl_cipher", "ssl_protocol")
+            tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
+            return [dict(x, source='elb') for x in tsv_file]
+
+        return json.loads(json.dumps(content))
+
+
+class AWSNLBBucket(AWSCustomBucket):
+
+    def __init__(self, **kwargs):
+        db_table_name = 'nlb'
+        AWSCustomBucket.__init__(self, db_table_name, **kwargs)
+
+    def load_information_from_file(self, log_key):
+        """Load data from a NLB access log file."""
+        content = []
+        with self.decompress_file(log_key=log_key) as f:
+            fieldnames = (
+                "type", "version", "time", "elb", "listener", "client_port", "destination_port", "connection_time", "tls_handshake_time", "received_bytes",
+                "sent_bytes", "incoming_tls_alert", "chosen_cert_arn", "chosen_cert_serial", "tls_cipher", "tls_protocol_version", "tls_named_group", "domain_name",
+                "alpn_fe_protocol", "alpn_client_preference_list")
+            tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
+            return [dict(x, source='nlb') for x in tsv_file]
+
+        return json.loads(json.dumps(content))
+
+
 class AWSService(WazuhIntegration):
     """
     Class for getting AWS Services logs from API calls
@@ -2341,6 +2400,12 @@ def main(argv):
                 bucket_type = CiscoUmbrella
             elif options.type.lower() == 'waf':
                 bucket_type = AWSWAFBucket
+            elif options.type.lower() == 'alb':
+                bucket_type = AWSALBBucket
+            elif options.type.lower() == 'elb':
+                bucket_type = AWSELBBucket
+            elif options.type.lower() == 'nlb':
+                bucket_type = AWSNLBBucket
             else:
                 raise Exception("Invalid type of bucket")
             bucket = bucket_type(reparse=options.reparse, access_key=options.access_key,


### PR DESCRIPTION
## Description

This PR adds ALB, ELB, and NLB access logs ingestion to the AWS module.

It creates three new classes under `wodles/aws/aws_s3.py`:
- `AWSALBBucket`. It expects https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-log-entry-format
- `AWSELBBucket`. It expects https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/access-log-collection.html#access-log-entry-format
- `AWSNLBBucket`. It expects https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-access-logs.html#access-log-entry-format

It also adds new bucket types as part of the wodle configuration under `src/config/wmodules-aws.c`.

## Configuration options

The new bucket types can be configured as follows:

```
<wodle name="aws-s3">
    <disabled>no</disabled>
    <remove_from_bucket>no</remove_from_bucket>
    <interval>10m</interval>
    <run_on_start>no</run_on_start>
    <skip_on_error>no</skip_on_error>
    <bucket type="alb">
        <name>alb_bucket</name>
        <aws_profile>stage-creds</aws_profile>
        <aws_account_id>111222333444</aws_account_id>
        <aws_account_alias>stage-account</aws_account_alias>
    </bucket>
    <bucket type="elb">
        <name>elb_bucket</name>
        <aws_profile>stage-creds</aws_profile>
        <aws_account_id>111222333444</aws_account_id>
        <aws_account_alias>stage-account</aws_account_alias>
    </bucket>
    <bucket type="nlb">
        <name>nlb_bucket</name>
        <aws_profile>stage-creds</aws_profile>
        <aws_account_id>111222333444</aws_account_id>
        <aws_account_alias>stage-account</aws_account_alias>
    </bucket>
</wodle>
```
## Logs/Alerts example

NLB sample alert:

```
{
	"timestamp": "2020-07-31T14:51:03.914+0000",
	"rule": {
		"level": 5,
		"description": "AWS NLB alert.",
		"id": "80335",
		"firedtimes": 4984,
		"mail": false,
		"groups": ["amazon", "aws", "aws_nlb"]
	},
	"agent": {
		"id": "002",
		"name": "Akkad",
		"ip": "redacted"
	},
	"manager": {
		"name": "Ur"
	},
	"id": "1596207063.11650995",
	"decoder": {
		"name": "json"
	},
	"data": {
		"aws": {
			"alpn_client_preference_list": "-",
			"connection_time": "5262",
			"sent_bytes": "0",
			"tls_protocol_version": "tlsv12",
			"listener": "c1c7b2c1996c5783",
			"tls_cipher": "ECDHE-RSA-AES128-GCM-SHA256",
			"client_port": "redacted",
			"chosen_cert_serial": "-",
			"destination_port": "redacted",
			"chosen_cert_arn": "redacted",
			"alpn_fe_protocol": "-",
			"incoming_tls_alert": "-",
			"elb": "redacted",
			"domain_name": "redacted",
			"source": "nlb",
			"version": "2.0",
			"tls_handshake_time": "206",
			"tls_named_group": "-",
			"time": "2020-07-30T18:27:47",
			"log_info": {
				"s3bucket": "redacted",
				"log_file": "AWSLogs/redacted.log.gz"
			},
			"received_bytes": "0",
			"type": "tls"
		},
		"integration": "aws"
	},
	"location": "Wazuh-AWS"
}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities