### PR TITLE
 Unit Test for wazuh-logtest

### DIFF
--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -17,6 +17,13 @@
 #include "plugin_decoders.h"
 #include "config.h"
 
+#ifdef WAZUH_UNIT_TESTING
+// Remove STATIC qualifier from tests
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 /* Internal functions */
 
 /**
@@ -29,7 +36,7 @@
  * @return char* The new string.
  * @warning This function assumes that "at" reserved memory is `OS_SIZE_1024`.
  */
-static char *_loadmemory(char *at, char* str, OSList* log_msg);
+STATIC char *_loadmemory(char *at, char* str, OSList* log_msg);
 
 /**
  * @brief Save internal decoder 'name' in 'decoder_store' list
@@ -37,7 +44,7 @@ static char *_loadmemory(char *at, char* str, OSList* log_msg);
  * @param decoder_store Decoder list which save the internals decoder
  * @return 1 on success, otherwise return 0
  */
-static int addDecoder2list(const char *name, OSStore **decoder_store);
+STATIC int addDecoder2list(const char *name, OSStore **decoder_store);
 
 /**
  * @brief Set decoders ids
@@ -45,9 +52,9 @@ static int addDecoder2list(const char *name, OSStore **decoder_store);
  * @param decoder_store all decoder list
  * @return 1 on success, otherwise return 0
  */
-static int os_setdecoderids(OSDecoderNode **decoderlist, OSStore **decoder_list);
+STATIC int os_setdecoderids(OSDecoderNode **decoderlist, OSStore **decoder_list);
 
-static int ReadDecodeAttrs(char *const *names, char *const *values);
+STATIC int ReadDecodeAttrs(char *const *names, char *const *values);
 
 
 int getDecoderfromlist(const char *name, OSStore **decoder_store) {
@@ -59,7 +66,7 @@ int getDecoderfromlist(const char *name, OSStore **decoder_store) {
     return (0);
 }
 
-static int addDecoder2list(const char *name, OSStore **decoder_store)
+STATIC int addDecoder2list(const char *name, OSStore **decoder_store)
 {
     if (*decoder_store == NULL) {
         *decoder_store = OSStore_Create();
@@ -78,7 +85,7 @@ static int addDecoder2list(const char *name, OSStore **decoder_store)
     return (1);
 }
 
-static int os_setdecoderids(OSDecoderNode **decoderlist, OSStore **decoder_list)
+STATIC int os_setdecoderids(OSDecoderNode **decoderlist, OSStore **decoder_list)
 {
     OSDecoderNode *node;
     OSDecoderNode *child_node;
@@ -135,7 +142,7 @@ static int os_setdecoderids(OSDecoderNode **decoderlist, OSStore **decoder_list)
     return (1);
 }
 
-static int ReadDecodeAttrs(char *const *names, char *const *values)
+STATIC int ReadDecodeAttrs(char *const *names, char *const *values)
 {
     if (!names || !values) {
         return (0);

--- a/src/analysisd/decoders/decoders_list.c
+++ b/src/analysisd/decoders/decoders_list.c
@@ -18,7 +18,14 @@
 #include "error_messages/debug_messages.h"
 #include "analysisd.h"
 
-static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi, OSList* log_msg);
+#ifdef WAZUH_UNIT_TESTING
+// Remove STATIC qualifier from tests
+#define STATIC
+#else
+#define STATIC static
+#endif
+
+STATIC OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi, OSList* log_msg);
 
 /* Create the Event List */
 void OS_CreateOSDecoderList() {
@@ -40,7 +47,7 @@ OSDecoderNode *OS_GetFirstOSDecoder(const char *p_name)
 }
 
 /* Add an osdecoder to the list */
-static OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi, OSList* log_msg)
+STATIC OSDecoderNode *_OS_AddOSDecoder(OSDecoderNode *s_node, OSDecoderInfo *pi, OSList* log_msg)
 {
     OSDecoderNode *tmp_node = s_node;
     OSDecoderNode *new_node;

--- a/src/analysisd/logmsg.c
+++ b/src/analysisd/logmsg.c
@@ -24,7 +24,7 @@ void _os_analysisd_add_logmsg(OSList * list, int level, int line, const char * f
 
     /* Generic message */
     new_msg->level = level;
-    os_malloc(OS_BUFFER_SIZE, new_msg->msg);
+    os_calloc(1, OS_BUFFER_SIZE, new_msg->msg);
     va_start(args, msg);
     (void)vsnprintf(new_msg->msg, OS_BUFFER_SIZE, msg, args);
     va_end(args);

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -677,7 +677,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             os_calloc(1, sizeof(FieldInfo), config_ruleinfo->fields[ifield]);
 
                             if (strcasecmp(rule_opt[k]->attributes[0], xml_name) == 0) {
-                                // Avoid STATIC fields
+                                // Avoid static fields
                                 if (strcasecmp(rule_opt[k]->values[0], xml_srcuser) &&
                                     strcasecmp(rule_opt[k]->values[0], xml_dstuser) &&
                                     strcasecmp(rule_opt[k]->values[0], xml_user) &&
@@ -696,7 +696,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                     config_ruleinfo->fields[ifield]->name = loadmemory(config_ruleinfo->fields[ifield]->name,
                                                                                         rule_opt[k]->values[0], log_msg);
                                 else {
-                                    smerror(log_msg, "Field '%s' is STATIC.", rule_opt[k]->values[0]);
+                                    smerror(log_msg, "Field '%s' is static.", rule_opt[k]->values[0]);
                                     goto cleanup;
                                 }
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -14,15 +14,22 @@
 #include "compiled_rules/compiled_rules.h"
 #include "analysisd.h"
 
+#ifdef WAZUH_UNIT_TESTING
+// Remove STATIC qualifier from tests
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 /* Global definition */
 RuleInfo *currently_rule;
 int default_timeframe;
 
 /* Do diff mutex */
-static pthread_mutex_t do_diff_mutex = PTHREAD_MUTEX_INITIALIZER;
+STATIC pthread_mutex_t do_diff_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* Hourly alerts mutex */
-static pthread_mutex_t hourly_alert_mutex = PTHREAD_MUTEX_INITIALIZER;
+STATIC pthread_mutex_t hourly_alert_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* Change path for test rule */
 #ifdef TESTRULE
@@ -31,17 +38,17 @@ static pthread_mutex_t hourly_alert_mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif
 
 /* Prototypes */
-static int getattributes(char **attributes,
+STATIC int getattributes(char **attributes,
                   char **values,
                   int *id, int *level,
                   int *maxsize, int *timeframe,
                   int *frequency, int *accuracy,
                   int *noalert, int *ignore_time, int *overwrite,
                   OSList* log_msg);
-static int doesRuleExist(int sid, RuleNode *r_node);
-static void Rule_AddAR(RuleInfo *config_rule);
-static char *loadmemory(char *at, const char *str, OSList* log_msg);
-static void printRuleinfo(const RuleInfo *rule, int node);
+STATIC int doesRuleExist(int sid, RuleNode *r_node);
+STATIC void Rule_AddAR(RuleInfo *config_rule);
+STATIC char *loadmemory(char *at, const char *str, OSList* log_msg);
+STATIC void printRuleinfo(const RuleInfo *rule, int node);
 
 /* Will initialize the rules list */
 void Rules_OP_CreateRules() {
@@ -670,7 +677,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                             os_calloc(1, sizeof(FieldInfo), config_ruleinfo->fields[ifield]);
 
                             if (strcasecmp(rule_opt[k]->attributes[0], xml_name) == 0) {
-                                // Avoid static fields
+                                // Avoid STATIC fields
                                 if (strcasecmp(rule_opt[k]->values[0], xml_srcuser) &&
                                     strcasecmp(rule_opt[k]->values[0], xml_dstuser) &&
                                     strcasecmp(rule_opt[k]->values[0], xml_user) &&
@@ -689,7 +696,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                     config_ruleinfo->fields[ifield]->name = loadmemory(config_ruleinfo->fields[ifield]->name,
                                                                                         rule_opt[k]->values[0], log_msg);
                                 else {
-                                    smerror(log_msg, "Field '%s' is static.", rule_opt[k]->values[0]);
+                                    smerror(log_msg, "Field '%s' is STATIC.", rule_opt[k]->values[0]);
                                     goto cleanup;
                                 }
 
@@ -1784,7 +1791,7 @@ cleanup:
  * If *at already exist, realloc the memory and cat str on it.
  * Returns the new string
  */
-static char *loadmemory(char *at, const char *str, OSList* log_msg)
+STATIC char *loadmemory(char *at, const char *str, OSList* log_msg)
 {
     if (at == NULL) {
         size_t strsize = 0;
@@ -1993,7 +2000,7 @@ int get_info_attributes(char **attributes, char **values, OSList* log_msg)
 }
 
 /* Get the attributes */
-static int getattributes(char **attributes, char **values,
+STATIC int getattributes(char **attributes, char **values,
                   int *id, int *level,
                   int *maxsize, int *timeframe,
                   int *frequency, int *accuracy,
@@ -2111,7 +2118,7 @@ static int getattributes(char **attributes, char **values,
 }
 
 /* Bind active responses to a rule */
-static void Rule_AddAR(RuleInfo *rule_config)
+STATIC void Rule_AddAR(RuleInfo *rule_config)
 {
     unsigned int rule_ar_size = 0;
     int mark_to_ar = 0;
@@ -2242,7 +2249,7 @@ static void Rule_AddAR(RuleInfo *rule_config)
     return;
 }
 
-static void printRuleinfo(const RuleInfo *rule, int node)
+STATIC void printRuleinfo(const RuleInfo *rule, int node)
 {
     mdebug1("%d : rule:%d, level %d, timeout: %d",
            node,
@@ -2307,7 +2314,7 @@ int _setlevels(RuleNode *node, int nnode)
 /* Test if a rule id exists
  * return 1 if exists, otherwise 0
  */
-static int doesRuleExist(int sid, RuleNode *r_node)
+STATIC int doesRuleExist(int sid, RuleNode *r_node)
 {
     while (r_node) {
         /* Check if the sigid matches */

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -13,10 +13,17 @@
 #include "eventinfo.h"
 #include "analysisd.h"
 
+#ifdef WAZUH_UNIT_TESTING
+// Remove STATIC qualifier from tests
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 
 /* _OS_Addrule: Internal AddRule */
-static RuleNode *_OS_AddRule(RuleNode *_rulenode, RuleInfo *read_rule);
-static int _AddtoRule(int sid, int level, int none, const char *group,
+STATIC RuleNode *_OS_AddRule(RuleNode *_rulenode, RuleInfo *read_rule);
+STATIC int _AddtoRule(int sid, int level, int none, const char *group,
                RuleNode *r_node, RuleInfo *read_rule);
 
 
@@ -33,7 +40,7 @@ RuleNode *OS_GetFirstRule()
 }
 
 /* Search all rules, including children */
-static int _AddtoRule(int sid, int level, int none, const char *group,
+STATIC int _AddtoRule(int sid, int level, int none, const char *group,
                RuleNode *r_node, RuleInfo *read_rule)
 {
     int r_code = 0;
@@ -187,7 +194,7 @@ int OS_AddChild(RuleInfo *read_rule, RuleNode **r_node, OSList* log_msg)
 }
 
 /* Add a rule in the chain */
-static RuleNode *_OS_AddRule(RuleNode *_rulenode, RuleInfo *read_rule)
+STATIC RuleNode *_OS_AddRule(RuleNode *_rulenode, RuleInfo *read_rule)
 {
     RuleNode *tmp_rulenode = _rulenode;
 

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -72,7 +72,7 @@ LIST(APPEND analysisd_names "test_eventinfo_list")
 LIST(APPEND analysisd_flags "-Wl,--wrap,Free_Eventinfo")
 
 LIST(APPEND analysisd_names "test_logmsg")
-LIST(APPEND analysisd_flags "-Wl,--wrap,isDebug -Wl,--wrap,OSList_AddData")
+LIST(APPEND analysisd_flags "-Wl,--wrap,isDebug -Wl,--wrap,OSList_AddData -Wl,--wrap,vsnprintf")
 
 list(LENGTH analysisd_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -48,9 +48,28 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap
                              -Wl,--wrap,OSList_SetMaxSize -Wl,--wrap,OSHash_setSize -Wl,--wrap,OSHash_Delete_ex \
                              -Wl,--wrap,OSHash_Free -Wl,--wrap,os_remove_rules_list -Wl,--wrap,os_remove_decoders_list \
                              -Wl,--wrap,os_remove_cdblist -Wl,--wrap,os_remove_cdbrules -Wl,--wrap,os_remove_eventlist \
-                             -Wl,--wrap,sleep -Wl,--wrap,OSHash_Begin -Wl,--wrap,time -Wl,--wrap,difftime -Wl,--wrap,OSHash_Next \
-                             -Wl,--wrap,FOREVER -Wl,--wrap,OSStore_Free -Wl,--wrap,pthread_mutex_lock \
-                             -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,OSHash_Add_ex")
+                             -Wl,--wrap,sleep -Wl,--wrap,OSHash_Begin -Wl,--wrap,time -Wl,--wrap,difftime \
+                             -Wl,--wrap,OSHash_Next -Wl,--wrap,FOREVER -Wl,--wrap,OS_CreateEventList \
+                             -Wl,--wrap,ReadDecodeXML -Wl,--wrap,Lists_OP_LoadList -Wl,--wrap,Lists_OP_MakeAll \
+                             -Wl,--wrap,Rules_OP_ReadRules -Wl,--wrap,OS_ListLoadRules -Wl,--wrap,_setlevels \
+                             -Wl,--wrap,AddHash_Rule -Wl,--wrap,Accumulate_Init -Wl,--wrap,OSStore_Free \
+                             -Wl,--wrap,SetDecodeXML -Wl,--wrap,randombytes -Wl,--wrap,cJSON_IsNumber \
+                             -Wl,--wrap,cJSON_GetObjectItemCaseSensitive -Wl,--wrap,_mdebug1 \
+                             -Wl,--wrap,_os_analysisd_add_logmsg -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,pthread_mutex_lock \
+                             -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSList_GetFirstNode \
+                             -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,wm_strcat \
+                             -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_AddItemToArray \
+                             -Wl,--wrap,os_analysisd_free_log_msg -Wl,--wrap,OSList_DeleteCurrentlyNode \
+                             -Wl,--wrap,os_analysisd_string_log_msg -Wl,--wrap,cJSON_ParseWithOpts \
+                             -Wl,--wrap,cJSON_IsString -Wl,--wrap,cJSON_DeleteItemFromObjectCaseSensitive \
+                             -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_AddNumberToObject  \
+                             -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_Delete \
+                             -Wl,--wrap,pthread_mutex_destroy -Wl,--wrap,cJSON_IsObject -Wl,--wrap,DecodeEvent \
+                             -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,OS_CleanMSG -Wl,--wrap,cJSON_GetObjectItem \
+                             -Wl,--wrap,OS_CheckIfRuleMatch -Wl,--wrap,OS_AddEvent -Wl,--wrap,IGnore \
+                             -Wl,--wrap,OSList_AddData -Wl,--wrap,accept -Wl,--wrap,OS_RecvSecureTCP \
+                             -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,CreateThreadJoinable -Wl,--wrap,_merror_exit \
+                             -Wl,--wrap,CreateThread -Wl,--wrap,pthread_join -Wl,--wrap,unlink")
 
 LIST(APPEND analysisd_names "test_logtest-config")
 LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nproc -Wl,--wrap,cJSON_CreateObject \
@@ -66,7 +85,8 @@ LIST(APPEND analysisd_names "test_lists_list")
 LIST(APPEND analysisd_flags "-Wl,--wrap,OSMatch_FreePattern")
 
 LIST(APPEND analysisd_names "test_rule_list")
-LIST(APPEND analysisd_flags "-Wl,--wrap,OSMatch_FreePattern -Wl,--wrap,OSRegex_FreePattern -Wl,--wrap,os_remove_cdbrules")
+LIST(APPEND analysisd_flags "-Wl,--wrap,OSMatch_FreePattern -Wl,--wrap,OSRegex_FreePattern -Wl,--wrap,os_remove_cdbrules \
+                            -Wl,--wrap,_os_analysisd_add_logmsg")
 
 LIST(APPEND analysisd_names "test_eventinfo_list")
 LIST(APPEND analysisd_flags "-Wl,--wrap,Free_Eventinfo")

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -71,6 +71,9 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,OSMatch_FreePattern -Wl,--wrap,OSRegex_F
 LIST(APPEND analysisd_names "test_eventinfo_list")
 LIST(APPEND analysisd_flags "-Wl,--wrap,Free_Eventinfo")
 
+LIST(APPEND analysisd_names "test_logmsg")
+LIST(APPEND analysisd_flags "-Wl,--wrap,isDebug -Wl,--wrap,OSList_AddData")
+
 list(LENGTH analysisd_names count)
 math(EXPR count "${count} - 1")
 foreach(counter RANGE ${count})

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -69,7 +69,9 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap
                              -Wl,--wrap,OS_CheckIfRuleMatch -Wl,--wrap,OS_AddEvent -Wl,--wrap,IGnore \
                              -Wl,--wrap,OSList_AddData -Wl,--wrap,accept -Wl,--wrap,OS_RecvSecureTCP \
                              -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,CreateThreadJoinable -Wl,--wrap,_merror_exit \
-                             -Wl,--wrap,CreateThread -Wl,--wrap,pthread_join -Wl,--wrap,unlink")
+                             -Wl,--wrap,CreateThread -Wl,--wrap,pthread_join -Wl,--wrap,unlink \
+                             -Wl,--wrap,Eventinfo_to_jsonstr -Wl,--wrap,cJSON_Parse -Wl,--wrap,ParseRuleComment \
+                             -Wl,--wrap,Accumulate -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddBoolToObject")
 
 LIST(APPEND analysisd_names "test_logtest-config")
 LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nproc -Wl,--wrap,cJSON_CreateObject \

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -81,7 +81,8 @@ LIST(APPEND analysisd_names "test_decoder_list")
 LIST(APPEND analysisd_flags "-Wl,--wrap,FreeDecoderInfo")
 
 LIST(APPEND analysisd_names "test_decode-xml")
-LIST(APPEND analysisd_flags "")
+LIST(APPEND analysisd_flags "-Wl,--wrap,_os_analysisd_add_logmsg -Wl,--wrap,_merror -Wl,--wrap,OSStore_Create \
+                             -Wl,--wrap,OSStore_Put")
 
 LIST(APPEND analysisd_names "test_lists_list")
 LIST(APPEND analysisd_flags "-Wl,--wrap,OSMatch_FreePattern")
@@ -89,6 +90,9 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,OSMatch_FreePattern")
 LIST(APPEND analysisd_names "test_rule_list")
 LIST(APPEND analysisd_flags "-Wl,--wrap,OSMatch_FreePattern -Wl,--wrap,OSRegex_FreePattern -Wl,--wrap,os_remove_cdbrules \
                             -Wl,--wrap,_os_analysisd_add_logmsg")
+
+LIST(APPEND analysisd_names "test_rules")
+LIST(APPEND analysisd_flags "-Wl,--wrap,_os_analysisd_add_logmsg -Wl,--wrap,_merror")
 
 LIST(APPEND analysisd_names "test_eventinfo_list")
 LIST(APPEND analysisd_flags "-Wl,--wrap,Free_Eventinfo")

--- a/src/unit_tests/analysisd/test_decode-xml.c
+++ b/src/unit_tests/analysisd/test_decode-xml.c
@@ -27,10 +27,45 @@
 
 
 void FreeDecoderInfo(OSDecoderInfo *pi);
+char *_loadmemory(char *at, char *str, OSList* log_msg);
+int addDecoder2list(const char *name, OSStore **decoder_store);
 
 /* setup/teardown */
 
 /* wraps */
+void __wrap__os_analysisd_add_logmsg(OSList * list, int level, int line, const char * func,
+                                    const char * file, char * msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(level);
+    check_expected_ptr(list);
+    check_expected(formatted_msg);
+}
+
+void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+OSStore * __wrap_OSStore_Create() {
+    return mock_type(OSStore *);
+}
+
+int __wrap_OSStore_Put(OSStore *list, const char *key, void *data) {
+    return mock_type(int);
+}
+
 
 /* tests */
 
@@ -67,12 +102,210 @@ void test_FreeDecoderInfo_OK(void **state)
     
 }
 
+// _loadmemory
+void test__loadmemory_null_append_ok(void ** state)
+{
+    char * at = NULL;
+    char * str;
+    
+    const size_t len = 1000;
+    char * expect_retval;
+    char * retval;
+    
+    os_calloc(len, sizeof(char), str);
+    memset(str, (int) '-', len - 1);
+    str[len-1] = '\0';
+    
+    os_calloc(len, sizeof(char), expect_retval);
+    memset(expect_retval, (int) '-', len - 1);
+    expect_retval[len-1] = '\0';
+
+    retval = _loadmemory(at,str, NULL);
+
+    assert_string_equal(retval, expect_retval);
+
+    os_free(str);
+    os_free(retval);
+    os_free(expect_retval);
+
+}
+
+void test__loadmemory_null_append_oversize(void ** state)
+{
+    char * at = NULL;
+    char * str;
+    OSList list_msg = {0};
+    
+    const size_t len = 1025;
+    char * retval;
+    
+    os_calloc(len, sizeof(char), str);
+    memset(str, (int) '-', len - 1);
+    str[len-1] = '\0';
+
+    char expect_msg[OS_SIZE_4096];
+
+    snprintf(expect_msg, OS_SIZE_4096, "(1104): Maximum string size reached for: %s.", str);
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, &list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, expect_msg);
+
+    retval = _loadmemory(at,str, &list_msg);
+
+    assert_null(retval);
+
+    os_free(str);
+
+}
+
+void test__loadmemory_append_oversize(void ** state)
+{
+    char * at = NULL;
+    char * str = NULL;
+    OSList list_msg = {0};
+    
+    const size_t len = 513;
+    char * retval;
+    
+    os_calloc(len, sizeof(char), str);
+    memset(str, (int) '-', len - 1);
+    str[len-1] = '\0';
+
+    os_calloc(len, sizeof(char), at);
+    memset(at, (int) '+', len - 1);
+    str[len-1] = '\0';
+
+    char expect_msg[OS_SIZE_4096];
+
+    snprintf(expect_msg, OS_SIZE_4096, "(1104): Maximum string size reached for: %s.", str);
+    
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, &list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, expect_msg);
+
+    retval = _loadmemory(at,str, &list_msg);
+
+    assert_null(retval);
+
+    os_free(str);
+    os_free(at);
+
+}
+void test__loadmemory_append_ok(void ** state)
+{
+    char * at = NULL;
+    char * str = NULL;
+    OSList list_msg = {0};
+    
+    const size_t len = 512;
+    char * retval;
+    char * expect_retval;
+    
+    os_calloc(len, sizeof(char), str);
+    memset(str, (int) '-', len - 1);
+    str[len-1] = '\0';
+
+    os_calloc(len, sizeof(char), at);
+    memset(at, (int) '+', len - 1);
+    at[len-1] = '\0';
+    
+    os_calloc(len * 2, sizeof(char), expect_retval);
+    strncat(expect_retval, at, len * 2);
+    strncat(expect_retval, str, len * 2);
+
+    retval = _loadmemory(at,str, &list_msg);
+
+    assert_non_null(retval);
+    assert_string_equal(retval, expect_retval);
+
+    os_free(str);
+    os_free(retval);
+    os_free(expect_retval);
+
+}
+
+// addDecoder2list
+void test_addDecoder2list_empty_list_deco_error(void ** state)
+{
+    const char * name = "test name";
+    OSStore * decoder_store = NULL;
+    int expect_retval = 0;
+    int retval;
+
+    will_return(__wrap_OSStore_Create, NULL);
+    expect_string(__wrap__merror, formatted_msg, "(1290): Unable to create a new list (calloc).");
+
+    retval = addDecoder2list(name, &decoder_store);
+
+    assert_int_equal(retval, expect_retval);
+
+}
+
+void test_addDecoder2list_empty_list_deco_ok(void ** state)
+{
+    const char * name = "test name";
+    OSStore * decoder_store = NULL;
+    int expect_retval = 1;
+    int retval;
+
+    will_return(__wrap_OSStore_Create, (OSStore *) 1);
+    will_return(__wrap_OSStore_Put, 1);
+
+    retval = addDecoder2list(name, &decoder_store);
+
+    assert_int_equal(retval, expect_retval);
+}
+
+void test_addDecoder2list_fail_push(void ** state)
+{
+    const char * name = "test name";
+    OSStore * decoder_store = NULL;
+    int expect_retval = 0;
+    int retval;
+    os_calloc(1, sizeof(OSStore), decoder_store);
+
+    will_return(__wrap_OSStore_Put, 0);
+    expect_string(__wrap__merror, formatted_msg, "(1291): Error adding nodes to list.");
+
+    retval = addDecoder2list(name, &decoder_store);
+
+    assert_int_equal(retval, expect_retval);
+    os_free(decoder_store);
+}
+
+void test_addDecoder2list_push_ok(void ** state)
+{
+    const char * name = "test name";
+    OSStore * decoder_store = NULL;
+    int expect_retval = 1;
+    int retval;
+    os_calloc(1, sizeof(OSStore), decoder_store);
+
+    will_return(__wrap_OSStore_Put, 1);
+
+    retval = addDecoder2list(name, &decoder_store);
+
+    assert_int_equal(retval, expect_retval);
+    os_free(decoder_store);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         // Tests FreeDecoderInfo
         cmocka_unit_test(test_FreeDecoderInfo_NULL),
-        cmocka_unit_test(test_FreeDecoderInfo_OK)
+        cmocka_unit_test(test_FreeDecoderInfo_OK),
+        // Tests _loadmemory
+        cmocka_unit_test(test__loadmemory_null_append_ok),
+        cmocka_unit_test(test__loadmemory_null_append_oversize),
+        cmocka_unit_test(test__loadmemory_append_oversize),
+        cmocka_unit_test(test__loadmemory_append_ok),
+        // Tests addDecoder2list
+        cmocka_unit_test(test_addDecoder2list_empty_list_deco_error),
+        cmocka_unit_test(test_addDecoder2list_empty_list_deco_ok),
+        cmocka_unit_test(test_addDecoder2list_fail_push),
+        cmocka_unit_test(test_addDecoder2list_push_ok),
+
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_decode-xml.c
+++ b/src/unit_tests/analysisd/test_decode-xml.c
@@ -99,7 +99,7 @@ void test_FreeDecoderInfo_OK(void **state)
     Config.decoder_order_size = 1;
 
     FreeDecoderInfo(info);
-    
+
 }
 
 // _loadmemory
@@ -107,15 +107,15 @@ void test__loadmemory_null_append_ok(void ** state)
 {
     char * at = NULL;
     char * str;
-    
+
     const size_t len = 1000;
     char * expect_retval;
     char * retval;
-    
+
     os_calloc(len, sizeof(char), str);
     memset(str, (int) '-', len - 1);
     str[len-1] = '\0';
-    
+
     os_calloc(len, sizeof(char), expect_retval);
     memset(expect_retval, (int) '-', len - 1);
     expect_retval[len-1] = '\0';
@@ -135,10 +135,10 @@ void test__loadmemory_null_append_oversize(void ** state)
     char * at = NULL;
     char * str;
     OSList list_msg = {0};
-    
+
     const size_t len = 1025;
     char * retval;
-    
+
     os_calloc(len, sizeof(char), str);
     memset(str, (int) '-', len - 1);
     str[len-1] = '\0';
@@ -163,10 +163,10 @@ void test__loadmemory_append_oversize(void ** state)
     char * at = NULL;
     char * str = NULL;
     OSList list_msg = {0};
-    
+
     const size_t len = 513;
     char * retval;
-    
+
     os_calloc(len, sizeof(char), str);
     memset(str, (int) '-', len - 1);
     str[len-1] = '\0';
@@ -178,7 +178,7 @@ void test__loadmemory_append_oversize(void ** state)
     char expect_msg[OS_SIZE_4096];
 
     snprintf(expect_msg, OS_SIZE_4096, "(1104): Maximum string size reached for: %s.", str);
-    
+
     expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
     expect_value(__wrap__os_analysisd_add_logmsg, list, &list_msg);
     expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, expect_msg);
@@ -196,11 +196,11 @@ void test__loadmemory_append_ok(void ** state)
     char * at = NULL;
     char * str = NULL;
     OSList list_msg = {0};
-    
+
     const size_t len = 512;
     char * retval;
     char * expect_retval;
-    
+
     os_calloc(len, sizeof(char), str);
     memset(str, (int) '-', len - 1);
     str[len-1] = '\0';
@@ -208,7 +208,7 @@ void test__loadmemory_append_ok(void ** state)
     os_calloc(len, sizeof(char), at);
     memset(at, (int) '+', len - 1);
     at[len-1] = '\0';
-    
+
     os_calloc(len * 2, sizeof(char), expect_retval);
     strncat(expect_retval, at, len * 2);
     strncat(expect_retval, str, len * 2);
@@ -304,8 +304,7 @@ int main(void)
         cmocka_unit_test(test_addDecoder2list_empty_list_deco_error),
         cmocka_unit_test(test_addDecoder2list_empty_list_deco_ok),
         cmocka_unit_test(test_addDecoder2list_fail_push),
-        cmocka_unit_test(test_addDecoder2list_push_ok),
-
+        cmocka_unit_test(test_addDecoder2list_push_ok)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_decode-xml.c
+++ b/src/unit_tests/analysisd/test_decode-xml.c
@@ -24,6 +24,7 @@
 #include "../../analysisd/decoders/decoder.h"
 #include "../../analysisd/decoders/plugin_decoders.h"
 #include "../../analysisd/config.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
 
 void FreeDecoderInfo(OSDecoderInfo *pi);
@@ -44,17 +45,6 @@ void __wrap__os_analysisd_add_logmsg(OSList * list, int level, int line, const c
 
     check_expected(level);
     check_expected_ptr(list);
-    check_expected(formatted_msg);
-}
-
-void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...) {
-    char formatted_msg[OS_MAXSTR];
-    va_list args;
-
-    va_start(args, msg);
-    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
-    va_end(args);
-
     check_expected(formatted_msg);
 }
 

--- a/src/unit_tests/analysisd/test_decoder_list.c
+++ b/src/unit_tests/analysisd/test_decoder_list.c
@@ -38,7 +38,7 @@ void __wrap_FreeDecoderInfo(OSDecoderInfo *pi) {
 
 /* tests */
 
-/* os_remove_decoders_list */   
+/* os_remove_decoders_list */
 void os_count_decoders_no_child(void **state)
 {
     OSDecoderNode * node;
@@ -151,7 +151,6 @@ int main(void)
         cmocka_unit_test(test_os_remove_decodernode_child),
         // Tests os_remove_decoders_list
         cmocka_unit_test(test_os_remove_decoders_list_OK)
-        
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_lists_list.c
+++ b/src/unit_tests/analysisd/test_lists_list.c
@@ -24,6 +24,8 @@
 
 void os_remove_cdblist(ListNode **l_node);
 void os_remove_cdbrules(ListRule **l_rule);
+ListNode *OS_FindList(const char *listname, ListNode **l_node);
+void OS_ListLoadRules(ListNode **l_node, ListRule **lrule);
 
 /* setup/teardown */
 
@@ -57,9 +59,148 @@ void test_os_remove_cdbrules_OK(void **state)
     os_calloc(1,sizeof(ListRule), l_rule->matcher);
     os_calloc(1,sizeof(char*), l_rule->dfield);
     os_calloc(1,sizeof(char*), l_rule->filename);
-    
     os_remove_cdbrules(&l_rule);
 
+}
+
+/* OS_FindList */
+void test_OS_FindList_dont_match(void ** state) {
+
+    const char list[] = "list_test.cbd";
+    ListNode * node;
+    ListNode * retval;
+
+    os_calloc(1, sizeof(ListNode), node);
+    node->next = NULL;
+    node->txt_filename = "not_list_test.cbd";
+    node->cdb_filename = "not_2_list_test.cbd";
+
+    retval = OS_FindList(list, &node);
+
+    assert_null(retval);
+
+    os_free(node);
+}
+
+void test_OS_FindList_empty_node(void ** state) {
+
+    const char list[] = "list_test.cbd";
+    ListNode * node = NULL;
+    ListNode * retval;
+
+    retval = OS_FindList(list, &node);
+
+    assert_null(retval);
+}
+
+void test_OS_FindList_txt_match(void ** state) {
+
+    const char list[] = "list_test.cbd";
+    ListNode * node;
+    os_calloc(1, sizeof(ListNode), node);
+    ListNode * retval;
+    const ListNode * expect_retval = node;
+
+    node->next = NULL;
+    node->txt_filename = "list_test.cbd";
+    node->cdb_filename = "not_2_list_test.cbd";
+
+    retval = OS_FindList(list, &node);
+
+    assert_non_null(retval);
+    assert_ptr_equal(retval, expect_retval);
+
+    os_free(node);
+}
+
+void test_OS_FindList_cdb_match(void ** state) {
+
+    const char list[] = "list_test.cbd";
+    ListNode * node;
+    os_calloc(1, sizeof(ListNode), node);
+    ListNode * retval;
+    const ListNode * expect_retval = node;
+
+    node->next = NULL;
+    node->txt_filename = "_not_list_test.cbd";
+    node->cdb_filename = "list_test.cbd";
+
+    retval = OS_FindList(list, &node);
+
+    assert_non_null(retval);
+    assert_ptr_equal(retval, expect_retval);
+
+    os_free(node);
+}
+
+/* OS_ListLoadRules */
+void test_OS_ListLoadRules_rule_null_check(void ** state) {
+    ListNode * l_node = (ListNode *) 1;
+    ListRule * lrule = NULL;
+
+    OS_ListLoadRules(&l_node, &lrule);
+}
+
+void test_OS_ListLoadRules_list_checked(void ** state) {
+    ListRule * lrule;
+    ListRule * firstrule;
+    ListNode * l_node = NULL;
+
+    os_calloc(1, sizeof(ListRule), lrule);
+    firstrule = lrule;
+    lrule->next = NULL;
+    lrule->loaded = 0;
+    lrule->filename = strdup("test_file");
+
+    OS_ListLoadRules(&l_node, &lrule);
+
+    assert_int_equal(firstrule->loaded, 1);
+    os_free(firstrule->filename);
+    os_free(firstrule);
+}
+
+void test_OS_ListLoadRules_list_checked_and_load (void ** state) {
+    ListRule * lrule;
+    ListRule * firstrule;
+    ListNode * l_node = NULL;
+
+    os_calloc(1, sizeof(ListRule), lrule);
+    firstrule = lrule;
+    lrule->next = NULL;
+    lrule->loaded = 0;
+    lrule->filename = strdup("list_test.cbd");
+
+    /* OS_FindList */
+    ListNode * node;
+    os_calloc(1, sizeof(ListNode), node);
+
+    node->next = NULL;
+    node->txt_filename = "_not_list_test.cbd";
+    node->cdb_filename = "list_test.cbd";
+
+    OS_ListLoadRules(&node, &lrule);
+
+    assert_int_equal(firstrule->loaded, 1);
+    os_free(firstrule->filename);
+    os_free(firstrule);
+    os_free(node);
+}
+
+void test_OS_ListLoadRules_already_load(void ** state) {
+    ListRule * lrule;
+    ListRule * firstrule;
+    ListNode * l_node = NULL;
+
+    os_calloc(1, sizeof(ListRule), lrule);
+    firstrule = lrule;
+    lrule->next = NULL;
+    lrule->loaded = 1;
+
+    OS_ListLoadRules(&l_node, &lrule);
+
+    assert_int_equal(firstrule->loaded, 1);
+    os_free(firstrule);
+    os_free(lrule);
 }
 
 int main(void)
@@ -68,7 +209,17 @@ int main(void)
         // Tests os_remove_cdblist
         cmocka_unit_test(test_os_remove_cdblist_OK),
         // Tests os_remove_cdbrules
-        cmocka_unit_test(test_os_remove_cdbrules_OK)
+        cmocka_unit_test(test_os_remove_cdbrules_OK),
+        // Tests OS_FindList
+        cmocka_unit_test(test_OS_FindList_dont_match),
+        cmocka_unit_test(test_OS_FindList_empty_node),
+        cmocka_unit_test(test_OS_FindList_cdb_match),
+        cmocka_unit_test(test_OS_FindList_txt_match),
+        // Tests OS_ListLoadRules
+        cmocka_unit_test(test_OS_ListLoadRules_rule_null_check),
+        cmocka_unit_test(test_OS_ListLoadRules_list_checked),
+        cmocka_unit_test(test_OS_ListLoadRules_list_checked_and_load),
+        cmocka_unit_test(test_OS_ListLoadRules_already_load),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_logmsg.c
+++ b/src/unit_tests/analysisd/test_logmsg.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../headers/shared.h"
+#include "../../analysisd/logmsg.h"
+
+void _os_analysisd_add_logmsg(OSList * list, int level, int line, const char * func, 
+                                const char * file, char * msg, ...) __attribute__((nonnull));
+char * os_analysisd_string_log_msg(os_analysisd_log_msg_t * log_msg);
+void os_analysisd_free_log_msg(os_analysisd_log_msg_t ** log_msg);
+
+/* setup/teardown */
+
+
+
+/* wraps */
+
+int __wrap_isDebug() {
+    return mock();
+}
+
+void * __wrap_OSList_AddData() {
+    return mock_type(void *);
+}
+
+
+/* tests */
+
+/* os_analysisd_free_log_msg */
+
+void test_os_analysisd_free_log_msg_NULL(void **state)
+{
+
+    os_analysisd_log_msg_t * message = NULL;
+
+    os_analysisd_free_log_msg(&message);
+
+}
+
+void test_os_analysisd_free_log_msg_OK(void **state)
+{
+
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+
+    message->level = LOGLEVEL_ERROR;
+    message->line = 500;
+    message->msg = strdup("Test Message");
+    message->file = strdup("Test_file.c");
+    message->func = strdup("TestFunction");
+
+
+    os_analysisd_free_log_msg(&message);
+
+}
+
+/* os_analysisd_string_log_msg */
+void test_os_analysisd_string_log_msg_NULL(void **state)
+{
+    char * retval = NULL;
+
+    os_analysisd_log_msg_t * message = NULL;
+
+    retval = os_analysisd_string_log_msg(message);
+    assert_null(retval);
+
+}
+
+void test_os_analysisd_string_log_msg_isDebug_false(void **state)
+{
+    char * retval = NULL;
+
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+
+    message->level = LOGLEVEL_ERROR;
+    message->line = 500;
+    message->msg = strdup("Test Message");
+    message->file = strdup("Test_file.c");
+    message->func = strdup("TestFunction");
+
+    will_return(__wrap_isDebug, 0);
+
+    retval = os_analysisd_string_log_msg(message);
+    assert_string_equal("Test Message", retval);
+
+    os_free(message->file);
+    os_free(message->func);
+    os_free(message->msg);
+    os_free(message);
+    os_free(retval);
+
+}
+
+void test_os_analysisd_string_log_msg_isDebug_true(void **state)
+{
+    char * retval = NULL;
+
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+
+    message->level = LOGLEVEL_ERROR;
+    message->line = 500;
+    message->msg = strdup("Test Message");
+    message->file = strdup("Test_file.c");
+    message->func = strdup("TestFunction");
+
+    will_return(__wrap_isDebug, 1);
+
+    retval = os_analysisd_string_log_msg(message);
+    assert_string_equal("Test_file.c:500 at TestFunction(): Test Message", retval);
+
+    os_free(message->file);
+    os_free(message->func);
+    os_free(message->msg);
+    os_free(message);
+    os_free(retval);
+
+}
+
+/* _os_analysisd_add_logmsg */
+
+void test__os_analysisd_add_logmsg_OK(void **state)
+{
+    OSList * list_msg;
+    os_calloc(1, sizeof(OSList), list_msg);
+    OSListNode * list_msg_node;
+
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+
+    message->level = LOGLEVEL_ERROR;
+    message->line = 500;
+    message->msg = strdup("Test Message");
+    message->file = strdup("Test_file.c");
+    message->func = strdup("TestFunction");
+
+    will_return(__wrap_OSList_AddData,"test");
+
+    _os_analysisd_add_logmsg(list_msg, message->level, message->line, message->func, message->file, message->msg);
+
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        //Test os_analysisd_free_log_msg
+        cmocka_unit_test(test_os_analysisd_free_log_msg_NULL),
+        cmocka_unit_test(test_os_analysisd_free_log_msg_OK),
+        //Test os_analysisd_string_log_msg
+        cmocka_unit_test(test_os_analysisd_string_log_msg_NULL),
+        cmocka_unit_test(test_os_analysisd_string_log_msg_isDebug_false),
+        cmocka_unit_test(test_os_analysisd_string_log_msg_isDebug_true),
+        //Test _os_analysisd_add_logmsg
+        cmocka_unit_test(test__os_analysisd_add_logmsg_OK),
+
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/analysisd/test_logmsg.c
+++ b/src/unit_tests/analysisd/test_logmsg.c
@@ -16,7 +16,7 @@
 #include "../../headers/shared.h"
 #include "../../analysisd/logmsg.h"
 
-void _os_analysisd_add_logmsg(OSList * list, int level, int line, const char * func, 
+void _os_analysisd_add_logmsg(OSList * list, int level, int line, const char * func,
                                 const char * file, char * msg, ...) __attribute__((nonnull));
 char * os_analysisd_string_log_msg(os_analysisd_log_msg_t * log_msg);
 void os_analysisd_free_log_msg(os_analysisd_log_msg_t ** log_msg);
@@ -39,8 +39,8 @@ void * __wrap_OSList_AddData(OSList *list, void *data) {
     return mock_type(void *);
 }
 
-int __wrap_vsnprintf (char *__restrict __s, size_t __maxlen,
-		            const char *__restrict __format, _G_va_list __arg) {
+int __wrap_vsnprintf(char *__restrict __s, size_t __maxlen,
+		            const char *__restrict __format, ...) {
 
     check_expected(__format);
 
@@ -183,8 +183,7 @@ int main(void)
         cmocka_unit_test(test_os_analysisd_string_log_msg_isDebug_false),
         cmocka_unit_test(test_os_analysisd_string_log_msg_isDebug_true),
         //Test _os_analysisd_add_logmsg
-        cmocka_unit_test(test__os_analysisd_add_logmsg_OK),
-
+        cmocka_unit_test(test__os_analysisd_add_logmsg_OK)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_logtest-config.c
+++ b/src/unit_tests/analysisd/test_logtest-config.c
@@ -15,6 +15,7 @@
 
 #include "../../headers/shared.h"
 #include "../../analysisd/logtest.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
 int Read_Logtest(XML_NODE node);
 cJSON *getRuleTestConfig();
@@ -24,39 +25,6 @@ cJSON *getRuleTestConfig();
 
 
 /* wraps */
-
-void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...) {
-    char formatted_msg[OS_MAXSTR];
-    va_list args;
-
-    va_start(args, msg);
-    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
-    va_end(args);
-
-    check_expected(formatted_msg);
-}
-
-void __wrap__mwarn(const char * file, int line, const char * func, const char *msg, ...) {
-    char formatted_msg[OS_MAXSTR];
-    va_list args;
-
-    va_start(args, msg);
-    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
-    va_end(args);
-
-    check_expected(formatted_msg);
-}
-
-void __wrap__mdebug2(const char * file, int line, const char * func, const char *msg, ...) {
-    char formatted_msg[OS_MAXSTR];
-    va_list args;
-
-    va_start(args, msg);
-    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
-    va_end(args);
-
-    check_expected(formatted_msg);
-}
 
 int __wrap_get_nproc(void) {
     return mock();

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -15,6 +15,7 @@
 
 #include "../../headers/shared.h"
 #include "../../analysisd/logtest.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
 int w_logtest_init_parameters();
 void * w_logtest_init();
@@ -69,42 +70,6 @@ int __wrap_accept(int __fd, __SOCKADDR_ARG __addr, socklen_t *__restrict __addr_
     return mock_type(int);
 }
 
-void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...) {
-    char formatted_msg[OS_MAXSTR];
-    va_list args;
-
-    va_start(args, msg);
-    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
-    va_end(args);
-
-    check_expected(formatted_msg);
-}
-
-void __wrap__merror_exit(__attribute__((unused)) const char * file,
-                         __attribute__((unused)) int line,
-                         __attribute__((unused)) const char * func,
-                         const char *msg, ...) {
-    char formatted_msg[OS_MAXSTR];
-    va_list args;
-
-    va_start(args, msg);
-    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
-    va_end(args);
-
-    check_expected(formatted_msg);
-}
-
-void __wrap__mdebug1(const char * file, int line, const char * func, const char *msg, ...) {
-    char formatted_msg[OS_MAXSTR];
-    va_list args;
-
-    va_start(args, msg);
-    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
-    va_end(args);
-
-    check_expected(formatted_msg);
-}
-
 void __wrap__os_analysisd_add_logmsg(OSList * list, int level, int line, const char * func,
                                     const char * file, char * msg, ...) {
     char formatted_msg[OS_MAXSTR];
@@ -133,8 +98,9 @@ int __wrap_pthread_join (pthread_t __th, void **__thread_return) {
     return mock_type(int);
 }
 
-int __wrap_unlink (const char *__name) {
-    return mock_type(int);
+int __wrap_unlink(const char *file) {
+    check_expected_ptr(file);
+    return mock();
 }
 
 int __wrap_pthread_mutex_init() {
@@ -180,17 +146,6 @@ OSListNode *__wrap_OSList_GetFirstNode(OSList * list) {
 
 int __wrap_OSList_SetMaxSize() {
     return mock();
-}
-
-void __wrap__minfo(const char * file, int line, const char * func, const char *msg, ...) {
-    char formatted_msg[OS_MAXSTR];
-    va_list args;
-
-    va_start(args, msg);
-    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
-    va_end(args);
-
-    check_expected(formatted_msg);
 }
 
 void __wrap_w_mutex_init() {
@@ -628,6 +583,7 @@ void test_w_logtest_init_pthread_fail(void **state)
     will_return(__wrap_pthread_join, 0);
     will_return(__wrap_close, 0);
 
+    expect_string(__wrap_unlink, file, LOGTEST_SOCK);
     will_return(__wrap_unlink, 0);
 
     will_return(__wrap_pthread_mutex_destroy, 0);
@@ -676,6 +632,7 @@ void test_w_logtest_init_unlink_fail(void **state)
 
     will_return(__wrap_close, 0);
 
+    expect_string(__wrap_unlink, file, LOGTEST_SOCK);
     will_return(__wrap_unlink, 1);
 
     char msg[OS_SIZE_4096];
@@ -731,6 +688,7 @@ void test_w_logtest_init_done(void **state)
 
     will_return(__wrap_close, 0);
 
+    expect_string(__wrap_unlink, file, LOGTEST_SOCK);
     will_return(__wrap_unlink, 0);
 
 

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -17,11 +17,41 @@
 #include "../../analysisd/logtest.h"
 
 int w_logtest_init_parameters();
-void *w_logtest_init();
-void w_logtest_remove_session(char *token);
-void *w_logtest_check_inactive_sessions(w_logtest_connection_t * connection);
+void * w_logtest_init();
+void w_logtest_remove_session(char * token);
+void w_logtest_register_session(w_logtest_connection_t * connection, w_logtest_session_t * session);
+void w_logtest_remove_old_session(w_logtest_connection_t * connection);
+void * w_logtest_check_inactive_sessions(w_logtest_connection_t * connection);
+int w_logtest_fts_init(OSList ** fts_list, OSHash ** fts_store);
+w_logtest_session_t * w_logtest_initialize_session(char * token, OSList * list_msg);
+char * w_logtest_generate_token();
+int w_logtest_get_rule_level(cJSON * json_log_processed);
+w_logtest_session_t * w_logtest_get_session(cJSON * req, OSList * list_msg, w_logtest_connection_t * connection);
+void w_logtest_add_msg_response(cJSON * response, OSList * list_msg, int * error_code);
+int w_logtest_check_input(char * input_json, cJSON ** req, OSList * list_msg);
+int w_logtest_check_input_request(cJSON * root, OSList * list_msg);
+int w_logtest_check_input_remove_session(cJSON * root, OSList * list_msg);
+char * w_logtest_process_request(char * raw_request, w_logtest_connection_t * connection);
+char * w_logtest_generate_error_response(char * msg);
+int w_logtest_preprocessing_phase(Eventinfo * lf, cJSON * request);
+void w_logtest_decoding_phase(Eventinfo * lf, w_logtest_session_t * session);
+int w_logtest_rulesmatching_phase(Eventinfo * lf, w_logtest_session_t * session, OSList * list_msg);
+cJSON *w_logtest_process_log(cJSON * request, w_logtest_session_t * session, OSList * list_msg);
+int w_logtest_process_request_remove_session(cJSON * json_request, cJSON * json_response, OSList * list_msg,
+                                             w_logtest_connection_t * connection);
+void * w_logtest_clients_handler(w_logtest_connection_t * connection);
+int w_logtest_process_request_log_processing(cJSON * json_request, cJSON * json_response, OSList * list_msg,
+                                             w_logtest_connection_t * connection);
 
 int logtest_enabled = 1;
+
+int w_logtest_conf_threads = 1;
+
+int random_bytes_result = 0;
+
+char * cJSON_error_ptr = NULL;
+
+bool session_load_acm_store = false;
 
 /* setup/teardown */
 
@@ -34,7 +64,7 @@ int __wrap_OS_BindUnixDomain(const char *path, int type, int max_msg_size) {
 }
 
 int __wrap_accept(int __fd, __SOCKADDR_ARG __addr, socklen_t *__restrict __addr_len) {
-    return mock();
+    return mock_type(int);
 }
 
 void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...) {
@@ -46,6 +76,63 @@ void __wrap__merror(const char * file, int line, const char * func, const char *
     va_end(args);
 
     check_expected(formatted_msg);
+}
+
+void __wrap__merror_exit(__attribute__((unused)) const char * file,
+                         __attribute__((unused)) int line,
+                         __attribute__((unused)) const char * func,
+                         const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+void __wrap__mdebug1(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+void __wrap__os_analysisd_add_logmsg(OSList * list, int level, int line, const char * func,
+                                    const char * file, char * msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(level);
+    check_expected_ptr(list);
+    check_expected(formatted_msg);
+}
+
+int __wrap_CreateThreadJoinable(pthread_t *lthread, void * (*function_pointer)(void *), void *data)
+{
+    return mock_type(int);
+}
+
+int __wrap_CreateThread(void * (*function_pointer)(void *), void *data)
+{
+    return mock_type(int);
+}
+
+int __wrap_pthread_join (pthread_t __th, void **__thread_return) {
+    return mock_type(int);
+}
+
+int __wrap_unlink (const char *__name) {
+    return mock_type(int);
 }
 
 int __wrap_pthread_mutex_init() {
@@ -68,6 +155,7 @@ int __wrap_ReadConfig(int modules, const char *cfgfile, void *d1, void *d2) {
     if (!logtest_enabled) {
         w_logtest_conf.enabled = false;
     }
+    w_logtest_conf.threads = w_logtest_conf_threads;
     return mock();
 }
 
@@ -82,6 +170,10 @@ int __wrap_OSHash_setSize(OSHash *self, unsigned int new_size) {
 
 OSList *__wrap_OSList_Create() {
     return mock_type(OSList *);
+}
+
+OSListNode *__wrap_OSList_GetFirstNode(OSList * list) {
+    return mock_type(OSListNode *);
 }
 
 int __wrap_OSList_SetMaxSize() {
@@ -125,10 +217,15 @@ void * __wrap_OSHash_Delete_ex(OSHash *self, const char *key) {
 }
 
 int __wrap_OSHash_Add_ex(OSHash *hash, const char *key, void *data) {
-    check_expected_ptr(key);
-    check_expected_ptr(hash);
-    check_expected_ptr(data);
+
+    if (key) check_expected(key);
+    if (data) check_expected(data);
     return mock_type(int);
+}
+
+void * __wrap_OSHash_Get_ex(OSHash *self, const char *key) {
+    if (key) check_expected(key);
+    return mock_type(void *);
 }
 
 void __wrap_os_remove_rules_list(RuleNode *node) {
@@ -153,6 +250,7 @@ void __wrap_os_remove_cdbrules(ListRule **l_rule) {
 }
 
 void __wrap_os_remove_eventlist(EventList *list) {
+    os_free(list);
     return;
 }
 
@@ -180,10 +278,193 @@ OSStore *__wrap_OSStore_Free(OSStore *list) {
     return mock_type(OSStore *);
 }
 
+void __wrap_OS_CreateEventList(int maxsize, EventList *list) {
+    return;
+}
+
+int __wrap_ReadDecodeXML(const char *file, OSDecoderNode **decoderlist_pn,
+                        OSDecoderNode **decoderlist_nopn, OSStore **decoder_list,
+                        OSList* log_msg) {
+    return mock_type(int);
+}
+
+int __wrap_SetDecodeXML(OSList* log_msg, OSStore **decoder_list,
+                        OSDecoderNode **decoderlist_npn, OSDecoderNode **decoderlist_pn) {
+    return mock_type(int);
+}
+
+int __wrap_Lists_OP_LoadList(char * files, ListNode ** cdblistnode) {
+    return mock_type(int);
+}
+
+void __wrap_Lists_OP_MakeAll(int force, int show_message, ListNode **lnode) {
+    return;
+}
+
+int __wrap_Rules_OP_ReadRules(char * file, RuleNode ** rule_list, ListNode ** cbd , EventList ** evet , OSList * msg) {
+    return mock_type(int);
+}
+
+void __wrap_OS_ListLoadRules(ListNode **l_node, ListRule **lrule) {
+    return;
+}
+
+int __wrap__setlevels(RuleNode *node, int nnode) {
+    return mock_type(int);
+}
+
+int __wrap_AddHash_Rule(RuleNode *node) {
+    return mock_type(int);
+}
+
+int __wrap_Accumulate_Init(OSHash **acm_store, int *acm_lookups, time_t *acm_purge_ts) {
+    if (session_load_acm_store) {
+        *acm_store = (OSHash *) 1;
+    }
+    return mock_type(int);
+}
+
+void __wrap_randombytes(void * ptr, size_t length) {
+    check_expected(length);
+    *((int32_t *) ptr) = random_bytes_result;
+    return;
+}
+
+cJSON * __wrap_cJSON_ParseWithOpts(const char *value, const char **return_parse_end,
+                                   cJSON_bool require_null_terminated) {
+    *return_parse_end = cJSON_error_ptr;
+    return mock_type(cJSON *);
+}
+
+cJSON * __wrap_cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string) {
+    return mock_type(cJSON *);
+}
+
+cJSON * __wrap_cJSON_GetObjectItem(const cJSON * const object, const char * const string) {
+    return mock_type(cJSON *);
+}
+
+char * __wrap_cJSON_GetStringValue(cJSON *item) {
+    return mock_type(char *);
+}
+
+int __wrap_OS_CleanMSG(char *msg, Eventinfo *lf) {
+    return mock_type(int);
+}
+
+cJSON_bool __wrap_cJSON_IsNumber(const cJSON * const item) {
+    return mock_type(cJSON_bool);
+}
+
+cJSON_bool __wrap_cJSON_IsObject(const cJSON * const item) {
+    return mock_type(cJSON_bool);
+}
+
+cJSON * __wrap_cJSON_CreateArray() {
+    return mock_type(cJSON *);
+}
+
+cJSON * __wrap_cJSON_CreateObject() { 
+    return mock_type(cJSON *); 
+}
+
+cJSON * __wrap_cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number) {
+    check_expected(number);
+    check_expected(name);
+    return mock_type(cJSON *);
+}
+
+char * __wrap_cJSON_PrintUnformatted(const cJSON *item){
+    return mock_type(char *);
+}
+
+void __wrap_cJSON_Delete(cJSON *item){
+    return;
+}
+
+cJSON_bool __wrap_cJSON_IsString(const cJSON * const item) {
+    return mock_type(cJSON_bool);
+}
+
+void __wrap_cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string){
+    return;
+}
+
+void __wrap_cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item){
+    check_expected(object);
+    check_expected(string);
+    return;
+}
+
+cJSON * __wrap_cJSON_CreateString(const char *string){
+    return mock_type(cJSON *);
+}
+
+void __wrap_cJSON_AddItemToArray(cJSON *array, cJSON *item) {
+    return;
+}
+
+void __wrap_os_analysisd_free_log_msg(os_analysisd_log_msg_t ** log_msg) {
+    os_free((*log_msg)->file);
+    os_free((*log_msg)->func);
+    os_free((*log_msg)->msg);
+    os_free(*log_msg);
+    return;
+}
+
+char * __wrap_os_analysisd_string_log_msg(os_analysisd_log_msg_t * log_msg) {
+    return mock_type(char *);
+}
+
+void __wrap_OSList_DeleteCurrentlyNode(OSList *list) {
+    if (list) {
+        os_free(list->cur_node)
+    }
+    return;
+}
+
+int __wrap_wm_strcat(char **str1, const char *str2, char sep) {
+    if(*str1 == NULL){
+        os_calloc(4 , sizeof(char), *str1);
+    }
+    check_expected(str2);
+    return mock_type(int);
+}
+
+void __wrap_DecodeEvent(struct _Eventinfo *lf, OSHash *rules_hash, regex_matching *decoder_match, OSDecoderNode *node) {
+    check_expected(node);
+}
+
+RuleInfo * __wrap_OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events, 
+                                      ListNode **cdblists, RuleNode *curr_node,
+                                      regex_matching *rule_match, OSList **fts_list, 
+                                      OSHash **fts_store) {
+    return mock_type(RuleInfo *);
+}
+
+void __wrap_OS_AddEvent(Eventinfo *lf, EventList *list) {
+    return;
+}
+
+int __wrap_IGnore(Eventinfo *lf, int pos) {
+    return mock_type(int);
+}
+
+void * __wrap_OSList_AddData(OSList *list, void *data) {
+    return mock_type(void *);
+}
+
+int __wrap_OS_RecvSecureTCP(int sock, char * ret,uint32_t size) {
+       return mock_type(int);
+}
+
+int __wrap_OS_SendSecureTCP(int sock, uint32_t size, const void * msg) {
+    return mock_type(int);
+}
+
 /* tests */
 
 /* w_logtest_init_parameters */
-
 void test_w_logtest_init_parameters_invalid(void **state)
 {
     will_return(__wrap_ReadConfig, OS_INVALID);
@@ -262,7 +543,7 @@ void test_w_logtest_init_OSHash_setSize_fail(void **state)
 
     will_return(__wrap_OSHash_Create, 1);
 
-    expect_value(__wrap_OSHash_setSize, new_size, 2048);
+    expect_in_range(__wrap_OSHash_setSize, new_size, 1, 400);
     will_return(__wrap_OSHash_setSize, NULL);
 
     expect_string(__wrap__merror, formatted_msg, "(7305): Failure to resize all_sessions hash");
@@ -271,22 +552,160 @@ void test_w_logtest_init_OSHash_setSize_fail(void **state)
 
 }
 
-void test_w_logtest_init_done(void **state)
+void test_w_logtest_init_pthread_fail(void **state)
 {
+    w_logtest_conf_threads = 2;
     will_return(__wrap_ReadConfig, 0);
 
     will_return(__wrap_OS_BindUnixDomain, OS_SUCCESS);
 
     will_return(__wrap_OSHash_Create, 1);
 
-    expect_value(__wrap_OSHash_setSize, new_size, 2048);
+    expect_in_range(__wrap_OSHash_setSize, new_size, 1, 400);
     will_return(__wrap_OSHash_setSize, 1);
+
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_pthread_mutex_init, 0);
 
     expect_string(__wrap__minfo, formatted_msg, "(7200): Logtest started");
 
-    // Needs to implement w_logtest_main
+    will_return(__wrap_CreateThreadJoinable, -1);
+
+    expect_string(__wrap__merror_exit, formatted_msg, "(1109): Unable to create new pthread.");
+
+    will_return(__wrap_CreateThread, 1);
+
+    //w_logtest_clients_handler
+    will_return(__wrap_FOREVER, 1);
+    
+    will_return(__wrap_pthread_mutex_lock, 0);
+
+    will_return(__wrap_accept, 5);
+    
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    will_return(__wrap_OS_RecvSecureTCP, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7314): Failure to receive message: empty or reception timeout");
+
+    will_return(__wrap_close, 0);
+    will_return(__wrap_FOREVER, 0);
+
+    
+    will_return(__wrap_pthread_join, 0);
+    will_return(__wrap_close, 0);
+
+    will_return(__wrap_unlink, 0);
+
+    will_return(__wrap_pthread_mutex_destroy, 0);
+    will_return(__wrap_pthread_mutex_destroy, 0);
 
     w_logtest_init();
+    w_logtest_conf_threads = 1;
+
+}
+
+void test_w_logtest_init_unlink_fail(void **state)
+{
+    w_logtest_conf_threads = 1;
+    will_return(__wrap_ReadConfig, 0);
+
+    will_return(__wrap_OS_BindUnixDomain, OS_SUCCESS);
+
+    will_return(__wrap_OSHash_Create, 1);
+
+    expect_in_range(__wrap_OSHash_setSize, new_size, 1, 400);
+    will_return(__wrap_OSHash_setSize, 1);
+
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_pthread_mutex_init, 0);
+
+    expect_string(__wrap__minfo, formatted_msg, "(7200): Logtest started");
+
+    will_return(__wrap_CreateThread, 1);
+
+    //w_logtest_clients_handler
+    will_return(__wrap_FOREVER, 1);
+    
+    will_return(__wrap_pthread_mutex_lock, 0);
+
+    will_return(__wrap_accept, 5);
+    
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    will_return(__wrap_OS_RecvSecureTCP, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7314): Failure to receive message: empty or reception timeout");
+
+    will_return(__wrap_close, 0);
+    will_return(__wrap_FOREVER, 0);
+
+    
+    will_return(__wrap_close, 0);
+
+    will_return(__wrap_unlink, 1);
+
+    char msg[OS_SIZE_4096];
+    errno = EBUSY;
+    snprintf(msg, OS_SIZE_4096, "(1129): Could not unlink file '%s' due to [(%d)-(%s)].", 
+            LOGTEST_SOCK, errno, strerror(errno));
+
+    expect_string(__wrap__merror, formatted_msg, msg);
+
+    will_return(__wrap_pthread_mutex_destroy, 0);
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+    w_logtest_init();
+    w_logtest_conf_threads = 1;
+
+}
+
+void test_w_logtest_init_done(void **state)
+{
+    w_logtest_conf_threads = 1;
+    will_return(__wrap_ReadConfig, 0);
+
+    will_return(__wrap_OS_BindUnixDomain, OS_SUCCESS);
+
+    will_return(__wrap_OSHash_Create, 1);
+
+    expect_in_range(__wrap_OSHash_setSize, new_size, 1, 400);
+    will_return(__wrap_OSHash_setSize, 1);
+
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_pthread_mutex_init, 0);
+
+    expect_string(__wrap__minfo, formatted_msg, "(7200): Logtest started");
+
+    will_return(__wrap_CreateThread, 1);
+
+    //w_logtest_clients_handler
+    will_return(__wrap_FOREVER, 1);
+    
+    will_return(__wrap_pthread_mutex_lock, 0);
+
+    will_return(__wrap_accept, 5);
+    
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    will_return(__wrap_OS_RecvSecureTCP, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7314): Failure to receive message: empty or reception timeout");
+
+    will_return(__wrap_close, 0);
+    will_return(__wrap_FOREVER, 0);
+
+    
+    will_return(__wrap_close, 0);
+
+    will_return(__wrap_unlink, 0);
+
+
+    will_return(__wrap_pthread_mutex_destroy, 0);
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+    w_logtest_init();
+    w_logtest_conf_threads = 1;
 
 }
 
@@ -424,6 +843,8 @@ void test_w_logtest_remove_session_OK(void **state)
 
     will_return(__wrap_OSHash_Free, session);
 
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
     w_logtest_remove_session(key);
 
 }
@@ -524,10 +945,12 @@ void test_w_logtest_check_inactive_sessions_remove(void **state)
 
     will_return(__wrap_OSHash_Free, session);
 
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+    will_return(__wrap_pthread_mutex_unlock, 0);
 
     will_return(__wrap_FOREVER, 0);
 
-    will_return(__wrap_pthread_mutex_unlock, 0);
 
     w_logtest_check_inactive_sessions(&connection);
 
@@ -535,6 +958,112 @@ void test_w_logtest_check_inactive_sessions_remove(void **state)
 
     os_free(hash_node);
 
+}
+
+/* w_logtest_remove_old_session */
+void test_w_logtest_remove_old_session_one(void ** state) {
+
+    w_logtest_connection_t connection;
+    
+    connection.active_client = 2;
+    w_logtest_conf.max_sessions = 1;
+
+    /* Oldest session */
+    w_logtest_session_t * old_session;
+    os_calloc(1, sizeof(w_logtest_session_t), old_session);
+    old_session->expired = 0;
+    old_session->last_connection = 100;
+    w_strdup("old_session", old_session->token);
+    OSHashNode * hash_node_old;
+    os_calloc(1, sizeof(OSHashNode), hash_node_old);
+    w_strdup("old_session", hash_node_old->key);
+    hash_node_old->data = old_session;
+
+    will_return(__wrap_OSHash_Begin, hash_node_old);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    /* Remove session */
+    expect_string(__wrap_OSHash_Delete_ex, key, "old_session");
+    will_return(__wrap_OSHash_Delete_ex, old_session);
+
+    will_return(__wrap_OSStore_Free, old_session->decoder_store);
+
+    will_return(__wrap_OSHash_Free, old_session);
+
+    will_return(__wrap_OSHash_Free, old_session);
+
+    will_return(__wrap_OSHash_Free, old_session);
+
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+
+    w_logtest_remove_old_session(&connection);
+
+    assert_int_equal(connection.active_client, w_logtest_conf.max_sessions);
+
+    os_free(hash_node_old->key);
+    os_free(hash_node_old);
+}
+
+void test_w_logtest_remove_old_session_many(void ** state) {
+
+    w_logtest_connection_t connection;
+    
+    connection.active_client = 3;
+    w_logtest_conf.max_sessions = 2;
+
+    /* Oldest session */
+    w_logtest_session_t * old_session;
+    os_calloc(1, sizeof(w_logtest_session_t), old_session);
+    old_session->expired = 0;
+    old_session->last_connection = 100;
+    w_strdup("old_session", old_session->token);
+    OSHashNode * hash_node_old;
+    os_calloc(1, sizeof(OSHashNode), hash_node_old);
+    w_strdup("old_session", hash_node_old->key);
+    hash_node_old->data = old_session;
+
+    /* Other session */
+    w_logtest_session_t other_session;
+    other_session.expired = 0;
+    other_session.last_connection = 300;
+    OSHashNode * hash_node_other;
+    os_calloc(1, sizeof(OSHashNode), hash_node_other);
+    w_strdup("other_session", hash_node_other->key);
+    hash_node_other->data = &other_session;
+
+    will_return(__wrap_OSHash_Begin, hash_node_other);
+    will_return(__wrap_OSHash_Next, hash_node_old);
+
+    will_return(__wrap_pthread_mutex_lock, 0);
+    will_return(__wrap_pthread_mutex_lock, 0);
+
+    will_return(__wrap_pthread_mutex_unlock, 0);
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    will_return(__wrap_OSHash_Next, NULL);
+
+    /* w_logtest_remove_session */
+    expect_value(__wrap_OSHash_Delete_ex, key, old_session->token);
+    will_return(__wrap_OSHash_Delete_ex, old_session);
+
+    will_return(__wrap_OSStore_Free, NULL);
+
+    will_return(__wrap_OSHash_Free, old_session);
+
+    will_return(__wrap_OSHash_Free, old_session);
+
+    will_return(__wrap_OSHash_Free, old_session);
+
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+    w_logtest_remove_old_session(&connection);
+    assert_int_equal(connection.active_client, w_logtest_conf.max_sessions);
+    
+    os_free(hash_node_other->key);
+    os_free(hash_node_old->key);
+    os_free(hash_node_other);
+    os_free(hash_node_old);
 }
 
 /* w_logtest_register_session */
@@ -552,7 +1081,6 @@ void test_w_logtest_register_session_dont_remove(void ** state) {
 
     will_return(__wrap_pthread_mutex_unlock, 0);
 
-    expect_value(__wrap_OSHash_Add_ex, hash, w_logtest_sessions);
     expect_value(__wrap_OSHash_Add_ex, key, session.token);
     expect_value(__wrap_OSHash_Add_ex, data, &session);
     will_return(__wrap_OSHash_Add_ex, 0);
@@ -619,9 +1147,10 @@ void test_w_logtest_register_session_remove_old(void ** state) {
 
     will_return(__wrap_OSHash_Free, old_session);
 
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
     will_return(__wrap_pthread_mutex_unlock, 0);
 
-    expect_value(__wrap_OSHash_Add_ex, hash, w_logtest_sessions);
     expect_value(__wrap_OSHash_Add_ex, key, session.token);
     expect_value(__wrap_OSHash_Add_ex, data, &session);
     will_return(__wrap_OSHash_Add_ex, 0);
@@ -636,6 +1165,2874 @@ void test_w_logtest_register_session_remove_old(void ** state) {
     os_free(hash_node_old);
 }
 
+/* w_logtest_initialize_session */
+void test_w_logtest_initialize_session_error_decoders(void ** state) {
+
+    char * token = strdup("test");
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_ReadDecodeXML, 0);
+
+    // test_w_logtest_remove_session_ok_error_load_decoder_cbd_rules_hash
+    will_return(__wrap_OSStore_Free, (OSStore *) 1);
+
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_null(session);
+
+    os_free(Config.decoders);
+    os_free(token);
+}
+
+void test_w_logtest_initialize_session_error_cbd_list(void ** state) {
+
+    char * token = strdup("test");
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_SetDecodeXML, 0);
+    will_return(__wrap_Lists_OP_LoadList, -1);
+
+    // test_w_logtest_remove_session_ok_error_load_decoder_cbd_rules_hash
+    will_return(__wrap_OSStore_Free, (OSStore *) 1);
+
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_null(session);
+
+    os_free(Config.decoders);
+    os_free(Config.lists);
+    os_free(token);
+}
+
+void test_w_logtest_initialize_session_error_rules(void ** state) {
+
+    char * token = strdup("test");
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    char * include_file = "test.xml";
+    Config.includes = calloc(2, sizeof(char *));
+    Config.includes[0] = include_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_SetDecodeXML, 0);
+    will_return(__wrap_Lists_OP_LoadList, 0);
+    will_return(__wrap_Rules_OP_ReadRules, -1);
+
+    // test_w_logtest_remove_session_ok_error_load_decoder_cbd_rules_hash
+    will_return(__wrap_OSStore_Free, (OSStore *) 1);
+
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_null(session);
+
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+    os_free(token);
+}
+
+void test_w_logtest_initialize_session_error_hash_rules(void ** state) {
+
+    char * token = strdup("test");
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    char * include_file = "test.xml";
+    Config.includes = calloc(2, sizeof(char *));
+    Config.includes[0] = include_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_SetDecodeXML, 0);
+    will_return(__wrap_Lists_OP_LoadList, 0);
+    will_return(__wrap_Rules_OP_ReadRules, 0);
+    will_return(__wrap__setlevels, 0);
+    will_return(__wrap_OSHash_Create, 0);
+
+    // test_w_logtest_remove_session_ok_error_load_decoder_cbd_rules_hash
+    will_return(__wrap_OSStore_Free, (OSStore *) 1);
+
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_null(session);
+
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+    os_free(token);
+}
+
+void test_w_logtest_initialize_session_error_fts_init(void ** state) {
+
+    char * token = strdup("test");
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    char * include_file = "test.xml";
+    Config.includes = calloc(2, sizeof(char *));
+    Config.includes[0] = include_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_SetDecodeXML, 0);
+    will_return(__wrap_Lists_OP_LoadList, 0);
+    will_return(__wrap_Rules_OP_ReadRules, 0);
+    will_return(__wrap__setlevels, 0);
+    will_return(__wrap_OSHash_Create, 1);
+    will_return(__wrap_AddHash_Rule, 0);
+
+    /* FTS init fail */
+    OSList * fts_list;
+    OSHash * fts_store;
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_OSList_Create, NULL);
+    expect_string(__wrap__merror, formatted_msg, "(1290): Unable to create a new list (calloc).");
+
+    // test_w_logtest_remove_session_ok_error_FTS_INIT
+    will_return(__wrap_OSStore_Free, (OSStore *) 1);
+    will_return(__wrap_OSHash_Free, (OSHash *) 0);
+
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_null(session);
+
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+    os_free(token);
+}
+
+void test_w_logtest_initialize_session_error_accumulate_init(void ** state) {
+
+    char * token = strdup("test");
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    char * include_file = "test.xml";
+    Config.includes = calloc(2, sizeof(char *));
+    Config.includes[0] = include_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_SetDecodeXML, 0);
+    will_return(__wrap_Lists_OP_LoadList, 0);
+    will_return(__wrap_Rules_OP_ReadRules, 0);
+    will_return(__wrap__setlevels, 0);
+    will_return(__wrap_OSHash_Create, 1);
+    will_return(__wrap_AddHash_Rule, 0);
+
+    /* FTS init success */
+    OSList * fts_list;
+    OSHash * fts_store;
+    OSList * list;
+    os_calloc(1, sizeof(OSList), list);
+    OSHash * hash = (OSHash *) 1;
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_OSList_Create, list);
+    will_return(__wrap_OSList_SetMaxSize, 1);
+    will_return(__wrap_OSHash_Create, hash);
+    expect_value(__wrap_OSHash_setSize, new_size, 2048);
+    will_return(__wrap_OSHash_setSize, 1);
+
+    will_return(__wrap_Accumulate_Init, 0);
+
+    // test_w_logtest_remove_session_ok_error_acm
+    will_return(__wrap_OSStore_Free, (OSStore *) 1);
+    will_return(__wrap_OSHash_Free, (OSStore *) 1);
+    will_return(__wrap_OSHash_Free, (OSStore *) 1);
+
+    will_return(__wrap_OSHash_Free, (OSStore *) 1);
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+    session_load_acm_store = true;
+
+    session = w_logtest_initialize_session(token, msg);
+
+    session_load_acm_store = false;
+
+    assert_null(session);
+
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+    os_free(token);
+}
+
+void test_w_logtest_initialize_session_success(void ** state) {
+
+    char * token = strdup("test");
+    OSList * msg = (OSList *) 1;
+    w_logtest_session_t * session;
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    char * include_file = "test.xml";
+    Config.includes = calloc(2, sizeof(char *));
+    Config.includes[0] = include_file;
+
+    will_return(__wrap_time, 1212);
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_SetDecodeXML, 0);
+    will_return(__wrap_Lists_OP_LoadList, 0);
+    will_return(__wrap_Rules_OP_ReadRules, 0);
+    will_return(__wrap__setlevels, 0);
+    will_return(__wrap_OSHash_Create, 1);
+    will_return(__wrap_AddHash_Rule, 0);
+
+    /* FTS init success */
+    OSList * fts_list;
+    OSHash * fts_store;
+    OSList * list = (OSList *) 1;
+    OSHash * hash = (OSHash *) 1;
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_OSList_Create, list);
+    will_return(__wrap_OSList_SetMaxSize, 1);
+    will_return(__wrap_OSHash_Create, hash);
+    expect_value(__wrap_OSHash_setSize, new_size, 2048);
+    will_return(__wrap_OSHash_setSize, 1);
+
+    will_return(__wrap_Accumulate_Init, 1);
+
+    session = w_logtest_initialize_session(token, msg);
+
+    assert_non_null(session);
+    assert_false(session->expired);
+    assert_int_equal(session->last_connection, 1212);
+
+    os_free(token);
+    os_free(session->eventlist);
+    os_free(session);
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+}
+
+/* w_logtest_generate_token */
+void test_w_logtest_generate_token_success(void ** state) {
+
+    char * token = NULL;
+
+    random_bytes_result = 1234565555; // 0x49_95_f9_b3
+    expect_value(__wrap_randombytes, length, W_LOGTEST_TOKEN_LENGH >> 1);
+
+    token = w_logtest_generate_token();
+
+    assert_non_null(token);
+    assert_string_equal(token, "4995f9b3");
+
+    os_free(token);
+}
+
+void test_w_logtest_generate_token_success_empty_bytes(void ** state) {
+
+    char * token = NULL;
+
+    random_bytes_result = 5555; // 0x15_b3
+    expect_value(__wrap_randombytes, length, W_LOGTEST_TOKEN_LENGH >> 1);
+
+    token = w_logtest_generate_token();
+
+    assert_non_null(token);
+    assert_string_equal(token, "000015b3");
+
+    os_free(token);
+}
+
+/* w_logtest_get_rule_level */
+void test_w_logtest_get_rule_level_empty_log(void ** state) {
+    cJSON * log = NULL;
+    int level;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7203): Empty log for check alert level");
+
+    level = w_logtest_get_rule_level(log);
+
+    assert_int_equal(level, 0);
+}
+
+void test_w_logtest_get_rule_level_empty_rule(void ** state) {
+    cJSON * log = (cJSON *) 1;
+    cJSON * rule = NULL;
+    int level;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, rule);
+    expect_string(__wrap__mdebug1, formatted_msg, "(7204): Output without rule");
+
+    level = w_logtest_get_rule_level(log);
+
+    assert_int_equal(level, 0);
+}
+
+void test_w_logtest_get_rule_level_empty_level(void ** state) {
+    cJSON * json_log = (cJSON *) 1;
+    cJSON * json_rule = (cJSON *) 1;
+    cJSON * json_level = NULL;
+    int level;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, json_rule);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, json_level);
+    expect_string(__wrap__mdebug1, formatted_msg, "(7205): Rule without alert level");
+
+    level = w_logtest_get_rule_level(json_log);
+
+    assert_int_equal(level, 0);
+}
+
+void test_w_logtest_get_rule_level_ok(void ** state) {
+    cJSON * json_log = (cJSON *) 1;
+    cJSON * json_rule = (cJSON *) 1;
+    cJSON * json_level;
+    const int expect_level = 5;
+    int ret_level;
+
+    os_calloc(1, sizeof(cJSON), json_level);
+    json_level->valueint = expect_level;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, json_rule);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, json_level);
+    will_return(__wrap_cJSON_IsNumber, 1);
+
+    ret_level = w_logtest_get_rule_level(json_log);
+
+    assert_int_equal(ret_level, expect_level);
+
+    os_free(json_level);
+}
+
+/* w_logtest_get_session */
+void test_w_logtest_get_session_fail(void ** state) {
+
+    w_logtest_session_t * ret_session;
+    w_logtest_connection_t connection;
+
+    cJSON * json_request = (cJSON *) 1;
+    OSList * list_msg = (OSList *) 55;
+
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+
+    /* Generate token */
+    random_bytes_result = 5555; // 0x00_00_15_b3
+    expect_value(__wrap_randombytes, length, W_LOGTEST_TOKEN_LENGH >> 1);
+
+    expect_string(__wrap_OSHash_Get_ex, key, "000015b3");
+    will_return(__wrap_OSHash_Get_ex, NULL);
+
+    /* Initialize session*/
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_ReadDecodeXML, 0);
+
+    // test_w_logtest_remove_session_ok_error_load_decoder_cbd_rules_hash
+    will_return(__wrap_OSStore_Free, (OSStore *) 1);
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+
+    /* w_logtest_get_session */
+    expect_string(__wrap__mdebug1, formatted_msg, "(7311): Failure to initializing session '000015b3'");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7311): Failure to initializing session '000015b3'");
+
+    ret_session = w_logtest_get_session(json_request, list_msg, &connection);
+
+    assert_null(ret_session);
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+
+
+}
+
+void test_w_logtest_get_session_active(void ** state) {
+
+    w_logtest_connection_t connection;
+    w_logtest_session_t active_session;
+    w_logtest_session_t * ret_session;
+
+    cJSON * json_request = (cJSON *) 1;
+    cJSON * json_request_token;
+    OSList * list_msg = (OSList *) 55;
+    char * token = strdup("test_token");
+    const time_t now = (time_t) 2020;
+
+    os_calloc(1, sizeof(cJSON), json_request_token);
+    json_request_token->valuestring = token;
+    active_session.expired = false;
+    active_session.last_connection = 0;
+
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, json_request_token);
+
+    expect_value(__wrap_OSHash_Get_ex, key, token);
+    will_return(__wrap_OSHash_Get_ex, &active_session);
+
+    will_return(__wrap_pthread_mutex_lock, 0);
+    will_return(__wrap_time, now);
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    ret_session = w_logtest_get_session(json_request, list_msg, &connection);
+
+    assert_ptr_equal(ret_session, &active_session);
+    assert_int_equal(now, ret_session->last_connection);
+
+    os_free(token);
+    os_free(json_request_token);
+}
+
+void test_w_logtest_get_session_expired_token(void ** state) {
+
+    w_logtest_session_t * ret_session;
+    w_logtest_connection_t connection;
+
+    cJSON * json_request = (cJSON *) 1;
+    cJSON * json_request_token;
+    OSList * list_msg = (OSList *) 55;
+    char req_token[] = "test_token";
+
+    os_calloc(1, sizeof(cJSON), json_request_token);
+    json_request_token->valuestring = req_token;
+
+    w_logtest_session_t expired_session;
+    expired_session.expired = true;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, json_request_token);
+
+    expect_string(__wrap_OSHash_Get_ex, key, "test_token");
+    will_return(__wrap_OSHash_Get_ex, &expired_session);
+    will_return(__wrap_pthread_mutex_lock, 0);
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7003): 'test_token' token expires");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_WARNING);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7003): 'test_token' token expires");
+
+    /* Generate token */
+    random_bytes_result = 5555; // 0x00_00_15_b3
+    expect_value(__wrap_randombytes, length, W_LOGTEST_TOKEN_LENGH >> 1);
+
+    expect_string(__wrap_OSHash_Get_ex, key, "000015b3");
+    will_return(__wrap_OSHash_Get_ex, NULL);
+
+    /* Initialize session*/
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    char * include_file = "test.xml";
+    Config.includes = calloc(2, sizeof(char *));
+    Config.includes[0] = include_file;
+
+    will_return(__wrap_time, 1212);
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_SetDecodeXML, 0);
+    will_return(__wrap_Lists_OP_LoadList, 0);
+    will_return(__wrap_Rules_OP_ReadRules, 0);
+    will_return(__wrap__setlevels, 0);
+    will_return(__wrap_OSHash_Create, 1);
+    will_return(__wrap_AddHash_Rule, 0);
+
+    /* Initialize session -- FTS init success */
+    OSList * fts_list;
+    OSHash * fts_store;
+    OSList * list = (OSList *) 1;
+    OSHash * hash = (OSHash *) 1;
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_OSList_Create, list);
+    will_return(__wrap_OSList_SetMaxSize, 1);
+    will_return(__wrap_OSHash_Create, hash);
+    expect_value(__wrap_OSHash_setSize, new_size, 2048);
+    will_return(__wrap_OSHash_setSize, 1);
+
+    will_return(__wrap_Accumulate_Init, 1);
+
+    /* w_logtest_register_session */
+    const int active_session = 5;
+
+    connection.active_client = active_session;
+    w_logtest_conf.max_sessions = active_session + 1;
+
+    will_return(__wrap_pthread_mutex_lock, 0);
+
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    expect_string(__wrap_OSHash_Add_ex, key, "000015b3");
+    expect_not_value(__wrap_OSHash_Add_ex, data, NULL);
+    will_return(__wrap_OSHash_Add_ex, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7202): Session initialized with token '000015b3'");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_INFO);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7202): Session initialized with token '000015b3'");
+
+    ret_session = w_logtest_get_session(json_request, list_msg, &connection);
+
+    assert_non_null(ret_session);
+    assert_false(ret_session->expired);
+    assert_int_equal(ret_session->last_connection, 1212);
+
+    os_free(ret_session->token);
+    os_free(ret_session->eventlist);
+    os_free(ret_session);
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+    os_free(json_request_token);
+}
+
+void test_w_logtest_get_session_new(void ** state) {
+
+    w_logtest_session_t * ret_session;
+    w_logtest_connection_t connection;
+
+    cJSON * json_request = (cJSON *) 1;
+    OSList * list_msg = (OSList *) 55;
+
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+
+    /* Generate token */
+    random_bytes_result = 5555; // 0x00_00_15_b3
+    expect_value(__wrap_randombytes, length, W_LOGTEST_TOKEN_LENGH >> 1);
+
+    expect_string(__wrap_OSHash_Get_ex, key, "000015b3");
+    will_return(__wrap_OSHash_Get_ex, NULL);
+
+    /* Initialize session*/
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    char * cbd_file = "test.xml";
+    Config.lists = calloc(2, sizeof(char *));
+    Config.lists[0] = cbd_file;
+
+    char * include_file = "test.xml";
+    Config.includes = calloc(2, sizeof(char *));
+    Config.includes[0] = include_file;
+
+    will_return(__wrap_time, 1212);
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_ReadDecodeXML, 1);
+    will_return(__wrap_SetDecodeXML, 0);
+    will_return(__wrap_Lists_OP_LoadList, 0);
+    will_return(__wrap_Rules_OP_ReadRules, 0);
+    will_return(__wrap__setlevels, 0);
+    will_return(__wrap_OSHash_Create, 1);
+    will_return(__wrap_AddHash_Rule, 0);
+
+    /* Initialize session -- FTS init success */
+    OSList * fts_list;
+    OSHash * fts_store;
+    OSList * list = (OSList *) 1;
+    OSHash * hash = (OSHash *) 1;
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_OSList_Create, list);
+    will_return(__wrap_OSList_SetMaxSize, 1);
+    will_return(__wrap_OSHash_Create, hash);
+    expect_value(__wrap_OSHash_setSize, new_size, 2048);
+    will_return(__wrap_OSHash_setSize, 1);
+
+    will_return(__wrap_Accumulate_Init, 1);
+
+    /* w_logtest_register_session */
+    const int active_session = 5;
+
+    connection.active_client = active_session;
+    w_logtest_conf.max_sessions = active_session + 1;
+
+    will_return(__wrap_pthread_mutex_lock, 0);
+
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    expect_string(__wrap_OSHash_Add_ex, key, "000015b3");
+    expect_not_value(__wrap_OSHash_Add_ex, data, NULL);
+    will_return(__wrap_OSHash_Add_ex, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7202): Session initialized with token '000015b3'");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_INFO);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7202): Session initialized with token '000015b3'");
+
+    ret_session = w_logtest_get_session(json_request, list_msg, &connection);
+
+    assert_non_null(ret_session);
+    assert_false(ret_session->expired);
+    assert_int_equal(ret_session->last_connection, 1212);
+
+    os_free(ret_session->token);
+    os_free(ret_session->eventlist);
+    os_free(ret_session);
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+}
+
+void test_w_logtest_add_msg_response_null_list(void ** state) {
+    cJSON * response;
+    OSList * list_msg;
+    int retval = 0;
+    const int ret_expect = retval;
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+
+    w_logtest_add_msg_response(response, list_msg, &retval);
+
+    assert_int_equal(retval, ret_expect);
+
+}
+
+void test_w_logtest_add_msg_response_new_field_msg(void ** state) {
+    cJSON * response = (cJSON*) 1;
+    OSList * list_msg;
+    os_calloc(1, sizeof(OSList), list_msg);
+    OSListNode * list_msg_node;
+    const int ret_expect = W_LOGTEST_RCODE_ERROR_PROCESS;
+    int retval = 999;
+
+    cJSON * json_arr_msg = (cJSON*) 2;
+
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+    message->level = LOGLEVEL_ERROR;
+    message->msg = strdup("Test Message");
+    message->file = NULL;
+    message->func = NULL;
+    os_calloc(1, sizeof(OSListNode), list_msg_node);
+    list_msg_node->data = message;
+    list_msg->cur_node = list_msg_node;
+
+    will_return(__wrap_OSList_GetFirstNode, list_msg_node);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_CreateArray, (cJSON*) 1);
+
+    expect_value(__wrap_cJSON_AddItemToObject, object, response);
+    expect_string(__wrap_cJSON_AddItemToObject, string, "messages");
+
+    will_return(__wrap_os_analysisd_string_log_msg, strdup("Test Message"));
+
+    expect_string(__wrap_wm_strcat, str2, "ERROR: ");
+    will_return(__wrap_wm_strcat, 0);
+
+    expect_string(__wrap_wm_strcat, str2, "Test Message");
+    will_return(__wrap_wm_strcat, 0);
+
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+
+    w_logtest_add_msg_response(response, list_msg, &retval);
+
+    assert_int_equal(retval, ret_expect);
+    os_free(list_msg);
+}
+
+void test_w_logtest_add_msg_response_error_msg(void ** state) {
+    cJSON * response = (cJSON*) 1;
+    OSList * list_msg;
+    os_calloc(1, sizeof(OSList), list_msg);
+    OSListNode * list_msg_node;
+    const int ret_expect = W_LOGTEST_RCODE_ERROR_PROCESS;
+    int retval = 999;
+
+    cJSON * json_arr_msg = (cJSON*) 2;
+
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+    message->level = LOGLEVEL_ERROR;
+    message->msg = strdup("Test Message");
+    message->file = NULL;
+    message->func = NULL;
+    os_calloc(1, sizeof(OSListNode), list_msg_node);
+    list_msg_node->data = message;
+    list_msg->cur_node = list_msg_node;
+
+    will_return(__wrap_OSList_GetFirstNode, list_msg_node);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON*) 1);
+
+    will_return(__wrap_os_analysisd_string_log_msg, strdup("Test Message"));
+
+    expect_string(__wrap_wm_strcat, str2, "ERROR: ");
+    will_return(__wrap_wm_strcat, 0);
+
+    expect_string(__wrap_wm_strcat, str2, "Test Message");
+    will_return(__wrap_wm_strcat, 0);
+
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+
+    w_logtest_add_msg_response(response, list_msg, &retval);
+
+    assert_int_equal(retval, ret_expect);
+    os_free(list_msg);
+}
+
+void test_w_logtest_add_msg_response_warn_msg(void ** state) {
+    cJSON * response = (cJSON*) 1;;
+    OSList * list_msg;
+    os_calloc(1, sizeof(OSList), list_msg);
+    OSListNode * list_msg_node;
+    const int ret_expect = W_LOGTEST_RCODE_WARNING;
+    int retval = W_LOGTEST_RCODE_SUCCESS;
+
+    cJSON * json_arr_msg = (cJSON*) 2;
+
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+    message->level = LOGLEVEL_WARNING;
+    message->msg = strdup("Test Message");
+    message->file = NULL;
+    message->func = NULL;
+    os_calloc(1, sizeof(OSListNode), list_msg_node);
+    list_msg_node->data = message;
+    list_msg->cur_node = list_msg_node;
+
+    will_return(__wrap_OSList_GetFirstNode, list_msg_node);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON*) 1);
+
+    will_return(__wrap_os_analysisd_string_log_msg, strdup("Test Message"));
+
+    expect_string(__wrap_wm_strcat, str2, "WARNING: ");
+    will_return(__wrap_wm_strcat, 0);
+
+    expect_string(__wrap_wm_strcat, str2, "Test Message");
+    will_return(__wrap_wm_strcat, 0);
+
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+
+    w_logtest_add_msg_response(response, list_msg, &retval);
+
+    assert_int_equal(retval, ret_expect);
+    os_free(list_msg);
+}
+
+void test_w_logtest_add_msg_response_warn_dont_remplaze_error_msg(void ** state) {
+    cJSON * response = (cJSON*) 1;
+    OSList * list_msg;
+    os_calloc(1, sizeof(OSList), list_msg);
+    OSListNode * list_msg_node;
+    const int ret_expect = W_LOGTEST_RCODE_ERROR_PROCESS;
+    int retval = W_LOGTEST_RCODE_ERROR_PROCESS;
+
+    cJSON * json_arr_msg = (cJSON*) 2;
+
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+    message->level = LOGLEVEL_WARNING;
+    message->msg = strdup("Test Message");
+    message->file = NULL;
+    message->func = NULL;
+    os_calloc(1, sizeof(OSListNode), list_msg_node);
+    list_msg_node->data = message;
+    list_msg->cur_node = list_msg_node;
+
+    will_return(__wrap_OSList_GetFirstNode, list_msg_node);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON*) 1);
+
+    will_return(__wrap_os_analysisd_string_log_msg, strdup("Test Message"));
+
+    expect_string(__wrap_wm_strcat, str2, "WARNING: ");
+    will_return(__wrap_wm_strcat, 0);
+
+    expect_string(__wrap_wm_strcat, str2, "Test Message");
+    will_return(__wrap_wm_strcat, 0);
+
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+
+    w_logtest_add_msg_response(response, list_msg, &retval);
+
+    assert_int_equal(retval, ret_expect);
+    os_free(list_msg);
+}
+
+void test_w_logtest_add_msg_response_info_msg(void ** state) {
+    cJSON * response = (cJSON*) 1;;
+    OSList * list_msg;
+    os_calloc(1, sizeof(OSList), list_msg);
+    OSListNode * list_msg_node;
+    const int ret_expect = 999;
+    int retval = ret_expect;
+
+    cJSON * json_arr_msg = (cJSON*) 2;
+
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+    message->level = LOGLEVEL_INFO;
+    message->msg = strdup("Test Message");
+    message->file = NULL;
+    message->func = NULL;
+    os_calloc(1, sizeof(OSListNode), list_msg_node);
+    list_msg_node->data = message;
+    list_msg->cur_node = list_msg_node;
+
+    will_return(__wrap_OSList_GetFirstNode, list_msg_node);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON*) 1);
+
+    will_return(__wrap_os_analysisd_string_log_msg, strdup("Test Message"));
+
+    expect_string(__wrap_wm_strcat, str2, "INFO: ");
+    will_return(__wrap_wm_strcat, 0);
+
+    expect_string(__wrap_wm_strcat, str2, "Test Message");
+    will_return(__wrap_wm_strcat, 0);
+
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+
+    w_logtest_add_msg_response(response, list_msg, &retval);
+
+    assert_int_equal(retval, ret_expect);
+    os_free(list_msg);
+
+}
+
+/* w_logtest_check_input */
+void test_w_logtest_check_input_malformed_json_long(void ** state) {
+
+    char * input_raw_json = strdup("Test_input_json|_long<error>Test_i|nput_json_long");
+    int pos_error = 25;
+    char expect_slice_json[] = "|_long<error>Test_i|";
+
+    int retval;
+    const int ret_expect = W_LOGTEST_REQUEST_ERROR;
+
+    cJSON * request;
+    OSList * list_msg = (OSList *) 2;
+
+    cJSON_error_ptr = input_raw_json + pos_error;
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7306): Error parsing JSON");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7306): Error parsing JSON");
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7307): Error in position 25, ... |_long<error>Test_i| ...");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg,
+                  "(7307): Error in position 25, ... |_long<error>Test_i| ...");
+
+    retval = w_logtest_check_input(input_raw_json, &request, list_msg);
+
+    assert_int_equal(retval, ret_expect);
+
+    os_free(input_raw_json);
+}
+
+void test_w_logtest_check_input_malformed_json_short(void ** state) {
+
+    char * input_raw_json = strdup("json<err>json");
+    int pos_error = 7;
+    char expect_slice_json[] = "json<err>json";
+
+    int retval;
+    const int ret_expect = W_LOGTEST_REQUEST_ERROR;
+
+    cJSON * request;
+    OSList * list_msg = (OSList *) 2;
+
+    cJSON_error_ptr = input_raw_json + pos_error;
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7306): Error parsing JSON");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7306): Error parsing JSON");
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7307): Error in position 7, ... json<err>json ...");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7307): Error in position 7, ... json<err>json ...");
+
+    retval = w_logtest_check_input(input_raw_json, &request, list_msg);
+
+    assert_int_equal(retval, ret_expect);
+
+    os_free(input_raw_json);
+}
+
+void test_w_logtest_check_input_type_remove_sesion_ok(void ** state) {
+
+    char * input_raw_json = strdup("{input json}");
+
+    int retval;
+    const int ret_expect = W_LOGTEST_REQUEST_TYPE_REMOVE_SESSION;
+
+    cJSON * request;
+    OSList * list_msg = (OSList *) 2;
+
+    will_return(__wrap_cJSON_ParseWithOpts, (cJSON *) 1);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
+
+    // w_logtest_check_input_remove_session ok
+    cJSON token = {0};
+    token.valuestring = strdup("12345678");
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &token);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+
+    assert_int_equal(W_LOGTEST_TOKEN_LENGH, strlen(token.valuestring));
+
+    retval = w_logtest_check_input(input_raw_json, &request, list_msg);
+
+    assert_int_equal(retval, ret_expect);
+    os_free(token.valuestring);
+    os_free(input_raw_json);
+
+}
+
+void test_w_logtest_check_input_type_request_ok(void ** state) {
+
+    char * input_raw_json = strdup("{input json}");
+
+    int retval;
+    const int ret_expect = W_LOGTEST_REQUEST_TYPE_LOG_PROCESSING;
+
+    cJSON * request;
+    OSList * list_msg = (OSList *) 2;
+
+    will_return(__wrap_cJSON_ParseWithOpts, (cJSON *) 1);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 0);
+
+    // w_logtest_check_input_request ok
+    /* location */
+    cJSON location = {0};
+    location.valuestring = strdup("location str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &location);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* log_format */
+    cJSON log_format = {0};
+    log_format.valuestring = strdup("log format str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &log_format);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* event */
+    cJSON event = {0};
+    event.valuestring = strdup("event str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &event);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* token */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+
+
+    retval = w_logtest_check_input(input_raw_json, &request, list_msg);
+
+    assert_int_equal(retval, ret_expect);
+    os_free(location.valuestring);
+    os_free(log_format.valuestring);
+    os_free(event.valuestring);
+    os_free(input_raw_json);
+
+}
+
+// w_logtest_check_input_request
+void test_w_logtest_check_input_request_empty_json(void ** state) {
+
+    cJSON root = {0};
+
+    int retval;
+    const int ret_expect = W_LOGTEST_REQUEST_ERROR;
+
+    OSList * list_msg = (OSList *) 2;
+
+    /* location */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7308): 'location' JSON field is required and must be a string");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg,
+                  "(7308): 'location' JSON field is required and must be a string");
+
+    /* log_format */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7308): 'log_format' JSON field is required and must be a string");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg,
+                  "(7308): 'log_format' JSON field is required and must be a string");
+
+    /* event */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+    will_return(__wrap_cJSON_IsObject, false);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7313): 'event' JSON field not found or is empty");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg,
+                  "(7313): 'event' JSON field not found or is empty");
+
+    /* token */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+
+    retval = w_logtest_check_input_request(&root, list_msg);
+
+    assert_int_equal(retval, ret_expect);
+}
+
+void test_w_logtest_check_input_request_missing_location(void ** state) {
+
+    cJSON root = {0};
+
+    int retval;
+    const int ret_expect = W_LOGTEST_REQUEST_ERROR;
+
+    OSList * list_msg = (OSList *) 2;
+
+    /* location */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7308): 'location' JSON field is required and must be a string");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg,
+                  "(7308): 'location' JSON field is required and must be a string");
+
+    /* log_format */
+    cJSON log_format = {0};
+    log_format.valuestring = strdup("log format str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &log_format);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* event */
+    cJSON event = {0};
+    event.valuestring = strdup("event str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &event);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* token */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+
+    retval = w_logtest_check_input_request(&root, list_msg);
+
+    assert_int_equal(retval, ret_expect);
+    
+    os_free(event.valuestring);
+    os_free(log_format.valuestring);
+}
+
+void test_w_logtest_check_input_request_missing_log_format(void ** state) {
+
+    cJSON root = {0};
+
+    int retval;
+    const int ret_expect = W_LOGTEST_REQUEST_ERROR;
+
+    OSList * list_msg = (OSList *) 2;
+
+    /* location */
+    cJSON location = {0};
+    location.valuestring = strdup("location str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &location);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* log_format */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7308): 'log_format' JSON field is required and must be a string");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg,
+                  "(7308): 'log_format' JSON field is required and must be a string");
+
+    /* event */
+    cJSON event = {0};
+    event.valuestring = strdup("event str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &event);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* token */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+
+    retval = w_logtest_check_input_request(&root, list_msg);
+
+    assert_int_equal(retval, ret_expect);
+    os_free(event.valuestring);
+    os_free(location.valuestring);
+}
+
+void test_w_logtest_check_input_request_missing_event(void ** state) {
+
+    cJSON root = {0};
+
+    int retval;
+    const int ret_expect = W_LOGTEST_REQUEST_ERROR;
+
+    OSList * list_msg = (OSList *) 2;
+
+    /* location */
+    cJSON location = {0};
+    location.valuestring = strdup("location str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &location);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* log_format */
+    cJSON log_format = {0};
+    log_format.valuestring = strdup("log format str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &log_format);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* event */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+    will_return(__wrap_cJSON_IsObject, false);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7313): 'event' JSON field not found or is empty");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg,
+                  "(7313): 'event' JSON field not found or is empty");
+
+    /* token */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+
+    retval = w_logtest_check_input_request(&root, list_msg);
+
+    assert_int_equal(retval, ret_expect);
+    os_free(location.valuestring);
+    os_free(log_format.valuestring);
+}
+
+void test_w_logtest_check_input_request_full(void ** state) {
+
+    cJSON root = {0};
+
+    int retval;
+    const int ret_expect = W_LOGTEST_REQUEST_TYPE_LOG_PROCESSING;
+
+    OSList * list_msg = (OSList *) 2;
+
+    /* location */
+    cJSON location = {0};
+    location.valuestring = strdup("location str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &location);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* log_format */
+    cJSON log_format = {0};
+    log_format.valuestring = strdup("log format str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &log_format);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* event */
+    cJSON event = {0};
+    event.valuestring = strdup("event str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &event);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* token */
+    cJSON token = {0};
+    token.valuestring = strdup("12345678");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &token);
+    will_return(__wrap_cJSON_IsString, true);
+
+    retval = w_logtest_check_input_request(&root, list_msg);
+
+    assert_int_equal(retval, ret_expect);
+
+    os_free(location.valuestring);
+    os_free(log_format.valuestring);
+    os_free(event.valuestring);
+    os_free(token.valuestring);
+}
+
+void test_w_logtest_check_input_request_full_empty_token(void ** state) {
+
+    cJSON root = {0};
+
+    int retval;
+    const int ret_expect = W_LOGTEST_REQUEST_TYPE_LOG_PROCESSING;
+
+    OSList * list_msg = (OSList *) 2;
+
+   /* location */
+    cJSON location = {0};
+    location.valuestring = strdup("location str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &location);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* log_format */
+    cJSON log_format = {0};
+    log_format.valuestring = strdup("log format str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &log_format);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* event */
+    cJSON event = {0};
+    event.valuestring = strdup("event str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &event);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* token */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+
+    retval = w_logtest_check_input_request(&root, list_msg);
+
+    assert_int_equal(retval, ret_expect);
+
+    os_free(location.valuestring);
+    os_free(log_format.valuestring);
+    os_free(event.valuestring);
+}
+
+void test_w_logtest_check_input_request_bad_token_lenght(void ** state) {
+
+    cJSON root = {0};
+
+    int retval;
+    const int ret_expect = W_LOGTEST_REQUEST_TYPE_LOG_PROCESSING;
+
+    OSList * list_msg = (OSList *) 2;
+
+   /* location */
+    cJSON location = {0};
+    location.valuestring = strdup("location str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &location);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* log_format */
+    cJSON log_format = {0};
+    log_format.valuestring = strdup("log format str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &log_format);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* event */
+    cJSON event = {0};
+    event.valuestring = strdup("event str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &event);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* token */
+    cJSON token = {0};
+    token.valuestring = strdup("1234");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &token);
+    will_return(__wrap_cJSON_IsString, true);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7309): '1234' is not a valid token");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_WARNING);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7309): '1234' is not a valid token");
+
+    retval = w_logtest_check_input_request(&root, list_msg);
+
+    assert_int_equal(retval, ret_expect);
+    os_free(location.valuestring);
+    os_free(log_format.valuestring);
+    os_free(event.valuestring);
+    os_free(token.valuestring);
+}
+
+// w_logtest_check_input_remove_session
+void test_w_logtest_check_input_remove_session_not_string(void ** state)
+{
+    cJSON root = {0};
+    OSList * list_msg = (OSList *) 2;
+    const int expected_retval = W_LOGTEST_REQUEST_ERROR;
+    int retval;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg,
+        "(7316): Failure to remove session. remove_session JSON field must be a string");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg,
+        "(7316): Failure to remove session. remove_session JSON field must be a string");
+
+    retval = w_logtest_check_input_remove_session(&root, list_msg);
+
+    assert_int_equal(retval, expected_retval);
+
+}
+
+void test_w_logtest_check_input_remove_session_invalid_token(void ** state)
+{
+    cJSON root = {0};
+    cJSON token = {0};
+    token.valuestring = strdup("1234567");
+    OSList * list_msg = (OSList *) 2;
+    const int expected_retval = W_LOGTEST_REQUEST_ERROR;
+    int retval;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &token);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7309): '1234567' is not a valid token");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7309): '1234567' is not a valid token");
+
+    assert_int_not_equal(W_LOGTEST_TOKEN_LENGH, strlen(token.valuestring));
+
+    retval = w_logtest_check_input_remove_session(&root, list_msg);
+
+    assert_int_equal(retval, expected_retval);
+    os_free(token.valuestring);
+}
+
+void test_w_logtest_check_input_remove_session_ok(void ** state)
+{
+    cJSON root = {0};
+    cJSON token = {0};
+    token.valuestring = strdup("12345678");
+    OSList * list_msg = (OSList *) 2;
+    const int expected_retval = W_LOGTEST_REQUEST_TYPE_REMOVE_SESSION;
+    int retval;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &token);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+
+    assert_int_equal(W_LOGTEST_TOKEN_LENGH, strlen(token.valuestring));
+    
+    retval = w_logtest_check_input_remove_session(&root, list_msg);
+
+    assert_int_equal(retval, expected_retval);
+    os_free(token.valuestring);
+}
+
+/* w_logtest_process_request */
+void test_w_logtest_process_request_error_list(void ** state) {
+
+    char raw_request[] = "Test request";
+    w_logtest_connection_t connection;
+    char * retval;
+
+    will_return(__wrap_OSList_Create, NULL);
+    expect_string(__wrap__merror, formatted_msg, "(1290): Unable to create a new list (calloc).");
+
+    retval = w_logtest_process_request(raw_request, &connection);
+
+    assert_null(retval);
+
+}
+
+void test_w_logtest_process_request_error_check_input(void ** state) {
+
+    char * retval;
+    w_logtest_connection_t connection;
+
+
+    /* w_logtest_add_msg_response */
+    OSList * list_msg;
+    os_calloc(1, sizeof(OSList), list_msg);
+    OSListNode * list_msg_node;
+
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+    message->level = LOGLEVEL_ERROR;
+    message->msg = strdup("Test Message");
+    message->file = NULL;
+    message->func = NULL;
+    os_calloc(1, sizeof(OSListNode), list_msg_node);
+    list_msg_node->data = message;
+    list_msg->cur_node = list_msg_node;
+
+    /* w_logtest_process_request */
+    will_return(__wrap_OSList_Create, list_msg);
+    will_return(__wrap_OSList_SetMaxSize, 0);
+
+    will_return(__wrap_cJSON_CreateObject, (cJSON *) 1);
+    
+    /* Error w_logtest_check_input */
+
+    char * input_raw_json = strdup("Test request");
+    int pos_error = 7;
+    char expect_slice_json[] = "Test request";
+
+
+    cJSON_error_ptr = input_raw_json + pos_error;
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7306): Error parsing JSON");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7306): Error parsing JSON");
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7307): Error in position 7, ... Test request ...");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7307): Error in position 7, ... Test request ...");
+
+    /* w_logtest_add_msg_response */
+
+    will_return(__wrap_OSList_GetFirstNode, list_msg_node);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON*) 1);
+
+    will_return(__wrap_os_analysisd_string_log_msg, strdup("Test Message"));
+
+    expect_string(__wrap_wm_strcat, str2, "ERROR: ");
+    will_return(__wrap_wm_strcat, 0);
+
+    expect_string(__wrap_wm_strcat, str2, "Test Message");
+    will_return(__wrap_wm_strcat, 0);
+
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+
+    /* w_logtest_process_request */
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "codemsg");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, -2);
+    will_return(__wrap_cJSON_AddNumberToObject, NULL);
+
+    will_return(__wrap_cJSON_PrintUnformatted, "{json response}");
+
+    retval = w_logtest_process_request(input_raw_json, &connection);
+
+    assert_string_equal(retval, "{json response}");
+    
+    os_free(input_raw_json);
+
+}
+
+void test_w_logtest_process_request_type_remove_session_ok(void ** state) {
+
+    char * retval;
+    char * input_raw_json = strdup("Test request");
+
+    /* w_logtest_add_msg_response */
+    OSList * list_msg;
+    os_calloc(1, sizeof(OSList), list_msg);
+    
+
+    /* w_logtest_process_request */
+    will_return(__wrap_OSList_Create, list_msg);
+    will_return(__wrap_OSList_SetMaxSize, 0);
+
+    will_return(__wrap_cJSON_CreateObject, (cJSON *) 1);
+    will_return(__wrap_cJSON_ParseWithOpts, (cJSON *) 1);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
+
+
+    // w_logtest_check_input_remove_session ok
+    cJSON token = {0};
+    token.valuestring = strdup("12345678");
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &token);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+    will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+    
+    /* w_logtest_process_request_remove_session_fail */
+    w_logtest_connection_t connection = {0};
+    connection.active_client = 5;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7316): Failure to remove session. remove_session JSON field must be a string");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7316): Failure to remove session. remove_session JSON field must be a string");
+
+
+    /*w_logtest_add_msg_response error*/
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+    message->level = LOGLEVEL_ERROR;
+    message->msg = strdup("Test Message");
+    message->file = NULL;
+    message->func = NULL;
+    OSListNode * list_msg_node;
+    os_calloc(1, sizeof(OSListNode), list_msg_node);
+    list_msg_node->data = message;
+    list_msg->cur_node = list_msg_node;
+
+    will_return(__wrap_OSList_GetFirstNode, list_msg_node);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON*) 1);
+
+    will_return(__wrap_os_analysisd_string_log_msg, strdup("Test Message"));
+
+    expect_string(__wrap_wm_strcat, str2, "ERROR: ");
+    will_return(__wrap_wm_strcat, 0);
+
+    expect_string(__wrap_wm_strcat, str2, "Test Message");
+    will_return(__wrap_wm_strcat, 0);
+
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+
+    /* w_logtest_process_request */
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "codemsg");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, -1);
+    will_return(__wrap_cJSON_AddNumberToObject, NULL);
+
+    will_return(__wrap_cJSON_PrintUnformatted, "{json response}");
+
+    retval = w_logtest_process_request(input_raw_json, &connection);
+
+    assert_string_equal(retval, "{json response}");
+    
+    os_free(input_raw_json);
+    os_free(token.valuestring);
+
+}
+
+
+
+void test_w_logtest_process_request_error_get_session (void ** state) {
+
+    char raw_request[] = "Test request";
+    char * retval;
+    w_logtest_connection_t connection;
+
+
+    /* w_logtest_add_msg_response */
+    OSList * list_msg;
+    os_calloc(1, sizeof(OSList), list_msg);
+    OSListNode * list_msg_node;
+
+    will_return(__wrap_OSList_Create, list_msg);
+
+    will_return(__wrap_OSList_SetMaxSize, 0);
+
+    /* w_logtest_check_input */
+    will_return(__wrap_cJSON_ParseWithOpts, (OSList *) 1);
+
+    cJSON location = {0};
+    location.valuestring = strdup("location str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &location);
+    will_return(__wrap_cJSON_IsString, true);
+
+    cJSON log_format = {0};
+    log_format.valuestring = strdup("log format str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &log_format);
+    will_return(__wrap_cJSON_IsString, true);
+
+    cJSON event = {0};
+    event.valuestring = strdup("event str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &event);
+    will_return(__wrap_cJSON_IsString, true);
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    will_return(__wrap_cJSON_IsString, false);
+
+    will_return(__wrap_cJSON_CreateObject, (cJSON *) 1);
+
+    /* w_logtest_get_session fail */
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+    
+    /* Generate token */
+
+    random_bytes_result = 5555; // 0x00_00_15_b3
+    expect_value(__wrap_randombytes, length, W_LOGTEST_TOKEN_LENGH >> 1);
+    expect_string(__wrap_OSHash_Get_ex, key, "000015b3");
+    will_return(__wrap_OSHash_Get_ex, NULL);
+    /* Initialize session*/
+
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+    will_return(__wrap_time, 0);
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_ReadDecodeXML, 0);
+    will_return(__wrap_OSStore_Free, (OSStore *) 1);
+    will_return(__wrap_pthread_mutex_destroy, 0);
+    
+    /* w_logtest_get_session */
+    expect_string(__wrap__mdebug1, formatted_msg, "(7311): Failure to initializing session '000015b3'");
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7311): Failure to initializing session '000015b3'");
+
+    /* w_logtest_add_msg_response */
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+    message->level = LOGLEVEL_ERROR;
+    message->msg = strdup("Test Message");
+    message->file = NULL;
+    message->func = NULL;
+    os_calloc(1, sizeof(OSListNode), list_msg_node);
+    list_msg_node->data = message;
+    list_msg->cur_node = list_msg_node;
+
+    will_return(__wrap_OSList_GetFirstNode, list_msg_node);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON*) 1);
+
+    will_return(__wrap_os_analysisd_string_log_msg, strdup("Test Message"));
+
+    expect_string(__wrap_wm_strcat, str2, "ERROR: ");
+    will_return(__wrap_wm_strcat, 0);
+
+    expect_string(__wrap_wm_strcat, str2, "Test Message");
+    will_return(__wrap_wm_strcat, 0);
+
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+    
+    /* w_logtest_process_request */
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "codemsg");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, -1);
+    will_return(__wrap_cJSON_AddNumberToObject, NULL);
+    
+    will_return(__wrap_cJSON_PrintUnformatted, "{json response}");
+
+    retval = w_logtest_process_request(raw_request, &connection);
+
+    assert_string_equal(retval, "{json response}");
+
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+    os_free(log_format.valuestring);
+    os_free(event.valuestring);
+    os_free(location.valuestring);
+}
+
+// test_w_logtest_generate_error_response_ok
+void test_w_logtest_generate_error_response_ok(void ** state) {
+    const char * retval_exp = "{json response}";
+    char * retval;
+
+    cJSON response = {0};
+
+    will_return(__wrap_cJSON_CreateObject, &response);
+    will_return(__wrap_cJSON_CreateArray, (cJSON *) 1);
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    expect_value(__wrap_cJSON_AddItemToObject, object, &response);
+    expect_string(__wrap_cJSON_AddItemToObject, string, "messages");
+
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "codemsg");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, -2);
+    will_return(__wrap_cJSON_AddNumberToObject, NULL);
+
+    will_return(__wrap_cJSON_PrintUnformatted, "{json response}");
+
+    retval = w_logtest_generate_error_response("test msg");
+
+    assert_string_equal(retval_exp, retval);
+}
+
+// Tests w_logtest_decoding_phase
+void test_w_logtest_decoding_phase_program_name(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+
+    lf.program_name = strdup("program name test");
+    os_calloc(1, sizeof(OSDecoderNode), session.decoderlist_forpname);
+    
+    expect_value(__wrap_DecodeEvent, node, session.decoderlist_forpname);
+    w_logtest_decoding_phase(&lf, &session);
+
+    os_free(lf.program_name);
+    os_free(session.decoderlist_forpname);
+
+}
+
+void test_w_logtest_decoding_phase_no_program_name(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+
+    lf.program_name = NULL;
+    os_calloc(1, sizeof(OSDecoderNode), session.decoderlist_nopname);
+    
+    expect_value(__wrap_DecodeEvent, node, session.decoderlist_nopname);
+    w_logtest_decoding_phase(&lf, &session);
+
+    os_free(session.decoderlist_nopname);
+}
+
+// w_logtest_preprocessing_phase
+void test_w_logtest_preprocessing_phase_json_event_ok(void ** state)
+{
+    Eventinfo lf = {0};
+    cJSON request = {0};
+    
+    cJSON json_event = {0};
+    cJSON json_event_child = {0};
+    char * raw_event = strdup("{event}");
+    char * str_location = strdup("location");
+
+    lf.log = strdup("{event}");
+    
+    json_event.child = &json_event_child;
+
+
+    const int expect_retval = 0;
+    int retval;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
+    will_return(__wrap_cJSON_PrintUnformatted, raw_event);
+    
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
+    will_return(__wrap_cJSON_GetStringValue, str_location);
+
+    will_return(__wrap_OS_CleanMSG, 0);
+
+
+    retval = w_logtest_preprocessing_phase(&lf, &request);
+    
+    assert_int_equal(retval, expect_retval);
+
+
+    os_free(str_location);
+    os_free(lf.log);
+
+
+}
+
+void test_w_logtest_preprocessing_phase_json_event_fail(void ** state)
+{
+    Eventinfo * lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+
+    cJSON request = {0};
+    
+    cJSON json_event = {0};
+    cJSON json_event_child = {0};
+    char * raw_event = strdup("{event}");
+    char * str_location = strdup("location");
+    
+    json_event.child = &json_event_child;
+
+
+    const int expect_retval = -1;
+    int retval;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
+    will_return(__wrap_cJSON_PrintUnformatted, raw_event);
+    
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
+    will_return(__wrap_cJSON_GetStringValue, str_location);
+
+    will_return(__wrap_OS_CleanMSG, -1);
+
+
+    retval = w_logtest_preprocessing_phase(lf, &request);
+    
+    assert_int_equal(retval, expect_retval);
+
+    os_free(str_location);
+
+}
+
+void test_w_logtest_preprocessing_phase_str_event_ok(void ** state)
+{
+    Eventinfo * lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+
+    cJSON request = {0};
+    cJSON json_event = {0};
+    char * raw_event = strdup("event");
+    char * str_location = strdup("location");
+    
+    lf->log = strdup("test log");
+
+    const int expect_retval = 0;
+    int retval;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
+    will_return(__wrap_cJSON_GetStringValue, raw_event);
+    
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
+    will_return(__wrap_cJSON_GetStringValue, str_location);
+
+    will_return(__wrap_OS_CleanMSG, 0);
+
+
+    retval = w_logtest_preprocessing_phase(lf, &request);
+    
+    assert_int_equal(retval, expect_retval);
+
+    os_free(str_location);
+    os_free(raw_event);
+    os_free(lf->log);
+    os_free(lf);
+
+}
+
+void test_w_logtest_preprocessing_phase_str_event_fail(void ** state)
+{
+    Eventinfo * lf;
+    os_calloc(1, sizeof(Eventinfo), lf);
+
+    cJSON request = {0};
+    cJSON json_event = {0};
+    char * raw_event = strdup("event");
+    char * str_location = strdup("location");
+    
+
+
+    const int expect_retval = -1;
+    int retval;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
+    will_return(__wrap_cJSON_GetStringValue, raw_event);
+    
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
+    will_return(__wrap_cJSON_GetStringValue, str_location);
+
+    will_return(__wrap_OS_CleanMSG, -1);
+
+
+    retval = w_logtest_preprocessing_phase(lf, &request);
+    
+    assert_int_equal(retval, expect_retval);
+
+    os_free(str_location);
+    os_free(raw_event);
+
+}
+
+// w_logtest_rulesmatching_phase
+void test_w_logtest_rulesmatching_phase_no_load_rules(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = -1;
+    int retval;
+
+    session.rule_list = NULL;
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+
+
+}
+
+void test_w_logtest_rulesmatching_phase_ossec_alert(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = 0;
+    int retval;
+
+    OSDecoderInfo decoder_info = {0};
+    lf.decoder_info = &decoder_info;
+    decoder_info.type = OSSEC_ALERT;
+    lf.generated_rule = NULL;
+
+    os_calloc(1, sizeof(RuleNode), session.rule_list);
+    session.rule_list->next = NULL;
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+
+    os_free(session.rule_list);
+
+
+}
+
+void test_w_logtest_rulesmatching_phase_dont_match_category(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = 0;
+    int retval;
+
+    OSDecoderInfo decoder_info = {0};
+    lf.decoder_info = &decoder_info;
+    decoder_info.type = SYSLOG;
+    lf.generated_rule = NULL;
+
+    RuleInfo ruleinfo = {0};
+    ruleinfo.category = FIREWALL;
+
+    assert_int_not_equal(ruleinfo.category, decoder_info.type);
+
+    os_calloc(1, sizeof(RuleNode), session.rule_list);
+    session.rule_list->next = NULL;
+    session.rule_list->ruleinfo = &ruleinfo;
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+
+    os_free(session.rule_list);
+
+
+}
+
+void test_w_logtest_rulesmatching_phase_dont_match(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = 0;
+    int retval;
+
+    OSDecoderInfo decoder_info = {0};
+    lf.decoder_info = &decoder_info;
+    decoder_info.type = SYSLOG;
+    lf.generated_rule = NULL;
+
+    RuleInfo ruleinfo = {0};
+    ruleinfo.category = SYSLOG;
+
+    assert_int_equal(ruleinfo.category, decoder_info.type);
+
+    os_calloc(1, sizeof(RuleNode), session.rule_list);
+    session.rule_list->next = NULL;
+    session.rule_list->ruleinfo = &ruleinfo;
+
+    will_return(__wrap_OS_CheckIfRuleMatch, NULL);
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+
+    os_free(session.rule_list);
+
+
+}
+
+void test_w_logtest_rulesmatching_phase_match_level_0(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = 0;
+    int retval;
+
+    OSDecoderInfo decoder_info = {0};
+    lf.decoder_info = &decoder_info;
+    decoder_info.type = SYSLOG;
+    lf.generated_rule = NULL;
+
+    RuleInfo ruleinfo = {0};
+    ruleinfo.level = 0;
+    ruleinfo.category = SYSLOG;
+
+    assert_int_equal(ruleinfo.category, decoder_info.type);
+
+    os_calloc(1, sizeof(RuleNode), session.rule_list);
+    session.rule_list->next = NULL;
+    session.rule_list->ruleinfo = &ruleinfo;
+
+    will_return(__wrap_OS_CheckIfRuleMatch, &ruleinfo);
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+    assert_int_equal(lf.generated_rule->level, 0);
+    assert_ptr_equal(lf.generated_rule, &ruleinfo);
+
+    os_free(session.rule_list);
+
+}
+
+void test_w_logtest_rulesmatching_phase_match_dont_ignore_first_time(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = 0;
+    int retval;
+
+    lf.generate_time = (time_t) 2020;
+
+    OSDecoderInfo decoder_info = {0};
+    lf.decoder_info = &decoder_info;
+    decoder_info.type = SYSLOG;
+    lf.generated_rule = NULL;
+
+    RuleInfo ruleinfo = {0};
+    ruleinfo.level = 5;
+    ruleinfo.category = SYSLOG;
+    ruleinfo.ignore_time = 1;
+
+    assert_int_equal(ruleinfo.category, decoder_info.type);
+
+    os_calloc(1, sizeof(RuleNode), session.rule_list);
+    session.rule_list->next = NULL;
+    session.rule_list->ruleinfo = &ruleinfo;
+
+    will_return(__wrap_OS_CheckIfRuleMatch, &ruleinfo);
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+    assert_ptr_equal(lf.generated_rule, &ruleinfo);
+    assert_ptr_equal(lf.generated_rule->time_ignored, (time_t) 2020);
+
+    os_free(session.rule_list);
+
+}
+
+void test_w_logtest_rulesmatching_phase_match_ignore_time_ignore(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = 0;
+    int retval;
+
+    lf.generate_time = (time_t) 2020;
+
+    OSDecoderInfo decoder_info = {0};
+    lf.decoder_info = &decoder_info;
+    decoder_info.type = SYSLOG;
+    lf.generated_rule = NULL;
+
+    RuleInfo ruleinfo = {0};
+    ruleinfo.level = 5;
+    ruleinfo.category = SYSLOG;
+    ruleinfo.ignore_time = 10; // ignore
+    ruleinfo.time_ignored = (time_t) 2015;
+
+    assert_int_equal(ruleinfo.category, decoder_info.type);
+
+    os_calloc(1, sizeof(RuleNode), session.rule_list);
+    session.rule_list->next = NULL;
+    session.rule_list->ruleinfo = &ruleinfo;
+
+    will_return(__wrap_OS_CheckIfRuleMatch, &ruleinfo);
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+    assert_ptr_equal(lf.generated_rule, &ruleinfo);
+    assert_ptr_equal(lf.generated_rule->time_ignored, (time_t) 2015);
+
+    os_free(session.rule_list);
+
+}
+
+void test_w_logtest_rulesmatching_phase_match_dont_ignore_time_out_windows(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = 0;
+    int retval;
+
+    lf.generate_time = (time_t) 2020;
+
+    OSDecoderInfo decoder_info = {0};
+    lf.decoder_info = &decoder_info;
+    decoder_info.type = SYSLOG;
+    lf.generated_rule = NULL;
+
+    RuleInfo ruleinfo = {0};
+    ruleinfo.level = 5;
+    ruleinfo.category = SYSLOG;
+    ruleinfo.ignore_time = 3; // Dont ignore
+    ruleinfo.time_ignored = (time_t) 2015;
+
+    assert_int_equal(ruleinfo.category, decoder_info.type);
+
+    os_calloc(1, sizeof(RuleNode), session.rule_list);
+    session.rule_list->next = NULL;
+    session.rule_list->ruleinfo = &ruleinfo;
+
+    will_return(__wrap_OS_CheckIfRuleMatch, &ruleinfo);
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+    assert_ptr_equal(lf.generated_rule, &ruleinfo);
+    assert_ptr_equal(lf.generated_rule->time_ignored, (time_t) 0);
+
+    os_free(session.rule_list);
+
+}
+
+void test_w_logtest_rulesmatching_phase_match_ignore_event(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = 0;
+    int retval;
+
+    OSDecoderInfo decoder_info = {0};
+    lf.decoder_info = &decoder_info;
+    decoder_info.type = SYSLOG;
+    lf.generated_rule = NULL;
+
+    RuleInfo ruleinfo = {0};
+    ruleinfo.level = 5;
+    ruleinfo.category = SYSLOG;
+    ruleinfo.ckignore = 1;
+
+    assert_int_equal(ruleinfo.category, decoder_info.type);
+
+    os_calloc(1, sizeof(RuleNode), session.rule_list);
+    session.rule_list->next = NULL;
+    session.rule_list->ruleinfo = &ruleinfo;
+
+    will_return(__wrap_OS_CheckIfRuleMatch, &ruleinfo);
+    will_return(__wrap_IGnore, 1);
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+    assert_null(lf.generated_rule);
+
+    os_free(session.rule_list);
+
+}
+
+void test_w_logtest_rulesmatching_phase_match_and_if_matched_sid_ok(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = 0;
+    int retval;
+
+    OSDecoderInfo decoder_info = {0};
+    lf.decoder_info = &decoder_info;
+    decoder_info.type = SYSLOG;
+    lf.generated_rule = NULL;
+
+    RuleInfo ruleinfo = {0};
+    ruleinfo.level = 5;
+    ruleinfo.category = SYSLOG;
+    ruleinfo.ckignore = 0;
+    
+
+    OSList pre_matched_list = {0};
+    pre_matched_list.last_node = (OSListNode *) 10;
+    ruleinfo.sid_prev_matched = &pre_matched_list;
+
+    assert_int_equal(ruleinfo.category, decoder_info.type);
+
+    os_calloc(1, sizeof(RuleNode), session.rule_list);
+    session.rule_list->next = NULL;
+    session.rule_list->ruleinfo = &ruleinfo;
+
+    will_return(__wrap_OS_CheckIfRuleMatch, &ruleinfo);
+    will_return(__wrap_OSList_AddData, 1);
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+    assert_ptr_equal(lf.generated_rule, &ruleinfo);
+    assert_ptr_equal(lf.sid_node_to_delete, (OSListNode *) 10);
+
+    os_free(session.rule_list);
+
+}
+
+void test_w_logtest_rulesmatching_phase_match_and_if_matched_sid_fail(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = 0;
+    int retval;
+
+    OSDecoderInfo decoder_info = {0};
+    lf.decoder_info = &decoder_info;
+    decoder_info.type = SYSLOG;
+    lf.generated_rule = NULL;
+
+    RuleInfo ruleinfo = {0};
+    ruleinfo.level = 5;
+    ruleinfo.category = SYSLOG;
+    ruleinfo.ckignore = 0;
+    
+
+    OSList pre_matched_list = {0};
+    pre_matched_list.last_node = (OSListNode *) 10;
+    ruleinfo.sid_prev_matched = &pre_matched_list;
+
+    assert_int_equal(ruleinfo.category, decoder_info.type);
+
+    os_calloc(1, sizeof(RuleNode), session.rule_list);
+    session.rule_list->next = NULL;
+    session.rule_list->ruleinfo = &ruleinfo;
+
+    will_return(__wrap_OS_CheckIfRuleMatch, &ruleinfo);
+    will_return(__wrap_OSList_AddData, 0);
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, &list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "Unable to add data to sig list.");
+
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+    assert_ptr_equal(lf.generated_rule, &ruleinfo);
+    assert_ptr_equal(lf.sid_node_to_delete, (OSListNode *) 0);
+
+    os_free(session.rule_list);
+
+}
+
+void test_w_logtest_rulesmatching_phase_match_and_group_prev_matched_fail(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = 0;
+    int retval;
+
+    OSDecoderInfo decoder_info = {0};
+    lf.decoder_info = &decoder_info;
+    decoder_info.type = SYSLOG;
+    lf.generated_rule = NULL;
+
+    RuleInfo ruleinfo = {0};
+    ruleinfo.level = 5;
+    ruleinfo.category = SYSLOG;
+    ruleinfo.ckignore = 0;
+    ruleinfo.sid_prev_matched = (OSList *) 0;
+    ruleinfo.group_prev_matched_sz = 1;
+    os_calloc(1, sizeof(RuleInfo *), ruleinfo.group_prev_matched);
+
+    OSList pre_matched_list = {0};
+    pre_matched_list.last_node = (OSListNode *) 10;
+
+    assert_int_equal(ruleinfo.category, decoder_info.type);
+
+    os_calloc(1, sizeof(RuleNode), session.rule_list);
+    session.rule_list->next = NULL;
+    session.rule_list->ruleinfo = &ruleinfo;
+
+    will_return(__wrap_OS_CheckIfRuleMatch, &ruleinfo);
+    will_return(__wrap_OSList_AddData, 0);
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, &list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "Unable to add data to grp list.");
+
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+    assert_ptr_equal(lf.generated_rule, &ruleinfo);
+    assert_ptr_equal(lf.sid_node_to_delete, (OSListNode *) 0);
+
+    os_free(session.rule_list);
+    os_free(ruleinfo.group_prev_matched);
+
+}
+
+void test_w_logtest_rulesmatching_phase_match_and_group_prev_matched(void ** state)
+{
+    Eventinfo lf = {0};
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+    const int expect_retval = 0;
+    int retval;
+
+    OSDecoderInfo decoder_info = {0};
+    lf.decoder_info = &decoder_info;
+    decoder_info.type = SYSLOG;
+    lf.generated_rule = NULL;
+
+    RuleInfo ruleinfo = {0};
+    ruleinfo.level = 5;
+    ruleinfo.category = SYSLOG;
+    ruleinfo.ckignore = 0;
+    os_calloc(1, sizeof(RuleInfo *), ruleinfo.group_prev_matched);
+
+    OSList pre_matched_list = {0};
+    pre_matched_list.last_node = (OSListNode *) 10;
+    
+    ruleinfo.sid_prev_matched = &pre_matched_list;
+
+
+    assert_int_equal(ruleinfo.category, decoder_info.type);
+
+    os_calloc(1, sizeof(RuleNode), session.rule_list);
+    session.rule_list->next = NULL;
+    session.rule_list->ruleinfo = &ruleinfo;
+
+    will_return(__wrap_OS_CheckIfRuleMatch, &ruleinfo);
+    will_return(__wrap_OSList_AddData, 1);
+
+    retval = w_logtest_rulesmatching_phase(&lf, &session, &list_msg);
+
+    assert_int_equal(retval, expect_retval);
+    assert_ptr_equal(lf.generated_rule, &ruleinfo);
+    assert_ptr_equal(lf.sid_node_to_delete, (OSListNode *) 10);
+
+    os_free(session.rule_list);
+    os_free(ruleinfo.group_prev_matched);
+}
+
+void test_w_logtest_process_log_preprocessing_fail(void ** state)
+{
+    Config.decoder_order_size = 1;
+
+    cJSON request = {0};
+    cJSON json_event = {0};
+    char * raw_event = strdup("event");
+    char * str_location = strdup("location");
+
+    w_logtest_session_t session = {0};
+    OSList list_msg = {0};
+
+    
+    cJSON * retval;
+
+    will_return(__wrap_cJSON_GetObjectItem, &json_event);
+    will_return(__wrap_cJSON_GetStringValue, raw_event);
+    
+    will_return(__wrap_cJSON_GetObjectItem, (cJSON *) 1);
+    will_return(__wrap_cJSON_GetStringValue, str_location);
+
+    will_return(__wrap_OS_CleanMSG, -1);
+
+
+    retval = w_logtest_process_log(&request, &session, &list_msg);
+    
+    assert_null(retval);
+
+    os_free(str_location);
+    os_free(raw_event);
+
+}
+
+// w_logtest_process_request_remove_session
+void test_w_logtest_process_request_remove_session_invalid_token(void ** state)
+{
+    cJSON * json_request = (cJSON *) 1;
+    cJSON * json_response = (cJSON *) 2;
+    OSList list_msg = {0};
+    w_logtest_connection_t connection = {0};
+    connection.active_client = 5;
+
+    const int expect_retval = W_LOGTEST_RCODE_ERROR_PROCESS;
+    int retval;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7316): Failure to remove session. remove_session JSON field must be a string");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, NULL);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7316): Failure to remove session. remove_session JSON field must be a string");
+
+
+    /*w_logtest_add_msg_response error*/
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+    message->level = LOGLEVEL_ERROR;
+    message->msg = strdup("Test Message");
+    message->file = NULL;
+    message->func = NULL;
+    OSListNode * list_msg_node;
+    os_calloc(1, sizeof(OSListNode), list_msg_node);
+    list_msg_node->data = message;
+    list_msg.cur_node = list_msg_node;
+
+    will_return(__wrap_OSList_GetFirstNode, list_msg_node);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON*) 1);
+
+    will_return(__wrap_os_analysisd_string_log_msg, strdup("Test Message"));
+
+    expect_string(__wrap_wm_strcat, str2, "ERROR: ");
+    will_return(__wrap_wm_strcat, 0);
+
+    expect_string(__wrap_wm_strcat, str2, "Test Message");
+    will_return(__wrap_wm_strcat, 0);
+
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+
+
+    retval = w_logtest_process_request_remove_session(json_request, json_response, NULL, &connection);
+
+    assert_int_equal(retval, expect_retval);
+    assert_int_equal(connection.active_client, 5);
+    
+    os_free(list_msg_node);
+}
+
+void test_w_logtest_process_request_remove_session_session_not_found(void ** state)
+{
+    cJSON * json_request = (cJSON *) 1;
+    cJSON * json_response = (cJSON *) 2;
+    OSList list_msg = {0};
+    w_logtest_connection_t connection = {0};
+    connection.active_client = 5;
+
+    cJSON token = {0};
+    token.valuestring = "000015b3";
+
+    const int expect_retval = W_LOGTEST_RCODE_ERROR_PROCESS;
+    int retval;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &token);
+
+    will_return(__wrap_pthread_mutex_lock, 0);
+    expect_string(__wrap_OSHash_Get_ex, key, "000015b3");
+    will_return(__wrap_OSHash_Get_ex, NULL);
+
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7004): No session found for token '000015b3'");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, NULL);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7004): No session found for token '000015b3'");
+
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    /*w_logtest_add_msg_response error*/
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+    message->level = LOGLEVEL_ERROR;
+    message->msg = strdup("Test Message");
+    message->file = NULL;
+    message->func = NULL;
+    OSListNode * list_msg_node;
+    os_calloc(1, sizeof(OSListNode), list_msg_node);
+    list_msg_node->data = message;
+    list_msg.cur_node = list_msg_node;
+
+    will_return(__wrap_OSList_GetFirstNode, list_msg_node);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON*) 1);
+
+    will_return(__wrap_os_analysisd_string_log_msg, strdup("Test Message"));
+
+    expect_string(__wrap_wm_strcat, str2, "ERROR: ");
+    will_return(__wrap_wm_strcat, 0);
+
+    expect_string(__wrap_wm_strcat, str2, "Test Message");
+    will_return(__wrap_wm_strcat, 0);
+
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+
+
+    retval = w_logtest_process_request_remove_session(json_request, json_response, NULL, &connection);
+
+    assert_int_equal(retval, expect_retval);
+    assert_int_equal(connection.active_client, 5);
+    os_free(list_msg_node);
+}
+
+void test_w_logtest_process_request_remove_session_ok(void ** state)
+{
+    cJSON * json_request = (cJSON *) 1;
+    cJSON * json_response = (cJSON *) 2;
+    OSList list_msg = {0};
+    w_logtest_connection_t connection = {0};
+    connection.active_client = 5;
+
+    cJSON token = {0};
+    token.valuestring = "000015b3";
+
+    w_logtest_session_t *session;
+    os_calloc(1, sizeof(w_logtest_session_t), session);
+
+    const int expect_retval = W_LOGTEST_RCODE_SUCCESS;
+    int retval;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &token);
+
+    will_return(__wrap_pthread_mutex_lock, 0);
+    expect_string(__wrap_OSHash_Get_ex, key, "000015b3");
+    will_return(__wrap_OSHash_Get_ex, session);
+
+    // remove session ok
+
+    expect_value(__wrap_OSHash_Delete_ex, key, "000015b3");
+    will_return(__wrap_OSHash_Delete_ex, session);
+
+    will_return(__wrap_OSStore_Free, session->decoder_store);
+
+    will_return(__wrap_OSHash_Free, session);
+
+    will_return(__wrap_OSHash_Free, session);
+
+    will_return(__wrap_OSHash_Free, session);
+
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_INFO);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, NULL);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7206): The session '000015b3' was closed successfully");
+
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    /*w_logtest_add_msg_response error*/
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+    message->level = LOGLEVEL_INFO;
+    message->msg = strdup("Test Message");
+    message->file = NULL;
+    message->func = NULL;
+    OSListNode * list_msg_node;
+    os_calloc(1, sizeof(OSListNode), list_msg_node);
+    list_msg_node->data = message;
+    list_msg.cur_node = list_msg_node;
+
+    will_return(__wrap_OSList_GetFirstNode, list_msg_node);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON*) 1);
+
+    will_return(__wrap_os_analysisd_string_log_msg, strdup("Test Message"));
+
+    expect_string(__wrap_wm_strcat, str2, "INFO: ");
+    will_return(__wrap_wm_strcat, 0);
+
+    expect_string(__wrap_wm_strcat, str2, "Test Message");
+    will_return(__wrap_wm_strcat, 0);
+
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+
+
+    retval = w_logtest_process_request_remove_session(json_request, json_response, NULL, &connection);
+
+    assert_int_equal(retval, expect_retval);
+    assert_int_equal(connection.active_client, 4);
+
+    os_free(list_msg_node);
+}
+
+void test_w_logtest_clients_handler_error_acept(void ** state)
+{
+    w_logtest_connection_t conection = {0};
+    char expected_str[OS_SIZE_1024];
+
+    will_return(__wrap_FOREVER, 1);
+    
+    will_return(__wrap_pthread_mutex_lock, 0);
+
+    will_return(__wrap_accept, -1);
+    
+    will_return(__wrap_pthread_mutex_unlock, 0);
+    errno = ENOMEM;
+    snprintf(expected_str, OS_SIZE_1024, "(7301): Failure to accept connection. Errno: %s", strerror(errno));
+
+    expect_string(__wrap__merror, formatted_msg, expected_str);
+
+    will_return(__wrap_FOREVER, 0);
+
+    assert_null(w_logtest_clients_handler(&conection));
+
+}
+
+void test_w_logtest_clients_handler_error_acept_close_socket(void ** state)
+{
+    w_logtest_connection_t conection = {0};
+    char expected_str[OS_SIZE_1024];
+
+    will_return(__wrap_FOREVER, 1);
+    
+    will_return(__wrap_pthread_mutex_lock, 0);
+
+    will_return(__wrap_accept, -1);
+    
+    will_return(__wrap_pthread_mutex_unlock, 0);
+    errno = EBADF;
+    snprintf(expected_str, OS_SIZE_1024, "(7301): Failure to accept connection. Errno: %s", strerror(errno));
+
+    expect_string(__wrap__merror, formatted_msg, expected_str);
+
+    assert_null(w_logtest_clients_handler(&conection));
+
+}
+
+void test_w_logtest_clients_handler_recv_error(void ** state)
+{
+    w_logtest_connection_t conection = {0};
+    char expected_str[OS_SIZE_1024];
+
+    will_return(__wrap_FOREVER, 1);
+    
+    will_return(__wrap_pthread_mutex_lock, 0);
+
+    will_return(__wrap_accept, 5);
+    
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    will_return(__wrap_OS_RecvSecureTCP, -1);
+    errno = ENOTCONN;
+    snprintf(expected_str, OS_SIZE_1024, "(7302): Failure to receive message: Errno: %s", strerror(ENOTCONN));
+
+    expect_string(__wrap__mdebug1, formatted_msg, expected_str);
+
+    will_return(__wrap_close, 0);
+    will_return(__wrap_FOREVER, 0);
+
+
+    assert_null(w_logtest_clients_handler(&conection));
+
+}
+
+void test_w_logtest_clients_handler_recv_msg_empty(void ** state)
+{
+    w_logtest_connection_t conection = {0};
+
+    will_return(__wrap_FOREVER, 1);
+    
+    will_return(__wrap_pthread_mutex_lock, 0);
+
+    will_return(__wrap_accept, 5);
+    
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    will_return(__wrap_OS_RecvSecureTCP, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7314): Failure to receive message: empty or reception timeout");
+
+    will_return(__wrap_close, 0);
+    will_return(__wrap_FOREVER, 0);
+
+
+    assert_null(w_logtest_clients_handler(&conection));
+
+}
+
+void test_w_logtest_clients_handler_recv_msg_oversize(void ** state)
+{
+    w_logtest_connection_t conection = {0};
+
+    will_return(__wrap_FOREVER, 1);
+    
+    will_return(__wrap_pthread_mutex_lock, 0);
+
+    will_return(__wrap_accept, 5);
+    
+    will_return(__wrap_pthread_mutex_unlock, 0);
+
+    will_return(__wrap_OS_RecvSecureTCP, -6);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7315): Failure to receive message: size is bigger than expected");
+
+    // w_logtest_generate_error_response
+    cJSON response = {0};
+    will_return(__wrap_cJSON_CreateObject, &response);
+    will_return(__wrap_cJSON_CreateArray, (cJSON *) 1);
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    expect_value(__wrap_cJSON_AddItemToObject, object, &response);
+    expect_string(__wrap_cJSON_AddItemToObject, string, "messages");
+
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "codemsg");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, -2);
+    will_return(__wrap_cJSON_AddNumberToObject, NULL);
+
+    will_return(__wrap_cJSON_PrintUnformatted, strdup("{json response}"));
+    will_return(__wrap_OS_SendSecureTCP, 0);
+
+    will_return(__wrap_close, 0);
+    will_return(__wrap_FOREVER, 0);
+
+
+    assert_null(w_logtest_clients_handler(&conection));
+
+}
+
+// w_logtest_process_request_log_processing
+void test_w_logtest_process_request_log_processing_fail_session(void ** state)
+{
+    cJSON json_request = {0};
+    cJSON json_response = {0};
+    OSList list_msg = {0};
+    w_logtest_connection_t connection = {0};
+
+    const int extpect_retval = W_LOGTEST_RCODE_ERROR_PROCESS;
+    int retval;
+
+    // Fail get session
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
+
+    /* Generate token */
+    random_bytes_result = 5555; // 0x00_00_15_b3
+    expect_value(__wrap_randombytes, length, W_LOGTEST_TOKEN_LENGH >> 1);
+
+    expect_string(__wrap_OSHash_Get_ex, key, "000015b3");
+    will_return(__wrap_OSHash_Get_ex, NULL);
+
+    /* Initialize session*/
+    char * decoder_file = "test.xml";
+    Config.decoders = calloc(2, sizeof(char *));
+    Config.decoders[0] = decoder_file;
+
+    will_return(__wrap_time, 0);
+    will_return(__wrap_pthread_mutex_init, 0);
+    will_return(__wrap_ReadDecodeXML, 0);
+
+    // test_w_logtest_remove_session_ok_error_load_decoder_cbd_rules_hash
+    will_return(__wrap_OSStore_Free, (OSStore *) 1);
+    will_return(__wrap_pthread_mutex_destroy, 0);
+
+
+    /* w_logtest_get_session */
+    expect_string(__wrap__mdebug1, formatted_msg, "(7311): Failure to initializing session '000015b3'");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, &list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7311): Failure to initializing session '000015b3'");
+
+    /* error w_logtest_add_msg_response */
+    os_analysisd_log_msg_t * message;
+    os_calloc(1, sizeof(os_analysisd_log_msg_t), message);
+    message->level = LOGLEVEL_ERROR;
+    message->msg = strdup("Test Message");
+    message->file = NULL;
+    message->func = NULL;
+
+    OSListNode * list_msg_node;
+    os_calloc(1, sizeof(OSListNode), list_msg_node);
+    list_msg_node->data = message;
+    list_msg.cur_node = list_msg_node;
+    will_return(__wrap_OSList_GetFirstNode, list_msg_node);
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON*) 1);
+
+    will_return(__wrap_os_analysisd_string_log_msg, strdup("Test Message"));
+
+    expect_string(__wrap_wm_strcat, str2, "ERROR: ");
+    will_return(__wrap_wm_strcat, 0);
+
+    expect_string(__wrap_wm_strcat, str2, "Test Message");
+    will_return(__wrap_wm_strcat, 0);
+
+    will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
+
+    will_return(__wrap_OSList_GetFirstNode, NULL);
+
+    retval = w_logtest_process_request_log_processing(&json_request, &json_response, &list_msg, &connection);
+
+    assert_int_equal(extpect_retval, retval);
+    os_free(Config.includes);
+    os_free(Config.decoders);
+    os_free(Config.lists);
+}
+
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -647,6 +4044,10 @@ int main(void)
         cmocka_unit_test(test_w_logtest_init_logtest_disabled),
         cmocka_unit_test(test_w_logtest_init_conection_fail),
         cmocka_unit_test(test_w_logtest_init_OSHash_create_fail),
+        cmocka_unit_test(test_w_logtest_init_OSHash_setSize_fail),
+        cmocka_unit_test(test_w_logtest_init_pthread_fail),
+        cmocka_unit_test(test_w_logtest_init_unlink_fail),
+        cmocka_unit_test(test_w_logtest_init_done),
         // Tests w_logtest_fts_init
         cmocka_unit_test(test_w_logtest_fts_init_create_list_failure),
         cmocka_unit_test(test_w_logtest_fts_init_SetMaxSize_failure),
@@ -659,9 +4060,107 @@ int main(void)
         // Tests w_logtest_check_inactive_sessions
         cmocka_unit_test(test_w_logtest_check_inactive_sessions_no_remove),
         cmocka_unit_test(test_w_logtest_check_inactive_sessions_remove),
+        // Test w_logtest_remove_old_session
+        cmocka_unit_test(test_w_logtest_remove_old_session_one),
+        cmocka_unit_test(test_w_logtest_remove_old_session_many),
         // Test w_logtest_register_session
         cmocka_unit_test(test_w_logtest_register_session_dont_remove),
         cmocka_unit_test(test_w_logtest_register_session_remove_old),
+        // Tests w_logtest_initialize_session
+        cmocka_unit_test(test_w_logtest_initialize_session_error_decoders),
+        cmocka_unit_test(test_w_logtest_initialize_session_error_cbd_list),
+        cmocka_unit_test(test_w_logtest_initialize_session_error_rules),
+        cmocka_unit_test(test_w_logtest_initialize_session_error_hash_rules),
+        cmocka_unit_test(test_w_logtest_initialize_session_error_fts_init),
+        cmocka_unit_test(test_w_logtest_initialize_session_error_accumulate_init),
+        cmocka_unit_test(test_w_logtest_initialize_session_success),
+        // Tests w_logtest_generate_token
+        cmocka_unit_test(test_w_logtest_generate_token_success),
+        cmocka_unit_test(test_w_logtest_generate_token_success_empty_bytes),
+        // Tests w_logtest_get_rule_level
+        cmocka_unit_test(test_w_logtest_get_rule_level_empty_log),
+        cmocka_unit_test(test_w_logtest_get_rule_level_empty_rule),
+        cmocka_unit_test(test_w_logtest_get_rule_level_empty_level),
+        cmocka_unit_test(test_w_logtest_get_rule_level_ok),
+        // Tests w_logtest_get_session
+        cmocka_unit_test(test_w_logtest_get_session_fail),
+        cmocka_unit_test(test_w_logtest_get_session_active),
+        cmocka_unit_test(test_w_logtest_get_session_expired_token),
+        cmocka_unit_test(test_w_logtest_get_session_new),
+        // Tests w_logtest_add_msg_response
+        cmocka_unit_test(test_w_logtest_add_msg_response_null_list),
+        cmocka_unit_test(test_w_logtest_add_msg_response_new_field_msg),
+        cmocka_unit_test(test_w_logtest_add_msg_response_error_msg),
+        cmocka_unit_test(test_w_logtest_add_msg_response_warn_msg),
+        cmocka_unit_test(test_w_logtest_add_msg_response_warn_dont_remplaze_error_msg),
+        cmocka_unit_test(test_w_logtest_add_msg_response_info_msg),
+        // Tests w_logtest_check_input
+        cmocka_unit_test(test_w_logtest_check_input_malformed_json_long),
+        cmocka_unit_test(test_w_logtest_check_input_malformed_json_short),
+        cmocka_unit_test(test_w_logtest_check_input_type_remove_sesion_ok),
+        cmocka_unit_test(test_w_logtest_check_input_type_request_ok),
+        // Tests w_logtest_check_input_request
+        cmocka_unit_test(test_w_logtest_check_input_request_empty_json),
+        cmocka_unit_test(test_w_logtest_check_input_request_missing_location),
+        cmocka_unit_test(test_w_logtest_check_input_request_missing_log_format),
+        cmocka_unit_test(test_w_logtest_check_input_request_missing_event),
+        cmocka_unit_test(test_w_logtest_check_input_request_full_empty_token),
+        cmocka_unit_test(test_w_logtest_check_input_request_full),
+        cmocka_unit_test(test_w_logtest_check_input_request_bad_token_lenght),
+        // Tests w_logtest_check_input_remove_session
+        cmocka_unit_test(test_w_logtest_check_input_remove_session_not_string),
+        cmocka_unit_test(test_w_logtest_check_input_remove_session_invalid_token),
+        cmocka_unit_test(test_w_logtest_check_input_remove_session_ok),
+        // Tests w_logtest_process_request
+        cmocka_unit_test(test_w_logtest_process_request_error_list),
+        cmocka_unit_test(test_w_logtest_process_request_error_check_input),
+        cmocka_unit_test(test_w_logtest_process_request_type_remove_session_ok),
+        // cmocka_unit_test(test_w_logtest_process_request_error_get_session),
+        // Tests w_logtest_generate_error_response
+        cmocka_unit_test(test_w_logtest_generate_error_response_ok),
+        // Tests w_logtest_preprocessing_phase
+        cmocka_unit_test(test_w_logtest_preprocessing_phase_json_event_ok),
+        cmocka_unit_test(test_w_logtest_preprocessing_phase_json_event_fail),
+        cmocka_unit_test(test_w_logtest_preprocessing_phase_str_event_ok),
+        cmocka_unit_test(test_w_logtest_preprocessing_phase_str_event_fail),
+        // Tests w_logtest_decoding_phase
+        cmocka_unit_test(test_w_logtest_decoding_phase_program_name),
+        cmocka_unit_test(test_w_logtest_decoding_phase_no_program_name),
+        // Tests w_logtest_rulesmatching_phase
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_no_load_rules),
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_ossec_alert),
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_dont_match_category),
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_dont_match),
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_match_level_0),
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_match_dont_ignore_first_time),
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_match_ignore_time_ignore),
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_match_dont_ignore_time_out_windows),
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_match_ignore_event),
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_match_and_if_matched_sid_ok),
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_match_and_if_matched_sid_fail),
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_match_and_group_prev_matched),
+        cmocka_unit_test(test_w_logtest_rulesmatching_phase_match_and_group_prev_matched_fail),
+        // Tests w_logtest_process_log
+        //cmocka_unit_test(test_w_logtest_process_log_preprocessing_fail),
+        //cmocka_unit_test(test_w_logtest_process_log_rule_match_fail),
+        //cmocka_unit_test(test_w_logtest_process_log_rule_dont_match),
+        //cmocka_unit_test(test_w_logtest_process_log_rule_match),
+        // Tests w_logtest_process_request_remove_session
+        cmocka_unit_test(test_w_logtest_process_request_remove_session_invalid_token),
+        cmocka_unit_test(test_w_logtest_process_request_remove_session_session_not_found),
+        cmocka_unit_test(test_w_logtest_process_request_remove_session_ok),
+        // Tests w_logtest_clients_handler
+        cmocka_unit_test(test_w_logtest_clients_handler_error_acept),
+        cmocka_unit_test(test_w_logtest_clients_handler_error_acept_close_socket),
+        cmocka_unit_test(test_w_logtest_clients_handler_recv_error),
+        cmocka_unit_test(test_w_logtest_clients_handler_recv_msg_empty),
+        cmocka_unit_test(test_w_logtest_clients_handler_recv_msg_oversize),
+        //cmocka_unit_test(test_w_logtest_clients_handler_ok),
+        cmocka_unit_test(test_w_logtest_process_request_log_processing_fail_session),
+
+
+
+
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -374,7 +374,7 @@ char* __wrap_ParseRuleComment(Eventinfo *lf) {
 }
 
 cJSON* __wrap_cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean) {
-    return mock_type(cJSON *);    
+    return mock_type(cJSON *);
 }
 
 cJSON_bool __wrap_cJSON_IsNumber(const cJSON * const item) {
@@ -389,8 +389,8 @@ cJSON * __wrap_cJSON_CreateArray() {
     return mock_type(cJSON *);
 }
 
-cJSON * __wrap_cJSON_CreateObject() { 
-    return mock_type(cJSON *); 
+cJSON * __wrap_cJSON_CreateObject() {
+    return mock_type(cJSON *);
 }
 
 cJSON * __wrap_cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number) {
@@ -468,9 +468,9 @@ void __wrap_DecodeEvent(struct _Eventinfo *lf, OSHash *rules_hash, regex_matchin
     check_expected(node);
 }
 
-RuleInfo * __wrap_OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events, 
+RuleInfo * __wrap_OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                                       ListNode **cdblists, RuleNode *curr_node,
-                                      regex_matching *rule_match, OSList **fts_list, 
+                                      regex_matching *rule_match, OSList **fts_list,
                                       OSHash **fts_store) {
     return mock_type(RuleInfo *);
 }
@@ -610,11 +610,11 @@ void test_w_logtest_init_pthread_fail(void **state)
 
     //w_logtest_clients_handler
     will_return(__wrap_FOREVER, 1);
-    
+
     will_return(__wrap_pthread_mutex_lock, 0);
 
     will_return(__wrap_accept, 5);
-    
+
     will_return(__wrap_pthread_mutex_unlock, 0);
 
     will_return(__wrap_OS_RecvSecureTCP, 0);
@@ -624,7 +624,7 @@ void test_w_logtest_init_pthread_fail(void **state)
     will_return(__wrap_close, 0);
     will_return(__wrap_FOREVER, 0);
 
-    
+
     will_return(__wrap_pthread_join, 0);
     will_return(__wrap_close, 0);
 
@@ -659,11 +659,11 @@ void test_w_logtest_init_unlink_fail(void **state)
 
     //w_logtest_clients_handler
     will_return(__wrap_FOREVER, 1);
-    
+
     will_return(__wrap_pthread_mutex_lock, 0);
 
     will_return(__wrap_accept, 5);
-    
+
     will_return(__wrap_pthread_mutex_unlock, 0);
 
     will_return(__wrap_OS_RecvSecureTCP, 0);
@@ -673,14 +673,14 @@ void test_w_logtest_init_unlink_fail(void **state)
     will_return(__wrap_close, 0);
     will_return(__wrap_FOREVER, 0);
 
-    
+
     will_return(__wrap_close, 0);
 
     will_return(__wrap_unlink, 1);
 
     char msg[OS_SIZE_4096];
     errno = EBUSY;
-    snprintf(msg, OS_SIZE_4096, "(1129): Could not unlink file '%s' due to [(%d)-(%s)].", 
+    snprintf(msg, OS_SIZE_4096, "(1129): Could not unlink file '%s' due to [(%d)-(%s)].",
             LOGTEST_SOCK, errno, strerror(errno));
 
     expect_string(__wrap__merror, formatted_msg, msg);
@@ -714,11 +714,11 @@ void test_w_logtest_init_done(void **state)
 
     //w_logtest_clients_handler
     will_return(__wrap_FOREVER, 1);
-    
+
     will_return(__wrap_pthread_mutex_lock, 0);
 
     will_return(__wrap_accept, 5);
-    
+
     will_return(__wrap_pthread_mutex_unlock, 0);
 
     will_return(__wrap_OS_RecvSecureTCP, 0);
@@ -728,7 +728,7 @@ void test_w_logtest_init_done(void **state)
     will_return(__wrap_close, 0);
     will_return(__wrap_FOREVER, 0);
 
-    
+
     will_return(__wrap_close, 0);
 
     will_return(__wrap_unlink, 0);
@@ -908,7 +908,7 @@ void test_w_logtest_check_inactive_sessions_no_remove(void **state)
     will_return(__wrap_OSHash_Begin, hash_node);
 
     will_return(__wrap_pthread_mutex_lock, 0);
-    
+
     will_return(__wrap_time, NULL);
 
     will_return(__wrap_difftime, 1);
@@ -997,7 +997,7 @@ void test_w_logtest_check_inactive_sessions_remove(void **state)
 void test_w_logtest_remove_old_session_one(void ** state) {
 
     w_logtest_connection_t connection;
-    
+
     connection.active_client = 2;
     w_logtest_conf.max_sessions = 1;
 
@@ -1041,7 +1041,7 @@ void test_w_logtest_remove_old_session_one(void ** state) {
 void test_w_logtest_remove_old_session_many(void ** state) {
 
     w_logtest_connection_t connection;
-    
+
     connection.active_client = 3;
     w_logtest_conf.max_sessions = 2;
 
@@ -1092,7 +1092,7 @@ void test_w_logtest_remove_old_session_many(void ** state) {
 
     w_logtest_remove_old_session(&connection);
     assert_int_equal(connection.active_client, w_logtest_conf.max_sessions);
-    
+
     os_free(hash_node_other->key);
     os_free(hash_node_old->key);
     os_free(hash_node_other);
@@ -2249,8 +2249,6 @@ void test_w_logtest_check_input_type_request_ok(void ** state) {
 
     /* token */
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
-    will_return(__wrap_cJSON_IsString, false);
-
 
     retval = w_logtest_check_input(input_raw_json, &request, list_msg);
 
@@ -2308,7 +2306,6 @@ void test_w_logtest_check_input_request_empty_json(void ** state) {
 
     /* token */
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
-    will_return(__wrap_cJSON_IsString, false);
 
     retval = w_logtest_check_input_request(&root, list_msg);
 
@@ -2349,12 +2346,11 @@ void test_w_logtest_check_input_request_missing_location(void ** state) {
 
     /* token */
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
-    will_return(__wrap_cJSON_IsString, false);
 
     retval = w_logtest_check_input_request(&root, list_msg);
 
     assert_int_equal(retval, ret_expect);
-    
+
     os_free(event.valuestring);
     os_free(log_format.valuestring);
 }
@@ -2393,7 +2389,6 @@ void test_w_logtest_check_input_request_missing_log_format(void ** state) {
 
     /* token */
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
-    will_return(__wrap_cJSON_IsString, false);
 
     retval = w_logtest_check_input_request(&root, list_msg);
 
@@ -2437,7 +2432,6 @@ void test_w_logtest_check_input_request_missing_event(void ** state) {
 
     /* token */
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
-    will_return(__wrap_cJSON_IsString, false);
 
     retval = w_logtest_check_input_request(&root, list_msg);
 
@@ -2477,6 +2471,7 @@ void test_w_logtest_check_input_request_full(void ** state) {
     cJSON token = {0};
     token.valuestring = strdup("12345678");
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &token);
+    will_return(__wrap_cJSON_IsString, true);
     will_return(__wrap_cJSON_IsString, true);
 
     retval = w_logtest_check_input_request(&root, list_msg);
@@ -2518,7 +2513,6 @@ void test_w_logtest_check_input_request_full_empty_token(void ** state) {
 
     /* token */
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
-    will_return(__wrap_cJSON_IsString, false);
 
     retval = w_logtest_check_input_request(&root, list_msg);
 
@@ -2561,6 +2555,8 @@ void test_w_logtest_check_input_request_bad_token_lenght(void ** state) {
     token.valuestring = strdup("1234");
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &token);
     will_return(__wrap_cJSON_IsString, true);
+    will_return(__wrap_cJSON_IsString, true);
+    will_return(__wrap_cJSON_IsString, true);
 
     expect_string(__wrap__mdebug1, formatted_msg, "(7309): '1234' is not a valid token");
 
@@ -2575,6 +2571,59 @@ void test_w_logtest_check_input_request_bad_token_lenght(void ** state) {
     os_free(log_format.valuestring);
     os_free(event.valuestring);
     os_free(token.valuestring);
+}
+
+void test_w_logtest_check_input_request_bad_token_type(void ** state) {
+
+    cJSON root = {0};
+
+    int retval;
+    const int ret_expect = W_LOGTEST_REQUEST_TYPE_LOG_PROCESSING;
+
+    OSList * list_msg = (OSList *) 2;
+
+   /* location */
+    cJSON location = {0};
+    location.valuestring = strdup("location str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &location);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* log_format */
+    cJSON log_format = {0};
+    log_format.valuestring = strdup("log format str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &log_format);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* event */
+    cJSON event = {0};
+    event.valuestring = strdup("event str");
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &event);
+    will_return(__wrap_cJSON_IsString, true);
+
+    /* token */
+    cJSON token = {0};
+    token.type = cJSON_Number;
+    token.valueint = 1234;
+
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &token);
+    will_return(__wrap_cJSON_IsString, false);
+
+    will_return(__wrap_cJSON_IsString, false);
+
+    will_return(__wrap_cJSON_PrintUnformatted, strdup("1234"));
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(7309): '1234' is not a valid token");
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_WARNING);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, "(7309): '1234' is not a valid token");
+
+    retval = w_logtest_check_input_request(&root, list_msg);
+
+    assert_int_equal(retval, ret_expect);
+    os_free(location.valuestring);
+    os_free(log_format.valuestring);
+    os_free(event.valuestring);
 }
 
 // w_logtest_check_input_remove_session
@@ -2645,7 +2694,7 @@ void test_w_logtest_check_input_remove_session_ok(void ** state)
     will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
 
     assert_int_equal(W_LOGTEST_TOKEN_LENGH, strlen(token.valuestring));
-    
+
     retval = w_logtest_check_input_remove_session(&root, list_msg);
 
     assert_int_equal(retval, expected_retval);
@@ -2694,7 +2743,7 @@ void test_w_logtest_process_request_error_check_input(void ** state) {
     will_return(__wrap_OSList_SetMaxSize, 0);
 
     will_return(__wrap_cJSON_CreateObject, (cJSON *) 1);
-    
+
     /* Error w_logtest_check_input */
 
     char * input_raw_json = strdup("Test request");
@@ -2744,7 +2793,7 @@ void test_w_logtest_process_request_error_check_input(void ** state) {
     retval = w_logtest_process_request(input_raw_json, &connection);
 
     assert_string_equal(retval, "{json response}");
-    
+
     os_free(input_raw_json);
 
 }
@@ -2757,7 +2806,7 @@ void test_w_logtest_process_request_type_remove_session_ok(void ** state) {
     /* w_logtest_add_msg_response */
     OSList * list_msg;
     os_calloc(1, sizeof(OSList), list_msg);
-    
+
 
     /* w_logtest_process_request */
     will_return(__wrap_OSList_Create, list_msg);
@@ -2776,7 +2825,7 @@ void test_w_logtest_process_request_type_remove_session_ok(void ** state) {
     will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
     will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
     will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
-    
+
     /* w_logtest_process_request_remove_session_fail */
     w_logtest_connection_t connection = {0};
     connection.active_client = 5;
@@ -2827,7 +2876,7 @@ void test_w_logtest_process_request_type_remove_session_ok(void ** state) {
     retval = w_logtest_process_request(input_raw_json, &connection);
 
     assert_string_equal(retval, "{json response}");
-    
+
     os_free(input_raw_json);
     os_free(token.valuestring);
 
@@ -2837,14 +2886,13 @@ void test_w_logtest_process_request_type_log_processing(void ** state) {
 
     char * retval;
     char * input_raw_json = strdup("Test request");
-    
+
     w_logtest_connection_t connection = {0};
     connection.active_client = 5;
 
     /* w_logtest_add_msg_response */
     OSList * list_msg;
     os_calloc(1, sizeof(OSList), list_msg);
-    
 
     /* w_logtest_process_request */
     will_return(__wrap_OSList_Create, list_msg);
@@ -2854,9 +2902,6 @@ void test_w_logtest_process_request_type_log_processing(void ** state) {
     will_return(__wrap_cJSON_ParseWithOpts, (cJSON *) 1);
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 0);
 
-
-    
-    
     // w_logtest_check_input_requeset ok
     /* location */
     cJSON location = {0};
@@ -2880,6 +2925,7 @@ void test_w_logtest_process_request_type_log_processing(void ** state) {
     cJSON token = {0};
     token.valuestring = strdup("12345678");
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &token);
+    will_return(__wrap_cJSON_IsString, true);
     will_return(__wrap_cJSON_IsString, true);
 
     /* log processing fail get session*/
@@ -2991,7 +3037,7 @@ void test_w_logtest_decoding_phase_program_name(void ** state)
 
     lf.program_name = strdup("program name test");
     os_calloc(1, sizeof(OSDecoderNode), session.decoderlist_forpname);
-    
+
     expect_value(__wrap_DecodeEvent, node, session.decoderlist_forpname);
     w_logtest_decoding_phase(&lf, &session);
 
@@ -3007,7 +3053,7 @@ void test_w_logtest_decoding_phase_no_program_name(void ** state)
 
     lf.program_name = NULL;
     os_calloc(1, sizeof(OSDecoderNode), session.decoderlist_nopname);
-    
+
     expect_value(__wrap_DecodeEvent, node, session.decoderlist_nopname);
     w_logtest_decoding_phase(&lf, &session);
 
@@ -3019,14 +3065,14 @@ void test_w_logtest_preprocessing_phase_json_event_ok(void ** state)
 {
     Eventinfo lf = {0};
     cJSON request = {0};
-    
+
     cJSON json_event = {0};
     cJSON json_event_child = {0};
     char * raw_event = strdup("{event}");
     char * str_location = strdup("location");
 
     lf.log = strdup("{event}");
-    
+
     json_event.child = &json_event_child;
 
 
@@ -3035,7 +3081,7 @@ void test_w_logtest_preprocessing_phase_json_event_ok(void ** state)
 
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
     will_return(__wrap_cJSON_PrintUnformatted, raw_event);
-    
+
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_GetStringValue, str_location);
 
@@ -3043,7 +3089,7 @@ void test_w_logtest_preprocessing_phase_json_event_ok(void ** state)
 
 
     retval = w_logtest_preprocessing_phase(&lf, &request);
-    
+
     assert_int_equal(retval, expect_retval);
 
 
@@ -3059,12 +3105,12 @@ void test_w_logtest_preprocessing_phase_json_event_fail(void ** state)
     os_calloc(1, sizeof(Eventinfo), lf);
 
     cJSON request = {0};
-    
+
     cJSON json_event = {0};
     cJSON json_event_child = {0};
     char * raw_event = strdup("{event}");
     char * str_location = strdup("location");
-    
+
     json_event.child = &json_event_child;
 
 
@@ -3073,7 +3119,7 @@ void test_w_logtest_preprocessing_phase_json_event_fail(void ** state)
 
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
     will_return(__wrap_cJSON_PrintUnformatted, raw_event);
-    
+
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_GetStringValue, str_location);
 
@@ -3081,7 +3127,7 @@ void test_w_logtest_preprocessing_phase_json_event_fail(void ** state)
 
 
     retval = w_logtest_preprocessing_phase(lf, &request);
-    
+
     assert_int_equal(retval, expect_retval);
 
     os_free(str_location);
@@ -3098,7 +3144,7 @@ void test_w_logtest_preprocessing_phase_str_event_ok(void ** state)
     cJSON json_event = {0};
     char * raw_event = strdup("event");
     char * str_location = strdup("location");
-    
+
     lf->log = strdup("test log");
 
     const int expect_retval = 0;
@@ -3106,7 +3152,7 @@ void test_w_logtest_preprocessing_phase_str_event_ok(void ** state)
 
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
     will_return(__wrap_cJSON_GetStringValue, raw_event);
-    
+
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_GetStringValue, str_location);
 
@@ -3114,7 +3160,7 @@ void test_w_logtest_preprocessing_phase_str_event_ok(void ** state)
 
 
     retval = w_logtest_preprocessing_phase(lf, &request);
-    
+
     assert_int_equal(retval, expect_retval);
 
     os_free(str_location);
@@ -3133,7 +3179,7 @@ void test_w_logtest_preprocessing_phase_str_event_fail(void ** state)
     cJSON json_event = {0};
     char * raw_event = strdup("event");
     char * str_location = strdup("location");
-    
+
 
 
     const int expect_retval = -1;
@@ -3141,7 +3187,7 @@ void test_w_logtest_preprocessing_phase_str_event_fail(void ** state)
 
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
     will_return(__wrap_cJSON_GetStringValue, raw_event);
-    
+
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_GetStringValue, str_location);
 
@@ -3149,7 +3195,7 @@ void test_w_logtest_preprocessing_phase_str_event_fail(void ** state)
 
 
     retval = w_logtest_preprocessing_phase(lf, &request);
-    
+
     assert_int_equal(retval, expect_retval);
 
     Free_Eventinfo(lf);
@@ -3469,7 +3515,7 @@ void test_w_logtest_rulesmatching_phase_match_and_if_matched_sid_ok(void ** stat
     ruleinfo.level = 5;
     ruleinfo.category = SYSLOG;
     ruleinfo.ckignore = 0;
-    
+
 
     OSList pre_matched_list = {0};
     pre_matched_list.last_node = (OSListNode *) 10;
@@ -3511,7 +3557,7 @@ void test_w_logtest_rulesmatching_phase_match_and_if_matched_sid_fail(void ** st
     ruleinfo.level = 5;
     ruleinfo.category = SYSLOG;
     ruleinfo.ckignore = 0;
-    
+
 
     OSList pre_matched_list = {0};
     pre_matched_list.last_node = (OSListNode *) 10;
@@ -3611,7 +3657,7 @@ void test_w_logtest_rulesmatching_phase_match_and_group_prev_matched(void ** sta
 
     OSList pre_matched_list = {0};
     pre_matched_list.last_node = (OSListNode *) 10;
-    
+
     ruleinfo.sid_prev_matched = &pre_matched_list;
 
 
@@ -3648,12 +3694,12 @@ void test_w_logtest_process_log_preprocessing_fail(void ** state)
     w_logtest_session_t session = {0};
     OSList list_msg = {0};
 
-    
+
     cJSON * retval;
 
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
     will_return(__wrap_cJSON_GetStringValue, raw_event);
-    
+
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_GetStringValue, str_location);
 
@@ -3666,7 +3712,7 @@ void test_w_logtest_process_log_preprocessing_fail(void ** state)
 
 
     retval = w_logtest_process_log(&request, &session, &list_msg);
-    
+
     assert_null(retval);
 
     os_free(str_location);
@@ -3690,12 +3736,12 @@ void test_w_logtest_process_log_rule_match_fail(void ** state)
     OSDecoderInfo decoder_info = {0};
     decoder_info.accumulate = 0;
     decoder_CleanMSG = &decoder_info;
-    
+
     cJSON * retval;
 
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
     will_return(__wrap_cJSON_GetStringValue, raw_event);
-    
+
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_GetStringValue, str_location);
 
@@ -3704,7 +3750,7 @@ void test_w_logtest_process_log_rule_match_fail(void ** state)
     expect_value(__wrap_DecodeEvent, node, session.decoderlist_forpname);
 
     retval = w_logtest_process_log(&request, &session, &list_msg);
-    
+
     assert_null(retval);
 
     os_free(str_location);
@@ -3740,13 +3786,13 @@ void test_w_logtest_process_log_rule_dont_match(void ** state)
     os_calloc(1, sizeof(RuleNode), session.rule_list);
     session.rule_list->next = NULL;
     session.rule_list->ruleinfo = &ruleinfo;
-    
+
     cJSON * retval;
 
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
     will_return(__wrap_cJSON_GetStringValue, raw_event);
 
-    // w_logtest_preprocessing_phase    
+    // w_logtest_preprocessing_phase
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_GetStringValue, str_location);
 
@@ -3759,7 +3805,7 @@ void test_w_logtest_process_log_rule_dont_match(void ** state)
     will_return(__wrap_cJSON_Parse, output);
 
     retval = w_logtest_process_log(&request, &session, &list_msg);
-    
+
     assert_non_null(retval);
 
     os_free(str_location);
@@ -3797,13 +3843,13 @@ void test_w_logtest_process_log_rule_match(void ** state)
     os_calloc(1, sizeof(RuleNode), session.rule_list);
     session.rule_list->next = NULL;
     session.rule_list->ruleinfo = &ruleinfo;
-    
+
     cJSON * retval;
 
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
     will_return(__wrap_cJSON_GetStringValue, raw_event);
 
-    // w_logtest_preprocessing_phase    
+    // w_logtest_preprocessing_phase
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_GetStringValue, str_location);
 
@@ -3825,7 +3871,7 @@ void test_w_logtest_process_log_rule_match(void ** state)
     will_return(__wrap_cJSON_Parse, output);
 
     retval = w_logtest_process_log(&request, &session, &list_msg);
-    
+
     assert_non_null(retval);
 
     os_free(str_location);
@@ -3889,7 +3935,7 @@ void test_w_logtest_process_request_remove_session_invalid_token(void ** state)
 
     assert_int_equal(retval, expect_retval);
     assert_int_equal(connection.active_client, 5);
-    
+
     os_free(list_msg_node);
 }
 
@@ -4043,11 +4089,11 @@ void test_w_logtest_clients_handler_error_acept(void ** state)
     char expected_str[OS_SIZE_1024];
 
     will_return(__wrap_FOREVER, 1);
-    
+
     will_return(__wrap_pthread_mutex_lock, 0);
 
     will_return(__wrap_accept, -1);
-    
+
     will_return(__wrap_pthread_mutex_unlock, 0);
     errno = ENOMEM;
     snprintf(expected_str, OS_SIZE_1024, "(7301): Failure to accept connection. Errno: %s", strerror(errno));
@@ -4066,11 +4112,11 @@ void test_w_logtest_clients_handler_error_acept_close_socket(void ** state)
     char expected_str[OS_SIZE_1024];
 
     will_return(__wrap_FOREVER, 1);
-    
+
     will_return(__wrap_pthread_mutex_lock, 0);
 
     will_return(__wrap_accept, -1);
-    
+
     will_return(__wrap_pthread_mutex_unlock, 0);
     errno = EBADF;
     snprintf(expected_str, OS_SIZE_1024, "(7301): Failure to accept connection. Errno: %s", strerror(errno));
@@ -4087,11 +4133,11 @@ void test_w_logtest_clients_handler_recv_error(void ** state)
     char expected_str[OS_SIZE_1024];
 
     will_return(__wrap_FOREVER, 1);
-    
+
     will_return(__wrap_pthread_mutex_lock, 0);
 
     will_return(__wrap_accept, 5);
-    
+
     will_return(__wrap_pthread_mutex_unlock, 0);
 
     will_return(__wrap_OS_RecvSecureTCP, -1);
@@ -4113,11 +4159,11 @@ void test_w_logtest_clients_handler_recv_msg_empty(void ** state)
     w_logtest_connection_t conection = {0};
 
     will_return(__wrap_FOREVER, 1);
-    
+
     will_return(__wrap_pthread_mutex_lock, 0);
 
     will_return(__wrap_accept, 5);
-    
+
     will_return(__wrap_pthread_mutex_unlock, 0);
 
     will_return(__wrap_OS_RecvSecureTCP, 0);
@@ -4137,11 +4183,11 @@ void test_w_logtest_clients_handler_recv_msg_oversize(void ** state)
     w_logtest_connection_t conection = {0};
 
     will_return(__wrap_FOREVER, 1);
-    
+
     will_return(__wrap_pthread_mutex_lock, 0);
 
     will_return(__wrap_accept, 5);
-    
+
     will_return(__wrap_pthread_mutex_unlock, 0);
 
     will_return(__wrap_OS_RecvSecureTCP, -6);
@@ -4177,11 +4223,11 @@ void test_w_logtest_clients_handler_ok(void ** state)
     w_logtest_connection_t conection = {0};
 
     will_return(__wrap_FOREVER, 1);
-    
+
     will_return(__wrap_pthread_mutex_lock, 0);
 
     will_return(__wrap_accept, 5);
-    
+
     will_return(__wrap_pthread_mutex_unlock, 0);
 
     will_return(__wrap_OS_RecvSecureTCP, 100);
@@ -4206,7 +4252,7 @@ void test_w_logtest_clients_handler_ok(void ** state)
     will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
     will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
     will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
-    
+
     /* w_logtest_process_request_remove_session_fail */
     w_logtest_connection_t connection = {0};
     connection.active_client = 5;
@@ -4401,7 +4447,7 @@ void test_w_logtest_process_request_log_processing_fail_process_log(void ** stat
     will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
 
     will_return(__wrap_OSList_GetFirstNode, NULL);
-  
+
     /* Fail w_logtest_process_log */
     cJSON json_event = {0};
     json_event.child = false;
@@ -4411,7 +4457,7 @@ void test_w_logtest_process_request_log_processing_fail_process_log(void ** stat
 
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
     will_return(__wrap_cJSON_GetStringValue, raw_event);
-    
+
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_GetStringValue, str_location);
 
@@ -4524,7 +4570,7 @@ void test_w_logtest_process_request_log_processing_ok_and_alert(void ** state)
     will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
 
     will_return(__wrap_OSList_GetFirstNode, NULL);
-  
+
     /* Alert w_logtest_process_log */
     Config.decoder_order_size = 1;
 
@@ -4550,11 +4596,11 @@ void test_w_logtest_process_request_log_processing_ok_and_alert(void ** state)
     os_calloc(1, sizeof(RuleNode), active_session.rule_list);
     active_session.rule_list->next = NULL;
     active_session.rule_list->ruleinfo = &ruleinfo;
-    
+
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &json_event);
     will_return(__wrap_cJSON_GetStringValue, raw_event);
 
-    // w_logtest_preprocessing_phase    
+    // w_logtest_preprocessing_phase
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_GetStringValue, str_location);
 
@@ -4680,6 +4726,7 @@ int main(void)
         cmocka_unit_test(test_w_logtest_check_input_request_full_empty_token),
         cmocka_unit_test(test_w_logtest_check_input_request_full),
         cmocka_unit_test(test_w_logtest_check_input_request_bad_token_lenght),
+        cmocka_unit_test(test_w_logtest_check_input_request_bad_token_type),
         // Tests w_logtest_check_input_remove_session
         cmocka_unit_test(test_w_logtest_check_input_remove_session_not_string),
         cmocka_unit_test(test_w_logtest_check_input_remove_session_invalid_token),
@@ -4732,11 +4779,7 @@ int main(void)
         // w_logtest_process_request_log_processing
         cmocka_unit_test(test_w_logtest_process_request_log_processing_fail_session),
         cmocka_unit_test(test_w_logtest_process_request_log_processing_fail_process_log),
-        cmocka_unit_test(test_w_logtest_process_request_log_processing_ok_and_alert),
-
-
-
-
+        cmocka_unit_test(test_w_logtest_process_request_log_processing_ok_and_alert)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_rule_list.c
+++ b/src/unit_tests/analysisd/test_rule_list.c
@@ -326,24 +326,6 @@ void test_os_remove_rules_list_OK(void **state)
 
 }
 
-// Test OS_AddChild
-void test_OS_AddChild_inconsistent_rule(void ** state) {
-    RuleInfo * read_rule = NULL;
-    RuleNode * r_node = NULL;
-    OSList list_msg = {0};
-    const int expect_value = 1;
-    int retval;
-
-    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
-    expect_value(__wrap__os_analysisd_add_logmsg, list, &list_msg);
-    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg,
-                  "rules_list: Passing a NULL rule. Inconsistent state");
-
-    retval = OS_AddChild(read_rule, &r_node, &list_msg);
-
-    assert_int_equal(retval, expect_value);
-}
-
 
 int main(void)
 {
@@ -358,9 +340,7 @@ int main(void)
         cmocka_unit_test(test_os_remove_ruleinfo_NULL),
         cmocka_unit_test(test_os_remove_ruleinfo_OK),
         // Tests os_remove_rules_list
-        cmocka_unit_test(test_os_remove_rules_list_OK),
-        // Tests OS_AddChild
-        cmocka_unit_test(test_OS_AddChild_inconsistent_rule),
+        cmocka_unit_test(test_os_remove_rules_list_OK)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_rules.c
+++ b/src/unit_tests/analysisd/test_rules.c
@@ -1,0 +1,428 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../analysisd/rules.h"
+#include "../../analysisd/config.h"
+#include "../../analysisd/eventinfo.h"
+#include "../../analysisd/analysisd.h"
+
+char *loadmemory(char *at, const char *str, OSList* log_msg);
+int get_info_attributes(char **attributes, char **values, OSList* log_msg);
+
+
+/* setup/teardown */
+
+/* wraps */
+void __wrap__os_analysisd_add_logmsg(OSList * list, int level, int line, const char * func,
+                                    const char * file, char * msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(level);
+    check_expected_ptr(list);
+    check_expected(formatted_msg);
+}
+
+void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...) {
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+/* tests */
+// loadmemory
+void test_loadmemory_null_append_ok(void ** state)
+{
+    char * at = NULL;
+    char * str;
+    
+    const size_t len = 1000;
+    char * expect_retval;
+    char * retval;
+    
+    os_calloc(len, sizeof(char), str);
+    memset(str, (int) '-', len - 1);
+    str[len-1] = '\0';
+    
+    os_calloc(len, sizeof(char), expect_retval);
+    memset(expect_retval, (int) '-', len - 1);
+    expect_retval[len-1] = '\0';
+
+    retval = loadmemory(at,str, NULL);
+
+    assert_string_equal(retval, expect_retval);
+
+    os_free(str);
+    os_free(retval);
+    os_free(expect_retval);
+
+}
+
+void test_loadmemory_null_append_oversize(void ** state)
+{
+    char * at = NULL;
+    char * str;
+    OSList list_msg = {0};
+    
+    const size_t len = 2049;
+    char * retval;
+    
+    os_calloc(len, sizeof(char), str);
+    memset(str, (int) '-', len - 1);
+    str[len-1] = '\0';
+
+    char expect_msg[OS_SIZE_4096];
+
+    snprintf(expect_msg, OS_SIZE_4096, "(1104): Maximum string size reached for: %s.", str);
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, &list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, expect_msg);
+
+    retval = loadmemory(at,str, &list_msg);
+
+    assert_null(retval);
+
+    os_free(str);
+
+}
+
+void test_loadmemory_append_oversize(void ** state)
+{
+    char * at = NULL;
+    char * str = NULL;
+    OSList list_msg = {0};
+    
+    const size_t len = 2050;
+    char * retval;
+    
+    os_calloc(len, sizeof(char), str);
+    memset(str, (int) '-', len - 1);
+    str[len-1] = '\0';
+
+    os_calloc(len, sizeof(char), at);
+    memset(at, (int) '+', len - 1);
+    str[len-1] = '\0';
+
+    char expect_msg[OS_SIZE_20480];
+
+    snprintf(expect_msg, OS_SIZE_20480, "(1104): Maximum string size reached for: %s.", str);
+    
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, &list_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, expect_msg);
+
+    retval = loadmemory(at,str, &list_msg);
+
+    assert_null(retval);
+
+    os_free(str);
+    os_free(at);
+
+}
+
+void test_loadmemory_append_ok(void ** state)
+{
+    char * at = NULL;
+    char * str = NULL;
+    OSList list_msg = {0};
+    
+    const size_t len = 512;
+    char * retval;
+    char * expect_retval;
+    
+    os_calloc(len, sizeof(char), str);
+    memset(str, (int) '-', len - 1);
+    str[len-1] = '\0';
+
+    os_calloc(len, sizeof(char), at);
+    memset(at, (int) '+', len - 1);
+    at[len-1] = '\0';
+    
+    os_calloc(len * 2, sizeof(char), expect_retval);
+    strncat(expect_retval, at, len * 2);
+    strncat(expect_retval, str, len * 2);
+
+    retval = loadmemory(at,str, &list_msg);
+
+    assert_non_null(retval);
+    assert_string_equal(retval, expect_retval);
+
+    os_free(str);
+    os_free(retval);
+    os_free(expect_retval);
+
+}
+
+// get_info_attributes
+void test_get_info_attributes_null(void ** state)
+{
+    OSList log_msg = {0};
+    char ** values = NULL;
+    char ** attributes = NULL;
+
+    int retval;
+    const int expect_retval = 0;
+
+    retval = get_info_attributes(attributes, values, &log_msg);
+    
+    assert_int_equal(retval, expect_retval);
+}
+
+void test_get_info_attributes_empty(void ** state)
+{
+    OSList log_msg = {0};
+    char ** values = NULL;
+    
+    char ** attributes;
+    os_calloc(1,sizeof(char *), attributes);
+    attributes[0] = NULL;
+
+    int retval;
+    const int expect_retval = 0;
+
+    retval = get_info_attributes(attributes, values, &log_msg);
+    
+    assert_int_equal(retval, expect_retval);
+
+    os_free(attributes);
+}
+
+void test_get_info_attributes_without_value(void ** state)
+{
+    OSList log_msg = {0};
+    char * attribute_k = "type";
+
+    char ** values;
+    os_calloc(1,sizeof(char *), values);
+    values[0] = NULL;
+
+    char ** attributes;
+    os_calloc(1,sizeof(char *), attributes);
+    attributes[0] = attribute_k;
+
+    int retval;
+    const int expect_retval = -1;
+
+    char excpect_msg[OS_SIZE_2048];
+    snprintf(excpect_msg, OS_SIZE_2048, "rules_op: Element info attribute \"%s\" does not have a value", attributes[0]);
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, &log_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, excpect_msg);
+
+    retval = get_info_attributes(attributes, values, &log_msg);
+    
+    assert_int_equal(retval, expect_retval);
+    
+    os_free(attributes);
+    os_free(values);
+}
+
+void test_get_info_attributes_text(void ** state)
+{
+    OSList log_msg = {0};
+    char * attribute_k = "type";
+    char * values_k = "text";
+
+    char ** values;
+    os_calloc(1,sizeof(char *), values);
+    values[0] = values_k;
+
+    char ** attributes;
+    os_calloc(1,sizeof(char *), attributes);
+    attributes[0] = attribute_k;
+
+    int retval;
+    const int expect_retval = 0;
+
+    retval = get_info_attributes(attributes, values, &log_msg);
+    
+    assert_int_equal(retval, expect_retval);
+    
+    os_free(attributes);
+    os_free(values);
+}
+
+void test_get_info_attributes_link(void ** state)
+{
+    OSList log_msg = {0};
+    char * attribute_k = "type";
+    char * values_k = "link";
+
+    char ** values;
+    os_calloc(1,sizeof(char *), values);
+    values[0] = values_k;
+
+    char ** attributes;
+    os_calloc(1,sizeof(char *), attributes);
+    attributes[0] = attribute_k;
+
+    int retval;
+    const int expect_retval = 1;
+
+    retval = get_info_attributes(attributes, values, &log_msg);
+    
+    assert_int_equal(retval, expect_retval);
+    
+    os_free(attributes);
+    os_free(values);
+}
+
+void test_get_info_attributes_cve(void ** state)
+{
+    OSList log_msg = {0};
+    char * attribute_k = "type";
+    char * values_k = "cve";
+
+    char ** values;
+    os_calloc(1,sizeof(char *), values);
+    values[0] = values_k;
+
+    char ** attributes;
+    os_calloc(1,sizeof(char *), attributes);
+    attributes[0] = attribute_k;
+
+    int retval;
+    const int expect_retval = 2;
+
+    retval = get_info_attributes(attributes, values, &log_msg);
+    
+    assert_int_equal(retval, expect_retval);
+    
+    os_free(attributes);
+    os_free(values);
+}
+
+void test_get_info_attributes_osvdb(void ** state)
+{
+    OSList log_msg = {0};
+    char * attribute_k = "type";
+    char * values_k = "osvdb";
+
+    char ** values;
+    os_calloc(1,sizeof(char *), values);
+    values[0] = values_k;
+
+    char ** attributes;
+    os_calloc(1,sizeof(char *), attributes);
+    attributes[0] = attribute_k;
+
+    int retval;
+    const int expect_retval = 3;
+
+    retval = get_info_attributes(attributes, values, &log_msg);
+    
+    assert_int_equal(retval, expect_retval);
+    
+    os_free(attributes);
+    os_free(values);
+}
+
+void test_get_info_attributes_invalid_value(void ** state)
+{
+    OSList log_msg = {0};
+    char * attribute_k = "bad_type";
+    char * values_k = "test_value";
+
+    char ** values;
+    os_calloc(1,sizeof(char *), values);
+    values[0] = values_k;
+
+    char ** attributes;
+    os_calloc(1,sizeof(char *), attributes);
+    attributes[0] = attribute_k;
+
+    int retval;
+    const int expect_retval = -1;
+
+    char excpect_msg[OS_SIZE_2048];
+    snprintf(excpect_msg, OS_SIZE_2048, "rules_op: Element info has invalid attribute \"%s\"", attributes[0]);
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, &log_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, excpect_msg);
+
+    retval = get_info_attributes(attributes, values, &log_msg);
+    
+    assert_int_equal(retval, expect_retval);
+    
+    os_free(attributes);
+    os_free(values);
+}
+
+void test_get_info_attributes_invalid_type(void ** state)
+{
+    OSList log_msg = {0};
+    char * attribute_k = "type";
+    char * values_k = "bad_value";
+
+    char ** values;
+    os_calloc(1,sizeof(char *), values);
+    values[0] = values_k;
+
+    char ** attributes;
+    os_calloc(1,sizeof(char *), attributes);
+    attributes[0] = attribute_k;
+
+    int retval;
+    const int expect_retval = -1;
+
+    char excpect_msg[OS_SIZE_2048];
+    snprintf(excpect_msg, OS_SIZE_2048, "rules_op: Element info attribute \"%s\""
+                            " has invalid value \"%s\"", attributes[0], values[0]);
+
+    expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
+    expect_value(__wrap__os_analysisd_add_logmsg, list, &log_msg);
+    expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, excpect_msg);
+
+    retval = get_info_attributes(attributes, values, &log_msg);
+    
+    assert_int_equal(retval, expect_retval);
+    
+    os_free(attributes);
+    os_free(values);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        // Tests _loadmemory
+        cmocka_unit_test(test_loadmemory_null_append_ok),
+        cmocka_unit_test(test_loadmemory_null_append_oversize),
+        cmocka_unit_test(test_loadmemory_append_oversize),
+        cmocka_unit_test(test_loadmemory_append_ok),
+        // Tests get_info_attributes
+        cmocka_unit_test(test_get_info_attributes_null),
+        cmocka_unit_test(test_get_info_attributes_empty),
+        cmocka_unit_test(test_get_info_attributes_without_value),
+        cmocka_unit_test(test_get_info_attributes_text),
+        cmocka_unit_test(test_get_info_attributes_link),
+        cmocka_unit_test(test_get_info_attributes_cve),
+        cmocka_unit_test(test_get_info_attributes_osvdb),
+        cmocka_unit_test(test_get_info_attributes_invalid_value),
+        //cmocka_unit_test(test_get_info_attributes_invalid_type),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/analysisd/test_rules.c
+++ b/src/unit_tests/analysisd/test_rules.c
@@ -56,15 +56,15 @@ void test_loadmemory_null_append_ok(void ** state)
 {
     char * at = NULL;
     char * str;
-    
+
     const size_t len = 1000;
     char * expect_retval;
     char * retval;
-    
+
     os_calloc(len, sizeof(char), str);
     memset(str, (int) '-', len - 1);
     str[len-1] = '\0';
-    
+
     os_calloc(len, sizeof(char), expect_retval);
     memset(expect_retval, (int) '-', len - 1);
     expect_retval[len-1] = '\0';
@@ -84,10 +84,10 @@ void test_loadmemory_null_append_oversize(void ** state)
     char * at = NULL;
     char * str;
     OSList list_msg = {0};
-    
+
     const size_t len = 2049;
     char * retval;
-    
+
     os_calloc(len, sizeof(char), str);
     memset(str, (int) '-', len - 1);
     str[len-1] = '\0';
@@ -112,10 +112,10 @@ void test_loadmemory_append_oversize(void ** state)
     char * at = NULL;
     char * str = NULL;
     OSList list_msg = {0};
-    
+
     const size_t len = 2050;
     char * retval;
-    
+
     os_calloc(len, sizeof(char), str);
     memset(str, (int) '-', len - 1);
     str[len-1] = '\0';
@@ -127,7 +127,7 @@ void test_loadmemory_append_oversize(void ** state)
     char expect_msg[OS_SIZE_20480];
 
     snprintf(expect_msg, OS_SIZE_20480, "(1104): Maximum string size reached for: %s.", str);
-    
+
     expect_value(__wrap__os_analysisd_add_logmsg, level, LOGLEVEL_ERROR);
     expect_value(__wrap__os_analysisd_add_logmsg, list, &list_msg);
     expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, expect_msg);
@@ -146,11 +146,11 @@ void test_loadmemory_append_ok(void ** state)
     char * at = NULL;
     char * str = NULL;
     OSList list_msg = {0};
-    
+
     const size_t len = 512;
     char * retval;
     char * expect_retval;
-    
+
     os_calloc(len, sizeof(char), str);
     memset(str, (int) '-', len - 1);
     str[len-1] = '\0';
@@ -158,7 +158,7 @@ void test_loadmemory_append_ok(void ** state)
     os_calloc(len, sizeof(char), at);
     memset(at, (int) '+', len - 1);
     at[len-1] = '\0';
-    
+
     os_calloc(len * 2, sizeof(char), expect_retval);
     strncat(expect_retval, at, len * 2);
     strncat(expect_retval, str, len * 2);
@@ -185,7 +185,7 @@ void test_get_info_attributes_null(void ** state)
     const int expect_retval = 0;
 
     retval = get_info_attributes(attributes, values, &log_msg);
-    
+
     assert_int_equal(retval, expect_retval);
 }
 
@@ -193,7 +193,7 @@ void test_get_info_attributes_empty(void ** state)
 {
     OSList log_msg = {0};
     char ** values = NULL;
-    
+
     char ** attributes;
     os_calloc(1,sizeof(char *), attributes);
     attributes[0] = NULL;
@@ -202,7 +202,7 @@ void test_get_info_attributes_empty(void ** state)
     const int expect_retval = 0;
 
     retval = get_info_attributes(attributes, values, &log_msg);
-    
+
     assert_int_equal(retval, expect_retval);
 
     os_free(attributes);
@@ -232,9 +232,9 @@ void test_get_info_attributes_without_value(void ** state)
     expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, excpect_msg);
 
     retval = get_info_attributes(attributes, values, &log_msg);
-    
+
     assert_int_equal(retval, expect_retval);
-    
+
     os_free(attributes);
     os_free(values);
 }
@@ -257,9 +257,9 @@ void test_get_info_attributes_text(void ** state)
     const int expect_retval = 0;
 
     retval = get_info_attributes(attributes, values, &log_msg);
-    
+
     assert_int_equal(retval, expect_retval);
-    
+
     os_free(attributes);
     os_free(values);
 }
@@ -282,9 +282,9 @@ void test_get_info_attributes_link(void ** state)
     const int expect_retval = 1;
 
     retval = get_info_attributes(attributes, values, &log_msg);
-    
+
     assert_int_equal(retval, expect_retval);
-    
+
     os_free(attributes);
     os_free(values);
 }
@@ -307,9 +307,9 @@ void test_get_info_attributes_cve(void ** state)
     const int expect_retval = 2;
 
     retval = get_info_attributes(attributes, values, &log_msg);
-    
+
     assert_int_equal(retval, expect_retval);
-    
+
     os_free(attributes);
     os_free(values);
 }
@@ -332,9 +332,9 @@ void test_get_info_attributes_osvdb(void ** state)
     const int expect_retval = 3;
 
     retval = get_info_attributes(attributes, values, &log_msg);
-    
+
     assert_int_equal(retval, expect_retval);
-    
+
     os_free(attributes);
     os_free(values);
 }
@@ -364,9 +364,9 @@ void test_get_info_attributes_invalid_value(void ** state)
     expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, excpect_msg);
 
     retval = get_info_attributes(attributes, values, &log_msg);
-    
+
     assert_int_equal(retval, expect_retval);
-    
+
     os_free(attributes);
     os_free(values);
 }
@@ -397,9 +397,9 @@ void test_get_info_attributes_invalid_type(void ** state)
     expect_string(__wrap__os_analysisd_add_logmsg, formatted_msg, excpect_msg);
 
     retval = get_info_attributes(attributes, values, &log_msg);
-    
+
     assert_int_equal(retval, expect_retval);
-    
+
     os_free(attributes);
     os_free(values);
 }
@@ -421,7 +421,7 @@ int main(void)
         cmocka_unit_test(test_get_info_attributes_cve),
         cmocka_unit_test(test_get_info_attributes_osvdb),
         cmocka_unit_test(test_get_info_attributes_invalid_value),
-        //cmocka_unit_test(test_get_info_attributes_invalid_type),
+        cmocka_unit_test(test_get_info_attributes_invalid_type)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_rules.c
+++ b/src/unit_tests/analysisd/test_rules.c
@@ -17,6 +17,7 @@
 #include "../../analysisd/config.h"
 #include "../../analysisd/eventinfo.h"
 #include "../../analysisd/analysisd.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
 char *loadmemory(char *at, const char *str, OSList* log_msg);
 int get_info_attributes(char **attributes, char **values, OSList* log_msg);
@@ -36,17 +37,6 @@ void __wrap__os_analysisd_add_logmsg(OSList * list, int level, int line, const c
 
     check_expected(level);
     check_expected_ptr(list);
-    check_expected(formatted_msg);
-}
-
-void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...) {
-    char formatted_msg[OS_MAXSTR];
-    va_list args;
-
-    va_start(args, msg);
-    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
-    va_end(args);
-
     check_expected(formatted_msg);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5364|

This issue covers the second round of unit tests for the new wazuh-logtest module. The tests to be developed will be those of the following functions:

## Tests

### New functions
**logtest.c**
- [x] w_logtest_init
- [x] w_logtest_init_parameters
- [x] w_logtest_clients_handler
- [x] w_logtest_process_log
- [x] w_logtest_preprocessing_phase
- [x] w_logtest_decoding_phase
- [x] w_logtest_rulesmatching_phase
- [x] w_logtest_initialize_session
- [x] w_logtest_remove_session
- [x] w_logtest_check_inactive_sessions
- [x] w_logtest_register_session
- [x] w_logtest_remove_old_session
- [x] w_logtest_fts_init
- [x] w_logtest_check_input
- [x] w_logtest_check_input_request
- [x] w_logtest_check_input_remove_session
- [x] w_logtest_generate_token
- [x] w_logtest_get_rule_level
- [x] w_logtest_add_msg_response
- [x] w_logtest_get_session
- [x] w_logtest_process_request
- [x] w_logtest_process_request_log_processing
- [x] w_logtest_process_request_remove_session
- [x] w_logtest_generate_error_response

**decoder_list.c**
- [x] os_remove_decoders_list
- [x] os_remove_decodernode
- [x] os_count_decoders

**decode-xml.c**
- [x] FreeDecoderInfo

**list_list.c**
- [x] os_remove_cdblist
- [x] os_remove_cdbrules

**rule_list.c**
- [x] os_remove_rules_list
- [x] os_remove_rulenode
- [x] os_remove_ruleinfo
- [x] os_count_rules

**eventinfo_list.c**
- [x] os_remove_eventlist

**logmsg.c**
- [x] _os_analysisd_add_list_log
- [x] os_analysisd_string_log_msg
- [x] os_analysisd_free_log_msg

### Modified functions

**rules.c**

- [x] loadmemory
- [x] get_info_attributes

**decode-xml.c**
- [x] _loadmemory
- [x] addDecoder2list			
- [x] FreeDecoderInfo		 

**list_list.c**
- [x] OS_ListLoadRules
- [x] OS_FindList