### PR TITLE
Remove unique constraint from table rules

### DIFF
--- a/api/test/integration/env/configurations/security/manager/schema_security_test.sql
+++ b/api/test/integration/env/configurations/security/manager/schema_security_test.sql
@@ -10,7 +10,7 @@ CREATE TABLE users (id INTEGER NOT NULL, username VARCHAR(32), password VARCHAR(
 
 CREATE TABLE roles (id INTEGER NOT NULL, name VARCHAR(20), created_at DATETIME,	PRIMARY KEY (id), CONSTRAINT name_role UNIQUE (name));
 
-CREATE TABLE rules (id INTEGER NOT NULL, name VARCHAR(20), rule TEXT, created_at DATETIME, PRIMARY KEY (id), CONSTRAINT rule_name UNIQUE (name), CONSTRAINT rule_definition UNIQUE (rule));
+CREATE TABLE rules (id INTEGER NOT NULL, name VARCHAR(20), rule TEXT, created_at DATETIME, PRIMARY KEY (id), CONSTRAINT rule_name UNIQUE (name));
 
 CREATE TABLE policies (id INTEGER NOT NULL, name VARCHAR(20), policy TEXT, created_at DATETIME, PRIMARY KEY (id), CONSTRAINT name_policy UNIQUE (name),	CONSTRAINT policy_definition UNIQUE (policy));
 

--- a/api/test/integration/test_security_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_POST_endpoints.tavern.yaml
@@ -170,7 +170,7 @@ stages:
           total_affected_items: 1
 
   # POST /security/rules
-  - name: Add a rule to the system
+  - name: Add a rule to the system (same rule but different name)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/rules"
@@ -181,7 +181,7 @@ stages:
         name: "test_i2"
         rule:
           FIND$:
-            definition: "normal_rule2"
+            definition: "normal_rule1"
     response:
       status_code: 200
       json:
@@ -191,7 +191,7 @@ stages:
               name: test_i2
               rule:
                 FIND$:
-                  definition: "normal_rule2"
+                  definition: "normal_rule1"
           total_affected_items: 1
 
 ---

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -326,6 +326,34 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
+  # PUT /security/rules/{rule_id}
+  - name: Modify a rule in the system (using different name but same rule)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/rules/103"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        name: "testModified2"
+        rule:
+          MATCH:
+            normal_rule: "modifiedR"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - id: 103
+                name: "testModified2"
+                rule:
+                  MATCH:
+                    normal_rule: "modifiedR"
+                roles: !anything
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
   # PUT /security/rules/{non-existent rule_id}
   - name: Modify a non-existent rule in the system
     request:

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -321,8 +321,7 @@ class Rules(_Base):
     name = Column('name', String(20))
     rule = Column('rule', TEXT)
     created_at = Column('created_at', DateTime, default=datetime.utcnow())
-    __table_args__ = (UniqueConstraint('name', name='rule_name'),
-                      UniqueConstraint('rule', name='rule_definition'))
+    __table_args__ = (UniqueConstraint('name', name='rule_name'),)
 
     # Relations
     roles = relationship("Roles", secondary='roles_rules',

--- a/framework/wazuh/tests/data/security/schema_security_test.sql
+++ b/framework/wazuh/tests/data/security/schema_security_test.sql
@@ -26,12 +26,12 @@ INSERT INTO roles VALUES(104,'normalUser','1970-01-01 00:00:00');
 INSERT INTO roles VALUES(105,'ossec','1970-01-01 00:00:00');
 
 /* Testing */
-INSERT INTO rules VALUES(100,'omegalul','{"FIND": {"r''^auth[a-zA-Z]+$''": ["administrator"]}}','1970-01-01 00:00:00');
-INSERT INTO rules VALUES(101,'omegalul1','{"FIND": {"r''^auth[a-zA-Z]+$''": ["administrator-app"]}}','1970-01-01 00:00:00');
-INSERT INTO rules VALUES(102,'omegalul2','{"MATCH": {"definition": "technicalRule"}}','1970-01-01 00:00:00');
-INSERT INTO rules VALUES(103,'omegalul3','{"MATCH": {"definition": "administratorRule"}}','1970-01-01 00:00:00');
-INSERT INTO rules VALUES(104,'omegalul4','{"MATCH": {"definition": "normalRule"}}','1970-01-01 00:00:00');
-INSERT INTO rules VALUES(105,'omegalul5','{"MATCH": {"definition": "ossecRule"}}','1970-01-01 00:00:00');
+INSERT INTO rules VALUES(100,'rule1','{"FIND": {"r''^auth[a-zA-Z]+$''": ["administrator"]}}','1970-01-01 00:00:00');
+INSERT INTO rules VALUES(101,'rule2','{"FIND": {"r''^auth[a-zA-Z]+$''": ["administrator-app"]}}','1970-01-01 00:00:00');
+INSERT INTO rules VALUES(102,'rule3','{"MATCH": {"definition": "technicalRule"}}','1970-01-01 00:00:00');
+INSERT INTO rules VALUES(103,'rule4','{"MATCH": {"definition": "administratorRule"}}','1970-01-01 00:00:00');
+INSERT INTO rules VALUES(104,'rule5','{"MATCH": {"definition": "normalRule"}}','1970-01-01 00:00:00');
+INSERT INTO rules VALUES(105,'rule6','{"MATCH": {"definition": "ossecRule"}}','1970-01-01 00:00:00');
 
 /* Testing */
 INSERT INTO policies VALUES(100,'wazuhPolicy','{"actions": ["*:*"], "resources": ["*:*"], "effect": "allow"}','1970-01-01 00:00:00');


### PR DESCRIPTION
Hello team,

This PR removes the `UNIQUE` constraint from the table `rules` (RBAC database). This allows the user to add multiple rules with the same field `rule`.

## Tests performed
```shell
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0
collected 53 items                                                                                                                                                                          

wazuh/rbac/tests/test_orm.py .....................................................                                                                                                    [100%]

==================================================================================== 53 passed in 45.09s ====================================================================================
```


Regards.