### PR TITLE
Fix logtest hardcoded path in restart.sh

### DIFF
--- a/active-response/restart.sh
+++ b/active-response/restart.sh
@@ -36,14 +36,14 @@ echo "`date` $0 $1 $2 $3 $4 $5" >> ${PWD}/logs/active-responses.log
 
 # Run logtest in managers
 if [ "$TYPE" = "manager" ]; then
-    if !(/var/ossec/bin/ossec-logtest -t > /dev/null 2>&1); then
+    if !(${PWD}/bin/ossec-logtest -t > /dev/null 2>&1); then
         exit 1;
     fi
 fi
 
 # Restart Wazuh
 if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
-    touch ${PWD}/var/run/.restart     
+    touch ${PWD}/var/run/.restart
     systemctl restart wazuh-$TYPE
     rm -f ${PWD}/var/run/.restart
 elif command -v service > /dev/null 2>&1; then
@@ -55,4 +55,3 @@ else
 fi
 
 exit $?;
-


### PR DESCRIPTION
|Related issue|
|---|
|#5614|


## Description

This issue closes #5614. 

Restarting the manager from the API was failing due to [restart.sh](https://github.com/wazuh/wazuh/blob/ff962364251c1fa38468bc750c8431ced9254b84/active-response/restart.sh#L38-L42) attempting to call `/var/ossec/bin/ossec-logtest` even if the manager is installed on a different directory.


## Tests

Before this PR, when issuing a `PUT /manager/restart`, we would see the following output on `ossec.log`:

```
2020/07/31 14:07:00 ossec-execd[2426] execd.c:365 at ExecdStart(): DEBUG: Received message: 'restart-wazuh '
```
No restart was performed, eventhough the active response log would show that the manager did restart and an alerts was generated.

After this PR, we see that the manager is correctly restarted:
```
2020/08/13 07:48:46 ossec-execd[17671] execd.c:365 at ExecdStart(): DEBUG: Received message: 'restart-wazuh '
2020/08/13 07:48:46 wazuh-modulesd:syscollector: INFO: Module finished.
2020/08/13 07:48:46 ossec-monitord: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2020/08/13 07:48:46 ossec-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2020/08/13 07:48:47 ossec-remoted: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2020/08/13 07:48:47 ossec-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2020/08/13 07:48:47 ossec-analysisd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2020/08/13 07:48:47 ossec-execd[17671] execd.c:58 at execd_shutdown(): INFO: (1314): Shutdown received. Deleting responses.
2020/08/13 07:48:47 ossec-execd[17671] sig_op.c:49 at HandleSIG(): INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2020/08/13 07:48:47 wazuh-db: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2020/08/13 07:48:48 ossec-authd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2020/08/13 07:48:49 ossec-authd: INFO: Exiting...
2020/08/13 07:48:50 ossec-csyslogd: INFO: Remote syslog server not configured. Clean exit.
2020/08/13 07:48:50 ossec-dbd: INFO: Database not configured. Clean exit.
2020/08/13 07:48:50 ossec-integratord: INFO: Remote integrations not configured. Clean exit.
2020/08/13 07:48:50 ossec-agentlessd: INFO: Not configured. Exiting.
2020/08/13 07:48:50 ossec-authd: INFO: Started (pid: 18713).
2020/08/13 07:48:50 ossec-authd: INFO: Accepting connections on port 1515. No password required.
```
