### PR TITLE
Syscollector: Enhance Windows registry fetcher

### DIFF
--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -78,6 +78,8 @@
 #define WM_SYS_HW_DIR   "/sys/class/dmi/id"
 #define WM_SYS_NET_DIR  "/proc/net/"
 #define RPM_DATABASE    "/var/lib/rpm/Packages"
+#define WIN_REG_HOTFIX "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\Packages"
+#define VISTA_REG_HOTFIX "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\HotFix"
 
 /* MAC package search paths */
 

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -78,8 +78,12 @@
 #define WM_SYS_HW_DIR   "/sys/class/dmi/id"
 #define WM_SYS_NET_DIR  "/proc/net/"
 #define RPM_DATABASE    "/var/lib/rpm/Packages"
-#define WIN_REG_HOTFIX "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\Packages"
-#define VISTA_REG_HOTFIX "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\HotFix"
+
+#define WIN_REG_HOTFIX    "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\Packages"
+#define VISTA_REG_HOTFIX  "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\HotFix"
+#define HOTFIX_INSTALLED  112
+#define HOTFIX_SUPERSEDED 80
+#define HOTFIX_STAGED     64
 
 /* MAC package search paths */
 

--- a/src/wazuh_modules/syscollector/syscollector_windows.c
+++ b/src/wazuh_modules/syscollector/syscollector_windows.c
@@ -981,7 +981,7 @@ void list_hotfixes(HKEY hKey, int usec, const char *timestamp, int ID, const cha
                 //  Open the hotfix key
                 result = RegOpenKeyEx(hKey, achKey, 0, KEY_READ, &subKey);
                 if (result != ERROR_SUCCESS) {
-                    merror("Error opening Windows registry.");
+                    mterror(WM_SYS_LOGTAG, "Error opening Windows registry.");
                     continue;
                 }
 
@@ -1061,7 +1061,7 @@ char * parse_Rollup_hotfix(HKEY hKey, char *value) {
     
     result = RegQueryValueEx(hKey, "InstallLocation", NULL, NULL, (LPBYTE)value, &dataSize);  
     if (result != ERROR_SUCCESS ) {
-        mtdebug2(WM_SYS_LOGTAG, "Error reading 'InstallLocation' from Windows registry. (Error %u)",(unsigned int)result);
+        mterror(WM_SYS_LOGTAG, "Error reading 'InstallLocation' from Windows registry. (Error %u)",(unsigned int)result);
         return NULL;
     }
 
@@ -1096,7 +1096,7 @@ bool valid_hotfix_status(HKEY hKey) {
     
     result = RegQueryValueEx(hKey, "CurrentState", NULL, NULL, (LPBYTE)&value, &dataSize);  
     if (result != ERROR_SUCCESS ) {
-        mtdebug2(WM_SYS_LOGTAG, "Error reading 'CurrentState' from Windows registry. (Error %u)",(unsigned int)result);
+        mterror(WM_SYS_LOGTAG, "Error reading 'CurrentState' from Windows registry. (Error %u)",(unsigned int)result);
         return false;
     }
 


### PR DESCRIPTION
|Related issue| 
|---|
|#5664|

## Description

This PR adds the capability to handle some odd and unexpected cases when fetching hotfixes' information from the Registry.

- Discard hotfixes which weren't successfully installed, by checking the `LastError` field. #5392
- Discard hotfixes which, for unknown reasons, have invalid states (by checking `CurrentState` field). #5392 
- Read hotfixes keys with less common name patterns.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [ ] Package installation
