### PR TITLE
Unit tests for session functions and memory release

### DIFF
--- a/src/analysisd/lists_list.c
+++ b/src/analysisd/lists_list.c
@@ -330,7 +330,6 @@ void os_remove_cdblist(ListNode **l_node) {
         os_free(tmp);
     }
 
-    os_free(*l_node);
 }
 
 void os_remove_cdbrules(ListRule **l_rule) {
@@ -349,5 +348,4 @@ void os_remove_cdbrules(ListRule **l_rule) {
         os_free(tmp);
     }
 
-    os_free(*l_rule);
 }

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -230,11 +230,12 @@ void w_logtest_remove_session(char *token) {
 
 
 void *w_logtest_check_inactive_sessions(__attribute__((unused)) void * arg) {
+
     OSHashNode *hash_node;
     unsigned int inode_it = 0;
     time_t current_time;
 
-    while (1) {
+    while (FOREVER()) {
 
         sleep(w_logtest_conf.session_timeout);
 
@@ -256,6 +257,8 @@ void *w_logtest_check_inactive_sessions(__attribute__((unused)) void * arg) {
         }
 
     }
+
+    return NULL;
 
 }
 

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -510,6 +510,7 @@ void os_remove_ruleinfo(RuleInfo *ruleinfo) {
             os_free(ruleinfo->ar[i]->ar_cmd->name);
             os_free(ruleinfo->ar[i]->ar_cmd->executable);
             os_free(ruleinfo->ar[i]->ar_cmd->extra_args);
+            os_free(ruleinfo->ar[i]->ar_cmd);
             os_free(ruleinfo->ar[i]);
         }
     }

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -45,11 +45,30 @@ LIST(APPEND analysisd_names "test_logtest")
 LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap,OS_BindUnixDomain -Wl,--wrap,OSHash_Create \
                              -Wl,--wrap,pthread_mutex_init -Wl,--wrap,_minfo -Wl,--wrap,_w_mutex_init -Wl,--wrap,w_create_thread \
                              -Wl,--wrap,mutex_destroy -Wl,--wrap,close -Wl,--wrap,getDefine_Int -Wl,--wrap,OSList_Create \
-                             -Wl,--wrap,OSList_SetMaxSize -Wl,--wrap,OSHash_setSize")
+                             -Wl,--wrap,OSList_SetMaxSize -Wl,--wrap,OSHash_setSize -Wl,--wrap,OSHash_Delete_ex \
+                             -Wl,--wrap,OSHash_Free -Wl,--wrap,os_remove_rules_list -Wl,--wrap,os_remove_decoders_list \
+                             -Wl,--wrap,os_remove_cdblist -Wl,--wrap,os_remove_cdbrules -Wl,--wrap,os_remove_eventlist \
+                             -Wl,--wrap,sleep -Wl,--wrap,OSHash_Begin -Wl,--wrap,time -Wl,--wrap,difftime -Wl,--wrap,OSHash_Next \
+                             -Wl,--wrap,FOREVER")
 
 LIST(APPEND analysisd_names "test_logtest-config")
 LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nproc -Wl,--wrap,cJSON_CreateObject \
                              -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddNumberToObject -Wl,--wrap,cJSON_AddItemToObject")
+
+LIST(APPEND analysisd_names "test_decoder_list")
+LIST(APPEND analysisd_flags "-Wl,--wrap,FreeDecoderInfo")
+
+LIST(APPEND analysisd_names "test_decode-xml")
+LIST(APPEND analysisd_flags "")
+
+LIST(APPEND analysisd_names "test_lists_list")
+LIST(APPEND analysisd_flags "-Wl,--wrap,OSMatch_FreePattern")
+
+LIST(APPEND analysisd_names "test_rule_list")
+LIST(APPEND analysisd_flags "-Wl,--wrap,OSMatch_FreePattern -Wl,--wrap,OSRegex_FreePattern -Wl,--wrap,os_remove_cdbrules")
+
+LIST(APPEND analysisd_names "test_eventinfo_list")
+LIST(APPEND analysisd_flags "-Wl,--wrap,Free_Eventinfo")
 
 list(LENGTH analysisd_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Generate analysisd library
 file(GLOB analysisd_files
     ${SRC_FOLDER}/analysisd/*.o
+    ${SRC_FOLDER}/analysisd/alerts/*.o
+    ${SRC_FOLDER}/analysisd/output/*.o
+    ${SRC_FOLDER}/analysisd/format/*.o
     ${SRC_FOLDER}/analysisd/cdb/*.o
     ${SRC_FOLDER}/analysisd/decoders/*.o
     ${SRC_FOLDER}/analysisd/decoders/plugins/*.o

--- a/src/unit_tests/analysisd/test_decode-xml.c
+++ b/src/unit_tests/analysisd/test_decode-xml.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+
+#include "../../headers/shared.h"
+#include "os_regex/os_regex.h"
+#include "os_xml/os_xml.h"
+#include "../../analysisd/analysisd.h"
+#include "../../analysisd/eventinfo.h"
+#include "../../analysisd/decoders/decoder.h"
+#include "../../analysisd/decoders/plugin_decoders.h"
+#include "../../analysisd/config.h"
+
+
+void FreeDecoderInfo(OSDecoderInfo *pi);
+
+/* setup/teardown */
+
+/* wraps */
+
+/* tests */
+
+/* FreeDecoderInfo */
+void test_FreeDecoderInfo_NULL(void **state)
+{
+    OSDecoderInfo *info = NULL;
+
+    FreeDecoderInfo(info);
+
+}
+
+void test_FreeDecoderInfo_OK(void **state)
+{
+    OSDecoderInfo *info;
+    os_calloc(1, sizeof(OSDecoderInfo), info);
+
+    os_calloc(1, sizeof(char), info->parent);
+    os_calloc(1, sizeof(char), info->name);
+    os_calloc(1, sizeof(char), info->ftscomment);
+    os_calloc(1, sizeof(char), info->fts_fields);
+    os_calloc(1, sizeof(char*), info->fields);
+    os_calloc(1, sizeof(char), info->fields[0]);
+
+    os_calloc(1, sizeof(OSRegex), info->regex);
+    os_calloc(1, sizeof(OSRegex), info->prematch);
+    os_calloc(1, sizeof(OSRegex), info->program_name);
+
+    os_calloc(1, sizeof(void*), info->order);
+
+    Config.decoder_order_size = 1;
+
+    FreeDecoderInfo(info);
+    
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        // Tests FreeDecoderInfo
+        cmocka_unit_test(test_FreeDecoderInfo_NULL),
+        cmocka_unit_test(test_FreeDecoderInfo_OK)
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/analysisd/test_decoder_list.c
+++ b/src/unit_tests/analysisd/test_decoder_list.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "headers/debug_op.h"
+#include "../../analysisd/decoders/decoder.h"
+#include "error_messages/error_messages.h"
+#include "error_messages/debug_messages.h"
+#include "../../analysisd/analysisd.h"
+
+void os_remove_decoders_list(OSDecoderNode *decoderlist_pn, OSDecoderNode *decoderlist_npn);
+void os_remove_decodernode(OSDecoderNode *node, OSDecoderInfo **decoders, int *pos, int *max_size);
+void os_count_decoders(OSDecoderNode *node, int *num_decoders);
+
+/* setup/teardown */
+
+
+
+/* wraps */
+
+void __wrap_FreeDecoderInfo(OSDecoderInfo *pi) {
+    os_free(pi);
+    return;
+}
+
+/* tests */
+
+/* os_remove_decoders_list */   
+void os_count_decoders_no_child(void **state)
+{
+    OSDecoderNode * node;
+    os_calloc(1, sizeof(OSDecoderNode), node);
+
+    int num_decoders = 0;
+
+    os_count_decoders(node, &num_decoders);
+
+    os_free(node);
+
+}
+
+void os_count_decoders_child(void **state)
+{
+    OSDecoderNode * node;
+    os_calloc(1, sizeof(OSDecoderNode), node);
+    os_calloc(1, sizeof(OSDecoderNode), node->child);
+
+    int num_decoders = 0;
+
+    os_count_decoders(node, &num_decoders);
+
+    os_free(node->child);
+    os_free(node);
+
+}
+
+/* os_remove_decodernode */
+void test_os_remove_decodernode_no_child(void **state)
+{
+    int pos = 0;
+    int max_size = 2;
+
+    OSDecoderNode * node;
+    os_calloc(1, sizeof(OSDecoderNode), node);
+    os_calloc(1, sizeof(OSDecoderInfo), node->osdecoder);
+    node->osdecoder->internal_saving = false;
+
+    OSDecoderInfo **decoders;
+    os_calloc(1, sizeof(OSDecoderInfo *), decoders);
+
+    int num_decoders = 0;
+
+    os_remove_decodernode(node, decoders, &pos, &max_size);
+
+    os_free(decoders[0]);
+    os_free(decoders);
+
+}
+
+void test_os_remove_decodernode_child(void **state)
+{
+    int pos = 0;
+    int max_size = 2;
+
+    OSDecoderNode * node;
+    os_calloc(1, sizeof(OSDecoderNode), node);
+    os_calloc(1, sizeof(OSDecoderNode), node->child);
+    os_calloc(1, sizeof(OSDecoderInfo), node->osdecoder);
+    os_calloc(1, sizeof(OSDecoderInfo), node->child->osdecoder);
+    node->osdecoder->internal_saving = false;
+    node->child->osdecoder->internal_saving = false;
+
+    OSDecoderInfo **decoders;
+    os_calloc(2, sizeof(OSDecoderInfo *), decoders);
+
+    int num_decoders = 0;
+
+    os_remove_decodernode(node, decoders, &pos, &max_size);
+
+    os_free(decoders[0]);
+    os_free(decoders[1]);
+    os_free(decoders);
+
+}
+
+/* os_remove_decoders_list */
+void test_os_remove_decoders_list_OK(void **state)
+{
+    OSDecoderNode * decoderlist_pn;
+    os_calloc(1, sizeof(OSDecoderNode), decoderlist_pn);
+    os_calloc(1, sizeof(OSDecoderNode), decoderlist_pn->child);
+    os_calloc(1, sizeof(OSDecoderInfo), decoderlist_pn->osdecoder);
+    os_calloc(1, sizeof(OSDecoderInfo), decoderlist_pn->child->osdecoder);
+    decoderlist_pn->osdecoder->internal_saving = false;
+    decoderlist_pn->child->osdecoder->internal_saving = false;
+
+
+    OSDecoderNode * decoderlist_npn;
+    os_calloc(1, sizeof(OSDecoderNode), decoderlist_npn);
+    os_calloc(1, sizeof(OSDecoderNode), decoderlist_npn->child);
+    os_calloc(1, sizeof(OSDecoderInfo), decoderlist_npn->osdecoder);
+    os_calloc(1, sizeof(OSDecoderInfo), decoderlist_npn->child->osdecoder);
+    decoderlist_npn->osdecoder->internal_saving = false;
+    decoderlist_npn->child->osdecoder->internal_saving = false;
+
+    os_remove_decoders_list(decoderlist_pn, decoderlist_npn);
+
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        // Tests os_count_decoders_no_child
+        cmocka_unit_test(os_count_decoders_no_child),
+        cmocka_unit_test(os_count_decoders_child),
+        // Tests os_remove_decodernode
+        cmocka_unit_test(test_os_remove_decodernode_no_child),
+        cmocka_unit_test(test_os_remove_decodernode_child),
+        // Tests os_remove_decoders_list
+        cmocka_unit_test(test_os_remove_decoders_list_OK)
+        
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/analysisd/test_eventinfo_list.c
+++ b/src/unit_tests/analysisd/test_eventinfo_list.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../headers/shared.h"
+#include "../../analysisd/eventinfo.h"
+#include "../../analysisd/rules.h"
+
+void os_remove_eventlist(EventList *list);
+
+/* setup/teardown */
+
+
+
+/* wraps */
+
+void __wrap_Free_Eventinfo(Eventinfo *lf) {
+    return;
+}
+
+/* tests */
+
+/* os_remove_eventlist */
+void test_os_remove_eventlist_OK(void **state)
+{
+    EventList *list;
+    os_calloc(1,sizeof(EventList), list);
+
+    os_calloc(1,sizeof(EventNode), list->first_node);
+
+    os_remove_eventlist(list);
+
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        // Tests os_remove_eventlist
+        cmocka_unit_test(test_os_remove_eventlist_OK)
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}
+

--- a/src/unit_tests/analysisd/test_lists_list.c
+++ b/src/unit_tests/analysisd/test_lists_list.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../headers/shared.h"
+#include "../../analysisd/rules.h"
+#include "../../analysisd/cdb/cdb.h"
+#include "../../analysisd/analysisd.h"
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+void os_remove_cdblist(ListNode **l_node);
+void os_remove_cdbrules(ListRule **l_rule);
+
+/* setup/teardown */
+
+
+
+/* wraps */
+
+void __wrap_OSMatch_FreePattern(OSMatch *reg) {
+    return;
+}
+
+/* tests */
+
+/* os_remove_cdblist */
+void test_os_remove_cdblist_OK(void **state)
+{
+    ListNode *l_node;
+    os_calloc(1,sizeof(ListNode), l_node);
+    os_calloc(1,sizeof(ListNode), l_node->cdb_filename);
+    os_calloc(1,sizeof(char*), l_node->txt_filename);
+
+    os_remove_cdblist(&l_node);
+
+}
+
+/* os_remove_cdbrules */
+void test_os_remove_cdbrules_OK(void **state)
+{
+    ListRule *l_rule;
+    os_calloc(1,sizeof(ListRule), l_rule);
+    os_calloc(1,sizeof(ListRule), l_rule->matcher);
+    os_calloc(1,sizeof(char*), l_rule->dfield);
+    os_calloc(1,sizeof(char*), l_rule->filename);
+    
+    os_remove_cdbrules(&l_rule);
+
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        // Tests os_remove_cdblist
+        cmocka_unit_test(test_os_remove_cdblist_OK),
+        // Tests os_remove_cdbrules
+        cmocka_unit_test(test_os_remove_cdbrules_OK)
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/analysisd/test_rule_list.c
+++ b/src/unit_tests/analysisd/test_rule_list.c
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../headers/shared.h"
+#include "../../analysisd/eventinfo.h"
+#include "../../analysisd/cdb/cdb.h"
+#include "../../analysisd/analysisd.h"
+
+void os_count_rules(RuleNode *node, int *num_rules);
+void os_remove_rulenode(RuleNode *node, RuleInfo **rules, int *pos, int *max_size);
+void os_remove_ruleinfo(RuleInfo *ruleinfo);
+void os_remove_rules_list(RuleNode *node);
+
+/* setup/teardown */
+
+
+
+/* wraps */
+
+void __wrap_OSMatch_FreePattern(OSMatch *reg) {
+    return;
+}
+
+void __wrap_OSRegex_FreePattern(OSRegex *reg) {
+    return;
+}
+
+void __wrap_os_remove_cdbrules(ListRule **l_rule) {
+    os_free(*l_rule);
+    return;
+}
+
+/* tests */
+
+/* os_count_rules */
+void test_os_count_rules_no_child(void **state)
+{
+    RuleNode *node;
+    os_calloc(1,sizeof(RuleNode), node);
+
+    int num_rules = 0;
+
+    os_count_rules(node, &num_rules);
+
+    os_free(node);
+
+}
+
+void test_os_count_rules_child(void **state)
+{
+    RuleNode *node;
+    os_calloc(1, sizeof(RuleNode), node);
+    os_calloc(1, sizeof(OSDecoderNode), node->child);
+
+    int num_rules = 0;
+
+    os_count_rules(node, &num_rules);
+
+    os_free(node->child);
+    os_free(node);
+
+}
+
+/* os_remove_rulenode */
+void test_os_remove_rulenode_no_child(void **state)
+{
+    int pos = 0;
+    int max_size = 2;
+
+    RuleNode * node;
+    os_calloc(1, sizeof(RuleNode), node);
+    os_calloc(1, sizeof(RuleInfo), node->ruleinfo);
+    node->ruleinfo->internal_saving = false;
+
+    RuleInfo **rules_info;
+    os_calloc(1, sizeof(OSDecoderInfo *), rules_info);
+
+    int num_decoders = 0;
+
+    os_remove_rulenode(node, rules_info, &pos, &max_size);
+
+    os_free(rules_info[0]);
+    os_free(rules_info);
+
+}
+
+void test_os_remove_rulenode_child(void **state)
+{
+    int pos = 0;
+    int max_size = 2;
+
+    RuleNode * node;
+    os_calloc(1, sizeof(RuleNode), node);
+    os_calloc(1, sizeof(RuleNode), node->child);
+    os_calloc(1, sizeof(RuleInfo), node->ruleinfo);
+    os_calloc(1, sizeof(RuleInfo), node->child->ruleinfo);
+    node->ruleinfo->internal_saving = false;
+    node->child->ruleinfo->internal_saving = false;
+
+    RuleInfo **rules_info;
+    os_calloc(2, sizeof(RuleInfo *), rules_info);
+
+    int num_decoders = 0;
+
+    os_remove_rulenode(node, rules_info, &pos, &max_size);
+
+    os_free(rules_info[0]);
+    os_free(rules_info[1]);
+    os_free(rules_info);
+
+}
+
+/* os_remove_ruleinfo */
+void test_os_remove_ruleinfo_NULL(void **state)
+{
+    RuleInfo *ruleinfo = NULL;
+
+    os_remove_ruleinfo(ruleinfo);
+
+}
+
+void test_os_remove_ruleinfo_OK(void **state)
+{
+    RuleInfo *ruleinfo;
+    os_calloc(1, sizeof(RuleInfo), ruleinfo);
+
+    os_calloc(2, sizeof(char*), ruleinfo->ignore_fields);
+    os_strdup("test_ignore_fields", ruleinfo->ignore_fields[0]);
+
+    os_calloc(2, sizeof(char*), ruleinfo->ckignore_fields);
+    os_strdup("test_ckignore_felds", ruleinfo->ckignore_fields[0]);
+
+    os_calloc(2, sizeof(os_ip*), ruleinfo->srcip);
+    os_calloc(1, sizeof(os_ip), ruleinfo->srcip[0]);
+    os_strdup("0.0.0.0", ruleinfo->srcip[0]->ip);
+
+    os_calloc(2, sizeof(os_ip*), ruleinfo->dstip);
+    os_calloc(1, sizeof(os_ip), ruleinfo->dstip[0]);
+    os_strdup("0.0.0.0", ruleinfo->dstip[0]->ip);
+
+    os_calloc(2, sizeof(FieldInfo*), ruleinfo->fields);
+    os_calloc(1, sizeof(FieldInfo), ruleinfo->fields[0]);
+    os_strdup("test_name", ruleinfo->fields[0]->name);
+    os_calloc(1, sizeof(OSRegex), ruleinfo->fields[0]->regex);
+
+    os_calloc(1, sizeof(RuleInfoDetail), ruleinfo->info_details);
+
+    os_calloc(2, sizeof(active_response*), ruleinfo->ar);
+    os_calloc(1, sizeof(active_response), ruleinfo->ar[0]);
+    os_strdup("test_ar_name", ruleinfo->ar[0]->name);
+    os_strdup("test_ar_command", ruleinfo->ar[0]->command);
+    os_strdup("test_ar_agent_id", ruleinfo->ar[0]->agent_id);
+    os_strdup("test_ar_rules_id", ruleinfo->ar[0]->rules_id);
+    os_strdup("testtest_ar_rules_group", ruleinfo->ar[0]->rules_group);
+    os_calloc(1, sizeof(ar_command), ruleinfo->ar[0]->ar_cmd);
+    os_strdup("test_ar_command_name", ruleinfo->ar[0]->ar_cmd->name);
+    os_strdup("test_ar_command_executable", ruleinfo->ar[0]->ar_cmd->executable);
+    os_strdup("test_ar_command_extra_args", ruleinfo->ar[0]->ar_cmd->extra_args);
+    
+    os_calloc(1, sizeof(ListRule), ruleinfo->lists);
+
+    os_calloc(2, sizeof(char*), ruleinfo->same_fields);
+    os_strdup("test_same_fields", ruleinfo->same_fields[0]);
+
+    os_calloc(2, sizeof(char*), ruleinfo->not_same_fields);
+    os_strdup("test_not_same_fields", ruleinfo->not_same_fields[0]);
+
+    os_calloc(2, sizeof(char*), ruleinfo->mitre_id);
+    os_strdup("test_mitre_id", ruleinfo->mitre_id[0]);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->match);
+
+    os_calloc(1, sizeof(OSRegex), ruleinfo->regex);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->dstgeoip);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->srcport);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->dstport);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->user);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->url);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->id);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->status);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->hostname);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->program_name);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->data);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->extra_data);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->location);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->system_name);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->protocol);
+
+    os_calloc(1, sizeof(OSRegex), ruleinfo->if_matched_regex);
+
+    os_calloc(1, sizeof(OSMatch), ruleinfo->if_matched_group);
+
+    os_remove_ruleinfo(ruleinfo);
+
+}
+
+/* os_remove_rules_list */
+void test_os_remove_rules_list_OK(void **state)
+{
+    RuleNode *node;
+    os_calloc(1,sizeof(RuleNode), node);
+
+    os_calloc(1, sizeof(RuleInfo), node->ruleinfo);
+
+    os_calloc(2, sizeof(char*), node->ruleinfo->ignore_fields);
+    os_strdup("test_ignore_fields", node->ruleinfo->ignore_fields[0]);
+
+    os_calloc(2, sizeof(char*), node->ruleinfo->ckignore_fields);
+    os_strdup("test_ckignore_felds", node->ruleinfo->ckignore_fields[0]);
+
+    os_calloc(2, sizeof(os_ip*), node->ruleinfo->srcip);
+    os_calloc(1, sizeof(os_ip), node->ruleinfo->srcip[0]);
+    os_strdup("0.0.0.0", node->ruleinfo->srcip[0]->ip);
+
+    os_calloc(2, sizeof(os_ip*), node->ruleinfo->dstip);
+    os_calloc(1, sizeof(os_ip), node->ruleinfo->dstip[0]);
+    os_strdup("0.0.0.0", node->ruleinfo->dstip[0]->ip);
+
+    os_calloc(2, sizeof(FieldInfo*), node->ruleinfo->fields);
+    os_calloc(1, sizeof(FieldInfo), node->ruleinfo->fields[0]);
+    os_strdup("test_name", node->ruleinfo->fields[0]->name);
+    os_calloc(1, sizeof(OSRegex), node->ruleinfo->fields[0]->regex);
+
+    os_calloc(1, sizeof(RuleInfoDetail), node->ruleinfo->info_details);
+
+    os_calloc(2, sizeof(active_response*), node->ruleinfo->ar);
+    os_calloc(1, sizeof(active_response), node->ruleinfo->ar[0]);
+    os_strdup("test_ar_name", node->ruleinfo->ar[0]->name);
+    os_strdup("test_ar_command", node->ruleinfo->ar[0]->command);
+    os_strdup("test_ar_agent_id", node->ruleinfo->ar[0]->agent_id);
+    os_strdup("test_ar_rules_id", node->ruleinfo->ar[0]->rules_id);
+    os_strdup("testtest_ar_rules_group", node->ruleinfo->ar[0]->rules_group);
+    os_calloc(1, sizeof(ar_command), node->ruleinfo->ar[0]->ar_cmd);
+    os_strdup("test_ar_command_name", node->ruleinfo->ar[0]->ar_cmd->name);
+    os_strdup("test_ar_command_executable", node->ruleinfo->ar[0]->ar_cmd->executable);
+    os_strdup("test_ar_command_extra_args", node->ruleinfo->ar[0]->ar_cmd->extra_args);
+    
+    os_calloc(1, sizeof(ListRule), node->ruleinfo->lists);
+
+    os_calloc(2, sizeof(char*), node->ruleinfo->same_fields);
+    os_strdup("test_same_fields", node->ruleinfo->same_fields[0]);
+
+    os_calloc(2, sizeof(char*), node->ruleinfo->not_same_fields);
+    os_strdup("test_same_fields", node->ruleinfo->not_same_fields[0]);
+
+    os_calloc(2, sizeof(char*), node->ruleinfo->mitre_id);
+    os_strdup("test_mitre_id", node->ruleinfo->mitre_id[0]);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->match);
+
+    os_calloc(1, sizeof(OSRegex), node->ruleinfo->regex);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->dstgeoip);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->srcport);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->dstport);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->user);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->url);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->id);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->status);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->hostname);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->program_name);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->data);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->extra_data);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->location);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->system_name);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->protocol);
+
+    os_calloc(1, sizeof(OSRegex), node->ruleinfo->if_matched_regex);
+
+    os_calloc(1, sizeof(OSMatch), node->ruleinfo->if_matched_group);
+
+    os_remove_rules_list(node);
+
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        // Tests os_count_rules
+        cmocka_unit_test(test_os_count_rules_no_child),
+        cmocka_unit_test(test_os_count_rules_child),
+        // Tests os_remove_rulenode
+        cmocka_unit_test(test_os_remove_rulenode_no_child),
+        cmocka_unit_test(test_os_remove_rulenode_child),
+        // Tests os_remove_ruleinfo
+        cmocka_unit_test(test_os_remove_ruleinfo_NULL),
+        cmocka_unit_test(test_os_remove_ruleinfo_OK),
+        // Tests os_remove_rules_list
+        cmocka_unit_test(test_os_remove_rules_list_OK)
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5597|

## Description

This issue covers the first round of unit tests for the new wazuh-logtest module. The tests to be developed will be those of the following functions:

**logtest.c**
- [x] w_logtest_init
- [x] w_logtest_init_parameters
- [x] w_logtest_remove_session
- [x] w_logtest_check_inactive_sessions
- [x] w_logtest_fts_init

**decoder_list.c**
- [x] os_remove_decoders_list
- [x] os_remove_decodernode
- [x] os_count_decoders

**decoder-xml.c**
- [x] FreeDecoderInfo

**list_list.c**
- [x] os_remove_cdblist
- [x] os_remove_cdbrules

**rule_list.c**
- [x] os_remove_rules_list
- [x] os_remove_rulenode
- [x] os_remove_ruleinfo
- [x] os_count_rules

**eventinfo_list.c**
- [x] os_remove_eventlist