### PR TITLE
Fix memleak bad opt rules - Analisysd

### DIFF
--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -50,6 +50,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
     OS_XML xml;
     XML_NODE node = NULL;
     XML_NODE rule = NULL;
+    XML_NODE rule_opt = NULL;
     int retval = -1;
 
     /* XML variables */
@@ -395,7 +396,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 program_name = NULL;
                 location = NULL;
 
-                XML_NODE rule_opt = NULL;
                 rule_opt =  OS_GetElementsbyNode(&xml, rule[j]);
                 if (rule_opt == NULL) {
                     smerror(log_msg, "Rule '%d' without any option. It may lead to false positives and some "
@@ -1646,6 +1646,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 }
 
                 OS_ClearNode(rule_opt);
+                rule_opt = NULL;
             } /* end of elements block */
 
             /* Assign an active response to the rule */
@@ -1760,7 +1761,8 @@ cleanup:
     free(data);
     free(rulepath);
     OS_ClearNode(rule);
-
+    OS_ClearNode(rule_opt);
+    
     if (retval) {
         os_remove_ruleinfo(config_ruleinfo);
     }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5704|

## Description

Hi team!

This PR fix a a memory leak when rules loading fails due to an invalid option.  This is not important in the current version since when loading a rule with an invalid option analisysd ends with a critical message but this is important for the new wazuh-logtest that it should never end its execution due to errors in loading rules and decoders.


## Tests

- [X] Linux: Compilation without warnings 
- [X] Valgrind (memcheck and descriptor leaks check)
- [X] Scan-build report
- [X] Check unit test

Regards,
Julian