### PR TITLE
[5670] Adding support for compound primary keys in DBSync library

### DIFF
--- a/src/dbsync/src/db_exception.h
+++ b/src/dbsync/src/db_exception.h
@@ -26,7 +26,7 @@ constexpr auto INVALID_PK_DATA          { std::make_pair(10, "Primary key not fo
 constexpr auto INVALID_COLUMN_TYPE      { std::make_pair(11, "Invalid column field type.") };
 constexpr auto INVALID_DATA_BIND        { std::make_pair(12, "Invalid data to bind.") };
 constexpr auto INVALID_TABLE            { std::make_pair(13, "Invalid table.") };
-constexpr auto INVALID_DELETE_INFO      { std::make_pair(13, "Invalid information provided for deletion.") };
+constexpr auto INVALID_DELETE_INFO      { std::make_pair(14, "Invalid information provided for deletion.") };
 
 namespace DbSync
 {

--- a/src/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -75,10 +75,10 @@ void SQLiteDBEngine::bulkInsert(const std::string& table,
 void SQLiteDBEngine::refreshTableData(const nlohmann::json& data,
                                       const DbSync::ResultCallback callback)
 {
-    const std::string table { data["table"].is_string() ? data["table"].get_ref<const std::string&>() : "" };
+    const std::string table { data.at("table").is_string() ? data.at("table").get_ref<const std::string&>() : "" };
     if (createCopyTempTable(table))
     {
-        bulkInsert(table + TEMP_TABLE_SUBFIX, data["data"]);
+        bulkInsert(table + TEMP_TABLE_SUBFIX, data.at("data"));
         if (0 != loadTableData(table))
         {
             std::vector<std::string> primaryKeyList;
@@ -153,10 +153,10 @@ void SQLiteDBEngine::syncTableRowData(const std::string& table,
         {
             ReturnTypeCallback resultCbType{ MODIFIED };
             nlohmann::json jsResult;
-            const bool diffExist { getRowDiff(primaryKeyList, table, data[0], jsResult) };
+            const bool diffExist { getRowDiff(primaryKeyList, table, data.at(0), jsResult) };
             if (diffExist)
             {
-                const nlohmann::json jsDataToUpdate{getDataToUpdate(primaryKeyList, jsResult, data[0], inTransaction)};
+                const nlohmann::json jsDataToUpdate{getDataToUpdate(primaryKeyList, jsResult, data.at(0), inTransaction)};
                 if (!jsDataToUpdate[0].empty())
                 {
                     const auto& transaction { m_sqliteFactory->createTransaction(m_sqliteConnection)};
@@ -487,7 +487,7 @@ bool SQLiteDBEngine::loadFieldData(const std::string& table)
             m_tableFields[table].push_back(std::make_tuple(stmt->column(0)->value(int32_t{}),
                                            fieldName,
                                            columnTypeName(stmt->column(2)->value(std::string{})),
-                                           1 == stmt->column(5)->value(int32_t{}),
+                                           0 != stmt->column(5)->value(int32_t{}),
                                            InternalColumnNames.end() != std::find(InternalColumnNames.begin(), 
                                            InternalColumnNames.end(), fieldName)));
         }
@@ -1004,7 +1004,7 @@ bool SQLiteDBEngine::getRowDiff(const std::vector<std::string>& primaryKeyList,
 
         if(it != tableFields.end())
         {
-            jsResult[pkValue] = data[pkValue];
+            jsResult[pkValue] = data.at(pkValue);
             bindJsonData(stmt, *it, data, index);
             ++index;
         }

--- a/src/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.h
@@ -150,13 +150,15 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
         std::string buildInsertBulkDataSqlQuery(const std::string& table);
 
         std::string buildDeleteBulkDataSqlQuery(const std::string& table, 
-                                                const std::vector<std::string>& primaryKeyList);
+                                                const std::vector<std::string>& primaryKeyList,
+                                                const nlohmann::json& jsData = {});
+
         std::string buildSelectQuery(const std::string& table,
                                      const nlohmann::json& jsQuery);
 
         ColumnType columnTypeName(const std::string& type);
 
-        void bindJsonData(std::unique_ptr<SQLite::IStatement>const & stmt, 
+        bool bindJsonData(const std::unique_ptr<SQLite::IStatement>& stmt,
                           const ColumnData& cd,
                           const nlohmann::json::value_type& valueType,
                           const unsigned int cid);

--- a/src/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/dbsync/tests/interface/dbsync_test.cpp
@@ -173,7 +173,9 @@ TEST_F(DBSyncTest, InsertData)
 TEST_F(DBSyncTest, InsertDataWithCompoundPKs)
 {
     const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `tid` BIGINT, PRIMARY KEY (`pid`, `tid`)) WITHOUT ROWID;"};
-    const auto insertionSqlStmt{ R"({"table":"processes","data":[{"pid":4,"name":"System", "tid":"100"}]})"};
+    const auto insertionSqlStmt{ R"({"table":"processes","data":[{"pid":4,"name":"System", "tid":"100"},
+                                                                 {"pid":5,"name":"User1", "tid":101},
+                                                                 {"pid":6,"name":"User2", "tid":102}]})"};
     
     const auto handle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
     ASSERT_NE(nullptr, handle);
@@ -1133,8 +1135,8 @@ TEST_F(DBSyncTest, deleteSingleDataByCompoundPK)
     const std::unique_ptr<cJSON, smartDeleterJson> jsMissingPKPID{ cJSON_Parse(singleRowWithoutCompleteCompoundPK) };
 
     EXPECT_EQ(0, dbsync_sync_row(handle, jsInitialData.get(), callbackData));  // Expect an insert event
-    EXPECT_EQ(0, dbsync_delete_rows(handle, jsSingleDeletion.get())); // It succeed and deletes the row.
-    EXPECT_EQ(0, dbsync_delete_rows(handle, jsMissingPKPID.get()));   // It succeed but doesn't delete the row.
+    EXPECT_EQ(0, dbsync_delete_rows(handle, jsSingleDeletion.get()));
+    EXPECT_EQ(0, dbsync_delete_rows(handle, jsMissingPKPID.get()));
 }
 
 TEST_F(DBSyncTest, deleteRowsByFilter)

--- a/src/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/dbsync/tests/interface/dbsync_test.cpp
@@ -161,6 +161,19 @@ TEST_F(DBSyncTest, InsertData)
 {
     const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, PRIMARY KEY (`pid`)) WITHOUT ROWID;"};
     const auto insertionSqlStmt{ R"({"table":"processes","data":[{"pid":4,"name":"System"}]})"};
+
+    const auto handle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
+    ASSERT_NE(nullptr, handle);
+
+    const std::unique_ptr<cJSON, smartDeleterJson> jsInsert{ cJSON_Parse(insertionSqlStmt) };
+
+    EXPECT_EQ(0, dbsync_insert_data(handle, jsInsert.get()));
+}
+
+TEST_F(DBSyncTest, InsertDataWithCompoundPKs)
+{
+    const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `tid` BIGINT, PRIMARY KEY (`pid`, `tid`)) WITHOUT ROWID;"};
+    const auto insertionSqlStmt{ R"({"table":"processes","data":[{"pid":4,"name":"System", "tid":"100"}]})"};
     
     const auto handle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
     ASSERT_NE(nullptr, handle);
@@ -1078,6 +1091,50 @@ TEST_F(DBSyncTest, deleteSingleAndComposedData)
     EXPECT_NE(0, dbsync_delete_rows(handle, nullptr));
     EXPECT_NE(0, dbsync_delete_rows(handle, jsWithoutTable.get()));
     EXPECT_NE(0, dbsync_delete_rows(reinterpret_cast<void *>(0xffffffff), jsSingleDeletion.get()));
+}
+
+TEST_F(DBSyncTest, deleteSingleDataByCompoundPK)
+{
+    const auto sql{ "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `tid` BIGINT, PRIMARY KEY (`pid`, `tid`)) WITHOUT ROWID;"};
+    const auto handle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
+    ASSERT_NE(nullptr, handle);
+
+    CallbackMock wrapper;
+    EXPECT_CALL(wrapper, callbackMock(INSERTED,
+                nlohmann::json::parse(R"([{"pid":4,"name":"System", "tid":100},
+                                          {"pid":5,"name":"System", "tid":101},
+                                          {"pid":6,"name":"System", "tid":102},
+                                          {"pid":7,"name":"System", "tid":103},
+                                          {"pid":8,"name":"System", "tid":104}])"))).Times(1);
+
+    const auto initialData{ R"({"table":"processes","data":[{"pid":4,"name":"System", "tid":100},
+                                                            {"pid":5,"name":"System", "tid":101},
+                                                            {"pid":6,"name":"System", "tid":102},
+                                                            {"pid":7,"name":"System", "tid":103},
+                                                            {"pid":8,"name":"System", "tid":104}]})"};
+
+    const auto singleRowToDelete
+    {
+        R"({"table":"processes",
+           "query":{"data":[{"pid":4, "tid":100}],
+           "where_filter_opt":""}})"
+    };
+
+    const auto singleRowWithoutCompleteCompoundPK
+    {
+        R"({"table":"processes",
+           "query":{"data":[{"tid":101}],
+                    "where_filter_opt":""}})"
+    };
+
+    callback_data_t callbackData { callback, &wrapper };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsInitialData{ cJSON_Parse(initialData) };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsSingleDeletion{ cJSON_Parse(singleRowToDelete) };
+    const std::unique_ptr<cJSON, smartDeleterJson> jsMissingPKPID{ cJSON_Parse(singleRowWithoutCompleteCompoundPK) };
+
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsInitialData.get(), callbackData));  // Expect an insert event
+    EXPECT_EQ(0, dbsync_delete_rows(handle, jsSingleDeletion.get())); // It succeed and deletes the row.
+    EXPECT_EQ(0, dbsync_delete_rows(handle, jsMissingPKPID.get()));   // It succeed but doesn't delete the row.
 }
 
 TEST_F(DBSyncTest, deleteRowsByFilter)


### PR DESCRIPTION
# Compound primary keys support

|Related issue|
|---|
|[5670](https://github.com/wazuh/wazuh/issues/5670)|

## Description
The goal of this issue is to extend the existent code to support compound primary keys like:
`CREATE TABLE processes(pid BIGINT, nameTEXT, tid BIGINT, PRIMARY KEY (pid, tid)) WITHOUT ROWID;`
This is a result of the assessment done as part of the issue #5632

## DoD
- [X] Development
- [X] RTR Tool execution
![image](https://user-images.githubusercontent.com/22640902/89960767-4c8e3200-dc16-11ea-940f-5f268d126426.png)

