### PR TITLE
sync-agent-info-get memory leak fix

### DIFF
--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -211,8 +211,13 @@ wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char
 
                 //Get labels if any
                 cJSON* json_labels = wdb_global_get_agent_labels(wdb, agent_id);
-                if (json_labels && json_labels->child){
-                    cJSON_AddItemToObject(json_agent, "labels", json_labels);
+                if (json_labels) {
+                    if (json_labels->child) {
+                        cJSON_AddItemToObject(json_agent, "labels", json_labels);
+                    }
+                    else {
+                        cJSON_Delete(json_labels);
+                    }                        
                 }
 
                 //Print Agent info


### PR DESCRIPTION
|Related issue|
|---|
|5769|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR fix a memory leak occured when a valid json object is returned as a labels query but the response has no child field.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

