### PR TITLE
Creation of sync-agent-info-command

### DIFF
--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -104,7 +104,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_LABELS_GET] = "SELECT * FROM labels WHERE id = ?;",
     [WDB_STMT_GLOBAL_LABELS_DEL] = "DELETE FROM labels WHERE id = ?;",
     [WDB_STMT_GLOBAL_LABELS_SET] = "INSERT INTO labels (id, key, value) VALUES (?,?,?);",
-    [WDB_STMT_GLOBAL_SYNC_REQ_GET] = "SELECT id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version config_sum, merged_sum, manager_host, node_name, last_keepalive FROM agent WHERE id > ? LIMIT 1;", 
+    [WDB_STMT_GLOBAL_SYNC_REQ_GET] = "SELECT id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version config_sum, merged_sum, manager_host, node_name, last_keepalive FROM agent WHERE id > ? AND sync_status = 1 LIMIT 1;", 
     [WDB_STMT_GLOBAL_SYNC_SET] = "UPDATE agent SET sync_status = ? WHERE id = ?;",
     [WDB_STMT_PRAGMA_JOURNAL_WAL] = "PRAGMA journal_mode=WAL;",
 };

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -104,6 +104,8 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_LABELS_GET] = "SELECT * FROM labels WHERE id = ?;",
     [WDB_STMT_GLOBAL_LABELS_DEL] = "DELETE FROM labels WHERE id = ?;",
     [WDB_STMT_GLOBAL_LABELS_SET] = "INSERT INTO labels (id, key, value) VALUES (?,?,?);",
+    [WDB_STMT_GLOBAL_SYNC_REQ_GET] = "SELECT id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version config_sum, merged_sum, manager_host, node_name, last_keepalive FROM agent WHERE id > ? LIMIT 1;", 
+    [WDB_STMT_GLOBAL_SYNC_SET] = "UPDATE agent SET sync_status = ? WHERE id = ?;",
     [WDB_STMT_PRAGMA_JOURNAL_WAL] = "PRAGMA journal_mode=WAL;",
 };
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -196,10 +196,10 @@ typedef enum {
 
 /// Enumeration of sync-agent-info-get-status.
 typedef enum {
-    WDB_CHUNKS_PENDING,       //There are still elements to get
-    WDB_CHUNKS_BUFFER_FULL,   //There are still elements to get but buffer is full
-    WDB_CHUNKS_COMPLETE,      //There aren't any more elements to get
-    WDB_CHUNKS_ERROR          //An error occured
+    WDB_CHUNKS_PENDING,       ///< There are still elements to get
+    WDB_CHUNKS_BUFFER_FULL,   ///< There are still elements to get but buffer is full
+    WDB_CHUNKS_COMPLETE,      ///< There aren't any more elements to get
+    WDB_CHUNKS_ERROR          ///< An error occured
 } wdb_chunks_status_t;
 
 extern char *schema_global_sql;
@@ -395,7 +395,10 @@ int wdb_set_agent_labels(int id, const char *labels);
 
 int wdb_global_set_sync_status(wdb_t *wdb, int id, wdb_sync_status_t status);
 
-/*DOXYGEN here*/
+/**
+ * @brief Gets and parses agents with status
+ * 
+ */
 wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char **output);
 
 /* Update agent's last keepalive. It opens and closes the DB. Returns number of affected rows or -1 on error. */

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -393,14 +393,6 @@ cJSON* wdb_get_agent_labels(int id);
  */
 int wdb_set_agent_labels(int id, const char *labels);
 
-int wdb_global_set_sync_status(wdb_t *wdb, int id, wdb_sync_status_t status);
-
-/**
- * @brief Gets and parses agents with status
- * 
- */
-wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char **output);
-
 /* Update agent's last keepalive. It opens and closes the DB. Returns number of affected rows or -1 on error. */
 int wdb_update_agent_keepalive(int id, wdb_sync_status_t sync_status);
 
@@ -715,7 +707,16 @@ int wdb_parse_global_get_agent_labels(wdb_t * wdb, char * input, char * output);
  */
 int wdb_parse_global_set_agent_labels(wdb_t * wdb, char * input, char * output);
 
-/*DOXYGEN here*/
+/**
+ * @brief Function to parse sync-agent-info-get params and set next ID to iterate on further calls.
+ *        If no start_id is provided. Last obtained ID is used.
+ * 
+ * @param wdb the global struct database.
+ * @param input String with starting ID [optional].
+ * @param output Response of the query.
+ * @retval 0 Success: response contains the value.
+ * @retval -1 On error: invalid DB query syntax.
+ */
 int wdb_parse_global_sync_agent_info_get(wdb_t * wdb, char * input, char * output);
 
 int wdbi_checksum_range(wdb_t * wdb, wdb_component_t component, const char * begin, const char * end, os_sha1 hexdigest);
@@ -827,6 +828,30 @@ int wdb_global_del_agent_labels(wdb_t *wdb, int id);
  * @retval -1 On error.
  */
 int wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value);
+
+/**
+ * @brief Function to update sync_status of a particular agent.
+ * 
+ * @param wdb The Global struct database.
+ * @param id The agent ID
+ * @param status The value of sync_status
+ * @retval 0 On success.
+ * @retval -1 On error.
+ */
+int wdb_global_set_sync_status(wdb_t *wdb, int id, wdb_sync_status_t status);
+
+/**
+ * @brief Gets and parses agents with WDB_SYNC_REQ sync_status and sets them to WDB_SYNCED.
+ *        Response is prepared in one chunk, 
+ *        if the size of the chunk exceeds WDB_MAX_RESPONSE_SIZE parsing stops and reports the amount of agents obtained.
+ *        Multiple calls to this function can be required to fully obtain all agents.
+ *       
+ * @param wdb The Global struct database.
+ * @param last_agent_id ID where to start querying.
+ * @param output buffer where the response is written. Must be de-allocated by the caller.
+ * @return wdb_chunks_status_t to represent if all agents has being obtained.
+ */
+wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char **output);
 
 // Finalize a statement securely
 #define wdb_finalize(x) { if (x) { sqlite3_finalize(x); x = NULL; } }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -110,3 +110,122 @@ int wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value) {
         return OS_INVALID;
     }
 }
+
+int wdb_global_set_sync_status(wdb_t *wdb, int id, wdb_sync_status_t status) {
+    sqlite3_stmt *stmt = NULL;
+
+    if (!wdb->transaction && wdb_begin2(wdb) < 0) {
+        mdebug1("cannot begin transaction");
+        return OS_INVALID;
+    }
+
+    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_SYNC_SET) < 0) {
+        mdebug1("cannot cache statement");
+        return OS_INVALID;
+    }
+
+    stmt = wdb->stmt[WDB_STMT_GLOBAL_SYNC_SET];
+
+    if (sqlite3_bind_int(stmt, 1, status) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return OS_INVALID;
+    }
+    if (sqlite3_bind_int(stmt, 2, id) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return OS_INVALID;
+    }
+
+    switch (wdb_step(stmt)) {
+    case SQLITE_ROW:
+    case SQLITE_DONE:
+        return OS_SUCCESS;
+        break;
+    default:
+        mdebug1("SQLite: %s", sqlite3_errmsg(wdb->db));
+        return OS_INVALID;
+    }
+}
+
+
+wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char **output) {    
+   sqlite3_stmt* agent_stmt = NULL;    
+    unsigned response_size = 2;     //Starts with "[]" size 
+    wdb_chunks_status_t status = WDB_CHUNKS_PENDING;     
+    
+    os_calloc(WDB_MAX_RESPONSE_SIZE, sizeof(char), *output);
+    char *response_aux = *output;      
+
+    if (!wdb->transaction && wdb_begin2(wdb) < 0) {
+        mdebug1("cannot begin transaction");
+        return OS_INVALID;
+    }
+
+    //Add array start
+    *response_aux++ = '[';
+
+    while (status == WDB_CHUNKS_PENDING) {
+        //Prepare SQL query
+        if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_SYNC_REQ_GET) < 0) {
+            mdebug1("cannot cache statement");
+            status = WDB_CHUNKS_ERROR;
+            break;
+        }
+        agent_stmt = wdb->stmt[WDB_STMT_GLOBAL_SYNC_REQ_GET];        
+        if (sqlite3_bind_int(agent_stmt, 1, *last_agent_id) != SQLITE_OK) {
+            merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+            status = WDB_CHUNKS_ERROR;
+            break;
+        }
+        
+        //Get agent info
+        cJSON* sql_agents_response = wdb_exec_stmt(agent_stmt);
+        if (sql_agents_response && sql_agents_response->child) {            
+            cJSON* json_agent = sql_agents_response->child;                 
+            cJSON* json_id = cJSON_GetObjectItemCaseSensitive(json_agent,"id");  
+            if (cJSON_IsNumber(json_id)) {
+                //Get ID     
+                int agent_id = json_id->valueint;
+
+                //Get labels if any                
+                cJSON* json_labels = wdb_global_get_agent_labels(wdb, agent_id);
+                if (json_labels && json_labels->child){                   
+                    cJSON_AddItemToObject(json_agent, "labels", json_labels);
+                }   
+
+                //Print Agent info
+                char *agent_str = cJSON_PrintUnformatted(json_agent);
+                unsigned agent_len = strlen(agent_str);                
+                cJSON_Delete(sql_agents_response);                                
+                
+                //Check if new agent fits in response                
+                if (response_size+agent_len+1 < WDB_MAX_RESPONSE_SIZE) { 
+                    //Set sync status as synced
+                    if (OS_SUCCESS != wdb_global_set_sync_status(wdb, agent_id, WDB_SYNCED)) {
+                        status = WDB_CHUNKS_ERROR;
+                        break;
+                    } 
+                    //Add new agent
+                    memcpy(response_aux, agent_str, agent_len); 
+                    response_aux+=agent_len;
+                    //Add separator
+                    *response_aux++ = ',';
+                    //Save size and last ID
+                    response_size += agent_len+1;
+                    *last_agent_id = agent_id; 
+                }
+                else {
+                    //Pending agents but buffer is full                    
+                    status = WDB_CHUNKS_BUFFER_FULL;
+                }
+                os_free(agent_str);                      
+            }
+        }
+        else {
+            status = WDB_CHUNKS_COMPLETE;
+        }
+    }    
+    //Add array end
+    *(response_aux-1) = ']';
+
+    return status;
+}

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -194,8 +194,7 @@ wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char
 
                 //Print Agent info
                 char *agent_str = cJSON_PrintUnformatted(json_agent);
-                unsigned agent_len = strlen(agent_str);                
-                cJSON_Delete(sql_agents_response);                                
+                unsigned agent_len = strlen(agent_str);
                 
                 //Check if new agent fits in response                
                 if (response_size+agent_len+1 < WDB_MAX_RESPONSE_SIZE) { 
@@ -218,11 +217,13 @@ wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char
                     status = WDB_CHUNKS_BUFFER_FULL;
                 }
                 os_free(agent_str);                      
-            }
+            }            
         }
         else {
+            //All agents has being obtained
             status = WDB_CHUNKS_COMPLETE;
         }
+        cJSON_Delete(sql_agents_response);
     }    
     //Add array end
     *(response_aux-1) = ']';

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -220,13 +220,18 @@ wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char
             }            
         }
         else {
-            //All agents has being obtained
+            //All agents have been obtained
             status = WDB_CHUNKS_COMPLETE;
         }
         cJSON_Delete(sql_agents_response);
-    }    
+    }
+    
+    if (response_size > 2) {
+        //Remove last ','
+        response_aux--;
+    } 
     //Add array end
-    *(response_aux-1) = ']';
+    *response_aux = ']';
 
     return status;
 }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -449,7 +449,12 @@ int wdb_parse(char * input, char * output) {
             } else {
                 result = wdb_parse_global_set_agent_labels(wdb, next, output);
             }
-        } else {
+        } 
+        else if (strcmp(query, "sync-agent-info-get") == 0) { 
+            result = wdb_parse_global_sync_agent_info_get(wdb, next, output);
+        }
+        
+        else {
             mdebug1("Invalid DB query syntax.");
             mdebug2("Global DB query error near: %s", query);
             snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
@@ -3943,6 +3948,31 @@ int wdb_parse_global_set_agent_labels(wdb_t * wdb, char * input, char * output) 
 
         snprintf(output, OS_MAXSTR + 1, "ok");
     }
+
+    return OS_SUCCESS;
+}
+
+int wdb_parse_global_sync_agent_info_get(wdb_t* wdb, char* input, char* output) {
+    static int start_id = 0; 
+    char* agent_info_sync = NULL;
+
+    char *next = wstr_chr(input, ' ');
+    if(next) {
+        *next++ = '\0';
+        if (strcmp(input, "start_id") == 0) {
+            start_id = atoi(next);
+        }   
+    }
+    
+    wdb_chunks_status_t status = wdb_sync_agent_info_get(wdb, &start_id, &agent_info_sync);  
+    if (status == WDB_CHUNKS_COMPLETE || status == WDB_CHUNKS_ERROR) {
+        start_id = 0;
+    }  
+    snprintf(output, OS_MAXSTR + 1, "%1d %s", status, agent_info_sync);
+    os_free(agent_info_sync)
+
+
+   
 
     return OS_SUCCESS;
 }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -3971,8 +3971,5 @@ int wdb_parse_global_sync_agent_info_get(wdb_t* wdb, char* input, char* output) 
     snprintf(output, OS_MAXSTR + 1, "%1d %s", status, agent_info_sync);
     os_free(agent_info_sync)
 
-
-   
-
     return OS_SUCCESS;
 }


### PR DESCRIPTION
|Related issue|
|---|
|5681|

## Description

The purpose of this PR is to create the command in charge of report all information from agents in SYNC_REQ status to be syncrhronized from a worker to a master. 

-Addition of SQL queries to get agents as SYNC_REQ and query to set sync_status
-Parsing of new sync-agent-info-get command
-Creation of **wdb_sync_agent_info_get()** and wdb_sync_agent_info_get() methods
--wdb_sync_agent_info_get() is the main improvement of this PR. This method will query Wazuh DB to obtain agents with SYNC_REQ status one by one, also, will query labels table to obtain every label of the particular agent. This information will be concatenated into response buffer if it fits. When an agents doesn't fits, the parse stops and the status is reported in order to respond as many agents as possible and can continue reporting with further iterations.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [ ] Package installation
