### PR TITLE
Remove the KB prefix when inserting patches into the MSU DB

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -7136,11 +7136,7 @@ int wm_vulndet_insert_msu_vul_entry(sqlite3 *db, vu_msu_vul_entry *vul) {
 
         sqlite3_bind_text(stmt, 1, vul->cveid, -1, NULL);
         sqlite3_bind_text(stmt, 2, vul->product, -1, NULL);
-        if (!strncmp(vul->patch, "KB", 2)) {
-            sqlite3_bind_text(stmt, 3, vul->patch + 2, -1, NULL);
-        } else {
-            sqlite3_bind_text(stmt, 3, vul->patch, -1, NULL);
-        }
+        sqlite3_bind_text(stmt, 3, strncmp(vul->patch, "KB", 2) ? vul->patch : vul->patch + 2, -1, NULL);
         sqlite3_bind_text(stmt, 4, vul->title, -1, NULL);
         sqlite3_bind_text(stmt, 5, vul->url, -1, NULL);
         sqlite3_bind_text(stmt, 6, vul->subtype, -1, NULL);
@@ -7169,24 +7165,12 @@ int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_dep_entry *dep) {
                 return wm_vuldet_sql_error(db, stmt);
             }
 
-            if (!strncmp(dep->patch, "KB", 2)) {
-                sqlite3_bind_text(stmt, 1, dep->patch + 2, -1, NULL);
-            } else {
-                sqlite3_bind_text(stmt, 1, dep->patch, -1, NULL);
-            }
-            if (!strncmp(dep->supers[i], "KB", 2)) {
-                sqlite3_bind_text(stmt, 2, dep->supers[i] + 2, -1, NULL);
+            sqlite3_bind_text(stmt, 1, strncmp(dep->patch, "KB", 2) ? dep->patch : dep->patch + 2, -1, NULL);
+            sqlite3_bind_text(stmt, 2, strncmp(dep->supers[i], "KB", 2) ? dep->supers[i] : dep->supers[i] + 2, -1, NULL);
 
-                // A super can be a patch too, so non-duplicated ones will be added as rows
-                sqlite3_bind_text(stmt, 3, dep->supers[i] + 2, -1, NULL);
-                sqlite3_bind_text(stmt, 4, dep->supers[i] + 2, -1, NULL);
-            } else {
-                sqlite3_bind_text(stmt, 2, dep->supers[i], -1, NULL);
-
-                // A super can be a patch too, so non-duplicated ones will be added as rows
-                sqlite3_bind_text(stmt, 3, dep->supers[i], -1, NULL);
-                sqlite3_bind_text(stmt, 4, dep->supers[i], -1, NULL);
-            }
+            // A super can be a patch too, so non-duplicated ones will be added as rows
+            sqlite3_bind_text(stmt, 3, strncmp(dep->supers[i], "KB", 2) ? dep->supers[i] : dep->supers[i] + 2, -1, NULL);
+            sqlite3_bind_text(stmt, 4, strncmp(dep->supers[i], "KB", 2) ? dep->supers[i] : dep->supers[i] + 2, -1, NULL);
 
             if (result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
                 return wm_vuldet_sql_error(db, stmt);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -7136,7 +7136,11 @@ int wm_vulndet_insert_msu_vul_entry(sqlite3 *db, vu_msu_vul_entry *vul) {
 
         sqlite3_bind_text(stmt, 1, vul->cveid, -1, NULL);
         sqlite3_bind_text(stmt, 2, vul->product, -1, NULL);
-        sqlite3_bind_text(stmt, 3, vul->patch, -1, NULL);
+        if (!strncmp(vul->patch, "KB", 2)) {
+            sqlite3_bind_text(stmt, 3, vul->patch + 2, -1, NULL);
+        } else {
+            sqlite3_bind_text(stmt, 3, vul->patch, -1, NULL);
+        }
         sqlite3_bind_text(stmt, 4, vul->title, -1, NULL);
         sqlite3_bind_text(stmt, 5, vul->url, -1, NULL);
         sqlite3_bind_text(stmt, 6, vul->subtype, -1, NULL);
@@ -7165,12 +7169,24 @@ int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_dep_entry *dep) {
                 return wm_vuldet_sql_error(db, stmt);
             }
 
-            sqlite3_bind_text(stmt, 1, dep->patch, -1, NULL);
-            sqlite3_bind_text(stmt, 2, dep->supers[i], -1, NULL);
+            if (!strncmp(dep->patch, "KB", 2)) {
+                sqlite3_bind_text(stmt, 1, dep->patch + 2, -1, NULL);
+            } else {
+                sqlite3_bind_text(stmt, 1, dep->patch, -1, NULL);
+            }
+            if (!strncmp(dep->supers[i], "KB", 2)) {
+                sqlite3_bind_text(stmt, 2, dep->supers[i] + 2, -1, NULL);
 
-            // A super can be a patch too, so non-duplicated ones will be added as rows
-            sqlite3_bind_text(stmt, 3, dep->supers[i], -1, NULL);
-            sqlite3_bind_text(stmt, 4, dep->supers[i], -1, NULL);
+                // A super can be a patch too, so non-duplicated ones will be added as rows
+                sqlite3_bind_text(stmt, 3, dep->supers[i] + 2, -1, NULL);
+                sqlite3_bind_text(stmt, 4, dep->supers[i] + 2, -1, NULL);
+            } else {
+                sqlite3_bind_text(stmt, 2, dep->supers[i], -1, NULL);
+
+                // A super can be a patch too, so non-duplicated ones will be added as rows
+                sqlite3_bind_text(stmt, 3, dep->supers[i], -1, NULL);
+                sqlite3_bind_text(stmt, 4, dep->supers[i], -1, NULL);
+            }
 
             if (result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
                 return wm_vuldet_sql_error(db, stmt);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2679,7 +2679,7 @@ void wm_vuldet_build_nvd_condition(vu_nvd_report *report, char **condition, char
             const char *patch_msg = "patch is not installed.";
             size = strlen(patch_msg) + strlen(report->necessary_patch) + 3;
             os_calloc(size + 1, sizeof(char), *condition);
-            snprintf(*condition, size, "%s %s", report->necessary_patch, patch_msg);
+            snprintf(*condition, size, "KB%s %s", report->necessary_patch, patch_msg);
             *is_hotfix = 1;
         }
 


### PR DESCRIPTION
## Description

This change fixes the case described at #5619. The patch `KB4565539` was not being taken into account because it is indexed with the `KB` prefix in the database (`MSU_SUPERSEDENCE` table).

```
sqlite> select * from MSU_SUPERSEDENCE where PATCH like "%4565539";
KB4565539|KB4565539
```

However, when looking for patches that fix the CVE-2020-1360, the Vulnerability Detector looks for `4565539` (omitting the prefix), so it was not matching.

https://github.com/wazuh/wazuh/blob/0ca87beba4baf5ff539249885bf5ca5a7e81788d/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c#L3291

Patches can be indexed with the prefix when coming from the Microsoft Update Catalog, or without the prefix when coming from the API. It was also leading to duplicated entries like:

```
sqlite> select * from MSU_SUPERSEDENCE where PATCH like "%4565524";
4565524|4565524
KB4565524|KB4565524
```

This PR removes the prefix every time a patch is indexed, avoiding these inconsistencies.

## Manual tests

After applying the change, duplicated entries disappear. Here we can see the difference:

**Before**

```
sqlite> select count(*) from MSU_SUPERSEDENCE where PATCH like "KB%";
639
sqlite> select count(*) from MSU_SUPERSEDENCE where SUPER like "KB%";
8982
sqlite> select count(*) from MSU_SUPERSEDENCE where SUPER not like "KB%";
16318
sqlite> select count(*) from MSU_SUPERSEDENCE where PATCH not like "KB%";
24661
```

**After**

```
sqlite> select count(*) from MSU_SUPERSEDENCE where SUPER not like "KB%";
24982
sqlite> select count(*) from MSU_SUPERSEDENCE where PATCH not like "KB%";
24982
sqlite> select count(*) from MSU_SUPERSEDENCE where SUPER like "KB%";
0
sqlite> select count(*) from MSU_SUPERSEDENCE where PATCH like "KB%";
0
```

In addition, now the CVE-2020-1360 is marked as fixed when `KB4565539` is installed.

```
2020/08/11 04:04:38 wazuh-modulesd:vulnerability-detector[69912] wm_vuln_detector_nvd.c:3361 at wm_vuldet_check_hotfix(): DEBUG: (5453): Agent '008' has installed 'KB4565539' that corrects the vulnerability 'CVE-2020-1360'
```

Tested the change in the following platforms:

- Windows 7
- Windows Server 2012
- Windows Server 2012 R2
- Windows Server 2016
- Windows 10
- Windows Server 2019

It only affects the Windows 7 report, where 28 false positives are removed related to the same patch.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
