### PR TITLE
Add raw parameter in order to get jwt token as plain text

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3908,6 +3908,13 @@ components:
       schema:
         type: string
         format: alphanumeric_symbols
+    raw:
+      in: query
+      name: raw
+      description: "Respond in raw format"
+      required: False
+      schema:
+        type: boolean
     registry:
       in: query
       name: registry
@@ -12617,12 +12624,13 @@ paths:
   /security/user/authenticate:
     get:
       tags:
-      - security
+        - security
       summary: "User/password authentication to get an access token"
       description: "This method should be called to get an API token. This token will expire at some time"
       operationId: api.controllers.security_controller.login_user
       parameters:
         - $ref: '#/components/parameters/auth_context'
+        - $ref: '#/components/parameters/raw'
       security:
         - basicAuth: []
       responses:
@@ -12637,6 +12645,10 @@ paths:
                     type: string
               example:
                 token: "<generated_token>"
+            text/plain:
+              schema:
+                type: string
+              example: "<generated_token>"
         '400':
           $ref: '#/components/responses/ResponseError'
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3911,7 +3911,7 @@ components:
     raw:
       in: query
       name: raw
-      description: "Respond in raw format"
+      description: "Format response in plain text"
       required: False
       schema:
         type: boolean

--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -11,6 +11,7 @@ variables:
   port: 55000
   user: testing
   pass: wazuh
+  basic_auth: dGVzdGluZzp3YXp1aA== # b64 encoded user:pass, update if user or pass changes
   login_endpoint: /security/user/authenticate
 
   # delays

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -9,7 +9,15 @@ def test_distinct_key(response):
     :param response: Request response
     :return: True if all request response items are unique
     """
-    assert not any(response.json()["data"]["affected_items"].count(item) > 1 for item in response.json()["data"]["affected_items"])
+    assert not any(
+        response.json()["data"]["affected_items"].count(item) > 1 for item in response.json()["data"]["affected_items"])
+
+
+def test_token_raw_format(response):
+    """
+    :param response: Request response
+    """
+    assert type(response.text) is str
 
 
 def test_select_key_affected_items(response, select_key):
@@ -53,7 +61,8 @@ def test_select_key_affected_items_with_agent_id(response, select_key):
         expected_keys_level0 = {'agent_id', select_key.split('.')[0]}
         expected_keys_level1 = {select_key.split('.')[1]}
         assert set(response.json()["data"]["affected_items"][0].keys()) == expected_keys_level0
-        assert set(response.json()["data"]["affected_items"][0][select_key.split('.')[0]].keys()) == expected_keys_level1
+        assert set(
+            response.json()["data"]["affected_items"][0][select_key.split('.')[0]].keys()) == expected_keys_level1
     else:
         expected_keys = {'agent_id', select_key}
         assert set(response.json()["data"]["affected_items"][0].keys()) == expected_keys

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -480,7 +480,7 @@ test_name: GET /security/user/authenticate
 
 stages:
 
-  - name: Get an API token
+  - name: Get an API token in raw format
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate"

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -476,6 +476,25 @@ stages:
         <<: *response_error
 
 ---
+test_name: GET /security/user/authenticate
+
+stages:
+
+  - name: Get an API token
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate"
+      headers:
+        Authorization: "Basic {basic_auth:s}"
+      params:
+        raw: True
+      method: GET
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_token_raw_format
+
+---
 test_name: GET /security/users
 
 stages:


### PR DESCRIPTION
**Related issue**
#5708 

Hi team,

This PR closes https://github.com/wazuh/wazuh/issues/5708. I have added `raw` parameter to `GET /security/user/authenticate` in order to choose the response format (json or plain text). I have added a new integration test case so this new functionality is tested.

-Test results:

Integration API test:
```
python3 api/test/integration/run_tests.py -k security_GET
Collected tests [1]:
test_security_GET_endpoints.tavern.yaml


test_security_GET_endpoints.tavern.yaml 
	 15 passed, 18 warnings
```

Unit test, test_security.py (sdk):
`================== 65 passed, 12 warnings in 65.81s (0:01:05) ==================
`