### PR TITLE
[API 4.0] Add support for AWS Cloudwatch Logs in aws-s3 module

### DIFF
--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -215,6 +215,8 @@ cJSON *wm_aws_dump(const wm_aws *aws_config) {
             if (iter->aws_account_alias) cJSON_AddStringToObject(service,"aws_account_alias",iter->aws_account_alias);
             if (iter->only_logs_after) cJSON_AddStringToObject(service,"only_logs_after",iter->only_logs_after);
             if (iter->regions) cJSON_AddStringToObject(service,"regions",iter->regions);
+            if (iter->aws_log_groups) cJSON_AddStringToObject(service,"aws_log_groups",iter->aws_log_groups);
+            if (iter->remove_log_streams) cJSON_AddStringToObject(service,"remove_log_streams","yes"); else cJSON_AddStringToObject(service,"remove_log_streams","no");
             cJSON_AddItemToArray(arr_services,service);
         }
         if (cJSON_GetArraySize(arr_services) > 0) {
@@ -478,6 +480,13 @@ void wm_aws_run_service(wm_aws *aws_config, wm_aws_service *exec_service) {
     if (exec_service->regions) {
         wm_strcat(&command, "--regions", ' ');
         wm_strcat(&command, exec_service->regions, ' ');
+    }
+    if (exec_service->aws_log_groups) {
+        wm_strcat(&command, "--aws_log_groups", ' ');
+        wm_strcat(&command, exec_service->aws_log_groups, ' ');
+    }
+    if (exec_service->remove_log_streams) {
+        wm_strcat(&command, "--remove-log-streams", ' ');
     }
     if (isDebug()) {
         wm_strcat(&command, "--debug", ' ');

--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -51,6 +51,8 @@ typedef struct wm_aws_service {
     char *aws_account_alias;            // AWS account alias
     char *only_logs_after;              // Date (YYYY-MMM-DD) to only parse logs after
     char *regions;                      // CSV of regions to parse
+    char *aws_log_groups;               // CSV of log groups to parse
+    unsigned int remove_log_streams:1;  // Remove the log stream from the log group
     struct wm_aws_service *next;     // Pointer to next
 } wm_aws_service;
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -45,6 +45,7 @@ from os import path
 import operator
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 from time import mktime
 
 # Python 2/3 compatibility
@@ -248,6 +249,9 @@ class WazuhIntegration:
                                             region_name=conn_args.get('region_name')
                                             )
                 client = sts_session.client(service_name=service_name)
+            elif service_name == 'cloudwatchlogs':
+                client = boto3.client('logs', region_name=region,
+                                      aws_access_key_id=access_key, aws_secret_access_key=secret_key)
             else:
                 client = boto_session.client(service_name=service_name)
         except botocore.exceptions.ClientError as e:
@@ -273,13 +277,12 @@ class WazuhIntegration:
 
         return sts_client
 
-    def send_msg(self, msg):
+    def send_msg(self, msg, dump_json=True):
         """
         Sends an AWS event to the Wazuh Queue
 
         :param msg: JSON message to be sent.
-        :param wazuh_queue: Wazuh queue path.
-        :param msg_header: Msg header.
+        :para dump_json: If json.dumps should be applied to the msg
         """
         try:
             json_msg = json.dumps(msg, default=str)
@@ -287,7 +290,7 @@ class WazuhIntegration:
             s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
             s.connect(self.wazuh_queue)
             s.send("{header}{msg}".format(header=self.msg_header,
-                                          msg=json_msg).encode())
+                                          msg=json_msg if dump_json else msg).encode())
             s.close()
         except socket.error as e:
             if e.errno == 111:
@@ -2038,7 +2041,7 @@ class AWSService(WazuhIntegration):
     """
 
     def __init__(self, access_key, secret_key, aws_profile, iam_role_arn,
-                 service_name, only_logs_after, region):
+                 service_name, only_logs_after, region, aws_log_groups=None, remove_log_streams=None):
         # DB name
         self.db_name = 'aws_services'
         # table name
@@ -2112,6 +2115,22 @@ class AWSService(WazuhIntegration):
         return '{Y}-{m}-{d} 00:00:00.0'.format(Y=self.only_logs_after[0:4],
                                                m=self.only_logs_after[4:6], d=self.only_logs_after[6:8])
 
+    def format_message(self, msg):
+        # rename service field to source
+        if 'service' in msg:
+            msg['source'] = msg['service'].lower()
+            del msg['service']
+        # cast createdAt
+        if 'createdAt' in msg:
+            msg['createdAt'] = datetime.strftime(msg['createdAt'],
+                                                 '%Y-%m-%dT%H:%M:%SZ')
+        # cast updatedAt
+        if 'updatedAt' in msg:
+            msg['updatedAt'] = datetime.strftime(msg['updatedAt'],
+                                                 '%Y-%m-%dT%H:%M:%SZ')
+
+        return {'integration': 'aws', 'aws': msg}
+
 
 class AWSInspector(AWSService):
     """
@@ -2125,14 +2144,16 @@ class AWSInspector(AWSService):
     """
 
     def __init__(self, reparse, access_key, secret_key, aws_profile,
-                 iam_role_arn, only_logs_after, region):
+                 iam_role_arn, only_logs_after, region, aws_log_groups=None,
+                 remove_log_streams=None):
 
         self.service_name = 'inspector'
         self.inspector_region = region
 
         AWSService.__init__(self, access_key=access_key, secret_key=secret_key,
                             aws_profile=aws_profile, iam_role_arn=iam_role_arn, only_logs_after=only_logs_after,
-                            service_name=self.service_name, region=region)
+                            service_name=self.service_name, region=region, aws_log_groups=aws_log_groups,
+                            remove_log_streams=remove_log_streams)
 
         # max DB records for region
         self.retain_db_records = 5
@@ -2199,21 +2220,465 @@ class AWSInspector(AWSService):
         self.db_connector.commit()
         self.close_db()
 
-    def format_message(self, msg):
-        # rename service field to source
-        if 'service' in msg:
-            msg['source'] = msg['service'].lower()
-            del msg['service']
-        # cast createdAt
-        if 'createdAt' in msg:
-            msg['createdAt'] = datetime.strftime(msg['createdAt'],
-                                                 '%Y-%m-%dT%H:%M:%SZ')
-        # cast updatedAt
-        if 'updatedAt' in msg:
-            msg['updatedAt'] = datetime.strftime(msg['updatedAt'],
-                                                 '%Y-%m-%dT%H:%M:%SZ')
 
-        return {'integration': 'aws', 'aws': msg}
+class AWSCloudWatchLogs(AWSService):
+    """
+    Class for getting AWS Cloudwatch logs
+
+    Attributes
+    ----------
+    access_key : str
+        AWS access key id
+    secret_key : str
+        AWS secret access key
+    aws_profile : str
+        AWS profile
+    iam_role_arn : str
+        IAM Role
+    only_logs_after : str
+        Date after which obtain logs
+    region : str
+        Region where the logs are located
+    aws_log_groups : str
+        String containing a list of log group names separated by a comma
+    remove_log_streams : bool
+        Indicate if log streams should be removed after being fetched
+    db_table_name : str
+        Name of the table to be created on aws_service.db
+    only_logs_after_millis : int
+        only_logs_after expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC
+    log_group_list : list of str
+        List of each log group to be parsed
+    sql_cloudwatch_create_table : str
+        Query for the creation of the table
+    sql_cloudwatch_insert : str
+        Query to insert the token for a given log stream
+    sql_cloudwatch_update : str
+        Query for updating the token, start_time and end_time values
+    sql_cloudwatch_select : str
+        Query to obtain the token, start_time and end_time values
+    sql_cloudwatch_select_logstreams : str
+        Query to get all logstreams in the DB
+    sql_cloudwatch_purge : str
+        Query to delete a row from the DB.
+    """
+
+    def __init__(self, reparse, access_key, secret_key, aws_profile,
+                 iam_role_arn, only_logs_after, region, aws_log_groups,
+                 remove_log_streams):
+
+        self.sql_cloudwatch_create_table = """
+                                CREATE TABLE 
+                                    {table_name} (
+                                        aws_region 'text' NOT NULL,
+                                        aws_log_group 'text' NOT NULL,
+                                        aws_log_stream 'text' NOT NULL,
+                                        next_token 'text',
+                                        start_time 'integer',
+                                        end_time 'integer',
+                                        PRIMARY KEY (aws_region, aws_log_group, aws_log_stream));"""
+
+        self.sql_cloudwatch_insert = """
+                                INSERT INTO {table_name} (
+                                    aws_region,
+                                    aws_log_group,
+                                    aws_log_stream,
+                                    next_token,
+                                    start_time,
+                                    end_time)
+                                VALUES
+                                    ('{aws_region}',
+                                    '{aws_log_group}',
+                                    '{aws_log_stream}',
+                                    '{next_token}',
+                                    '{start_time}',
+                                    '{end_time}');"""
+
+        self.sql_cloudwatch_update = """
+                                UPDATE 
+                                    {table_name}
+                                SET
+                                    next_token='{next_token}',
+                                    start_time='{start_time}',
+                                    end_time='{end_time}'
+                                WHERE
+                                    aws_region='{aws_region}' AND
+                                    aws_log_group='{aws_log_group}' AND
+                                    aws_log_stream='{aws_log_stream}';"""
+
+        self.sql_cloudwatch_select = """
+                            SELECT
+                                next_token,
+                                start_time,
+                                end_time
+                            FROM
+                                '{table_name}'
+                            WHERE
+                                aws_region='{aws_region}' AND 
+                                aws_log_group='{aws_log_group}' AND 
+                                aws_log_stream='{aws_log_stream}'"""
+        self.sql_cloudwatch_select_logstreams = """
+                            SELECT
+                                aws_log_stream
+                            FROM
+                                '{table_name}'
+                            WHERE
+                                aws_region='{aws_region}' AND 
+                                aws_log_group='{aws_log_group}'
+                            ORDER BY
+                                aws_log_stream;"""
+        self.sql_cloudwatch_purge = """
+                            DELETE FROM
+                                {table_name}
+                            WHERE
+                                aws_region='{aws_region}' AND 
+                                aws_log_group='{aws_log_group}' AND 
+                                aws_log_stream='{aws_log_stream}';"""
+
+        AWSService.__init__(self, access_key=access_key, secret_key=secret_key,
+                            aws_profile=aws_profile, iam_role_arn=iam_role_arn, only_logs_after=only_logs_after,
+                            region=region, aws_log_groups=aws_log_groups, remove_log_streams=remove_log_streams,
+                            service_name='cloudwatchlogs')
+
+        self.region = region
+        self.db_table_name = 'cloudwatch_logs'
+        self.log_group_list = [group for group in aws_log_groups.split(",") if group != ""] if aws_log_groups else []
+        self.remove_log_streams = remove_log_streams
+        self.only_logs_after_millis = int(datetime.strptime(only_logs_after, '%Y%m%d').replace(
+            tzinfo=timezone.utc).timestamp() * 1000) if only_logs_after else None
+        debug("only logs: {}".format(self.only_logs_after_millis), 1)
+
+    def get_alerts(self):
+        """Iterate over all the log streams for each log group provided by the user in the given region to get their
+        logs and send them to analysisd, which will raise alerts if applicable.
+
+        It will avoid getting duplicate events by using the token, start_time and end_time variables stored in the DB.
+        Logs with a timestamp lesser that start_time and greater than end_time will be fetched using the
+        `get_alerts_within_range` function.
+
+        The log streams will be removed after fetching them if `remove_log_streams` value is True.
+
+        The database will be purged to remove unnecessary records at the end of each log group iteration.
+        """
+        self.init_db(self.sql_cloudwatch_create_table.format(table_name=self.db_table_name))
+
+        try:
+            for log_group in self.log_group_list:
+                for log_stream in self.get_log_streams(log_group=log_group):
+                    debug('Getting data from DB for log stream "{}" in log group "{}"'.format(log_stream, log_group), 1)
+                    db_values = self.get_data_from_db(log_group=log_group, log_stream=log_stream)
+                    debug('Token: "{}", start_time: "{}", '
+                          'end_time: "{}"'.format(db_values['token'] if db_values else None,
+                                                  db_values['start_time'] if db_values else None,
+                                                  db_values['end_time'] if db_values else None), 2)
+                    result_before = None
+                    result_after = None
+                    if self.only_logs_after_millis is None:
+                        if db_values:
+                            result_before = self.get_alerts_within_range(log_group=log_group, log_stream=log_stream,
+                                                                         token=None, start_time=None,
+                                                                         end_time=db_values['start_time'])
+                            if db_values['end_time'] is not None:
+                                result_after = self.get_alerts_within_range(log_group=log_group, log_stream=log_stream,
+                                                                            token=db_values['token'],
+                                                                            start_time=db_values['end_time'] + 1,
+                                                                            end_time=None)
+                        else:
+                            result_after = self.get_alerts_within_range(log_group=log_group, log_stream=log_stream,
+                                                                        token=None, start_time=None, end_time=None)
+                    elif db_values is None:
+                        result_before = self.get_alerts_within_range(log_group=log_group, log_stream=log_stream,
+                                                                     token=None, start_time=self.only_logs_after_millis,
+                                                                     end_time=None)
+                    elif db_values['start_time'] is not None and self.only_logs_after_millis < db_values['start_time']:
+                        result_before = self.get_alerts_within_range(log_group=log_group, log_stream=log_stream,
+                                                                     token=None, start_time=self.only_logs_after_millis,
+                                                                     end_time=db_values['start_time'])
+                        if db_values['end_time'] is not None:
+                            result_after = self.get_alerts_within_range(log_group=log_group, log_stream=log_stream,
+                                                                        token=db_values['token'],
+                                                                        start_time=db_values['end_time'] + 1,
+                                                                        end_time=None)
+                    elif db_values['end_time'] is not None and self.only_logs_after_millis < db_values['end_time']:
+                        result_after = self.get_alerts_within_range(log_group=log_group, log_stream=log_stream,
+                                                                    token=db_values['token'],
+                                                                    start_time=db_values['end_time'] + 1,
+                                                                    end_time=None)
+                    else:
+                        result_after = self.get_alerts_within_range(log_group=log_group, log_stream=log_stream,
+                                                                    token=None, start_time=self.only_logs_after_millis,
+                                                                    end_time=None)
+
+                    db_values = self.update_values(values=db_values, result_before=result_before,
+                                                   result_after=result_after)
+
+                    self.save_data_db(log_group=log_group, log_stream=log_stream, values=db_values)
+
+                    if self.remove_log_streams:
+                        self.remove_aws_log_stream(log_group=log_group, log_stream=log_stream)
+
+                self.purge_db(log_group=log_group)
+        finally:
+            self.close_database()
+
+    def remove_aws_log_stream(self, log_group, log_stream):
+        """Remove a log stream from a log group in AWS Cloudwatch Logs.
+
+        Parameters
+        ----------
+        log_group : str
+            Name of the group where the log stream is stored
+        log_stream : str
+            Name of the log stream to be removed
+        """
+        try:
+            debug('Removing log stream "{}" from log group "{}"'.format(log_group, log_stream), 1)
+            self.client.delete_log_stream(logGroupName=log_group, logStreamName=log_stream)
+        except Exception:
+            debug('Error trying to remove "{}" log stream from "{}" log group.'.format(log_stream, log_group), 0)
+
+    def get_alerts_within_range(self, log_group, log_stream, token, start_time, end_time):
+        """Get all the logs from a log stream with a timestamp between the range of the provided start and end times and
+        send them to Analysisd.
+
+        It will fetch every log from the given log stream using boto3 `get_log_events` until it returns an empty
+        response.
+
+        Parameters
+        ----------
+        log_group : str
+            Name of the log group where the log stream is stored
+        log_stream : str
+            Name of the log stream to get its logs
+        token : str
+            Token to the next set of logs. Obtained from a previous call and stored in DB.
+        start_time : int
+            The start of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.
+            Logs with a timestamp equal to this time or later will be fetched.
+        end_time : int
+            The end of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.
+            Events with a timestamp equal to or later than this time won't be fetched.
+
+        Returns
+        -------
+        A dict containing the Token for the next set of logs, the timestamp of the first fetched log and the timestamp
+        of the latest one.
+        """
+        response = None
+        min_start_time = start_time
+        max_end_time = end_time
+        while response is None or response['events'] != list():
+            debug('Getting CloudWatch logs from log stream "{}" in log group "{}" using token "{}", start_time '
+                  '"{}" and end_time "{}"'.format(log_stream, log_group, token, start_time, end_time), 1)
+
+            parameters = {'logGroupName': log_group,
+                          'logStreamName': log_stream,
+                          'nextToken': token,
+                          'startTime': start_time,
+                          'endTime': end_time,
+                          'startFromHead': True}
+
+            response = self.client.get_log_events(
+                **{param: value for param, value in parameters.items() if value is not None})
+
+            token = response['nextForwardToken']
+
+            # Send events to Analysisd
+            for event in response['events']:
+                debug('+++ Sending events to Analysd...', 1)
+                debug('The message is "{}"'.format(event['message']), 2)
+                self.send_msg(event['message'], dump_json=False)
+
+                if min_start_time is None:
+                    min_start_time = event['timestamp']
+                elif event['timestamp'] < min_start_time:
+                    min_start_time = event['timestamp']
+
+                if max_end_time is None:
+                    max_end_time = event['timestamp']
+                elif event['timestamp'] > max_end_time:
+                    max_end_time = event['timestamp']
+
+        if token is None and min_start_time is None and max_end_time is None:
+            return None
+        return {'token': token, 'start_time': min_start_time, 'end_time': max_end_time}
+
+    def get_data_from_db(self, log_group, log_stream):
+        """Get the token, start time and end time of a log stream stored in DB.
+
+        Parameters
+        ----------
+        log_group : str
+            Name of the log group
+        log_stream : str
+            Name of the log stream
+
+        Returns
+        -------
+        A dict containing the token, start_time and end_time of the log stream. None if no data were found in the DB.
+        """
+        self.db_cursor.execute(self.sql_cloudwatch_select.format(table_name=self.db_table_name,
+                                                                 aws_region=self.region,
+                                                                 aws_log_group=log_group,
+                                                                 aws_log_stream=log_stream))
+        query_result = self.db_cursor.fetchone()
+        if query_result:
+            return {'token': None if query_result[0] == "None" else query_result[0],
+                    'start_time': None if query_result[1] == "None" else query_result[1],
+                    'end_time': None if query_result[2] == "None" else query_result[2]}
+
+    def update_values(self, values, result_after, result_before):
+        """Update the values for token, start_time and end_time using the results of previous 'get_alerts_within_range'
+        executions.
+
+        Parameters
+        ----------
+        values : dict
+            A dict containing the token, start_time and end_time values to be updated
+        result_after : dict
+            A dict containing the resulting token, start_time and end_time values of a 'get_alerts_within_range'
+            execution
+        result_before : dict
+            A dict containing the resulting token, start_time and end_time values of a 'get_alerts_within_range'
+            execution
+
+        Returns
+        -------
+        A dict containing the last token, minimal start_time and maximum end_value of the provided parameters.
+        """
+        min_start_time = result_before['start_time'] if result_before else None
+        max_end_time = result_before['end_time'] if result_before else None
+
+        if result_after is not None:
+            if min_start_time is None:
+                min_start_time = result_after['start_time']
+            else:
+                min_start_time = result_after['start_time'] if result_after[
+                                                                   'start_time'] < min_start_time else min_start_time
+
+            if max_end_time is None:
+                max_end_time = result_after['start_time']
+            else:
+                max_end_time = result_after['start_time'] if result_after['start_time'] > max_end_time else max_end_time
+
+        token = result_before['token'] if result_before is not None else None
+        token = result_after['token'] if result_after is not None else token
+
+        if values is None:
+            return {'token': token, 'start_time': min_start_time, 'end_time': max_end_time}
+        else:
+            result = {'token': token}
+
+            if values['start_time'] is not None:
+                result['start_time'] = min_start_time if min_start_time < values['start_time'] else values['start_time']
+            else:
+                result['start_time'] = max_end_time
+
+            if values['end_time'] is not None:
+                result['end_time'] = max_end_time if max_end_time > values['end_time'] else values['end_time']
+            else:
+                result['end_time'] = max_end_time
+            return result
+
+    def save_data_db(self, log_group, log_stream, values):
+        """Insert the token, start_time and end_time values into the DB. If the values already exists they will be
+        updated instead.
+
+        Parameters
+        ----------
+        log_group : str
+            Name of the log group
+        log_stream : str
+            Name of the log stream
+        values : dict
+            Dict containing the token, start_time and end_time.
+        """
+        debug('Saving data for log group "{}" and log stream "{}".'.format(log_group, log_stream), 1)
+        debug('The saved values are "{}"'.format(values), 2)
+        try:
+            self.db_cursor.execute(self.sql_cloudwatch_insert.format(table_name=self.db_table_name,
+                                                                     aws_region=self.region,
+                                                                     aws_log_group=log_group,
+                                                                     aws_log_stream=log_stream,
+                                                                     next_token=values['token'],
+                                                                     start_time=values['start_time'],
+                                                                     end_time=values['end_time']))
+        except sqlite3.IntegrityError:
+            debug("Some data already exists on DB for that key. Updating their values...", 2)
+            self.db_cursor.execute(self.sql_cloudwatch_update.format(table_name=self.db_table_name,
+                                                                     aws_region=self.region,
+                                                                     aws_log_group=log_group,
+                                                                     aws_log_stream=log_stream,
+                                                                     next_token=values['token'],
+                                                                     start_time=values['start_time'],
+                                                                     end_time=values['end_time']))
+
+    def get_log_streams(self, log_group):
+        """Get the list of log streams stored in the specified log group.
+
+        Parameters
+        ----------
+        log_group : str
+            Name of the log group to get its log streams
+
+        Returns
+        -------
+        A list with the name of each log stream for the given log group.
+        """
+
+        result_list = list()
+        try:
+            debug('Getting log streams for "{}" log group'.format(log_group), 1)
+            response = self.client.describe_log_streams(logGroupName=log_group)
+
+            for log_stream in response['logStreams']:
+                debug('Found "{}" log stream in {}'.format(log_stream['logStreamName'], log_group), 2)
+                result_list.append(log_stream['logStreamName'])
+
+            if result_list == list():
+                debug('No log streams were found for log group "{}"'.format(log_group), 1)
+        except Exception:
+            debug('++++ The specified "{}" log group does not exist or insufficient privileges to access it.'.format(log_group), 0)
+        finally:
+            return result_list
+
+    def purge_db(self, log_group):
+        """Remove from AWS_Service.db any record for log streams that no longer exists on AWS CloudWatch.
+
+        Parameters
+        ----------
+        log group : str
+            Name of the log group to check its log streams
+        """
+        debug('Purging the BD', 1)
+        # Get the list of log streams from DB
+        self.db_cursor.execute(self.sql_cloudwatch_select_logstreams.format(table_name=self.db_table_name,
+                                                                            aws_region=self.region,
+                                                                            aws_log_group=log_group))
+        query_result = self.db_cursor.fetchall()
+        log_streams_sql = set()
+        for log_stream in query_result:
+            log_streams_sql.add(log_stream[0])
+
+        # Get the list of log streams from AWS
+        log_streams_aws = set(self.get_log_streams(log_group))
+
+        # Check the difference and remove if applicable
+        log_streams_to_purge = log_streams_sql - log_streams_aws
+        if log_streams_to_purge != set():
+            debug('Data for the following log streams will be removed from {}: "{}"'.format(self.db_table_name,
+                                                                                            log_streams_to_purge), 2)
+        for log_stream in log_streams_to_purge:
+            self.db_cursor.execute(self.sql_cloudwatch_purge.format(table_name=self.db_table_name,
+                                                                    aws_region=self.region,
+                                                                    aws_log_group=log_group,
+                                                                    aws_log_stream=log_stream))
+
+    def close_database(self):
+        """Commit the changes to the DB and close the connection."""
+        debug("committing changes and closing the DB", 1)
+        self.db_connector.commit()
+        self.close_db()
 
 
 ################################################################################
@@ -2309,6 +2774,11 @@ def get_script_arguments():
     parser.add_argument('-o', '--reparse', action='store_true', dest='reparse',
                         help='Parse the log file, even if its been parsed before', default=False)
     parser.add_argument('-t', '--type', dest='type', type=str, help='Bucket type.', default='cloudtrail')
+    parser.add_argument('-g', '--aws_log_groups', dest='aws_log_groups', help='Name of the log group to be parsed',
+                        default='')
+    parser.add_argument('-P', '--remove-log-streams', action='store_true', dest='deleteLogStreams',
+                        help='Remove processed log streams from the log group', default=False)
+
     return parser.parse_args()
 
 
@@ -2362,6 +2832,8 @@ def main(argv):
         elif options.service:
             if options.service.lower() == 'inspector':
                 service_type = AWSInspector
+            elif options.service.lower() == 'cloudwatchlogs':
+                service_type = AWSCloudWatchLogs
             else:
                 raise Exception("Invalid type of service")
 
@@ -2372,10 +2844,16 @@ def main(argv):
                                    'eu-central-1', 'eu-west-1']
 
             for region in options.regions:
-                service = service_type(reparse=options.reparse, access_key=options.access_key,
-                                       secret_key=options.secret_key, aws_profile=options.aws_profile,
-                                       iam_role_arn=options.iam_role_arn, only_logs_after=options.only_logs_after,
-                                       region=region)
+                debug('+++ Getting alerts from "{}" region.'.format(region), 1)
+                service = service_type(reparse=options.reparse,
+                                       access_key=options.access_key,
+                                       secret_key=options.secret_key,
+                                       aws_profile=options.aws_profile,
+                                       iam_role_arn=options.iam_role_arn,
+                                       only_logs_after=options.only_logs_after,
+                                       region=region,
+                                       aws_log_groups=options.aws_log_groups,
+                                       remove_log_streams=options.deleteLogStreams)
                 service.get_alerts()
 
     except Exception as err:


### PR DESCRIPTION
Hello Team, 

This PR closes #5187 

# Description

This PR adds support for `AWS Cloudwatch Logs` to our `AWS-S3` module.

Cloudwatch Logs is an AWS service used to store and access logs files from Amazon instances (EC2 and Fargate), AWS CloudTrail, Route 53, and other, regardless of their source, as a single and consistent flow of events ordered by time.

AWS Cloudwatch Logs are stored using log groups and log streams. Our AWS module needs to be able to access those log groups, extract their contents and finally send them to analysd.

This PR adds a new `AWSCloudwatchLogs` class which inherits from `AWSService` in the `AWS-S3.py` module.

Changes to `wmodules-aws.c`, `wm_aws.c` and `wm_aws.h` were also necessary to be able to parse and provide the new parameters.


# How the new Service works

This new class connects to `AWS Cloudwatch Logs`, gets the log groups provided by parameter and extracts all logs for each log stream in those log groups. Once the logs are collected they are sent to the `Analysisd` daemon so they will be analyzed and alerts will be raised if applicable.

To avoid getting duplicated events we are using the `aws_service` database to store following variables:

* `Token`: The token retreived from boto3 used to point to the next set of items to return. Its received every time we call `getLogEvents`. The token expires after 24 hours. If the token is expired the next call will return every single event from the beginning if we don't use any additional parameters.

* `start_time`:  The timestamp with the lowest value of all fetched events, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC. Its used to filter the events we get from boto3.

* `end_time`: Same usage and attributes as `start_time` but for the timestamp with the largest value. 

Those variables will be stored in table called `cloudwatch_logs` in `aws_service` database using `log_group`, `log_stream` and `region` as primary key.

Every time the module is executed, it will try to retrieve those parameters from the database. If they don't exists it will meant that the combination of `log_group`, `log_stream` and `region` is new and no filter using token, start_time or end_time will be necessary.

If the parameters are already present in the database for that primary key they will be used to ensure only the logs with a timestamp lower than `start_time` or higher than `end_time` will be fetched, while applying `only_logs_after` parameter if present. Any log with a timestamp between `start_time` and `end_time` will be ignored as they will have already been processed in a previous execution.

Finally, after each execution of the module, the values for `token`, `start_time` and `end_time` will be updated in database accordingly.

# Available parameters

This module needs two new parameters that are used exclusively for the AWSCloudwatchLogs service:

* `aws_log_groups`: a log group name or a list of them (comma-sepparated) where the logs streams are stored in AWS.

* `remove_log_streams`: A bool to indicate whether to remove the log streams after their logs are extracted or not.

Here are the complete set of parameters available for this Service:
```
<wodle name="aws-s3"> 
  <disabled> no </disabled> 
  <interval> 5m </interval> 
  <run_on_start> yes </run_on_start> 
  <service type="cloudwatchlogs"> 
    <aws_account_id> account </aws_account_id> 
    <aws_account_alias> alias </aws_account_alias> 
    <access_key> access </access_key> 
    <secret_key> secret </secret_key> 
    <aws_profile> profile </aws_profile> 
    <iam_role_arn> role </iam_role_arn> 
    <aws_log_groups> log_group1,log_group2 </aws_log_groups> 
    <only_logs_after> only_logs_after </only_logs_after> 
    <regions> region1,region2 </regions> 
    <remove_log_streams> no </remove_log_streams> 
   </service> 
 </wodle> 
```

# Error management

### Invalid log group
If the log group provided with `aws_log_groups` is invalid, doesn't exists or the user doesn't have enough privileges to access it, the following message will appear in the `ossec.log`:

```
The specified "invalid_log_group_name" log group does not exist or insufficient privileges to access it
```

Take into account that the execution will continue, so if there is one or more log groups in `aws_log_groups` their logs will be extracted as expected.

### Insufficient privileges when trying to remove a log stream

If the user doesn't have enough privileges to remove a particular log stream from AWS Cloudwatch Logs or it was removed using the console during the execution the following error message will appear in the `ossec.log`:

```
Error trying to remove "log log_stream_name" log stream from "log_group_name" log group.
```

### Invalid parameters

The validation process of the rest of the existing parameters has not been modified, so their behaviour will not altered by this PR.


# Manual test performed

To ensure everything is working as expected many manual tests have been performed, including the following one, having log data stored in AWS Cloudwatch Logs with timestamps for 2020-JUN-10 and 2020-JUN-11:

## Test Case

1. Remove the database
2. Execute the module without `only_logs_after` parameter.
3. Executing the module again but this time using `<only_logs_after>2020-JUN-20<only_logs_after>`
4. Executing the module again but this time using `<only_logs_after>2020-JUN-01<only_logs_after>`
5. Executing the module again but this time using `<only_logs_after>2020-JUN-10<only_logs_after>`

After every single step the database values, alert.json and ossec.log where checked. The module behaved as expected.

Additionaly, `test_aws.py` were executed. Here are the results:

```
========================== test session starts ===========================
platform linux -- Python 3.7.4, pytest-4.5.0, py-1.8.0, pluggy-0.13.0
rootdir: /home/carlos/GIT/wazuh/wodles/aws/tests
plugins: pudb-0.7.0, cov-2.8.1
collected 11 items                                                       

test_aws.py ...........                                            [100%]

======================= 11 passed in 0.24 seconds ========================
```