### PR TITLE
Fix compilation error in old versions of GCC

### DIFF
--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -143,7 +143,7 @@ struct _EventNode {
     EventNode *prev;
 };
 
-typedef struct EventList {
+struct EventList {
     EventNode *first_node;
     EventNode *last_node;
     EventNode *last_added_node;
@@ -152,7 +152,7 @@ typedef struct EventList {
     int _memorymaxsize;
     int _max_freq;
     pthread_mutex_t event_mutex;
-} EventList;
+};
 
 #ifdef TESTRULE
 extern int full_output;


### PR DESCRIPTION
Hello team,

The compilation in old GCC versions cause the following error:

```
./analysisd/eventinfo.h:155: error: redefinition of typedef 'EventList'
./analysisd/rules.h:86: note: previous declaration of 'EventList' was here
```

This PR solves it

Regards,
Eva

## Tests

- [x] Compilation without warnings in old and new GCC versions (Red Hat 4.4.7-23 and Ubuntu 9.3.0-10ubuntu2)
- [x] Scan-build report (Ubuntu 20.04 - GCC 9.3.0)

