### PR TITLE
Fix windows gui restart action with no keys

### DIFF
--- a/src/win32/ui/os_win32ui.c
+++ b/src/win32/ui/os_win32ui.c
@@ -345,8 +345,7 @@ BOOL CALLBACK DlgProc(HWND hwnd, UINT Message, WPARAM wParam,
                     break;
                 case UI_MENU_MANAGE_RESTART:
 
-                    if ((strcmp(config_inst.key, FL_NOKEY) == 0) ||
-                            (strcmp(config_inst.server, FL_NOSERVER) == 0)) {
+                    if (strcmp(config_inst.server, FL_NOSERVER) == 0) {
                         MessageBox(hwnd, "Unable to restart agent (check config)",
                                    "Error -- Unable to Restart Agent", MB_OK);
                         break;


### PR DESCRIPTION
|Related issue|
|---|
|5911|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
With auto-enrollment, Agents can be started without a key as it will be requested automatically.
Windows Agent GUI had an extra check that was adapted to the new functionality on this [fix](https://github.com/wazuh/wazuh/commit/e2a516d23b680bdbc34ab23402171cdc2be99867).
This PR extend this fix to the RESTART ACTION on Windows GUI.

## Tests

Check the Windows GUI RESTART action without keys

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Package installation
