### PR TITLE
Fix some API integration tests cases

### DIFF
--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -508,7 +508,6 @@ stages:
               global: !anything
               integration: !anything
               localfile: !anything
-              open-scap: !anything
               osquery: !anything
               remote: !anything
               rootcheck: !anything

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -142,7 +142,6 @@ stages:
               global: !anything
               integration: !anything
               localfile: !anything
-              open-scap: !anything
               osquery: !anything
               remote: !anything
               rootcheck: !anything
@@ -665,7 +664,6 @@ stages:
             - ossec-execd: !anything
             - ossec-integratord: !anything
             - ossec-logcollector: !anything
-            - ossec-maild: !anything
             - ossec-monitord: !anything
             - ossec-remoted: !anything
             - ossec-rootcheck: !anything
@@ -677,11 +675,10 @@ stages:
             - wazuh-modulesd:control: !anything
             - wazuh-modulesd:database: !anything
             - wazuh-modulesd:download: !anything
-            - wazuh-modulesd:oscap: !anything
             - wazuh-modulesd:osquery: !anything
             - wazuh-modulesd:syscollector: !anything
           failed_items: []
-          total_affected_items: 23
+          total_affected_items: 21
           total_failed_items: 0
 
 ---

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -655,30 +655,9 @@ stages:
       status_code: 200
       json:
         data:
-          affected_items:
-            - ossec-agentlessd: !anything
-            - ossec-analysisd: !anything
-            - ossec-authd: !anything
-            - ossec-csyslogd: !anything
-            - ossec-dbd: !anything
-            - ossec-execd: !anything
-            - ossec-integratord: !anything
-            - ossec-logcollector: !anything
-            - ossec-monitord: !anything
-            - ossec-remoted: !anything
-            - ossec-rootcheck: !anything
-            - ossec-syscheckd: !anything
-            - sca: !anything
-            - wazuh-db: !anything
-            - wazuh-modulesd: !anything
-            - wazuh-modulesd:ciscat: !anything
-            - wazuh-modulesd:control: !anything
-            - wazuh-modulesd:database: !anything
-            - wazuh-modulesd:download: !anything
-            - wazuh-modulesd:osquery: !anything
-            - wazuh-modulesd:syscollector: !anything
+          affected_items: !anydict
           failed_items: []
-          total_affected_items: 21
+          total_affected_items: !anyint
           total_failed_items: 0
 
 ---


### PR DESCRIPTION
Hi team,

In this PR I have fixed some failed API integration test cases in:

```
test_cluster_endpoints.tavern.yaml
Before: 53 passed, 3 failed
Now: 55 passed, 1 failed
```

```
test_manager_endpoints.tavern.yaml
Before: 32 passed, 3 failed
Now: 34 passed, 1 failed
```

In both of these tests I have deleted expected items which were not returned in the response.

Regards,
Manuel.