### PR TITLE
Unit testing for wdb_parser.c

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -21,7 +21,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
                              -Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg \
-                             -Wl,--wrap,wdb_global_insert_agent -Wl,--wrap,wdb_global_update_agent_name")
+                             -Wl,--wrap,wdb_global_insert_agent -Wl,--wrap,wdb_global_update_agent_name -Wl,--wrap,wdb_global_update_agent_version \
+                            -Wl,--wrap,wdb_global_get_agent_labels")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -22,7 +22,7 @@ list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
                              -Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg \
                              -Wl,--wrap,wdb_global_insert_agent -Wl,--wrap,wdb_global_update_agent_name -Wl,--wrap,wdb_global_update_agent_version \
-                            -Wl,--wrap,wdb_global_get_agent_labels")
+                             -Wl,--wrap,wdb_global_get_agent_labels -Wl,--wrap,wdb_global_del_agent_labels -Wl,--wrap,wdb_global_set_agent_label")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -22,7 +22,12 @@ list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
                              -Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg \
                              -Wl,--wrap,wdb_global_insert_agent -Wl,--wrap,wdb_global_update_agent_name -Wl,--wrap,wdb_global_update_agent_version \
-                             -Wl,--wrap,wdb_global_get_agent_labels -Wl,--wrap,wdb_global_del_agent_labels -Wl,--wrap,wdb_global_set_agent_label")
+                             -Wl,--wrap,wdb_global_get_agent_labels -Wl,--wrap,wdb_global_del_agent_labels -Wl,--wrap,wdb_global_set_agent_label \
+                             -Wl,--wrap,wdb_global_update_agent_keepalive -Wl,--wrap,wdb_global_delete_agent -Wl,--wrap,wdb_global_select_agent_name \
+                             -Wl,--wrap,wdb_global_select_agent_group -Wl,--wrap,wdb_global_delete_agent_belong -Wl,--wrap,wdb_global_find_agent \
+                             -Wl,--wrap,wdb_global_select_agent_fim_offset -Wl,--wrap,wdb_global_select_agent_reg_offset \
+                             -Wl,--wrap,wdb_global_update_agent_fim_offset -Wl,--wrap,wdb_global_update_agent_reg_offset -Wl,--wrap,wdb_global_select_agent_status \
+                             -Wl,--wrap,wdb_global_update_agent_status -Wl,--wrap,wdb_global_update_agent_group")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -30,7 +30,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,wdb_global_update_agent_status -Wl,--wrap,wdb_global_update_agent_group -Wl,--wrap,wdb_global_find_group \
                              -Wl,--wrap,wdb_global_insert_agent_group -Wl,--wrap,wdb_global_insert_agent_belong -Wl,--wrap,wdb_global_delete_group_belong \
                              -Wl,--wrap,wdb_global_delete_group -Wl,--wrap,wdb_global_select_groups -Wl,--wrap,wdb_global_select_agent_keepalive \
-                             -Wl,--wrap,wdb_sync_agent_info_get -Wl,--wrap,wdb_global_sync_agent_info_set -Wl,--wrap,wdb_global_get_agents_by_keepalive")
+                             -Wl,--wrap,wdb_sync_agent_info_get -Wl,--wrap,wdb_global_sync_agent_info_set -Wl,--wrap,wdb_global_get_agents_by_keepalive \
+                             -Wl,--wrap,wdb_global_get_all_agents -Wl,--wrap,wdb_global_get_agent_info")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -27,7 +27,9 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,wdb_global_select_agent_group -Wl,--wrap,wdb_global_delete_agent_belong -Wl,--wrap,wdb_global_find_agent \
                              -Wl,--wrap,wdb_global_select_agent_fim_offset -Wl,--wrap,wdb_global_select_agent_reg_offset \
                              -Wl,--wrap,wdb_global_update_agent_fim_offset -Wl,--wrap,wdb_global_update_agent_reg_offset -Wl,--wrap,wdb_global_select_agent_status \
-                             -Wl,--wrap,wdb_global_update_agent_status -Wl,--wrap,wdb_global_update_agent_group")
+                             -Wl,--wrap,wdb_global_update_agent_status -Wl,--wrap,wdb_global_update_agent_group -Wl,--wrap,wdb_global_find_group \
+                             -Wl,--wrap,wdb_global_insert_agent_group -Wl,--wrap,wdb_global_insert_agent_belong -Wl,--wrap,wdb_global_delete_group_belong \
+                             -Wl,--wrap,wdb_global_delete_group")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -20,7 +20,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
-                             -Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg")
+                             -Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg \
+                             -Wl,--wrap,wdb_global_insert_agent -Wl,--wrap,wdb_global_update_agent_name")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -29,7 +29,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,wdb_global_update_agent_fim_offset -Wl,--wrap,wdb_global_update_agent_reg_offset -Wl,--wrap,wdb_global_select_agent_status \
                              -Wl,--wrap,wdb_global_update_agent_status -Wl,--wrap,wdb_global_update_agent_group -Wl,--wrap,wdb_global_find_group \
                              -Wl,--wrap,wdb_global_insert_agent_group -Wl,--wrap,wdb_global_insert_agent_belong -Wl,--wrap,wdb_global_delete_group_belong \
-                             -Wl,--wrap,wdb_global_delete_group")
+                             -Wl,--wrap,wdb_global_delete_group -Wl,--wrap,wdb_global_select_groups -Wl,--wrap,wdb_global_select_agent_keepalive")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -29,7 +29,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,wdb_global_update_agent_fim_offset -Wl,--wrap,wdb_global_update_agent_reg_offset -Wl,--wrap,wdb_global_select_agent_status \
                              -Wl,--wrap,wdb_global_update_agent_status -Wl,--wrap,wdb_global_update_agent_group -Wl,--wrap,wdb_global_find_group \
                              -Wl,--wrap,wdb_global_insert_agent_group -Wl,--wrap,wdb_global_insert_agent_belong -Wl,--wrap,wdb_global_delete_group_belong \
-                             -Wl,--wrap,wdb_global_delete_group -Wl,--wrap,wdb_global_select_groups -Wl,--wrap,wdb_global_select_agent_keepalive")
+                             -Wl,--wrap,wdb_global_delete_group -Wl,--wrap,wdb_global_select_groups -Wl,--wrap,wdb_global_select_agent_keepalive \
+                             -Wl,--wrap,wdb_sync_agent_info_get -Wl,--wrap,wdb_global_sync_agent_info_set -Wl,--wrap,wdb_global_get_agents_by_keepalive")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -9,6 +9,7 @@
 #include "wazuh_db/wdb.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
+#include "../wrappers/wazuh/wazuh_db/wdb_global_wrappers.h"
 #include "../wrappers/externals/sqlite/sqlite3_wrappers.h"
 
 typedef struct test_struct {
@@ -139,13 +140,217 @@ void test_wdb_global_parse_sql_fail(void **state)
 
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: sql TEST QUERY");
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "GLobal DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: TEST QUERY");
 
     ret = wdb_parse(query, data->output);
 
     assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_global_parse_actor_fail(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "error ";
+
+    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Invalid DB query actor: error");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query actor: 'error'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_global_parse_insert_agent_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for insert-agent.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: insert-agent");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'insert-agent'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_global_parse_insert_agent_invalid_json(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent {INVALID_JSON}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent {INVALID_JSON}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when inserting agent.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_global_parse_insert_agent_compliant_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent {\"id\":1,\"name\":\"test_name\",\"date_add\":null}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent {\"id\":1,\"name\":\"test_name\",\"date_add\":null}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when inserting agent. Not compliant with constraints defined in the database.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid JSON data, near '{\"id\":1,\"name\":\"test_name\",\"date'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_global_parse_insert_agent_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent {\"id\":1,\"name\":\"test_name\",\"date_add\":123}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent {\"id\":1,\"name\":\"test_name\",\"date_add\":123}");
+    
+    expect_value(__wrap_wdb_global_insert_agent, id, 1);
+    expect_string(__wrap_wdb_global_insert_agent, name, "test_name");
+    expect_value(__wrap_wdb_global_insert_agent, ip, NULL);
+    expect_value(__wrap_wdb_global_insert_agent, register_ip, NULL);
+    expect_value(__wrap_wdb_global_insert_agent, internal_key, NULL);
+    expect_value(__wrap_wdb_global_insert_agent, group, NULL);
+    expect_value(__wrap_wdb_global_insert_agent, date_add, 123);
+    will_return(__wrap_wdb_global_insert_agent, OS_INVALID);
+    will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_global_parse_insert_agent_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent {\"id\":1,\"name\":\"test_name\",\"date_add\":123,\
+    \"ip\":\"0.0.0.0\",\"register_ip\":\"1.1.1.1\",\"internal_key\":\"test_key\",\"group\":\"test_group\"}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent {\"id\":1,\"name\":\"test_name\",\"date_add\":123,\
+    \"ip\":\"0.0.0.0\",\"register_ip\":\"1.1.1.1\",\"internal_key\":\"test_key\",\"group\":\"test_group\"}");
+    
+    expect_value(__wrap_wdb_global_insert_agent, id, 1);
+    expect_string(__wrap_wdb_global_insert_agent, name, "test_name");
+    expect_string(__wrap_wdb_global_insert_agent, ip, "0.0.0.0");
+    expect_string(__wrap_wdb_global_insert_agent, register_ip, "1.1.1.1");
+    expect_string(__wrap_wdb_global_insert_agent, internal_key, "test_key");
+    expect_string(__wrap_wdb_global_insert_agent, group, "test_group");
+    expect_value(__wrap_wdb_global_insert_agent, date_add, 123);
+    will_return(__wrap_wdb_global_insert_agent, OS_SUCCESS);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_global_parse_update_agent_name_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-agent-name";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-name");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for update-agent-name.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: update-agent-name");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-agent-name'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_global_parse_update_agent_name_invalid_json(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-agent-name {INVALID_JSON}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-name {INVALID_JSON}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when updating agent name.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_global_parse_update_agent_name_invalid_data(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-agent-name {\"id\":1,\"name\":null}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-name {\"id\":1,\"name\":null}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when updating agent name.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid JSON data, near '{\"id\":1,\"name\":null}'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_global_parse_update_agent_name_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-agent-name {\"id\":1,\"name\":\"test_name\"}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-name {\"id\":1,\"name\":\"test_name\"}");
+    expect_value(__wrap_wdb_global_update_agent_name, id, 1);
+    expect_string(__wrap_wdb_global_update_agent_name, name, "test_name");
+    will_return(__wrap_wdb_global_update_agent_name, OS_INVALID);
+    will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_global_parse_update_agent_name_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-agent-name {\"id\":1,\"name\":\"test_name\"}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-name {\"id\":1,\"name\":\"test_name\"}");
+    expect_value(__wrap_wdb_global_update_agent_name, id, 1);
+    expect_string(__wrap_wdb_global_update_agent_name, name, "test_name");
+    will_return(__wrap_wdb_global_update_agent_name, OS_SUCCESS);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(ret, OS_SUCCESS);
 }
 
 int main()
@@ -156,7 +361,18 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_parse_substr_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_parse_sql_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_parse_sql_success, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_sql_fail, test_setup, test_teardown)
+        cmocka_unit_test_setup_teardown(test_wdb_global_parse_sql_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_parse_actor_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_parse_insert_agent_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_parse_insert_agent_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_parse_insert_agent_compliant_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_parse_insert_agent_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_parse_insert_agent_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_parse_update_agent_name_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_parse_update_agent_name_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_parse_update_agent_name_invalid_data, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_parse_update_agent_name_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_parse_update_agent_name_success, test_setup, test_teardown)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -1591,6 +1591,307 @@ void test_wdb_parse_global_update_agent_group_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+void test_wdb_parse_global_find_group_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global find-group";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: find-group");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for find-group.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: find-group");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'find-group'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_find_group_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global find-group test_group";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: find-group test_group");
+    expect_string(__wrap_wdb_global_find_group, group_name, "test_group");
+    will_return(__wrap_wdb_global_find_group, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error getting group id from global.db.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Error getting group id from global.db.");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_find_group_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global find-group test_group";
+    cJSON *j_object = NULL;
+
+    j_object = cJSON_CreateObject();
+    cJSON_AddNumberToObject(j_object, "id", 1);
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: find-group test_group");
+    expect_string(__wrap_wdb_global_find_group, group_name, "test_group");
+    will_return(__wrap_wdb_global_find_group, j_object);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok {\"id\":1}");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_parse_global_insert_agent_group_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent-group";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent-group");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for insert-agent-group.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: insert-agent-group");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'insert-agent-group'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_insert_agent_group_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent-group test_group";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent-group test_group");
+    expect_string(__wrap_wdb_global_insert_agent_group, group_name, "test_group");
+    will_return(__wrap_wdb_global_insert_agent_group, OS_INVALID);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error inserting group in global.db.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Error inserting group in global.db.");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_insert_agent_group_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent-group test_group";
+    cJSON *j_object = NULL;
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent-group test_group");
+    expect_string(__wrap_wdb_global_insert_agent_group, group_name, "test_group");
+    will_return(__wrap_wdb_global_insert_agent_group, OS_SUCCESS);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_parse_global_insert_agent_belong_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent-belong";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent-belong");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for insert-agent-belong.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: insert-agent-belong");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'insert-agent-belong'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_insert_agent_belong_invalid_json(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent-belong {INVALID_JSON}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent-belong {INVALID_JSON}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when inserting agent to belongs table.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_insert_agent_belong_invalid_data(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent-belong {\"id_group\":1,\"id_agent\":null}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent-belong {\"id_group\":1,\"id_agent\":null}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when inserting agent to belongs table.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid JSON data, near '{\"id_group\":1,\"id_agent\":null}'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_insert_agent_belong_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent-belong {\"id_group\":1,\"id_agent\":2}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent-belong {\"id_group\":1,\"id_agent\":2}");
+    expect_value(__wrap_wdb_global_insert_agent_belong, id_group, 1);
+    expect_value(__wrap_wdb_global_insert_agent_belong, id_agent, 2);
+    will_return(__wrap_wdb_global_insert_agent_belong, OS_INVALID);
+    will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_insert_agent_belong_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global insert-agent-belong {\"id_group\":1,\"id_agent\":2}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent-belong {\"id_group\":1,\"id_agent\":2}");
+    expect_value(__wrap_wdb_global_insert_agent_belong, id_group, 1);
+    expect_value(__wrap_wdb_global_insert_agent_belong, id_agent, 2);
+    will_return(__wrap_wdb_global_insert_agent_belong, OS_SUCCESS);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_parse_global_delete_group_belong_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global delete-group-belong";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: delete-group-belong");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for delete-group-belong.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: delete-group-belong");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'delete-group-belong'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_delete_group_belong_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global delete-group-belong test_group";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: delete-group-belong test_group");
+    expect_string(__wrap_wdb_global_delete_group_belong, group_name, "test_group");
+    will_return(__wrap_wdb_global_delete_group_belong, OS_INVALID);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error deleting group from belongs table in global.db.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Error deleting group from belongs table in global.db.");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_delete_group_belong_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global delete-group-belong test_group";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: delete-group-belong test_group");
+    expect_string(__wrap_wdb_global_delete_group_belong, group_name, "test_group");
+    will_return(__wrap_wdb_global_delete_group_belong, OS_SUCCESS);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_parse_global_delete_group_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global delete-group";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: delete-group");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for delete-group.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: delete-group");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'delete-group'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_delete_group_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global delete-group test_group";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: delete-group test_group");
+    expect_string(__wrap_wdb_global_delete_group, group_name, "test_group");
+    will_return(__wrap_wdb_global_delete_group, OS_INVALID);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error deleting group in global.db.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Error deleting group in global.db.");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_delete_group_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global delete-group test_group";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: delete-group test_group");
+    expect_string(__wrap_wdb_global_delete_group, group_name, "test_group");
+    will_return(__wrap_wdb_global_delete_group, OS_SUCCESS);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] = {
@@ -1674,7 +1975,24 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_group_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_group_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_group_query_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_group_success, test_setup, test_teardown)
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_group_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_find_group_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_find_group_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_find_group_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_group_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_group_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_group_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_belong_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_belong_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_belong_invalid_data, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_belong_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_belong_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_belong_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_belong_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_belong_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_success, test_setup, test_teardown)
        };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -38,7 +38,7 @@ static int test_teardown(void **state){
     return 0;
 }
 
-void test_wdb_global_parse_open_global_fail(void **state)
+void test_wdb_parse_global_open_global_fail(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -54,7 +54,7 @@ void test_wdb_global_parse_open_global_fail(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_no_space(void **state)
+void test_wdb_parse_global_no_space(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -69,7 +69,7 @@ void test_wdb_global_parse_no_space(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_substr_fail(void **state)
+void test_wdb_parse_global_substr_fail(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -87,7 +87,7 @@ void test_wdb_global_parse_substr_fail(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_sql_error(void **state)
+void test_wdb_parse_global_sql_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -104,7 +104,7 @@ void test_wdb_global_parse_sql_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_sql_success(void **state)
+void test_wdb_parse_global_sql_success(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -128,7 +128,7 @@ void test_wdb_global_parse_sql_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-void test_wdb_global_parse_sql_fail(void **state)
+void test_wdb_parse_global_sql_fail(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -149,7 +149,7 @@ void test_wdb_global_parse_sql_fail(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_actor_fail(void **state)
+void test_wdb_parse_global_actor_fail(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -163,7 +163,7 @@ void test_wdb_global_parse_actor_fail(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_insert_agent_syntax_error(void **state)
+void test_wdb_parse_global_insert_agent_syntax_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -180,7 +180,7 @@ void test_wdb_global_parse_insert_agent_syntax_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_insert_agent_invalid_json(void **state)
+void test_wdb_parse_global_insert_agent_invalid_json(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -197,7 +197,7 @@ void test_wdb_global_parse_insert_agent_invalid_json(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_insert_agent_compliant_error(void **state)
+void test_wdb_parse_global_insert_agent_compliant_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -213,7 +213,7 @@ void test_wdb_global_parse_insert_agent_compliant_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_insert_agent_query_error(void **state)
+void test_wdb_parse_global_insert_agent_query_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -239,7 +239,7 @@ void test_wdb_global_parse_insert_agent_query_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_insert_agent_success(void **state)
+void test_wdb_parse_global_insert_agent_success(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -265,7 +265,7 @@ void test_wdb_global_parse_insert_agent_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-void test_wdb_global_parse_update_agent_name_syntax_error(void **state)
+void test_wdb_parse_global_update_agent_name_syntax_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -282,7 +282,7 @@ void test_wdb_global_parse_update_agent_name_syntax_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_update_agent_name_invalid_json(void **state)
+void test_wdb_parse_global_update_agent_name_invalid_json(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -299,7 +299,7 @@ void test_wdb_global_parse_update_agent_name_invalid_json(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_update_agent_name_invalid_data(void **state)
+void test_wdb_parse_global_update_agent_name_invalid_data(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -315,7 +315,7 @@ void test_wdb_global_parse_update_agent_name_invalid_data(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_update_agent_name_query_error(void **state)
+void test_wdb_parse_global_update_agent_name_query_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -335,7 +335,7 @@ void test_wdb_global_parse_update_agent_name_query_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_global_parse_update_agent_name_success(void **state)
+void test_wdb_parse_global_update_agent_name_success(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -353,26 +353,246 @@ void test_wdb_global_parse_update_agent_name_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+void test_wdb_parse_global_update_agent_version_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-agent-version";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-version");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for update-agent-version.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: update-agent-version");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-agent-version'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_update_agent_version_invalid_json(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-agent-version {INVALID_JSON}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-version {INVALID_JSON}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when updating agent version.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_update_agent_version_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-agent-version {\"id\":1,\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
+    \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
+    \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
+    \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
+    \"sync_status\":1}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, 
+    "Global query: update-agent-version {\"id\":1,\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
+    \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
+    \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
+    \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
+    \"sync_status\":1}");
+
+    expect_value(__wrap_wdb_global_update_agent_version, id, 1);
+    expect_string(__wrap_wdb_global_update_agent_version, os_name, "test_name");
+    expect_string(__wrap_wdb_global_update_agent_version, os_version, "test_version");
+    expect_string(__wrap_wdb_global_update_agent_version, os_major, "test_major");
+    expect_string(__wrap_wdb_global_update_agent_version, os_minor, "test_minor");
+    expect_string(__wrap_wdb_global_update_agent_version, os_codename, "test_codename");
+    expect_string(__wrap_wdb_global_update_agent_version, os_platform, "test_platform");
+    expect_string(__wrap_wdb_global_update_agent_version, os_build, "test_build");
+    expect_string(__wrap_wdb_global_update_agent_version, os_uname, "test_uname");
+    expect_string(__wrap_wdb_global_update_agent_version, os_arch, "test_arch");
+    expect_string(__wrap_wdb_global_update_agent_version, version, "test_version");
+    expect_string(__wrap_wdb_global_update_agent_version, config_sum, "test_config");
+    expect_string(__wrap_wdb_global_update_agent_version, merged_sum, "test_merged");
+    expect_string(__wrap_wdb_global_update_agent_version, manager_host, "test_manager");
+    expect_string(__wrap_wdb_global_update_agent_version, node_name, "test_node");
+    expect_string(__wrap_wdb_global_update_agent_version, agent_ip, "test_ip");
+    expect_value(__wrap_wdb_global_update_agent_version, sync_status, WDB_SYNC_REQ);
+
+    will_return(__wrap_wdb_global_update_agent_version, OS_INVALID);
+
+    will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_update_agent_version_invalid_data(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-agent-version {\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
+    \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
+    \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
+    \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
+    \"sync_status\":1}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, 
+    "Global query: update-agent-version {\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
+    \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
+    \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
+    \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
+    \"sync_status\":1}");
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when updating agent version.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid JSON data, near '{\"os_name\":\"test_name\",\"os_versi'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_update_agent_version_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-agent-version {\"id\":1,\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
+    \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
+    \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
+    \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
+    \"sync_status\":1}";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, 
+    "Global query: update-agent-version {\"id\":1,\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
+    \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
+    \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
+    \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
+    \"sync_status\":1}");
+
+    expect_value(__wrap_wdb_global_update_agent_version, id, 1);
+    expect_string(__wrap_wdb_global_update_agent_version, os_name, "test_name");
+    expect_string(__wrap_wdb_global_update_agent_version, os_version, "test_version");
+    expect_string(__wrap_wdb_global_update_agent_version, os_major, "test_major");
+    expect_string(__wrap_wdb_global_update_agent_version, os_minor, "test_minor");
+    expect_string(__wrap_wdb_global_update_agent_version, os_codename, "test_codename");
+    expect_string(__wrap_wdb_global_update_agent_version, os_platform, "test_platform");
+    expect_string(__wrap_wdb_global_update_agent_version, os_build, "test_build");
+    expect_string(__wrap_wdb_global_update_agent_version, os_uname, "test_uname");
+    expect_string(__wrap_wdb_global_update_agent_version, os_arch, "test_arch");
+    expect_string(__wrap_wdb_global_update_agent_version, version, "test_version");
+    expect_string(__wrap_wdb_global_update_agent_version, config_sum, "test_config");
+    expect_string(__wrap_wdb_global_update_agent_version, merged_sum, "test_merged");
+    expect_string(__wrap_wdb_global_update_agent_version, manager_host, "test_manager");
+    expect_string(__wrap_wdb_global_update_agent_version, node_name, "test_node");
+    expect_string(__wrap_wdb_global_update_agent_version, agent_ip, "test_ip");
+    expect_value(__wrap_wdb_global_update_agent_version, sync_status, WDB_SYNC_REQ);
+    will_return(__wrap_wdb_global_update_agent_version, OS_SUCCESS);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_parse_global_get_agent_labels_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-labels";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-labels");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for get-labels.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: get-labels");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-labels'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_agent_labels_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-labels 1";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-labels 1");
+    expect_value(__wrap_wdb_global_get_agent_labels, id, 1);
+    will_return(__wrap_wdb_global_get_agent_labels, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error getting agent labels from global.db.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Error getting agent labels from global.db.");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_agent_labels_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-labels 1";
+    cJSON *root = NULL;
+    cJSON *object = NULL;
+
+    root = cJSON_CreateArray();
+    object = cJSON_CreateObject();
+    cJSON_AddNumberToObject(object, "id", 1);
+    cJSON_AddStringToObject(object, "key", "test_key");
+    cJSON_AddStringToObject(object, "value", "test_value");
+    cJSON_AddItemToArray(root, object);
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-labels 1");
+    expect_value(__wrap_wdb_global_get_agent_labels, id, 1);
+    will_return(__wrap_wdb_global_get_agent_labels, root);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok [{\"id\":1,\"key\":\"test_key\",\"value\":\"test_value\"}]");
+    assert_int_equal(ret, OS_SUCCESS);
+
+}
+
 int main()
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_open_global_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_no_space, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_substr_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_sql_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_sql_success, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_sql_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_actor_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_insert_agent_syntax_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_insert_agent_invalid_json, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_insert_agent_compliant_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_insert_agent_query_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_insert_agent_success, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_update_agent_name_syntax_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_update_agent_name_invalid_json, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_update_agent_name_invalid_data, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_update_agent_name_query_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_parse_update_agent_name_success, test_setup, test_teardown)
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_open_global_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_no_space, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_substr_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_sql_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_sql_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_sql_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_actor_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_compliant_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_invalid_data, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_version_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_version_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_version_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_version_invalid_data, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_version_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_labels_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_labels_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_labels_success, test_setup, test_teardown)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -7,43 +7,9 @@
 #include <string.h>
 
 #include "wazuh_db/wdb.h"
-
-int __wrap__mdebug1()
-{
-    return 0;
-}
-
-int __wrap__mdebug2()
-{
-    return 0;
-}
-
-int __wrap__mwarn()
-{
-    return 0;
-}
-
-int __wrap__merror()
-{
-    return 0;
-}
-
-wdb_t * __wrap_wdb_open_global()
-{
-    return mock_type(wdb_t * );
-}
-
-void __wrap_wdb_leave(){}
-
-cJSON * __wrap_wdb_exec()
-{
-    return mock_type(cJSON *);
-}
-
-const char * __wrap_sqlite3_errmsg(sqlite3 *db)
-{
-    return mock_type(const char*);
-}
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
+#include "../wrappers/externals/sqlite/sqlite3_wrappers.h"
 
 typedef struct test_struct {
     wdb_t *socket;
@@ -75,116 +41,111 @@ void test_wdb_global_parse_open_global_fail(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char *query = NULL;
+    char query[OS_BUFFER_SIZE] = "global ";
 
-    os_strdup("global ",query);
     will_return(__wrap_wdb_open_global, NULL);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: ");
+    expect_string(__wrap__mdebug2, formatted_msg, "Couldn't open DB global: queue/db/global.db");
 
     ret = wdb_parse(query, data->output);
 
     assert_string_equal(data->output, "err Couldn't open DB global");
-    assert_int_equal(ret, -1);
-
-    os_free(query);
+    assert_int_equal(ret, OS_INVALID);
 }
 
 void test_wdb_global_parse_no_space(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char * expected_output = NULL;
-    char *query = NULL;
+    char query[OS_BUFFER_SIZE] = "global";
 
-    os_strdup("global",query);
-    os_strdup ("err Invalid DB query syntax, near 'global'",expected_output);
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid DB query syntax.");
+    expect_string(__wrap__mdebug2, formatted_msg, "DB query: global");
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, expected_output);
-    assert_int_equal(ret, -1);
-
-    os_free(query);
-    os_free(expected_output);
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'global'");
+    assert_int_equal(ret, OS_INVALID);
 }
 
 void test_wdb_global_parse_substr_fail(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char *query = NULL;
-    char * expected_output = NULL;
+    char query[OS_BUFFER_SIZE] = "global error";
 
-    will_return(__wrap_wdb_open_global, 1);
-    os_strdup("global error",query);
-    os_strdup("err Invalid DB query syntax, near 'error'",expected_output);
+    will_return(__wrap_wdb_open_global, (wdb_t*)1);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: error");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid DB query syntax.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: error");
+
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, expected_output);
-    assert_int_equal(ret, -1);
-
-    os_free(query);
-    os_free(expected_output);
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'error'");
+    assert_int_equal(ret, OS_INVALID);
 }
 
 void test_wdb_global_parse_sql_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char *query = NULL; 
-    char * expected_output = NULL;
+    char query[OS_BUFFER_SIZE] = "global sql";
 
-    os_strdup("err Invalid DB query syntax, near 'sql'",expected_output);
-    os_strdup("global sql",query);
-    will_return(__wrap_wdb_open_global, 1);
+    will_return(__wrap_wdb_open_global, (wdb_t*)1);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: sql");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: sql");
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, expected_output);
-    assert_int_equal(ret, -1);
-
-    os_free(query);
-    os_free(expected_output);
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'sql'");
+    assert_int_equal(ret, OS_INVALID);
 }
 
 void test_wdb_global_parse_sql_success(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char *query = NULL; 
+    char query[OS_BUFFER_SIZE] = "global sql TEST QUERY";
+    cJSON *root = NULL;
+    cJSON *object = NULL;
+
+    root = cJSON_CreateArray();
+    object = cJSON_CreateObject();
+    cJSON_AddStringToObject(object, "test_field", "test_value");
+    cJSON_AddItemToArray(root, object);
 
     will_return(__wrap_wdb_open_global, data->socket);
-    os_strdup("global sql EXAMPLE QUERY",query);
-    cJSON *object = cJSON_CreateString("EXPECTED RESULT FROM EXAMPLE QUERY");
-    will_return(__wrap_wdb_exec,object);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: sql TEST QUERY");
+    will_return(__wrap_wdb_exec,root);
+    expect_string(__wrap_wdb_exec, sql, "TEST QUERY");
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, "ok \"EXPECTED RESULT FROM EXAMPLE QUERY\"");
-    assert_int_equal(ret, 0);
-
-    os_free(query);
+    assert_string_equal(data->output, "ok [{\"test_field\":\"test_value\"}]");
+    assert_int_equal(ret, OS_SUCCESS);
 }
 
 void test_wdb_global_parse_sql_fail(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char *query = NULL; 
+    char query[OS_BUFFER_SIZE] = "global sql TEST QUERY";
 
     will_return(__wrap_wdb_open_global, data->socket);
-    will_return(__wrap_wdb_exec,NULL);
-    will_return(__wrap_sqlite3_errmsg, "test_error");
-    will_return(__wrap_sqlite3_errmsg, "test_error");
+    expect_string(__wrap_wdb_exec, sql, "TEST QUERY");
+    will_return(__wrap_wdb_exec, NULL);
 
-    os_strdup("global sql EXAMPLE QUERY",query);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: sql TEST QUERY");
+    will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "GLobal DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: TEST QUERY");
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, "err Cannot execute Global database query; test_error");
-    assert_int_equal(ret, -1);
-
-    os_free(query);
+    assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
+    assert_int_equal(ret, OS_INVALID);
 }
 
 int main()

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2201,7 +2201,7 @@ void test_wdb_parse_global_sync_agent_info_set_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-void test_wdb_parse_get_agents_by_keepalive_syntax_error(void **state)
+void test_wdb_parse_global_get_agents_by_keepalive_syntax_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -2218,7 +2218,7 @@ void test_wdb_parse_get_agents_by_keepalive_syntax_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_get_agents_by_keepalive_condition_error(void **state)
+void test_wdb_parse_global_get_agents_by_keepalive_condition_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -2234,7 +2234,7 @@ void test_wdb_parse_get_agents_by_keepalive_condition_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_get_agents_by_keepalive_condition2_error(void **state)
+void test_wdb_parse_global_get_agents_by_keepalive_condition2_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -2250,7 +2250,7 @@ void test_wdb_parse_get_agents_by_keepalive_condition2_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_get_agents_by_keepalive_condition3_error(void **state)
+void test_wdb_parse_global_get_agents_by_keepalive_condition3_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -2266,7 +2266,7 @@ void test_wdb_parse_get_agents_by_keepalive_condition3_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_get_agents_by_keepalive_start_id_error(void **state)
+void test_wdb_parse_global_get_agents_by_keepalive_start_id_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -2282,7 +2282,7 @@ void test_wdb_parse_get_agents_by_keepalive_start_id_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_get_agents_by_keepalive_start_id2_error(void **state)
+void test_wdb_parse_global_get_agents_by_keepalive_start_id2_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -2298,7 +2298,7 @@ void test_wdb_parse_get_agents_by_keepalive_start_id2_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_get_agents_by_keepalive_success(void **state)
+void test_wdb_parse_global_get_agents_by_keepalive_success(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -2317,6 +2317,130 @@ void test_wdb_parse_get_agents_by_keepalive_success(void **state)
     assert_string_equal(data->output, "ok 1,2,3,4,5");
     assert_int_equal(ret, OS_SUCCESS);
 }
+
+void test_wdb_parse_global_get_all_agents_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-all-agents";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-all-agents");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for get-all-agents.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: get-all-agents");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-all-agents'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_all_agents_argument_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-all-agents invalid";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-all-agents invalid");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments 'start_id' not found.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid arguments 'start_id' not found");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_all_agents_argument2_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-all-agents start_id";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-all-agents start_id");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments 'start_id' not found.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid arguments 'start_id' not found");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_all_agents_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-all-agents start_id 1";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-all-agents start_id 1");
+    expect_value(__wrap_wdb_global_get_all_agents, *last_agent_id, 1);
+    will_return(__wrap_wdb_global_get_all_agents, "1,2,3,4,5");
+    will_return(__wrap_wdb_global_get_all_agents, WDBC_OK);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok 1,2,3,4,5");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_parse_global_get_agent_info_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-agent-info";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agent-info");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for get-agent-info.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: get-agent-info");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-agent-info'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_agent_info_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-agent-info 1";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agent-info 1");
+    expect_value(__wrap_wdb_global_get_agent_info, id, 1);
+    will_return(__wrap_wdb_global_get_agent_info, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error getting agent information from global.db.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Error getting agent information from global.db.");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_agent_info_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-agent-info 1";
+    cJSON *j_object = NULL;
+
+    j_object = cJSON_CreateObject();
+    cJSON_AddStringToObject(j_object, "name", "test_name");
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agent-info 1");
+    expect_value(__wrap_wdb_global_get_agent_info, id, 1);
+    will_return(__wrap_wdb_global_get_agent_info, j_object);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok {\"name\":\"test_name\"}");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
 
 int main()
 {
@@ -2434,13 +2558,20 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_del_label_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_set_label_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_success, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_get_agents_by_keepalive_syntax_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_get_agents_by_keepalive_condition_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_get_agents_by_keepalive_condition2_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_get_agents_by_keepalive_condition3_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_get_agents_by_keepalive_start_id_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_get_agents_by_keepalive_start_id2_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_get_agents_by_keepalive_success, test_setup, test_teardown)
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_condition_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_condition2_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_condition3_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_start_id_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_start_id2_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_all_agents_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_all_agents_argument_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_all_agents_argument2_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_all_agents_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_success, test_setup, test_teardown)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -228,10 +228,38 @@ cJSON* __wrap_wdb_global_select_groups(__attribute__((unused)) wdb_t *wdb) {
     return mock_ptr_type(cJSON*);
 }
 
-cJSON* __wrap_wdb_global_select_agent_keepalive(   __attribute__((unused)) wdb_t *wdb,
-                                            char* name,
-                                            char* ip) {
+cJSON* __wrap_wdb_global_select_agent_keepalive(__attribute__((unused)) wdb_t *wdb,
+                                                char* name,
+                                                char* ip) {
     check_expected(name);
     check_expected(ip);
     return mock_ptr_type(cJSON*);
+}
+
+wdbc_result __wrap_wdb_sync_agent_info_get( __attribute__((unused)) wdb_t *wdb,
+                                            int* last_agent_id,
+                                            char **output) {
+    check_expected(*last_agent_id);
+    os_strdup(mock_ptr_type(char*), *output);
+    return mock();
+}
+
+int __wrap_wdb_global_sync_agent_info_set(  __attribute__((unused)) wdb_t *wdb,
+                                            cJSON *json_agent) {
+    char *str_agent = cJSON_PrintUnformatted(json_agent);
+    check_expected(str_agent);
+    os_free(str_agent);
+    return mock();
+}
+
+wdbc_result __wrap_wdb_global_get_agents_by_keepalive(  __attribute__((unused)) wdb_t *wdb,
+                                                        int* last_agent_id,
+                                                        char comparator,
+                                                        int keep_alive,
+                                                        char **output) {
+    check_expected(*last_agent_id);
+    check_expected(comparator);
+    check_expected(keep_alive);
+    os_strdup(mock_ptr_type(char*), *output);
+    return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -1,0 +1,43 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "wdb_global_wrappers.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+int __wrap_wdb_global_insert_agent(__attribute__((unused)) wdb_t *wdb,
+                            int id,
+                            char* name,
+                            char* ip,
+                            char* register_ip,
+                            char* internal_key,
+                            char* group,
+                            int date_add) {
+    check_expected(id);
+    check_expected(name);
+    check_expected(ip);
+    check_expected(register_ip);
+    check_expected(internal_key);
+    check_expected(group);
+    check_expected(date_add);
+
+    return mock();
+}
+
+int __wrap_wdb_global_update_agent_name(__attribute__((unused)) wdb_t *wdb,
+                                        int id,
+                                        char* name) {
+    check_expected(id);
+    check_expected(name);
+
+    return mock();
+}
+

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -102,3 +102,92 @@ int __wrap_wdb_global_set_agent_label(  __attribute__((unused)) wdb_t *wdb,
     return mock();
 }
 
+int __wrap_wdb_global_update_agent_keepalive(__attribute__((unused)) wdb_t *wdb,
+                                            int id,
+                                            wdb_sync_status_t status) {
+    check_expected(id);
+    check_expected(status);
+    return mock();
+}
+
+int __wrap_wdb_global_delete_agent( __attribute__((unused)) wdb_t *wdb,
+                                    int id) {
+    check_expected(id);
+    return mock();
+}
+
+cJSON* __wrap_wdb_global_select_agent_name( __attribute__((unused)) wdb_t *wdb,
+                                            int id) {
+    check_expected(id);
+    return mock_ptr_type(cJSON*);   
+}
+
+cJSON* __wrap_wdb_global_select_agent_group(__attribute__((unused)) wdb_t *wdb,
+                                            int id) {
+    check_expected(id);
+    return mock_ptr_type(cJSON*);   
+}
+
+int __wrap_wdb_global_delete_agent_belong(  __attribute__((unused)) wdb_t *wdb,
+                                            int id) {
+    check_expected(id);
+    return mock();   
+}
+
+cJSON* __wrap_wdb_global_find_agent(__attribute__((unused)) wdb_t *wdb,
+                                    const char *name,
+                                    const char *ip) {
+    check_expected(name);
+    check_expected(ip);
+    return mock_ptr_type(cJSON*);
+}
+
+cJSON* __wrap_wdb_global_select_agent_fim_offset(   __attribute__((unused)) wdb_t *wdb,
+                                                    int id) {
+    check_expected(id);
+    return mock_ptr_type(cJSON*);
+}
+
+cJSON* __wrap_wdb_global_select_agent_reg_offset(   __attribute__((unused)) wdb_t *wdb,
+                                                    int id) {
+    check_expected(id);
+    return mock_ptr_type(cJSON*);
+}
+
+int __wrap_wdb_global_update_agent_fim_offset(  __attribute__((unused)) wdb_t *wdb,
+                                                int id,
+                                                long offset) {
+    check_expected(id);
+    check_expected(offset);
+    return mock();
+}
+
+int __wrap_wdb_global_update_agent_reg_offset(  __attribute__((unused)) wdb_t *wdb,
+                                                int id,
+                                                long offset) {
+    check_expected(id);
+    check_expected(offset);
+    return mock();
+}
+
+cJSON* __wrap_wdb_global_select_agent_status(       __attribute__((unused)) wdb_t *wdb,
+                                                    int id) {
+    check_expected(id);
+    return mock_ptr_type(cJSON*);
+}
+
+int __wrap_wdb_global_update_agent_status(      __attribute__((unused)) wdb_t *wdb,
+                                                int id,
+                                                char *status) {
+    check_expected(id);
+    check_expected(status);
+    return mock();
+}
+
+int __wrap_wdb_global_update_agent_group(       __attribute__((unused)) wdb_t *wdb,
+                                                int id,
+                                                char *group) {
+    check_expected(id);
+    check_expected(group);
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -41,3 +41,47 @@ int __wrap_wdb_global_update_agent_name(__attribute__((unused)) wdb_t *wdb,
     return mock();
 }
 
+int __wrap_wdb_global_update_agent_version( __attribute__((unused)) wdb_t *wdb,
+                                            int id,
+                                            const char *os_name,
+                                            const char *os_version,
+                                            const char *os_major,
+                                            const char *os_minor,
+                                            const char *os_codename,
+                                            const char *os_platform,
+                                            const char *os_build,
+                                            const char *os_uname,
+                                            const char *os_arch,
+                                            const char *version,
+                                            const char *config_sum,
+                                            const char *merged_sum,
+                                            const char *manager_host,
+                                            const char *node_name,
+                                            const char *agent_ip,
+                                            wdb_sync_status_t sync_status) {
+    check_expected(id);
+    check_expected(os_name);
+    check_expected(os_version);
+    check_expected(os_major);
+    check_expected(os_minor);
+    check_expected(os_codename);
+    check_expected(os_platform);
+    check_expected(os_build);
+    check_expected(os_uname);
+    check_expected(os_arch);
+    check_expected(version);
+    check_expected(config_sum);
+    check_expected(merged_sum);
+    check_expected(manager_host);
+    check_expected(node_name);
+    check_expected(agent_ip);
+    check_expected(sync_status);
+
+    return mock();
+}
+
+cJSON* __wrap_wdb_global_get_agent_labels(  __attribute__((unused)) wdb_t *wdb,
+                                            int id) {
+    check_expected(id);
+    return mock_ptr_type(cJSON*);
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -263,3 +263,17 @@ wdbc_result __wrap_wdb_global_get_agents_by_keepalive(  __attribute__((unused)) 
     os_strdup(mock_ptr_type(char*), *output);
     return mock();
 }
+
+wdbc_result __wrap_wdb_global_get_all_agents(   __attribute__((unused)) wdb_t *wdb,
+                                                int* last_agent_id,
+                                                char **output) {
+    check_expected(*last_agent_id);
+    os_strdup(mock_ptr_type(char*), *output);
+    return mock();
+}
+
+cJSON* __wrap_wdb_global_get_agent_info(__attribute__((unused)) wdb_t *wdb,
+                                        int id){
+    check_expected(id);
+    return mock_ptr_type(cJSON*);
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -85,3 +85,20 @@ cJSON* __wrap_wdb_global_get_agent_labels(  __attribute__((unused)) wdb_t *wdb,
     check_expected(id);
     return mock_ptr_type(cJSON*);
 }
+
+int __wrap_wdb_global_del_agent_labels( __attribute__((unused)) wdb_t *wdb,
+                                        int id) {
+    check_expected(id);
+    return mock();
+}
+
+int __wrap_wdb_global_set_agent_label(  __attribute__((unused)) wdb_t *wdb,
+                                        int id,
+                                        char* key,
+                                        char* value){
+    check_expected(id);
+    check_expected(key);
+    check_expected(value);
+    return mock();
+}
+

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -191,3 +191,35 @@ int __wrap_wdb_global_update_agent_group(       __attribute__((unused)) wdb_t *w
     check_expected(group);
     return mock();
 }
+
+cJSON* __wrap_wdb_global_find_group(__attribute__((unused)) wdb_t *wdb,
+                                    char *group_name) {
+    check_expected(group_name);
+    return mock_ptr_type(cJSON*);
+}
+
+int __wrap_wdb_global_insert_agent_group(   __attribute__((unused)) wdb_t *wdb,
+                                            char *group_name) {
+    check_expected(group_name);
+    return mock();
+}
+
+int __wrap_wdb_global_insert_agent_belong(  __attribute__((unused)) wdb_t *wdb,
+                                            int id_group,
+                                            int id_agent) {
+    check_expected(id_group);
+    check_expected(id_agent);
+    return mock();
+}
+
+int __wrap_wdb_global_delete_group_belong(   __attribute__((unused)) wdb_t *wdb,
+                                            char *group_name) {
+    check_expected(group_name);
+    return mock();
+}
+
+int __wrap_wdb_global_delete_group(         __attribute__((unused)) wdb_t *wdb,
+                                            char *group_name) {
+    check_expected(group_name);
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -218,8 +218,20 @@ int __wrap_wdb_global_delete_group_belong(   __attribute__((unused)) wdb_t *wdb,
     return mock();
 }
 
-int __wrap_wdb_global_delete_group(         __attribute__((unused)) wdb_t *wdb,
-                                            char *group_name) {
+int __wrap_wdb_global_delete_group( __attribute__((unused)) wdb_t *wdb,
+                                    char *group_name) {
     check_expected(group_name);
     return mock();
+}
+
+cJSON* __wrap_wdb_global_select_groups(__attribute__((unused)) wdb_t *wdb) {
+    return mock_ptr_type(cJSON*);
+}
+
+cJSON* __wrap_wdb_global_select_agent_keepalive(   __attribute__((unused)) wdb_t *wdb,
+                                            char* name,
+                                            char* ip) {
+    check_expected(name);
+    check_expected(ip);
+    return mock_ptr_type(cJSON*);
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -14,7 +14,9 @@
 #include "wazuh_db/wdb.h"
 
 int __wrap_wdb_global_insert_agent(wdb_t *wdb, int id, char* name, char* ip, char* register_ip, char* internal_key,char* group, int date_add);
+
 int __wrap_wdb_global_update_agent_name(wdb_t *wdb, int id, char* name);
+
 int __wrap_wdb_global_update_agent_version(wdb_t *wdb,
                                     int id,
                                     const char *os_name,
@@ -35,5 +37,9 @@ int __wrap_wdb_global_update_agent_version(wdb_t *wdb,
                                     wdb_sync_status_t sync_status);
 
 cJSON* __wrap_wdb_global_get_agent_labels(wdb_t *wdb, int id);
+
+int __wrap_wdb_global_del_agent_labels(wdb_t *wdb, int id);
+
+int __wrap_wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -82,4 +82,10 @@ cJSON* __wrap_wdb_global_select_groups(wdb_t *wdb);
 
 cJSON* __wrap_wdb_global_select_agent_keepalive(wdb_t *wdb, char* name, char* ip);
 
+wdbc_result __wrap_wdb_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char **output);
+
+int __wrap_wdb_global_sync_agent_info_set(wdb_t *wdb,cJSON * json_agent);
+
+wdbc_result __wrap_wdb_global_get_agents_by_keepalive(wdb_t *wdb, int* last_agent_id, char comparator, int keep_alive, char **output);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -42,4 +42,30 @@ int __wrap_wdb_global_del_agent_labels(wdb_t *wdb, int id);
 
 int __wrap_wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value);
 
+int __wrap_wdb_global_update_agent_keepalive(wdb_t *wdb, int id, wdb_sync_status_t status);
+
+int __wrap_wdb_global_delete_agent(wdb_t *wdb, int id);
+
+cJSON* __wrap_wdb_global_select_agent_name(wdb_t *wdb, int id);
+
+cJSON* __wrap_wdb_global_select_agent_group(wdb_t *wdb, int id);
+
+int __wrap_wdb_global_delete_agent_belong(wdb_t *wdb, int id);
+
+cJSON* __wrap_wdb_global_find_agent(wdb_t *wdb, const char *name, const char *ip);
+
+cJSON* __wrap_wdb_global_select_agent_fim_offset(wdb_t *wdb, int id);
+
+cJSON* __wrap_wdb_global_select_agent_reg_offset(wdb_t *wdb, int id);
+
+int __wrap_wdb_global_update_agent_fim_offset(wdb_t *wdb, int id, long offset);
+
+int __wrap_wdb_global_update_agent_reg_offset(wdb_t *wdb, int id, long offset);
+
+cJSON* __wrap_wdb_global_select_agent_status(wdb_t *wdb, int id);
+
+int __wrap_wdb_global_update_agent_status(wdb_t *wdb, int id, char *status);
+
+int __wrap_wdb_global_update_agent_group(wdb_t *wdb, int id, char *group);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -88,4 +88,8 @@ int __wrap_wdb_global_sync_agent_info_set(wdb_t *wdb,cJSON * json_agent);
 
 wdbc_result __wrap_wdb_global_get_agents_by_keepalive(wdb_t *wdb, int* last_agent_id, char comparator, int keep_alive, char **output);
 
+wdbc_result __wrap_wdb_global_get_all_agents(wdb_t *wdb, int* last_agent_id, char **output);
+
+cJSON* __wrap_wdb_global_get_agent_info(wdb_t *wdb, int id);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -78,4 +78,8 @@ int __wrap_wdb_global_delete_group_belong(wdb_t *wdb, char* group_name);
 
 int __wrap_wdb_global_delete_group(wdb_t *wdb, char* group_name);
 
+cJSON* __wrap_wdb_global_select_groups(wdb_t *wdb);
+
+cJSON* __wrap_wdb_global_select_agent_keepalive(wdb_t *wdb, char* name, char* ip);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -15,5 +15,25 @@
 
 int __wrap_wdb_global_insert_agent(wdb_t *wdb, int id, char* name, char* ip, char* register_ip, char* internal_key,char* group, int date_add);
 int __wrap_wdb_global_update_agent_name(wdb_t *wdb, int id, char* name);
+int __wrap_wdb_global_update_agent_version(wdb_t *wdb,
+                                    int id,
+                                    const char *os_name,
+                                    const char *os_version,
+                                    const char *os_major,
+                                    const char *os_minor,
+                                    const char *os_codename,
+                                    const char *os_platform,
+                                    const char *os_build,
+                                    const char *os_uname,
+                                    const char *os_arch,
+                                    const char *version,
+                                    const char *config_sum,
+                                    const char *merged_sum,
+                                    const char *manager_host,
+                                    const char *node_name,
+                                    const char *agent_ip,
+                                    wdb_sync_status_t sync_status);
+
+cJSON* __wrap_wdb_global_get_agent_labels(wdb_t *wdb, int id);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -68,4 +68,14 @@ int __wrap_wdb_global_update_agent_status(wdb_t *wdb, int id, char *status);
 
 int __wrap_wdb_global_update_agent_group(wdb_t *wdb, int id, char *group);
 
+cJSON* __wrap_wdb_global_find_group(wdb_t *wdb, char* group_name);
+
+int __wrap_wdb_global_insert_agent_group(wdb_t *wdb, char* group_name);
+
+int __wrap_wdb_global_insert_agent_belong(wdb_t *wdb, int id_group, int id_agent);
+
+int __wrap_wdb_global_delete_group_belong(wdb_t *wdb, char* group_name);
+
+int __wrap_wdb_global_delete_group(wdb_t *wdb, char* group_name);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -1,0 +1,19 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef WDB_GLOBAL_WRAPPERS_H
+#define WDB_GLOBAL_WRAPPERS_H
+
+#include "wazuh_db/wdb.h"
+
+int __wrap_wdb_global_insert_agent(wdb_t *wdb, int id, char* name, char* ip, char* register_ip, char* internal_key,char* group, int date_add);
+int __wrap_wdb_global_update_agent_name(wdb_t *wdb, int id, char* name);
+
+#endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -91,10 +91,6 @@ cJSON * __wrap_wdb_exec_stmt(__attribute__((unused)) sqlite3_stmt *stmt) {
     return mock_ptr_type(cJSON *);
 }
 
-cJSON * __wrap_wdb_exec(__attribute__((unused)) sqlite3_stmt *stmt) {
-    return mock_ptr_type(cJSON *);
-}
-
 int __wrap_wdbc_parse_result(char *result, char **payload) {
     int retval = mock();
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -13,6 +13,10 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
+wdb_t* __wrap_wdb_open_global() {
+    return mock_ptr_type(wdb_t*);
+}
+
 int __wrap_wdb_begin2(__attribute__((unused)) wdb_t* aux) {
     return mock();
 }
@@ -146,3 +150,10 @@ cJSON* __wrap_wdbc_query_parse_json(__attribute__((unused)) int *sock,
 
     return mock_ptr_type(cJSON *);
 }
+cJSON* __wrap_wdb_exec(__attribute__((unused)) sqlite3 *db, 
+                 const char *sql) {
+    check_expected(sql);
+    return mock_ptr_type(cJSON*);
+}
+
+void __wrap_wdb_leave(__attribute__((unused)) wdb_t * wdb){;}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -156,4 +156,4 @@ cJSON* __wrap_wdb_exec(__attribute__((unused)) sqlite3 *db,
     return mock_ptr_type(cJSON*);
 }
 
-void __wrap_wdb_leave(__attribute__((unused)) wdb_t * wdb){;}
+void __wrap_wdb_leave(__attribute__((unused)) wdb_t *wdb){;}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -13,6 +13,8 @@
 
 #include "wazuh_db/wdb.h"
 
+wdb_t* __wrap_wdb_open_global();
+
 int __wrap_wdb_begin2(wdb_t* aux);
 
 int __wrap_wdb_fim_clean_old_entries(wdb_t* socket);
@@ -46,5 +48,9 @@ int __wrap_wdbi_query_checksum(wdb_t *wdb, wdb_component_t component, const char
 int __wrap_wdbi_query_clear(wdb_t *wdb, wdb_component_t component, const char *payload);
 
 cJSON* __wrap_wdbc_query_parse_json(int *sock, const char *query, char *response, const int len);
+
+cJSON* __wrap_wdb_exec(sqlite3 *db, const char *sql);
+
+void __wrap_wdb_leave(wdb_t *wdb);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -43,8 +43,6 @@ int __wrap_wdb_syscheck_save2(wdb_t *wdb, const char *payload);
 
 cJSON * __wrap_wdb_exec_stmt(__attribute__((unused)) sqlite3_stmt *stmt);
 
-cJSON * __wrap_wdb_exec(__attribute__((unused)) sqlite3_stmt *stmt);
-
 int __wrap_wdbc_parse_result(char *result, char **payload);
 
 int __wrap_wdbc_query_ex(int *sock, const char *query, char *response, const int len);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1199,7 +1199,7 @@ int wdb_parse_global_sync_agent_info_set(wdb_t * wdb, char * input, char * outpu
  * @param [out] output Response of the query.
  * @return 0 Success: response contains the value. -1 On error: invalid DB query syntax.
  */
-int wdb_parse_get_agents_by_keepalive(wdb_t* wdb, char* input, char* output);
+int wdb_parse_global_get_agents_by_keepalive(wdb_t* wdb, char* input, char* output);
 
 /**
  * @brief Function to parse start_id get-all-agents.
@@ -1209,7 +1209,7 @@ int wdb_parse_get_agents_by_keepalive(wdb_t* wdb, char* input, char* output);
  * @param [out] output Response of the query.
  * @return 0 Success: response contains the value. -1 On error: invalid DB query syntax.
  */
-int wdb_parse_get_all_agents(wdb_t* wdb, char* input, char* output);
+int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output);
 
 int wdbi_checksum_range(wdb_t * wdb, wdb_component_t component, const char * begin, const char * end, os_sha1 hexdigest);
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -4253,7 +4253,7 @@ int wdb_parse_global_update_agent_version(wdb_t * wdb, char * input, char * outp
         j_agent_ip = cJSON_GetObjectItem(agent_data, "agent_ip");
         j_sync_status = cJSON_GetObjectItem(agent_data, "sync_status");
 
-        if (cJSON_IsNumber(j_id)) {
+        if (cJSON_IsNumber(j_id) && j_id->valueint) {
             // Getting each field
             int id = j_id->valueint;
             char *os_name = cJSON_IsString(j_os_name) ? j_os_name->valuestring : NULL;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -18,8 +18,8 @@ int wdb_parse(char * input, char * output) {
     char * query;
     char * sql;
     char * next;
-    int agent_id;
-    char sagent_id[64];
+    int agent_id = 0;
+    char sagent_id[64] = "000";
     wdb_t * wdb;
     cJSON * data;
     char * out;
@@ -419,7 +419,7 @@ int wdb_parse(char * input, char * output) {
                     os_free(out);
                     cJSON_Delete(data);
                 } else {
-                    mdebug1("GLobal DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB2_GLOB_NAME, sqlite3_errmsg(wdb->db));
+                    mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB2_GLOB_NAME, sqlite3_errmsg(wdb->db));
                     mdebug2("Global DB SQL query: %s", next);
                     snprintf(output, OS_MAXSTR + 1, "err Cannot execute Global database query; %s", sqlite3_errmsg(wdb->db));
                     result = OS_INVALID;
@@ -4131,7 +4131,7 @@ int wdb_parse_global_insert_agent(wdb_t * wdb, char * input, char * output) {
 
         // These are the only constraints defined in the database for this
         // set of parameters. All the other parameters could be NULL.
-        if (cJSON_IsNumber(j_id) &&
+        if (cJSON_IsNumber(j_id) && j_id->valueint &&
             cJSON_IsString(j_name) && j_name->valuestring &&
             cJSON_IsNumber(j_date_add) && j_date_add->valueint) {
 
@@ -4180,7 +4180,7 @@ int wdb_parse_global_update_agent_name(wdb_t * wdb, char * input, char * output)
         j_id = cJSON_GetObjectItem(agent_data, "id");
         j_name = cJSON_GetObjectItem(agent_data, "name");
 
-        if (cJSON_IsNumber(j_id) &&
+        if (cJSON_IsNumber(j_id) && j_id->valueint &&
             cJSON_IsString(j_name) && j_name->valuestring) {
 
             // Getting each field

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -4990,8 +4990,8 @@ int wdb_parse_global_sync_agent_info_set(wdb_t * wdb, char * input, char * outpu
                 agent_id = cJSON_IsNumber(json_field) ? json_field->valueint : -1;
 
                 if (agent_id == -1){
-                    mdebug1("Global DB Cannot execute SQL query; incorrect agent id in labels array");
-                    snprintf(output, OS_MAXSTR + 1, "err Cannot update labels due to invalid id;");
+                    mdebug1("Global DB Cannot execute SQL query; incorrect agent id in labels array.");
+                    snprintf(output, OS_MAXSTR + 1, "err Cannot update labels due to invalid id.");
                     cJSON_Delete(root);
                     return OS_INVALID;
                 }
@@ -5062,20 +5062,20 @@ int wdb_parse_get_agents_by_keepalive(wdb_t* wdb, char* input, char* output) {
     /* Get keepalive condition */
     next = strtok_r(input, delim, &savedptr);
     if (next == NULL || strcmp(input, "condition") != 0) {
-        mdebug1("Invalid arguments 'condition' not found");
+        mdebug1("Invalid arguments 'condition' not found.");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'condition' not found");
         return OS_INVALID;
     }
     next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL) {
-        mdebug1("Invalid arguments 'condition' not found");
+        mdebug1("Invalid arguments 'condition' not found.");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'condition' not found");
         return OS_INVALID;
     }
     comparator = *next;
     next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL) {
-        mdebug1("Invalid arguments 'condition' not found");
+        mdebug1("Invalid arguments 'condition' not found.");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'condition' not found");
         return OS_INVALID;
     }
@@ -5084,13 +5084,13 @@ int wdb_parse_get_agents_by_keepalive(wdb_t* wdb, char* input, char* output) {
     /* Get start_id*/
     next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL || strcmp(next, "start_id") != 0) {
-        mdebug1("Invalid arguments 'start_id' not found");
+        mdebug1("Invalid arguments 'start_id' not found.");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'start_id' not found");
         return OS_INVALID;
     }
     next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL) {
-        mdebug1("Invalid arguments 'start_id' not found");
+        mdebug1("Invalid arguments 'start_id' not found.");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'start_id' not found");
         return OS_INVALID;
     }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -662,7 +662,7 @@ int wdb_parse(char * input, char * output) {
                 snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
                 result = OS_INVALID;
             } else {
-                result = wdb_parse_get_agents_by_keepalive(wdb, next, output);
+                result = wdb_parse_global_get_agents_by_keepalive(wdb, next, output);
             }
         }
         else if (strcmp(query, "get-all-agents") == 0) { 
@@ -672,12 +672,12 @@ int wdb_parse(char * input, char * output) {
                 snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
                 result = OS_INVALID;
             } else {
-                result = wdb_parse_get_all_agents(wdb, next, output);
+                result = wdb_parse_global_get_all_agents(wdb, next, output);
             }
         }
         else if (strcmp(query, "get-agent-info") == 0) {
             if (!next) {
-                mdebug1("Global DB Invalid DB query syntax.");
+                mdebug1("Global DB Invalid DB query syntax for get-agent-info.");
                 mdebug2("Global DB query error near: %s", query);
                 snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
                 result = OS_INVALID;
@@ -5037,7 +5037,7 @@ int wdb_parse_global_get_agent_info(wdb_t* wdb, char* input, char* output) {
     agent_id = atoi(input);
 
     if (agent_info = wdb_global_get_agent_info(wdb, agent_id), !agent_info) {
-        mdebug1("Error getting agent information from Wazuh DB.");
+        mdebug1("Error getting agent information from global.db.");
         snprintf(output, OS_MAXSTR + 1, "err Error getting agent information from global.db.");
         return OS_INVALID;
     }
@@ -5050,7 +5050,7 @@ int wdb_parse_global_get_agent_info(wdb_t* wdb, char* input, char* output) {
     return OS_SUCCESS;
 }
 
-int wdb_parse_get_agents_by_keepalive(wdb_t* wdb, char* input, char* output) {
+int wdb_parse_global_get_agents_by_keepalive(wdb_t* wdb, char* input, char* output) {
     static int start_id = 0;
     char* out = NULL;
     char *next = NULL;
@@ -5104,7 +5104,7 @@ int wdb_parse_get_agents_by_keepalive(wdb_t* wdb, char* input, char* output) {
     return OS_SUCCESS;
 }
 
-int wdb_parse_get_all_agents(wdb_t* wdb, char* input, char* output) {
+int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output) {
     int start_id = 0;
     char* out = NULL;
     char *next = NULL;
@@ -5114,13 +5114,13 @@ int wdb_parse_get_all_agents(wdb_t* wdb, char* input, char* output) {
     /* Get start_id*/
     next = strtok_r(input, delim, &savedptr);
     if (next == NULL || strcmp(input, "start_id") != 0) {
-        mdebug1("Invalid arguments 'start_id' not found");
+        mdebug1("Invalid arguments 'start_id' not found.");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'start_id' not found");
         return OS_INVALID;
     }
     next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL) {
-        mdebug1("Invalid arguments 'start_id' not found");
+        mdebug1("Invalid arguments 'start_id' not found.");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'start_id' not found");
         return OS_INVALID;
     }


### PR DESCRIPTION
|Related issue|
|---|
|#5883|

## Description
This PR adds UT for all the **wdb_parse_global_** methods in `wdb_parser.c` and for every command related to Wazuh DB in **wdb_parse()**
<!--
Add a clear description of how the problem has been solved.
-->
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)
