### PR TITLE
5891 fix password json field on client config dump

### DIFF
--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -131,7 +131,7 @@ cJSON *getClientConfig(void) {
         if (agt->enrollment_cfg->cert_cfg->agent_key)    
             cJSON_AddStringToObject(enrollment_cfg, "agent_key_path", agt->enrollment_cfg->cert_cfg->agent_key);
         if(agt->enrollment_cfg->cert_cfg->authpass)
-            cJSON_AddStringToObject(enrollment_cfg, "authorization_pass_path", agt->enrollment_cfg->cert_cfg->authpass);
+            cJSON_AddStringToObject(enrollment_cfg, "authorization_pass_path", agt->enrollment_cfg->cert_cfg->authpass_file);
         
         cJSON_AddStringToObject(enrollment_cfg,"auto_method",agt->enrollment_cfg->cert_cfg->auto_method ? "yes": "no");
         cJSON_AddItemToObject(client,"enrollment",enrollment_cfg);

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -328,7 +328,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
     const char *xml_server_ca_path = "server_ca_path";
     const char *xml_agent_certif_path = "agent_certificate_path";
     const char *xml_agent_key_path = "agent_key_path";
-    const char *xml_auth_password = "authorization_pass_path";
+    const char *xml_auth_password_path = "authorization_pass_path";
     const char *xml_auto_method = "auto_method";
     const char *xml_delay_after_enrollment = "delay_after_enrollment";
     const char *xml_use_source_ip = "use_source_ip";
@@ -420,7 +420,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
         } else if (strcmp(node[j]->element, xml_agent_key_path) == 0) {
             os_free(cert_cfg->agent_key);
             os_strdup(node[j]->content, cert_cfg->agent_key);
-        } else if (strcmp(node[j]->element, xml_auth_password) == 0) {
+        } else if (strcmp(node[j]->element, xml_auth_password_path) == 0) {
             os_free(cert_cfg->authpass_file);
             os_strdup(node[j]->content, cert_cfg->authpass_file);
         } else if (strcmp(node[j]->element, xml_auto_method) == 0) {


### PR DESCRIPTION
|Related issue|
|---|
|5891|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR modifies the filed to be used when the agent configuration is dumped.
Previously, **authpass** data was being dumped and should have been **authpass_file**.

Minimum changes were implemented.
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows

