### PR TITLE
Analysisd + Logtest fixes

### DIFF
--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -520,18 +520,32 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     if (lf->location[0] == '[') {
         /* Messages from an agent */
         char *orig = lf->location;
+        bool extra_info = false;
 
         lf->agent_id = lf->location + 1;
         lf->location = strchr(lf->agent_id, ']');
 
         if (!lf->location) {
+            lf->location = orig;
+            lf->agent_id = NULL;
+            lf->hostname = NULL;
             merror(FORMAT_ERROR);
             return (-1);
         }
 
+        if (strlen(lf->location) > 1) {
+            extra_info = true;
+        }
+
         *lf->location = '\0';
         os_strdup(lf->agent_id, lf->agent_id);
-        os_strdup(lf->location + 2, lf->location);
+
+        if (extra_info) {
+            os_strdup(lf->location + 2, lf->location);
+        } else {
+            os_strdup("", lf->location);
+        }
+
 
         if (lf->location[0] == '(') {
             char * end;

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -187,8 +187,8 @@ cJSON *w_logtest_process_log(cJSON * request, w_logtest_session_t * session, OSL
 
     /* Preprocessing */
     if (w_logtest_preprocessing_phase(lf, request) != 0) {
-        os_free(lf->fields);
-        os_free(lf);
+        Free_Eventinfo(lf);
+        smerror(list_msg, FORMAT_ERROR);
         return output;
     }
 
@@ -258,7 +258,6 @@ int w_logtest_preprocessing_phase(Eventinfo * lf, cJSON * request) {
     snprintf(log, logsize, "1:%s:%s", location_str, event_str);
 
     if (OS_CleanMSG(log, lf) < 0) {
-        Free_Eventinfo(lf);
         os_free(log);
         if (event_json) os_free(event_str);
         return -1;


### PR DESCRIPTION
|Related issue|
|---|
|--|

Hey Team!,

After observing a strange behavior in the unit tests with a memory leak, I went back to review the analisysd functions that we considered valid.

This PR fixes 4 bugs in analysisd and logtest
- Invalid free (logtest, maybe analisysd)
- Invalid read (Logtest)
- Memleak (Analysisd + logtest)
- Bad ouput (logtest)

These bugs can be exploited with the location field with an invalid value.

Check out these cases:


```
{"token": "0d72687f","event": "Dec 18 18:06:28 hostname smbd[832]: Denied connection from (192.168.3.23)", "log_format":"syslog", "location":"[julian]"}
```
Multiple Invalid read


```
{"token": "22d5308e","event": "Dec 18 18:06:28 hostname smbd[832]: Denied connection from (192.168.3.23)", "log_format":"syslog", "location":"[julian"}
```
invalid pointer to free.

## Tasks
  - [x] Scan-build report
  - [x] Compile witouth warnings in linux
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] Unit Test

Regards,
Julian.