### PR TITLE
Logtest-memleak-rule-dont-match

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -97,7 +97,6 @@ static unsigned int hourly_events;
 static unsigned int hourly_syscheck;
 static unsigned int hourly_firewall;
 
-void w_free_event_info(Eventinfo *lf);
 
 /* Output threads */
 void * w_main_output_thread(__attribute__((unused)) void * args);
@@ -1362,35 +1361,6 @@ void * ad_input_main(void * args) {
     return NULL;
 }
 
-void w_free_event_info(Eventinfo *lf) {
-    /** Cleaning the memory **/
-    int force_remove = 1;
-    /* Only clear the memory if the eventinfo was not
-        * added to the stateful memory
-        * -- message is free inside clean event --
-    */
-    if (lf->generated_rule == NULL) {
-        Free_Eventinfo(lf);
-        force_remove = 0;
-    } else if (lf->last_events) {
-        int i;
-        if (lf->queue_added) {
-            force_remove = 0;
-        }
-        if (lf->last_events) {
-            for (i = 0; lf->last_events[i]; i++) {
-                os_free(lf->last_events[i]);
-            }
-            os_free(lf->last_events);
-        }
-    } else if (lf->queue_added) {
-        force_remove = 0;
-    }
-
-    if (force_remove) {
-        Free_Eventinfo(lf);
-    }
-}
 
 void * w_writer_thread(__attribute__((unused)) void * args ){
     Eventinfo *lf = NULL;

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -1368,3 +1368,33 @@ void w_copy_event_for_log(Eventinfo *lf,Eventinfo *lf_cpy){
     lf_cpy->rootcheck_fts = lf->rootcheck_fts;
     lf_cpy->is_a_copy = 1;
 }
+
+void w_free_event_info(Eventinfo *lf) {
+    /** Cleaning the memory **/
+    int force_remove = 1;
+    /* Only clear the memory if the eventinfo was not
+        * added to the stateful memory
+        * -- message is free inside clean event --
+    */
+    if (lf->generated_rule == NULL) {
+        Free_Eventinfo(lf);
+        force_remove = 0;
+    } else if (lf->last_events) {
+        int i;
+        if (lf->queue_added) {
+            force_remove = 0;
+        }
+        if (lf->last_events) {
+            for (i = 0; lf->last_events[i]; i++) {
+                os_free(lf->last_events[i]);
+            }
+            os_free(lf->last_events);
+        }
+    } else if (lf->queue_added) {
+        force_remove = 0;
+    }
+
+    if (force_remove) {
+        Free_Eventinfo(lf);
+    }
+}

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -201,6 +201,13 @@ void Zero_Eventinfo(Eventinfo *lf);
  */
 void Free_Eventinfo(Eventinfo *lf);
 
+/**
+ * @brief Clear the memory if the eventinfo was not added to the stateful memory
+ * 
+ * @param lf Eventinfo to free
+ */
+void w_free_event_info(Eventinfo *lf);
+
 /* Add and event to the list of previous events */
 void OS_AddEvent(Eventinfo *lf, EventList *list);
 

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -187,10 +187,8 @@ cJSON *w_logtest_process_log(cJSON * request, w_logtest_session_t * session, OSL
     output = cJSON_Parse(output_str);
     os_free(output_str);
 
-    /* Only clear the memory if the event was not added to the stateful memory */
-    if (lf->generated_rule == NULL) {
-        Free_Eventinfo(lf);
-    }
+    /* Clear the memory if the event was not added to the stateful memory */
+    w_free_event_info(lf);
 
     return output;
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5830|

Hi Team, 

This fix is based on the current implementation to remove the event information from the current analysisd.

- Tasks
- [X] Compile without warning in linux
- [x] Valgrind
- [X] Scan-build
- [X] Unit test pass



Regards,
Julian