### PR TITLE
Fix security_PUT yaml error

### DIFF
--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -345,11 +345,11 @@ stages:
         data:
           affected_items:
             - id: 103
-                name: "testModified2"
-                rule:
-                  MATCH:
-                    normal_rule: "modifiedR"
-                roles: !anything
+              name: "testModified2"
+              rule:
+                MATCH:
+                  normal_rule: "modifiedR"
+              roles: !anything
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0


### PR DESCRIPTION
Hi team,

This PR fixes a format error within the integrated test security_PUT.

### Integrated tests
```
adriiiprodri@wazuh python3 run_tests.py -rbac both -k security
Collected tests [6]:
test_rbac_black_security_endpoints.tavern.yaml, test_rbac_white_security_endpoints.tavern.yaml, test_security_DELETE_endpoints.tavern.yaml, test_security_GET_endpoints.tavern.yaml, test_security_POST_endpoints.tavern.yaml, test_security_PUT_endpoints.tavern.yaml


test_rbac_black_security_endpoints.tavern.yaml 
	 24 passed, 125 warnings

test_rbac_white_security_endpoints.tavern.yaml 
	 24 passed, 122 warnings

test_security_DELETE_endpoints.tavern.yaml 
	 15 passed, 90 warnings

test_security_GET_endpoints.tavern.yaml 
	 17 passed, 128 warnings

test_security_POST_endpoints.tavern.yaml 
	 6 passed, 62 warnings

test_security_PUT_endpoints.tavern.yaml 
	 8 passed, 52 warning
```

Regards