### PR TITLE
Fix experimental endpoints

### DIFF
--- a/api/api/controllers/experimental_controller.py
+++ b/api/api/controllers/experimental_controller.py
@@ -3,6 +3,7 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import logging
+from functools import wraps
 
 from aiohttp import web
 
@@ -18,11 +19,17 @@ from wazuh.core.exception import WazuhResourceNotFound
 logger = logging.getLogger('wazuh')
 
 
-def check_experimental_feature_value():
-    if not configuration.api_conf['experimental_features']:
-        raise_if_exc(WazuhResourceNotFound(code=1122))
+def check_experimental_feature_value(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not configuration.api_conf['experimental_features']:
+            raise_if_exc(WazuhResourceNotFound(code=1122))
+        else:
+            return func(*args, **kwargs)
+    return wrapper
 
 
+@check_experimental_feature_value
 async def clear_syscheck_database(request, pretty=False, wait_for_complete=False, list_agents=None):
     """ Clear the syscheck database for all agents.
 
@@ -31,8 +38,6 @@ async def clear_syscheck_database(request, pretty=False, wait_for_complete=False
     :param list_agents: List of agent's IDs.
     :return: AllItemsResponseAgentIDs
     """
-    check_experimental_feature_value()
-
     if 'all' in list_agents:
         list_agents = '*'
 
@@ -52,6 +57,7 @@ async def clear_syscheck_database(request, pretty=False, wait_for_complete=False
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@check_experimental_feature_value
 async def get_cis_cat_results(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                               select=None, sort=None, search=None, benchmark=None, profile=None, fail=None, error=None,
                               notchecked=None, unknown=None, score=None):
@@ -75,8 +81,6 @@ async def get_cis_cat_results(request, pretty=False, wait_for_complete=False, li
     :param score: Filters by final score
     :return: AllItemsResponseCiscatResult
     """
-    check_experimental_feature_value()
-
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -109,6 +113,7 @@ async def get_cis_cat_results(request, pretty=False, wait_for_complete=False, li
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@check_experimental_feature_value
 async def get_hardware_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                             select=None, sort=None, search=None, board_serial=None):
     """ Get hardware info from all agents or a list of them.
@@ -125,8 +130,6 @@ async def get_hardware_info(request, pretty=False, wait_for_complete=False, list
     :param board_serial: Filters by board_serial
     :return: AllItemsResponseSyscollectorHardware
     """
-    check_experimental_feature_value()
-
     filters = {
         'board_serial': board_serial
     }
@@ -158,6 +161,7 @@ async def get_hardware_info(request, pretty=False, wait_for_complete=False, list
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@check_experimental_feature_value
 async def get_network_address_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0,
                                    limit=None, select=None, sort=None, search=None, iface_name=None, proto=None,
                                    address=None, broadcast=None, netmask=None):
@@ -179,8 +183,6 @@ async def get_network_address_info(request, pretty=False, wait_for_complete=Fals
     :param netmask: Filters by netmask
     :return: AllItemsResponseSyscollectorNetwork
     """
-    check_experimental_feature_value()
-
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -211,6 +213,7 @@ async def get_network_address_info(request, pretty=False, wait_for_complete=Fals
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@check_experimental_feature_value
 async def get_network_interface_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0,
                                      limit=None, select=None, sort=None, search=None, adapter=None, state=None,
                                      mtu=None):
@@ -230,8 +233,6 @@ async def get_network_interface_info(request, pretty=False, wait_for_complete=Fa
     :param mtu: Filters by mtu
     :return: AllItemsResponseSyscollectorInterface
     """
-    check_experimental_feature_value()
-
     filters = {
         'adapter': adapter,
         'type': request.query.get('type', None),
@@ -267,6 +268,7 @@ async def get_network_interface_info(request, pretty=False, wait_for_complete=Fa
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@check_experimental_feature_value
 async def get_network_protocol_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0,
                                     limit=None, select=None, sort=None, search=None, iface=None, gateway=None,
                                     dhcp=None):
@@ -286,8 +288,6 @@ async def get_network_protocol_info(request, pretty=False, wait_for_complete=Fal
     :param dhcp: Filters by dhcp
     :return: AllItemsResponseSyscollectorProtocol
     """
-    check_experimental_feature_value()
-
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -317,6 +317,7 @@ async def get_network_protocol_info(request, pretty=False, wait_for_complete=Fal
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@check_experimental_feature_value
 async def get_os_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                       select=None, sort=None, search=None, os_name=None, architecture=None, os_version=None,
                       version=None, release=None):
@@ -338,8 +339,6 @@ async def get_os_info(request, pretty=False, wait_for_complete=False, list_agent
     :param release: Filters by release
     :return: AllItemsResponseSyscollectorOS
     """
-    check_experimental_feature_value()
-
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -370,6 +369,7 @@ async def get_os_info(request, pretty=False, wait_for_complete=False, list_agent
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@check_experimental_feature_value
 async def get_packages_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                             select=None,
                             sort=None, search=None, vendor=None, name=None, architecture=None, version=None):
@@ -390,8 +390,6 @@ async def get_packages_info(request, pretty=False, wait_for_complete=False, list
     :param version: Filters by format
     :return: AllItemsResponseSyscollectorPackages
     """
-    check_experimental_feature_value()
-
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -422,6 +420,7 @@ async def get_packages_info(request, pretty=False, wait_for_complete=False, list
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@check_experimental_feature_value
 async def get_ports_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                          select=None, sort=None, search=None, pid=None, protocol=None, tx_queue=None, state=None,
                          process=None):
@@ -443,8 +442,6 @@ async def get_ports_info(request, pretty=False, wait_for_complete=False, list_ag
     :param process: Filters by process
     :return: AllItemsResponseSyscollectorPorts
     """
-    check_experimental_feature_value()
-
     filters = {
         'pid': pid,
         'protocol': protocol,
@@ -481,6 +478,7 @@ async def get_ports_info(request, pretty=False, wait_for_complete=False, list_ag
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@check_experimental_feature_value
 async def get_processes_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                              select=None, sort=None, search=None, pid=None, state=None, ppid=None, egroup=None,
                              euser=None, fgroup=None, name=None, nlwp=None, pgrp=None, priority=None, rgroup=None,
@@ -512,8 +510,6 @@ async def get_processes_info(request, pretty=False, wait_for_complete=False, lis
     :param suser: Filters by process suser
     :return: AllItemsResponseSyscollectorProcesses
     """
-    check_experimental_feature_value()
-
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -553,6 +549,7 @@ async def get_processes_info(request, pretty=False, wait_for_complete=False, lis
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+@check_experimental_feature_value
 async def get_hotfixes_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                             sort=None, search=None, select=None, hotfix=None):
     """ Get hotfixes info from all agents or a list of them.
@@ -569,8 +566,6 @@ async def get_hotfixes_info(request, pretty=False, wait_for_complete=False, list
     :param hotfix: Filters by hotfix in Windows agents
     :return:AllItemsResponseSyscollectorHotfixes
     """
-    check_experimental_feature_value()
-
     filters = {'hotfix': hotfix}
 
     f_kwargs = {'agent_list': list_agents,

--- a/api/api/controllers/experimental_controller.py
+++ b/api/api/controllers/experimental_controller.py
@@ -18,15 +18,11 @@ from wazuh.core.exception import WazuhResourceNotFound
 logger = logging.getLogger('wazuh')
 
 
-def check_experimental_feature_value(func):
-    def wrapper():
-        if not configuration.api_conf['experimental_features']:
-            raise_if_exc(WazuhResourceNotFound(code=1122))
-
-    return wrapper
+def check_experimental_feature_value():
+    if not configuration.api_conf['experimental_features']:
+        raise_if_exc(WazuhResourceNotFound(code=1122))
 
 
-@check_experimental_feature_value
 async def clear_syscheck_database(request, pretty=False, wait_for_complete=False, list_agents=None):
     """ Clear the syscheck database for all agents.
 
@@ -35,6 +31,8 @@ async def clear_syscheck_database(request, pretty=False, wait_for_complete=False
     :param list_agents: List of agent's IDs.
     :return: AllItemsResponseAgentIDs
     """
+    check_experimental_feature_value()
+
     if 'all' in list_agents:
         list_agents = '*'
 
@@ -111,7 +109,6 @@ async def get_cis_cat_results(request, pretty=False, wait_for_complete=False, li
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-@check_experimental_feature_value
 async def get_hardware_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                             select=None, sort=None, search=None, board_serial=None):
     """ Get hardware info from all agents or a list of them.
@@ -128,6 +125,8 @@ async def get_hardware_info(request, pretty=False, wait_for_complete=False, list
     :param board_serial: Filters by board_serial
     :return: AllItemsResponseSyscollectorHardware
     """
+    check_experimental_feature_value()
+
     filters = {
         'board_serial': board_serial
     }
@@ -159,7 +158,6 @@ async def get_hardware_info(request, pretty=False, wait_for_complete=False, list
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-@check_experimental_feature_value
 async def get_network_address_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0,
                                    limit=None, select=None, sort=None, search=None, iface_name=None, proto=None,
                                    address=None, broadcast=None, netmask=None):
@@ -181,6 +179,8 @@ async def get_network_address_info(request, pretty=False, wait_for_complete=Fals
     :param netmask: Filters by netmask
     :return: AllItemsResponseSyscollectorNetwork
     """
+    check_experimental_feature_value()
+
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -211,7 +211,6 @@ async def get_network_address_info(request, pretty=False, wait_for_complete=Fals
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-@check_experimental_feature_value
 async def get_network_interface_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0,
                                      limit=None, select=None, sort=None, search=None, adapter=None, state=None,
                                      mtu=None):
@@ -231,6 +230,8 @@ async def get_network_interface_info(request, pretty=False, wait_for_complete=Fa
     :param mtu: Filters by mtu
     :return: AllItemsResponseSyscollectorInterface
     """
+    check_experimental_feature_value()
+
     filters = {
         'adapter': adapter,
         'type': request.query.get('type', None),
@@ -266,7 +267,6 @@ async def get_network_interface_info(request, pretty=False, wait_for_complete=Fa
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-@check_experimental_feature_value
 async def get_network_protocol_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0,
                                     limit=None, select=None, sort=None, search=None, iface=None, gateway=None,
                                     dhcp=None):
@@ -286,6 +286,8 @@ async def get_network_protocol_info(request, pretty=False, wait_for_complete=Fal
     :param dhcp: Filters by dhcp
     :return: AllItemsResponseSyscollectorProtocol
     """
+    check_experimental_feature_value()
+
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -315,7 +317,6 @@ async def get_network_protocol_info(request, pretty=False, wait_for_complete=Fal
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-@check_experimental_feature_value
 async def get_os_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                       select=None, sort=None, search=None, os_name=None, architecture=None, os_version=None,
                       version=None, release=None):
@@ -337,6 +338,8 @@ async def get_os_info(request, pretty=False, wait_for_complete=False, list_agent
     :param release: Filters by release
     :return: AllItemsResponseSyscollectorOS
     """
+    check_experimental_feature_value()
+
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -367,7 +370,6 @@ async def get_os_info(request, pretty=False, wait_for_complete=False, list_agent
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-@check_experimental_feature_value
 async def get_packages_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                             select=None,
                             sort=None, search=None, vendor=None, name=None, architecture=None, version=None):
@@ -388,6 +390,8 @@ async def get_packages_info(request, pretty=False, wait_for_complete=False, list
     :param version: Filters by format
     :return: AllItemsResponseSyscollectorPackages
     """
+    check_experimental_feature_value()
+
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -418,7 +422,6 @@ async def get_packages_info(request, pretty=False, wait_for_complete=False, list
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-@check_experimental_feature_value
 async def get_ports_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                          select=None, sort=None, search=None, pid=None, protocol=None, tx_queue=None, state=None,
                          process=None):
@@ -440,6 +443,8 @@ async def get_ports_info(request, pretty=False, wait_for_complete=False, list_ag
     :param process: Filters by process
     :return: AllItemsResponseSyscollectorPorts
     """
+    check_experimental_feature_value()
+
     filters = {
         'pid': pid,
         'protocol': protocol,
@@ -476,7 +481,6 @@ async def get_ports_info(request, pretty=False, wait_for_complete=False, list_ag
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-@check_experimental_feature_value
 async def get_processes_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                              select=None, sort=None, search=None, pid=None, state=None, ppid=None, egroup=None,
                              euser=None, fgroup=None, name=None, nlwp=None, pgrp=None, priority=None, rgroup=None,
@@ -508,6 +512,8 @@ async def get_processes_info(request, pretty=False, wait_for_complete=False, lis
     :param suser: Filters by process suser
     :return: AllItemsResponseSyscollectorProcesses
     """
+    check_experimental_feature_value()
+
     f_kwargs = {'agent_list': list_agents,
                 'offset': offset,
                 'limit': limit,
@@ -547,7 +553,6 @@ async def get_processes_info(request, pretty=False, wait_for_complete=False, lis
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-@check_experimental_feature_value
 async def get_hotfixes_info(request, pretty=False, wait_for_complete=False, list_agents='*', offset=0, limit=None,
                             sort=None, search=None, select=None, hotfix=None):
     """ Get hotfixes info from all agents or a list of them.
@@ -564,6 +569,8 @@ async def get_hotfixes_info(request, pretty=False, wait_for_complete=False, list
     :param hotfix: Filters by hotfix in Windows agents
     :return:AllItemsResponseSyscollectorHotfixes
     """
+    check_experimental_feature_value()
+
     filters = {'hotfix': hotfix}
 
     f_kwargs = {'agent_list': list_agents,

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -534,19 +534,27 @@ stages:
                 state: !anystr
                 tx_queue: !anyint
             - <<: *ports_response
+              agent_id: '000'
             - <<: *ports_response
+              agent_id: '001'
             - <<: *ports_response
+              agent_id: '002'
             - <<: *ports_response
+              agent_id: '003'
             - <<: *ports_response
+              agent_id: '004'
             - <<: *ports_response
+              agent_id: '005'
             - <<: *ports_response
+              agent_id: '006'
             - <<: *ports_response
+              agent_id: '007'
             - <<: *ports_response
-            - <<: *ports_response
-            - <<: *ports_response
+              agent_id: '008'
           failed_items: []
-          total_affected_items: 12
+          total_affected_items: !anyint
           total_failed_items: 0
+        message: !anystr
 
   - name: Request
     request:

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -379,17 +379,14 @@ stages:
       json:
         data:
           affected_items:
-            # agent 000 has 4 different ports as it is the master node
-            - agent_id: '000'
-            - agent_id: '000'
-            - agent_id: '000'
+            # The answer must include at least one item whose agent is shown below
             - agent_id: '000'
             - agent_id: '002'
             - agent_id: '004'
             - agent_id: '006'
             - agent_id: '008'
           failed_items: []
-          total_affected_items: 8
+          total_affected_items: !anyint
           total_failed_items: 0
 
   - name: Request


### PR DESCRIPTION
Hi team!

## Description

This test fixes some errors in `experimental` controller and in black_experimental integration tests. The following decorator was not calling the decorated function:
https://github.com/wazuh/wazuh/blob/9e553cb4b692768ae58d070921ccfdb7c82166e8/api/api/controllers/experimental_controller.py#L21-L26

I tried to fix it but the decorator was throwing errors with the arguments that each function expected, so I have finally made it into a function that is called on each experimental endpoint.

The changes in the integration test makes the `experimental/syscollector/ports` endpoint test more flexible, so it does not fail randomly any more.

## Tests

```
pytest test_rbac_black_experimental_endpoints.tavern.yaml -vv
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-42-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 11 items                                                                                                                                                                                           

test_rbac_black_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck PASSED                                                                                                               [  9%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/ciscat/results PASSED                                                                                                            [ 18%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hardware PASSED                                                                                                     [ 27%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netaddr PASSED                                                                                                      [ 36%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netiface PASSED                                                                                                     [ 45%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netproto PASSED                                                                                                     [ 54%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/os PASSED                                                                                                           [ 63%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/packages PASSED                                                                                                     [ 72%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/ports PASSED                                                                                                        [ 81%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/processes PASSED                                                                                                    [ 90%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hotfixes PASSED                                                                                                     [100%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 11 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.rbac_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================ 11 passed, 13 warnings in 236.46s (0:03:56) =================================================================================
```

```
pytest test_experimental_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 11 items                                                                                                                                                                                           

test_experimental_endpoints.tavern.yaml ...........                                                                                                                                                    [100%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 11 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.base_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================ 11 passed, 13 warnings in 220.06s (0:03:40) =================================================================================

```
Kind regards,
Selu.