### PR TITLE
Vulnerability-Detector: Unit test for the MSU feed 

### DIFF
--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 # Tests list and flags
 list(APPEND shared_tests_names "test_file_op")
-list(APPEND shared_tests_flags "-Wl,--wrap,isChroot -Wl,--wrap,stat -Wl,--wrap,chmod -Wl,--wrap,File_DateofChange -Wl,--wrap,getpid -Wl,--wrap,unlink -Wl,--wrap,_merror -Wl,--wrap,_minfo -Wl,--wrap,_mwarn -Wl,--wrap,fopen -Wl,--wrap,_mferror")
+list(APPEND shared_tests_flags "-Wl,--wrap,isChroot -Wl,--wrap,stat -Wl,--wrap,chmod -Wl,--wrap,File_DateofChange -Wl,--wrap,getpid -Wl,--wrap,unlink -Wl,--wrap,_merror -Wl,--wrap,_minfo -Wl,--wrap,_mwarn -Wl,--wrap,fopen -Wl,--wrap,_mferror,--wrap=fread,--wrap=fclose,--wrap=fprintf,--wrap=bzip2_uncompress,--wrap=mdebug1")
 
 list(APPEND shared_tests_names "test_integrity_op")
 list(APPEND shared_tests_flags " ")

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -83,6 +83,50 @@ FILE* __wrap_fopen(const char* path, const char* mode) {
     }
 }
 
+size_t __real_fread(void *ptr, size_t size, size_t n, FILE *stream);
+size_t __wrap_fread(void *ptr, size_t size, size_t n, FILE *stream) {
+    if (unit_testing) {
+        strncpy((char *) ptr, mock_type(char *), n);
+        return mock();
+    }
+    return __real_fread(ptr, size, n, stream);
+}
+
+extern int __real_fclose ( FILE * stream );
+int __wrap_fclose ( FILE * stream ) {
+    if(!unit_testing)
+        return __real_fclose(stream);
+    return 0;
+}
+
+int __wrap_bzip2_uncompress(const char *filebz2, const char *file) {
+
+    check_expected_ptr(filebz2);
+    check_expected_ptr(file);
+    return mock();
+}
+
+extern int __real_fprintf ( FILE * stream, const char * format, ... );
+int __wrap_fprintf ( FILE * stream, const char * format, ... ) {
+    char formatted_msg[60];
+    va_list args;
+
+    va_start(args, format);
+    vsnprintf(formatted_msg, 60, format, args);
+    va_end(args);
+
+    if(!unit_testing)
+        return __real_fprintf(stream, formatted_msg);
+
+    check_expected(stream);
+    check_expected(formatted_msg);
+    return 0;
+}
+
+int __wrap__mdebug1() {
+    return 0;
+}
+
 /* setups/teardowns */
 static int setup_group(void **state) {
     unit_testing = 1;
@@ -107,10 +151,6 @@ void test_CreatePID_success(void **state)
 {
     (void) state;
     int ret;
-    FILE* fp = __real_fopen("./test_file.tmp", "a");
-    char* content = NULL;
-
-    *state = content;
 
     will_return(__wrap_isChroot, 1);
 
@@ -119,21 +159,13 @@ void test_CreatePID_success(void **state)
 
     expect_string(__wrap_fopen, path, "/var/run/test-42.pid");
     expect_string(__wrap_fopen, mode, "a");
-    will_return(__wrap_fopen, fp);
+    will_return(__wrap_fopen, 1);
+
+    expect_value(__wrap_fprintf, stream, 1);
+    expect_string(__wrap_fprintf, formatted_msg, "42\n");
 
     ret = CreatePID("test", 42);
     assert_int_equal(0, ret);
-
-    // Reopen the file for content checking
-    fp = __real_fopen("./test_file.tmp", "r");
-
-    assert_non_null(fp);
-
-    char buff[256];
-    fgets(buff, 256, fp);
-    fclose(fp);
-
-    assert_string_equal(buff, "42\n");
 }
 
 void test_CreatePID_failure_chmod(void **state)
@@ -152,6 +184,9 @@ void test_CreatePID_failure_chmod(void **state)
     expect_string(__wrap_fopen, path, "/var/run/test-42.pid");
     expect_string(__wrap_fopen, mode, "a");
     will_return(__wrap_fopen, fp);
+
+    expect_value(__wrap_fprintf, stream, fp);
+    expect_string(__wrap_fprintf, formatted_msg, "42\n");
 
     ret = CreatePID("test", 42);
     assert_int_equal(-1, ret);
@@ -199,6 +234,86 @@ void test_DeletePID_failure(void **state)
     assert_int_equal(-1, ret);
 }
 
+// w_is_compressed_gz_file
+
+void test_w_is_compressed_gz_file_uncompressed(void **state) {
+
+    char * path = "/test/file.gz";
+    int ret = 0;
+
+    expect_string(__wrap_fopen, path, "/test/file.gz");
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    will_return(__wrap_fread, "fake");
+    will_return(__wrap_fread, 2);
+
+    ret = w_is_compressed_gz_file(path);
+    assert_int_equal(ret, 0);
+}
+
+// w_is_compressed_bz2_file
+
+void test_w_is_compressed_bz2_file_compressed(void **state) {
+
+    char * path = "/test/file.bz2";
+    int ret = 0;
+
+    expect_string(__wrap_fopen, path, "/test/file.bz2");
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    // BZh is 0x42 0x5a 0x68
+    will_return(__wrap_fread, "BZh");
+    will_return(__wrap_fread, 3);
+
+    ret = w_is_compressed_bz2_file(path);
+    assert_int_equal(ret, 1);
+}
+
+void test_w_is_compressed_bz2_file_uncompressed(void **state) {
+
+    char * path = "/test/file.bz2";
+    int ret = 0;
+
+    expect_string(__wrap_fopen, path, "/test/file.bz2");
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    will_return(__wrap_fread, "fake");
+    will_return(__wrap_fread, 3);
+
+    ret = w_is_compressed_bz2_file(path);
+    assert_int_equal(ret, 0);
+}
+
+// w_uncompress_bz2_gz_file
+
+void test_w_uncompress_bz2_gz_file_bz2(void **state) {
+
+    char * path = "/test/file.bz2";
+    char * dest = "/test/file";
+    int ret;
+
+    expect_string(__wrap_fopen, path, "/test/file.bz2");
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    will_return(__wrap_fread, "BZh");
+    will_return(__wrap_fread, 3);
+
+    expect_string(__wrap_bzip2_uncompress, filebz2, "/test/file.bz2");
+    expect_string(__wrap_bzip2_uncompress, file, "/test/file");
+    will_return(__wrap_bzip2_uncompress, 0);
+
+    expect_string(__wrap_fopen, path, "/test/file.bz2");
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 0);
+
+    ret = w_uncompress_bz2_gz_file(path, dest);
+    assert_int_equal(ret, 0);
+
+}
 
 int main(void) {
     const struct CMUnitTest tests[] = {
@@ -207,6 +322,10 @@ int main(void) {
         cmocka_unit_test(test_CreatePID_failure_fopen),
         cmocka_unit_test(test_DeletePID_success),
         cmocka_unit_test(test_DeletePID_failure),
+        cmocka_unit_test(test_w_is_compressed_gz_file_uncompressed),
+        cmocka_unit_test(test_w_is_compressed_bz2_file_compressed),
+        cmocka_unit_test(test_w_is_compressed_bz2_file_uncompressed),
+        cmocka_unit_test(test_w_uncompress_bz2_gz_file_bz2)
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -60,6 +60,7 @@ void wm_vuldet_clean_vulnerability_info(wm_vuldet_db *ctrl_block);
 int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_stmt *stmt);
 void wm_vuldet_set_subversion(char *version, char **os_minor);
 void wm_vuldet_get_package_os(const char *version, const char **os_major, char **os_minor);
+char * wm_vuldet_get_hash(const char *target);
 
 /* setup/teardown */
 
@@ -15469,6 +15470,83 @@ void test_wm_vuldet_get_package_os_rhel8(void **state)
     os_free(os_minor);
 }
 
+void wm_vuldet_get_hash_open_fail(void **state) 
+{
+    will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
+
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
+    will_return(__wrap_sqlite3_close_v2, 1);
+
+    char *str = wm_vuldet_get_hash("MSU");
+    assert_null(str);
+}
+
+void wm_vuldet_get_hash_prepare_fail(void **state) 
+{
+    will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
+
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
+    will_return(__wrap_sqlite3_close_v2, 1);
+
+    char *str = wm_vuldet_get_hash("MSU");
+    assert_null(str);
+}
+
+void wm_vuldet_get_hash_one_row(void **state) 
+{
+    will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    char *hash = "hashvalue1234567";
+    char *target = "MSU";
+
+    expect_value(__wrap_sqlite3_bind_text, a, 1);
+    expect_string(__wrap_sqlite3_bind_text, b, target);
+    will_return(__wrap_sqlite3_bind_text, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_text, i, 0);
+    will_return(__wrap_sqlite3_column_text, hash);
+
+    will_return(__wrap_sqlite3_close_v2, 1);
+
+    char *str = wm_vuldet_get_hash(target);
+    assert_string_equal(hash, str);
+
+    os_free(str);
+}
+
+void wm_vuldet_get_hash_no_row(void **state) 
+{
+    will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    char *hash = "hashvalue1234567";
+    char *target = "MSU";
+
+    expect_value(__wrap_sqlite3_bind_text, a, 1);
+    expect_string(__wrap_sqlite3_bind_text, b, target);
+    will_return(__wrap_sqlite3_bind_text, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    will_return(__wrap_sqlite3_close_v2, 1);
+
+    char *str = wm_vuldet_get_hash(target);
+    assert_null(str);
+}
+
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -15873,7 +15951,12 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_get_package_os_rhel5),
         cmocka_unit_test(test_wm_vuldet_get_package_os_rhel6),
         cmocka_unit_test(test_wm_vuldet_get_package_os_rhel7),
-        cmocka_unit_test(test_wm_vuldet_get_package_os_rhel8)
+        cmocka_unit_test(test_wm_vuldet_get_package_os_rhel8),
+        // Tests wm_vuldet_get_hash
+        cmocka_unit_test(wm_vuldet_get_hash_open_fail),
+        cmocka_unit_test(wm_vuldet_get_hash_prepare_fail),
+        cmocka_unit_test(wm_vuldet_get_hash_one_row),
+        cmocka_unit_test(wm_vuldet_get_hash_no_row),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -63,6 +63,7 @@ void wm_vuldet_get_package_os(const char *version, const char **os_major, char *
 char * wm_vuldet_get_hash(const char *target);
 feed_metadata * wm_vuldet_parse_MSU_metadata(char *path);
 bool wm_vuldet_check_enabled_msu(sqlite3 *db);
+int wm_insert_MSU_metadata(feed_metadata *msu, update_node *update);
 
 /* setup/teardown */
 
@@ -15654,6 +15655,84 @@ void wm_vuldet_check_enabled_msu_one_row(void **state)
 
 }
 
+void wm_insert_MSU_metadata_open_fail(void **state)
+{
+    will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
+
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
+    will_return(__wrap_sqlite3_close_v2, 1);
+
+    int ret = wm_insert_MSU_metadata(NULL, NULL);
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void wm_insert_MSU_metadata_prepare_fail(void **state) 
+{
+    will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
+
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
+    will_return(__wrap_sqlite3_close_v2, 1);
+
+    int ret = wm_insert_MSU_metadata(NULL, NULL);
+    assert_int_equal(ret, OS_INVALID);
+}
+
+// void wm_vuldet_get_hash_one_row(void **state) 
+// {
+//     feed_metadata *msu = NULL;
+
+//     calloc(1, sizeof(feed_metadata), msu);
+//     mus->sha256 = "12/13/12";
+//     mus->sha256 = "123456";
+
+//     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
+//     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+//     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+//     allways_will_return(__wrap_sqlite3_bind_text, 0);
+
+//     expect_value(__wrap_sqlite3_bind_text, a, 1);
+//     expect_string(__wrap_sqlite3_bind_text, b, "msu");
+
+//     expect_value(__wrap_sqlite3_bind_text, a, 2);
+//     expect_string(__wrap_sqlite3_bind_text, b, "msu");
+
+//     expect_value(__wrap_sqlite3_bind_text, a, 3);
+//     expect_string(__wrap_sqlite3_bind_text, b, "msu");
+
+//     expect_value(__wrap_sqlite3_bind_text, a, 4);
+//     expect_string(__wrap_sqlite3_bind_text, b, "msu");
+
+//     expect_value(__wrap_sqlite3_bind_text, a, 5);
+//     expect_string(__wrap_sqlite3_bind_text, b, "msu");
+
+//     expect_value(__wrap_sqlite3_bind_text, a, 6);
+//     expect_string(__wrap_sqlite3_bind_text, b, "msu");
+
+//     expect_value(__wrap_sqlite3_bind_text, a, 7);
+//     expect_int(__wrap_sqlite3_bind_text, b, 1233);
+
+//     expect_value(__wrap_sqlite3_bind_text, a, 8);
+//     expect_int(__wrap_sqlite3_bind_text, b, 1123);
+
+//     will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+
+//     will_return(__wrap_sqlite3_close_v2, 1);
+
+//     char *str = wm_vuldet_get_hash(target);
+//     assert_string_equal(hash, str);
+
+//     os_free(str);
+// }
+
 
 int main(void)
 {
@@ -16072,6 +16151,9 @@ int main(void)
         cmocka_unit_test(wm_vuldet_check_enabled_msu_prepare_fail),
         cmocka_unit_test(wm_vuldet_check_enabled_msu_no_rows),
         cmocka_unit_test(wm_vuldet_check_enabled_msu_one_row),
+        // Tests wm_insert_MSU_metadata
+        cmocka_unit_test(wm_insert_MSU_metadata_open_fail),
+        cmocka_unit_test(wm_insert_MSU_metadata_prepare_fail),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -15740,6 +15740,7 @@ void test_wm_insert_MSU_metadata_one_row(void **state)
     assert_int_equal(ret, 0);
 
     os_free(msu);
+    os_free(update);
 }
 
 void test_wm_insert_MSU_metadata_no_row(void **state) 
@@ -15801,6 +15802,7 @@ void test_wm_insert_MSU_metadata_no_row(void **state)
     assert_int_equal(ret, OS_INVALID);
 
     os_free(msu);
+    os_free(update);
 }
 
 // Tests wm_vuldet_fetch_MSU_metadata

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -16190,7 +16190,7 @@ void test_wm_vuldet_fetch_MSU_updated(void **state)
     os_free(update);
 }
 
-void test_wm_vuldet_fetch_invalid_hash(void **state)
+void test_wm_vuldet_fetch_MSU_invalid_hash(void **state)
 {
     update_node *update = NULL;
     char repo [OS_MAXSTR] = {0};
@@ -16234,7 +16234,7 @@ void test_wm_vuldet_fetch_invalid_hash(void **state)
     os_free(update);
 }
 
-void test_wm_vuldet_fetch_max_attempts(void **state)
+void test_wm_vuldet_fetch_MSU_max_attempts(void **state)
 {
     update_node *update = NULL;
 
@@ -16738,8 +16738,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_update_MSU_valid_metadata, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_update_MSU_updated, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_updated, setup_group, teardown_group),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_invalid_hash, setup_group, teardown_group),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_max_attempts, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_invalid_hash, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_max_attempts, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -9832,10 +9832,12 @@ void test_wm_vuldet_oval_xml_preparser_redhat(void **state)
 
     // Skip undesired line
     expect_value(__wrap_fgets, __n, OS_MAXSTR);
-    will_return(__wrap_fgets, "<![CDATA[(?<=^saved_entry=).*]]>   </ind-def:pattern>");
+    will_return(__wrap_fgets, "<![CDATA[(?<=^saved_entry=).*]]> </ind-def:pattern>");
     will_return(__wrap_fgets, 1);
 
-    will_return(__wrap_fwrite, 1);
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "<ind-def:pattern operation=\"pattern match\"> <![CDATA[(?<=^saved_entry=).*]]> </ind-def:pattern>");
+    will_return(__wrap_fgets, 1);
 
     // random line
     expect_value(__wrap_fgets, __n, OS_MAXSTR);

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -64,6 +64,7 @@ char * wm_vuldet_get_hash(const char *target);
 feed_metadata * wm_vuldet_parse_MSU_metadata(char *path);
 bool wm_vuldet_check_enabled_msu(sqlite3 *db);
 int wm_insert_MSU_metadata(feed_metadata *msu, update_node *update);
+feed_metadata * wm_vuldet_fetch_MSU_metadata(update_node *update);
 
 /* setup/teardown */
 
@@ -15475,7 +15476,7 @@ void test_wm_vuldet_get_package_os_rhel8(void **state)
 
 // Tests wm_vuldet_get_hash
 
-void wm_vuldet_get_hash_open_fail(void **state) 
+void test_wm_vuldet_get_hash_open_fail(void **state) 
 {
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
@@ -15489,7 +15490,7 @@ void wm_vuldet_get_hash_open_fail(void **state)
     assert_null(str);
 }
 
-void wm_vuldet_get_hash_prepare_fail(void **state) 
+void test_wm_vuldet_get_hash_prepare_fail(void **state) 
 {
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -15504,7 +15505,7 @@ void wm_vuldet_get_hash_prepare_fail(void **state)
     assert_null(str);
 }
 
-void wm_vuldet_get_hash_one_row(void **state) 
+void test_wm_vuldet_get_hash_one_row(void **state) 
 {
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -15530,7 +15531,7 @@ void wm_vuldet_get_hash_one_row(void **state)
     os_free(str);
 }
 
-void wm_vuldet_get_hash_no_row(void **state) 
+void test_wm_vuldet_get_hash_no_row(void **state) 
 {
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -15553,7 +15554,7 @@ void wm_vuldet_get_hash_no_row(void **state)
 
 // Tests wm_vuldet_parse_MSU_metadata
 
-void wm_vuldet_parse_MSU_metadata_open_fail(void **state)
+void test_wm_vuldet_parse_MSU_metadata_open_fail(void **state)
 {
     char *path = "/usr/bin/ls";
     expect_string(__wrap_fopen, __filename, path);
@@ -15564,7 +15565,7 @@ void wm_vuldet_parse_MSU_metadata_open_fail(void **state)
     assert_null(ret);
 } 
 
-void wm_vuldet_parse_MSU_metadata_full(void **state) 
+void test_wm_vuldet_parse_MSU_metadata_full(void **state) 
 {
     char *path = "/usr/bin/ls";
     expect_string(__wrap_fopen, __filename, path);
@@ -15617,7 +15618,7 @@ void wm_vuldet_parse_MSU_metadata_full(void **state)
 
 // Tests wm_vuldet_check_enabled_msu
 
-void wm_vuldet_check_enabled_msu_prepare_fail(void **state)
+void test_wm_vuldet_check_enabled_msu_prepare_fail(void **state)
 {
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
 
@@ -15629,7 +15630,7 @@ void wm_vuldet_check_enabled_msu_prepare_fail(void **state)
     assert_int_equal(ret, false);
 }
 
-void wm_vuldet_check_enabled_msu_no_rows(void **state)
+void test_wm_vuldet_check_enabled_msu_no_rows(void **state)
 {
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_step, SQLITE_ERROR);
@@ -15642,7 +15643,7 @@ void wm_vuldet_check_enabled_msu_no_rows(void **state)
     assert_int_equal(ret, false);
 }
 
-void wm_vuldet_check_enabled_msu_one_row(void **state)
+void test_wm_vuldet_check_enabled_msu_one_row(void **state)
 {
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
@@ -15655,7 +15656,7 @@ void wm_vuldet_check_enabled_msu_one_row(void **state)
 
 }
 
-void wm_insert_MSU_metadata_open_fail(void **state)
+void test_wm_insert_MSU_metadata_open_fail(void **state)
 {
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
@@ -15669,7 +15670,7 @@ void wm_insert_MSU_metadata_open_fail(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void wm_insert_MSU_metadata_prepare_fail(void **state) 
+void test_wm_insert_MSU_metadata_prepare_fail(void **state) 
 {
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
@@ -15684,7 +15685,7 @@ void wm_insert_MSU_metadata_prepare_fail(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void wm_insert_MSU_metadata_one_row(void **state) 
+void test_wm_insert_MSU_metadata_one_row(void **state) 
 {
     feed_metadata *msu = NULL;
     update_node *update = NULL;
@@ -15741,7 +15742,7 @@ void wm_insert_MSU_metadata_one_row(void **state)
     os_free(msu);
 }
 
-void wm_insert_MSU_metadata_no_row(void **state) 
+void test_wm_insert_MSU_metadata_no_row(void **state) 
 {
     feed_metadata *msu = NULL;
     update_node *update = NULL;
@@ -15800,6 +15801,106 @@ void wm_insert_MSU_metadata_no_row(void **state)
     assert_int_equal(ret, OS_INVALID);
 
     os_free(msu);
+}
+
+// Tests wm_vuldet_fetch_MSU_metadata
+
+void test_wm_vuldet_fetch_MSU_metadata_max_attempts(void **state)
+{
+    update_node *update = NULL;
+    char *repo = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_MSU;
+    repo = MSU_REPO_META;
+    update->timeout = 300;
+
+    // Function fails attepting to download
+    expect_string(__wrap_wurl_request, url, repo);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, OS_INVALID);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(5405): The download can not be completed. Retrying in '0' seconds.");
+
+    will_return(__wrap_sleep, OS_SUCCESS);
+
+    // Second try
+    expect_string(__wrap_wurl_request, url, repo);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, OS_INVALID);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(5405): The download can not be completed. Retrying in '1' seconds.");
+
+    will_return(__wrap_sleep, OS_SUCCESS);
+
+    // Third try
+    expect_string(__wrap_wurl_request, url, repo);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, OS_INVALID);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(5405): The download can not be completed. Retrying in '2' seconds.");
+
+    will_return(__wrap_sleep, OS_SUCCESS);
+
+    // Fourth try
+    expect_string(__wrap_wurl_request, url, repo);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, OS_INVALID);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(5405): The download can not be completed. Retrying in '3' seconds.");
+
+    will_return(__wrap_sleep, OS_SUCCESS);
+
+    // Fifth try
+    expect_string(__wrap_wurl_request, url, repo);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, OS_INVALID);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(5405): The download can not be completed. Retrying in '4' seconds.");
+
+    will_return(__wrap_sleep, OS_SUCCESS);
+
+    // Last try
+    expect_string(__wrap_wurl_request, url, repo);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, OS_INVALID);
+
+    feed_metadata *ret = wm_vuldet_fetch_MSU_metadata(update);
+    assert_null(ret);
+
+    os_free(update);
+}
+
+void test_wm_vuldet_fetch_MSU_metadata_valid_attempt(void **state)
+{
+    update_node *update = NULL;
+    char *repo = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_MSU;
+    repo = MSU_REPO_META;
+    update->timeout = 300;
+
+    expect_string(__wrap_wurl_request, url, repo);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, 0);
+
+    char *path = VU_FIT_TEMP_FILE;
+    expect_string(__wrap_fopen, __filename, path);
+    expect_string(__wrap_fopen, __modes, "r");
+    will_return(__wrap_fopen, NULL);
+
+    feed_metadata *ret = wm_vuldet_fetch_MSU_metadata(update);
+    assert_null(ret);
+
+    os_free(update);
 }
 
 int main(void)
@@ -16208,22 +16309,26 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_get_package_os_rhel7),
         cmocka_unit_test(test_wm_vuldet_get_package_os_rhel8),
         // Tests wm_vuldet_get_hash
-        cmocka_unit_test(wm_vuldet_get_hash_open_fail),
-        cmocka_unit_test(wm_vuldet_get_hash_prepare_fail),
-        cmocka_unit_test(wm_vuldet_get_hash_one_row),
-        cmocka_unit_test(wm_vuldet_get_hash_no_row),
+        cmocka_unit_test(test_wm_vuldet_get_hash_open_fail),
+        cmocka_unit_test(test_wm_vuldet_get_hash_prepare_fail),
+        cmocka_unit_test(test_wm_vuldet_get_hash_one_row),
+        cmocka_unit_test(test_wm_vuldet_get_hash_no_row),
         // Tests wm_vuldet_parse_MSU_metadata
-        cmocka_unit_test_setup_teardown(wm_vuldet_parse_MSU_metadata_open_fail, setup_group, teardown_group),
-        cmocka_unit_test_setup_teardown(wm_vuldet_parse_MSU_metadata_full, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_parse_MSU_metadata_open_fail, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_parse_MSU_metadata_full, setup_group, teardown_group),
         // Tests wm_vuldet_check_enabled_msu
-        cmocka_unit_test(wm_vuldet_check_enabled_msu_prepare_fail),
-        cmocka_unit_test(wm_vuldet_check_enabled_msu_no_rows),
-        cmocka_unit_test(wm_vuldet_check_enabled_msu_one_row),
+        cmocka_unit_test(test_wm_vuldet_check_enabled_msu_prepare_fail),
+        cmocka_unit_test(test_wm_vuldet_check_enabled_msu_no_rows),
+        cmocka_unit_test(test_wm_vuldet_check_enabled_msu_one_row),
         // Tests wm_insert_MSU_metadata
-        cmocka_unit_test(wm_insert_MSU_metadata_open_fail),
-        cmocka_unit_test(wm_insert_MSU_metadata_prepare_fail),
-        cmocka_unit_test(wm_insert_MSU_metadata_one_row),
-        cmocka_unit_test(wm_insert_MSU_metadata_no_row),
+        cmocka_unit_test(test_wm_insert_MSU_metadata_open_fail),
+        cmocka_unit_test(test_wm_insert_MSU_metadata_prepare_fail),
+        cmocka_unit_test(test_wm_insert_MSU_metadata_one_row),
+        cmocka_unit_test(test_wm_insert_MSU_metadata_no_row),
+        // Tests wm_vuldet_fetch_MSU_metadata
+        cmocka_unit_test(test_wm_vuldet_fetch_MSU_metadata_max_attempts),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_metadata_valid_attempt, setup_group, teardown_group),
+
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -62,6 +62,7 @@ void wm_vuldet_set_subversion(char *version, char **os_minor);
 void wm_vuldet_get_package_os(const char *version, const char **os_major, char **os_minor);
 char * wm_vuldet_get_hash(const char *target);
 feed_metadata * wm_vuldet_parse_MSU_metadata(char *path);
+bool wm_vuldet_check_enabled_msu(sqlite3 *db);
 
 /* setup/teardown */
 
@@ -15613,6 +15614,46 @@ void wm_vuldet_parse_MSU_metadata_full(void **state)
     os_free(ret);
 }
 
+// Tests wm_vuldet_check_enabled_msu
+
+void wm_vuldet_check_enabled_msu_prepare_fail(void **state)
+{
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
+
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
+
+    bool ret = wm_vuldet_check_enabled_msu((sqlite3*) 1);
+    assert_int_equal(ret, false);
+}
+
+void wm_vuldet_check_enabled_msu_no_rows(void **state)
+{
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    will_return(__wrap_sqlite3_step, SQLITE_ERROR);
+
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
+
+    bool ret = wm_vuldet_check_enabled_msu((sqlite3*) 1);
+    assert_int_equal(ret, false);
+}
+
+void wm_vuldet_check_enabled_msu_one_row(void **state)
+{
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_int, i, 0);
+    will_return(__wrap_sqlite3_column_int, 1);
+
+    bool ret = wm_vuldet_check_enabled_msu((sqlite3*) 1);
+    assert_int_equal(ret, true);
+
+}
+
 
 int main(void)
 {
@@ -16027,6 +16068,10 @@ int main(void)
         // Tests wm_vuldet_parse_MSU_metadata
         cmocka_unit_test_setup_teardown(wm_vuldet_parse_MSU_metadata_open_fail, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(wm_vuldet_parse_MSU_metadata_full, setup_group, teardown_group),
+        // Tests wm_vuldet_check_enabled_msu
+        cmocka_unit_test(wm_vuldet_check_enabled_msu_prepare_fail),
+        cmocka_unit_test(wm_vuldet_check_enabled_msu_no_rows),
+        cmocka_unit_test(wm_vuldet_check_enabled_msu_one_row),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -65,6 +65,7 @@ feed_metadata * wm_vuldet_parse_MSU_metadata(char *path);
 bool wm_vuldet_check_enabled_msu(sqlite3 *db);
 int wm_insert_MSU_metadata(feed_metadata *msu, update_node *update);
 feed_metadata * wm_vuldet_fetch_MSU_metadata(update_node *update);
+bool wm_vuldet_update_MSU(update_node *update);
 
 /* setup/teardown */
 
@@ -15905,6 +15906,226 @@ void test_wm_vuldet_fetch_MSU_metadata_valid_attempt(void **state)
     os_free(update);
 }
 
+// wm_vuldet_update_MSU
+
+void test_wm_vuldet_update_MSU_invalid_metadata(void **state) 
+{
+
+    update_node *update = NULL;
+    char *repo = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_MSU;
+    repo = MSU_REPO_META;
+    update->timeout = 300;
+
+    // download metadata
+    expect_string(__wrap_wurl_request, url, repo);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, 0);
+
+    char *path = VU_FIT_TEMP_FILE;
+    expect_string(__wrap_fopen, __filename, path);
+    expect_string(__wrap_fopen, __modes, "r");
+    will_return(__wrap_fopen, NULL);
+
+    bool val = wm_vuldet_update_MSU(update);
+    assert_int_equal(val, true);
+
+    os_free(update);
+}
+
+void test_wm_vuldet_update_MSU_incomplete_metadata(void **state)
+{
+    update_node *update = NULL;
+    char *repo = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_MSU;
+    repo = MSU_REPO_META;
+    update->timeout = 300;
+    
+    // download metadata
+    expect_string(__wrap_wurl_request, url, repo);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, 0);
+
+    expect_string(__wrap_fopen, __filename, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_fopen, __modes, "r");
+    will_return(__wrap_fopen, 1);
+
+    // parse elements
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "lastModifiedDate:12/13/13");
+    will_return(__wrap_fgets, 1);
+
+    // end loop 
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "");
+    will_return(__wrap_fgets, 0);
+
+    will_return(__wrap_fclose, OS_SUCCESS);
+
+    bool val = wm_vuldet_update_MSU(update);
+    assert_int_equal(val, true);
+
+    os_free(update);
+}
+
+void test_wm_vuldet_update_MSU_valid_metadata(void **state)
+{
+    update_node *update = NULL;
+    char *repo = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_MSU;
+    repo = MSU_REPO_META;
+    update->timeout = 300;
+    
+    // download metadata
+    expect_string(__wrap_wurl_request, url, repo);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, 0);
+
+    expect_string(__wrap_fopen, __filename, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_fopen, __modes, "r");
+    will_return(__wrap_fopen, 1);
+
+    // parse elements
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "lastModifiedDate:12/13/13");
+    will_return(__wrap_fgets, 1);
+
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "sha256:abcdef");
+    will_return(__wrap_fgets, 1);
+
+    // end loop 
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "");
+    will_return(__wrap_fgets, 0);
+
+    will_return(__wrap_fclose, OS_SUCCESS);
+
+    // check timestamp
+    will_return(__wrap_sqlite3_open_v2, NULL);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
+
+    // Insert
+    feed_metadata msu = {0};
+    msu.last_mod = "12/13/13";
+    msu.sha256 = "abcdef";
+
+    // open DB
+    will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+
+    // prepare DB
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return_always(__wrap_sqlite3_bind_int, 0);
+
+    // Insert values
+    expect_value(__wrap_sqlite3_bind_text, a, 1);
+    expect_string(__wrap_sqlite3_bind_text, b, vu_feed_tag[update->dist_tag_ref]);
+
+    expect_value(__wrap_sqlite3_bind_text, a, 2);
+    expect_string(__wrap_sqlite3_bind_text, b, vu_feed_ext[update->dist_tag_ref]);
+
+    expect_value(__wrap_sqlite3_bind_text, a, 3);
+    expect_string(__wrap_sqlite3_bind_text, b, "1");
+
+    expect_value(__wrap_sqlite3_bind_text, a, 4);
+    expect_string(__wrap_sqlite3_bind_text, b, "1");
+
+    expect_value(__wrap_sqlite3_bind_text, a, 5);
+    expect_string(__wrap_sqlite3_bind_text, b, msu.last_mod);
+
+    expect_value(__wrap_sqlite3_bind_text, a, 6);
+    expect_string(__wrap_sqlite3_bind_text, b, msu.sha256);
+
+    expect_value(__wrap_sqlite3_bind_int, a, 7);
+    expect_value(__wrap_sqlite3_bind_int, b, 0);
+
+    expect_value(__wrap_sqlite3_bind_int, a, 8);
+    expect_value(__wrap_sqlite3_bind_int, b, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    will_return(__wrap_sqlite3_close_v2, 1);
+
+    bool val = wm_vuldet_update_MSU(update);
+    assert_int_equal(val, true);
+
+    os_free(update);
+}
+
+void test_wm_vuldet_update_MSU_updated(void **state)
+{
+    update_node *update = NULL;
+    char *repo = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_ref = FEED_MSU;
+    update->dist_ext = "MSU";
+    repo = MSU_REPO_META;
+    update->timeout = 300;
+    
+    // download metadata
+    expect_string(__wrap_wurl_request, url, repo);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, 0);
+
+    expect_string(__wrap_fopen, __filename, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_fopen, __modes, "r");
+    will_return(__wrap_fopen, 1);
+
+    // parse elements
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "lastModifiedDate:2020-06-02");
+    will_return(__wrap_fgets, 1);
+
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "sha256:abcdef");
+    will_return(__wrap_fgets, 1);
+
+    // end loop 
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "");
+    will_return(__wrap_fgets, 0);
+
+    will_return(__wrap_fclose, OS_SUCCESS);
+
+    // check timestamp
+    will_return(__wrap_sqlite3_open_v2, (sqlite3 *)1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, a, 1);
+    expect_value(__wrap_sqlite3_bind_text, b, vu_feed_tag[update->dist_tag_ref]);
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_text, i, 0);
+    will_return(__wrap_sqlite3_column_text, "2020-06-02");
+
+    will_return(__wrap_sqlite3_close_v2, 1);
+
+    // updated msg
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(5406): The feed 'MSU' is in its latest version.");
+
+    bool val = wm_vuldet_update_MSU(update);
+    assert_int_equal(val, false);
+
+    os_free(update);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -16330,7 +16551,11 @@ int main(void)
         // Tests wm_vuldet_fetch_MSU_metadata
         cmocka_unit_test(test_wm_vuldet_fetch_MSU_metadata_max_attempts),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_metadata_valid_attempt, setup_group, teardown_group),
-
+        // Tests wm_vuldet_update_MSU
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_update_MSU_invalid_metadata, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_update_MSU_incomplete_metadata, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_update_MSU_valid_metadata, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_update_MSU_updated, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -61,6 +61,7 @@ int wm_vuldet_insert_cve_info(wm_vuldet_db *parsed_oval, sqlite3 *db, sqlite3_st
 void wm_vuldet_set_subversion(char *version, char **os_minor);
 void wm_vuldet_get_package_os(const char *version, const char **os_major, char **os_minor);
 char * wm_vuldet_get_hash(const char *target);
+feed_metadata * wm_vuldet_parse_MSU_metadata(char *path);
 
 /* setup/teardown */
 
@@ -15470,6 +15471,8 @@ void test_wm_vuldet_get_package_os_rhel8(void **state)
     os_free(os_minor);
 }
 
+// Tests wm_vuldet_get_hash
+
 void wm_vuldet_get_hash_open_fail(void **state) 
 {
     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
@@ -15544,6 +15547,70 @@ void wm_vuldet_get_hash_no_row(void **state)
 
     char *str = wm_vuldet_get_hash(target);
     assert_null(str);
+}
+
+// Tests wm_vuldet_parse_MSU_metadata
+
+void wm_vuldet_parse_MSU_metadata_open_fail(void **state)
+{
+    char *path = "/usr/bin/ls";
+    expect_string(__wrap_fopen, __filename, path);
+    expect_string(__wrap_fopen, __modes, "r");
+    will_return(__wrap_fopen, NULL);
+
+    feed_metadata *ret = wm_vuldet_parse_MSU_metadata(path);
+    assert_null(ret);
+} 
+
+void wm_vuldet_parse_MSU_metadata_full(void **state) 
+{
+    char *path = "/usr/bin/ls";
+    expect_string(__wrap_fopen, __filename, path);
+    expect_string(__wrap_fopen, __modes, "r");
+    will_return(__wrap_fopen, 1);
+
+    // parse elements
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "lastModifiedDate:12/13/13");
+    will_return(__wrap_fgets, 1);
+
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "testfake:fakeee");
+    will_return(__wrap_fgets, 1);
+
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "sha256:abcdef");
+    will_return(__wrap_fgets, 1);
+
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "size:1012919291");
+    will_return(__wrap_fgets, 1);
+
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "gzSize:1012919291");
+    will_return(__wrap_fgets, 1);
+
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "version:1012919291");
+    will_return(__wrap_fgets, 1);
+
+    // end loop 
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "");
+    will_return(__wrap_fgets, 0);
+
+    will_return(__wrap_fclose, OS_SUCCESS);
+
+    feed_metadata *ret = wm_vuldet_parse_MSU_metadata(path);
+    assert_string_equal(ret->last_mod, "12/13/13");
+    assert_string_equal(ret->sha256, "abcdef");
+
+    os_free(ret->sha256);
+    os_free(ret->last_mod);
+    os_free(ret->version);
+    os_free(ret->size);
+    os_free(ret->g_size);
+    os_free(ret);
 }
 
 
@@ -15957,6 +16024,9 @@ int main(void)
         cmocka_unit_test(wm_vuldet_get_hash_prepare_fail),
         cmocka_unit_test(wm_vuldet_get_hash_one_row),
         cmocka_unit_test(wm_vuldet_get_hash_no_row),
+        // Tests wm_vuldet_parse_MSU_metadata
+        cmocka_unit_test_setup_teardown(wm_vuldet_parse_MSU_metadata_open_fail, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(wm_vuldet_parse_MSU_metadata_full, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -15684,55 +15684,123 @@ void wm_insert_MSU_metadata_prepare_fail(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-// void wm_vuldet_get_hash_one_row(void **state) 
-// {
-//     feed_metadata *msu = NULL;
+void wm_insert_MSU_metadata_one_row(void **state) 
+{
+    feed_metadata *msu = NULL;
+    update_node *update = NULL;
 
-//     calloc(1, sizeof(feed_metadata), msu);
-//     mus->sha256 = "12/13/12";
-//     mus->sha256 = "123456";
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_tag_ref = FEED_MSU;
 
-//     will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
-//     will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
-//     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    os_calloc(1, sizeof(feed_metadata), msu);
+    msu->last_mod = "12/13/12";
+    msu->sha256 = "123456";
 
-//     allways_will_return(__wrap_sqlite3_bind_text, 0);
+    // open DB
+    will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
 
-//     expect_value(__wrap_sqlite3_bind_text, a, 1);
-//     expect_string(__wrap_sqlite3_bind_text, b, "msu");
+    // prepare DB
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
-//     expect_value(__wrap_sqlite3_bind_text, a, 2);
-//     expect_string(__wrap_sqlite3_bind_text, b, "msu");
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return_always(__wrap_sqlite3_bind_int, 0);
 
-//     expect_value(__wrap_sqlite3_bind_text, a, 3);
-//     expect_string(__wrap_sqlite3_bind_text, b, "msu");
+    // Insert values
+    expect_value(__wrap_sqlite3_bind_text, a, 1);
+    expect_string(__wrap_sqlite3_bind_text, b, vu_feed_tag[update->dist_tag_ref]);
 
-//     expect_value(__wrap_sqlite3_bind_text, a, 4);
-//     expect_string(__wrap_sqlite3_bind_text, b, "msu");
+    expect_value(__wrap_sqlite3_bind_text, a, 2);
+    expect_string(__wrap_sqlite3_bind_text, b, vu_feed_ext[update->dist_tag_ref]);
 
-//     expect_value(__wrap_sqlite3_bind_text, a, 5);
-//     expect_string(__wrap_sqlite3_bind_text, b, "msu");
+    expect_value(__wrap_sqlite3_bind_text, a, 3);
+    expect_string(__wrap_sqlite3_bind_text, b, "1");
 
-//     expect_value(__wrap_sqlite3_bind_text, a, 6);
-//     expect_string(__wrap_sqlite3_bind_text, b, "msu");
+    expect_value(__wrap_sqlite3_bind_text, a, 4);
+    expect_string(__wrap_sqlite3_bind_text, b, "1");
 
-//     expect_value(__wrap_sqlite3_bind_text, a, 7);
-//     expect_int(__wrap_sqlite3_bind_text, b, 1233);
+    expect_value(__wrap_sqlite3_bind_text, a, 5);
+    expect_string(__wrap_sqlite3_bind_text, b, msu->last_mod);
 
-//     expect_value(__wrap_sqlite3_bind_text, a, 8);
-//     expect_int(__wrap_sqlite3_bind_text, b, 1123);
+    expect_value(__wrap_sqlite3_bind_text, a, 6);
+    expect_string(__wrap_sqlite3_bind_text, b, msu->sha256);
 
-//     will_return(__wrap_sqlite3_step, SQLITE_DONE);
+    expect_value(__wrap_sqlite3_bind_int, a, 7);
+    expect_value(__wrap_sqlite3_bind_int, b, 0);
 
+    expect_value(__wrap_sqlite3_bind_int, a, 8);
+    expect_value(__wrap_sqlite3_bind_int, b, 0);
 
-//     will_return(__wrap_sqlite3_close_v2, 1);
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
 
-//     char *str = wm_vuldet_get_hash(target);
-//     assert_string_equal(hash, str);
+    will_return(__wrap_sqlite3_close_v2, 1);
 
-//     os_free(str);
-// }
+    int ret = wm_insert_MSU_metadata(msu, update);
+    assert_int_equal(ret, 0);
 
+    os_free(msu);
+}
+
+void wm_insert_MSU_metadata_no_row(void **state) 
+{
+    feed_metadata *msu = NULL;
+    update_node *update = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_tag_ref = FEED_MSU;
+
+    os_calloc(1, sizeof(feed_metadata), msu);
+    msu->last_mod = "12/13/12";
+    msu->sha256 = "123456";
+
+    // open DB
+    will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+
+    // prepare DB
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return_always(__wrap_sqlite3_bind_int, 0);
+
+    // Insert values
+    expect_value(__wrap_sqlite3_bind_text, a, 1);
+    expect_string(__wrap_sqlite3_bind_text, b, vu_feed_tag[update->dist_tag_ref]);
+
+    expect_value(__wrap_sqlite3_bind_text, a, 2);
+    expect_string(__wrap_sqlite3_bind_text, b, vu_feed_ext[update->dist_tag_ref]);
+
+    expect_value(__wrap_sqlite3_bind_text, a, 3);
+    expect_string(__wrap_sqlite3_bind_text, b, "1");
+
+    expect_value(__wrap_sqlite3_bind_text, a, 4);
+    expect_string(__wrap_sqlite3_bind_text, b, "1");
+
+    expect_value(__wrap_sqlite3_bind_text, a, 5);
+    expect_string(__wrap_sqlite3_bind_text, b, msu->last_mod);
+
+    expect_value(__wrap_sqlite3_bind_text, a, 6);
+    expect_string(__wrap_sqlite3_bind_text, b, msu->sha256);
+
+    expect_value(__wrap_sqlite3_bind_int, a, 7);
+    expect_value(__wrap_sqlite3_bind_int, b, 0);
+
+    expect_value(__wrap_sqlite3_bind_int, a, 8);
+    expect_value(__wrap_sqlite3_bind_int, b, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_ERROR);
+
+    // ERROR
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
+    will_return(__wrap_sqlite3_close_v2, 1);
+
+    int ret = wm_insert_MSU_metadata(msu, update);
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(msu);
+}
 
 int main(void)
 {
@@ -16154,6 +16222,8 @@ int main(void)
         // Tests wm_insert_MSU_metadata
         cmocka_unit_test(wm_insert_MSU_metadata_open_fail),
         cmocka_unit_test(wm_insert_MSU_metadata_prepare_fail),
+        cmocka_unit_test(wm_insert_MSU_metadata_one_row),
+        cmocka_unit_test(wm_insert_MSU_metadata_no_row),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -66,6 +66,7 @@ bool wm_vuldet_check_enabled_msu(sqlite3 *db);
 int wm_insert_MSU_metadata(feed_metadata *msu, update_node *update);
 feed_metadata * wm_vuldet_fetch_MSU_metadata(update_node *update);
 bool wm_vuldet_update_MSU(update_node *update);
+int wm_vuldet_fetch_MSU(update_node *update, char *repo);
 
 /* setup/teardown */
 
@@ -16126,6 +16127,186 @@ void test_wm_vuldet_update_MSU_updated(void **state)
     os_free(update);
 }
 
+// Tests wm_vuldet_fetch_MSU
+
+void test_wm_vuldet_fetch_MSU_updated(void **state)
+{
+    update_node *update = NULL;
+    char repo [OS_MAXSTR] = {0};
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_tag_ref = FEED_MSU;
+    update->dist_ext = "MSU";
+    update->timeout = 300;
+
+    // download metadata
+    expect_string(__wrap_wurl_request, url, MSU_REPO_META);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, 0);
+
+    expect_string(__wrap_fopen, __filename, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_fopen, __modes, "r");
+    will_return(__wrap_fopen, 1);
+
+    // parse elements
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "lastModifiedDate:2020-06-02");
+    will_return(__wrap_fgets, 1);
+
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "sha256:abcdef");
+    will_return(__wrap_fgets, 1);
+
+    // end loop 
+    expect_value(__wrap_fgets, __n, OS_MAXSTR);
+    will_return(__wrap_fgets, "");
+    will_return(__wrap_fgets, 0);
+
+    will_return(__wrap_fclose, OS_SUCCESS);
+
+    // check timestamp
+    will_return(__wrap_sqlite3_open_v2, (sqlite3 *)1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, a, 1);
+    expect_value(__wrap_sqlite3_bind_text, b, vu_feed_tag[update->dist_tag_ref]);
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_text, i, 0);
+    will_return(__wrap_sqlite3_column_text, "2020-06-02");
+
+    will_return(__wrap_sqlite3_close_v2, 1);
+
+    // updated msg
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(5406): The feed 'MSU' is in its latest version.");
+
+    int val = wm_vuldet_fetch_MSU(update, repo);
+    assert_int_equal(val, VU_NOT_NEED_UPDATE);
+
+    os_free(update);
+}
+
+void test_wm_vuldet_fetch_invalid_hash(void **state)
+{
+    update_node *update = NULL;
+    char repo [OS_MAXSTR] = {0};
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_tag_ref = FEED_MSU;
+    update->dist_ext = "MSU";
+    update->timeout = 300;
+
+    // download metadata
+    expect_string(__wrap_wurl_request, url, MSU_REPO_META);
+    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request, timeout, update->timeout);
+    will_return(__wrap_wurl_request, 0);
+
+    // failed to open metadata file
+    expect_string(__wrap_fopen, __filename, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_fopen, __modes, "r");
+    will_return(__wrap_fopen, NULL);
+
+    // open db to check hash
+    will_return(__wrap_sqlite3_open_v2, (sqlite3*) 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
+
+    will_return(__wrap_sqlite3_errmsg, "error");
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5503): SQL error: 'error'");
+    will_return(__wrap_sqlite3_close_v2, 1);
+
+    expect_string(__wrap__merror, formatted_msg, "Failed to retrieve hash value. File integrity won't be checked.");
+    
+    // download msu
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, url, MSU_REPO);
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request_uncompress_bz2_gz, timeout, update->timeout);
+    will_return(__wrap_wurl_request_uncompress_bz2_gz, 0);
+
+    int val = wm_vuldet_fetch_MSU(update, repo);
+    assert_int_equal(val, 0);
+
+    os_free(update);
+}
+
+void test_wm_vuldet_fetch_max_attempts(void **state)
+{
+    update_node *update = NULL;
+
+    os_calloc(1, sizeof(update_node), update);
+    update->dist_tag_ref = FEED_MSU;
+    update->dist_ext = "MSU";
+    update->timeout = 300;
+    char *repo = MSU_REPO;
+
+    // Function fails attepting to download
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, url, repo);
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request_uncompress_bz2_gz, timeout, update->timeout);
+    will_return(__wrap_wurl_request_uncompress_bz2_gz, OS_INVALID);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(5405): The download can not be completed. Retrying in '0' seconds.");
+
+    will_return(__wrap_sleep, OS_SUCCESS);
+
+    // Second try
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, url, repo);
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request_uncompress_bz2_gz, timeout, update->timeout);
+    will_return(__wrap_wurl_request_uncompress_bz2_gz, OS_INVALID);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(5405): The download can not be completed. Retrying in '1' seconds.");
+
+    will_return(__wrap_sleep, OS_SUCCESS);
+
+    // Third try
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, url, repo);
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request_uncompress_bz2_gz, timeout, update->timeout);
+    will_return(__wrap_wurl_request_uncompress_bz2_gz, OS_INVALID);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(5405): The download can not be completed. Retrying in '2' seconds.");
+
+    will_return(__wrap_sleep, OS_SUCCESS);
+
+    // Fourth try
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, url, repo);
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request_uncompress_bz2_gz, timeout, update->timeout);
+    will_return(__wrap_wurl_request_uncompress_bz2_gz, OS_INVALID);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(5405): The download can not be completed. Retrying in '3' seconds.");
+
+    will_return(__wrap_sleep, OS_SUCCESS);
+
+    // Fifth try
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, url, repo);
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request_uncompress_bz2_gz, timeout, update->timeout);
+    will_return(__wrap_wurl_request_uncompress_bz2_gz, OS_INVALID);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(5405): The download can not be completed. Retrying in '4' seconds.");
+
+    will_return(__wrap_sleep, OS_SUCCESS);
+
+    // Last try
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, url, repo);
+    expect_string(__wrap_wurl_request_uncompress_bz2_gz, dest, VU_FIT_TEMP_FILE);
+    expect_value(__wrap_wurl_request_uncompress_bz2_gz, timeout, update->timeout);
+    will_return(__wrap_wurl_request_uncompress_bz2_gz, OS_INVALID);
+
+    int val = wm_vuldet_fetch_MSU(update, repo);
+    assert_int_equal(val, VU_INV_FEED);
+
+    os_free(update);
+
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -16556,6 +16737,9 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_update_MSU_incomplete_metadata, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_update_MSU_valid_metadata, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_update_MSU_updated, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_updated, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_invalid_hash, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_max_attempts, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2886,7 +2886,8 @@ char *wm_vuldet_oval_xml_preparser(char *path, vu_feed dist) {
             default:
                 /* The XML parser fails to analyse correctly this section.
                 * This is just a workaround, for more information -> Issues #5300 and #5299. */
-                if (strstr(buffer, "<![CDATA")) {
+                if (strstr(buffer, "<![CDATA") || 
+                    strstr(buffer, "<ind-def:pattern operation=\"pattern match\">")) {
                     continue;
 
                 } else if (strstr(buffer, "<criteria ")) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5459,6 +5459,8 @@ feed_metadata * wm_vuldet_parse_MSU_metadata(char *path) {
         }
     }
 
+    fclose(fp);
+
     return msu;
 }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2801,7 +2801,6 @@ char *wm_vuldet_oval_xml_preparser(char *path, vu_feed dist) {
     parser_state state = V_START;
     char *found;
     char *tmp_file;
-    char *cdata = NULL;
 
     os_strdup(VU_FIT_TEMP_FILE, tmp_file);
 
@@ -2887,10 +2886,9 @@ char *wm_vuldet_oval_xml_preparser(char *path, vu_feed dist) {
             default:
                 /* The XML parser fails to analyse correctly this section.
                 * This is just a workaround, for more information -> Issues #5300 and #5299. */
-                if (cdata = strstr(buffer, "<![CDATA"), cdata) {
-                    if (strtok(buffer, ">")) {
-                        memset(buffer, (char) ' ', strlen(cdata) + 1);
-                    }
+                if (strstr(buffer, "<![CDATA")) {
+                    continue;
+
                 } else if (strstr(buffer, "<criteria ")) {
                     state = V_CRITERIA;
                 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3803,7 +3803,8 @@ char * wm_vuldet_get_hash(const char *target) {
 
     sqlite3_bind_text(stmt, 1, target, -1, NULL);
     if (wm_vuldet_step(stmt) == SQLITE_ROW) {
-        sqlite_strdup((const char *) sqlite3_column_text(stmt, 0), hash);
+        char *val = sqlite3_column_text(stmt, 0);
+        sqlite_strdup((const char *) val, hash);
     }
 
     sqlite3_close_v2(db);


### PR DESCRIPTION
|Related issue|
|---|
|#5798|

## Description
This PR adds unit tests for the functions added in #5678 and #5745. In addition, some minor bugs have been fixed.

## Tests
<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)
