### PR TITLE
[API 4.0] Remove wazuh-apid from integration tests

### DIFF
--- a/api/test/integration/env/base/agent/Dockerfile
+++ b/api/test/integration/env/base/agent/Dockerfile
@@ -8,7 +8,7 @@ ARG wazuhbranch
 RUN apt-get update && apt-get install tree python python3 git gnupg2 gcc make vim libc6-dev curl policycoreutils automake autoconf libtool apt-transport-https lsb-release python-cryptography sqlite3 build-essential openjdk-8-jre -y && curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add - && echo "deb https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/staging/apt/ unstable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
 ## install Wazuh
-RUN git clone https://github.com/wazuh/wazuh && cd /wazuh && git checkout $wazuhbranch
+RUN git clone https://github.com/wazuh/wazuh && cd /wazuh && git checkout stable
 ADD base/agent/preloaded-vars.conf /wazuh/etc/preloaded-vars.conf
 RUN /wazuh/install.sh
 

--- a/api/test/integration/env/base/manager/entrypoint.sh
+++ b/api/test/integration/env/base/manager/entrypoint.sh
@@ -22,7 +22,7 @@ else
 fi
 
 sleep 1
-/var/ossec/bin/ossec-control restart
+
 
 # Manager configuration
 for py_file in /configuration_files/*.py; do
@@ -33,11 +33,13 @@ for sh_file in /configuration_files/*.sh; do
   . $sh_file
 done
 
+/var/ossec/bin/ossec-control restart
+
 # RBAC configuration
 for sql_file in /configuration_files/*.sql; do
   sqlite3 /var/ossec/api/configuration/security/rbac.db < $sql_file
 done
 
-/var/ossec/bin/ossec-control restart
+
 
 /usr/bin/supervisord

--- a/api/test/integration/env/base/manager/entrypoint.sh
+++ b/api/test/integration/env/base/manager/entrypoint.sh
@@ -38,6 +38,6 @@ for sql_file in /configuration_files/*.sql; do
   sqlite3 /var/ossec/api/configuration/security/rbac.db < $sql_file
 done
 
-/var/ossec/bin/wazuh-apid restart
+/var/ossec/bin/ossec-control restart
 
 /usr/bin/supervisord

--- a/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
@@ -699,7 +699,7 @@ stages:
     response:
       status_code: 200
       json:
-        message: "Agent '002' removed from 'group2'."
+        message: !anystr
     delay_after: !float "{global_db_delay}"
 
 ---
@@ -1381,7 +1381,7 @@ stages:
                 - "006"
                 - "010"
           total_failed_items: 3
-        message: "Could not send command to some agents"
+        message: !anystr
     delay_after: !float "{restart_delay}"
 
 ---
@@ -1472,7 +1472,7 @@ stages:
           failed_items:
             - error:
                 code: 1707
-                message: "Impossible to restart non-active agent: never_connected"
+                message: !anystr
               id:
                 - '012'
           total_affected_items: 1

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -308,7 +308,6 @@ stages:
               global: !anything
               integration: !anything
               localfile: !anything
-              open-scap: !anything
               osquery: !anything
               remote: !anything
               rootcheck: !anything


### PR DESCRIPTION
Hello team,

This PR removes `wazuh-apid` usage from our integration tests' entrypoint as wazuh-apid now works as a daemon. It also updates `test_rbac_white_agents_endpoint` integration test to expect !anystr instead of an specific message.

## Integration test restuls

```
test_rbac_black_sca_endpoints.tavern.yaml 
         2 passed, 4 warnings

test_rbac_black_security_endpoints.tavern.yaml 
         24 passed, 26 warnings

test_rbac_black_syscheck_endpoints.tavern.yaml 
         4 passed, 6 warnings

test_rbac_black_syscollector_endpoints.tavern.yaml 
         9 passed, 11 warnings

test_security_DELETE_endpoints.tavern.yaml 
         15 passed, 17 warnings

test_security_GET_endpoints.tavern.yaml 
         17 passed, 20 warnings

test_security_POST_endpoints.tavern.yaml 
         6 passed, 8 warnings

test_security_PUT_endpoints.tavern.yaml 
         8 passed, 10 warnings

```