### PR TITLE
Modify default retry interval

### DIFF
--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -59,6 +59,6 @@ void Free_Client(agent * config);
 bool Validate_Address(agent_server *servers);
 
 #define DEFAULT_MAX_RETRIES 5
-#define DEFAULT_RETRY_INTERVAL 5
+#define DEFAULT_RETRY_INTERVAL 10
 
 #endif /* CAGENTD_H */


### PR DESCRIPTION
|Related issue|
|---|
|5939|


## Description
This PR modifies the default value of retry_interval from 5 to 10.

## Tests

  - [x] Run agentd integration tests