### PR TITLE
Fix wazuh.json path and add clean to setup.py 4.0.0 installation

### DIFF
--- a/framework/setup.py
+++ b/framework/setup.py
@@ -30,7 +30,7 @@ class InstallCommand(install):
 
     def run(self):
         here = os.path.abspath(os.path.dirname(__file__))
-        with open(os.path.join(here, 'wazuh', 'wazuh.json'), 'w') as f:
+        with open(os.path.join(here, 'wazuh', 'core', 'wazuh.json'), 'w') as f:
             json.dump({'install_type': self.install_type,
                        'wazuh_version': self.wazuh_version,
                        'installation_date': datetime.utcnow().strftime('%a %b %d %H:%M:%S UTC %Y')
@@ -47,7 +47,7 @@ setup(name='wazuh',
       author_email='hello@wazuh.com',
       license='GPLv2',
       packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
-      package_data={'wazuh': ['wazuh.json', 'core/cluster/cluster.json', 'rbac/default/*.yaml']},
+      package_data={'wazuh': ['core/wazuh.json', 'core/cluster/cluster.json', 'rbac/default/*.yaml']},
       include_package_data=True,
       install_requires=[],
       zip_safe=False,

--- a/src/Makefile
+++ b/src/Makefile
@@ -1580,7 +1580,7 @@ install_dependencies: install_python
 	LD_LIBRARY_PATH="${PREFIX}/lib" LDFLAGS="-L${PREFIX}/lib" ${WPYTHON_DIR}/bin/pip3 install -r ../framework/${python_dependencies}  --index-url=file://${ROUTE_PATH}/${EXTERNAL_CPYTHON}/Dependencies/simple
 
 install_framework: install_python
-	cd ../framework && ${WPYTHON_DIR}/bin/python3 setup.py clean -all install --prefix=${WPYTHON_DIR} --wazuh-version=$(shell cat VERSION) --install-type=${TARGET}
+	cd ../framework && ${WPYTHON_DIR}/bin/python3 setup.py clean --all install --prefix=${WPYTHON_DIR} --wazuh-version=$(shell cat VERSION) --install-type=${TARGET}
 	chown -R root:${OSSEC_GROUP} ${WPYTHON_DIR}
 	chmod -R o=- ${WPYTHON_DIR}
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1580,7 +1580,7 @@ install_dependencies: install_python
 	LD_LIBRARY_PATH="${PREFIX}/lib" LDFLAGS="-L${PREFIX}/lib" ${WPYTHON_DIR}/bin/pip3 install -r ../framework/${python_dependencies}  --index-url=file://${ROUTE_PATH}/${EXTERNAL_CPYTHON}/Dependencies/simple
 
 install_framework: install_python
-	cd ../framework && ${WPYTHON_DIR}/bin/python3 setup.py install --prefix=${WPYTHON_DIR} --wazuh-version=$(shell cat VERSION) --install-type=${TARGET}
+	cd ../framework && ${WPYTHON_DIR}/bin/python3 setup.py clean -all install --prefix=${WPYTHON_DIR} --wazuh-version=$(shell cat VERSION) --install-type=${TARGET}
 	chown -R root:${OSSEC_GROUP} ${WPYTHON_DIR}
 	chmod -R o=- ${WPYTHON_DIR}
 


### PR DESCRIPTION
Hello team, 

This PR fixes a problem where `wazuh.json` was not being generated in the correct folder during framework installation, causing some empty fields in GET /manager/info responses. It also adds a clean step to framework installation for 4.0.0 to avoid using old version build.

### Tests:

```
curl -X GET "https://localhost:55000/manager/info" -H  "accept: application/json" -H  "Authorization: Bearer TOKEN"
{
  "data": {
    "affected_items": [
      {
        "path": "/var/ossec",
        "version": "v4.0.0",
        "compilation_date": "2020-08-19T07:11:05Z",
        "type": "server",
        "max_agents": "N/A",
        "openssl_support": "N/A",
        "ruleset_version": "40000",
        "tz_offset": "+0000",
        "tz_name": "UTC"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Basic information read successfully in specified node"
}
```

```
Installed /var/ossec/framework/python/lib/python3.8/site-packages/wazuh-4.0.0-py3.8.egg
Processing dependencies for wazuh==4.0.0
Finished processing dependencies for wazuh==4.0.0
```


