### PR TITLE
Improve enrollment log messages

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -282,7 +282,7 @@ int try_enroll_to_server(const char * server_rip) {
     int enroll_result = w_enrollment_request_key(agt->enrollment_cfg, server_rip);
     if (enroll_result == 0) {
         /* Wait for key update on agent side */
-        minfo("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
+        minfo("Waiting %d seconds before server connection", agt->enrollment_cfg->delay_after_enrollment);
         sleep(agt->enrollment_cfg->delay_after_enrollment);
         /* Successfull enroll, read keys */
         OS_UpdateKeys(&keys);

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -282,7 +282,7 @@ int try_enroll_to_server(const char * server_rip) {
     int enroll_result = w_enrollment_request_key(agt->enrollment_cfg, server_rip);
     if (enroll_result == 0) {
         /* Wait for key update on agent side */
-        mdebug1("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
+        minfo("Sleeping %d seconds to allow manager key file updates", agt->enrollment_cfg->delay_after_enrollment);
         sleep(agt->enrollment_cfg->delay_after_enrollment);
         /* Successfull enroll, read keys */
         OS_UpdateKeys(&keys);

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -115,7 +115,7 @@ void w_enrollment_destroy(w_enrollment_ctx *cfg) {
 int w_enrollment_request_key(w_enrollment_ctx *cfg, const char * server_address) {
     assert(cfg != NULL);
     int ret = -1;
-    minfo("Starting enrollment process to server: %s", server_address ? server_address : cfg->target_cfg->manager_name);
+    minfo("Requesting a key to server: %s", server_address ? server_address : cfg->target_cfg->manager_name);
     int socket = w_enrollment_connect(cfg, server_address ? server_address : cfg->target_cfg->manager_name);
     if ( socket >= 0) {
         w_enrollment_load_pass(cfg->cert_cfg);
@@ -236,7 +236,7 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
         return ENROLLMENT_CONNECTION_FAILURE;
     }
 
-    minfo("Connected to %s:%d", ip_address, cfg->target_cfg->port);
+    mdebug1("Connected to %s:%d", ip_address, cfg->target_cfg->port);
 
     w_enrollment_verify_ca_certificate(cfg->ssl, cfg->cert_cfg->ca_cert, server_address);
     
@@ -296,7 +296,7 @@ static int w_enrollment_send_message(w_enrollment_ctx *cfg) {
             os_free(lhostname);
         return -1;
     }
-    minfo("Request sent to manager");
+    mdebug1("Request sent to manager");
 
     os_free(buf);
     if(lhostname != cfg->target_cfg->agent_name)
@@ -337,7 +337,6 @@ static int w_enrollment_process_response(SSL *ssl) {
                 }
             }
         } else if (strncmp(buf, "OSSEC K:'", 9) == 0) {
-            minfo("Received response with agent key");
             status = w_enrollment_process_agent_key(buf);
             break;
         }
@@ -348,7 +347,7 @@ static int w_enrollment_process_response(SSL *ssl) {
     {
     case SSL_ERROR_NONE:
     case SSL_ERROR_ZERO_RETURN:
-        minfo("Connection closed.");
+        mdebug1("Connection closed.");
         break;
     default:
         if(!manager_error) {
@@ -434,11 +433,11 @@ static int w_enrollment_process_agent_key(char *buffer) {
             OS_IsValidIP(entrys[ENTRY_IP], NULL) && OS_IsValidName(entrys[ENTRY_KEY])) {
         if( !w_enrollment_store_key_entry(keys) ) {
             // Key was stored
-            minfo("Valid key created. Finished.");
+            minfo("Valid key received");
             ret = 0;
         }
     } else {
-        merror("One of the received key parameters does not have a valid format.");
+        merror("One of the received key parameters does not have a valid format");
     }
     int i;
     for(i=0; i<4; i++){
@@ -460,13 +459,13 @@ static void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_ce
     if (ca_cert) {
         minfo("Verifying manager's certificate");
         if (check_x509_cert(ssl, hostname) != VERIFY_TRUE) {
-            merror("Unable to verify server certificate.");
+            merror("Unable to verify server certificate");
         } else {
             minfo("Manager has been verified successfully");
         }
     }
     else {
-        minfo("Registering agent to unverified manager.");
+        minfo("Registering agent to unverified manager");
     }
 }
 
@@ -551,7 +550,7 @@ static void w_enrollment_load_pass(w_enrollment_cert *cert_cfg) {
         }
 
         if (!cert_cfg->authpass) {
-            minfo("No authentication password provided.");
+            minfo("No authentication password provided");
         }
     }
 }

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -115,7 +115,7 @@ void w_enrollment_destroy(w_enrollment_ctx *cfg) {
 int w_enrollment_request_key(w_enrollment_ctx *cfg, const char * server_address) {
     assert(cfg != NULL);
     int ret = -1;
-    minfo("Requesting a key to server: %s", server_address ? server_address : cfg->target_cfg->manager_name);
+    minfo("Requesting a key from server: %s", server_address ? server_address : cfg->target_cfg->manager_name);
     int socket = w_enrollment_connect(cfg, server_address ? server_address : cfg->target_cfg->manager_name);
     if ( socket >= 0) {
         w_enrollment_load_pass(cfg->cert_cfg);
@@ -321,7 +321,7 @@ static int w_enrollment_process_response(SSL *ssl) {
     os_calloc(OS_SIZE_65536 + OS_SIZE_4096 + 1, sizeof(char), buf);
     buf[OS_SIZE_65536 + OS_SIZE_4096] = '\0';
 
-    minfo("Waiting for manager reply");
+    minfo("Waiting for server reply");
 
     while(ret = SSL_read(ssl, buf, OS_SIZE_65536 + OS_SIZE_4096), ret > 0) {
         buf[ret] = '\0';
@@ -465,7 +465,7 @@ static void w_enrollment_verify_ca_certificate(const SSL *ssl, const char *ca_ce
         }
     }
     else {
-        minfo("Registering agent to unverified manager");
+        mdebug1("Registering agent to unverified manager");
     }
 }
 

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -23,7 +23,7 @@ list(APPEND shared_tests_flags "-Wl,--wrap,_merror")
 
 list(APPEND shared_tests_names "test_enrollment_op")
 set(ENROLLMENT_OP_BASE_FLAGS "-Wl,--wrap=OS_IsValidIP,--wrap=_merror,--wrap=_mwarn,--wrap=check_x509_cert \
-                                -Wl,--wrap=_minfo,--wrap=OS_GetHost,--wrap=os_ssl_keys,--wrap=OS_ConnectTCP \
+                                -Wl,--wrap=_minfo,--wrap=_mdebug1,--wrap=OS_GetHost,--wrap=os_ssl_keys,--wrap=OS_ConnectTCP \
                                 -Wl,--wrap=SSL_new,--wrap=SSL_connect,--wrap=SSL_get_error,--wrap=SSL_set_bio \
                                 -Wl,--wrap=SSL_write,--wrap=fopen,--wrap=fclose,--wrap=SSL_read \
                                 -Wl,--wrap=BIO_new_socket,--wrap=_merror_exit,--wrap=TempFile,--wrap=OS_MoveFile \

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -60,6 +60,17 @@ void __wrap__minfo(const char * file, int line, const char * func, const char *m
     check_expected(formatted_msg);
 }
 
+void __wrap__mdebug1(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
 void __wrap__merror_exit(const char * file, int line, const char * func, const char *msg, ...) 
 {
     char formatted_msg[OS_MAXSTR];
@@ -463,7 +474,7 @@ void test_w_enrollment_verify_ca_certificate_null_connection(void **state) {
 
 void test_w_enrollment_verify_ca_certificate_no_certificate(void **state) {
     SSL *ssl = *state;
-    expect_string(__wrap__minfo, formatted_msg, "Registering agent to unverified manager.");
+    expect_string(__wrap__minfo, formatted_msg, "Registering agent to unverified manager");
     w_enrollment_verify_ca_certificate(ssl, NULL, "hostname");
 }
 
@@ -475,7 +486,7 @@ void test_verificy_ca_certificate_invalid_certificate(void **state) {
     will_return(__wrap_check_x509_cert, VERIFY_FALSE);
 
     expect_string(__wrap__minfo, formatted_msg, "Verifying manager's certificate");
-    expect_string(__wrap__merror, formatted_msg, "Unable to verify server certificate.");
+    expect_string(__wrap__merror, formatted_msg, "Unable to verify server certificate");
     w_enrollment_verify_ca_certificate(ssl, "BAD_CERTIFICATE", "hostname");
 }
 
@@ -618,7 +629,7 @@ void test_w_enrollment_connect_success(void **state) {
     will_return(__wrap_SSL_new, cfg->ssl);
     will_return(__wrap_SSL_connect, 1);
 
-    expect_string(__wrap__minfo, formatted_msg, "Connected to 127.0.0.1:1234");
+    expect_string(__wrap__mdebug1, formatted_msg, "Connected to 127.0.0.1:1234");
 
     // verify_ca_certificate
     expect_value(__wrap_check_x509_cert, ssl, cfg->ssl);
@@ -708,7 +719,7 @@ void test_w_enrollment_send_message_success(void **state) {
     expect_value(__wrap_SSL_write, ssl, cfg->ssl);
     expect_string(__wrap_SSL_write, buf, "OSSEC PASS: test_password OSSEC A:'test_agent' G:'test_group' IP:'192.168.1.1'\n");
     will_return(__wrap_SSL_write, 0);
-    expect_string(__wrap__minfo, formatted_msg,"Request sent to manager");
+    expect_string(__wrap__mdebug1, formatted_msg,"Request sent to manager");
     int ret = w_enrollment_send_message(cfg);
     assert_int_equal(ret, 0);
 }
@@ -786,7 +797,7 @@ void test_w_enrollment_process_agent_key_invalid_key(void **state) {
     expect_string(__wrap_OS_IsValidIP, ip_address, "NOT_AN_IP");
     expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
     will_return(__wrap_OS_IsValidIP, 0);
-    expect_string(__wrap__merror, formatted_msg, "One of the received key parameters does not have a valid format.");
+    expect_string(__wrap__merror, formatted_msg, "One of the received key parameters does not have a valid format");
     int ret = w_enrollment_process_agent_key(key);
     assert_int_equal(ret,-1);
 }
@@ -817,7 +828,7 @@ void test_w_enrollment_process_agent_key_valid_key(void **state) {
         expect_string(__wrap_OS_MoveFile, dst, KEYSFILE_PATH);
         will_return(__wrap_OS_MoveFile, 0);
     #endif
-    expect_string(__wrap__minfo, formatted_msg, "Valid key created. Finished.");
+    expect_string(__wrap__minfo, formatted_msg, "Valid key received");
     int ret = w_enrollment_process_agent_key(key);
     assert_int_equal(ret,0);
 }
@@ -853,7 +864,7 @@ void test_w_enrollment_process_response_message_error(void **state) {
     will_return(__wrap_SSL_read, 0);
     expect_value(__wrap_SSL_get_error, i, 0);
     will_return(__wrap_SSL_get_error, SSL_ERROR_NONE);
-    expect_string(__wrap__minfo, formatted_msg, "Connection closed.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Connection closed.");
     int ret = w_enrollment_process_response(ssl);
     assert_int_equal(ret, -1);
 }
@@ -864,8 +875,7 @@ void test_w_enrollment_process_response_success(void **state) {
     expect_string(__wrap__minfo, formatted_msg, "Waiting for manager reply");
     expect_value(__wrap_SSL_read, ssl, ssl);
     will_return(__wrap_SSL_read, string);
-    will_return(__wrap_SSL_read, strlen(string));
-    expect_string(__wrap__minfo, formatted_msg, "Received response with agent key");
+    will_return(__wrap_SSL_read, strlen(string));    
     // w_enrollment_process_agent_key
     {
         expect_string(__wrap_OS_IsValidIP, ip_address, "192.168.1.1");
@@ -892,11 +902,11 @@ void test_w_enrollment_process_response_success(void **state) {
             expect_string(__wrap_OS_MoveFile, dst, KEYSFILE_PATH);
             will_return(__wrap_OS_MoveFile, 0);
         #endif
-        expect_string(__wrap__minfo, formatted_msg, "Valid key created. Finished.");
+        expect_string(__wrap__minfo, formatted_msg, "Valid key received");
     }
     expect_value(__wrap_SSL_get_error, i, strlen(string));
     will_return(__wrap_SSL_get_error, SSL_ERROR_NONE);
-    expect_string(__wrap__minfo, formatted_msg, "Connection closed.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Connection closed.");
 
     int ret = w_enrollment_process_response(ssl);
     assert_int_equal(ret, 0);
@@ -911,7 +921,7 @@ void test_w_enrollment_request_key(void **state) {
     w_enrollment_ctx *cfg = *state; 
     SSL_CTX *ctx = get_ssl_context(DEFAULT_CIPHERS, 0);
     
-    expect_string(__wrap__minfo, formatted_msg, "Starting enrollment process to server: valid_hostname");
+    expect_string(__wrap__minfo, formatted_msg, "Requesting a key to server: valid_hostname");
 
     // w_enrollment_connect
     {
@@ -938,7 +948,7 @@ void test_w_enrollment_request_key(void **state) {
         will_return(__wrap_SSL_new, cfg->ssl);
         will_return(__wrap_SSL_connect, 1);
 
-        expect_string(__wrap__minfo, formatted_msg, "Connected to 192.168.1.1:1234");
+        expect_string(__wrap__mdebug1, formatted_msg, "Connected to 192.168.1.1:1234");
 
         // verify_ca_certificate
         expect_value(__wrap_check_x509_cert, ssl, cfg->ssl);
@@ -956,7 +966,7 @@ void test_w_enrollment_request_key(void **state) {
         expect_value(__wrap_SSL_write, ssl, cfg->ssl);
         expect_string(__wrap_SSL_write, buf, "OSSEC PASS: test_password OSSEC A:'test_agent' G:'test_group' IP:'192.168.1.1'\n");
         will_return(__wrap_SSL_write, 0);
-        expect_string(__wrap__minfo, formatted_msg,"Request sent to manager");
+        expect_string(__wrap__mdebug1, formatted_msg,"Request sent to manager");
     }
     // w_enrollment_process_repsonse
     {
@@ -964,8 +974,7 @@ void test_w_enrollment_request_key(void **state) {
         expect_string(__wrap__minfo, formatted_msg, "Waiting for manager reply");
         expect_value(__wrap_SSL_read, ssl, cfg->ssl);
         will_return(__wrap_SSL_read, string);
-        will_return(__wrap_SSL_read, strlen(string));
-        expect_string(__wrap__minfo, formatted_msg, "Received response with agent key");
+        will_return(__wrap_SSL_read, strlen(string));        
         // w_enrollment_process_agent_key
         {
             expect_string(__wrap_OS_IsValidIP, ip_address, "192.168.1.1");
@@ -992,11 +1001,11 @@ void test_w_enrollment_request_key(void **state) {
                 expect_string(__wrap_OS_MoveFile, dst, KEYSFILE_PATH);
                 will_return(__wrap_OS_MoveFile, 0);
             #endif
-            expect_string(__wrap__minfo, formatted_msg, "Valid key created. Finished.");
+            expect_string(__wrap__minfo, formatted_msg, "Valid key received");
         }
         expect_value(__wrap_SSL_get_error, i, strlen(string));
         will_return(__wrap_SSL_get_error, SSL_ERROR_NONE);
-        expect_string(__wrap__minfo, formatted_msg, "Connection closed.");
+        expect_string(__wrap__mdebug1, formatted_msg, "Connection closed.");
     }
     int ret = w_enrollment_request_key(cfg, NULL);
     assert_int_equal(ret, 0);
@@ -1054,7 +1063,7 @@ void test_w_enrollment_load_pass_empty_file(void **state) {
     char buff[1024];
     snprintf(buff, 1024, "Using password specified on file: %s", AUTHDPASS_PATH);
     expect_string(__wrap__minfo, formatted_msg, buff);
-    expect_string(__wrap__minfo, formatted_msg, "No authentication password provided.");
+    expect_string(__wrap__minfo, formatted_msg, "No authentication password provided");
     
     w_enrollment_load_pass(cert);
     assert_int_equal(cert->authpass, NULL);

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -474,7 +474,7 @@ void test_w_enrollment_verify_ca_certificate_null_connection(void **state) {
 
 void test_w_enrollment_verify_ca_certificate_no_certificate(void **state) {
     SSL *ssl = *state;
-    expect_string(__wrap__minfo, formatted_msg, "Registering agent to unverified manager");
+    expect_string(__wrap__mdebug1, formatted_msg, "Registering agent to unverified manager");
     w_enrollment_verify_ca_certificate(ssl, NULL, "hostname");
 }
 
@@ -840,7 +840,7 @@ void test_w_enrollment_process_response_ssl_null(void **state) {
 
 void test_w_enrollment_process_response_ssl_error(void **state) {
      SSL *ssl = *state;
-    expect_string(__wrap__minfo, formatted_msg, "Waiting for manager reply");
+    expect_string(__wrap__minfo, formatted_msg, "Waiting for server reply");
     expect_value(__wrap_SSL_read, ssl, ssl);
     will_return(__wrap_SSL_read, "");
     will_return(__wrap_SSL_read, -1);
@@ -854,7 +854,7 @@ void test_w_enrollment_process_response_ssl_error(void **state) {
 
 void test_w_enrollment_process_response_message_error(void **state) {
     SSL *ssl = *state;
-    expect_string(__wrap__minfo, formatted_msg, "Waiting for manager reply");
+    expect_string(__wrap__minfo, formatted_msg, "Waiting for server reply");
     expect_value(__wrap_SSL_read, ssl, ssl);
     will_return(__wrap_SSL_read, "ERROR: Unable to add agent.");
     will_return(__wrap_SSL_read, strlen("ERROR: Unable to add agent."));
@@ -872,7 +872,7 @@ void test_w_enrollment_process_response_message_error(void **state) {
 void test_w_enrollment_process_response_success(void **state) { 
     const char *string = "OSSEC K:'006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f'";
     SSL *ssl = *state;
-    expect_string(__wrap__minfo, formatted_msg, "Waiting for manager reply");
+    expect_string(__wrap__minfo, formatted_msg, "Waiting for server reply");
     expect_value(__wrap_SSL_read, ssl, ssl);
     will_return(__wrap_SSL_read, string);
     will_return(__wrap_SSL_read, strlen(string));    
@@ -921,7 +921,7 @@ void test_w_enrollment_request_key(void **state) {
     w_enrollment_ctx *cfg = *state; 
     SSL_CTX *ctx = get_ssl_context(DEFAULT_CIPHERS, 0);
     
-    expect_string(__wrap__minfo, formatted_msg, "Requesting a key to server: valid_hostname");
+    expect_string(__wrap__minfo, formatted_msg, "Requesting a key from server: valid_hostname");
 
     // w_enrollment_connect
     {
@@ -971,7 +971,7 @@ void test_w_enrollment_request_key(void **state) {
     // w_enrollment_process_repsonse
     {
         const char *string = "OSSEC K:'006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f'";
-        expect_string(__wrap__minfo, formatted_msg, "Waiting for manager reply");
+        expect_string(__wrap__minfo, formatted_msg, "Waiting for server reply");
         expect_value(__wrap_SSL_read, ssl, cfg->ssl);
         will_return(__wrap_SSL_read, string);
         will_return(__wrap_SSL_read, strlen(string));        

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -321,7 +321,7 @@ void InstallAuthKeys(char *msg)
         fprintf(fp, "%s\n", key);
         fclose(fp);
 
-        printf("INFO: Valid key created. Finished.\n");
+        printf("INFO: Valid key received\n");
     }
     else
         merror_exit("Unknown message received (%s)", msg);


### PR DESCRIPTION
|Related issue|
|---|
| #5714  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR changes enrollment log messages to be more user friendly.

Enrollment messages without DEBUG
![Enrollment Info](https://user-images.githubusercontent.com/11434230/89950879-d6cb9b80-dc00-11ea-992b-88532899ce6e.PNG)

Enrollment messages with DEBUG
![Enrollment Debug](https://user-images.githubusercontent.com/11434230/89950922-e945d500-dc00-11ea-8ce7-da2d9a2cc43b.PNG)




## Tests

Changes affect only Wazuh agent.
Minimal changes were implemented.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
- [X] Source installation
- [X] Log validation
- [X] Unit tests
- [X] Integration tests for agentd 