### PR TITLE
Initialize agent-upgrade as a default module

### DIFF
--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -13,17 +13,6 @@
 
 static const char *XML_NAME = "name";
 
-/**
- * List of modules that will be initialized by default
- * last position should be NULL
- * */
-static const void *default_modules[] = {
-    wm_agent_upgrade_read,
-    NULL
-};
-
-static bool default_modules_initialized = false;
-
 // Read wodle element
 
 int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
@@ -44,56 +33,32 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
         return OS_INVALID;
     }
 
-    cur_wmodule = *wmodules;
+    // Allocate memory
 
-    // Wodles that are going to be enabled by default
-    int i=0;
-    while (default_modules[i] && !default_modules_initialized) {
-        if(!cur_wmodule) {
-            *wmodules = cur_wmodule = calloc(1, sizeof(wmodule));
-        } else {
+    if ((cur_wmodule = *wmodules)) {
+        cur_wmodule_exists = *wmodules;
+        int found = 0;
+
+        while (cur_wmodule_exists) {
+            if(cur_wmodule_exists->tag) {
+                if(strcmp(cur_wmodule_exists->tag,node->values[0]) == 0) {
+                    cur_wmodule = cur_wmodule_exists;
+                    found = 1;
+                    break;
+                }
+            }
+            cur_wmodule_exists = cur_wmodule_exists->next;
+        }
+
+        if(!found) {
+            while (cur_wmodule->next)
+                cur_wmodule = cur_wmodule->next;
+
             os_calloc(1, sizeof(wmodule), cur_wmodule->next);
             cur_wmodule = cur_wmodule->next;
-            if (!cur_wmodule) {
-                merror(MEM_ERROR, errno, strerror(errno));
-                return (OS_INVALID);
-            }
         }
-        // Point to read function
-        int (*function_ptr)(xml_node **nodes, wmodule *module) = default_modules[i];
-        
-        if(function_ptr(NULL, cur_wmodule) == OS_INVALID) {
-            return OS_INVALID;
-        }
-        i++;
-    }
-
-    default_modules_initialized = true;
-
-
-    // Allocate memory
-    cur_wmodule_exists = *wmodules;
-    int found = 0;
-
-    while (cur_wmodule_exists) {
-        if(cur_wmodule_exists->tag) {
-            if(strcmp(cur_wmodule_exists->tag,node->values[0]) == 0) {
-                cur_wmodule = cur_wmodule_exists;
-                found = 1;
-                break;
-            }
-        }
-        cur_wmodule_exists = cur_wmodule_exists->next;
-    }
-
-    if(!found) {
-        while (cur_wmodule->next)
-            cur_wmodule = cur_wmodule->next;
-
-        os_calloc(1, sizeof(wmodule), cur_wmodule->next);
-        cur_wmodule = cur_wmodule->next;
-    }
-    
+    } else
+        *wmodules = cur_wmodule = calloc(1, sizeof(wmodule));
 
     if (!cur_wmodule) {
         merror(MEM_ERROR, errno, strerror(errno));

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -21,6 +21,25 @@ int wm_kill_timeout;        // Time for a process to quit before killing it
 int wm_debug_level;
 
 
+/**
+ * List of modules that will be initialized by default
+ * last position should be NULL
+ * */
+static const void *default_modules[] = {
+    wm_agent_upgrade_read,
+    NULL
+};
+
+/**
+ * Initializes the default wmodules (will be enabled even if the wodle section for that module)
+ * is not defined
+ * @param wmodules pointer to wmodules array structure
+ * @return a status flag
+ * @retval OS_SUCCESS if all reading methods are executed successfully
+ * @retval OS_INVALID if there is an error
+ * */
+static int wm_initialize_default_modules(wmodule **wmodules);
+
 // Read XML configuration and internal options
 
 int wm_config() {
@@ -32,6 +51,11 @@ int wm_config() {
     wm_task_nice = getDefine_Int("wazuh_modules", "task_nice", -20, 19);
     wm_max_eps = getDefine_Int("wazuh_modules", "max_eps", 1, 1000);
     wm_kill_timeout = getDefine_Int("wazuh_modules", "kill_timeout", 0, 3600);
+
+    if(wm_initialize_default_modules(&wmodules) < 0) {
+        return OS_INVALID;
+    }
+
 
     // Read configuration: ossec.conf
 
@@ -472,3 +496,28 @@ void freegate(gateway *gate){
     os_free(gate);
 }
 #endif
+
+static int wm_initialize_default_modules(wmodule **wmodules) {
+    wmodule *cur_wmodule = *wmodules;
+    int i=0;
+    while (default_modules[i]) {
+        if(!cur_wmodule) {
+            *wmodules = cur_wmodule = calloc(1, sizeof(wmodule));
+        } else {
+            os_calloc(1, sizeof(wmodule), cur_wmodule->next);
+            cur_wmodule = cur_wmodule->next;
+            if (!cur_wmodule) {
+                merror(MEM_ERROR, errno, strerror(errno));
+                return (OS_INVALID);
+            }
+        }
+        // Point to read function
+        int (*function_ptr)(xml_node **nodes, wmodule *module) = default_modules[i];
+        
+        if(function_ptr(NULL, cur_wmodule) == OS_INVALID) {
+            return OS_INVALID;
+        }
+        i++;
+    }
+    return OS_SUCCESS;
+}


### PR DESCRIPTION
## Description

Change default behaviour on `agent-upgrade` module so it is enabled by default. 

## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

