### PR TITLE
Add header to socket messages

### DIFF
--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -317,5 +317,11 @@ int w_logtest_process_request_log_processing(cJSON * json_request, cJSON * json_
  */
 int w_logtest_process_request_remove_session(cJSON * json_request, cJSON * json_response, OSList * list_msg,
                                              w_logtest_connection_t * connection);
+/*
+ * @brief Generate failure response with \ref W_LOGTEST_JSON_CODE =  \ref W_LOGTEST_RCODE_ERROR_INPUT
+ * @param msg string error description at \ref W_LOGTEST_JSON_MESSAGES field
+ * @return string (json format) with the response
+ */
+char * w_logtest_generate_error_response(char * msg);
 
 #endif

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -502,7 +502,7 @@
 #define LOGTEST_ERROR_RECV_MSG_ERRNO                "(7302): Failure to receive message: Errno: %s"
 #define LOGTEST_ERROR_INIT_HASH                     "(7303): Failure to initialize all_sessions hash"
 #define LOGTEST_ERROR_INV_CONF                      "(7304): Invalid wazuh-logtest configuration"
-#define LOGTEST_ERROR_SIZE_HASH                     "(7305): Failure to resize all_sesssions hash"
+#define LOGTEST_ERROR_SIZE_HASH                     "(7305): Failure to resize all_sessions hash"
 #define LOGTEST_ERROR_JSON_PARSE                    "(7306): Error parsing JSON"
 #define LOGTEST_ERROR_JSON_PARSE_POS                "(7307): Error in position %i, ... %s ..."
 #define LOGTEST_ERROR_JSON_REQUIRED_SFIELD          "(7308): '%s' JSON field is required and must be a string"

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -499,8 +499,8 @@
 /* Wazuh Logtest error messsages */
 #define LOGTEST_ERROR_BIND_SOCK                     "(7300): Unable to bind to socket '%s'. Errno: (%d) %s"
 #define LOGTEST_ERROR_ACCEPT_CONN                   "(7301): Failure to accept connection. Errno: %s"
-#define LOGTEST_ERROR_RECV_MSG                      "(7302): Failure to receive message:"
-#define LOGTEST_ERROR_INIT_HASH                     "(7303): Failure to initialize all_sesssions hash"
+#define LOGTEST_ERROR_RECV_MSG_ERRNO                "(7302): Failure to receive message: Errno: %s"
+#define LOGTEST_ERROR_INIT_HASH                     "(7303): Failure to initialize all_sessions hash"
 #define LOGTEST_ERROR_INV_CONF                      "(7304): Invalid wazuh-logtest configuration"
 #define LOGTEST_ERROR_SIZE_HASH                     "(7305): Failure to resize all_sesssions hash"
 #define LOGTEST_ERROR_JSON_PARSE                    "(7306): Error parsing JSON"
@@ -511,7 +511,9 @@
 #define LOGTEST_ERROR_INITIALIZE_SESSION            "(7311): Failure to initializing session '%s'"
 #define LOGTEST_ERROR_PROCESS_EVENT                 "(7312): Failed to process the event"
 #define LOGTEST_ERROR_FIELD_NOT_FOUND               "(7313): '%s' JSON field not found or is empty"
-#define LOGTEST_ERROR_TOKEN_INVALID_TYPE            "(7309): Failure to remove session. remove_session JSON field must be a string"
+#define LOGTEST_ERROR_RECV_MSG_EMPTY_TO             "(7314): Failure to receive message: empty or reception timeout"
+#define LOGTEST_ERROR_RECV_MSG_OVERSIZE             "(7315): Failure to receive message: size is bigger than expected"
+#define LOGTEST_ERROR_TOKEN_INVALID_TYPE            "(7316): Failure to remove session. remove_session JSON field must be a string"
 
 
 /* Verbose messages */

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -499,7 +499,7 @@
 /* Wazuh Logtest error messsages */
 #define LOGTEST_ERROR_BIND_SOCK                     "(7300): Unable to bind to socket '%s'. Errno: (%d) %s"
 #define LOGTEST_ERROR_ACCEPT_CONN                   "(7301): Failure to accept connection. Errno: %s"
-#define LOGTEST_ERROR_RECV_MSG                      "(7302): Failure to receive message. Errno: %s"
+#define LOGTEST_ERROR_RECV_MSG                      "(7302): Failure to receive message:"
 #define LOGTEST_ERROR_INIT_HASH                     "(7303): Failure to initialize all_sesssions hash"
 #define LOGTEST_ERROR_INV_CONF                      "(7304): Invalid wazuh-logtest configuration"
 #define LOGTEST_ERROR_SIZE_HASH                     "(7305): Failure to resize all_sesssions hash"
@@ -512,6 +512,7 @@
 #define LOGTEST_ERROR_PROCESS_EVENT                 "(7312): Failed to process the event"
 #define LOGTEST_ERROR_FIELD_NOT_FOUND               "(7313): '%s' JSON field not found or is empty"
 #define LOGTEST_ERROR_TOKEN_INVALID_TYPE            "(7309): Failure to remove session. remove_session JSON field must be a string"
+
 
 /* Verbose messages */
 #define STARTUP_MSG "Started (pid: %d)."

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -248,7 +248,7 @@ void test_w_logtest_init_OSHash_create_fail(void **state)
 
     will_return(__wrap_OSHash_Create, NULL);
 
-    expect_string(__wrap__merror, formatted_msg, "(7303): Failure to initialize all_sesssions hash");
+    expect_string(__wrap__merror, formatted_msg, "(7303): Failure to initialize all_sessions hash");
 
     w_logtest_init();
 
@@ -265,7 +265,7 @@ void test_w_logtest_init_OSHash_setSize_fail(void **state)
     expect_value(__wrap_OSHash_setSize, new_size, 2048);
     will_return(__wrap_OSHash_setSize, NULL);
 
-    expect_string(__wrap__merror, formatted_msg, "(7305): Failure to resize all_sesssions hash");
+    expect_string(__wrap__merror, formatted_msg, "(7305): Failure to resize all_sessions hash");
 
     w_logtest_init();
 


### PR DESCRIPTION
## Description

Hi team!

This PR fix socket header (4bytes of payload size) support.

## Tests

- [X] Linux: Compilation without warnings 
- [X] Valgrind (memcheck and descriptor leaks check)
- [X] Scan-build report
- [X] Check unit test

Regards,
Juan Nicolas
