### PR TITLE
Unit Test for wazuh-logtest

### DIFF
--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -49,7 +49,9 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap
                              -Wl,--wrap,OSHash_Free -Wl,--wrap,os_remove_rules_list -Wl,--wrap,os_remove_decoders_list \
                              -Wl,--wrap,os_remove_cdblist -Wl,--wrap,os_remove_cdbrules -Wl,--wrap,os_remove_eventlist \
                              -Wl,--wrap,sleep -Wl,--wrap,OSHash_Begin -Wl,--wrap,time -Wl,--wrap,difftime -Wl,--wrap,OSHash_Next \
-                             -Wl,--wrap,FOREVER")
+                             -Wl,--wrap,FOREVER -Wl,--wrap,OS_CreateEventList -Wl,--wrap,ReadDecodeXML -Wl,--wrap,Lists_OP_LoadList \
+                             -Wl,--wrap,Lists_OP_MakeAll -Wl,--wrap,Rules_OP_ReadRules -Wl,--wrap,OS_ListLoadRules \
+                             -Wl,--wrap,_setlevels -Wl,--wrap,AddHash_Rule -Wl,--wrap,Accumulate_Init")
 
 LIST(APPEND analysisd_names "test_logtest-config")
 LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nproc -Wl,--wrap,cJSON_CreateObject \

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -169,6 +169,43 @@ OSHashNode *__wrap_OSHash_Next(const OSHash *self, unsigned int *i, OSHashNode *
     return mock_type(OSHashNode *);
 }
 
+void __wrap_OS_CreateEventList(int maxsize, EventList *list) {
+    return;
+}
+
+int __wrap_ReadDecodeXML(const char *file, OSDecoderNode **decoderlist_pn, 
+                         OSDecoderNode **decoderlist_nopn, OSList* log_msg) {
+    return mock_type(int);
+}
+
+int __wrap_Lists_OP_LoadList(char * files, ListNode ** cdblistnode) {
+    return mock_type(int);
+}
+
+void __wrap_Lists_OP_MakeAll(int force, int show_message, ListNode **lnode) {
+    return;
+}
+
+int __wrap_Rules_OP_ReadRules(char * file, RuleNode ** rule_list, ListNode ** cbd , EventList ** evet , OSList * msg) {
+    return mock_type(int);
+}
+
+void __wrap_OS_ListLoadRules(ListNode **l_node, ListRule **lrule) {
+    return;
+}
+
+int __wrap__setlevels(RuleNode *node, int nnode) {
+    return mock_type(int);
+}
+
+int __wrap_AddHash_Rule(RuleNode *node) {
+    return mock_type(int);
+}
+
+int __wrap_Accumulate_Init(OSHash **acm_store, int *acm_lookups, time_t *acm_purge_ts) {
+    return mock_type(int);
+}
+
 /* tests */
 
 /* w_logtest_init_parameters */
@@ -492,6 +529,266 @@ void test_w_logtest_check_inactive_sessions_remove(void **state)
 
 }
 
+/* w_logtest_initialize_session */
+void test_w_logtest_initialize_session_error_decoders(void ** state) {
+
+    char * token = "test";
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_ReadDecodeXML, 0);
+
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_null(session);
+    
+    os_free(Config.decoders);
+
+}
+
+void test_w_logtest_initialize_session_error_cbd_list(void ** state) {
+
+    char * token = "test";
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+    
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_Lists_OP_LoadList, -1);
+
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_null(session);
+    
+    os_free(Config.decoders);
+    os_free(Config.lists);
+
+}
+
+void test_w_logtest_initialize_session_error_rules(void ** state) {
+
+    char * token = "test";
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+    
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    char * include_file = "test.xml";
+    Config.includes = calloc(2, sizeof(char *));
+    Config.includes[0] = include_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_Lists_OP_LoadList, 0);
+    will_return(__wrap_Rules_OP_ReadRules, -1);
+
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_null(session);
+
+
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+
+}
+
+void test_w_logtest_initialize_session_error_hash_rules(void ** state) {
+
+    char * token = "test";
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    char * include_file = "test.xml";
+    Config.includes = calloc(2, sizeof(char *));
+    Config.includes[0] = include_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_Lists_OP_LoadList, 0);
+    will_return(__wrap_Rules_OP_ReadRules, 0);
+    will_return(__wrap__setlevels, 0);
+    will_return(__wrap_OSHash_Create, 0);
+
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_null(session);
+
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+}
+
+void test_w_logtest_initialize_session_error_fts_init(void ** state) {
+
+    char * token = "test";
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    char * include_file = "test.xml";
+    Config.includes = calloc(2, sizeof(char *));
+    Config.includes[0] = include_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_Lists_OP_LoadList, 0);
+    will_return(__wrap_Rules_OP_ReadRules, 0);
+    will_return(__wrap__setlevels, 0);
+    will_return(__wrap_OSHash_Create, 1);
+    will_return(__wrap_AddHash_Rule, 0);
+
+    /* FTS init fail */
+    OSList * fts_list;
+    OSHash * fts_store;
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_OSList_Create, NULL);
+    expect_string(__wrap__merror, formatted_msg, "(1290): Unable to create a new list (calloc).");
+
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_null(session);
+
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+
+}
+
+void test_w_logtest_initialize_session_error_accumulate_init(void ** state) {
+
+    char * token = "test";
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    char * include_file = "test.xml";
+    Config.includes = calloc(2, sizeof(char *));
+    Config.includes[0] = include_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_Lists_OP_LoadList, 0);
+    will_return(__wrap_Rules_OP_ReadRules, 0);
+    will_return(__wrap__setlevels, 0);
+    will_return(__wrap_OSHash_Create, 1);
+    will_return(__wrap_AddHash_Rule, 0);
+
+    /* FTS init success */
+    OSList *fts_list;
+    OSHash *fts_store;
+    OSList *list = (OSList *) 1;
+    OSHash *hash = (OSHash *) 1;
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_OSList_Create, list);
+    will_return(__wrap_OSList_SetMaxSize, 1);
+    will_return(__wrap_OSHash_Create, hash);
+    expect_value(__wrap_OSHash_setSize, new_size, 2048);
+    will_return(__wrap_OSHash_setSize, 1);
+
+    will_return(__wrap_Accumulate_Init, 0);
+
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_null(session);
+
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+
+}
+
+void test_w_logtest_initialize_session_success(void ** state) {
+
+    char * token = "test";
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    char * include_file = "test.xml";
+    Config.includes = calloc(2, sizeof(char *));
+    Config.includes[0] = include_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_Lists_OP_LoadList, 0);
+    will_return(__wrap_Rules_OP_ReadRules, 0);
+    will_return(__wrap__setlevels, 0);
+    will_return(__wrap_OSHash_Create, 1);
+    will_return(__wrap_AddHash_Rule, 0);
+
+    /* FTS init success */
+    OSList *fts_list;
+    OSHash *fts_store;
+    OSList *list = (OSList *) 1;
+    OSHash *hash = (OSHash *) 1;
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_OSList_Create, list);
+    will_return(__wrap_OSList_SetMaxSize, 1);
+    will_return(__wrap_OSHash_Create, hash);
+    expect_value(__wrap_OSHash_setSize, new_size, 2048);
+    will_return(__wrap_OSHash_setSize, 1);
+
+    will_return(__wrap_Accumulate_Init, 1);
+    
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_non_null(session);
+
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -514,7 +811,15 @@ int main(void)
         cmocka_unit_test(test_w_logtest_remove_session_OK),
         // Tests w_logtest_check_inactive_sessions
         cmocka_unit_test(test_w_logtest_check_inactive_sessions_no_remove),
-        cmocka_unit_test(test_w_logtest_check_inactive_sessions_remove)
+        cmocka_unit_test(test_w_logtest_check_inactive_sessions_remove),
+        // w_logtest_initialize_session
+        cmocka_unit_test(test_w_logtest_initialize_session_error_decoders),
+        cmocka_unit_test(test_w_logtest_initialize_session_error_cbd_list),
+        cmocka_unit_test(test_w_logtest_initialize_session_error_rules),
+        cmocka_unit_test(test_w_logtest_initialize_session_error_hash_rules),
+        cmocka_unit_test(test_w_logtest_initialize_session_error_fts_init),
+        cmocka_unit_test(test_w_logtest_initialize_session_error_accumulate_init),
+        cmocka_unit_test(test_w_logtest_initialize_session_success)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5364|

This issue covers the second round of unit tests for the new wazuh-logtest module. The tests to be developed will be those of the following functions:

## Tests

### New functions
**logtest.c**
- [x] w_logtest_init
- [x] w_logtest_init_parameters
- [ ] w_logtest_main
- [ ] w_logtest_process_log
- [x] w_logtest_initialize_session
- [x] w_logtest_remove_session
- [x] w_logtest_check_inactive_sessions
- [x] w_logtest_fts_init
- [ ] w_logtest_check_input
- [ ] w_logtest_generate_token
- [ ] w_logtest_get_rule_level
- [ ] w_logtest_add_msg_response
- [ ] w_logtest_get_session

**decoder_list.c**
- [x] os_remove_decoders_list
- [x] os_remove_decodernode
- [x] os_count_decoders

**decode-xml.c**
- [x] FreeDecoderInfo

**list_list.c**
- [x] os_remove_cdblist
- [x] os_remove_cdbrules

**rule_list.c**
- [x] os_remove_rules_list
- [x] os_remove_rulenode
- [x] os_remove_ruleinfo
- [x] os_count_rules

**eventinfo_list.c**
- [ ] os_remove_eventlist

**list_log.c**
- [ ] _os_analysisd_add_list_log
- [ ] os_analysisd_string_log_msg
- [ ] os_analysisd_free_log_msg

### Modified functions
**analysisd.c**
- [ ] OS_CheckIfRuleMatch();
- [ ] main_analysisd

**rules.c**
- [ ] Rules_OP_ReadRules();
- [ ] loadmemory
- [ ] Rules_OP_ReadRules
- [ ] get_info_attributes
- [ ] getattributes
- [ ] Rules_OP_CreateRules

**testrule.c**
- [ ] OS_ReadMSG();

**list_make.c:**
- [ ] Lists_OP_MakeAll

**decode-xml.c**
- [ ] ReadDecodeXML
- [ ] _loadmemory
- [ ] ReadDecodeXML
- [ ] SetDecodeXML
- [ ] FreeDecoderInfo

**decoders_list**
- [ ] ReadDecodeXML
- [ ] OS_AddOSDecoder
- [ ] _OS_AddOSDecoder

**rules_list.c**
- [ ] OS_AddChild

**list_list.c**
- [ ] OS_ListLoadRules

**shared/validate_op.c**
- [ ] OS_IsValidDay

**shared/rules_op.c**
- [ ] OS_ReadXMLRules

**config/syscheck-config.c**
- [ ] Read_Syscheck