### PR TITLE
Remove white line in the alerts checksum file

### DIFF
--- a/src/monitord/sign_log.c
+++ b/src/monitord/sign_log.c
@@ -146,12 +146,12 @@ void OS_SignLog(const char *logfile, const char *logfile_old, const char * ext)
 
     fprintf(fp, "Current checksum:\n");
     fprintf(fp, "MD5  (%s) = %s\n", logfile, mf_sum);
-    fprintf(fp, "SHA1 (%s) = %s\n\n", logfile, sf_sum);
+    fprintf(fp, "SHA1 (%s) = %s\n", logfile, sf_sum);
     fprintf(fp, "SHA256 (%s) = %s\n\n", logfile, sf256_sum);
 
     fprintf(fp, "Chained checksum:\n");
     fprintf(fp, "MD5  (%s) = %s\n", logfilesum_old, mf_sum_old);
-    fprintf(fp, "SHA1 (%s) = %s\n\n", logfilesum_old, sf_sum_old);
+    fprintf(fp, "SHA1 (%s) = %s\n", logfilesum_old, sf_sum_old);
     fprintf(fp, "SHA256 (%s) = %s\n\n", logfilesum_old, sf256_sum_old);
     fclose(fp);
 


### PR DESCRIPTION
## Description

Removing a white line between the SHA1 and SHA256 in the alerts checksum file introduced when added the support for SHA256.

## Logs/Alerts example

**Before**

```
# cat /var/ossec/logs/alerts/2020/Aug/ossec-alerts-09.json.sum
Current checksum:
MD5  (/logs/alerts/2020/Aug/ossec-alerts-09) = 867e1f9c7c9be2713b918e112e9fc3b1
SHA1 (/logs/alerts/2020/Aug/ossec-alerts-09) = f318e60bbc3e28d74dd9231ca8995ce208a6b5c0

SHA256 (/logs/alerts/2020/Aug/ossec-alerts-09) = 4fc97833f1c58cb9980904fac123fd1a7e8c454668391b92533de17fd6ddda22

Chained checksum:
MD5  (/logs/alerts/2020/Aug/ossec-alerts-08.json.sum) = 4fdb7de985264c6471f4e55397ad531e
SHA1 (/logs/alerts/2020/Aug/ossec-alerts-08.json.sum) = 02fea7e0e2eb2b6ad9ea6b20fc21f7678f4f13ee

SHA256 (/logs/alerts/2020/Aug/ossec-alerts-08.json.sum) = 78b185fabdb323971d13bd329fefc8038e08559aa51c4996de18db0639a51df6
```

**After**

```
# cat /var/ossec/logs/alerts/2020/Aug/ossec-alerts-09.json.sum
Current checksum:
MD5  (/logs/alerts/2020/Aug/ossec-alerts-09) = 867e1f9c7c9be2713b918e112e9fc3b1
SHA1 (/logs/alerts/2020/Aug/ossec-alerts-09) = f318e60bbc3e28d74dd9231ca8995ce208a6b5c0
SHA256 (/logs/alerts/2020/Aug/ossec-alerts-09) = 4fc97833f1c58cb9980904fac123fd1a7e8c454668391b92533de17fd6ddda22

Chained checksum:
MD5  (/logs/alerts/2020/Aug/ossec-alerts-08.json.sum) = 4fdb7de985264c6471f4e55397ad531e
SHA1 (/logs/alerts/2020/Aug/ossec-alerts-08.json.sum) = 02fea7e0e2eb2b6ad9ea6b20fc21f7678f4f13ee
SHA256 (/logs/alerts/2020/Aug/ossec-alerts-08.json.sum) = 78b185fabdb323971d13bd329fefc8038e08559aa51c4996de18db0639a51df6
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Review logs syntax and correct language
