### PR TITLE
[5667] Adding flexible way to use the deleteRowsData APIs

### DIFF
--- a/src/dbsync/smokeTests/InsertionUpdateDeleteSelect/deleteRows.json
+++ b/src/dbsync/smokeTests/InsertionUpdateDeleteSelect/deleteRows.json
@@ -68,7 +68,7 @@
                     "handle_count":-1,
                     "percent_processor_time":-1
                 }],
-            "row_filter_opt":"WHERE pid>=4"
+            "row_filter_opt":"pid>=4"
         }
     }
 }

--- a/src/dbsync/smokeTests/InsertionUpdateDeleteSelect/deleteRows.json
+++ b/src/dbsync/smokeTests/InsertionUpdateDeleteSelect/deleteRows.json
@@ -1,7 +1,8 @@
 {
     "action": "dbsync_delete_rows",
-        "body": {
-            "table": "processes",
+    "body": {
+        "table":"processes",
+        "query": {
             "data":[
                 {
                     "pid":4,
@@ -34,8 +35,8 @@
                     "elapsed_time":-1,
                     "handle_count":-1,
                     "percent_processor_time":-1
-                 },
-                 {
+                },
+                {
                     "pid":6,
                     "name":"System",
                     "path":"/usr/lib",
@@ -66,7 +67,8 @@
                     "elapsed_time":-1,
                     "handle_count":-1,
                     "percent_processor_time":-1
-                }       
-            ]
+                }],
+            "row_filter_opt":"WHERE pid>=4"
         }
-    } 
+    }
+}

--- a/src/dbsync/src/db_exception.h
+++ b/src/dbsync/src/db_exception.h
@@ -26,6 +26,7 @@ constexpr auto INVALID_PK_DATA          { std::make_pair(10, "Primary key not fo
 constexpr auto INVALID_COLUMN_TYPE      { std::make_pair(11, "Invalid column field type.") };
 constexpr auto INVALID_DATA_BIND        { std::make_pair(12, "Invalid data to bind.") };
 constexpr auto INVALID_TABLE            { std::make_pair(13, "Invalid table.") };
+constexpr auto INVALID_DELETE_INFO      { std::make_pair(13, "Invalid information provided for deletion.") };
 
 namespace DbSync
 {

--- a/src/dbsync/src/dbengine.h
+++ b/src/dbsync/src/dbengine.h
@@ -53,7 +53,7 @@ namespace DbSync
                                 const ResultCallback& callback) = 0;
 
         virtual void deleteTableRowsData(const std::string& table,
-                                         const nlohmann::json& data) = 0;
+                                         const nlohmann::json& jsDeletionData) = 0;
 
         virtual void addTableRelationship(const nlohmann::json& data) = 0;
 

--- a/src/dbsync/src/dbsync_implementation.cpp
+++ b/src/dbsync/src/dbsync_implementation.cpp
@@ -79,7 +79,7 @@ void DBSyncImplementation::deleteRowsData(const DBSYNC_HANDLE  handle,
     const auto ctx{ dbEngineContext(handle) };
     const auto json { nlohmann::json::parse(jsonRaw) };
     ctx->m_dbEngine->deleteTableRowsData(json.at(0).at("table"),
-                                         json.at(0).at("data"));
+                                         json.at(0).at("query"));
 }
 
 void DBSyncImplementation::updateSnapshotData(const DBSYNC_HANDLE  handle,

--- a/src/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -357,7 +357,7 @@ void SQLiteDBEngine::deleteTableRowsData(const std::string&    table,
         {
             // Deletion via condition on "row_filter_opt" json field.
             const auto& transaction { m_sqliteFactory->createTransaction(m_sqliteConnection) };
-            deleteRowsByFilter(table, itFilter);
+            m_sqliteConnection->execute("DELETE FROM "+table+" "+itFilter->get<std::string>());
             transaction->commit();
         }
         else
@@ -866,16 +866,6 @@ void SQLiteDBEngine::deleteRowsbyPK(const std::string& table,
             stmt->reset();
         }
     }
-}
-
-void SQLiteDBEngine::deleteRowsByFilter(const std::string& table,
-                                        const nlohmann::json::const_iterator& itFilter)
-{
-    const auto& stmt
-    {
-        getStatement("DELETE FROM "+table+" "+itFilter->get<std::string>())
-    };
-    stmt->step();
 }
 
 void SQLiteDBEngine::bindFieldData(const std::unique_ptr<SQLite::IStatement>& stmt,

--- a/src/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -355,7 +355,7 @@ void SQLiteDBEngine::deleteTableRowsData(const std::string&    table,
         }
         else if(itFilter != jsDeletionData.end() && !itFilter->get<std::string>().empty())
         {
-            // Deletion via condition on "row_filter_opt" json field.
+            // Deletion via condition on "where_filter_opt" json field.
             m_sqliteConnection->execute("DELETE FROM "+table+" WHERE "+itFilter->get<std::string>());
         }
         else

--- a/src/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -350,7 +350,7 @@ void SQLiteDBEngine::deleteTableRowsData(const std::string&    table,
         {
             // Deletion via primary keys on "data" json field.
             const auto& transaction { m_sqliteFactory->createTransaction(m_sqliteConnection) };
-            deleteRowsbyPK(table, jsDeletionData.at("data"));
+            deleteRowsbyPK(table, *itData);
             transaction->commit();
         }
         else if(itFilter != jsDeletionData.end() && !itFilter->get<std::string>().empty())

--- a/src/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -344,7 +344,7 @@ void SQLiteDBEngine::deleteTableRowsData(const std::string&    table,
     if (0 != loadTableData(table))
     {
         const auto& itData{ jsDeletionData.find("data")};
-        const auto& itFilter{ jsDeletionData.find("row_filter_opt")};
+        const auto& itFilter{ jsDeletionData.find("where_filter_opt")};
 
         if(itData != jsDeletionData.end() && itData->size() > 0)
         {
@@ -356,9 +356,7 @@ void SQLiteDBEngine::deleteTableRowsData(const std::string&    table,
         else if(itFilter != jsDeletionData.end() && !itFilter->get<std::string>().empty())
         {
             // Deletion via condition on "row_filter_opt" json field.
-            const auto& transaction { m_sqliteFactory->createTransaction(m_sqliteConnection) };
-            m_sqliteConnection->execute("DELETE FROM "+table+" "+itFilter->get<std::string>());
-            transaction->commit();
+            m_sqliteConnection->execute("DELETE FROM "+table+" WHERE "+itFilter->get<std::string>());
         }
         else
         {

--- a/src/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.h
@@ -193,9 +193,6 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
         void deleteRowsbyPK(const std::string& table,
                             const nlohmann::json& data);
 
-        void deleteRowsByFilter(const std::string& table,
-                                const nlohmann::json::const_iterator& itFilter);
-
         void getTableData(std::unique_ptr<SQLite::IStatement>const & stmt,
                           const int32_t index,
                           const ColumnType& type,

--- a/src/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.h
@@ -133,7 +133,7 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
                         const DbSync::ResultCallback& callback) override;
 
         void deleteTableRowsData(const std::string& table,
-                                 const nlohmann::json& data) override;
+                                 const nlohmann::json& jsDeletionData) override;
         
         void addTableRelationship(const nlohmann::json& data) override;
 
@@ -176,7 +176,7 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
         bool getRowDiff(const std::vector<std::string>& primaryKeyList,
                         const std::string& table,
                         const nlohmann::json& data,
-                        nlohmann::json& jsResult);                              
+                        nlohmann::json& jsResult);
 
         bool insertNewRows(const std::string& table,
                            const std::vector<std::string>& primaryKeyList,
@@ -189,6 +189,12 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
         void deleteRows(const std::string& table,
                         const nlohmann::json& data,
                         const std::vector<std::string>& primaryKeyList);
+
+        void deleteRowsbyPK(const std::string& table,
+                            const nlohmann::json& data);
+
+        void deleteRowsByFilter(const std::string& table,
+                                const nlohmann::json::const_iterator& itFilter);
 
         void getTableData(std::unique_ptr<SQLite::IStatement>const & stmt,
                           const int32_t index,

--- a/src/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/dbsync/tests/interface/dbsync_test.cpp
@@ -1032,12 +1032,34 @@ TEST_F(DBSyncTest, deleteSingleAndComposedData)
                                                             {"pid":7,"name":"System", "tid":103},
                                                             {"pid":8,"name":"System", "tid":104}]})"};
 
-    const auto singleRowToDelete{ R"({"table":"processes","data":[{"pid":4,"name":"System", "tid":101}]})"};
-    const auto composedRowsToDelete{ R"({"table":"processes","data":[{"pid":5,"name":"Systemmm", "tid":105},
-                                                                     {"pid":7,"name":"Systemmm", "tid":105},
-                                                                     {"pid":8,"name":"Systemmm", "tid":105}]})"};
-    const auto unexistentRowToDelete{ R"({"table":"processes","data":[{"pid":9,"name":"Systemmm", "tid":101}]})"};
-    const auto dataWithoutTable{ R"({"data":[{"pid":9,"name":"Systemmm", "tid":101}]})"};
+    const auto singleRowToDelete
+    {
+        R"({"table":"processes",
+           "query":{"data":[{"pid":4,"name":"System", "tid":101}],
+           "row_filter_opt":""}})"
+    };
+
+    const auto composedRowsToDelete
+    {
+        R"({"table":"processes",
+           "query":{"data":[{"pid":5,"name":"Systemmm", "tid":101},
+                            {"pid":7,"name":"Systemmm", "tid":103},
+                            {"pid":8,"name":"Systemmm", "tid":104}],
+                    "row_filter_opt":""}})"
+    };
+
+    const auto unexistentRowToDelete
+    {
+        R"({"table":"processes",
+           "query":{"data":[{"pid":9,"name":"Systemmm", "tid":101}],
+           "row_filter_opt":""}})"
+    };
+
+    const auto dataWithoutTable
+    {
+        R"({"query":{"data":[{"pid":9,"name":"Systemmm", "tid":101}],
+           "row_filter_opt":""})"
+    };
 
     callback_data_t callbackData { callback, &wrapper };
     const std::unique_ptr<cJSON, smartDeleterJson> jsInitialData{ cJSON_Parse(initialData) };
@@ -1047,6 +1069,7 @@ TEST_F(DBSyncTest, deleteSingleAndComposedData)
     const std::unique_ptr<cJSON, smartDeleterJson> jsWithoutTable{ cJSON_Parse(dataWithoutTable) };
 
     EXPECT_EQ(0, dbsync_sync_row(handle, jsInitialData.get(), callbackData));  // Expect an insert event
+
     EXPECT_EQ(0, dbsync_delete_rows(handle, jsSingleDeletion.get()));
     EXPECT_EQ(0, dbsync_delete_rows(handle, jsComposedDeletion.get()));
     EXPECT_EQ(0, dbsync_delete_rows(handle, jsUnexistentDeletion.get()));
@@ -1055,4 +1078,145 @@ TEST_F(DBSyncTest, deleteSingleAndComposedData)
     EXPECT_NE(0, dbsync_delete_rows(handle, nullptr));
     EXPECT_NE(0, dbsync_delete_rows(handle, jsWithoutTable.get()));
     EXPECT_NE(0, dbsync_delete_rows(reinterpret_cast<void *>(0xffffffff), jsSingleDeletion.get()));
+}
+
+TEST_F(DBSyncTest, deleteRowsByFilter)
+{
+    const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `tid` BIGINT, PRIMARY KEY (`pid`)) WITHOUT ROWID;"};
+    const auto handle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
+    ASSERT_NE(nullptr, handle);
+
+    CallbackMock wrapper;
+    EXPECT_CALL(wrapper, callbackMock(INSERTED,
+                nlohmann::json::parse(R"([{"pid":4,"name":"System", "tid":100},
+                                          {"pid":5,"name":"User1", "tid":101},
+                                          {"pid":6,"name":"User2", "tid":102},
+                                          {"pid":7,"name":"User3", "tid":103},
+                                          {"pid":8,"name":"User4", "tid":104}])"))).Times(1);
+
+    const auto initialData{ R"({"table":"processes","data":[{"pid":4,"name":"System", "tid":100},
+                                                            {"pid":5,"name":"User1", "tid":101},
+                                                            {"pid":6,"name":"User2", "tid":102},
+                                                            {"pid":7,"name":"User3", "tid":103},
+                                                            {"pid":8,"name":"User4", "tid":104}]})"};
+
+    const auto rowDeleteByPIDFilter
+    {
+        R"({"table":"processes",
+           "query":{"data":[],
+           "row_filter_opt":"WHERE pid=5"}})"
+    };
+
+    const auto rowDeleteByTIDFilter
+    {
+        R"({"table":"processes",
+           "query":{"data":[],
+           "row_filter_opt":"WHERE tid>=103"}})"
+    };
+
+    const auto rowDeleteByNameFilter
+    {
+        R"({"table":"processes",
+           "query":{"data":[],
+           "row_filter_opt":"WHERE name LIKE '%User2%'"}})"
+    };
+
+    callback_data_t callbackData { callback, &wrapper };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsInitialData{ cJSON_Parse(initialData) };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsrowDeleteByPIDFilter{ cJSON_Parse(rowDeleteByPIDFilter) };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsrowDeleteByTIDFilter{ cJSON_Parse(rowDeleteByTIDFilter) };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsrowDeleteByNameFilter{ cJSON_Parse(rowDeleteByNameFilter) };
+
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsInitialData.get(), callbackData));  // Expect an insert event
+    EXPECT_EQ(0, dbsync_delete_rows(handle, jsrowDeleteByPIDFilter.get()));
+    EXPECT_EQ(0, dbsync_delete_rows(handle, jsrowDeleteByTIDFilter.get()));
+    EXPECT_EQ(0, dbsync_delete_rows(handle, jsrowDeleteByNameFilter.get()));
+}
+
+TEST_F(DBSyncTest, deleteRowsWithDataMorePriorityThanFilter)
+{
+    const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `tid` BIGINT, PRIMARY KEY (`pid`)) WITHOUT ROWID;"};
+    const auto handle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
+    ASSERT_NE(nullptr, handle);
+
+    CallbackMock wrapper;
+    EXPECT_CALL(wrapper, callbackMock(INSERTED,
+                nlohmann::json::parse(R"([{"pid":4,"name":"System", "tid":100},
+                                          {"pid":5,"name":"User1", "tid":101},
+                                          {"pid":6,"name":"User2", "tid":102},
+                                          {"pid":7,"name":"User3", "tid":103},
+                                          {"pid":8,"name":"User4", "tid":104}])"))).Times(1);
+
+    const auto initialData{ R"({"table":"processes","data":[{"pid":4,"name":"System", "tid":100},
+                                                            {"pid":5,"name":"User1", "tid":101},
+                                                            {"pid":6,"name":"User2", "tid":102},
+                                                            {"pid":7,"name":"User3", "tid":103},
+                                                            {"pid":8,"name":"User4", "tid":104}]})"};
+
+    const auto rowDeletePID4
+    {
+        R"({"table":"processes",
+           "query":{"data":[{"pid":4,"name":"System", "tid":100}],
+           "row_filter_opt":""}})"
+    };
+
+    const auto rowDeletePID6
+    {
+        R"({"table":"processes",
+           "query":{"data":[{"pid":6,"name":"User2", "tid":102}],
+           "row_filter_opt":"WHERE tid>=103"}})"
+    };
+
+    const auto rowDeletePID8
+    {
+        R"({"table":"processes",
+           "query":{"data":[{"pid":8,"name":"User4", "tid":104}],
+           "row_filter_opt":"WHERE name LIKE '%User2%'"}})"
+    };
+
+    callback_data_t callbackData { callback, &wrapper };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsInitialData{ cJSON_Parse(initialData) };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsRowDeletePID4{ cJSON_Parse(rowDeletePID4) };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsRowDeletePID6{ cJSON_Parse(rowDeletePID6) };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsRowDeletePID8{ cJSON_Parse(rowDeletePID8) };
+
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsInitialData.get(), callbackData));  // Expect an insert event
+    EXPECT_EQ(0, dbsync_delete_rows(handle, jsRowDeletePID4.get()));
+    EXPECT_EQ(0, dbsync_delete_rows(handle, jsRowDeletePID6.get()));
+    EXPECT_EQ(0, dbsync_delete_rows(handle, jsRowDeletePID8.get()));
+}
+
+TEST_F(DBSyncTest, deleteRowsWithNoDataAndFilterShouldFail)
+{
+    const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `tid` BIGINT, PRIMARY KEY (`pid`)) WITHOUT ROWID;"};
+    const auto handle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
+    ASSERT_NE(nullptr, handle);
+
+    CallbackMock wrapper;
+    EXPECT_CALL(wrapper, callbackMock(INSERTED,
+                nlohmann::json::parse(R"([{"pid":4,"name":"System", "tid":100},
+                                          {"pid":5,"name":"User1", "tid":101},
+                                          {"pid":6,"name":"User2", "tid":102},
+                                          {"pid":7,"name":"User3", "tid":103},
+                                          {"pid":8,"name":"User4", "tid":104}])"))).Times(1);
+
+    const auto initialData{ R"({"table":"processes","data":[{"pid":4,"name":"System", "tid":100},
+                                                            {"pid":5,"name":"User1", "tid":101},
+                                                            {"pid":6,"name":"User2", "tid":102},
+                                                            {"pid":7,"name":"User3", "tid":103},
+                                                            {"pid":8,"name":"User4", "tid":104}]})"};
+
+    const auto rowEmpty
+    {
+        R"({"table":"processes",
+           "query":{"data":[],
+           "row_filter_opt":""}})"
+    };
+
+    callback_data_t callbackData { callback, &wrapper };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsInitialData{ cJSON_Parse(initialData) };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsRowEmpty{ cJSON_Parse(rowEmpty) };
+
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsInitialData.get(), callbackData));  // Expect an insert event
+    EXPECT_NE(0, dbsync_delete_rows(handle, jsRowEmpty.get()));
 }

--- a/src/dbsync/testtool/input/deleteRows.json
+++ b/src/dbsync/testtool/input/deleteRows.json
@@ -68,7 +68,7 @@
                     "handle_count":-1,
                     "percent_processor_time":-1
                 }],
-            "row_filter_opt":"WHERE pid>=4"
+            "row_filter_opt":"pid>=4"
         }
     }
 }

--- a/src/dbsync/testtool/input/deleteRows.json
+++ b/src/dbsync/testtool/input/deleteRows.json
@@ -1,7 +1,8 @@
 {
     "action": "dbsync_delete_rows",
-        "body": {
-            "table": "processes",
+    "body": {
+        "table":"processes",
+        "query": {
             "data":[
                 {
                     "pid":4,
@@ -34,8 +35,8 @@
                     "elapsed_time":-1,
                     "handle_count":-1,
                     "percent_processor_time":-1
-                 },
-                 {
+                },
+                {
                     "pid":6,
                     "name":"System",
                     "path":"/usr/lib",
@@ -66,7 +67,8 @@
                     "elapsed_time":-1,
                     "handle_count":-1,
                     "percent_processor_time":-1
-                }       
-            ]
+                }],
+            "row_filter_opt":"WHERE pid>=4"
         }
-    } 
+    }
+}


### PR DESCRIPTION
## **Related Issue**
Issue #5667 

## **Description**
Allow to make complex filters in the where of the delete function.

![image](https://user-images.githubusercontent.com/22640902/89795898-58d39b80-daff-11ea-93d6-39ddd475c1e6.png)



## **DoD**
- [X] Implementation
- [X] RTR Tool execution
![image](https://user-images.githubusercontent.com/22640902/89696545-c5c41700-d8ee-11ea-8235-ce62dfa5457e.png)
