### PR TITLE
Logtest remove client on demand

### DIFF
--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -395,7 +395,7 @@ w_logtest_session_t *w_logtest_initialize_session(char *token, OSList* list_msg)
     files = Config.includes;
 
     while (files && *files) {
-        if (Rules_OP_ReadRules(*files, &session->rule_list, &session->cdblistnode, 
+        if (Rules_OP_ReadRules(*files, &session->rule_list, &session->cdblistnode,
                             &session->eventlist, &session->decoder_store, list_msg) < 0) {
             return NULL;
         }
@@ -506,12 +506,12 @@ void *w_logtest_check_inactive_sessions(w_logtest_connection_t * connection) {
             w_mutex_unlock(&session->mutex);
 
             hash_node = OSHash_Next(w_logtest_sessions, &inode_it, hash_node);
-            
+
             if (session->expired) {
                 connection->active_client -= 1;
                 w_logtest_remove_session(token_session);
             }
-            
+
         }
 
         w_mutex_unlock(&connection->mutex_hash_table);
@@ -551,16 +551,12 @@ int w_logtest_fts_init(OSList **fts_list, OSHash **fts_store) {
 }
 
 
-bool w_logtest_check_input(char * input_json, cJSON ** req, OSList * list_msg) {
+int w_logtest_check_input(char * input_json, cJSON ** req, OSList * list_msg) {
 
-    /* Nodes JSON input */
+    /* Node JSON input */
     cJSON * root;
-    cJSON * location;
-    cJSON * log_format;
-    cJSON * event;
-    cJSON * token;
 
-    bool retval = true;
+    int retval = W_LOGTEST_REQUEST_ERROR;
 
     /* Parse raw JSON input */
     const char * jsonErrPtr;
@@ -584,8 +580,54 @@ bool w_logtest_check_input(char * input_json, cJSON ** req, OSList * list_msg) {
         smerror(list_msg, LOGTEST_ERROR_JSON_PARSE_POS, (int) (jsonErrPtr - input_json), slice_json);
 
         os_free(slice_json);
-        return false;
+        return retval;
     }
+
+    if (cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_REMOVE_SESSION)) {
+        retval = w_logtest_check_input_remove_session(root, list_msg);
+    } else {
+        retval = w_logtest_check_input_request(root, list_msg);
+    }
+
+
+    return retval;
+}
+
+int w_logtest_check_input_remove_session(cJSON * root, OSList * list_msg) {
+
+    cJSON * token;
+
+    int retval = W_LOGTEST_REQUEST_TYPE_REMOVE_SESSION;
+
+    token = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_REMOVE_SESSION);
+    if (!cJSON_IsString(token) || (cJSON_IsString(token) && token->valuestring == NULL) ) {
+
+        mdebug1(LOGTEST_ERROR_TOKEN_INVALID_TYPE);
+        smerror(list_msg, LOGTEST_ERROR_TOKEN_INVALID_TYPE);
+
+        retval = W_LOGTEST_REQUEST_ERROR;
+
+    } else if (cJSON_IsString(token) && token->valuestring != NULL
+               && strlen(token->valuestring) != W_LOGTEST_TOKEN_LENGH) {
+
+        mdebug1(LOGTEST_ERROR_TOKEN_INVALID, token->valuestring);
+        smerror(list_msg, LOGTEST_ERROR_TOKEN_INVALID, token->valuestring);
+
+        retval = W_LOGTEST_REQUEST_ERROR;
+    }
+
+    return retval;
+
+}
+
+int w_logtest_check_input_request(cJSON * root, OSList * list_msg) {
+
+    cJSON * location;
+    cJSON * log_format;
+    cJSON * event;
+    cJSON * token;
+
+    int retval = W_LOGTEST_REQUEST_TYPE_LOG_PROCESSING;
 
     /* Check JSON fields */
     location = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_LOCATION);
@@ -593,26 +635,26 @@ bool w_logtest_check_input(char * input_json, cJSON ** req, OSList * list_msg) {
 
         mdebug1(LOGTEST_ERROR_JSON_REQUIRED_SFIELD, W_LOGTEST_JSON_LOCATION);
         smerror(list_msg, LOGTEST_ERROR_JSON_REQUIRED_SFIELD, W_LOGTEST_JSON_LOCATION);
-        retval = false;
+        retval = W_LOGTEST_REQUEST_ERROR;
     }
 
-    log_format = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_LOGFORMAT); 
-    if (!(cJSON_IsString(log_format) && log_format->valuestring != NULL 
+    log_format = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_LOGFORMAT);
+    if (!(cJSON_IsString(log_format) && log_format->valuestring != NULL
           && strlen(log_format->valuestring) > 0)) {
 
         mdebug1(LOGTEST_ERROR_JSON_REQUIRED_SFIELD, W_LOGTEST_JSON_LOGFORMAT);
         smerror(list_msg, LOGTEST_ERROR_JSON_REQUIRED_SFIELD, W_LOGTEST_JSON_LOGFORMAT);
-        retval = false;
+        retval = W_LOGTEST_REQUEST_ERROR;
     }
 
     /* An event can be a string or a json object */
-    event = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_EVENT);    
-    if ( !(cJSON_IsString(event) && event->valuestring != NULL  && strlen(event->valuestring) > 0)
+    event = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_EVENT);
+    if ( !(cJSON_IsString(event) && event->valuestring != NULL && strlen(event->valuestring) > 0)
          && !(cJSON_IsObject(event) && event->child != NULL)) {
 
         mdebug1(LOGTEST_ERROR_FIELD_NOT_FOUND, W_LOGTEST_JSON_EVENT);
         smerror(list_msg, LOGTEST_ERROR_FIELD_NOT_FOUND, W_LOGTEST_JSON_EVENT);
-        retval = false;
+        retval = W_LOGTEST_REQUEST_ERROR;
     }
 
     token = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_TOKEN);
@@ -828,11 +870,9 @@ void w_logtest_add_msg_response(cJSON * response, OSList * list_msg, int * error
 char * w_logtest_process_request(char * raw_request, w_logtest_connection_t * connection) {
 
     char * str_response = NULL;
+    int request_type;
     cJSON * json_request = NULL;
     cJSON * json_response = NULL;
-    cJSON * json_log_processed = NULL;
-
-    w_logtest_session_t * current_session = NULL;
 
     /* error & message handlers */
     int retval = W_LOGTEST_RCODE_SUCCESS;
@@ -845,20 +885,47 @@ char * w_logtest_process_request(char * raw_request, w_logtest_connection_t * co
 
     /* Check message and generate a request */
     json_response = cJSON_CreateObject();
-    if (!w_logtest_check_input(raw_request, &json_request, list_msg)) {
+    request_type = w_logtest_check_input(raw_request, &json_request, list_msg);
+
+    if (request_type == W_LOGTEST_REQUEST_ERROR) {
+
         w_logtest_add_msg_response(json_response, list_msg, &retval);
         retval = W_LOGTEST_RCODE_ERROR_INPUT;
+
+    } else if (request_type == W_LOGTEST_REQUEST_TYPE_LOG_PROCESSING) {
+
+        retval = w_logtest_process_request_log_processing(json_request, json_response, list_msg, connection);
+
+    } else if (request_type == W_LOGTEST_REQUEST_TYPE_REMOVE_SESSION) {
+
+        retval = w_logtest_process_request_remove_session(json_request, json_response, list_msg, connection);
+
     }
+
+    cJSON_AddNumberToObject(json_response, W_LOGTEST_JSON_CODE, retval);
+
+    str_response = cJSON_PrintUnformatted(json_response);
+    cJSON_Delete(json_response);
+    cJSON_Delete(json_request);
+    os_free(list_msg);
+
+    return str_response;
+}
+
+int w_logtest_process_request_log_processing(cJSON * json_request, cJSON * json_response, OSList * list_msg,
+                                             w_logtest_connection_t * connection) {
+
+    w_logtest_session_t * current_session = NULL;
+    cJSON * json_log_processed = NULL;
+
+    int retval = W_LOGTEST_RCODE_SUCCESS;
 
     /* Get session */
-    if (retval >= W_LOGTEST_RCODE_SUCCESS) {
-
-        current_session = w_logtest_get_session(json_request, list_msg, connection);
-        if (current_session) {
-            cJSON_AddStringToObject(json_response, W_LOGTEST_JSON_TOKEN, current_session->token);
-        }
-        w_logtest_add_msg_response(json_response, list_msg, &retval);
+    current_session = w_logtest_get_session(json_request, list_msg, connection);
+    if (current_session) {
+        cJSON_AddStringToObject(json_response, W_LOGTEST_JSON_TOKEN, current_session->token);
     }
+    w_logtest_add_msg_response(json_response, list_msg, &retval);
 
     /* Proccess log */
     if (retval >= W_LOGTEST_RCODE_SUCCESS && current_session) {
@@ -880,12 +947,43 @@ char * w_logtest_process_request(char * raw_request, w_logtest_connection_t * co
         cJSON_AddBoolToObject(json_response, W_LOGTEST_JSON_ALERT, alert);
     }
 
-    cJSON_AddNumberToObject(json_response, W_LOGTEST_JSON_CODE, retval);
+    return retval;
+}
 
-    str_response = cJSON_PrintUnformatted(json_response);
-    cJSON_Delete(json_response);
-    cJSON_Delete(json_request);
-    os_free(list_msg);
+int w_logtest_process_request_remove_session(cJSON * json_request, cJSON * json_response, OSList * list_msg,
+                                             w_logtest_connection_t * connection) {
 
-    return str_response;
+    w_logtest_session_t * session = NULL;
+    int retval = W_LOGTEST_RCODE_SUCCESS;
+    cJSON * j_token = NULL;
+    char * s_token = NULL;
+
+    j_token = cJSON_GetObjectItemCaseSensitive(json_request, W_LOGTEST_JSON_REMOVE_SESSION);
+
+    if (j_token && j_token->valuestring != NULL) {
+        s_token = j_token->valuestring;
+
+        w_mutex_lock(&connection->mutex_hash_table);
+
+        if (session = OSHash_Get_ex(w_logtest_sessions, s_token), session) {
+
+            connection->active_client -= 1;
+            w_logtest_remove_session(s_token);
+            sminfo(list_msg, LOGTEST_INFO_SESSION_REMOVE, s_token);
+
+        } else {
+            smerror(list_msg, LOGTEST_WARN_SESSION_NOT_FOUND, s_token);
+            mdebug1(LOGTEST_WARN_SESSION_NOT_FOUND, s_token);
+        }
+
+        w_mutex_unlock(&connection->mutex_hash_table);
+
+    } else {
+        smerror(list_msg, LOGTEST_ERROR_TOKEN_INVALID_TYPE);
+        mdebug1(LOGTEST_ERROR_TOKEN_INVALID_TYPE);
+    }
+
+    w_logtest_add_msg_response(json_response, list_msg, &retval);
+
+    return retval;
 }

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -28,14 +28,15 @@
 
 
 /* JSON REQUEST / RESPONSE fields names */
-#define W_LOGTEST_JSON_TOKEN            "token"   ///< Token field name of json input/output
-#define W_LOGTEST_JSON_EVENT            "event"   ///< Event field name of json input
-#define W_LOGTEST_JSON_LOGFORMAT   "log_format"   ///< Log format field name of json input
-#define W_LOGTEST_JSON_LOCATION      "location"   ///< Location field name of json input
-#define W_LOGTEST_JSON_ALERT            "alert"   ///< Alert field name of json output (boolean)
-#define W_LOGTEST_JSON_MESSAGES      "messages"   ///< Message format field name of json output
-#define W_LOGTEST_JSON_CODE           "codemsg"   ///< Code of message field name of json output (number)
-#define W_LOGTEST_JSON_OUTPUT          "output"   ///< Output field name of json output
+#define W_LOGTEST_JSON_TOKEN                    "token"   ///< Token field name of json input/output
+#define W_LOGTEST_JSON_EVENT                    "event"   ///< Event field name of json input
+#define W_LOGTEST_JSON_LOGFORMAT           "log_format"   ///< Log format field name of json input
+#define W_LOGTEST_JSON_LOCATION              "location"   ///< Location field name of json input
+#define W_LOGTEST_JSON_REMOVE_SESSION  "remove_session"   ///< Remove session field name of json input
+#define W_LOGTEST_JSON_ALERT                    "alert"   ///< Alert field name of json output (boolean)
+#define W_LOGTEST_JSON_MESSAGES              "messages"   ///< Message format field name of json output
+#define W_LOGTEST_JSON_CODE                   "codemsg"   ///< Code of message field name of json output (number)
+#define W_LOGTEST_JSON_OUTPUT                  "output"   ///< Output field name of json output
 
 #define W_LOGTEST_TOKEN_LENGH                 8   ///< Lenght of token
 #define W_LOGTEST_ERROR_JSON_PARSE_NSTR      20   ///< Number of characters to show in parsing error
@@ -46,6 +47,11 @@
 #define W_LOGTEST_RCODE_SUCCESS               0   ///< Return code: Successful request
 #define W_LOGTEST_RCODE_WARNING               1   ///< Return code: Successful request with warning messages
 
+/* Type of request */
+#define W_LOGTEST_REQUEST_ERROR                  -1   ///< Request error: Missing fields or don't matches
+#define W_LOGTEST_REQUEST_TYPE_REMOVE_SESSION     0   ///< Request remove session
+#define W_LOGTEST_REQUEST_TYPE_LOG_PROCESSING     1   ///< Request log processing
+
 
 /**
  * @brief A w_logtest_session_t instance represents a client
@@ -55,7 +61,7 @@ typedef struct w_logtest_session_t {
     char *token;                            ///< Client ID
     time_t last_connection;                 ///< Timestamp of the last query
     bool expired;                           ///< Indicates that the session expired and will be deleted
-    pthread_mutex_t mutex;                  ///< Prevent race condition between get a session and remove it for inactivity 
+    pthread_mutex_t mutex;                  ///< Prevent race condition between get a session and remove it for inactivity
 
     RuleNode *rule_list;                    ///< Rule list
     OSDecoderNode *decoderlist_forpname;    ///< Decoder list to match logs which have a program name
@@ -194,9 +200,29 @@ int w_logtest_fts_init(OSList **fts_list, OSHash **fts_store);
  * @param req Client request information
  * @param input_json Raw JSON input of requeset
  * @param list_msg list of \ref os_analysisd_log_msg_t for store messages
- * @return true on valid input, otherwise false
+ * @retval \ref W_LOGTEST_REQUEST_ERROR on invalid input
+ * @retval \ref W_LOGTEST_REQUEST_TYPE_LOG_PROCESSING on valid request input
+ * @retval \ref W_LOGTEST_REQUEST_TYPE_REMOVE_SESSION on valid remove session input
  */
-bool w_logtest_check_input(char* input_json, cJSON** req, OSList* list_msg);
+int w_logtest_check_input(char* input_json, cJSON** req, OSList* list_msg);
+
+/**
+ * @brief Check validity of the json for a log processing request
+ * @param root json to validate
+ * @param list_msg list of \ref os_analysisd_log_msg_t for store messages
+ * @retval \ref W_LOGTEST_REQUEST_ERROR on invalid input
+ * @retval \ref W_LOGTEST_REQUEST_TYPE_LOG_PROCESSING on valid request input
+ */
+int w_logtest_check_input_request(cJSON * root, OSList * list_msg);
+
+/**
+ * @brief Check validity of the json for a remove session request
+ * @param root json to validate
+ * @param list_msg list of \ref os_analysisd_log_msg_t for store messages
+ * @retval \ref W_LOGTEST_REQUEST_ERROR on invalid input
+ * @retval \ref W_LOGTEST_REQUEST_TYPE_REMOVE_SESSION on valid request input
+ */
+int w_logtest_check_input_remove_session(cJSON * root, OSList * list_msg);
 
 /**
  * @brief Add the messages to the json array and clear the list.
@@ -206,7 +232,7 @@ bool w_logtest_check_input(char* input_json, cJSON** req, OSList* list_msg);
  * \ref W_LOGTEST_RCODE_SUCCESS If the list is empty or there are only info messages.
  * \ref W_LOGTEST_RCODE_WARNING If there are warning messages.
  * \ref W_LOGTEST_RCODE_ERROR_PROCESS If there are error messages.
- * 
+ *
  * @param response json response for the client
  * @param list_msg list of \ref os_analysisd_log_msg_t for store messages
  * @param error_code Actual level error
@@ -234,7 +260,7 @@ w_logtest_session_t * w_logtest_get_session(cJSON * req, OSList * list_msg, w_lo
 
 /**
  * @brief Register a session as active in connection
- * 
+ *
  * Register a session on the hash table
  *
  * @param connection Manager of connections
@@ -265,5 +291,31 @@ int w_logtest_get_rule_level(cJSON* json_log_processed);
  * @return string (json format) with the result of the request
  */
 char * w_logtest_process_request(char * raw_request, w_logtest_connection_t * connection);
+
+/**
+ * @brief Processes a client input log procecessing request
+ * @param json_request Client request
+ * @param json_response Client response
+ * @param list_msg list of \ref os_analysisd_log_msg_t for store messages
+ * @param connection Manager of connections
+ * @retval \ref W_LOGTEST_RCODE_ERROR_PROCESS on failure
+ * @retval \ref W_LOGTEST_RCODE_SUCCESS on success
+ * @retval \ref W_LOGTEST_RCODE_WARNING on success with warnings
+ */
+int w_logtest_process_request_log_processing(cJSON * json_request, cJSON * json_response, OSList * list_msg,
+                                             w_logtest_connection_t * connection);
+
+/**
+ * @brief Processes a client input remove request
+ * @param json_request Client request
+ * @param json_response Client response
+ * @param list_msg list of \ref os_analysisd_log_msg_t for store messages
+ * @param connection Manager of connections
+ * @retval \ref W_LOGTEST_RCODE_ERROR_PROCESS on failure
+ * @retval \ref W_LOGTEST_RCODE_SUCCESS on success
+ * @retval \ref W_LOGTEST_RCODE_WARNING on success with warnings
+ */
+int w_logtest_process_request_remove_session(cJSON * json_request, cJSON * json_response, OSList * list_msg,
+                                             w_logtest_connection_t * connection);
 
 #endif

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -511,6 +511,7 @@
 #define LOGTEST_ERROR_INITIALIZE_SESSION            "(7311): Failure to initializing session '%s'"
 #define LOGTEST_ERROR_PROCESS_EVENT                 "(7312): Failed to process the event"
 #define LOGTEST_ERROR_FIELD_NOT_FOUND               "(7313): '%s' JSON field not found or is empty"
+#define LOGTEST_ERROR_TOKEN_INVALID_TYPE            "(7309): Failure to remove session. remove_session JSON field must be a string"
 
 /* Verbose messages */
 #define STARTUP_MSG "Started (pid: %d)."

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -65,5 +65,6 @@
 #define LOGTEST_INFO_LOG_EMPTY              "(7203): Empty log for check alert level"
 #define LOGTEST_INFO_LOG_NOALERT            "(7204): Output without rule"
 #define LOGTEST_INFO_LOG_NOLEVEL            "(7205): Rule without alert level"
+#define LOGTEST_INFO_SESSION_REMOVE         "(7206): The session '%s' was closed successfully"
 
 #endif /* INFO_MESSAGES_H */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -59,6 +59,7 @@
 #define LOGTEST_INV_NUM_THREADS             "(7000): Number of logtest threads too high. Only creates %d threads"
 #define LOGTEST_INV_NUM_USERS               "(7001): Number of maximum users connected in logtest too high. Only allows %d users"
 #define LOGTEST_INV_NUM_TIMEOUT             "(7002): Number of maximum user timeouts in logtest too high. Only allows %ds maximum timeouts"
-#define LOGTEST_WARN_TOKEN_EXPIRED          "(7003): '%s' token expires."
+#define LOGTEST_WARN_TOKEN_EXPIRED          "(7003): '%s' token expires"
+#define LOGTEST_WARN_SESSION_NOT_FOUND      "(7004): No session found for token '%s'"
 
 #endif /* WARN_MESSAGES_H */


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5837|

Hi Team, 

This pr adds the feature to remove sessions on demand through a json query. It does this by checking if the remove_session field is present in the query.

## Outputs of this PR

### **First request to create a session**
```
{
	"token": "kTy234Sdvtp7",
	"event": {
		"timestamp": "2016-05-02T17:46:48.515262+0000",
		"flow_id": 1234,
		"in_iface": "eth0",
		"src_ip": "16.10.10.10",
		"src_port": 5555,
		"dest_ip": "16.10.10.11",
		"dest_port": 80,
		"proto": "TCP",
		"alert": {
			"action": "allowed",
			"gid": 1,
			"signature_id": 2019236,
			"rev": 3,
			"signature": "ET WEB_SERVER Possible CVE-2014-6271 Attempt in HTTP Version Number",
			"category": "Attempted Administrator Privilege Gain",
			"severity": 1
		},
		"payload": "21YW5kXBtgdW5zIGRlcHJY2F0QgYWI",
		"payload_printable": "this_is_an_example",
		"stream": 0,
		"host": "suricata.com"
	},
	"log_format": "syslog",
	"location": "master->/var/log/syslog"
}
```
**quick test:**
```
echo '{"token": "kTy234Sdvtp7","event": {   "timestamp": "2016-05-02T17:46:48.515262+0000", "flow_id": 1234,   "in_iface": "eth0",   "src_ip": "16.10.10.10",   "src_port": 5555,   "dest_ip": "16.10.10.11",   "dest_port": 80,   "proto": "TCP",   "alert": {       "action": "allowed",      "gid": 1,      "signature_id": 2019236,      "rev": 3,      "signature": "ET WEB_SERVER Possible CVE-2014-6271 Attempt in HTTP Version Number",      "category": "Attempted Administrator Privilege Gain",      "severity": 1   },   "payload": "21YW5kXBtgdW5zIGRlcHJY2F0QgYWI",   "payload_printable": "this_is_an_example",   "stream": 0,   "host": "suricata.com" },"log_format": "syslog","location": "master->/var/log/syslog"}' | nc -U /var/ossec/queue/ossec/logtest
```

**output**
```
{
	"token": "7a5e0e6f",
	"messages": [
                             "WARNING: (7309): 'kTy234Sdvtp7' is not a valid token", 
                             "INFO: (7202): Session initialized with token '7a5e0e6f'"
        ],
	"output": {
		"timestamp": "2020-08-27T21:37:52.459+0000",
		"agent": {
			"id": "000",
			"name": "u20-40-Manager"
		},
		"manager": {
			"name": "u20-40-Manager"
		},
		"id": "1598564272.0",
		"full_log": "{\"timestamp\":\"2016-05-02T17:46:48.515262+0000\",\"flow_id\":1234,\"in_iface\":\"eth0\",\"src_ip\":\"16.10.10.10\",\"src_port\":5555,\"dest_ip\":\"16.10.10.11\",\"dest_port\":80,\"proto\":\"TCP\",\"alert\":{\"action\":\"allowed\",\"gid\":1,\"signature_id\":2019236,\"rev\":3,\"signature\":\"ET WEB_SERVER Possible CVE-2014-6271 Attempt in HTTP Version Number\",\"category\":\"Attempted Administrator Privilege Gain\",\"severity\":1},\"payload\":\"21YW5kXBtgdW5zIGRlcHJY2F0QgYWI\",\"payload_printable\":\"this_is_an_example\",\"stream\":0,\"host\":\"suricata.com\"}",
		"decoder": {
			"name": "json"
		},
		"data": {
			"timestamp": "2016-05-02T17:46:48.515262+0000",
			"flow_id": "1234",
			"in_iface": "eth0",
			"src_ip": "16.10.10.10",
			"src_port": "5555",
			"dest_ip": "16.10.10.11",
			"dest_port": "80",
			"proto": "TCP",
			"alert": {
				"action": "allowed",
				"gid": "1",
				"signature_id": "2019236",
				"rev": "3",
				"signature": "ET WEB_SERVER Possible CVE-2014-6271 Attempt in HTTP Version Number",
				"category": "Attempted Administrator Privilege Gain",
				"severity": "1"
			},
			"payload": "21YW5kXBtgdW5zIGRlcHJY2F0QgYWI",
			"payload_printable": "this_is_an_example",
			"stream": "0",
			"host": "suricata.com"
		},
		"location": "master->/var/log/syslog"
	},
	"alert": false,
	"codemsg": 1
}
```

### **Remove invalid token type**

**input**
```
{
	"remove_session": 6
}
```

**output**
```
{
	"messages": ["ERROR: (7309): Failure to remove session. remove_session JSON field must be a string"],
	"codemsg": -2
}
```

### **Remove invalid json**

**input**
```
{
	"remove_session": asd
}
```

**output**
```
{
	"messages": ["ERROR: (7306): Error parsing JSON", "ERROR: (7307): Error in position 20, ... ession\" : asd}\n ..."],
	"codemsg": -2
}
```

### **Remove invalid token type**

**input**
```
{
	"remove_session": {}
}
```

**output**
```
{
	"messages": ["ERROR: (7309): Failure to remove session. remove_session JSON field must be a string"],
	"codemsg": -2
}
```

### **Remove invalid token**

**input**
```
{
	"remove_session": "{asd}"
}
```

**output**
```
{
	"messages": ["ERROR: (7309): '{asd}' is not a valid token"],
	"codemsg": -2
}
```


### **Remove non-exist session**

**input**
```
{
	"remove_session": "12345678"
}
```

**output**
```
{
	"messages": ["ERROR: (7004): No session found for token '12345678'"],
	"codemsg": -1
}
```

### **Remove session OK**
**input**
```
{
	"remove_session": "7a5e0e6f"
}
```

**output**
```
{
	"messages": ["INFO: (7206): The session '7a5e0e6f' was closed successfully"],
	"codemsg": 0
}
```
If we want to delete the session already deleted
**output**
```
{
	"messages": ["ERROR: (7004): No session found for token '7a5e0e6f'"],
	"codemsg": -1
}
```



## Tasks
- [X] Compile without warning in linux
- [x] Valgrind
- [X] Scan-build
- [X] Unit test pass



Regards,
Julian