### PR TITLE
Vulnerability-Detector: Handle invalid configuration options

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -730,6 +730,11 @@ int wm_vuldet_provider_os_list(xml_node **node, vu_os_feed **feeds, char *pr_nam
         }
     }
 
+    if (feeds_it == NULL) {
+        merror("'%s' tag required for '%s' provider", XML_OS, pr_name);
+        return OS_INVALID;
+    }
+
     if (debian_provider && feeds_it) {
         // A second iteration to check for a custom location for the JSON Security Tracker
         // If found, we assign the new location to all Debian nodes read above

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -908,6 +908,7 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
     int i, j;
     int elements;
     int8_t rhel_enabled = (strcasestr(name, vu_feed_tag[FEED_REDHAT])) ? 1 : 0;
+    int8_t msu_enabled = (strcasestr(name, vu_feed_tag[FEED_MSU])) ? 1 : 0;
 
     memset(options, '\0', sizeof(provider_options));
 
@@ -919,7 +920,12 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
             // Deprecated in RHEL
             if (rhel_enabled) {
                 minfo("'%s' option at module '%s' is deprecated. Use '%s' instead.", XML_UPDATE_FROM_YEAR, WM_VULNDETECTOR_CONTEXT.name, XML_OS);
+            // Even though MSU is a multi_provider, it does not use the update_from_year option.
+            } else if (msu_enabled) {
+                mwarn("'%s' option cannot be used for '%s' provider.", node[i]->element, name);
+                continue;
             }
+
             if (multi_provider || rhel_enabled) {
                 int min_year = rhel_enabled ? RED_HAT_REPO_MIN_YEAR : NVD_REPO_MIN_YEAR;
                 if (!wm_vuldet_is_valid_year(node[i]->content, &options->update_since, min_year)) {


### PR DESCRIPTION
Small PR that adds some `error` and `warning` messages in order to handle invalid configuration options depending on the provider.

- No `os` tag specified for Canonical, Debian or RedHat providers. (**error**)
- `update_from_year` tag specified for MSU provider. (**warning**)

## Logs/Alerts example

- `ERROR: 'os' tag required for 'canonical' provider`
- `WARNING: 'update_from_year' option cannot be used for 'msu' provider.`

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
 