### PR TITLE
[5725] Adding flexibility to the insert operation and control every stmt step

### DIFF
--- a/src/dbsync/cppcheckSuppress.txt
+++ b/src/dbsync/cppcheckSuppress.txt
@@ -1,1 +1,1 @@
-*:src/sqlite/sqlite_dbengine.cpp:122
+*:src/sqlite/sqlite_dbengine.cpp:131

--- a/src/dbsync/src/db_exception.h
+++ b/src/dbsync/src/db_exception.h
@@ -27,6 +27,7 @@ constexpr auto INVALID_COLUMN_TYPE      { std::make_pair(11, "Invalid column fie
 constexpr auto INVALID_DATA_BIND        { std::make_pair(12, "Invalid data to bind.") };
 constexpr auto INVALID_TABLE            { std::make_pair(13, "Invalid table.") };
 constexpr auto INVALID_DELETE_INFO      { std::make_pair(14, "Invalid information provided for deletion.") };
+constexpr auto BIND_FIELDS_DOES_MATCH   { std::make_pair(15, "Invalid information provided for statement creation.") };
 
 namespace DbSync
 {

--- a/src/dbsync/src/db_exception.h
+++ b/src/dbsync/src/db_exception.h
@@ -13,21 +13,21 @@
 #include <stdexcept>
 #include <string>
 
-constexpr auto FACTORY_INSTANTATION     { std::make_pair(1, "Unspecified type during factory instantiation") };
-constexpr auto INVALID_HANDLE           { std::make_pair(2, "Invalid handle value.") };
-constexpr auto INVALID_TRANSACTION      { std::make_pair(3, "Invalid transaction value.") };
-constexpr auto SQLITE_CONNECTION_ERROR  { std::make_pair(4, "No connection available for executions.") };
-constexpr auto EMPTY_DATABASE_PATH      { std::make_pair(5, "Empty database store path.") };
-constexpr auto EMPTY_TABLE_METADATA     { std::make_pair(6, "Empty table metadata.") };
-constexpr auto INVALID_PARAMETERS       { std::make_pair(7, "Invalid parameters.") };
-constexpr auto DATATYPE_NOT_IMPLEMENTED { std::make_pair(8, "Datatype not implemented.") };
-constexpr auto SQL_STMT_ERROR           { std::make_pair(9, "Invalid SQL statement.") };
-constexpr auto INVALID_PK_DATA          { std::make_pair(10, "Primary key not found.") };
-constexpr auto INVALID_COLUMN_TYPE      { std::make_pair(11, "Invalid column field type.") };
-constexpr auto INVALID_DATA_BIND        { std::make_pair(12, "Invalid data to bind.") };
-constexpr auto INVALID_TABLE            { std::make_pair(13, "Invalid table.") };
-constexpr auto INVALID_DELETE_INFO      { std::make_pair(14, "Invalid information provided for deletion.") };
-constexpr auto BIND_FIELDS_DOES_MATCH   { std::make_pair(15, "Invalid information provided for statement creation.") };
+constexpr auto FACTORY_INSTANTATION       { std::make_pair(1, "Unspecified type during factory instantiation") };
+constexpr auto INVALID_HANDLE             { std::make_pair(2, "Invalid handle value.") };
+constexpr auto INVALID_TRANSACTION        { std::make_pair(3, "Invalid transaction value.") };
+constexpr auto SQLITE_CONNECTION_ERROR    { std::make_pair(4, "No connection available for executions.") };
+constexpr auto EMPTY_DATABASE_PATH        { std::make_pair(5, "Empty database store path.") };
+constexpr auto EMPTY_TABLE_METADATA       { std::make_pair(6, "Empty table metadata.") };
+constexpr auto INVALID_PARAMETERS         { std::make_pair(7, "Invalid parameters.") };
+constexpr auto DATATYPE_NOT_IMPLEMENTED   { std::make_pair(8, "Datatype not implemented.") };
+constexpr auto SQL_STMT_ERROR             { std::make_pair(9, "Invalid SQL statement.") };
+constexpr auto INVALID_PK_DATA            { std::make_pair(10, "Primary key not found.") };
+constexpr auto INVALID_COLUMN_TYPE        { std::make_pair(11, "Invalid column field type.") };
+constexpr auto INVALID_DATA_BIND          { std::make_pair(12, "Invalid data to bind.") };
+constexpr auto INVALID_TABLE              { std::make_pair(13, "Invalid table.") };
+constexpr auto INVALID_DELETE_INFO        { std::make_pair(14, "Invalid information provided for deletion.") };
+constexpr auto BIND_FIELDS_DOES_NOT_MATCH { std::make_pair(15, "Invalid information provided for statement creation.") };
 
 namespace DbSync
 {

--- a/src/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -69,7 +69,7 @@ void SQLiteDBEngine::bulkInsert(const std::string& table,
             }
             if (SQLITE_ERROR == stmt->step())
             {
-                throw dbengine_error{ BIND_FIELDS_DOES_MATCH };
+                throw dbengine_error{ BIND_FIELDS_DOES_NOT_MATCH };
             }
             stmt->reset();
         }
@@ -852,7 +852,7 @@ bool SQLiteDBEngine::deleteRows(const std::string& table,
             }
             if (SQLITE_ERROR == stmt->step())
             {
-                throw dbengine_error{ BIND_FIELDS_DOES_MATCH };
+                throw dbengine_error{ BIND_FIELDS_DOES_NOT_MATCH };
             }
             stmt->reset();
         }
@@ -902,7 +902,7 @@ void SQLiteDBEngine::deleteRowsbyPK(const std::string& table,
             }
             if (SQLITE_ERROR == stmt->step())
             {
-                throw dbengine_error{ BIND_FIELDS_DOES_MATCH };
+                throw dbengine_error{ BIND_FIELDS_DOES_NOT_MATCH };
             }
             stmt->reset();
         }
@@ -1139,7 +1139,7 @@ void SQLiteDBEngine::bulkInsert(const std::string& table,
         }
         if (SQLITE_ERROR == stmt->step())
         {
-            throw dbengine_error{ BIND_FIELDS_DOES_MATCH };
+            throw dbengine_error{ BIND_FIELDS_DOES_NOT_MATCH };
         }
         stmt->reset();
     }
@@ -1419,7 +1419,7 @@ void SQLiteDBEngine::updateSingleRow(const std::string& table,
         }
         if (SQLITE_ERROR == stmt->step())
         {
-            throw dbengine_error{ BIND_FIELDS_DOES_MATCH };
+            throw dbengine_error{ BIND_FIELDS_DOES_NOT_MATCH };
         }
         stmt->reset();
     }

--- a/src/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/dbsync/src/sqlite/sqlite_dbengine.h
@@ -147,7 +147,8 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
 
         bool loadFieldData(const std::string& table);
 
-        std::string buildInsertBulkDataSqlQuery(const std::string& table);
+        std::string buildInsertBulkDataSqlQuery(const std::string& table,
+                                                const nlohmann::json& data = {});
 
         std::string buildDeleteBulkDataSqlQuery(const std::string& table, 
                                                 const std::vector<std::string>& primaryKeyList,
@@ -220,7 +221,8 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
                                const std::vector<std::string>& primaryKeyList,
                                std::vector<Row>& returnRows);
 
-        void bulkInsert(const std::string& table, const std::vector<Row>& data);
+        void bulkInsert(const std::string& table,
+                        const std::vector<Row>& data);
 
         void deleteTempTable(const std::string& table);
 

--- a/src/dbsync/src/sqlite/sqlite_wrapper.h
+++ b/src/dbsync/src/sqlite/sqlite_wrapper.h
@@ -91,6 +91,8 @@ namespace SQLite
     private:
         std::shared_ptr<IConnection> m_connection;
         std::shared_ptr<sqlite3_stmt> m_stmt;
+        int m_bindParametersCount;
+        int m_bindParametersIndex;
     };
 }
 

--- a/src/dbsync/src/sqlite/sqlite_wrapper.h
+++ b/src/dbsync/src/sqlite/sqlite_wrapper.h
@@ -91,7 +91,7 @@ namespace SQLite
     private:
         std::shared_ptr<IConnection> m_connection;
         std::shared_ptr<sqlite3_stmt> m_stmt;
-        int m_bindParametersCount;
+        const int m_bindParametersCount;
         int m_bindParametersIndex;
     };
 }


### PR DESCRIPTION
# Adding flexibility to the insert operation and throw exception when statements are wrong

## Related Issue
[5725](https://github.com/wazuh/wazuh/issues/5725)

## Description
This issue was found, during the review of #5670, this indicates that the generalization does not prevent inserts with partial and sufficient data.

## Expected results
- Throw an exception when the prepared statement does not have all the fields bind of the prepared statement.
- Insert bulk based on the arguments received in the JSON, this will be validated with the metadata if the insert fails because it cannot meet the minimum fields for an insert statement of that table, it will throw an exception.

## DoD
- [X] Development
- [X] RTR Tool execution
![image](https://user-images.githubusercontent.com/22640902/90289418-353b8880-de52-11ea-9d11-5cb3555ea7af.png)

