### PR TITLE
Fix severity in VDT alerts when CVE is not indexed in the NVD

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -5233,7 +5233,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
     expect_string(__wrap_cJSON_AddStringToObject, name, "rationale");
     expect_string(__wrap_cJSON_AddStringToObject, string, "The CVE description or rationale.");
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "-");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "High");
 
     // Normalize date
     char * published;
@@ -5560,7 +5560,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **
     expect_string(__wrap_cJSON_AddStringToObject, name, "rationale");
     expect_string(__wrap_cJSON_AddStringToObject, string, "The CVE description or rationale.");
     expect_string(__wrap_cJSON_AddStringToObject, name, "severity");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "-");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "High");
 
     // Normalize date
     char * published;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1041,8 +1041,6 @@ int wm_vuldet_fill_report_nvd_scoring(sqlite3 *db, sqlite3_stmt *stmt, int cve_t
         } else {
             os_strdup(vu_severities[VU_LOW], report->severity);
         }
-    } else {
-        os_strdup(vu_severities[VU_UNKNOWN], report->severity);
     }
 
     return SQLITE_OK;
@@ -1101,15 +1099,21 @@ int wm_vuldet_fill_report_oval_data(sqlite3 *db, sqlite3_stmt *stmt, agent_softw
         cwe = (char *)sqlite3_column_text(stmt, 8);
 
         if (!report->rationale) w_strdup(rationale, report->rationale);
-        if (severity && agents_it->dist == FEED_REDHAT) {
-            /* For RHEL/CentOS agents we trust in the severity
-            from the vendor feed instead of the NVD.
-            It avoids NULL severity for some vulnerabilities */
-            os_free(report->severity);
-            w_strdup(severity, report->severity);
+
+        if (severity) {
+            if (agents_it->dist == FEED_REDHAT) {
+                /* For RHEL/CentOS agents we trust in the severity
+                from the vendor feed instead of the NVD.
+                It avoids NULL severity for some vulnerabilities */
+                os_free(report->severity);
+                w_strdup(severity, report->severity);
+            } else if (!report->severity) {
+                w_strdup(severity, report->severity);
+            }
         } else if (!report->severity) {
-            w_strdup(severity, report->severity);
+            os_strdup(vu_severities[VU_UNKNOWN], report->severity);
         }
+
         if (!report->published) w_strdup(published, report->published);
         if (!report->updated && updated) w_strdup(updated, report->updated);
         if (!report->cvss2 && cvss) {


### PR DESCRIPTION
## Description

Reported vulnerabilities that were not indexed in the NVD (as for example [CVE-2019-8842](https://nvd.nist.gov/vuln/detail/CVE-2019-8842)), is not taking the severity from the vendor feed due to the NVD severity had precedence.

This PR fixes this condition. Now the severity from the vendor feed is included in alerts when no severity is coming from the NVD.

## Logs/Alerts example

**Before**
```js
{"timestamp":"2020-08-28T05:48:24.358-0700","rule":{"level":7,"description":"CVE-2019-17006 affects nss-tools","id":"23504","firedtimes":1396,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"005","name":"10-ae40369d-rhel7.8-sample01txt","ip":"10.0.2.15"},"manager":{"name":"ubuntu"},"id":"1598618904.10315960","decoder":{"name":"json"},"data":{"vulnerability":{"package":{"name":"nss-tools","version":"3.44.0-7.el7_7","architecture":"x86_64","condition":"Package unfixed"},"cvss":{"cvss3":{"vector":{"attack_vector":"network","access_complexity":"high","privileges_required":"none","user_interaction":"none","scope":"unchanged","confidentiality_impact":"high","integrity_impact":"high","availability":"high"},"base_score":"8.100000"}},"cve":"CVE-2019-17006","title":"CVE-2019-17006 affects nss-tools","rationale":"nss: Check length of inputs for cryptographic primitives","severity":"-","published":"2019-12-26T00:00:00Z","cwe_reference":"CWE-122","advisories_ids":["RHSA-2020:3280"],"bugzilla_references":["https://bugzilla.redhat.com/show_bug.cgi?id=1775916"],"references":["https://access.redhat.com/security/cve/CVE-2019-17006"]}},"location":"vulnerability-detector"}
```

**After**
```js
{"timestamp":"2020-08-28T05:48:24.358-0700","rule":{"level":7,"description":"CVE-2019-17006 affects nss-tools","id":"23504","firedtimes":1396,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"005","name":"10-ae40369d-rhel7.8-sample01txt","ip":"10.0.2.15"},"manager":{"name":"ubuntu"},"id":"1598618904.10315960","decoder":{"name":"json"},"data":{"vulnerability":{"package":{"name":"nss-tools","version":"3.44.0-7.el7_7","architecture":"x86_64","condition":"Package unfixed"},"cvss":{"cvss3":{"vector":{"attack_vector":"network","access_complexity":"high","privileges_required":"none","user_interaction":"none","scope":"unchanged","confidentiality_impact":"high","integrity_impact":"high","availability":"high"},"base_score":"8.100000"}},"cve":"CVE-2019-17006","title":"CVE-2019-17006 affects nss-tools","rationale":"nss: Check length of inputs for cryptographic primitives","severity":"Medium","published":"2019-12-26T00:00:00Z","cwe_reference":"CWE-122","advisories_ids":["RHSA-2020:3280"],"bugzilla_references":["https://bugzilla.redhat.com/show_bug.cgi?id=1775916"],"references":["https://access.redhat.com/security/cve/CVE-2019-17006"]}},"location":"vulnerability-detector"}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] Added unit tests (for new features)
