### PR TITLE
Add missed syscheck fields to the mail alerts.

### DIFF
--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -25,6 +25,7 @@
  */
 void add_field_from_json(const cJSON *json_object, const char *field, char *dest, size_t *size, const char *prefix) {
     cJSON *json_field;
+    cJSON *item;
     size_t log_size = 0;
     char *value = NULL;
 
@@ -43,7 +44,14 @@ void add_field_from_json(const cJSON *json_object, const char *field, char *dest
         case cJSON_Number:
             value = w_long_str((long) json_field->valuedouble);
         break;
+
+        case cJSON_Array:
+            cJSON_ArrayForEach(item, json_field) {
+                wm_strcat(&value, item->valuestring, ',');
+            }
+        break;
     }
+
     if (value != NULL) {
         log_size = strlen(value) + strlen(prefix) + 3;
         if (*size > log_size) {
@@ -376,6 +384,8 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         add_field_from_json(json_object, "path", logs, &body_size, "File: ");
         add_field_from_json(json_object, "event", logs, &body_size, "Event: ");
         add_field_from_json(json_object, "mode", logs, &body_size, "Mode: ");
+        add_field_from_json(json_object, "changed_attributes", logs, &body_size, "Changed attributes: ");
+
         add_field_from_json(json_object, "size_before", logs, &body_size, "Size before: ");
         add_field_from_json(json_object, "size_after", logs, &body_size, "Size after: ");
         add_field_from_json(json_object, "md5_before", logs, &body_size, "Old md5sum was: ");
@@ -384,19 +394,20 @@ MailMsg *OS_RecvMailQ_JSON(file_queue *fileq, MailConfig *Mail, MailMsg **msg_sm
         add_field_from_json(json_object, "sha1_after", logs, &body_size, "New sha1sum is: ");
         add_field_from_json(json_object, "sha256_before", logs, &body_size, "Old sha256sum was: ");
         add_field_from_json(json_object, "sha256_after", logs, &body_size, "New sha256sum is: ");
-
         strcat(logs, "\nAttributes\n");
         body_size -= 12;
 
-        add_field_from_json(json_object, "size_after", logs, &body_size, "- Size: ");
-        add_field_from_json(json_object, "perm_after", logs, &body_size, "- Permissions: ");
-        add_field_from_json(json_object, "inode_after", logs, &body_size, "- Inode: ");
-        add_field_from_json(json_object, "sha256_after", logs, &body_size, "- New sha256sum is: ");
-        add_field_from_json(json_object, "uname", logs, &body_size, "- User name: ");
-        add_field_from_json(json_object, "gname", logs, &body_size, "- Group name: ");
-        add_field_from_json(json_object, "md5_after", logs, &body_size, "- MD5: ");
-        add_field_from_json(json_object, "sha1_after", logs, &body_size, "- SHA1: ");
-        add_field_from_json(json_object, "sha256_after", logs, &body_size, "- SHA256: ");
+        add_field_from_json(json_object, "size_after", logs, &body_size, " - Size: ");
+        add_field_from_json(json_object, "perm_after", logs, &body_size, " - Permissions: ");
+        add_field_from_json(json_object, "mtime_after", logs, &body_size, " - Date: ");
+        add_field_from_json(json_object, "inode_after", logs, &body_size, " - Inode: ");
+        add_field_from_json(json_object, "uname_after", logs, &body_size, " - User name: ");
+        add_field_from_json(json_object, "uid_after", logs, &body_size, " - User ID: ");
+        add_field_from_json(json_object, "gname_after", logs, &body_size, " - Group name: ");
+        add_field_from_json(json_object, "gid_after", logs, &body_size, " - Group ID: ");
+        add_field_from_json(json_object, "md5_after", logs, &body_size, " - MD5: ");
+        add_field_from_json(json_object, "sha1_after", logs, &body_size, " - SHA1: ");
+        add_field_from_json(json_object, "sha256_after", logs, &body_size, " - SHA256: ");
 
         // get audit information
         if (json_audit = cJSON_GetObjectItem(json_object,"audit"), json_audit){

--- a/src/shared/read-alert.c
+++ b/src/shared/read-alert.c
@@ -60,6 +60,8 @@
 #define GROUP_BEGIN_SZ     20
 #define PERM_BEGIN        "Permissions changed from "
 #define PERM_BEGIN_SZ     25
+
+#define LOG_SZ_LIMIT      100
 /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
 
 
@@ -67,193 +69,69 @@ void FreeAlertData(alert_data *al_data)
 {
     char **p;
 
-    if (al_data->alertid) {
-        free(al_data->alertid);
-        al_data->alertid = NULL;
-    }
-    if (al_data->date) {
-        free(al_data->date);
-        al_data->date = NULL;
-    }
-    if (al_data->location) {
-        free(al_data->location);
-        al_data->location = NULL;
-    }
-    if (al_data->comment) {
-        free(al_data->comment);
-        al_data->comment = NULL;
-    }
-    if (al_data->group) {
-        free(al_data->group);
-        al_data->group = NULL;
-    }
-    if (al_data->srcip) {
-        free(al_data->srcip);
-        al_data->srcip = NULL;
-    }
-    if (al_data->dstip) {
-        free(al_data->dstip);
-        al_data->dstip = NULL;
-    }
-    if (al_data->user) {
-        free(al_data->user);
-        al_data->user = NULL;
-    }
-    if (al_data->filename) {
-        free(al_data->filename);
-        al_data->filename = NULL;
-    }
-    if (al_data->old_md5) {
-        free(al_data->old_md5);
-        al_data->old_md5 = NULL;
-    }
-    if (al_data->new_md5) {
-        free(al_data->new_md5);
-        al_data->new_md5 = NULL;
-    }
-    if (al_data->old_sha1) {
-        free(al_data->old_sha1);
-        al_data->old_sha1 = NULL;
-    }
-    if (al_data->new_sha1) {
-        free(al_data->new_sha1);
-        al_data->new_sha1 = NULL;
-    }
-    if (al_data->old_sha256) {
-        free(al_data->old_sha256);
-        al_data->old_sha256 = NULL;
-    }
-    if (al_data->new_sha256) {
-        free(al_data->new_sha256);
-        al_data->new_sha256 = NULL;
-    }
-/* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-    if(al_data->file_size)
-    {
-        free(al_data->file_size);
-        al_data->file_size = NULL;
-    }
-    if(al_data->owner_chg)
-    {
-        free(al_data->owner_chg);
-        al_data->owner_chg = NULL;
-    }
-    if(al_data->group_chg)
-    {
-        free(al_data->group_chg);
-        al_data->group_chg = NULL;
-    }
-    if(al_data->perm_chg)
-    {
-        free(al_data->perm_chg);
-        al_data->perm_chg = NULL;
-    }
+    os_free(al_data->alertid);
+    os_free(al_data->date);
+    os_free(al_data->location);
+    os_free(al_data->comment);
+    os_free(al_data->group);
+    os_free(al_data->srcip);
+    os_free(al_data->dstip);
+    os_free(al_data->user);
+    os_free(al_data->filename);
+    os_free(al_data->old_md5);
+    os_free(al_data->new_md5);
+    os_free(al_data->old_sha1);
+    os_free(al_data->new_sha1);
+    os_free(al_data->old_sha256);
+    os_free(al_data->new_sha256);
+    os_free(al_data->file_size);
+    os_free(al_data->owner_chg);
+    os_free(al_data->group_chg);
+    os_free(al_data->perm_chg);
+
 /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
     if (al_data->log) {
         p = al_data->log;
 
         while (*(p)) {
-            free(*(p));
-            *(p) = NULL;
+            os_free(*(p));
             p++;
         }
-        free(al_data->log);
-        al_data->log = NULL;
+        os_free(al_data->log);
     }
 #ifdef LIBGEOIP_ENABLED
-    if (al_data->srcgeoip) {
-        free(al_data->srcgeoip);
-        al_data->srcgeoip = NULL;
-    }
-    if (al_data->dstgeoip) {
-        free(al_data->dstgeoip);
-        al_data->dstgeoip = NULL;
-    }
+
+    os_free(al_data->srcgeoip);
+    os_free(al_data->dstgeoip);
+
 #endif
-    free(al_data);
-    al_data = NULL;
+    os_free(al_data);
 }
 
 /* Return alert data for the file specified */
-alert_data *GetAlertData(int flag, FILE *fp)
-{
+alert_data *GetAlertData(int flag, FILE *fp) {
+    alert_data *al_data;
+    os_calloc(1, sizeof(alert_data), al_data);
+
     int _r = 0, issyscheck = 0;
     size_t log_size = 0;
     char *p;
-
-    char *alertid = NULL;
-    char *date = NULL;
-    char *comment = NULL;
-    char *location = NULL;
-    char *srcip = NULL;
-    char *dstip = NULL;
-    char *user = NULL;
-    char *group = NULL;
-    char *filename = NULL;
-    char *old_md5 = NULL;
-    char *new_md5 = NULL;
-    char *old_sha1 = NULL;
-    char *new_sha1 = NULL;
-    char *old_sha256 = NULL;
-    char *new_sha256 = NULL;
-    char **log = NULL;
-/* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-    char *file_size = NULL;
-    char *owner_chg = NULL;
-    char *group_chg = NULL;
-    char *perm_chg = NULL;
-/* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-#ifdef LIBGEOIP_ENABLED
-    char *srcgeoip = NULL;
-    char *dstgeoip = NULL;
-#endif
-    int level = 0, rule = 0, srcport = 0, dstport = 0;
-
     char str[OS_MAXSTR + 1];
     str[OS_MAXSTR] = '\0';
 
     while (fgets(str, OS_MAXSTR, fp) != NULL) {
+        if (log_size == LOG_SZ_LIMIT) {
+            return (al_data);
+        }
         /* End of alert */
-        if (strcmp(str, "\n") == 0 && log_size > 0) {
-            /* Found in here */
-            if (_r == 2) {
-                alert_data *al_data;
-                os_calloc(1, sizeof(alert_data), al_data);
-                al_data->alertid = alertid;
-                al_data->level = level;
-                al_data->rule = rule;
-                al_data->location = location;
-                al_data->comment = comment;
-                al_data->group = group;
-                al_data->log = log;
-                al_data->srcip = srcip;
-                al_data->srcport = srcport;
-                al_data->dstip = dstip;
-                al_data->dstport = dstport;
-                al_data->user = user;
-                al_data->date = date;
-                al_data->filename = filename;
-#ifdef LIBGEOIP_ENABLED
-                al_data->srcgeoip  = srcgeoip ;
-                al_data->dstgeoip = dstgeoip;
-#endif
-                al_data->old_md5 = old_md5;
-                al_data->new_md5 = new_md5;
-                al_data->old_sha1 = old_sha1;
-                al_data->new_sha1 = new_sha1;
-                al_data->old_sha256 = old_sha256;
-                al_data->new_sha256 = new_sha256;
-            /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-                al_data->file_size = file_size;
-                al_data->owner_chg = owner_chg;
-                al_data->group_chg = group_chg;
-                al_data->perm_chg = perm_chg;
-            /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-
-
+        if ((strncmp(ALERT_BEGIN, str, ALERT_BEGIN_SZ) == 0 && _r == 2)) {
+            // This means that the last fgets readed the beggining of the next alert.
+            if (fseek(fp, -strlen(str), SEEK_CUR) != -1) {
+                _r = 0;
                 return (al_data);
+            } else {
+                goto l_error;
             }
-            _r = 0;
         }
 
         /* Check for the header */
@@ -268,9 +146,9 @@ alert_data *GetAlertData(int flag, FILE *fp)
             }
 
             z = strlen(p) - strlen(m);
-            os_realloc(alertid, (z + 1)*sizeof(char), alertid);
-            strncpy(alertid, p, z);
-            alertid[z] = '\0';
+            os_realloc(al_data->alertid, (z + 1) * sizeof(char), al_data->alertid);
+            strncpy(al_data->alertid, p, z);
+            al_data->alertid[z] = '\0';
 
             /* Search for email flag */
             p = strchr(p, ' ');
@@ -293,12 +171,12 @@ alert_data *GetAlertData(int flag, FILE *fp)
                 while (*p == ' ') {
                         p++;
                 }
-                free(group);
-                os_strdup(p, group);
+                os_free(al_data->group);
+                os_strdup(p, al_data->group);
 
                 /* Clean newline from group */
-                os_clearnl(group, p);
-                if (group != NULL && strstr(group, "syscheck") != NULL) {
+                os_clearnl(al_data->group, p);
+                if (al_data->group != NULL && strstr(al_data->group, "syscheck") != NULL) {
                     issyscheck = 1;
                 }
             }
@@ -333,13 +211,13 @@ alert_data *GetAlertData(int flag, FILE *fp)
             }
 
             /* If not, str is date and p is the location */
-            if (date || location || !p) {
+            if (al_data->date || al_data->location || !p) {
                 merror("date or location not NULL or p is NULL");
                 goto l_error;
             }
 
-            os_strdup(str, date);
-            os_strdup(p, location);
+            os_strdup(str, al_data->date);
+            os_strdup(p, al_data->location);
             _r = 2;
             log_size = 0;
             continue;
@@ -349,7 +227,7 @@ alert_data *GetAlertData(int flag, FILE *fp)
                 os_clearnl(str, p);
 
                 p = str + RULE_BEGIN_SZ;
-                rule = atoi(p);
+                al_data->rule = atoi(p);
 
                 p = strchr(p, ' ');
                 if (p) {
@@ -364,7 +242,7 @@ alert_data *GetAlertData(int flag, FILE *fp)
                     goto l_error;
                 }
 
-                level = atoi(p);
+                al_data->level = atoi(p);
 
                 /* Get the comment */
                 p = strchr(p, '\'');
@@ -373,11 +251,11 @@ alert_data *GetAlertData(int flag, FILE *fp)
                 }
 
                 p++;
-                free(comment);
-                os_strdup(p, comment);
+                os_free(al_data->comment);
+                os_strdup(p, al_data->comment);
 
                 /* Must have the closing \' */
-                p = strrchr(comment, '\'');
+                p = strrchr(al_data->comment, '\'');
                 if (p) {
                     *p = '\0';
                 } else {
@@ -390,16 +268,16 @@ alert_data *GetAlertData(int flag, FILE *fp)
                 os_clearnl(str, p);
 
                 p = str + SRCIP_BEGIN_SZ;
-                free(srcip);
-                os_strdup(p, srcip);
+                os_free(al_data->srcip);
+                os_strdup(p,al_data->srcip);
             }
 #ifdef LIBGEOIP_ENABLED
             /* GeoIP Source Location */
             else if (strncmp(GEOIP_BEGIN_SRC, str, GEOIP_BEGIN_SRC_SZ) == 0) {
                 os_clearnl(str, p);
                 p = str + GEOIP_BEGIN_SRC_SZ;
-                free(srcgeoip);
-                os_strdup(p, srcgeoip);
+                free(alert_data->srcgeoip);
+                os_strdup(p, alert_data->srcgeoip);
             }
 #endif
             /* srcport */
@@ -407,23 +285,23 @@ alert_data *GetAlertData(int flag, FILE *fp)
                 os_clearnl(str, p);
 
                 p = str + SRCPORT_BEGIN_SZ;
-                srcport = atoi(p);
+                al_data->srcport = atoi(p);
             }
             /* dstip */
             else if (strncmp(DSTIP_BEGIN, str, DSTIP_BEGIN_SZ) == 0) {
                 os_clearnl(str, p);
 
                 p = str + DSTIP_BEGIN_SZ;
-                free(dstip);
-                os_strdup(p, dstip);
+                os_free(al_data->dstip);
+                os_strdup(p, al_data->dstip);
             }
 #ifdef LIBGEOIP_ENABLED
             /* GeoIP Destination Location */
             else if (strncmp(GEOIP_BEGIN_DST, str, GEOIP_BEGIN_DST_SZ) == 0) {
                 os_clearnl(str, p);
                 p = str + GEOIP_BEGIN_DST_SZ;
-                free(dstgeoip);
-                os_strdup(p, dstgeoip);
+                os_free(al_data->dstgeoip);
+                os_strdup(p, al_data->dstgeoip);
             }
 #endif
             /* dstport */
@@ -431,271 +309,116 @@ alert_data *GetAlertData(int flag, FILE *fp)
                 os_clearnl(str, p);
 
                 p = str + DSTPORT_BEGIN_SZ;
-                dstport = atoi(p);
+                al_data->dstport = atoi(p);
             }
             /* username */
             else if (strncmp(USER_BEGIN, str, USER_BEGIN_SZ) == 0) {
                 os_clearnl(str, p);
 
                 p = str + USER_BEGIN_SZ;
-                free(user);
-                os_strdup(p, user);
+                os_free(al_data->user);
+                os_strdup(p, al_data->user);
             }
-            /* Old MD5 */
-            else if (strncmp(OLDMD5_BEGIN, str, OLDMD5_BEGIN_SZ) == 0) {
-                os_clearnl(str, p);
 
-                p = str + OLDMD5_BEGIN_SZ;
-                free(old_md5);
-                os_strdup(p, old_md5);
-            }
-            /* New MD5 */
-            else if (strncmp(NEWMD5_BEGIN, str, NEWMD5_BEGIN_SZ) == 0) {
-                os_clearnl(str, p);
-
-                p = str + NEWMD5_BEGIN_SZ;
-                free(new_md5);
-                os_strdup(p, new_md5);
-            }
-            /* Old SHA-1 */
-            else if (strncmp(OLDSHA1_BEGIN, str, OLDSHA1_BEGIN_SZ) == 0) {
-                os_clearnl(str, p);
-
-                p = str + OLDSHA1_BEGIN_SZ;
-                free(old_sha1);
-                os_strdup(p, old_sha1);
-            }
-            /* New SHA-1 */
-            else if (strncmp(NEWSHA1_BEGIN, str, NEWSHA1_BEGIN_SZ) == 0) {
-                os_clearnl(str, p);
-
-                p = str + NEWSHA1_BEGIN_SZ;
-                free(new_sha1);
-                os_strdup(p, new_sha1);
-            }
-            /* Old SHA-256 */
-            else if (strncmp(OLDSHA256_BEGIN, str, OLDSHA256_BEGIN_SZ) == 0) {
-                os_clearnl(str, p);
-
-                p = str + OLDSHA256_BEGIN_SZ;
-                free(old_sha256);
-                os_strdup(p, old_sha256);
-            }
-            /* New SHA-256 */
-            else if (strncmp(NEWSHA256_BEGIN, str, NEWSHA256_BEGIN_SZ) == 0) {
-                os_clearnl(str, p);
-
-                p = str + NEWSHA256_BEGIN_SZ;
-                free(new_sha256);
-                os_strdup(p, new_sha256);
-            }
-         /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-            /* File Size */
-            else if(strncmp(SIZE_BEGIN, str, SIZE_BEGIN_SZ) == 0)
-            {
-                os_clearnl(str,p);
-
-                p = str + SIZE_BEGIN_SZ;
-                free(file_size);
-                os_strdup(p, file_size);
-            }
-            /* File Ownership */
-            else if(strncmp(OWNER_BEGIN, str, OWNER_BEGIN_SZ) == 0)
-            {
-                os_clearnl(str,p);
-
-                p = str + OWNER_BEGIN_SZ;
-                free(owner_chg);
-                os_strdup(p, owner_chg);
-            }
-            /* File Group Ownership */
-            else if(strncmp(GROUP_BEGIN, str, GROUP_BEGIN_SZ) == 0)
-            {
-                os_clearnl(str,p);
-
-                p = str + GROUP_BEGIN_SZ;
-                free(group_chg);
-                os_strdup(p, group_chg);
-            }
-            /* File Permissions */
-            else if(strncmp(PERM_BEGIN, str, PERM_BEGIN_SZ) == 0)
-            {
-                os_clearnl(str,p);
-
-                p = str + PERM_BEGIN_SZ;
-                free(perm_chg);
-                os_strdup(p, perm_chg);
-            }
          /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
             /* It is a log message */
-            else if (log_size < 20) {
+            else if (log_size < LOG_SZ_LIMIT - 1) {
                 os_clearnl(str, p);
-
                 if (issyscheck == 1) {
                     if (strncmp(str, "Integrity checksum changed for: '", 33) == 0) {
-                        filename = strdup(str + 33);
-                        if (filename) {
-                            filename[strlen(filename) - 1] = '\0';
+                        al_data->filename = strdup(str + 33);
+                        if (al_data->filename) {
+                            al_data->filename[strlen(al_data->filename) - 1] = '\0';
                         }
                     }
                     issyscheck = 0;
                 }
 
-                os_realloc(log, (log_size + 2)*sizeof(char *), log);
-                os_strdup(str, log[log_size]);
+                os_realloc(al_data->log, (log_size + 2) * sizeof(char *), al_data->log);
+                os_strdup(str, al_data->log[log_size]);
                 log_size++;
-                log[log_size] = NULL;
+                al_data->log[log_size] = NULL;
+
+            } else {
+                os_malloc(28 * sizeof(char), al_data->log[log_size]);
+                strcpy(al_data->log[log_size], "The limit has been reached.\n");
+                log_size++;
+                al_data->log[log_size] = NULL;
             }
         }
-
         continue;
 l_error:
         /* Free the memory */
         _r = 0;
-        if (date) {
-            free(date);
-            date = NULL;
-        }
-        if (location) {
-            free(location);
-            location = NULL;
-        }
-        if (comment) {
-            free(comment);
-            comment = NULL;
-        }
-        if (srcip) {
-            free(srcip);
-            srcip = NULL;
-        }
+        os_free(al_data->date);
+        os_free(al_data->location);
+        os_free(al_data->comment);
+        os_free(al_data->srcip);
+
 #ifdef LIBGEOIP_ENABLED
-        if (srcgeoip) {
-            free(srcgeoip);
-            srcgeoip = NULL;
-        }
-        if (dstgeoip) {
-            free(dstgeoip);
-            dstgeoip = NULL;
-        }
+        os_free(al_data->srcgeoip);
+        os_free(al_data->dstgeoip);
+
 #endif
-        if (user) {
-            free(user);
-            user = NULL;
-        }
-        if (filename) {
-            free(filename);
-            filename = NULL;
-        }
-        if (group) {
-            free(group);
-            group = NULL;
-        }
-        if (old_md5) {
-            free(old_md5);
-            old_md5 = NULL;
-        }
+        os_free(al_data->user);
+        os_free(al_data->filename);
+        os_free(al_data->group);
+        os_free(al_data->old_md5);
+        os_free(al_data->new_md5);
+        os_free(al_data->old_sha1);
+        os_free(al_data->new_sha1);
+        os_free(al_data->old_sha256);
+        os_free(al_data->new_sha256);
 
-        if (new_md5) {
-            free(new_md5);
-            new_md5 = NULL;
-        }
-
-        if (old_sha1) {
-            free(old_sha1);
-            old_sha1 = NULL;
-        }
-
-        if (new_sha1) {
-            free(new_sha1);
-            new_sha1 = NULL;
-        }
-
-        if (old_sha256) {
-            free(old_sha256);
-            old_sha256 = NULL;
-        }
-
-        if (new_sha256) {
-            free(new_sha256);
-            new_sha256 = NULL;
-        }
 /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-        if(file_size)
-        {
-            free(file_size);
-            file_size = NULL;
-        }
-        if(owner_chg)
-        {
-            free(owner_chg);
-            owner_chg = NULL;
-        }
-        if(group_chg)
-        {
-            free(group_chg);
-            group_chg = NULL;
-        }
-        if(perm_chg)
-        {
-            free(perm_chg);
-            perm_chg = NULL;
-        }
+
+        os_free(al_data->file_size);
+        os_free(al_data->owner_chg);
+        os_free(al_data->group_chg);
+        os_free(al_data->perm_chg);
+
 /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
         while (log_size > 0) {
             log_size--;
-            if (log[log_size]) {
-                free(log[log_size]);
-                log[log_size] = NULL;
-            }
+            os_free(al_data->log[log_size]);
         }
     }
+    // We reached the end of the alert and the information is saved.
+    if (feof(fp) && strncmp(str, "\0",1) == 0 && _r == 2) {
+        return al_data;
+    }
 
-    if (alertid) {
-        free(alertid);
-        alertid = NULL;
-    }
-    if (group) {
-        free(group);
-        group = NULL;
-    }
-    if (location) {
-        free(location);
-        location = NULL;
-    }
-    if (date) {
-        free(date);
-        date = NULL;
-    }
+    os_free(al_data->alertid);
+    os_free(al_data->group);
+    os_free(al_data->location);
+    os_free(al_data->date);
 
     while (log_size > 0) {
         log_size--;
-        if (log[log_size]) {
-            free(log[log_size]);
-            log[log_size] = NULL;
-        }
+        os_free(al_data->log[log_size]);
     }
 
-    free(log);
-    free(comment);
-    free(srcip);
-    free(dstip);
-    free(user);
-    free(old_md5);
-    free(new_md5);
-    free(old_sha1);
-    free(new_sha1);
-    free(old_sha256);
-    free(new_sha256);
-    free(filename);
+    os_free(al_data->log);
+    os_free(al_data->comment);
+    os_free(al_data->srcip);
+    os_free(al_data->dstip);
+    os_free(al_data->user);
+    os_free(al_data->old_md5);
+    os_free(al_data->new_md5);
+    os_free(al_data->old_sha1);
+    os_free(al_data->new_sha1);
+    os_free(al_data->old_sha256);
+    os_free(al_data->new_sha256);
+    os_free(al_data->filename);
 /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-    free(file_size);
-    free(owner_chg);
-    free(group_chg);
-    free(perm_chg);
+    os_free(al_data->file_size);
+    os_free(al_data->owner_chg);
+    os_free(al_data->group_chg);
+    os_free(al_data->perm_chg);
 /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
 #ifdef LIBGEOIP_ENABLED
-    free(srcgeoip);
-    free(dstgeoip);
+    os_free(al_data->srcgeoip);
+    os_free(al_data->dstgeoip);
 #endif
 
     /* We need to clean end of file before returning */

--- a/src/shared/read-alert.c
+++ b/src/shared/read-alert.c
@@ -345,7 +345,6 @@ alert_data *GetAlertData(int flag, FILE *fp) {
 
 l_error:
     /* Free the memory */
-    _r = 0;
     FreeAlertData(al_data);
     /* We need to clean end of file before returning */
     clearerr(fp);


### PR DESCRIPTION
|Related issue|
|---|
|#953| 
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to fix https://github.com/wazuh/wazuh/issues/953 by adding the fields that are missing from the alerts to the mail body. 
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

- [x] Source upgrade
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

