### PR TITLE
Ignore VDT deprecated configuration

### DIFF
--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -132,11 +132,9 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
 #ifndef WIN32
 #ifndef CLIENT
     else if (!strcmp(node->values[0], WM_VULNDETECTOR_CONTEXT.name)) {
-        mwarn("This vulnerability-detector declaration is deprecated. Use <vulnerability-detector> instead.");
-        if (Read_Vuln(xml, children, cur_wmodule, 0) < 0) {
-            OS_ClearNode(children);
-            return OS_INVALID;
-        }
+        mwarn("Found a Vulnerability Detector deprecated block. Ignoring it.");
+        OS_ClearNode(children);
+        return 0;
     } else if (!strcmp(node->values[0], WM_AZURE_CONTEXT.name)) {
         if (wm_azure_read(xml, children, cur_wmodule) < 0) {
             OS_ClearNode(children);

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -132,7 +132,7 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
 #ifndef WIN32
 #ifndef CLIENT
     else if (!strcmp(node->values[0], WM_VULNDETECTOR_CONTEXT.name)) {
-        mwarn("Found a Vulnerability Detector deprecated block. Ignoring it.");
+        mwarn("A deprecated Vulnerability Detector configuration block was found. It will be ignored.");
         OS_ClearNode(children);
         return 0;
     } else if (!strcmp(node->values[0], WM_AZURE_CONTEXT.name)) {


### PR DESCRIPTION
## Description

As a solution for https://github.com/wazuh/wazuh/issues/5875 it is proposed to ignore the deprecated configuration of the Vulnerability Detector module. Particularly, the following tags:

- `<wodle name="vulnerability-detector">`

```
2020/09/01 05:39:22 wazuh-modulesd: WARNING: Found a Vulnerability Detector deprecated block. Ignoring it.
```

- `<update_ubuntu_oval interval="1d" version="16,14,12">yes</update_ubuntu_oval>`

```
2020/09/01 05:39:22 wazuh-modulesd: WARNING: 'update_ubuntu_oval' option at module 'vulnerability-detector' is deprecated. Use 'provider' instead.
```

- `<update_redhat_oval interval="1d" version="7,6,5">yes</update_redhat_oval>`

```
2020/09/01 05:39:22 wazuh-modulesd: WARNING: 'update_redhat_oval' option at module 'vulnerability-detector' is deprecated. Use 'provider' instead.
```

- `<feed>`

```
2020/09/01 05:41:06 wazuh-modulesd: WARNING: 'feed' option at module 'vulnerability-detector' is deprecated. Use 'provider' instead.
```

Apart from the warning message, when found any of the tags above the configuration block is not read.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- [x] Retrocompatibility with older Wazuh versions
- [x] Added unit tests (for new features)
