### PR TITLE
Fix index patterns version in wazuh-template

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -1,8 +1,8 @@
 {
   "order": 0,
   "index_patterns": [
-    "wazuh-alerts-3.x-*",
-    "wazuh-archives-3.x-*"
+    "wazuh-alerts-4.x-*",
+    "wazuh-archives-4.x-*"
   ],
   "settings": {
     "index.refresh_interval": "5s",


### PR DESCRIPTION
The PR https://github.com/wazuh/wazuh/pull/5796 adapted all configuration files related, the wazuh-template.json was not correctly updated. This PR updates the index patterns name in the wazuh-template.json.