### PR TITLE
Fix launcher.sh generation in macOS source installation

### DIFF
--- a/src/init/darwin-init.sh
+++ b/src/init/darwin-init.sh
@@ -12,6 +12,8 @@ LAUNCHER_SCRIPT=/Library/StartupItems/WAZUH/launcher.sh
 STARTUP_SCRIPT=/Library/StartupItems/WAZUH/WAZUH
 
 launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist 2> /dev/null
+mkdir -p /Library/StartupItems/WAZUH
+chown root:wheel /Library/StartupItems/WAZUH
 rm -f $STARTUP $STARTUP_SCRIPT $SERVICE
 echo > $LAUNCHER_SCRIPT
 chown root:wheel $LAUNCHER_SCRIPT
@@ -35,9 +37,6 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
 chown root:wheel $SERVICE
 chmod u=rw-,go=r-- $SERVICE
 launchctl load $SERVICE
-
-mkdir -p /Library/StartupItems/WAZUH
-chown root:wheel /Library/StartupItems/WAZUH
 
 echo '
 #!/bin/sh


### PR DESCRIPTION
Hello team,

In this PR fixes a problem in the generation of the `launcher.sh` file for macOS systems source installations, this file controls the Wazuh service.

This file is generated by running, `darwin-init.sh`, when running the source installation we found the following error:

![imagen](https://user-images.githubusercontent.com/19505384/92136373-3c7c0380-ee0c-11ea-99ca-d369d5fd4177.png)

This error appears because the directory `/Library/StartupItems/WAZUH` does not exist when we try to create the launcher.sh script.

https://github.com/wazuh/wazuh/blob/67d39a0e492179b79725a0fc769680d5cbbb4129/src/init/darwin-init.sh#L16

Regards,
Daniel Folch