### PR TITLE
Unit Testing for wdb_global.c code

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -25,7 +25,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
                              -Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 \
-                             -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,wdb_step -Wl,--wrap,sqlite3_bind_text")
+                             -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,wdb_step -Wl,--wrap,sqlite3_bind_text \
+                             -Wl,--wrap,sqlite3_bind_parameter_index")
 
 
 # Compilig tests

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -25,7 +25,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
                              -Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 \
-                             -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int")
+                             -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,wdb_step -Wl,--wrap,sqlite3_bind_text")
 
 
 # Compilig tests

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -22,6 +22,11 @@ list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
                              -Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg")
 
+list(APPEND wdb_tests_names "test_wdb_global")
+list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
+                             -Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 \
+                             -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int")
+
 
 # Compilig tests
 list(LENGTH wdb_tests_names count)

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -1,0 +1,150 @@
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "wazuh_db/wdb.h"
+
+void __wrap__mdebug1(const char * file, int line, const char * func, const char *msg, ...)
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+int __wrap__mdebug2()
+{
+    return 0;
+}
+
+int __wrap__mwarn()
+{
+    return 0;
+}
+
+void __wrap__merror(const char * file, int line, const char * func, const char *msg, ...)
+{
+    char formatted_msg[OS_MAXSTR];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(formatted_msg, OS_MAXSTR, msg, args);
+    va_end(args);
+
+    check_expected(formatted_msg);
+}
+
+int __wrap_sqlite3_bind_int()
+{
+    return mock_type(int);
+}
+
+
+int __wrap_wdb_open_global()
+{
+    return mock_type(int);
+}
+
+void __wrap_wdb_leave(){}
+
+int  __wrap_wdb_begin2(){
+    return mock_type(int);
+}
+
+int  __wrap_wdb_stmt_cache(){
+    return mock_type(int);
+}
+
+cJSON * __wrap_wdb_exec()
+{
+    return mock_type(cJSON *);
+}
+
+const char * __wrap_sqlite3_errmsg(sqlite3 *db)
+{
+    return NULL;
+}
+
+typedef struct test_struct {
+    wdb_t *socket;
+    char *output;
+} test_struct_t;
+
+static int test_setup(void **state) {
+    test_struct_t *init_data = NULL;
+    os_calloc(1,sizeof(test_struct_t),init_data);
+    os_calloc(1,sizeof(wdb_t),init_data->socket);
+    os_strdup("000",init_data->socket->id);
+    os_calloc(256,sizeof(char),init_data->output);
+    os_calloc(1,sizeof(sqlite3 *),init_data->socket->db);
+    *state = init_data;
+    return 0;
+}
+
+static int test_teardown(void **state){
+    test_struct_t *data  = (test_struct_t *)*state;
+    os_free(data->output);
+    os_free(data->socket->id);
+    os_free(data->socket->db);
+    os_free(data->socket);
+    os_free(data);
+    return 0;
+}
+
+void test_get_agent_labels_transaction_fail(void **state)
+{
+    cJSON *output = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "cannot begin transaction");
+
+    output = wdb_global_get_agent_labels(data->socket, atoi(data->socket->id));
+    assert_null(output);
+}
+
+void test_get_agent_labels_cache_fail(void **state)
+{
+    cJSON *output = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "cannot cache statement");
+
+    output = wdb_global_get_agent_labels(data->socket, atoi(data->socket->id));
+    assert_null(output);
+}
+
+void test_get_agent_labels_bind_fail(void **state)
+{
+    cJSON *output = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): (null)");
+
+    output = wdb_global_get_agent_labels(data->socket, atoi(data->socket->id));
+    assert_null(output);
+}
+
+int main()
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_get_agent_labels_transaction_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_get_agent_labels_cache_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_get_agent_labels_bind_fail, test_setup, test_teardown)      
+        };
+    
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -47,6 +47,10 @@ int __wrap_sqlite3_bind_int()
     return mock_type(int);
 }
 
+int __wrap_sqlite3_bind_text()
+{
+    return mock_type(int);
+}
 
 int __wrap_wdb_open_global()
 {
@@ -59,8 +63,17 @@ int  __wrap_wdb_begin2(){
     return mock_type(int);
 }
 
+int  __wrap_wdb_step(){
+    return mock_type(int);
+}
+
 int  __wrap_wdb_stmt_cache(){
     return mock_type(int);
+}
+
+cJSON * __wrap_wdb_exec_stmt()
+{
+    return mock_type(cJSON *);
 }
 
 cJSON * __wrap_wdb_exec()
@@ -138,12 +151,331 @@ void test_get_agent_labels_bind_fail(void **state)
     assert_null(output);
 }
 
+void test_get_agent_labels_exec_fail(void **state)
+{
+    cJSON *output = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_exec_stmt, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "sqlite3_step(): (null)");
+
+    output = wdb_global_get_agent_labels(data->socket, atoi(data->socket->id));
+    assert_null(output);
+}
+
+void test_get_agent_labels_success(void **state)
+{
+    cJSON *output = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_exec_stmt, (cJSON*)1);
+
+    output = wdb_global_get_agent_labels(data->socket, atoi(data->socket->id));
+    assert_non_null(output);
+}
+
+void test_del_agent_labels_transaction_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "cannot begin transaction");
+
+    result = wdb_global_del_agent_labels(data->socket, atoi(data->socket->id));
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_del_agent_labels_cache_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "cannot cache statement");
+
+    result = wdb_global_del_agent_labels(data->socket, atoi(data->socket->id));
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_del_agent_labels_bind_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): (null)");
+
+    result = wdb_global_del_agent_labels(data->socket, atoi(data->socket->id));
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_del_agent_labels_step_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_step, SQLITE_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "SQLite: (null)");
+
+    result = wdb_global_del_agent_labels(data->socket, atoi(data->socket->id));
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_del_agent_labels_success(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_step, SQLITE_DONE);
+
+    result = wdb_global_del_agent_labels(data->socket, atoi(data->socket->id));
+    assert_int_equal(result, OS_SUCCESS);
+}
+
+void test_set_agent_label_transaction_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char key[] = "test_key";
+    char value[] = "test_value";
+
+    will_return(__wrap_wdb_begin2, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "cannot begin transaction");
+
+    result = wdb_global_set_agent_label(data->socket, atoi(data->socket->id), key, value);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_set_agent_label_cache_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char key[] = "test_key";
+    char value[] = "test_value";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "cannot cache statement");
+
+    result = wdb_global_set_agent_label(data->socket, atoi(data->socket->id), key, value);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_set_agent_label_bind1_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char key[] = "test_key";
+    char value[] = "test_value";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): (null)");
+
+    result = wdb_global_set_agent_label(data->socket, atoi(data->socket->id), key, value);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_set_agent_label_bind2_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char key[] = "test_key";
+    char value[] = "test_value";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): (null)");
+
+    result = wdb_global_set_agent_label(data->socket, atoi(data->socket->id), key, value);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_set_agent_label_bind3_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char key[] = "test_key";
+    char value[] = "test_value";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): (null)");
+
+    result = wdb_global_set_agent_label(data->socket, atoi(data->socket->id), key, value);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_set_agent_label_step_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char key[] = "test_key";
+    char value[] = "test_value";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    will_return(__wrap_wdb_step, SQLITE_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "SQLite: (null)");
+
+    result = wdb_global_set_agent_label(data->socket, atoi(data->socket->id), key, value);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_set_agent_label_success(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char key[] = "test_key";
+    char value[] = "test_value";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    will_return(__wrap_wdb_step, SQLITE_DONE);
+
+    result = wdb_global_set_agent_label(data->socket, atoi(data->socket->id), key, value);
+    assert_int_equal(result, OS_SUCCESS);
+}
+
+void test_wdb_global_set_sync_status_transaction_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+ 
+    will_return(__wrap_wdb_begin2, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "cannot begin transaction");
+
+    result = wdb_global_set_sync_status(data->socket, atoi(data->socket->id), WDB_SYNCED);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_set_sync_status_cache_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "cannot cache statement");
+
+    result = wdb_global_set_sync_status(data->socket, atoi(data->socket->id), WDB_SYNCED);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_set_sync_status_bind1_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): (null)");
+
+    result = wdb_global_set_sync_status(data->socket, atoi(data->socket->id), WDB_SYNCED);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_set_sync_status_bind2_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+ 
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): (null)");
+
+    result = wdb_global_set_sync_status(data->socket, atoi(data->socket->id), WDB_SYNCED);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_set_sync_status_step_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+  
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_step, SQLITE_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "SQLite: (null)");
+
+    result = wdb_global_set_sync_status(data->socket, atoi(data->socket->id), WDB_SYNCED);
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_set_sync_status_success(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+   
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_step, SQLITE_DONE);
+
+    result = wdb_global_set_sync_status(data->socket, atoi(data->socket->id), WDB_SYNCED);
+    assert_int_equal(result, OS_SUCCESS);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_get_agent_labels_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_get_agent_labels_cache_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_get_agent_labels_bind_fail, test_setup, test_teardown)      
+        cmocka_unit_test_setup_teardown(test_get_agent_labels_bind_fail, test_setup, test_teardown),      
+        cmocka_unit_test_setup_teardown(test_get_agent_labels_exec_fail, test_setup, test_teardown),      
+        cmocka_unit_test_setup_teardown(test_get_agent_labels_success, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_del_agent_labels_transaction_fail, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_del_agent_labels_cache_fail, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_del_agent_labels_bind_fail, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_del_agent_labels_step_fail, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_del_agent_labels_success, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_set_agent_label_transaction_fail, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_set_agent_label_cache_fail, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_set_agent_label_bind1_fail, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_set_agent_label_bind2_fail, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_set_agent_label_bind3_fail, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_set_agent_label_step_fail, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_set_agent_label_success, test_setup, test_teardown),       
+        cmocka_unit_test_setup_teardown(test_wdb_global_set_sync_status_transaction_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_set_sync_status_cache_fail, test_setup, test_teardown),              
+        cmocka_unit_test_setup_teardown(test_wdb_global_set_sync_status_bind1_fail, test_setup, test_teardown),              
+        cmocka_unit_test_setup_teardown(test_wdb_global_set_sync_status_bind2_fail, test_setup, test_teardown),              
+        cmocka_unit_test_setup_teardown(test_wdb_global_set_sync_status_step_fail, test_setup, test_teardown),              
+        cmocka_unit_test_setup_teardown(test_wdb_global_set_sync_status_success, test_setup, test_teardown)              
         };
     
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -52,7 +52,7 @@ cJSON* wdb_global_get_agent_labels(wdb_t *wdb, int id) {
     stmt = wdb->stmt[WDB_STMT_GLOBAL_LABELS_GET];
 
     if (sqlite3_bind_int(stmt, 1, id) != SQLITE_OK) {
-        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return NULL;
     }
 

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -180,7 +180,7 @@ wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
         mdebug1("cannot begin transaction");
-        return OS_INVALID;
+        return WDB_CHUNKS_ERROR;
     }
 
     //Add array start
@@ -195,7 +195,7 @@ wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char
         }
         agent_stmt = wdb->stmt[WDB_STMT_GLOBAL_SYNC_REQ_GET];
         if (sqlite3_bind_int(agent_stmt, 1, *last_agent_id) != SQLITE_OK) {
-            merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+            merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
             status = WDB_CHUNKS_ERROR;
             break;
         }
@@ -229,6 +229,7 @@ wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char
                     //Set sync status as synced
                     if (OS_SUCCESS != wdb_global_set_sync_status(wdb, agent_id, WDB_SYNCED)) {
                         status = WDB_CHUNKS_ERROR;
+                        os_free(agent_str);
                         break;
                     }
                     //Add new agent

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -272,12 +272,12 @@ int wdb_global_sync_agent_info_set(wdb_t *wdb,cJSON * json_agent){
     cJSON *json_field = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("Cannot begin transaction");
+        mdebug1("cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_UPDATE_AGENT_INFO) < 0) {
-        mdebug1("Cannot cache statement");
+        mdebug1("cannot cache statement");
         return OS_INVALID;
     }
 
@@ -285,7 +285,7 @@ int wdb_global_sync_agent_info_set(wdb_t *wdb,cJSON * json_agent){
 
      for (n = 0 ; global_db_agent_fields[n] ; n++){
         // Every column name of Global DB is stored in global_db_agent_fields 
-        json_field = cJSON_GetObjectItemCaseSensitive(json_agent, global_db_agent_fields[n]+1);
+        json_field = cJSON_GetObjectItem(json_agent, global_db_agent_fields[n]+1);
         index = sqlite3_bind_parameter_index(stmt, global_db_agent_fields[n]);
         if (cJSON_IsNumber(json_field) && index != 0){
             if (sqlite3_bind_int(stmt, index , json_field->valueint) != SQLITE_OK) {

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -81,7 +81,7 @@ int wdb_global_del_agent_labels(wdb_t *wdb, int id) {
     stmt = wdb->stmt[WDB_STMT_GLOBAL_LABELS_DEL];
 
     if (sqlite3_bind_int(stmt, 1, id) != SQLITE_OK) {
-        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }
 
@@ -155,7 +155,7 @@ int wdb_global_set_sync_status(wdb_t *wdb, int id, wdb_sync_status_t status) {
         return OS_INVALID;
     }
     if (sqlite3_bind_int(stmt, 2, id) != SQLITE_OK) {
-        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|5851|


## Description

This PR adds unit tests for all the methods inside **wdb_global.c** in the new file **test_wdb_global.c**.
All the code lines are covered and the _Valgrind_ was successfully performed.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
 - [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)
