### PR TITLE
Fix issues reported by coverity scan in FIM module

### DIFF
--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -274,7 +274,7 @@ char *unescape_syscheck_field(char *sum);
  * @param uid The user ID
  * @return The user name on success, NULL on failure
  */
-char *get_user(__attribute__((unused)) const char *path, int uid, __attribute__((unused)) char **sid);
+char *get_user(int uid);
 
 /**
  * @brief Retrieves the group name from a group ID in UNIX
@@ -295,7 +295,7 @@ const char *get_group(int gid);
  * @param [out] sid The user ID associated to the user
  * @return The user name on success, NULL on failure
  */
-char *get_user(const char *path, __attribute__((unused)) int uid, char **sid);
+char *get_user(const char *path, char **sid);
 
 /**
  * @brief Check if a directory exists

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -597,7 +597,7 @@ char *unescape_syscheck_field(char *sum) {
     return NULL;
 }
 
-char *get_user(__attribute__((unused)) const char *path, int uid, __attribute__((unused)) char **sid) {
+char *get_user(int uid) {
     struct passwd pwd;
     struct passwd *result;
     char *buf;
@@ -656,7 +656,7 @@ void ag_send_syscheck(char * message) {
 
 #else /* #ifndef WIN32 */
 
-char *get_user(const char *path, __attribute__((unused)) int uid, char **sid) {
+char *get_user(const char *path, char **sid) {
     DWORD dwRtnCode = 0;
     DWORD dwSecurityInfoErrorCode = 0;
     PSID pSidOwner = NULL;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -931,23 +931,21 @@ cJSON * fim_json_event(char * file_name, fim_entry_data * old_data, fim_entry_da
 #ifndef WIN32
     char** paths = NULL;
 
-    if (new_data) {
-        if (paths = fim_db_get_paths_from_inode(syscheck.database, new_data->inode, new_data->dev), paths){
-            if (paths[0] && paths[1]) {
-                cJSON *hard_links = cJSON_CreateArray();
-                int i;
-                for(i = 0; paths[i]; i++) {
-                    if(strcmp(file_name, paths[i])) {
-                        cJSON_AddItemToArray(hard_links, cJSON_CreateString(paths[i]));
-                    }
-                    os_free(paths[i]);
+    if (paths = fim_db_get_paths_from_inode(syscheck.database, new_data->inode, new_data->dev), paths){
+        if (paths[0] && paths[1]) {
+            cJSON *hard_links = cJSON_CreateArray();
+            int i;
+            for(i = 0; paths[i]; i++) {
+                if(strcmp(file_name, paths[i])) {
+                    cJSON_AddItemToArray(hard_links, cJSON_CreateString(paths[i]));
                 }
-                cJSON_AddItemToObject(data, "hard_links", hard_links);
-            } else {
-                os_free(paths[0]);
+                os_free(paths[i]);
             }
-            os_free(paths);
+            cJSON_AddItemToObject(data, "hard_links", hard_links);
+        } else {
+            os_free(paths[0]);
         }
+        os_free(paths);
     }
 #endif
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -753,7 +753,7 @@ fim_entry_data * fim_get_data(const char *file, fim_element *item) {
 
 #ifdef WIN32
     if (item->configuration & CHECK_OWNER) {
-        data->user_name = get_user(file, 0, &data->uid);
+        data->user_name = get_user(file, &data->uid);
     }
 #else
     if (item->configuration & CHECK_OWNER) {
@@ -761,7 +761,7 @@ fim_entry_data * fim_get_data(const char *file, fim_element *item) {
         snprintf(aux, OS_SIZE_64, "%u", item->statbuf.st_uid);
         os_strdup(aux, data->uid);
 
-        data->user_name = get_user(file, item->statbuf.st_uid, NULL);
+        data->user_name = get_user(item->statbuf.st_uid);
     }
 
     if (item->configuration & CHECK_GROUP) {

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -887,6 +887,7 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_entry_data *new, fi
         sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_PATH_COUNT]);
 
         res = sqlite3_column_int(fim_sql->stmt[FIMDB_STMT_GET_PATH_COUNT], 0);
+        inode_id = sqlite3_column_int(fim_sql->stmt[FIMDB_STMT_GET_PATH_COUNT], 1);
         if (res == 1) {
             // The inode has only one entry, delete the entry data.
             fim_db_clean_stmt(fim_sql, FIMDB_STMT_DELETE_DATA);

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -702,7 +702,7 @@ void audit_parse(char *buffer) {
                 match_size = match[1].rm_eo - match[1].rm_so;
                 os_malloc(match_size + 1, w_evt->user_id);
                 snprintf (w_evt->user_id, match_size +1, "%.*s", match_size, buffer + match[1].rm_so);
-                w_evt->user_name = get_user("", atoi(w_evt->user_id), NULL);
+                w_evt->user_name = get_user(atoi(w_evt->user_id));
             }
             // audit_name & audit_uid
             if(regexec(&regexCompiled_auid, buffer, 2, match, 0) == 0) {
@@ -718,7 +718,7 @@ void audit_parse(char *buffer) {
                     w_evt->audit_name = NULL;
                     w_evt->audit_uid = NULL;
                 } else {
-                    w_evt->audit_name = get_user("",atoi(auid), NULL);
+                    w_evt->audit_name = get_user(atoi(auid));
                     w_evt->audit_uid = strdup(auid);
                 }
                 os_free(auid);
@@ -728,7 +728,7 @@ void audit_parse(char *buffer) {
                 match_size = match[1].rm_eo - match[1].rm_so;
                 os_malloc(match_size + 1, w_evt->effective_uid);
                 snprintf (w_evt->effective_uid, match_size + 1, "%.*s", match_size, buffer + match[1].rm_so);
-                w_evt->effective_name = get_user("",atoi(w_evt->effective_uid), NULL);
+                w_evt->effective_name = get_user(atoi(w_evt->effective_uid));
             }
             // group_name & group_id
             if(regexec(&regexCompiled_gid, buffer, 2, match, 0) == 0) {

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -2147,7 +2147,7 @@ static void test_get_user_success(void **state) {
     will_return(__wrap_getpwuid_r, 0);
     #endif
 
-    user = get_user(NULL, 1, NULL);
+    user = get_user(1);
 
     *state = user;
 
@@ -2167,7 +2167,7 @@ static void test_get_user_uid_not_found(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "User with uid '1' not found.\n");
 
-    user = get_user(NULL, 1, NULL);
+    user = get_user(1);
 
     *state = user;
 
@@ -2187,7 +2187,7 @@ static void test_get_user_error(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "Failed getting user_name (2): 'No such file or directory'\n");
 
-    user = get_user(NULL, 1, NULL);
+    user = get_user(1);
 
     *state = user;
 
@@ -2988,7 +2988,7 @@ static void test_get_user_CreateFile_error_access_denied(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "At get_user(C:\\a\\path): CreateFile(): An error message (5)");
 
-    array[0] = get_user("C:\\a\\path", 0, &array[1]);
+    array[0] = get_user("C:\\a\\path", &array[1]);
 
     assert_string_equal(array[0], "");
 }
@@ -3005,7 +3005,7 @@ static void test_get_user_CreateFile_error_sharing_violation(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "At get_user(C:\\a\\path): CreateFile(): An error message (32)");
 
-    array[0] = get_user("C:\\a\\path", 0, &array[1]);
+    array[0] = get_user("C:\\a\\path", &array[1]);
 
     assert_string_equal(array[0], "");
 }
@@ -3022,7 +3022,7 @@ static void test_get_user_CreateFile_error_generic(void **state) {
 
     expect_string(__wrap__mwarn, formatted_msg, "At get_user(C:\\a\\path): CreateFile(): An error message (127)");
 
-    array[0] = get_user("C:\\a\\path", 0, &array[1]);
+    array[0] = get_user("C:\\a\\path", &array[1]);
 
     assert_string_equal(array[0], "");
 }
@@ -3047,7 +3047,7 @@ static void test_get_user_GetSecurityInfo_error(void **state) {
 
     expect_string(__wrap__merror, formatted_msg, "GetSecurityInfo error = 1337");
 
-    array[0] = get_user("C:\\a\\path", 0, &array[1]);
+    array[0] = get_user("C:\\a\\path", &array[1]);
 
     assert_string_equal(array[0], "");
 }
@@ -3074,7 +3074,7 @@ static void test_get_user_LookupAccountSid_error(void **state) {
 
     expect_string(__wrap__merror, formatted_msg, "Error in LookupAccountSid.");
 
-    array[0] = get_user("C:\\a\\path", 0, &array[1]);
+    array[0] = get_user("C:\\a\\path", &array[1]);
 
     assert_string_equal(array[0], "");
     assert_string_equal(array[1], "sid");
@@ -3102,7 +3102,7 @@ static void test_get_user_LookupAccountSid_error_none_mapped(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "Account owner not found for file 'C:\\a\\path'");
 
-    array[0] = get_user("C:\\a\\path", 0, &array[1]);
+    array[0] = get_user("C:\\a\\path", &array[1]);
 
     assert_string_equal(array[0], "");
     assert_string_equal(array[1], "sid");
@@ -3126,7 +3126,7 @@ static void test_get_user_success(void **state) {
     will_return(wrap_syscheck_op_LookupAccountSid, "domainName");
     will_return(wrap_syscheck_op_LookupAccountSid, 1);
 
-    array[0] = get_user("C:\\a\\path", 0, &array[1]);
+    array[0] = get_user("C:\\a\\path", &array[1]);
 
     assert_string_equal(array[0], "accountName");
     assert_string_equal(array[1], "sid");

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -261,11 +261,20 @@ int __wrap_fim_db_set_scanned(fdb_t *fim_sql, char *path) {
     return mock();
 }
 
-char *__wrap_get_user(const char *path, int uid, char **sid) {
+#ifndef TEST_WINAGENT
+char *__wrap_get_user(int uid) {
     check_expected(uid);
 
     return mock_type(char*);
 }
+#else
+char *__wrap_get_user(const char *path, char **sid) {
+    check_expected(path);
+    *sid = mock_type(char*);
+
+    return mock_type(char*);
+}
+#endif
 
 const char *__wrap_get_group(int gid) {
     check_expected(gid);
@@ -1403,13 +1412,17 @@ static void test_fim_file_add(void **state) {
     fim_data->item->configuration |= CHECK_SEECHANGES;
 
     // Inside fim_get_data
+    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_user, uid, 0);
     will_return(__wrap_get_user, strdup("user"));
 
-    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
     #else
+    will_return(__wrap_get_user, "0");
+    will_return(__wrap_get_user, strdup("user"));
+    expect_string(__wrap_get_user, path, "file");
+
     expect_string(__wrap_w_get_file_permissions, file_path, "file");
     will_return(__wrap_w_get_file_permissions, "permissions");
     will_return(__wrap_w_get_file_permissions, 0);
@@ -1498,13 +1511,17 @@ static void test_fim_file_modify(void **state) {
     strcpy(fim_data->local_data->checksum, "");
 
     // Inside fim_get_data
+    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_user, uid, 0);
     will_return(__wrap_get_user, strdup("user"));
 
-    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
     #else
+    will_return(__wrap_get_user, "0");
+    will_return(__wrap_get_user, strdup("user"));
+    expect_string(__wrap_get_user, path, "file");
+
     expect_string(__wrap_w_get_file_permissions, file_path, "file");
     will_return(__wrap_w_get_file_permissions, "permissions");
     will_return(__wrap_w_get_file_permissions, 0);
@@ -1557,13 +1574,17 @@ static void test_fim_file_no_attributes(void **state) {
     fim_data->item->index = 1;
 
     // Inside fim_get_data
+    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_user, uid, 0);
     will_return(__wrap_get_user, strdup("user"));
 
-    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
     #else
+    will_return(__wrap_get_user, "0");
+    will_return(__wrap_get_user, strdup("user"));
+    expect_string(__wrap_get_user, path, "file");
+
     expect_string(__wrap_w_get_file_permissions, file_path, "file");
     will_return(__wrap_w_get_file_permissions, "permissions");
     will_return(__wrap_w_get_file_permissions, 0);
@@ -1627,13 +1648,17 @@ static void test_fim_file_error_on_insert(void **state) {
     strcpy(fim_data->local_data->checksum, "");
 
     // Inside fim_get_data
+    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_user, uid, 0);
     will_return(__wrap_get_user, strdup("user"));
 
-    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
     #else
+    will_return(__wrap_get_user, "0");
+    will_return(__wrap_get_user, strdup("user"));
+    expect_string(__wrap_get_user, path, "file");
+
     expect_string(__wrap_w_get_file_permissions, file_path, "file");
     will_return(__wrap_w_get_file_permissions, "permissions");
     will_return(__wrap_w_get_file_permissions, 0);
@@ -1857,12 +1882,10 @@ static void test_fim_checker_fim_regular(void **state) {
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
 
-    #ifndef TEST_WINAGENT
     expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
     expect_value(__wrap_fim_db_get_paths_from_inode, inode, 999);
     expect_value(__wrap_fim_db_get_paths_from_inode, dev, 1);
     will_return(__wrap_fim_db_get_paths_from_inode, NULL);
-    #endif
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, "/media/test.file");
@@ -1903,12 +1926,10 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
 
-    #ifndef TEST_WINAGENT
     expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
     expect_value(__wrap_fim_db_get_paths_from_inode, inode, 999);
     expect_value(__wrap_fim_db_get_paths_from_inode, dev, 1);
     will_return(__wrap_fim_db_get_paths_from_inode, NULL);
-    #endif
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, "/media/test.file");
@@ -2072,12 +2093,10 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
 
-    #ifndef TEST_WINAGENT
     expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
     expect_value(__wrap_fim_db_get_paths_from_inode, inode, 999);
     expect_value(__wrap_fim_db_get_paths_from_inode, dev, 1);
     will_return(__wrap_fim_db_get_paths_from_inode, NULL);
-    #endif
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, "/test.file");
@@ -2566,8 +2585,9 @@ static void test_fim_checker_fim_regular(void **state) {
     will_return(__wrap_HasFilesystem, 0);
 
     // Inside fim_file
-    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, "0");
     will_return(__wrap_get_user, strdup("user"));
+    expect_string(__wrap_get_user, path, expanded_path);
 
     expect_string(__wrap_w_get_file_permissions, file_path, expanded_path);
     will_return(__wrap_w_get_file_permissions, "permissions");
@@ -2681,8 +2701,9 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     will_return(__wrap_HasFilesystem, 0);
 
     // Inside fim_file
-    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, "0");
     will_return(__wrap_get_user, strdup("user"));
+    expect_string(__wrap_get_user, path, expanded_path);
 
     expect_string(__wrap_w_get_file_permissions, file_path, expanded_path);
     will_return(__wrap_w_get_file_permissions, "permissions");
@@ -2778,8 +2799,9 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
     fim_data->item->mode = FIM_REALTIME;
 
     // Inside fim_file
-    expect_value(__wrap_get_user, uid, 0);
+    will_return(__wrap_get_user, "0");
     will_return(__wrap_get_user, strdup("user"));
+    expect_string(__wrap_get_user, path, "c:\\test.file");
 
     expect_string(__wrap_w_get_file_permissions, file_path, "c:\\test.file");
     will_return(__wrap_w_get_file_permissions, "permissions");
@@ -3570,13 +3592,17 @@ static void test_fim_get_data(void **state) {
                                     CHECK_SHA1SUM |
                                     CHECK_SHA256SUM;
 
+    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_user, uid, 0);
     will_return(__wrap_get_user, strdup("user"));
 
-    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
     #else
+    will_return(__wrap_get_user, "0");
+    will_return(__wrap_get_user, strdup("user"));
+    expect_string(__wrap_get_user, path, "test");
+
     expect_string(__wrap_w_get_file_permissions, file_path, "test");
     will_return(__wrap_w_get_file_permissions, "permissions");
     will_return(__wrap_w_get_file_permissions, 0);
@@ -3630,13 +3656,17 @@ static void test_fim_get_data_no_hashes(void **state) {
                                     CHECK_OWNER |
                                     CHECK_GROUP;
 
+    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_user, uid, 0);
     will_return(__wrap_get_user, strdup("user"));
 
-    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
     #else
+    will_return(__wrap_get_user, "0");
+    will_return(__wrap_get_user, strdup("user"));
+    expect_string(__wrap_get_user, path, "test");
+
     expect_string(__wrap_w_get_file_permissions, file_path, "test");
     will_return(__wrap_w_get_file_permissions, "permissions");
     will_return(__wrap_w_get_file_permissions, 0);
@@ -3670,13 +3700,17 @@ static void test_fim_get_data_hash_error(void **state) {
     buf.st_gid = 0;
     fim_data->item->statbuf = buf;
 
+    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_user, uid, 0);
     will_return(__wrap_get_user, strdup("user"));
 
-    #ifndef TEST_WINAGENT
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
     #else
+    will_return(__wrap_get_user, "0");
+    will_return(__wrap_get_user, strdup("user"));
+    expect_string(__wrap_get_user, path, "test");
+
     expect_string(__wrap_w_get_file_permissions, file_path, "test");
     will_return(__wrap_w_get_file_permissions, "permissions");
     will_return(__wrap_w_get_file_permissions, 0);

--- a/src/unit_tests/syscheckd/test_fim_db.c
+++ b/src/unit_tests/syscheckd/test_fim_db.c
@@ -1113,6 +1113,9 @@ void test_fim_db_insert_inode_id_nonull(void **state) {
     expect_value(__wrap_sqlite3_column_int, iCol, 0);
     will_return(__wrap_sqlite3_column_int, 1);
 
+    expect_value(__wrap_sqlite3_column_int, iCol, 1);
+    will_return(__wrap_sqlite3_column_int, 1);
+
     // Inside fim_db_clean_stmt
     {
         will_return(__wrap_sqlite3_reset, SQLITE_OK);
@@ -1178,6 +1181,9 @@ void test_fim_db_insert_inode_id_null(void **state) {
 
     expect_value(__wrap_sqlite3_column_int, iCol, 0);
     will_return(__wrap_sqlite3_column_int, 1);
+
+    expect_value(__wrap_sqlite3_column_int, iCol, 1);
+    will_return(__wrap_sqlite3_column_int, 0);
 
     // Inside fim_db_clean_stmt
     {

--- a/src/unit_tests/syscheckd/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/test_syscheck_audit.c
@@ -270,7 +270,7 @@ void __wrap_closeproc(PROCTAB* PT)
     check_expected(PT);
 }
 
-char *__wrap_get_user(__attribute__((unused)) const char *path, int uid, __attribute__((unused)) char **sid)
+char *__wrap_get_user(int uid)
 {
     check_expected(uid);
     return mock_type(char*);
@@ -302,7 +302,7 @@ int __wrap_recv(int __fd, void *__buf, size_t __n, int __flags)
 
     return ret;
 }
-  
+
 int __wrap_pthread_cond_init(pthread_cond_t *__cond, const pthread_condattr_t *__cond_attr) {
     function_called();
     return 0;
@@ -2406,7 +2406,7 @@ void test_audit_read_events_select_case_0_healthcheck(void **state)
     expect_value(__wrap_recv, __fd, *audit_sock);
     will_return(__wrap_recv, strlen(buffer));
     will_return(__wrap_recv, buffer);
- 
+
     // In audit_parse()
     expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
     expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
@@ -2541,7 +2541,7 @@ void test_audit_read_events_select_success_recv_success(void **state)
     will_return(__wrap_recv, strlen(buffer));
     will_return(__wrap_recv, buffer);
 
-    for (int i = 0; i<2; i++){    
+    for (int i = 0; i<2; i++){
         // In audit_parse()
         expect_string(__wrap__mdebug2, msg, FIM_AUDIT_MATCH_KEY);
         expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_fim\"'");
@@ -2622,7 +2622,7 @@ void test_audit_read_events_select_success_recv_success_no_id(void **state)
 
     expect_string(__wrap__mwarn, formatted_msg, "(6928): Couldn't get event ID from Audit message. Line: '         type=SYSC arch=c000003e syscall=263 success=yes exit'.");
 
-    
+
 
     will_return(__wrap_select, 1);
 
@@ -2653,7 +2653,7 @@ void test_audit_read_events_select_success_recv_success_too_long(void **state)
     will_return(__wrap_recv, strlen(buffer));
     will_return(__wrap_recv, buffer);
 
-    
+
     char * buffer2 = "type=SYSCALLmsg=audit(1571914029.306:3004254):aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n";
 
     will_return(__wrap_select, 1);
@@ -2748,6 +2748,6 @@ int main(void) {
         cmocka_unit_test(test_audit_health_check_no_creation_event_detected),
         cmocka_unit_test_setup_teardown(test_audit_health_check_success, setup_hc_success, teardown_hc_success),
     };
-  
+
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }


### PR DESCRIPTION
|Related issue|
|---|
|none|

## Description

Fixed serveral bugs reported by coverity:
- Dereference before null check in `new_data`
https://github.com/wazuh/wazuh/blob/21a7670a49e03ee32f2cedbcda8a77038ad3a52e/src/syscheckd/create_db.c#L929-L935
- Using uninitialized value `inode_id`
https://github.com/wazuh/wazuh/blob/21a7670a49e03ee32f2cedbcda8a77038ad3a52e/src/syscheckd/fim_db.c#L867-L893
- Untrusted value as argument (TAINTED_SCALAR)

## Test
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
