### PR TITLE
Fix API integration tests for new wpk repo for upgrading to 4.x

### DIFF
--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -100,12 +100,13 @@ def test_validate_upgrade(response):
            or response.json().get('code', None) == 1718
     if response.json().get('message', None) == "Upgrade procedure started":
         time.sleep(45)
-        return Box({"upgraded": True})
+        return Box({"upgraded": 1})
     else:
-        return Box({"upgraded": False})
+        return Box({"upgraded": 0})
 
 
 def test_validate_upgrade_result(response, upgraded):
+    upgraded = int(upgraded, 10)
     if upgraded == 1:
         assert response.json().get('message', None) == "Agent upgraded successfully"
     else:

--- a/api/test/integration/test_agents_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_GET_endpoints.tavern.yaml
@@ -4027,3 +4027,41 @@ stages:
        function: tavern_utils:test_validate_upgrade_result
        extra_kwargs:
         upgraded: "{upgraded:b}"
+
+ - name: Upgrade an agent to an invalid version
+   request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/002/upgrade?wait_for_complete=true"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        version: 10000.10000.10000
+        force: True
+   response:
+      status_code:
+        - 200
+        - 500
+      verify_response_with:
+        function: tavern_utils:test_validate_upgrade
+      save:
+        $ext:
+          function: tavern_utils:test_validate_upgrade
+
+ - name: Get agent upgrade result (invalid version)
+   request:
+     verify: False
+     url: "{protocol:s}://{host:s}:{port:d}/agents/002/upgrade_result?wait_for_complete=true"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+     params:
+       wait_for_complete: True
+   response:
+     status_code:
+       - 200
+       - 400
+     verify_response_with:
+       function: tavern_utils:test_validate_upgrade_result
+       extra_kwargs:
+         upgraded: "{upgraded:b}"

--- a/api/test/integration/test_agents_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_PUT_endpoints.tavern.yaml
@@ -669,7 +669,7 @@ test_name: PUT /agents/{agent_id}/upgrade
 stages:
 
     # PUT /agents/002/upgrade
-  - name: Try to upgrade a not existing agent
+  - name: Try to upgrade a non existing agent
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/999/upgrade"
@@ -707,11 +707,11 @@ stages:
       json:
         <<: *error_spec
 
-    # PUT /agents/001/upgrade
+    # PUT /agents/006/upgrade
   - name: Upgrade an agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/upgrade"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/006/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -726,11 +726,11 @@ stages:
         function: tavern_utils:test_validate_upgrade
     delay_after: !float "{upgrade_delay}"
 
-    # PUT /agents/001/upgrade
+    # PUT /agents/006/upgrade
   - name: Try to upgrade an agent that is updated to the latest version
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/upgrade"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/006/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"


### PR DESCRIPTION
Hi team,

In this PR I have fixed some errors that appeared when https://github.com/wazuh/wazuh/pull/5707 merged into develop and with the functionality some API integration tests were testing.
Some API integration test cases were testing the new wpk path for 4.x in the upgrade module. Some fixes in that tests were needed:
**-test_agents_PUT_endpoints.tavern.yaml**: a different agent is being upgrading for a test in order to avoid race conditions.
**-test_agents_GET_endpoints.tavern.yaml**: changes on the function test_validate_upgrade_result of tavern_utils.py. Some variable casting were needed in order to make an if-else statement work again. Added a new test case to this integration test, too (upgrading an agent to an invalid version).

The only tests with changes or with functions that were changed are `test_agents_PUT_endpoints.tavern.yaml` and `test_agents_GET_endpoints.tavern.yaml`.
**Test results:**

```
python3 run_tests.py -k agents_PUT
Collected tests [1]:
test_agents_PUT_endpoints.tavern.yaml


test_agents_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings
```
	 
```
python3 run_tests.py -k agents_GET
Collected tests [1]:
test_agents_GET_endpoints.tavern.yaml


test_agents_GET_endpoints.tavern.yaml 
	 90 passed, 97 warnings
```