### PR TITLE
Replace calls to expect_any_always in unit tests

### DIFF
--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(${SRC_FOLDER}/external/openssl/include)
 include_directories(${SRC_FOLDER}/external/audit-userspace/lib)
 include_directories(${SRC_FOLDER}/external/bzip2)
 include_directories(${SRC_FOLDER})
+add_definitions(-DWAZUH_UNIT_TESTING)
 
 # Wazuh libraries
 find_library(WAZUHLIB NAMES libwazuh.a HINTS "${SRC_FOLDER}")
@@ -44,7 +45,6 @@ if(NOT WAZUHEXT)
   message(FATAL_ERROR "libwazuhext not found! Aborting...")
 endif()
 
-add_definitions(-DWAZUH_UNIT_TESTING)
 add_subdirectory(syscheckd)
 add_subdirectory(shared)
 

--- a/src/unit_tests/shared/test_agent_op.c
+++ b/src/unit_tests/shared/test_agent_op.c
@@ -20,6 +20,7 @@
 #include "../../headers/sec.h"
 #include "../../addagent/manage_agents.h"
 
+#include "../wrappers/common.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
 /* redefinitons/wrapping */

--- a/src/unit_tests/shared/test_mq_op.c
+++ b/src/unit_tests/shared/test_mq_op.c
@@ -18,6 +18,8 @@
 
 #include "../headers/shared.h"
 
+#include "../wrappers/common.h"
+
 /* Define values may be changed */
 
 #define MAX_ATTEMPTS 100
@@ -48,8 +50,8 @@ void __wrap__mdebug1(const char * file, int line, const char * func, const char 
     check_expected(formatted_msg);
 }
 
-int __wrap_OS_getsocketsize(int ossock) { 
-    return SOCKET_SIZE; 
+int __wrap_OS_getsocketsize(int ossock) {
+    return SOCKET_SIZE;
 }
 
 void __wrap_sleep(unsigned int seconds){};
@@ -66,32 +68,32 @@ int __wrap_OS_ConnectUnixDomain(const char * path, int type, int max_msg_size){
 
 void test_start_mq_read_success(void ** state){
     (void)state; // Unused
-    
+
     /* Function parameters */
     short int n_attempts = 0;
     short int type = READ;
     char * path = "/test";
-    
+
     int ret = 0;
 
     will_return(__wrap_OS_BindUnixDomain, 0);
-    
+
     ret = StartMQ(path, type, n_attempts);
     assert_false(ret);
 }
 
 void test_start_mq_read_fail(void ** state){
     (void)state; // Unused
-    
+
     /* Function parameters */
     short int n_attempts = 0;
     short int type = READ;
     char * path = "/test";
 
     int ret = 0;
-    
+
     will_return(__wrap_OS_BindUnixDomain, -1);
-    
+
     ret = StartMQ(path, type, n_attempts);
     assert_int_equal(ret, -1);
 
@@ -99,17 +101,17 @@ void test_start_mq_read_fail(void ** state){
 
 void test_start_mq_write_simple_success(void ** state){
     (void)state; // Unused
-    
+
     /* Function parameters */
     short int n_attempts = 1;
     short int type = WRITE;
     char * path = "/test";
-    
+
     int ret = 0;
     char messages[2][OS_SIZE_64];
 
     will_return(__wrap_OS_ConnectUnixDomain, 0);
-    
+
     snprintf(messages[0], OS_SIZE_64,"Connected succesfully to '%s' after %d attempts", path, 0);
     expect_string(__wrap__mdebug1, formatted_msg, messages[0]);
 
@@ -122,7 +124,7 @@ void test_start_mq_write_simple_success(void ** state){
 
 void test_start_mq_write_simple_fail(void ** state){
     (void)state; // Unused
-    
+
     /* Function parameters */
     short int n_attempts = 1;
     short int type = WRITE;
@@ -134,7 +136,7 @@ void test_start_mq_write_simple_fail(void ** state){
 
     will_return(__wrap_OS_ConnectUnixDomain, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Can't connect to '/test': Socket operation on non-socket (88). Attempt: 1");
-    
+
     snprintf(expected_str, OS_SIZE_64, "(1210): Queue '%s' not accessible: '%s'", path,strerror(errno));
     expect_string(__wrap__merror, formatted_msg, expected_str);
 
@@ -204,7 +206,7 @@ void test_start_mq_write_inf_success(void ** state){
     short int n_attempts = 0;
     short int type = WRITE;
     char * path = "/test";
-    
+
     int ret = 0;
     char messages[MAX_ATTEMPTS + 1][OS_SIZE_1024];
 
@@ -245,7 +247,7 @@ void test_start_mq_write_inf_fail(void ** state){
     will_return(__wrap_OS_ConnectUnixDomain, 0);
     /* Ignoring output */
     expect_any_always(__wrap__mdebug1, formatted_msg);
-    
+
     ret = StartMQ(path, type, n_attempts);
 }
 
@@ -262,6 +264,6 @@ int main(void){
        cmocka_unit_test(test_start_mq_write_inf_success),
        cmocka_unit_test(test_start_mq_write_inf_fail)
        };
-    
+
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/syscheckd/test_syscheck_config.c
+++ b/src/unit_tests/syscheckd/test_syscheck_config.c
@@ -17,6 +17,7 @@
 #include "../syscheckd/syscheck.h"
 #include "../config/syscheck-config.h"
 
+#include "../wrappers/common.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
 /* redefinitons/wrapping */

--- a/src/unit_tests/syscheckd/test_win_registry.c
+++ b/src/unit_tests/syscheckd/test_win_registry.c
@@ -18,6 +18,7 @@
 #include<libloaderapi.h>
 #include <openssl/evp.h>
 
+#include "../wrappers/common.h"
 #include "../wrappers/externals/openssl/digest_wrappers.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/syscheckd/create_db_wrappers.h"

--- a/src/unit_tests/wazuh_modules/aws/test_wm_aws.c
+++ b/src/unit_tests/wazuh_modules/aws/test_wm_aws.c
@@ -19,6 +19,7 @@
 #include "wazuh_modules/wmodules.h"
 #include "wazuh_modules/wm_aws.h"
 #include "../scheduling/wmodules_scheduling_helpers.h"
+#include "../../wrappers/common.h"
 #include "../../wrappers/libc/stdlib_wrappers.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/wazuh_modules/wmodules_wrappers.h"

--- a/src/unit_tests/wazuh_modules/azure/test_wm_azure.c
+++ b/src/unit_tests/wazuh_modules/azure/test_wm_azure.c
@@ -21,6 +21,7 @@
 #include "wazuh_modules/wm_azure.h"
 
 #include "../scheduling/wmodules_scheduling_helpers.h"
+#include "../../wrappers/common.h"
 #include "../../wrappers/libc/stdlib_wrappers.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/mq_op_wrappers.h"

--- a/src/unit_tests/wazuh_modules/ciscat/test_wm_ciscat.c
+++ b/src/unit_tests/wazuh_modules/ciscat/test_wm_ciscat.c
@@ -20,6 +20,7 @@
 #include "wazuh_modules/wmodules.h"
 #include "wazuh_modules/wm_ciscat.h"
 #include "../scheduling/wmodules_scheduling_helpers.h"
+#include "../../wrappers/common.h"
 #include "../../wrappers/libc/stdlib_wrappers.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/file_op_wrappers.h"

--- a/src/unit_tests/wazuh_modules/command/test_wm_command.c
+++ b/src/unit_tests/wazuh_modules/command/test_wm_command.c
@@ -21,6 +21,7 @@
 #include "wazuh_modules/wm_command.h"
 
 #include "../scheduling/wmodules_scheduling_helpers.h"
+#include "../../wrappers/common.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/wazuh_modules/wm_exec_wrappers.h"
 #include "../../wrappers/wazuh/shared/mq_op_wrappers.h"

--- a/src/unit_tests/wazuh_modules/docker/test_wm_docker.c
+++ b/src/unit_tests/wazuh_modules/docker/test_wm_docker.c
@@ -17,6 +17,7 @@
 #include <time.h>
 
 #include "shared.h"
+#include "../../wrappers/common.h"
 #include "../../wrappers/libc/stdio_wrappers.h"
 #include "../../wrappers/libc/stdlib_wrappers.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"

--- a/src/unit_tests/wazuh_modules/oscap/test_wm_oscap.c
+++ b/src/unit_tests/wazuh_modules/oscap/test_wm_oscap.c
@@ -19,6 +19,7 @@
 #include "wazuh_modules/wmodules.h"
 #include "wazuh_modules/wm_oscap.h"
 #include "../scheduling/wmodules_scheduling_helpers.h"
+#include "../../wrappers/common.h"
 #include "../../wrappers/libc/stdlib_wrappers.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/mq_op_wrappers.h"

--- a/src/unit_tests/wazuh_modules/sca/test_wm_sca.c
+++ b/src/unit_tests/wazuh_modules/sca/test_wm_sca.c
@@ -21,6 +21,7 @@
 #include "wazuh_modules/wmodules.h"
 #include "../scheduling/wmodules_scheduling_helpers.h"
 
+#include "../../wrappers/common.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/file_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/mq_op_wrappers.h"

--- a/src/unit_tests/wrappers/common.h
+++ b/src/unit_tests/wrappers/common.h
@@ -28,4 +28,8 @@ extern time_t time_mock_value;
 #define time(x) wrap_time(x)
 #endif
 
+#ifndef expect_any_always
+#define expect_any_always(function, parameter) expect_any_count(function, parameter, -1)
+#endif
+
 #endif /* COMMON_H */


### PR DESCRIPTION
|Related issue|
|---|
|None|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Calls to expect_any_always have been replaced with equivalent calls to expect_any_count in order to maintain compatibility with older versions of cmocka. The latest version of cmocka is not available in some of the older OS versions that we still support, this PR should improve compatibility with those.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux