### PR TITLE
Fix memory leak when load analisysd config

### DIFF
--- a/src/config/rules-config.c
+++ b/src/config/rules-config.c
@@ -392,12 +392,36 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
     OSRegex_FreePattern(&regex);
 
 cleanup:
-    free(exclude_decoders);
-    free(exclude_rules);
-    free(decoder_dirs);
-    free(rules_dirs);
-    free(decoder_dirs_pattern);
-    free(rules_dirs_pattern);
+
+    for (i = 0; exclude_decoders[i]; i++) {
+        free(exclude_decoders[i]);
+    }
+    os_free(exclude_decoders);
+
+    for (i = 0; exclude_rules[i]; i++) {
+        free(exclude_rules[i]);
+    }
+    os_free(exclude_rules);
+
+    for (i = 0; decoder_dirs[i]; i++) {
+        free(decoder_dirs[i]);
+    }
+    os_free(decoder_dirs);
+
+    for (i = 0; rules_dirs[i]; i++) {
+        free(rules_dirs[i]);
+    }
+    os_free(rules_dirs);
+
+    for (i = 0; decoder_dirs_pattern[i]; i++) {
+        free(decoder_dirs_pattern[i]);
+    }
+    os_free(decoder_dirs_pattern);
+
+    for (i = 0; rules_dirs_pattern[i]; i++) {
+        free(rules_dirs_pattern[i]);
+    }
+    os_free(rules_dirs_pattern);
 
     return retval;
 }

--- a/src/config/rules-config.c
+++ b/src/config/rules-config.c
@@ -392,36 +392,12 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
     OSRegex_FreePattern(&regex);
 
 cleanup:
-
-    for (i = 0; exclude_decoders[i]; i++) {
-        free(exclude_decoders[i]);
-    }
-    os_free(exclude_decoders);
-
-    for (i = 0; exclude_rules[i]; i++) {
-        free(exclude_rules[i]);
-    }
-    os_free(exclude_rules);
-
-    for (i = 0; decoder_dirs[i]; i++) {
-        free(decoder_dirs[i]);
-    }
-    os_free(decoder_dirs);
-
-    for (i = 0; rules_dirs[i]; i++) {
-        free(rules_dirs[i]);
-    }
-    os_free(rules_dirs);
-
-    for (i = 0; decoder_dirs_pattern[i]; i++) {
-        free(decoder_dirs_pattern[i]);
-    }
-    os_free(decoder_dirs_pattern);
-
-    for (i = 0; rules_dirs_pattern[i]; i++) {
-        free(rules_dirs_pattern[i]);
-    }
-    os_free(rules_dirs_pattern);
+    free_strarray(exclude_decoders);
+    free_strarray(exclude_rules);
+    free_strarray(decoder_dirs);
+    free_strarray(rules_dirs);
+    free_strarray(decoder_dirs_pattern);
+    free_strarray(rules_dirs_pattern);
 
     return retval;
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5703|


## Description

Hi team!

This PR fix a a memory leak when load analisysd config.

Before:
```
==31560== LEAK SUMMARY:
==31560==    definitely lost: 100 bytes in 9 blocks
==31560==    indirectly lost: 0 bytes in 0 blocks
==31560==      possibly lost: 11,424 bytes in 42 blocks
==31560==    still reachable: 1,851,870 bytes in 436 blocks
==31560==         suppressed: 0 bytes in 0 blocks
==31560== Reachable blocks (those to which a pointer was found) are not shown.
==31560== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

With this change:
```
==23846== LEAK SUMMARY:
==23846==    definitely lost: 0 bytes in 0 blocks
==23846==    indirectly lost: 0 bytes in 0 blocks
==23846==      possibly lost: 13,872 bytes in 51 blocks
==23846==    still reachable: 41,810,886 bytes in 205,990 blocks
==23846==         suppressed: 0 bytes in 0 blocks
==23846== Reachable blocks (those to which a pointer was found) are not shown.
==23846== To see them, rerun with: --leak-check=full --show-leak-kinds=all

```

## Tests

- [X] Linux: Compilation without warnings 
- [X] Valgrind (memcheck and descriptor leaks check)
- [X] Scan-build report
- [X] Check unit test

Regards,
Julian