### PR TITLE
Fix cluster's unit test

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -66,6 +66,7 @@ def test_read_empty_configuration():
     Test reading an empty cluster configuration
     """
     with patch('wazuh.core.cluster.utils.get_ossec_conf') as m:
+        wazuh.core.cluster.utils.read_config.cache_clear()
         m.side_effect = WazuhException(1106)
         configuration = wazuh.core.cluster.utils.read_config()
         configuration['disabled'] = 'yes' if configuration['disabled'] else 'no'

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -42,6 +42,7 @@ def test_read_cluster_config():
             utils.read_cluster_config()
 
     with patch('wazuh.core.cluster.utils.get_ossec_conf', return_value={'cluster': default_cluster_config}):
+        utils.read_config.cache_clear()
         default_cluster_config.pop('hidden')
         default_cluster_config['disabled'] = 'no'
         config = utils.read_cluster_config()
@@ -108,6 +109,8 @@ def test_manager_restart():
 
 def test_get_cluster_items():
     """Verify the cluster files information."""
+    utils.get_cluster_items.cache_clear()
+
     with patch('os.path.abspath', side_effect=FileNotFoundError):
         with pytest.raises(WazuhException, match='.* 3005 .*'):
             utils.get_cluster_items()


### PR DESCRIPTION
Hi team!

## Description

This PR adds multiple fixes so cluster tests no longer fail. It solves problems with lru_cache (which lead to errors when running all tests, but not when running them one by one), and with logger, which is now replaced with pytest builtin `caplog`.

These tests have been run using a virtual environment with same requierments as Wazuh installation.

## Tests
```

python3 -m pytest wazuh/core/cluster/tests/ -x
====================================== test session starts ======================================
platform linux -- Python 3.8.2, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: trio-0.6.0, asyncio-0.14.0
collected 53 items                                                                              

wazuh/core/cluster/tests/test_cluster.py ..................                               [ 33%]
wazuh/core/cluster/tests/test_common.py .......                                           [ 47%]
wazuh/core/cluster/tests/test_control.py .....                                            [ 56%]
wazuh/core/cluster/tests/test_local_client.py .                                           [ 58%]
wazuh/core/cluster/tests/test_utils.py .......                                            [ 71%]
wazuh/core/cluster/tests/test_worker.py ...............                                   [100%]

======================================= warnings summary ========================================
wazuh/core/cluster/tests/test_worker.py::test_WorkerHandler
  /usr/lib/python3.8/unittest/mock.py:2052: RuntimeWarning: coroutine 'WorkerHandler.process_files_from_master' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================= 53 passed, 1 warning in 0.40s =================================
```

Kind regards,
Selu.