### PR TITLE
[5726] Changed getStatement call to createStatement so that the statement is…

### DIFF
--- a/src/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -299,7 +299,7 @@ void SQLiteDBEngine::selectData(const std::string& table,
 {
     if (0 != loadTableData(table))
     {
-        const auto& stmt { getStatement(buildSelectQuery(table, query)) };
+        const auto& stmt { m_sqliteFactory->createStatement(m_sqliteConnection, buildSelectQuery(table, query)) };
 
         while (SQLITE_ROW == stmt->step())
         {


### PR DESCRIPTION
# Do not use statements cache in select operations.
|Related issue|
|---|
|[5726](https://github.com/wazuh/wazuh/issues/5726)|

## Description
The goal of this issue is to avoid the misused of statements cache in select queries.

## DoD
- [X] Development
- [X] RTR Tool execution
![image](https://user-images.githubusercontent.com/54002291/90256594-541f2800-de1c-11ea-8ac3-4190c6f55c22.png)
