### PR TITLE
Change some spec.yaml descriptions and minor changes

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3652,7 +3652,7 @@ components:
     file_format:
       in: query
       name: format
-      description: "Select output format to return the file. JSON will format the file in JSON format and XML will return the XML raw file in a string"
+      description: "Filter by file format. For example 'deb' will output deb files."
       schema:
         type: string
         format: alphanumeric
@@ -6671,6 +6671,8 @@ paths:
             $ref: '#/components/responses/ResponseError'
           '401':
             $ref: '#/components/responses/UnauthorizedResponse'
+          '403':
+            $ref: '#/components/responses/PermissionDeniedResponse'
           '405':
             $ref: '#/components/responses/InvalidHTTPMethodResponse'
           '429':
@@ -12653,6 +12655,14 @@ paths:
               example: "<generated_token>"
         '400':
           $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
 
     delete:
       tags:
@@ -12671,6 +12681,14 @@ paths:
                 message: "User wazuh logout correctly."
         '400':
           $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
 
   /security/actions:
     get:
@@ -13323,7 +13341,7 @@ paths:
       tags:
         - security
       summary: "Create a relation between one role and one or more policies"
-      description: "Create a specify relation role-policy, one role may have multiples policies"
+      description: "Create a specified relation role-policy, one role may have multiples policies"
       operationId: api.controllers.security_controller.set_role_policy
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/security:update'
@@ -13390,8 +13408,8 @@ paths:
     delete:
       tags:
         - security
-      summary: "Delete a specify relation role-policy"
-      description: "Delete a specify relation role-policy"
+      summary: "Delete a specified relation role-policy"
+      description: "Delete a specified relation role-policy"
       operationId: api.controllers.security_controller.remove_role_policy
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/security:delete'
@@ -13437,8 +13455,8 @@ paths:
     post:
       tags:
         - security
-      summary: "Create a specify relation between one user and one role"
-      description: "Create a specify relation role-policy, one user may have multiples roles"
+      summary: "Create a specified relation between one user and one role"
+      description: "Create a specified relation role-policy, one user may have multiples roles"
       operationId: api.controllers.security_controller.set_user_role
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/security:update'
@@ -13486,8 +13504,8 @@ paths:
     delete:
       tags:
         - security
-      summary: "Delete a specify relation user-roles"
-      description: "Delete a specify relation user-roles"
+      summary: "Delete a specified relation user-roles"
+      description: "Delete a specified relation user-roles"
       operationId: api.controllers.security_controller.remove_user_role
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/security:delete'
@@ -13592,6 +13610,14 @@ paths:
                   message: Current user information was shown
         '400':
           $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
 
   /security/users:
     get:
@@ -13695,7 +13721,7 @@ paths:
                 - password
       responses:
         '200':
-          description: "User created successful"
+          description: "User created successfully"
           content:
             application/json:
               schema:


### PR DESCRIPTION
Hi team,

In this PR, I have made some changes to the spec.yaml file. Changed some endpoint descriptions and added some examples of responses that were missing.

**Summary of the changes:**
```
-file_format had a wrong description, changed to a more appropriate one.
-PUT /agents/node/{node_id}/restart: added 403 response.
-GET /security/user/authenticate: added 401, 403, 405 and 429 responses.
-DELETE /security/user/authenticate: added 401, 403, 405 and 429 responses.
-GET /security/users/me: added 401, 403, 405 and 429 responses.
-POST /security/users/me: changed 200 response message.
-Changed "specify" to "specified" in next endpoint descriptions:
     POST /security/roles/{role_id}/policies
     DELETE /security/roles/{role_id}/policies
     POST /security/users/{user_id}/roles
     DELETE /security/users/{user_id}/roles
```