### PR TITLE
Change default label_cache_maxage

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -31,7 +31,7 @@ analysisd.decoder_order_size=256
 # Output GeoIP data at JSON alerts
 analysisd.geoip_jsonout=0
 # Maximum label cache age (margin seconds with no reloading) [0..60]
-analysisd.label_cache_maxage=1
+analysisd.label_cache_maxage=10
 # Show hidden labels on alerts
 analysisd.show_hidden_labels=0
 # Maximum number of file descriptor that Analysisd can open [1024..1048576]

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -65,7 +65,7 @@ int GlobalConf(const char *cfgfile)
     Config.includes = NULL;
     Config.lists = NULL;
     Config.decoders = NULL;
-    Config.label_cache_maxage = 0;
+    Config.label_cache_maxage = 10;
     Config.show_hidden_labels = 0;
 
     Config.cluster_name = NULL;


### PR DESCRIPTION
|Related issue|
|---|
|5706|

## Description
This PR modifies the default value of label_cache_maxage to 10.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
