### PR TITLE
Standardize wdb_sync_agent_info_get response

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -122,7 +122,7 @@ void test_get_agent_labels_transaction_fail(void **state)
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "cannot begin transaction");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
     output = wdb_global_get_agent_labels(data->socket, atoi(data->socket->id));
     assert_null(output);
@@ -135,7 +135,7 @@ void test_get_agent_labels_cache_fail(void **state)
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "cannot cache statement");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
     output = wdb_global_get_agent_labels(data->socket, atoi(data->socket->id));
     assert_null(output);
@@ -190,7 +190,7 @@ void test_del_agent_labels_transaction_fail(void **state)
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "cannot begin transaction");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
     result = wdb_global_del_agent_labels(data->socket, atoi(data->socket->id));
     assert_int_equal(result, OS_INVALID);
@@ -203,7 +203,7 @@ void test_del_agent_labels_cache_fail(void **state)
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "cannot cache statement");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
     result = wdb_global_del_agent_labels(data->socket, atoi(data->socket->id));
     assert_int_equal(result, OS_INVALID);
@@ -260,7 +260,7 @@ void test_set_agent_label_transaction_fail(void **state)
     char value[] = "test_value";
 
     will_return(__wrap_wdb_begin2, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "cannot begin transaction");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
     result = wdb_global_set_agent_label(data->socket, atoi(data->socket->id), key, value);
     assert_int_equal(result, OS_INVALID);
@@ -275,7 +275,7 @@ void test_set_agent_label_cache_fail(void **state)
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "cannot cache statement");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
     result = wdb_global_set_agent_label(data->socket, atoi(data->socket->id), key, value);
     assert_int_equal(result, OS_INVALID);
@@ -375,7 +375,7 @@ void test_wdb_global_set_sync_status_transaction_fail(void **state)
     test_struct_t *data  = (test_struct_t *)*state;
  
     will_return(__wrap_wdb_begin2, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "cannot begin transaction");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
     result = wdb_global_set_sync_status(data->socket, atoi(data->socket->id), WDB_SYNCED);
     assert_int_equal(result, OS_INVALID);
@@ -388,7 +388,7 @@ void test_wdb_global_set_sync_status_cache_fail(void **state)
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "cannot cache statement");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
     result = wdb_global_set_sync_status(data->socket, atoi(data->socket->id), WDB_SYNCED);
     assert_int_equal(result, OS_INVALID);
@@ -462,12 +462,12 @@ void test_wdb_sync_agent_info_get_transaction_fail(void **state)
     char *output = NULL;
    
     will_return(__wrap_wdb_begin2, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "cannot begin transaction");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
     result = wdb_sync_agent_info_get(data->socket, &last_agent_id, &output);
 
     os_free(output);
-    assert_int_equal(result, WDB_CHUNKS_ERROR);
+    assert_int_equal(result, WDBC_ERROR);
 }
 
 void test_wdb_sync_agent_info_get_cache_fail(void **state)
@@ -479,12 +479,12 @@ void test_wdb_sync_agent_info_get_cache_fail(void **state)
    
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "cannot cache statement");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
     result = wdb_sync_agent_info_get(data->socket, &last_agent_id, &output);
 
     os_free(output);
-    assert_int_equal(result, WDB_CHUNKS_ERROR);
+    assert_int_equal(result, WDBC_ERROR);
 }
 
 void test_wdb_sync_agent_info_get_bind_fail(void **state)
@@ -502,7 +502,7 @@ void test_wdb_sync_agent_info_get_bind_fail(void **state)
     result = wdb_sync_agent_info_get(data->socket, &last_agent_id, &output);
 
     os_free(output);
-    assert_int_equal(result, WDB_CHUNKS_ERROR);
+    assert_int_equal(result, WDBC_ERROR);
 }
 
 void test_wdb_sync_agent_info_get_no_agents(void **state)
@@ -520,7 +520,7 @@ void test_wdb_sync_agent_info_get_no_agents(void **state)
     result = wdb_sync_agent_info_get(data->socket, &last_agent_id, &output);
 
     os_free(output);
-    assert_int_equal(result, WDB_CHUNKS_COMPLETE);
+    assert_int_equal(result, WDBC_OK);
 }
 
 void test_wdb_sync_agent_info_get_success(void **state)
@@ -601,7 +601,7 @@ void test_wdb_sync_agent_info_get_success(void **state)
 
     os_free(output);
     cJSON_Delete(json_output);
-    assert_int_equal(result, WDB_CHUNKS_COMPLETE);
+    assert_int_equal(result, WDBC_OK);
 }
 
 void test_wdb_sync_agent_info_get_sync_fail(void **state)
@@ -632,12 +632,12 @@ void test_wdb_sync_agent_info_get_sync_fail(void **state)
     // Required for wdb_global_set_sync_status()
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: (null)");
+    expect_string(__wrap__merror, formatted_msg, "Cannot set sync_status for agent 1");
 
     result = wdb_sync_agent_info_get(data->socket, &last_agent_id, &output);
 
     os_free(output);
-    cJSON_Delete(root);
-    assert_int_equal(result, WDB_CHUNKS_ERROR);
+    assert_int_equal(result, WDBC_ERROR);
 }
 
 void test_wdb_sync_agent_info_get_full(void **state)
@@ -679,7 +679,7 @@ void test_wdb_sync_agent_info_get_full(void **state)
     result = wdb_sync_agent_info_get(data->socket, &last_agent_id, &output);
 
     os_free(output);
-    assert_int_equal(result, WDB_CHUNKS_BUFFER_FULL);
+    assert_int_equal(result, WDBC_DUE);
 }
 
 void test_wdb_global_sync_agent_info_set_transaction_fail(void **state)
@@ -689,7 +689,7 @@ void test_wdb_global_sync_agent_info_set_transaction_fail(void **state)
     cJSON *json_agent = NULL;
    
     will_return(__wrap_wdb_begin2, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "cannot begin transaction");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
     result = wdb_global_sync_agent_info_set(data->socket, json_agent);
 
@@ -704,7 +704,7 @@ void test_wdb_global_sync_agent_info_set_cache_fail(void **state)
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "cannot cache statement");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
     result = wdb_global_sync_agent_info_set(data->socket, json_agent);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -225,14 +225,6 @@ typedef enum {
     WDB_SYNC_REQ
 } wdb_sync_status_t;
 
-/// Enumeration of sync-agent-info-get-status.
-typedef enum {
-    WDB_CHUNKS_ERROR = -1,  ///< An error occured
-    WDB_CHUNKS_PENDING,     ///< There are still elements to get
-    WDB_CHUNKS_BUFFER_FULL, ///< There are still elements to get but buffer is full
-    WDB_CHUNKS_COMPLETE     ///< There aren't any more elements to get    
-} wdb_chunks_status_t;
-
 extern char *schema_global_sql;
 extern char *schema_agents_sql;
 extern char *schema_upgrade_v1_sql;
@@ -1596,9 +1588,9 @@ int wdb_global_set_sync_status(wdb_t *wdb, int id, wdb_sync_status_t status);
  * @param [in] wdb The Global struct database.
  * @param [in] last_agent_id ID where to start querying.
  * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
- * @return wdb_chunks_status_t to represent if all agents has being obtained.
+ * @return wdbc_result to represent if all agents has being obtained.
  */
-wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char **output);
+wdbc_result wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char **output);
 
 /**
  * @brief Function to update the information of an agent.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -744,12 +744,12 @@ cJSON* wdb_global_find_group(wdb_t *wdb, char* group_name) {
     cJSON * result = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return NULL;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_FIND_GROUP) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return NULL;
     }
 
@@ -773,12 +773,12 @@ int wdb_global_insert_agent_group(wdb_t *wdb, char* group_name) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_INSERT_AGENT_GROUP) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -804,12 +804,12 @@ int wdb_global_insert_agent_belong(wdb_t *wdb, int id_group, int id_agent) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_INSERT_AGENT_BELONG) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -995,12 +995,12 @@ int wdb_global_set_sync_status(wdb_t *wdb, int id, wdb_sync_status_t status) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_SYNC_SET) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -1026,33 +1026,36 @@ int wdb_global_set_sync_status(wdb_t *wdb, int id, wdb_sync_status_t status) {
     }
 }
 
-wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char **output) {
+wdbc_result wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char **output) {
     sqlite3_stmt* agent_stmt = NULL;
     unsigned response_size = 2;     //Starts with "[]" size
-    wdb_chunks_status_t status = WDB_CHUNKS_PENDING;
+    wdbc_result status = WDBC_UNKNOWN;
     
     os_calloc(WDB_MAX_RESPONSE_SIZE, sizeof(char), *output);
     char *response_aux = *output;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
-        return WDB_CHUNKS_ERROR;
+        mdebug1("Cannot begin transaction");
+        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot begin transaction");
+        return WDBC_ERROR;
     }
 
     //Add array start
     *response_aux++ = '[';
 
-    while (status == WDB_CHUNKS_PENDING) {
+    while (status == WDBC_UNKNOWN) {
         //Prepare SQL query
         if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_SYNC_REQ_GET) < 0) {
-            mdebug1("cannot cache statement");
-            status = WDB_CHUNKS_ERROR;
+            mdebug1("Cannot cache statement");
+            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot cache statement");
+            status = WDBC_ERROR;
             break;
         }
         agent_stmt = wdb->stmt[WDB_STMT_GLOBAL_SYNC_REQ_GET];
         if (sqlite3_bind_int(agent_stmt, 1, *last_agent_id) != SQLITE_OK) {
             merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-            status = WDB_CHUNKS_ERROR;
+            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
+            status = WDBC_ERROR;
             break;
         }
         
@@ -1082,12 +1085,6 @@ wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char
                 
                 //Check if new agent fits in response
                 if (response_size+agent_len+1 < WDB_MAX_RESPONSE_SIZE) {
-                    //Set sync status as synced
-                    if (OS_SUCCESS != wdb_global_set_sync_status(wdb, agent_id, WDB_SYNCED)) {
-                        status = WDB_CHUNKS_ERROR;
-                        os_free(agent_str);
-                        break;
-                    }
                     //Add new agent
                     memcpy(response_aux, agent_str, agent_len); 
                     response_aux+=agent_len;
@@ -1096,28 +1093,35 @@ wdb_chunks_status_t wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char
                     //Save size and last ID
                     response_size += agent_len+1;
                     *last_agent_id = agent_id;
+                    //Set sync status as synced
+                    if (OS_SUCCESS != wdb_global_set_sync_status(wdb, agent_id, WDB_SYNCED)) {
+                        merror("Cannot set sync_status for agent %d", agent_id);
+                        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s %d", "Cannot set sync_status for agent", agent_id);
+                        status = WDBC_ERROR;
+                    }                    
                 }
                 else {
                     //Pending agents but buffer is full
-                    status = WDB_CHUNKS_BUFFER_FULL;
+                    status = WDBC_DUE;
                 }
                 os_free(agent_str);
             }
         }
         else {
             //All agents have been obtained
-            status = WDB_CHUNKS_COMPLETE;
+            status = WDBC_OK;
         }
         cJSON_Delete(sql_agents_response);
     }
     
-    if (response_size > 2) {
-        //Remove last ','
-        response_aux--;
+    if (status != WDBC_ERROR) {
+        if (response_size > 2) {
+            //Remove last ','
+            response_aux--;
+        }
+        //Add array end
+        *response_aux = ']';
     }
-    //Add array end
-    *response_aux = ']';
-
     return status;
 }
 
@@ -1128,12 +1132,12 @@ int wdb_global_sync_agent_info_set(wdb_t *wdb,cJSON * json_agent){
     cJSON *json_field = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_UPDATE_AGENT_INFO) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -1221,18 +1225,21 @@ wdbc_result wdb_global_get_agents_by_keepalive(wdb_t *wdb, int* last_agent_id, c
     else
     {
         merror("Invalid comparator");
+        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Invalid comparator");
         return WDBC_ERROR;
     }
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
+        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot begin transaction");
         return WDBC_ERROR;
     }
 
     while (status == WDBC_UNKNOWN) {
         //Prepare SQL query
         if (wdb_stmt_cache(wdb, stmt_index) < 0) {
-            mdebug1("cannot cache statement");
+            mdebug1("Cannot cache statement");
+            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot cache statement");
             status = WDBC_ERROR;
             break;
         }
@@ -1240,12 +1247,14 @@ wdbc_result wdb_global_get_agents_by_keepalive(wdb_t *wdb, int* last_agent_id, c
         sqlite3_stmt* stmt = wdb->stmt[stmt_index];
         if (sqlite3_bind_int(stmt, 1, *last_agent_id) != SQLITE_OK) {
             merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
             status = WDBC_ERROR;
             break;
         }
 
         if (sqlite3_bind_int(stmt, 2, keep_alive) != SQLITE_OK) {
             merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
             status = WDBC_ERROR;
             break;
         }
@@ -1287,13 +1296,15 @@ wdbc_result wdb_global_get_agents_by_keepalive(wdb_t *wdb, int* last_agent_id, c
         }
         cJSON_Delete(sql_agents_response);
     }
-    
-    if (response_size > 0) {
-        //Remove last ','
-        response_aux--;
+
+    if (status != WDBC_ERROR) {
+        if (response_size > 0) {
+            //Remove last ','
+            response_aux--;
+        }
+        //Add string end
+        *response_aux = '\0';
     }
-    //Add string end
-    *response_aux = '\0';
 
     return status;
 }
@@ -1306,20 +1317,23 @@ wdbc_result wdb_global_get_all_agents(wdb_t *wdb, int* last_agent_id, char **out
     char *response_aux = *output;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
+        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot begin transaction");
         return WDBC_ERROR;
     }
 
     while (status == WDBC_UNKNOWN) {
         //Prepare SQL query
         if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENTS) < 0) {
-            mdebug1("cannot cache statement");
+            mdebug1("Cannot cache statement");
+            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot cache statement");
             status = WDBC_ERROR;
             break;
         }
         sqlite3_stmt* stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS];
         if (sqlite3_bind_int(stmt, 1, *last_agent_id) != SQLITE_OK) {
             merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
             status = WDBC_ERROR;
             break;
         }        
@@ -1362,12 +1376,14 @@ wdbc_result wdb_global_get_all_agents(wdb_t *wdb, int* last_agent_id, char **out
         cJSON_Delete(sql_agents_response);
     }
     
-    if (response_size > 0) {
-        //Remove last ','
-        response_aux--;
+    if (status != WDBC_ERROR) {
+        if (response_size > 0) {
+            //Remove last ','
+            response_aux--;
+        }
+        //Add string end
+        *response_aux = '\0';
     }
-    //Add string end
-    *response_aux = '\0';
 
     return status;
 }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -39,12 +39,12 @@ int wdb_global_insert_agent(wdb_t *wdb, int id, char* name, char* ip, char* regi
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_INSERT_AGENT) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -94,12 +94,12 @@ int wdb_global_update_agent_name(wdb_t *wdb, int id, char* name) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_UPDATE_AGENT_NAME) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -148,12 +148,12 @@ int wdb_global_update_agent_version(wdb_t *wdb,
     int index = 1;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, agent_ip ? WDB_STMT_GLOBAL_UPDATE_AGENT_VERSION_IP : WDB_STMT_GLOBAL_UPDATE_AGENT_VERSION) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -247,12 +247,12 @@ cJSON* wdb_global_get_agent_labels(wdb_t *wdb, int id) {
     int index = 0;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return NULL;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_LABELS_GET) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return NULL;
     }
 
@@ -279,12 +279,12 @@ int wdb_global_del_agent_labels(wdb_t *wdb, int id) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_LABELS_DEL) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -310,12 +310,12 @@ int wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_LABELS_SET) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -349,12 +349,12 @@ int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, wdb_sync_status_t stat
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -384,12 +384,12 @@ int wdb_global_delete_agent(wdb_t *wdb, int id) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_DELETE_AGENT) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -416,12 +416,12 @@ cJSON* wdb_global_select_agent_name(wdb_t *wdb, int id) {
     cJSON * result = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return NULL;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_SELECT_AGENT_NAME) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return NULL;
     }
 
@@ -446,12 +446,12 @@ cJSON* wdb_global_select_agent_group(wdb_t *wdb, int id) {
     cJSON * result = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return NULL;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_SELECT_AGENT_GROUP) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return NULL;
     }
 
@@ -476,12 +476,12 @@ cJSON* wdb_global_find_agent(wdb_t *wdb, const char *name, const char *ip) {
     cJSON * result = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return NULL;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_FIND_AGENT) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return NULL;
     }
 
@@ -514,12 +514,12 @@ cJSON* wdb_global_select_agent_fim_offset(wdb_t *wdb, int id) {
     cJSON * result = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return NULL;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_SELECT_FIM_OFFSET) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return NULL;
     }
 
@@ -544,12 +544,12 @@ cJSON* wdb_global_select_agent_reg_offset(wdb_t *wdb, int id) {
     cJSON * result = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return NULL;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_SELECT_REG_OFFSET) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return NULL;
     }
 
@@ -573,12 +573,12 @@ int wdb_global_update_agent_fim_offset(wdb_t *wdb, int id, long offset) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_UPDATE_FIM_OFFSET) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -608,12 +608,12 @@ int wdb_global_update_agent_reg_offset(wdb_t *wdb, int id, long offset) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_UPDATE_REG_OFFSET) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -644,12 +644,12 @@ cJSON* wdb_global_select_agent_status(wdb_t *wdb, int id) {
     cJSON * result = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return NULL;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_SELECT_AGENT_STATUS) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return NULL;
     }
 
@@ -673,12 +673,12 @@ int wdb_global_update_agent_status(wdb_t *wdb, int id, char *status) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_UPDATE_AGENT_STATUS) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -708,12 +708,12 @@ int wdb_global_update_agent_group(wdb_t *wdb, int id, char *group) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_UPDATE_AGENT_GROUP) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -839,12 +839,12 @@ int wdb_global_delete_group_belong(wdb_t *wdb, char* group_name) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_DELETE_GROUP_BELONG) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -870,12 +870,12 @@ int wdb_global_delete_group(wdb_t *wdb, char* group_name) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_DELETE_GROUP) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
@@ -902,12 +902,12 @@ cJSON* wdb_global_select_groups(wdb_t *wdb) {
     cJSON * result = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return NULL;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_SELECT_GROUPS) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return NULL;
     }
 
@@ -927,12 +927,12 @@ cJSON* wdb_global_select_agent_keepalive(wdb_t *wdb, char* name, char* ip) {
     cJSON * result = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return NULL;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_SELECT_AGENT_KEEPALIVE) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return NULL;
     }
 
@@ -964,12 +964,12 @@ int wdb_global_delete_agent_belong(wdb_t *wdb, int id) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
-        mdebug1("cannot begin transaction");
+        mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
     if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_DELETE_AGENT_BELONG) < 0) {
-        mdebug1("cannot cache statement");
+        mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5064,35 +5064,35 @@ int wdb_parse_get_agents_by_keepalive(wdb_t* wdb, char* input, char* output) {
     if (next == NULL || strcmp(input, "condition") != 0) {
         mdebug1("Invalid arguments 'condition' not found");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'condition' not found");
-        return WDB_CHUNKS_ERROR;
+        return OS_INVALID;
     }
     next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL) {
         mdebug1("Invalid arguments 'condition' not found");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'condition' not found");
-        return WDB_CHUNKS_ERROR;
+        return OS_INVALID;
     }
     comparator = *next;
     next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL) {
-       mdebug1("Invalid arguments 'condition' not found");
+        mdebug1("Invalid arguments 'condition' not found");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'condition' not found");
-        return WDB_CHUNKS_ERROR;
+        return OS_INVALID;
     }
     keep_alive = atoi(next);
     
     /* Get start_id*/
     next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL || strcmp(next, "start_id") != 0) {
-        mdebug1("Invalid arguments 'condition' not found");
+        mdebug1("Invalid arguments 'start_id' not found");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'start_id' not found");
-        return WDB_CHUNKS_ERROR;
+        return OS_INVALID;
     }
     next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL) {
-        mdebug1("Invalid arguments 'condition' not found");
+        mdebug1("Invalid arguments 'start_id' not found");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'start_id' not found");
-        return WDB_CHUNKS_ERROR;
+        return OS_INVALID;
     }
     start_id = atoi(next);
     
@@ -5116,13 +5116,13 @@ int wdb_parse_get_all_agents(wdb_t* wdb, char* input, char* output) {
     if (next == NULL || strcmp(input, "start_id") != 0) {
         mdebug1("Invalid arguments 'start_id' not found");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'start_id' not found");
-        return WDB_CHUNKS_ERROR;
+        return OS_INVALID;
     }
     next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL) {
         mdebug1("Invalid arguments 'start_id' not found");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'start_id' not found");
-        return WDB_CHUNKS_ERROR;
+        return OS_INVALID;
     }
     start_id = atoi(next);
     

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -4937,12 +4937,12 @@ int wdb_parse_global_sync_agent_info_get(wdb_t* wdb, char* input, char* output) 
         }
     }
 
-    wdb_chunks_status_t status = wdb_sync_agent_info_get(wdb, &start_id, &agent_info_sync);
-    if (status == WDB_CHUNKS_COMPLETE || status == WDB_CHUNKS_ERROR) {
+    wdbc_result status = wdb_sync_agent_info_get(wdb, &start_id, &agent_info_sync);
+    snprintf(output, WDB_MAX_RESPONSE_SIZE, "%s %s",  WDBC_RESULT[status], agent_info_sync);
+    os_free(agent_info_sync)
+    if (status != WDBC_DUE) {
         start_id = 0;
     }
-    snprintf(output, OS_MAXSTR + 1, "%1d %s", status, agent_info_sync);
-    os_free(agent_info_sync)
 
     return OS_SUCCESS;
 }


### PR DESCRIPTION
|Related issue|
|---|
|5893|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR changes the way wdb_**sync_agent_info_get()** creates a response to match with other Wazuh-DB responses.
Now, the response will have the following format:

Successful query with no pending data: **"ok {PAYLOAD}"**
Successful query with pending data: **"due {PAYLOAD}"**
Unsuccesful query: **"err {ERROR MESSAGE}"**


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
