### PR TITLE
Fix launcher.sh generation in macOS source installation

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -10,8 +10,10 @@ variables:
   host: localhost
   port: 55000
   user: testing
+  user_auth_context: testing_auth_context
   pass: wazuh
   basic_auth: dGVzdGluZzp3YXp1aA== # b64 encoded user:pass, update if user or pass changes
+  basic_auth_context: dGVzdGluZ19hdXRoX2NvbnRleHQ6d2F6dWg== # b64 encoded user:pass, update if user or pass changes
   login_endpoint: /security/user/authenticate
 
   # delays

--- a/api/test/integration/env/configurations/authorization/manager/schema_security_test.sql
+++ b/api/test/integration/env/configurations/authorization/manager/schema_security_test.sql
@@ -1,0 +1,28 @@
+/*
+ * SQL Schema security tests
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * February 13, 2019.
+ * This program is a free software, you can redistribute it
+ * and/or modify it under the terms of GPLv2.
+ */
+
+CREATE TABLE users (id INTEGER NOT NULL, username VARCHAR(32), password VARCHAR(256), allow_run_as BOOLEAN NOT NULL, created_at DATETIME, PRIMARY KEY (id), CONSTRAINT username_restriction UNIQUE (username), CHECK (allow_run_as IN (0, 1)));
+
+CREATE TABLE roles (id INTEGER NOT NULL, name VARCHAR(20), created_at DATETIME,	PRIMARY KEY (id), CONSTRAINT name_role UNIQUE (name));
+
+CREATE TABLE rules (id INTEGER NOT NULL, name VARCHAR(20), rule TEXT, created_at DATETIME, PRIMARY KEY (id), CONSTRAINT rule_name UNIQUE (name), CONSTRAINT rule_definition UNIQUE (rule));
+
+CREATE TABLE policies (id INTEGER NOT NULL, name VARCHAR(20), policy TEXT, created_at DATETIME, PRIMARY KEY (id), CONSTRAINT name_policy UNIQUE (name),	CONSTRAINT policy_definition UNIQUE (policy));
+
+CREATE TABLE roles_policies (id INTEGER NOT NULL, role_id INTEGER, policy_id INTEGER, level INTEGER, created_at DATETIME, PRIMARY KEY (id), CONSTRAINT role_policy UNIQUE (role_id, policy_id), FOREIGN KEY(role_id) REFERENCES roles (id) ON DELETE CASCADE, FOREIGN KEY(policy_id) REFERENCES policies (id) ON DELETE CASCADE);
+
+CREATE TABLE user_roles (id INTEGER NOT NULL, user_id INTEGER, role_id INTEGER, level INTEGER,	created_at DATETIME, PRIMARY KEY (id), CONSTRAINT user_role UNIQUE (user_id, role_id), FOREIGN KEY(user_id) REFERENCES users (username) ON DELETE CASCADE, FOREIGN KEY(role_id) REFERENCES roles (id) ON DELETE CASCADE);
+
+CREATE TABLE roles_rules (id INTEGER NOT NULL, role_id INTEGER, rule_id INTEGER, created_at DATETIME, PRIMARY KEY (id), CONSTRAINT role_rule UNIQUE (role_id, rule_id), FOREIGN KEY(role_id) REFERENCES roles (id) ON DELETE CASCADE, FOREIGN KEY(rule_id) REFERENCES rules (id) ON DELETE CASCADE);
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+
+/* testing user */
+INSERT INTO users VALUES(199,'testing_auth_context','pbkdf2:sha256:150000$OMVAATei$cb30da77537eea26b964265dab6f403e9499f18522c7cc9e6ba2cb2d33694e1f',1,'1970-01-01 00:00:00');
+
+COMMIT;

--- a/api/test/integration/env/configurations/authorization/manager/security_config.sh
+++ b/api/test/integration/env/configurations/authorization/manager/security_config.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# RBAC configuration
+sqlite3 /var/ossec/api/configuration/security/rbac.db < /configuration_files/schema_security_test.sql
+chown ossec:ossec /var/ossec/api/configuration/security/rbac.db

--- a/api/test/integration/env/configurations/base/manager/security/base_security_test.sql
+++ b/api/test/integration/env/configurations/base/manager/security/base_security_test.sql
@@ -10,7 +10,7 @@ PRAGMA foreign_keys=OFF;
 BEGIN TRANSACTION;
 
 /* Testing user */
-INSERT INTO users VALUES(99,'testing','pbkdf2:sha256:150000$OMVAATei$cb30da77537eea26b964265dab6f403e9499f18522c7cc9e6ba2cb2d33694e1f',1,'1970-01-01 00:00:00');
+INSERT INTO users VALUES(99,'testing','pbkdf2:sha256:150000$OMVAATei$cb30da77537eea26b964265dab6f403e9499f18522c7cc9e6ba2cb2d33694e1f',0,'1970-01-01 00:00:00');
 
 /* Testing role */
 INSERT INTO roles VALUES(99,'testing','1970-01-01 00:00:00');

--- a/api/test/integration/env/configurations/security/manager/schema_security_test.sql
+++ b/api/test/integration/env/configurations/security/manager/schema_security_test.sql
@@ -173,7 +173,7 @@ INSERT INTO roles_policies VALUES(120,105,103,9,'1970-01-01 00:00:00');
 
 /* Default user-roles links */
 INSERT INTO user_roles VALUES(1,1,1,0,'1970-01-01 00:00:00');
-INSERT INTO user_roles VALUES(2,2,2,0,'1970-01-01 00:00:00');
+INSERT INTO user_roles VALUES(2,2,1,0,'1970-01-01 00:00:00');
 
 /* Testing */
 INSERT INTO user_roles VALUES(100,100,100,0,'1970-01-01 00:00:00');

--- a/api/test/integration/test_authorization_context_login.tavern.yaml
+++ b/api/test/integration/test_authorization_context_login.tavern.yaml
@@ -2,7 +2,7 @@
 test_name: POST /security/user/authenticate/run_as
 
 marks:
-  - base_tests
+  - rbac_tests
 
 stages:
 
@@ -11,7 +11,7 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate/run_as"
       headers:
-        Authorization: "Basic {basic_auth:s}"
+        Authorization: "Basic {basic_auth_context:s}"
       method: POST
       json:
         username: "elastic"
@@ -28,7 +28,7 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate/run_as"
       headers:
-        Authorization: "Basic {basic_auth:s}"
+        Authorization: "Basic {basic_auth_context:s}"
       method: POST
       json:
         testing: "integration"
@@ -44,7 +44,7 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate/run_as"
       headers:
-        Authorization: "Basic {basic_auth:s}"
+        Authorization: "Basic {basic_auth_context:s}"
       method: POST
     response:
       status_code: 400
@@ -54,7 +54,7 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate/run_as"
       headers:
-        Authorization: "Basic {basic_auth:s}"
+        Authorization: "Basic {basic_auth_context:s}"
       method: POST
       json:
         testing: "unknown"

--- a/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
@@ -225,13 +225,14 @@ stages:
           affected_items:
             - id: 1
             - id: 2
+            - id: 99
             - id: 100
             - id: 101
             - id: 102
             - id: 104
             - id: 105
           failed_items: []
-          total_affected_items: 7
+          total_affected_items: 8
           total_failed_items: 0
 
   - name: Get a specified rule by its id (Deny)
@@ -1045,6 +1046,7 @@ stages:
           failed_items: []
 
   - name: Delete all rules in the system (Allow and deny)
+    delay_after: 5
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/rules"
@@ -1058,13 +1060,19 @@ stages:
       json:
         data:
           affected_items: # Admin rules cannot be deleted. 105 is denied
+            - id: 99
             - id: 100
             - id: 101
             - id: 102
             - id: 104
           failed_items: []
-          total_affected_items: 4
+          total_affected_items: 5
           total_failed_items: 0
+
+---
+test_name: DELETE /security/rules (invalid)
+
+stages:
 
   - name: Delete one specified rule in the system (Deny)
     request:

--- a/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
@@ -27,7 +27,7 @@ stages:
               username: wazuh-wui
               allow_run_as: true
               roles:
-                - 2
+                - 1
             - id: 99
               username: testing
               allow_run_as: false

--- a/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
@@ -305,6 +305,7 @@ stages:
           affected_items:
             - id: 1
             - id: 2
+            - id: 99
             - id: 100
             - id: 101
             - id: 102
@@ -312,7 +313,7 @@ stages:
             - id: 104
             - id: 105
           failed_items: []
-          total_affected_items: 8
+          total_affected_items: 9
           total_failed_items: 0
 
 ---

--- a/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
@@ -682,6 +682,7 @@ stages:
           total_affected_items: 1
 
   - name: Delete all rules in the system
+    delay_after: 1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/rules"
@@ -695,14 +696,20 @@ stages:
       json:
         data:
           affected_items: # Admin rules cannot be deleted
+            - id: 99
             - id: 101
             - id: 102
             - id: 103
             - id: 104
             - id: 105
-          total_affected_items: 5
+          total_affected_items: 6
           total_failed_items: 0
           failed_items: []
+
+---
+test_name: DELETE /security/rules (invalid)
+
+stages:
 
   - name: Delete all rules in the system (invalid)
     request:

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -782,7 +782,7 @@ stages:
               username: wazuh-wui
               allow_run_as: true
               roles:
-                - 2
+                - 1
             - id: 99
               username: testing
               allow_run_as: false
@@ -1083,7 +1083,7 @@ stages:
               username: wazuh-wui
               allow_run_as: true
               roles:
-                - 2
+                - 1
             - id: 1
               username: wazuh
               allow_run_as: false
@@ -1192,7 +1192,7 @@ stages:
               username: wazuh-wui
               allow_run_as: true
               roles:
-                - 2
+                - 1
           total_affected_items: 9
           total_failed_items: 0
           failed_items: []

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -776,40 +776,54 @@ stages:
             - id: 1
               username: wazuh
               allow_run_as: false
-              roles: []
+              roles:
+                - 1
             - id: 2
               username: wazuh-wui
               allow_run_as: true
-              roles: []
+              roles:
+                - 2
             - id: 99
               username: testing
               allow_run_as: false
-              roles: []
+              roles:
+                - 99
             - id: 100
               username: administrator
               allow_run_as: false
-              roles: []
+              roles:
+                - 100
+                - 101
             - id: 101
               username: normal
               allow_run_as: false
-              roles: []
+              roles:
+                - 104
+                - 105
+                - 103
             - id: 102
               username: ossec
               allow_run_as: false
-              roles: []
+              roles:
+                - 101
+                - 104
             - id: 103
               username: python
               allow_run_as: false
-              roles: []
+              roles:
+                - 101
             - id: 104
               username: rbac
               allow_run_as: false
-              roles: []
+              roles:
+                - 104
+                - 102
+                - 103
             - id: 105
               username: guest
               allow_run_as: false
               roles: []
-          total_affected_items: 9
+          total_affected_items: !anyint
           total_failed_items: 0
           failed_items: []
 

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -12,6 +12,7 @@ from time import time
 
 import yaml
 from sqlalchemy import create_engine, UniqueConstraint, Column, DateTime, String, Integer, ForeignKey, Boolean
+from sqlalchemy import desc
 from sqlalchemy.dialects.sqlite import TEXT
 from sqlalchemy.exc import IntegrityError, InvalidRequestError
 from sqlalchemy.ext.declarative import declarative_base
@@ -21,6 +22,9 @@ from werkzeug.security import check_password_hash, generate_password_hash
 
 from api.configuration import security_conf
 from api.constants import SECURITY_PATH
+
+# Max reserved ID value
+max_id_reserved = 99
 
 # Start a session and set the default security elements
 _auth_db_file = os.path.join(SECURITY_PATH, 'rbac.db')
@@ -216,7 +220,8 @@ class User(_Base):
     roles = relationship("Roles", secondary='user_roles',
                          backref=backref("rolesu", cascade="all, delete", order_by=UserRoles.role_id), lazy='dynamic')
 
-    def __init__(self, username, password, allow_run_as=False):
+    def __init__(self, username, password, allow_run_as=False, user_id=None):
+        self.id = user_id
         self.username = username
         self.password = password
         self.allow_run_as = allow_run_as
@@ -279,7 +284,8 @@ class Roles(_Base):
     rules = relationship("Rules", secondary='roles_rules',
                          backref=backref("ruless", cascade="all, delete", order_by=RolesRules.id), lazy='dynamic')
 
-    def __init__(self, name):
+    def __init__(self, name, role_id=None):
+        self.id = role_id
         self.name = name
         self.created_at = datetime.utcnow()
 
@@ -327,7 +333,8 @@ class Rules(_Base):
     roles = relationship("Roles", secondary='roles_rules',
                          backref=backref("ruless", cascade="all, delete", order_by=id), lazy='dynamic')
 
-    def __init__(self, name, rule):
+    def __init__(self, name, rule, rule_id=None):
+        self.id = rule_id
         self.name = name
         self.rule = rule
         self.created_at = datetime.utcnow()
@@ -371,7 +378,8 @@ class Policies(_Base):
     roles = relationship("Roles", secondary='roles_policies',
                          backref=backref("roless", cascade="all, delete", order_by=id), lazy='dynamic')
 
-    def __init__(self, name, policy):
+    def __init__(self, name, policy, policy_id=None):
+        self.id = policy_id
         self.name = name
         self.policy = policy
         self.created_at = datetime.utcnow()
@@ -572,17 +580,34 @@ class AuthenticationManager:
     It manages users and token generation.
     """
 
-    def add_user(self, username: str, password: str, allow_run_as: bool = False):
+    def add_user(self, username: str, password: str, allow_run_as: bool = False, check_default: bool = True):
         """Creates a new user if it does not exist.
 
-        :param username: string Unique user name
-        :param password: string Password provided by user. It will be stored hashed
-        :param allow_run_as: Flag that indicates if the user can log into the API throw an authorization context
-        :return: True if the user has been created successfully. False otherwise (i.e. already exists)
+        Parameters
+        ----------
+        username : str
+            Unique user name
+        password : str
+            Password provided by user. It will be stored hashed
+        allow_run_as : bool
+            Flag that indicates if the user can log into the API throw an authorization context
+        check_default : bool
+            Flag that indicates if the user ID can be less than max_id_reserved
+
+        Returns
+        -------
+        True if the user has been created successfully. False otherwise (i.e. already exists)
         """
         try:
+            user_id = None
+            try:
+                if check_default and self.session.query(User).order_by(desc(User.id)
+                                                                       ).limit(1).scalar().id < max_id_reserved:
+                    user_id = max_id_reserved + 1
+            except (TypeError, AttributeError):
+                pass
             self.session.add(User(username=username, password=generate_password_hash(password),
-                                  allow_run_as=allow_run_as))
+                                  allow_run_as=allow_run_as, user_id=user_id))
             self.session.commit()
             return True
         except IntegrityError:
@@ -777,15 +802,29 @@ class RolesManager:
         except IntegrityError:
             return SecurityError.ROLE_NOT_EXIST
 
-    def add_role(self, name: str):
-        """Add a new role
+    def add_role(self, name: str, check_default: bool = True):
+        """Add a new role.
 
-        :param name: Name of the new role
-        :param rule: Rule of the new role
-        :return: True -> Success | Role already exist | Invalid rule
+        Parameters
+        ----------
+        name : str
+            Name of the new role
+        check_default : bool
+            Flag that indicates if the user ID can be less than max_id_reserved
+
+        Returns
+        -------
+        True -> Success | Role already exist
         """
         try:
-            self.session.add(Roles(name=name))
+            role_id = None
+            try:
+                if check_default and self.session.query(Roles).order_by(desc(Roles.id)
+                                                                        ).limit(1).scalar().id < max_id_reserved:
+                    role_id = max_id_reserved + 1
+            except (TypeError, AttributeError):
+                pass
+            self.session.add(Roles(name=name, role_id=role_id))
             self.session.commit()
             return True
         except IntegrityError:
@@ -945,7 +984,7 @@ class RulesManager:
         except IntegrityError:
             return SecurityError.RULE_NOT_EXIST
 
-    def add_rule(self, name: str, rule: dict):
+    def add_rule(self, name: str, rule: dict, check_default: bool = True):
         """Add a new rule.
 
         Parameters
@@ -954,6 +993,9 @@ class RulesManager:
             Name of the new rule.
         rule : dict
             Rule dictionary.
+        check_default : bool
+            Flag that indicates if the user ID can be less than max_id_reserved
+
         Returns
         -------
         True -> Success | Rule already exists | Invalid rule
@@ -961,7 +1003,15 @@ class RulesManager:
         try:
             if rule is not None and not json_validator(rule):
                 return SecurityError.INVALID
-            self.session.add(Rules(name=name, rule=json.dumps(rule)))
+            rule_id = None
+            try:
+                if check_default and \
+                        self.session.query(Policies).order_by(desc(Policies.id)
+                                                              ).limit(1).scalar().id < max_id_reserved:
+                    rule_id = max_id_reserved + 1
+            except (TypeError, AttributeError):
+                pass
+            self.session.add(Rules(name=name, rule=json.dumps(rule), rule_id=rule_id))
             self.session.commit()
             return True
         except IntegrityError:
@@ -1130,12 +1180,21 @@ class PoliciesManager:
         except IntegrityError:
             return SecurityError.POLICY_NOT_EXIST
 
-    def add_policy(self, name: str, policy: dict):
-        """Add a new role
+    def add_policy(self, name: str, policy: dict, check_default: bool = True):
+        """Add a new policy.
 
-        :param name: Name of the new policy
-        :param policy: Policy of the new policy
-        :return: True -> Success | Invalid policy | Missing key (actions, resources, effect) or invalid policy (regex)
+        Parameters
+        ----------
+        name : str
+            Name of the new policy
+        policy : dict
+            Policy of the new policy
+        check_default : bool
+            Flag that indicates if the user ID can be less than max_id_reserved
+
+        Returns
+        -------
+        True -> Success | Invalid policy | Missing key (actions, resources, effect) or invalid policy (regex)
         """
         try:
             if policy is not None and not json_validator(policy):
@@ -1156,7 +1215,15 @@ class PoliciesManager:
                         for resource in policy['resources']:
                             if not re.match(regex, resource):
                                 return SecurityError.INVALID
-                        self.session.add(Policies(name=name, policy=json.dumps(policy)))
+                        policy_id = None
+                        try:
+                            if check_default and \
+                                    self.session.query(Policies).order_by(desc(Policies.id)
+                                                                          ).limit(1).scalar().id < max_id_reserved:
+                                policy_id = max_id_reserved + 1
+                        except (TypeError, AttributeError):
+                            pass
+                        self.session.add(Policies(name=name, policy=json.dumps(policy), policy_id=policy_id))
                         self.session.commit()
                     else:
                         return SecurityError.INVALID
@@ -2078,7 +2145,7 @@ with open(os.path.join(default_path, "users.yaml"), 'r') as stream:
     with AuthenticationManager() as auth:
         for d_username, payload in default_users[next(iter(default_users))].items():
             auth.add_user(username=d_username, password=payload['password'],
-                          allow_run_as=payload['allow_run_as'])
+                          allow_run_as=payload['allow_run_as'], check_default=False)
 
 # Create default roles if they don't exist yet
 with open(os.path.join(default_path, "roles.yaml"), 'r') as stream:
@@ -2086,14 +2153,14 @@ with open(os.path.join(default_path, "roles.yaml"), 'r') as stream:
 
     with RolesManager() as rm:
         for d_role_name, payload in default_roles[next(iter(default_roles))].items():
-            rm.add_role(name=d_role_name)
+            rm.add_role(name=d_role_name, check_default=False)
 
 with open(os.path.join(default_path, 'rules.yaml'), 'r') as stream:
     default_rules = yaml.safe_load(stream)
 
     with RulesManager() as rum:
         for d_rule_name, payload in default_rules[next(iter(default_rules))].items():
-            rum.add_rule(name=d_rule_name, rule=payload['rule'])
+            rum.add_rule(name=d_rule_name, rule=payload['rule'], check_default=False)
 
 # Create default policies if they don't exist yet
 with open(os.path.join(default_path, "policies.yaml"), 'r') as stream:
@@ -2102,7 +2169,7 @@ with open(os.path.join(default_path, "policies.yaml"), 'r') as stream:
     with PoliciesManager() as pm:
         for d_policy_name, payload in default_policies[next(iter(default_policies))].items():
             for name, policy in payload['policies'].items():
-                pm.add_policy(name=f'{d_policy_name}_{name}', policy=policy)
+                pm.add_policy(name=f'{d_policy_name}_{name}', policy=policy, check_default=False)
 
 # Create the relationships
 with open(os.path.join(default_path, "relationships.yaml"), 'r') as stream:

--- a/framework/wazuh/rbac/tests/test_orm.py
+++ b/framework/wazuh/rbac/tests/test_orm.py
@@ -419,12 +419,9 @@ def test_add_user_roles(db_setup):
             roles_ids.append(rm.get_role('advanced')['id'])
 
         # New user-role
-        for role in roles_ids:
-            assert urm.add_role_to_user(user_id='3', role_id=role)
-            assert urm.add_user_to_role(user_id='4', role_id=role)
-        for role in roles_ids:
-            assert urm.exist_user_role(user_id='3', role_id=role)
-            assert urm.exist_role_user(user_id='4', role_id=role)
+        for user in user_list:
+            for role in roles_ids:
+                assert urm.add_role_to_user(user_id=user, role_id=role)
 
         return user_list, roles_ids
 
@@ -605,8 +602,9 @@ def test_exist_user_role(db_setup):
         user_ids, roles_ids = test_add_user_roles(db_setup)
         for role in roles_ids:
             for user_id in user_ids:
+                with db_setup.AuthenticationManager() as am:
+                    assert am.get_user(username='normalUser')
                 assert urm.exist_user_role(user_id=user_id, role_id=role)
-                assert urm.exist_role_user(user_id=user_id, role_id=role)
 
         assert urm.exist_user_role(user_id='999', role_id=8) == db_setup.SecurityError.USER_NOT_EXIST
         assert urm.exist_user_role(user_id=user_ids[0], role_id=99) == db_setup.SecurityError.ROLE_NOT_EXIST

--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -6,6 +6,7 @@
 
 import glob
 import os
+from contextvars import ContextVar
 from importlib import reload
 from unittest.mock import patch
 
@@ -137,8 +138,10 @@ def test_revoke_tokens(db_setup):
     """Checks that the return value of revoke_tokens is a WazuhResult."""
     with patch('wazuh.core.security.change_secret', side_effect=None):
         security, WazuhResult, _ = db_setup
-        result = security.revoke_current_user_tokens()
-        assert isinstance(result, WazuhResult)
+        mock_current_user = ContextVar('current_user', default='wazuh')
+        with patch("wazuh.sca.common.current_user", new=mock_current_user):
+            result = security.revoke_current_user_tokens()
+            assert isinstance(result, WazuhResult)
 
 
 @pytest.mark.parametrize('role_list, expected_users', [
@@ -161,26 +164,45 @@ def test_check_relationships(db_setup, role_list, expected_users):
     assert core_security.check_relationships(roles=[role_id for role_id in role_list]) == expected_users
 
 
-@pytest.mark.parametrize('role_list, user_list, expected_users', [
-    ([104], None, {101, 104, 102}),
-    ([102, 103], [100], {101, 104, 100}),
-    ([], [1, 2], {1, 2})
+@pytest.mark.parametrize('user_list, expected_users', [
+    ([104], {104}),
+    ([102, 103], {102, 103}),
+    ([], set())
 ])
-def test_invalid_users_tokens(db_setup, role_list, user_list, expected_users):
-    """Check that the argument passed to `TokenManager.add_user_rules` formed by `roles` and
-    `users` is correct.
+def test_invalid_users_tokens(db_setup, user_list, expected_users):
+    """Check that the argument passed to `TokenManager.add_user_roles_rules` formed by `users` is correct.
 
     Parameters
     ----------
-    role_list : list
-        List of role IDs.
     user_list : list
         List of users.
     expected_users : set
         Expected users.
     """
-    with patch('wazuh.security.TokenManager.add_user_rules') as TM_mock:
+    with patch('wazuh.security.TokenManager.add_user_roles_rules') as TM_mock:
         _, _, core_security = db_setup
-        core_security.invalid_users_tokens(roles=[role_id for role_id in role_list], users=user_list)
+        core_security.invalid_users_tokens(users=[user_id for user_id in user_list])
         related_users = TM_mock.call_args.kwargs['users']
         assert set(related_users) == expected_users
+
+
+@pytest.mark.parametrize('role_list, expected_roles', [
+    ([104], {104}),
+    ([102, 103], {102, 103}),
+    ([], set())
+])
+def test_invalid_users_tokens(db_setup, role_list, expected_roles):
+    """Check that the argument passed to `TokenManager.add_user_roles_rules` formed by `roles` is correct.
+
+    Parameters
+    ----------
+    role_list : list
+        List of roles.
+    expected_roles : set
+        Expected roles.
+    """
+    with patch('wazuh.security.TokenManager.add_user_roles_rules') as TM_mock:
+        _, _, core_security = db_setup
+        core_security.invalid_roles_tokens(roles=[role_id for role_id in role_list])
+        related_roles = TM_mock.call_args.kwargs['roles']
+        assert set(related_roles) == expected_roles

--- a/src/init/darwin-init.sh
+++ b/src/init/darwin-init.sh
@@ -12,6 +12,8 @@ LAUNCHER_SCRIPT=/Library/StartupItems/WAZUH/launcher.sh
 STARTUP_SCRIPT=/Library/StartupItems/WAZUH/WAZUH
 
 launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist 2> /dev/null
+mkdir -p /Library/StartupItems/WAZUH
+chown root:wheel /Library/StartupItems/WAZUH
 rm -f $STARTUP $STARTUP_SCRIPT $SERVICE
 echo > $LAUNCHER_SCRIPT
 chown root:wheel $LAUNCHER_SCRIPT
@@ -35,9 +37,6 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
 chown root:wheel $SERVICE
 chmod u=rw-,go=r-- $SERVICE
 launchctl load $SERVICE
-
-mkdir -p /Library/StartupItems/WAZUH
-chown root:wheel /Library/StartupItems/WAZUH
 
 echo '
 #!/bin/sh


### PR DESCRIPTION
Hello team,

In this PR fixes a problem in the generation of the `launcher.sh` file for macOS systems source installations, this file controls the Wazuh service.

This file is generated by running, `darwin-init.sh`, when running the source installation we found the following error:

![imagen](https://user-images.githubusercontent.com/19505384/92136373-3c7c0380-ee0c-11ea-99ca-d369d5fd4177.png)

This error appears when the directory `/Library/StartupItems/WAZUH` does not exist.

Regards,
Daniel Folch