### PR TITLE
Changed the default manager-agent connection protocol to TCP

### DIFF
--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -26,7 +26,7 @@
   <remote>
     <connection>secure</connection>
     <port>1514</port>
-    <protocol>udp</protocol>
+    <protocol>tcp</protocol>
   </remote>
 
   <!-- Policy monitoring -->

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -26,7 +26,7 @@
   <remote>
     <connection>secure</connection>
     <port>1514</port>
-    <protocol>udp</protocol>
+    <protocol>tcp</protocol>
   </remote>
 
   <!-- Policy monitoring -->

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -31,7 +31,7 @@
   <remote>
     <connection>secure</connection>
     <port>1514</port>
-    <protocol>udp</protocol>
+    <protocol>tcp</protocol>
   </remote>
 
   <!-- Policy monitoring -->

--- a/etc/templates/config/generic/remote-secure.template
+++ b/etc/templates/config/generic/remote-secure.template
@@ -1,6 +1,6 @@
   <remote>
     <connection>secure</connection>
     <port>1514</port>
-    <protocol>udp</protocol>
+    <protocol>tcp</protocol>
     <queue_size>131072</queue_size>
   </remote>

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -23,7 +23,7 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     char f_ip[128] = {'\0'};
     char * rip = NULL;
     int port = DEFAULT_SECURE;
-    int protocol = IPPROTO_UDP;
+    int protocol = IPPROTO_TCP;
 
     /* XML definitions */
     const char *xml_client_server = "server";
@@ -229,7 +229,7 @@ int Read_Client_Server(XML_NODE node, agent * logr)
     char * rip = NULL;
     /* Default values */
     int port = DEFAULT_SECURE;
-    int protocol = IPPROTO_UDP;
+    int protocol = IPPROTO_TCP;
     int max_retries = DEFAULT_MAX_RETRIES; 
     int retry_interval = DEFAULT_RETRY_INTERVAL;
 

--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -233,7 +233,11 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 
     /* Set default protocol */
     if (logr->proto[pl] == 0) {
+#if defined(__linux__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+        logr->proto[pl] = IPPROTO_TCP;
+#else
         logr->proto[pl] = IPPROTO_UDP;
+#endif
     }
 
     /* Queue_size is only for secure connections */

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -343,7 +343,7 @@ WriteAgent()
       echo "      <address>$HNAME</address>" >> $NEWCONFIG
     fi
     echo "      <port>1514</port>" >> $NEWCONFIG
-    echo "      <protocol>udp</protocol>" >> $NEWCONFIG
+    echo "      <protocol>tcp</protocol>" >> $NEWCONFIG
     echo "    </server>" >> $NEWCONFIG
     if [ "X${USER_AGENT_CONFIG_PROFILE}" != "X" ]; then
          PROFILE=${USER_AGENT_CONFIG_PROFILE}

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -70,7 +70,7 @@ add_adress_block() {
         echo "    <server>" >> ${DIRECTORY}/etc/ossec.conf
         echo "      <address>$i</address>" >> ${DIRECTORY}/etc/ossec.conf
         echo "      <port>1514</port>" >> ${DIRECTORY}/etc/ossec.conf
-        echo "      <protocol>udp</protocol>" >> ${DIRECTORY}/etc/ossec.conf
+        echo "      <protocol>tcp</protocol>" >> ${DIRECTORY}/etc/ossec.conf
         echo "    </server>" >> ${DIRECTORY}/etc/ossec.conf
     done
 

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -101,7 +101,7 @@ If objFSO.fileExists(home_dir & "ossec.conf") Then
                     formatted_list = formatted_list & "    <server>" & vbCrLf
                     formatted_list = formatted_list & "      <address>" & ip & "</address>" & vbCrLf
                     formatted_list = formatted_list & "      <port>1514</port>" & vbCrLf
-                    formatted_list = formatted_list & "      <protocol>udp</protocol>" & vbCrLf
+                    formatted_list = formatted_list & "      <protocol>tcp</protocol>" & vbCrLf
                     formatted_list = formatted_list & "    </server>" & vbCrLf
                 End If
             next

--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -10,7 +10,7 @@
     <server>
       <address>0.0.0.0</address>
       <port>1514</port>
-      <protocol>udp</protocol>
+      <protocol>tcp</protocol>
     </server>
     <crypto_method>aes</crypto_method>
     <notify_time>10</notify_time>

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -10,7 +10,7 @@
     <server>
       <address>0.0.0.0</address>
       <port>1514</port>
-      <protocol>udp</protocol>
+      <protocol>tcp</protocol>
     </server>
     <crypto_method>aes</crypto_method>
     <notify_time>10</notify_time>


### PR DESCRIPTION
|Related issue|
|---|
|#5579|

## Description
I have replaced the `<protocol>` option value to tcp in some configuration files and the `<remote>` configuration template. Also, I have changed the default protocol option value to TCP in the ossec-agentd/ossec-remoted configuration parser. In that way, the connection protocol between Manager and Agent will be TCP by default.

## Configuration options
### Manager
```xml
  <remote>
    <connection>secure</connection>
    <port>1514</port>
    <protocol>tcp</protocol>
    <queue_size>131072</queue_size>
  </remote>
```
or
```xml
  <remote>
    <connection>secure</connection>
    <port>1514</port>
    <queue_size>131072</queue_size>
  </remote>
```
### Agent
```xml
<client>
    <server>
      <address>MANAGER_IP</address>
      <port>1514</port>
      <protocol>tcp</protocol>
    </server>
    ...
</client>
```
or 

```xml
<client>
    <server>
      <address>MANAGER_IP</address>
      <port>1514</port>
    </server>
    ...
</client>
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
  - [x] Manager: Ubuntu
  - [x] Manager: Centos
  - [x] Agent: Ubuntu
  - [x] Agent: Centos
  - [x] Agent: Windows
  - [x] Agent: MacOS
- [x] Package installation
  - [x] Manager: Ubuntu
  - [x] Manager: Centos
  - [x] Agent: Ubuntu
  - [x] Agent: Centos
  - [x] Agent: Windows
