### PR TITLE
Vulnerability Detector: Allowed compressed feeds for offline updates

### DIFF
--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -561,31 +561,31 @@ char * abspath(const char * path, char * buffer, size_t size);
 char * w_get_file_content(const char * path, int max_size);
 
 /**
- * @brief Check if a file is gzip compressed.
+ * @brief Check if a file is gzip compressed
  *
- * @param path File location.
- * @retval 0 The file is not gzip compressed.
- * @retval 1 The file is gzip compressed.
+ * @param path File location
+ * @retval 0 The file is not gzip compressed
+ * @retval 1 The file is gzip compressed
  */
 int w_is_compressed_gz_file(const char * path);
 
 /**
- * @brief Check if a file is bzip2 compressed.
- * 
- * @param path File location.
- * @retval 0 The file is not bzip2 compressed.
- * @retval 1 The file is bzip2 compressed.
+ * @brief Check if a file is bzip2 compressed
+ *
+ * @param path File location
+ * @retval 0 The file is not bzip2 compressed
+ * @retval 1 The file is bzip2 compressed
  */
 int w_is_compressed_bz2_file(const char * path);
 
 /**
- * @brief Check if a file from a path is compressed and uncompressed it.
+ * @brief Check if a file from a path is compressed in bunzip2 or gzip and uncompressed it
  * 
- * @param path File location.
- * @retval -1 The file cannot be uncompressed.
- * @retval 0 The file was uncompressed (.gz or .bz2).
- * @retval 1 The file is not compressed.
+ * @param path File location
+ * @retval -1 The file cannot be uncompressed
+ * @retval 0 The file has been uncompressed (.gz or .bz2)
+ * @retval 1 The file is not compressed
  */
-int w_check_compress_type_file(const char * path, const char * dest);
+int w_uncompress_bz2_gz_file(const char * path, const char * dest);
 
 #endif /* FILE_OP_H */

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -560,4 +560,22 @@ char * abspath(const char * path, char * buffer, size_t size);
  */
 char * w_get_file_content(const char * path, int max_size);
 
+/**
+ * @brief Check if a file is gzip compressed.
+ *
+ * @param path File location.
+ * @retval 0 The file is not gzip compressed.
+ * @retval 1 The file is gzip compressed.
+ */
+int w_is_compressed_gz_file(const char * path);
+
+/**
+ * @brief Check if a file is bzip2 compressed.
+ * 
+ * @param path File location.
+ * @retval 0 The file is not bzip2 compressed.
+ * @retval 1 The file is bzip2 compressed.
+ */
+int w_is_compressed_bz2_file(const char * path);
+
 #endif /* FILE_OP_H */

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -578,4 +578,14 @@ int w_is_compressed_gz_file(const char * path);
  */
 int w_is_compressed_bz2_file(const char * path);
 
+/**
+ * @brief Check if a file from a path is compressed and uncompressed it.
+ * 
+ * @param path File location.
+ * @retval -1 The file cannot be uncompressed.
+ * @retval 0 The file was uncompressed (.gz or .bz2).
+ * @retval 1 The file is not compressed.
+ */
+int w_check_compress_type_file(const char * path, const char * dest);
+
 #endif /* FILE_OP_H */

--- a/src/headers/url.h
+++ b/src/headers/url.h
@@ -24,6 +24,8 @@ int w_download_status(int status,const char *url,const char *dest);
 int wurl_request(const char * url, const char * dest, const char *header, const char *data, const long timeout);
 int wurl_request_gz(const char * url, const char * dest, const char * header, const char * data, const long timeout);
 char * wurl_http_get(const char * url);
+int wurl_request_bz2(const char * url, const char * dest, const char * header, const char * data, const long timeout);
+int wurl_request_check_compression_types(const char * url, const char * dest, const long timeout);
 
 /* Check download module availability */
 int wurl_check_connection();

--- a/src/headers/url.h
+++ b/src/headers/url.h
@@ -25,7 +25,7 @@ int wurl_request(const char * url, const char * dest, const char *header, const 
 int wurl_request_gz(const char * url, const char * dest, const char * header, const char * data, const long timeout);
 char * wurl_http_get(const char * url);
 int wurl_request_bz2(const char * url, const char * dest, const char * header, const char * data, const long timeout);
-int wurl_request_check_compression_types(const char * url, const char * dest, const long timeout);
+int wurl_request_uncompress_bz2_gz(const char * url, const char * dest, const long timeout);
 
 /* Check download module availability */
 int wurl_check_connection();

--- a/src/headers/url.h
+++ b/src/headers/url.h
@@ -25,7 +25,7 @@ int wurl_request(const char * url, const char * dest, const char *header, const 
 int wurl_request_gz(const char * url, const char * dest, const char * header, const char * data, const long timeout);
 char * wurl_http_get(const char * url);
 int wurl_request_bz2(const char * url, const char * dest, const char * header, const char * data, const long timeout);
-int wurl_request_uncompress_bz2_gz(const char * url, const char * dest, const long timeout);
+int wurl_request_uncompress_bz2_gz(const char * url, const char * dest, const char * header, const char * data, const long timeout);
 
 /* Check download module availability */
 int wurl_check_connection();

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -3111,3 +3111,37 @@ end:
 
     return buffer;
 }
+
+/* Check if a file is gzip compressed. */
+int w_is_compressed_gz_file(const char * path) {
+    unsigned char buf[2];
+    FILE *fp;
+
+    fp = fopen(path, "rb");
+    /* Magic number: 1f 8b */
+    if (fp && fread(buf, 1, 2, fp) == 2) {
+        if (buf[0] == 0x1f && buf[1] == 0x8b) {
+            fclose(fp);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/* Check if a file is bzip2 compressed. */
+int w_is_compressed_bz2_file(const char * path) {
+    unsigned char buf[3];
+    FILE *fp;
+
+    fp = fopen(path, "rb");
+    /* Magic number: 42 5a 68 */
+    if (fp && fread(buf, 1, 3, fp) == 3) {
+        if (buf[0] == 0x42 && buf[1] == 0x5a && buf[2] == 68) {
+            fclose(fp);
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -3115,38 +3115,48 @@ end:
 /* Check if a file is gzip compressed. */
 int w_is_compressed_gz_file(const char * path) {
     unsigned char buf[2];
+    int retval = 0;
     FILE *fp;
 
     fp = fopen(path, "rb");
+
     /* Magic number: 1f 8b */
     if (fp && fread(buf, 1, 2, fp) == 2) {
         if (buf[0] == 0x1f && buf[1] == 0x8b) {
-            fclose(fp);
-            return 1;
+            retval = 1;
         }
     }
 
-    return 0;
+    if (fp) {
+        fclose(fp);
+    }
+
+    return retval;
 }
 
 /* Check if a file is bzip2 compressed. */
 int w_is_compressed_bz2_file(const char * path) {
     unsigned char buf[3];
+    int retval = 0;
     FILE *fp;
 
     fp = fopen(path, "rb");
+
     /* Magic number: 42 5a 68 */
     if (fp && fread(buf, 1, 3, fp) == 3) {
         if (buf[0] == 0x42 && buf[1] == 0x5a && buf[2] == 0x68) {
-            fclose(fp);
-            return 1;
+            retval = 1;
         }
     }
 
-    return 0;
+    if (fp) {
+        fclose(fp);
+    }
+
+    return retval;
 }
 
-int w_check_compress_type_file(const char * path, const char * dest) {
+int w_uncompress_bz2_gz_file(const char * path, const char * dest) {
     int result = 1;
 
     if (w_is_compressed_bz2_file(path)) {

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -3137,11 +3137,29 @@ int w_is_compressed_bz2_file(const char * path) {
     fp = fopen(path, "rb");
     /* Magic number: 42 5a 68 */
     if (fp && fread(buf, 1, 3, fp) == 3) {
-        if (buf[0] == 0x42 && buf[1] == 0x5a && buf[2] == 68) {
+        if (buf[0] == 0x42 && buf[1] == 0x5a && buf[2] == 0x68) {
             fclose(fp);
             return 1;
         }
     }
 
     return 0;
+}
+
+int w_check_compress_type_file(const char * path, const char * dest) {
+    int result = 1;
+
+    if (w_is_compressed_bz2_file(path)) {
+        result = bzip2_uncompress(path, dest);
+    }
+
+    if (w_is_compressed_gz_file(path)) {
+        result = w_uncompress_gzfile(path, dest);
+    }
+
+    if (!result) {
+        mdebug1("The file '%s' was successfully uncompressed into '%s'", path, dest);
+    }
+
+    return result;
 }

--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -327,7 +327,7 @@ int wurl_request_uncompress_bz2_gz(const char * url, const char * dest, const lo
     }
 
     if (compress == 1 && !res_url_request) {
-        mdebug1("The file from url '%s' was successfully uncompressed into '%s'", url, dest);
+        mdebug1("File from URL '%s' was successfully uncompressed into '%s'", url, dest);
     }
 
     return res_url_request;

--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -206,7 +206,7 @@ int wurl_request_gz(const char * url, const char * dest, const char * header, co
         return retval;
     } else {
         if (w_uncompress_gzfile(compressed_file, dest)) {
-            merror("Could not uncompress the file downloaded from '%s'.", url);
+            merror("Could not uncompress the file downloaded from '%s'", url);
         } else {
             retval = 0;
         }
@@ -298,7 +298,7 @@ int wurl_request_bz2(const char * url, const char * dest, const char * header, c
         return retval;
     } else {
         if (bzip2_uncompress(compressed_file, dest)) {
-            merror("Could not uncompress the file downloaded from '%s'.", url);
+            merror("Could not uncompress the file downloaded from '%s'", url);
         } else {
             retval = 0;
         }
@@ -312,7 +312,7 @@ int wurl_request_bz2(const char * url, const char * dest, const char * header, c
 }
 
 // Check the compression type of the file and try to download and uncompress it.
-int wurl_request_check_compression_types(const char * url, const char * dest, const long timeout) {
+int wurl_request_uncompress_bz2_gz(const char * url, const char * dest, const long timeout) {
     int res_url_request;
     int compress = 0;
 

--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -314,13 +314,20 @@ int wurl_request_bz2(const char * url, const char * dest, const char * header, c
 // Check the compression type of the file and try to download and uncompress it.
 int wurl_request_check_compression_types(const char * url, const char * dest, const long timeout) {
     int res_url_request;
+    int compress = 0;
 
     if (wstr_end((char *)url, ".gz")) {
+        compress = 1;
         res_url_request = wurl_request_gz(url, dest, NULL, NULL, timeout);
     } else if (wstr_end((char *)url, ".bz2")) {
+        compress = 1;
         res_url_request = wurl_request_bz2(url, dest, NULL, NULL, timeout);
     } else {
         res_url_request = wurl_request(url, dest, NULL, NULL, timeout);
+    }
+
+    if (compress == 1 && !res_url_request) {
+        mdebug1("The file from url '%s' was successfully uncompressed into '%s'", url, dest);
     }
 
     return res_url_request;

--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -312,18 +312,18 @@ int wurl_request_bz2(const char * url, const char * dest, const char * header, c
 }
 
 // Check the compression type of the file and try to download and uncompress it.
-int wurl_request_uncompress_bz2_gz(const char * url, const char * dest, const long timeout) {
+int wurl_request_uncompress_bz2_gz(const char * url, const char * dest, const char * header, const char * data, const long timeout) {
     int res_url_request;
     int compress = 0;
 
     if (wstr_end((char *)url, ".gz")) {
         compress = 1;
-        res_url_request = wurl_request_gz(url, dest, NULL, NULL, timeout);
+        res_url_request = wurl_request_gz(url, dest, header, data, timeout);
     } else if (wstr_end((char *)url, ".bz2")) {
         compress = 1;
-        res_url_request = wurl_request_bz2(url, dest, NULL, NULL, timeout);
+        res_url_request = wurl_request_bz2(url, dest, header, data, timeout);
     } else {
-        res_url_request = wurl_request(url, dest, NULL, NULL, timeout);
+        res_url_request = wurl_request(url, dest, header, data, timeout);
     }
 
     if (compress == 1 && !res_url_request) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4082,11 +4082,27 @@ int wm_vuldet_json_rh_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilit
 
 int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *parsed_vulnerabilities, update_node *update) {
     int retval = OS_INVALID;
+    int compress = 0;
+
+    if (w_is_compressed_gz_file(json_path)) {
+        compress = 1;
+        if (w_uncompress_gzfile(json_path, VU_TEMP_FILE)) {
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_CONTENT_FEED_ERROR, update->dist_ext, json_path);
+            return retval;
+        }
+    }
+
+    if (w_is_compressed_bz2_file(json_path)) {
+        compress = 1;
+        if (bzip2_uncompress(json_path, VU_TEMP_FILE)) {
+            mterror(WM_VULNDETECTOR_LOGTAG, VU_CONTENT_FEED_ERROR, update->dist_ext, json_path);
+            return retval;
+        }
+    }
 
     if (update->dist_ref == FEED_NVD) {
         char *json_feed;
-
-        if (json_feed = w_get_file_content(json_path, JSON_MAX_FSIZE), !json_feed) {
+        if (json_feed = w_get_file_content(compress ? VU_TEMP_FILE : json_path, JSON_MAX_FSIZE), !json_feed) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_CONTENT_FEED_ERROR, update->dist_ext, json_path);
             return retval;
         }
@@ -4099,7 +4115,7 @@ int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *parsed_vulnerabilities,
     else {
         cJSON *json_feed;
 
-        if (json_feed = wm_vuldet_json_fread(json_path), !json_feed) {
+        if (json_feed = wm_vuldet_json_fread(compress ? VU_TEMP_FILE : json_path), !json_feed) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_PARSED_FEED_ERROR, update->dist_ext, json_path);
             return retval;
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3474,7 +3474,7 @@ int wm_vuldet_fetch_redhat(update_node *update) {
 
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_DOWNLOAD_START, repo);
     while (1) {
-        res_url_request = wurl_request_check_compression_types(repo, VU_FIT_TEMP_FILE, update->timeout);
+        res_url_request = wurl_request_uncompress_bz2_gz(repo, VU_FIT_TEMP_FILE, update->timeout);
         if (res_url_request) {
             if (attempt == RED_HAT_REPO_MAX_ATTEMPTS) {
                 mtwarn(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV_NEW, repo, RED_HAT_REPO_MAX_ATTEMPTS);
@@ -3544,7 +3544,7 @@ int wm_vuldet_index_feed(update_node *update) {
             update->dist_ref == FEED_DEBIAN ||
             update->dist_ref == FEED_REDHAT) {
 
-            switch (w_check_compress_type_file(path, VU_TEMP_FILE)) {
+            switch (w_uncompress_bz2_gz_file(path, VU_TEMP_FILE)) {
             case -1:
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_CONTENT_FEED_ERROR, update->dist_ext, path);
                 goto free_mem;
@@ -3603,7 +3603,7 @@ int wm_vuldet_fetch_oval(update_node *update, char *repo) {
     vu_logic retval = VU_INV_FEED;
 
     for (attempts = 0;; attempts++) {
-        int res_url_request = wurl_request_check_compression_types(repo, VU_TEMP_FILE, update->timeout);
+        int res_url_request = wurl_request_uncompress_bz2_gz(repo, VU_TEMP_FILE, update->timeout);
         if (!res_url_request) {
             break;
         } else if (attempts == WM_VULNDETECTOR_DOWN_ATTEMPTS) {
@@ -3871,7 +3871,7 @@ cJSON *wm_vuldet_get_debian_status_feed(update_node *update) {
     if (path) {
         // Fetch Debian Security Tracker feed locally
         if (w_is_file(path)) {
-            switch (w_check_compress_type_file(path, VU_DEB_TEMP_FILE)) {
+            switch (w_uncompress_bz2_gz_file(path, VU_DEB_TEMP_FILE)) {
             case -1:
                 return NULL;
             case 0:
@@ -3892,7 +3892,7 @@ cJSON *wm_vuldet_get_debian_status_feed(update_node *update) {
         // Download Debian status feed
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DEB_STATUS_FETCH, url);
         for (attempts = 0;; attempts++) {
-            res_url_request = wurl_request_check_compression_types(url, VU_DEB_TEMP_FILE, update->timeout);
+            res_url_request = wurl_request_uncompress_bz2_gz(url, VU_DEB_TEMP_FILE, update->timeout);
             if (!res_url_request) {
                 break;
             } else if (attempts == WM_VULNDETECTOR_DOWN_ATTEMPTS) {
@@ -4097,7 +4097,7 @@ int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *parsed_vulnerabilities,
     int retval = OS_INVALID;
     int compress = 0;
 
-    switch (w_check_compress_type_file(json_path, VU_FIT_TEMP_FILE)) {
+    switch (w_uncompress_bz2_gz_file(json_path, VU_FIT_TEMP_FILE)) {
     case -1:
         mterror(WM_VULNDETECTOR_LOGTAG, VU_CONTENT_FEED_ERROR, update->dist_ext, json_path);
         return retval;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3460,6 +3460,7 @@ int wm_vuldet_fetch_redhat(update_node *update) {
     FILE *fp = NULL;
     char *repo = NULL;
     char buffer[OS_SIZE_128 + 1];
+    int res_url_request;
 
     if (update->multi_url) {
         char tag[10 + 1];
@@ -3473,7 +3474,8 @@ int wm_vuldet_fetch_redhat(update_node *update) {
 
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_DOWNLOAD_START, repo);
     while (1) {
-        if (wurl_request(repo, VU_FIT_TEMP_FILE, NULL, NULL, update->timeout)) {
+        res_url_request = wurl_request_check_compression_types(repo, VU_FIT_TEMP_FILE, update->timeout);
+        if (res_url_request) {
             if (attempt == RED_HAT_REPO_MAX_ATTEMPTS) {
                 mtwarn(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV_NEW, repo, RED_HAT_REPO_MAX_ATTEMPTS);
                 update->update_state = VU_TRY_NEXT_PAGE;
@@ -3588,13 +3590,7 @@ int wm_vuldet_fetch_oval(update_node *update, char *repo) {
     vu_logic retval = VU_INV_FEED;
 
     for (attempts = 0;; attempts++) {
-        int res_url_request;
-        if (update->dist_ref == FEED_DEBIAN) {
-            res_url_request = wurl_request(repo, VU_TEMP_FILE, NULL, NULL, update->timeout);
-        } else {
-            res_url_request = wurl_request(repo, VU_TEMP_FILE_BZ2, NULL, NULL, update->timeout);
-        }
-
+        int res_url_request = wurl_request_check_compression_types(repo, VU_TEMP_FILE, update->timeout);
         if (!res_url_request) {
             break;
         } else if (attempts == WM_VULNDETECTOR_DOWN_ATTEMPTS) {
@@ -3602,13 +3598,6 @@ int wm_vuldet_fetch_oval(update_node *update, char *repo) {
         }
         mdebug1(VU_DOWNLOAD_FAIL, attempts);
         sleep(attempts);
-    }
-
-    if (update->dist_ref != FEED_DEBIAN) {
-        int result;
-        if (result = bzip2_uncompress(VU_TEMP_FILE_BZ2, VU_TEMP_FILE), result == -1) {
-            goto end;
-        }
     }
 
     if (fp = fopen(VU_TEMP_FILE, "r"), !fp) {
@@ -3880,7 +3869,8 @@ cJSON *wm_vuldet_get_debian_status_feed(update_node *update) {
         // Download Debian status feed
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DEB_STATUS_FETCH, url);
         for (attempts = 0;; attempts++) {
-            if (res_url_request = wurl_request(url, VU_DEB_TEMP_FILE, NULL, NULL, update->timeout), !res_url_request) {
+            res_url_request = wurl_request_check_compression_types(url, VU_DEB_TEMP_FILE, update->timeout);
+            if (!res_url_request) {
                 break;
             } else if (attempts == WM_VULNDETECTOR_DOWN_ATTEMPTS) {
                 return NULL;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3474,7 +3474,7 @@ int wm_vuldet_fetch_redhat(update_node *update) {
 
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_DOWNLOAD_START, repo);
     while (1) {
-        res_url_request = wurl_request_uncompress_bz2_gz(repo, VU_FIT_TEMP_FILE, update->timeout);
+        res_url_request = wurl_request_uncompress_bz2_gz(repo, VU_FIT_TEMP_FILE, NULL, NULL, update->timeout);
         if (res_url_request) {
             if (attempt == RED_HAT_REPO_MAX_ATTEMPTS) {
                 mtwarn(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV_NEW, repo, RED_HAT_REPO_MAX_ATTEMPTS);
@@ -3603,7 +3603,7 @@ int wm_vuldet_fetch_oval(update_node *update, char *repo) {
     vu_logic retval = VU_INV_FEED;
 
     for (attempts = 0;; attempts++) {
-        int res_url_request = wurl_request_uncompress_bz2_gz(repo, VU_TEMP_FILE, update->timeout);
+        int res_url_request = wurl_request_uncompress_bz2_gz(repo, VU_TEMP_FILE, NULL, NULL, update->timeout);
         if (!res_url_request) {
             break;
         } else if (attempts == WM_VULNDETECTOR_DOWN_ATTEMPTS) {
@@ -3892,7 +3892,7 @@ cJSON *wm_vuldet_get_debian_status_feed(update_node *update) {
         // Download Debian status feed
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DEB_STATUS_FETCH, url);
         for (attempts = 0;; attempts++) {
-            res_url_request = wurl_request_uncompress_bz2_gz(url, VU_DEB_TEMP_FILE, update->timeout);
+            res_url_request = wurl_request_uncompress_bz2_gz(url, VU_DEB_TEMP_FILE, NULL, NULL, update->timeout);
             if (!res_url_request) {
                 break;
             } else if (attempts == WM_VULNDETECTOR_DOWN_ATTEMPTS) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3520,6 +3520,7 @@ int wm_vuldet_index_feed(update_node *update) {
     const char *OS_VERSION;
     char *path;
     char success = 0;
+    int compress;
 
     memset(&parsed_vulnerabilities, 0, sizeof(wm_vuldet_db));
     OS_VERSION = vu_feed_tag[update->dist_tag_ref];
@@ -3542,7 +3543,19 @@ int wm_vuldet_index_feed(update_node *update) {
         if (update->dist_ref == FEED_UBUNTU ||
             update->dist_ref == FEED_DEBIAN ||
             update->dist_ref == FEED_REDHAT) {
-            if (wm_vuldet_oval_process(update, path, &parsed_vulnerabilities)) {
+
+            switch (w_check_compress_type_file(path, VU_TEMP_FILE)) {
+            case -1:
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_CONTENT_FEED_ERROR, update->dist_ext, path);
+                goto free_mem;
+            case 0:
+                compress = 1;
+                break;
+            default:
+                compress = 0;
+            }
+
+            if (wm_vuldet_oval_process(update, compress ? VU_TEMP_FILE : path, &parsed_vulnerabilities)) {
                 goto free_mem;
             }
         }
@@ -3845,6 +3858,7 @@ cJSON *wm_vuldet_get_debian_status_feed(update_node *update) {
     char * path = NULL;
     char * url = DEBIAN_REPO_STATUS;
     cJSON * json_file = NULL;
+    int compress;
 
     if (update->multi_path) {
         path = update->multi_path;
@@ -3857,8 +3871,17 @@ cJSON *wm_vuldet_get_debian_status_feed(update_node *update) {
     if (path) {
         // Fetch Debian Security Tracker feed locally
         if (w_is_file(path)) {
+            switch (w_check_compress_type_file(path, VU_DEB_TEMP_FILE)) {
+            case -1:
+                return NULL;
+            case 0:
+                compress = 1;
+                break;
+            default:
+                compress = 0;
+            }
             mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_DEB_STATUS_FETCH, path);
-            json_file = wm_vuldet_json_fread(path);
+            json_file = wm_vuldet_json_fread(compress ? VU_DEB_TEMP_FILE : path);
             return json_file;
         } else {
             mtdebug1(WM_VULNDETECTOR_LOGTAG, "Unable to read file '%s'", path);
@@ -4074,25 +4097,20 @@ int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *parsed_vulnerabilities,
     int retval = OS_INVALID;
     int compress = 0;
 
-    if (w_is_compressed_gz_file(json_path)) {
+    switch (w_check_compress_type_file(json_path, VU_FIT_TEMP_FILE)) {
+    case -1:
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_CONTENT_FEED_ERROR, update->dist_ext, json_path);
+        return retval;
+    case 0:
         compress = 1;
-        if (w_uncompress_gzfile(json_path, VU_TEMP_FILE)) {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_CONTENT_FEED_ERROR, update->dist_ext, json_path);
-            return retval;
-        }
-    }
-
-    if (w_is_compressed_bz2_file(json_path)) {
-        compress = 1;
-        if (bzip2_uncompress(json_path, VU_TEMP_FILE)) {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_CONTENT_FEED_ERROR, update->dist_ext, json_path);
-            return retval;
-        }
+        break;
+    default:
+        compress = 0;
     }
 
     if (update->dist_ref == FEED_NVD) {
         char *json_feed;
-        if (json_feed = w_get_file_content(compress ? VU_TEMP_FILE : json_path, JSON_MAX_FSIZE), !json_feed) {
+        if (json_feed = w_get_file_content(compress ? VU_FIT_TEMP_FILE : json_path, JSON_MAX_FSIZE), !json_feed) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_CONTENT_FEED_ERROR, update->dist_ext, json_path);
             return retval;
         }
@@ -4105,7 +4123,7 @@ int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *parsed_vulnerabilities,
     else {
         cJSON *json_feed;
 
-        if (json_feed = wm_vuldet_json_fread(compress ? VU_TEMP_FILE : json_path), !json_feed) {
+        if (json_feed = wm_vuldet_json_fread(compress ? VU_FIT_TEMP_FILE : json_path), !json_feed) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_PARSED_FEED_ERROR, update->dist_ext, json_path);
             return retval;
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -845,7 +845,7 @@ int wm_vuldet_fetch_nvd_cve(update_node *update) {
         repo = wstr_replace(update->multi_url, MULTI_URL_TAG, tag);
 
         for (attempt = 0; attempt < NVD_REPO_MAX_ATTEMPTS; attempt++) {
-            if (wurl_request(repo, VU_FIT_TEMP_FILE, NULL, NULL, update->timeout)) {
+            if (wurl_request_uncompress_bz2_gz(repo, VU_FIT_TEMP_FILE, NULL, NULL, update->timeout)) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV, repo, attempt * DOWNLOAD_SLEEP_FACTOR);
                 sleep(attempt * DOWNLOAD_SLEEP_FACTOR);
                 continue;
@@ -932,7 +932,7 @@ int wm_vuldet_fetch_nvd_cve(update_node *update) {
         // At this point we know that we must update the feed for this year
         snprintf(repo, OS_SIZE_2048, NVD_CVE_REPO, update->update_it);
         for (attempt = 0; attempt < NVD_REPO_MAX_ATTEMPTS; attempt++) {
-            res_url_request = wurl_request_uncompress_bz2_gz(repo, VU_FIT_TEMP_FILE, update->timeout);
+            res_url_request = wurl_request_uncompress_bz2_gz(repo, VU_FIT_TEMP_FILE, NULL, NULL, update->timeout);
             if (res_url_request) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV, repo, attempt * DOWNLOAD_SLEEP_FACTOR);
                 sleep(attempt * DOWNLOAD_SLEEP_FACTOR);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -932,7 +932,7 @@ int wm_vuldet_fetch_nvd_cve(update_node *update) {
         // At this point we know that we must update the feed for this year
         snprintf(repo, OS_SIZE_2048, NVD_CVE_REPO, update->update_it);
         for (attempt = 0; attempt < NVD_REPO_MAX_ATTEMPTS; attempt++) {
-            res_url_request = wurl_request_check_compression_types(repo, VU_FIT_TEMP_FILE, update->timeout);
+            res_url_request = wurl_request_uncompress_bz2_gz(repo, VU_FIT_TEMP_FILE, update->timeout);
             if (res_url_request) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV, repo, attempt * DOWNLOAD_SLEEP_FACTOR);
                 sleep(attempt * DOWNLOAD_SLEEP_FACTOR);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -835,6 +835,7 @@ int wm_vuldet_fetch_nvd_cve(update_node *update) {
     sqlite3 *db = NULL;
     static char *feed_last_mod = "lastModifiedDate:";
     char *last_mod = NULL;
+    int res_url_request;
 
     if (update->multi_url) {
         char tag[10 + 1];
@@ -931,7 +932,8 @@ int wm_vuldet_fetch_nvd_cve(update_node *update) {
         // At this point we know that we must update the feed for this year
         snprintf(repo, OS_SIZE_2048, NVD_CVE_REPO, update->update_it);
         for (attempt = 0; attempt < NVD_REPO_MAX_ATTEMPTS; attempt++) {
-            if (wurl_request_gz(repo, VU_FIT_TEMP_FILE, NULL, NULL, update->timeout)) {
+            res_url_request = wurl_request_check_compression_types(repo, VU_FIT_TEMP_FILE, update->timeout);
+            if (res_url_request) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV, repo, attempt * DOWNLOAD_SLEEP_FACTOR);
                 sleep(attempt * DOWNLOAD_SLEEP_FACTOR);
                 continue;


### PR DESCRIPTION
|Related issue|
|---|
|#5152|

## Description

This Pull Request enables Vulnerability Detector module to download/open feeds that are compressed (gzip or bzip2). In that way, you do not need to uncompressed them before configuring this module and storage consumption is reduced.
 
## Configuration options

```xml
<provider name="canonical">
    <enabled>yes</enabled>
    <os path="/local_path/com.ubuntu.focal.cve.oval.xml.bz2">focal</os>
    <os path="/local_path/com.ubuntu.bionic.cve.oval.xml.bz2">bionic</os>
    <os path="/local_path/com.ubuntu.xenial.cve.oval.xml.bz2">xenial</os>
    <os path="/local_path/com.ubuntu.trusty.cve.oval.xml.bz2">trusty</os>
    <update_interval>1h</update_interval>
</provider>
```

```xml
<provider name="redhat">
    <enabled>yes</enabled>
    <os path="/local_path/com.redhat.rhsa-RHEL5.xml.bz2">5</os>
    <os path="/local_path/rhel-6-including-unpatched.oval.xml.bz2">6</os>
    <os path="/local_path/rhel-7-including-unpatched.oval.xml.bz2">7</os>
    <os path="/local_path/rhel-8-including-unpatched.oval.xml.bz2">8</os>
    <path>/local_path/redhat-feed.*json.gz$</path>
    <update_interval>1h</update_interval>
</provider>
```

```xml
<provider name="nvd">
    <enabled>yes</enabled>
    <path>/local_path/nvd-feed.*json.gz$</path>
    <update_interval>1h</update_interval>
</provider>
```

## Logs/Alerts example

> 2020/08/14 15:07:05 wazuh-modulesd[22896] url.c:330 at wurl_request_check_compression_types(): DEBUG: The file from url 'https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2020.json.gz' was successfully uncompressed into 'tmp/vuln-temp-fitted'

> 2020/08/14 15:00:46 wazuh-modulesd[22896] file_op.c:3161 at w_check_compress_type_file(): DEBUG: The file '/local_path/redhat-feed1.json.gz' was successfully uncompressed into 'tmp/vuln-temp-fitted'


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
