### PR TITLE
Updating comunication error messages of agentd 

### DIFF
--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -148,27 +148,27 @@ int receive_msg()
                 /* Connect to the Security configuration assessment queue */
                 if (agt->cfgadq >= 0) {
                     if (OS_SendUnix(agt->cfgadq, tmp_msg, 0) < 0) {
-                        merror("Error communicating with Security configuration assessment");
+                        mwarn("Error communicating with Security configuration assessment");
                         close(agt->cfgadq);
 
                         if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE, 1)) < 0) {
-                            merror("Unable to connect to the Security configuration assessment "
+                            mwarn("Unable to connect to the Security configuration assessment "
                                     "queue (disabled).");
                             agt->cfgadq = -1;
                         } else if (OS_SendUnix(agt->cfgadq, tmp_msg, 0) < 0) {
-                            merror("Error communicating with Security configuration assessment");
+                            mwarn("Error communicating with Security configuration assessment");
                             close(agt->cfgadq);
                             agt->cfgadq = -1;
                         }
                     }
                 } else {
                     if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE, 1)) < 0) {
-                        merror("Unable to connect to the Security configuration assessment "
+                        mwarn("Unable to connect to the Security configuration assessment "
                             "queue (disabled).");
                         agt->cfgadq = -1;
                     } else {
                          if (OS_SendUnix(agt->cfgadq, tmp_msg, 0) < 0) {
-                            merror("Error communicating with Security configuration assessment");
+                            mwarn("Error communicating with Security configuration assessment");
                             close(agt->cfgadq);
                             agt->cfgadq = -1;
                         }

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -634,12 +634,12 @@ void ag_send_syscheck(char * message) {
     int sock = OS_ConnectUnixDomain(DEFAULTDIR SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR);
 
     if (sock < 0) {
-        merror("dbsync: cannot connect to syscheck: %s (%d)", strerror(errno), errno);
+        mwarn("dbsync: cannot connect to syscheck: %s (%d)", strerror(errno), errno);
         return;
     }
 
     if (OS_SendSecureTCP(sock, strlen(message), message) < 0) {
-        merror("Cannot send message to syscheck: %s (%d)", strerror(errno), errno);
+        mwarn("Cannot send message to syscheck: %s (%d)", strerror(errno), errno);
     }
 
     close(sock);

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -2114,7 +2114,7 @@ static void test_ag_send_syscheck_unable_to_connect(void **state) {
 
     errno = EADDRNOTAVAIL;
 
-    expect_string(__wrap__merror, formatted_msg, "dbsync: cannot connect to syscheck: Cannot assign requested address (99)");
+    expect_string(__wrap__mwarn, formatted_msg, "dbsync: cannot connect to syscheck: Cannot assign requested address (99)");
 
     ag_send_syscheck(input);
 
@@ -2137,7 +2137,7 @@ static void test_ag_send_syscheck_error_sending_message(void **state) {
 
     errno = EWOULDBLOCK;
 
-    expect_string(__wrap__merror, formatted_msg, "Cannot send message to syscheck: Resource temporarily unavailable (11)");
+    expect_string(__wrap__mwarn, formatted_msg, "Cannot send message to syscheck: Resource temporarily unavailable (11)");
 
     ag_send_syscheck(input);
 


### PR DESCRIPTION
|Related issue|
|---|
|#5816|

## Description

The **merror** calls where replaced by **mwarn** in `receiver.c` and `syscheck_op.c` for SCA and FIM modules.
The unit tests where also updated.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux