### PR TITLE
Wazuh-logtest: fix race condition

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -539,7 +539,7 @@ int main_analysisd(int argc, char **argv)
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
                     if (!ReadDecodeXML(*decodersfiles, &os_analysisd_decoderlist_pn, 
-                                        &os_analysisd_decoderlist_nopn, list_msg)) {
+                                        &os_analysisd_decoderlist_nopn, &os_analysisd_decoder_store, list_msg)) {
                         node_log_msg = OSList_GetFirstNode(list_msg);
 
                         while (node_log_msg) {
@@ -559,7 +559,7 @@ int main_analysisd(int argc, char **argv)
             }
 
             /* Load decoders */
-            SetDecodeXML(list_msg);
+            SetDecodeXML(list_msg, &os_analysisd_decoder_store, &os_analysisd_decoderlist_nopn, &os_analysisd_decoderlist_pn);
             node_log_msg = OSList_GetFirstNode(list_msg);
             while (node_log_msg) {
                 os_analysisd_log_msg_t * data_msg = node_log_msg->data;
@@ -630,7 +630,8 @@ int main_analysisd(int argc, char **argv)
                     }
 
                     if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist,
-                                           &os_analysisd_cdblists, &os_analysisd_last_events, list_msg) < 0) {
+                                           &os_analysisd_cdblists, &os_analysisd_last_events,
+                                           &os_analysisd_decoder_store, list_msg) < 0) {
                         error_exit = 1;
                     }
 

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -50,6 +50,11 @@ OSDecoderNode *os_analysisd_decoderlist_pn;
 OSDecoderNode *os_analysisd_decoderlist_nopn;
 
 /**
+ * @brief Decoder list to save internals decoders
+ */
+OSStore *os_analysisd_decoder_store;
+
+/**
  * @brief Structure to save all rules read in starting.
  */
 RuleNode *os_analysisd_rulelist;

--- a/src/analysisd/decoders/ciscat.c
+++ b/src/analysisd/decoders/ciscat.c
@@ -20,12 +20,14 @@
 
 static OSDecoderInfo *ciscat_decoder = NULL;
 
+extern OSStore *os_analysisd_decoder_store;
+
 #define VAR_LENGTH  32
 
 void CiscatInit(){
 
     os_calloc(1, sizeof(OSDecoderInfo), ciscat_decoder);
-    ciscat_decoder->id = getDecoderfromlist(CISCAT_MOD);
+    ciscat_decoder->id = getDecoderfromlist(CISCAT_MOD, &os_analysisd_decoder_store);
     ciscat_decoder->name = CISCAT_MOD;
     ciscat_decoder->type = OSSEC_RL;
     ciscat_decoder->fts = 0;

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -102,16 +102,27 @@ int OS_AddOSDecoder(OSDecoderInfo *pi, OSDecoderNode **pn_osdecodernode,
                     OSDecoderNode **npn_osdecodernode, OSList* log_msg);
 
 OSDecoderNode *OS_GetFirstOSDecoder(const char *pname);
-int getDecoderfromlist(const char *name);
+
+/**
+ * @brief Get decoder from list
+ * @param name decoder name
+ * @param decoder_store decoder list
+ * @return decoder position on success, otherwise 0
+ */
+int getDecoderfromlist(const char *name, OSStore **decoder_store);
+
 char *GetGeoInfobyIP(char *ip_addr);
 
 /**
- * @brief Read decoder files and save them in the decoder list.
+ * @brief Add internal decoders to decoder_list and set ids to xml decoders
  * @param log_msg list to save log messages.
+ * @param decoder_list list to save all decoders (internals and xml decoders)
+ * @param decoderlist_npn list of decoders which haven't program_name
+ * @param decoderlist_pn list of decoders which have program_name
  * @retval 0 in case of error.
  * @retval 1 successful.
  */
-int SetDecodeXML(OSList* log_msg);
+int SetDecodeXML(OSList* log_msg, OSStore **decoder_list, OSDecoderNode **decoderlist_npn, OSDecoderNode **decoderlist_pn);
 
 void HostinfoInit(void);
 int fim_init(void);
@@ -120,7 +131,19 @@ void SyscollectorInit(void);
 void CiscatInit(void);
 void WinevtInit(void);
 void SecurityConfigurationAssessmentInit(void);
-int ReadDecodeXML(const char *file, OSDecoderNode **decoderlist_pn, OSDecoderNode **decoderlist_nopn, OSList* log_msg);
+
+/**
+ * @brief Read decoder files and save them in the decoder list
+ * @param file name of file which read
+ * @param decoderlist_pn list of decoders which have program_name
+ * @param decoderlist_nopn list of decoders which haven't program_name
+ * @param decoder_store list to save all decoders (internals and xml decoders)
+ * @param log_msg list to save log messages
+ * @return
+ */
+int ReadDecodeXML(const char *file, OSDecoderNode **decoderlist_pn,
+                  OSDecoderNode **decoderlist_nopn, OSStore **decoder_list,
+                  OSList* log_msg);
 
 /**
  * @brief Remove decoder information

--- a/src/analysisd/decoders/decoders_list.c
+++ b/src/analysisd/decoders/decoders_list.c
@@ -25,6 +25,7 @@ void OS_CreateOSDecoderList() {
 
     os_analysisd_decoderlist_pn = NULL;
     os_analysisd_decoderlist_nopn = NULL;
+    os_analysisd_decoder_store = NULL;
 }
 
 /* Get first osdecoder */

--- a/src/analysisd/decoders/hostinfo.c
+++ b/src/analysisd/decoders/hostinfo.c
@@ -72,12 +72,12 @@ void HostinfoInit()
 
     /* Zero decoder */
     os_calloc(1, sizeof(OSDecoderInfo), hostinfo_dec);
-    hostinfo_dec->id = getDecoderfromlist(HOSTINFO_MOD);
+    hostinfo_dec->id = getDecoderfromlist(HOSTINFO_MOD, &os_analysisd_decoder_store);
     hostinfo_dec->type = OSSEC_RL;
     hostinfo_dec->name = HOSTINFO_MOD;
     hostinfo_dec->fts = 0;
-    id_new = getDecoderfromlist(HOSTINFO_NEW);
-    id_mod = getDecoderfromlist(HOSTINFO_MOD);
+    id_new = getDecoderfromlist(HOSTINFO_NEW, &os_analysisd_decoder_store);
+    id_mod = getDecoderfromlist(HOSTINFO_MOD, &os_analysisd_decoder_store);
 
     /* Open HOSTINFO_FILE */
     snprintf(_hi_buf, OS_SIZE_1024, "%s", HOSTINFO_FILE);

--- a/src/analysisd/decoders/rootcheck.c
+++ b/src/analysisd/decoders/rootcheck.c
@@ -48,7 +48,7 @@ void RootcheckInit()
 
     /* Zero decoder */
     os_calloc(1, sizeof(OSDecoderInfo), rootcheck_dec);
-    rootcheck_dec->id = getDecoderfromlist(ROOTCHECK_MOD);
+    rootcheck_dec->id = getDecoderfromlist(ROOTCHECK_MOD, &os_analysisd_decoder_store);
     rootcheck_dec->type = OSSEC_RL;
     rootcheck_dec->name = ROOTCHECK_MOD;
     rootcheck_dec->fts = 0;

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -72,7 +72,7 @@ void SecurityConfigurationAssessmentInit()
 {
 
     os_calloc(1, sizeof(OSDecoderInfo), sca_json_dec);
-    sca_json_dec->id = getDecoderfromlist(SCA_MOD);
+    sca_json_dec->id = getDecoderfromlist(SCA_MOD, &os_analysisd_decoder_store);
     sca_json_dec->type = OSSEC_RL;
     sca_json_dec->name = SCA_MOD;
     sca_json_dec->fts = 0;

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -115,9 +115,9 @@ OSHash *fim_agentinfo;
 int fim_init(void) {
     //Create hash table for agent information
     fim_agentinfo = OSHash_Create();
-    decode_event_add = getDecoderfromlist(SYSCHECK_NEW);
-    decode_event_modify = getDecoderfromlist(SYSCHECK_MOD);
-    decode_event_delete = getDecoderfromlist(SYSCHECK_DEL);
+    decode_event_add = getDecoderfromlist(SYSCHECK_NEW, &os_analysisd_decoder_store);
+    decode_event_modify = getDecoderfromlist(SYSCHECK_MOD, &os_analysisd_decoder_store);
+    decode_event_delete = getDecoderfromlist(SYSCHECK_DEL, &os_analysisd_decoder_store);
     if (fim_agentinfo == NULL) return 0;
     return 1;
 }
@@ -130,7 +130,7 @@ void sdb_init(_sdb *localsdb, OSDecoderInfo *fim_decoder) {
     sdb_clean(localsdb);
 
     // Create decoder
-    fim_decoder->id = getDecoderfromlist(SYSCHECK_MOD);
+    fim_decoder->id = getDecoderfromlist(SYSCHECK_MOD, &os_analysisd_decoder_store);
     fim_decoder->name = SYSCHECK_MOD;
     fim_decoder->type = OSSEC_RL;
     fim_decoder->fts = 0;

--- a/src/analysisd/decoders/syscollector.c
+++ b/src/analysisd/decoders/syscollector.c
@@ -42,7 +42,7 @@ static OSDecoderInfo *sysc_decoder = NULL;
 void SyscollectorInit(){
 
     os_calloc(1, sizeof(OSDecoderInfo), sysc_decoder);
-    sysc_decoder->id = getDecoderfromlist(SYSCOLLECTOR_MOD);
+    sysc_decoder->id = getDecoderfromlist(SYSCOLLECTOR_MOD, &os_analysisd_decoder_store);
     sysc_decoder->name = SYSCOLLECTOR_MOD;
     sysc_decoder->type = OSSEC_RL;
     sysc_decoder->fts = 0;

--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -39,7 +39,7 @@ static int first_time = 0;
 void WinevtInit(){
 
     os_calloc(1, sizeof(OSDecoderInfo), winevt_decoder);
-    winevt_decoder->id = getDecoderfromlist(WINEVT_MOD);
+    winevt_decoder->id = getDecoderfromlist(WINEVT_MOD, &os_analysisd_decoder_store);
     winevt_decoder->name = WINEVT_MOD;
     winevt_decoder->type = OSSEC_RL;
     winevt_decoder->fts = 0;

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -32,6 +32,7 @@ typedef struct w_logtest_session_t {
     RuleNode *rule_list;                    ///< Rule list
     OSDecoderNode *decoderlist_forpname;    ///< Decoder list to match logs which have a program name
     OSDecoderNode *decoderlist_nopname;     ///< Decoder list to match logs which haven't a program name
+    OSStore *decoder_store;                  ///< Decoder list to save internals decoders
     ListNode *cdblistnode;                  ///< List of CDB lists
     ListRule *cdblistrule;                  ///< List to attach rules and CDB lists
     EventList *eventlist;                   ///< Previous events list
@@ -92,7 +93,7 @@ void w_logtest_process_log(char * token);
  * @brief Create resources necessary to service client
  * @param fd File descriptor which represents the client
  */
-w_logtest_session_t *w_logtest_initialize_session(char * token, OSList* log_msg);
+w_logtest_session_t *w_logtest_initialize_session(char * token, OSList* list_msg);
 
 /**
  * @brief Free resources after client closes connection

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -45,7 +45,7 @@ void Rules_OP_CreateRules() {
 }
 
 int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, 
-                       EventList **last_event_list, OSList* log_msg)
+                       EventList **last_event_list, OSStore **decoder_list, OSList* log_msg)
 {
     OS_XML xml;
     XML_NODE node = NULL;
@@ -416,7 +416,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                        rule_opt[k]->content, log_msg);
                     } else if (strcasecmp(rule_opt[k]->element, xml_decoded) == 0) {
                         config_ruleinfo->decoded_as =
-                            getDecoderfromlist(rule_opt[k]->content);
+                            getDecoderfromlist(rule_opt[k]->content, decoder_list);
 
                         if (config_ruleinfo->decoded_as == 0) {
                             smerror(log_msg, "Invalid decoder name: '%s'.", rule_opt[k]->content);

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -313,7 +313,7 @@ void Rules_OP_CreateRules(void);
  * @return 0 on success, otherwise -1
  */
 int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, 
-                       EventList **last_event_list, OSList* log_msg);
+                       EventList **last_event_list, OSStore **decoder_list, OSList* log_msg);
 
 int AddHash_Rule(RuleNode *node);
 

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -236,7 +236,8 @@ int main(int argc, char **argv)
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
                     if (!ReadDecodeXML(*decodersfiles, &os_analysisd_decoderlist_pn,
-                                       &os_analysisd_decoderlist_nopn, list_msg)) {
+                                       &os_analysisd_decoderlist_nopn,
+                                       &os_analysisd_decoder_store, list_msg)) {
                         node_log_msg = OSList_GetFirstNode(list_msg);
 
                         while (node_log_msg) {
@@ -257,7 +258,9 @@ int main(int argc, char **argv)
 
                 /* Read local ones */
 
-                c = ReadDecodeXML(XML_LDECODER, &os_analysisd_decoderlist_pn, &os_analysisd_decoderlist_nopn, list_msg);
+                c = ReadDecodeXML(XML_LDECODER, &os_analysisd_decoderlist_pn,
+                                  &os_analysisd_decoderlist_nopn,
+                                  &os_analysisd_decoder_store, list_msg);
                 node_log_msg = OSList_GetFirstNode(list_msg);
                 while (node_log_msg) {
                     os_analysisd_log_msg_t * data_msg = node_log_msg->data;
@@ -291,9 +294,11 @@ int main(int argc, char **argv)
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
                     if (!ReadDecodeXML(*decodersfiles, &os_analysisd_decoderlist_pn,
-                                       &os_analysisd_decoderlist_nopn, list_msg)) {
+                                       &os_analysisd_decoderlist_nopn,
+                                       &os_analysisd_decoder_store,
+                                       list_msg)) {
                         node_log_msg = OSList_GetFirstNode(list_msg);
-                        
+
                         while (node_log_msg) {
                             os_analysisd_log_msg_t * data_msg = node_log_msg->data;
                             msg = os_analysisd_string_log_msg(data_msg);
@@ -312,7 +317,7 @@ int main(int argc, char **argv)
             }
 
             /* Load decoders */
-            SetDecodeXML(list_msg);
+            SetDecodeXML(list_msg, &os_analysisd_decoder_store, &os_analysisd_decoderlist_nopn, &os_analysisd_decoderlist_pn);
             node_log_msg = OSList_GetFirstNode(list_msg);
             while (node_log_msg) {
                 os_analysisd_log_msg_t * data_msg = node_log_msg->data;
@@ -372,7 +377,7 @@ int main(int argc, char **argv)
                 while (rulesfiles && *rulesfiles) {
                     mdebug1("Reading rules file: '%s'", *rulesfiles);
                     if (Rules_OP_ReadRules(*rulesfiles, &os_analysisd_rulelist, &os_analysisd_cdblists, 
-                                           &os_analysisd_last_events, list_msg) < 0) {
+                                           &os_analysisd_last_events, &os_analysisd_decoder_store, list_msg) < 0) {
                         error_exit = 1;
                     }
                     node_log_msg = OSList_GetFirstNode(list_msg);


### PR DESCRIPTION
Hello team,

Branch `feature/5337logtest-enhancement` contains race conditions because Logtest use `decoder_store` global variable. This PR do each Logtest session have its own `decoder_store`.

Regards,
Eva

## Tests

- [x] Compile without warnings on Linux
- [x] Scan-build report
- [x] Memory test
- [x] Ruleset test
