### PR TITLE
Fix ID filter in MITRE

### DIFF
--- a/api/api/controllers/mitre_controller.py
+++ b/api/api/controllers/mitre_controller.py
@@ -15,13 +15,12 @@ from wazuh.core.cluster.dapi.dapi import DistributedAPI
 logger = logging.getLogger('wazuh')
 
 
-async def get_attack(request, pretty=False, wait_for_complete=False, attack_id=None, offset=0, limit=database_limit,
+async def get_attack(request, pretty=False, wait_for_complete=False, offset=0, limit=database_limit,
                      phase_name=None, platform_name=None, q=None, search=None, select=None, sort=None):
     """Get information from MITRE ATT&CK database
 
     :param pretty: Show results in human-readable format
     :param wait_for_complete: Disable timeout response
-    :param attack_id: Filters by attack ID.
     :param phase_name: Filters by phase
     :param platform_name: Filters by platform
     :param search: Search if the string is contained in the db
@@ -32,7 +31,7 @@ async def get_attack(request, pretty=False, wait_for_complete=False, attack_id=N
     :param q: Query to filter by
     :return: Data
     """
-    f_kwargs = {'id_': attack_id,
+    f_kwargs = {'id_': request.query.get('id', None),
                 'phase_name': phase_name,
                 'platform_name': platform_name,
                 'select': select,

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -24,26 +24,30 @@ stages:
               json: !anydict
               platform_name: !anylist
 
-    # GET /mitre?limit=1
+    # GET /mitre?limit=5
   - name: Try to get MITRE attacks using limit parameter
     request:
       verify: False
       <<: *get_mitre
       params:
-        limit: 1
+        limit: 5
     response:
       status_code: 200
       json:
         data:
           affected_items:
             - <<: *full_items_array
+            - <<: *full_items_array
+            - <<: *full_items_array
+            - <<: *full_items_array
+            - <<: *full_items_array
       # Save some data for future use in the test
       save:
         json:
-          returned_phase: data.affected_items[0].phase_name
-          returned_id: data.affected_items[0].id
-          returned_json: data.affected_items[0].json
-          returned_platform: data.affected_items[0].platform_name
+          returned_phase: data.affected_items[2].phase_name
+          returned_id: data.affected_items[2].id
+          returned_json: data.affected_items[2].json
+          returned_platform: data.affected_items[2].platform_name
 
     # We implement a dual stage to check offset parameter behaviour
     # GET /mitre?limit=2&offset=0
@@ -99,6 +103,7 @@ stages:
       <<: *get_mitre
       params:
         id: "{returned_id}"
+        limit: 1
     response:
       status_code: 200
       json:


### PR DESCRIPTION
Hello team!

# Description

Due to a bug, when trying to filter MITRE attacks by `ID` it did return all of them. However, it was working if filtering ID inside `q` parameter.

In one of the MITRE tests (integration tests), the id of the first attack returned when performing the request `/mitre?limit=1` was stored. Then, in another test which was checking the behaviour of ID filter, it used said ID. Even though it was not the only id returned, the one specified was the first in the response, so it matched and the test passed.

Now it has been modified in order to store a different ID (not the first one) and I checked that it works fine now.

# Tests performed
## Unit tests
```
python3 -m pytest wazuh/tests/test_mitre.py 
============================================ test session starts ============================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, html-2.0.1
collected 180 items                                                                                         

wazuh/tests/test_mitre.py ........................................................................... [ 41%]
..................................................................................................... [ 97%]
....                                                                                                  [100%]

============================================ 180 passed in 0.58s ============================================
```
## Integration tests
```
pytest -vv test_mitre_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-42-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, html-2.0.1
collected 1 item                                                                                                                                                                                             

test_mitre_endpoints.tavern.yaml::GET /mitre PASSED                                                                                                                                                    [100%]

============================================================================================== warnings summary ==============================================================================================
```

Kind regards,
Selu.