### PR TITLE
Fix check token type

### DIFF
--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -679,8 +679,7 @@ int w_logtest_check_input_request(cJSON * root, OSList * list_msg) {
     }
 
     token = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_TOKEN);
-    if (token && (!cJSON_IsString(token)
-        || (cJSON_IsString(token) && token->valuestring && strlen(token->valuestring) != W_LOGTEST_TOKEN_LENGH))) {
+    if (token && (!cJSON_IsString(token) || !valid_str_session(token, W_LOGTEST_TOKEN_LENGH)) {
         
         char * str_token = NULL;
         

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -679,10 +679,21 @@ int w_logtest_check_input_request(cJSON * root, OSList * list_msg) {
     }
 
     token = cJSON_GetObjectItemCaseSensitive(root, W_LOGTEST_JSON_TOKEN);
-    if (cJSON_IsString(token) && token->valuestring != NULL && strlen(token->valuestring) != W_LOGTEST_TOKEN_LENGH) {
+    if (token && (!cJSON_IsString(token)
+        || (cJSON_IsString(token) && token->valuestring && strlen(token->valuestring) != W_LOGTEST_TOKEN_LENGH))) {
+        
+        char * str_token = NULL;
+        
+        if (cJSON_IsString(token)) {
+            os_strdup(token->valuestring, str_token);
+        } else {
+            str_token = cJSON_PrintUnformatted(token);
+        }
 
-        mdebug1(LOGTEST_ERROR_TOKEN_INVALID, token->valuestring);
-        smwarn(list_msg, LOGTEST_ERROR_TOKEN_INVALID, token->valuestring);
+        mdebug1(LOGTEST_ERROR_TOKEN_INVALID, str_token);
+        smwarn(list_msg, LOGTEST_ERROR_TOKEN_INVALID, str_token);
+        os_free(str_token);
+
         cJSON_DeleteItemFromObjectCaseSensitive(root, W_LOGTEST_JSON_TOKEN);
     }
 

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -52,6 +52,7 @@
 #define W_LOGTEST_REQUEST_TYPE_REMOVE_SESSION     0   ///< Request remove session
 #define W_LOGTEST_REQUEST_TYPE_LOG_PROCESSING     1   ///< Request log processing
 
+#define valid_str_session(x,y) (cJSON_IsString(x) && x->valuestring && strlen(x->valuestring) == y) ? 1 : 0)
 
 /**
  * @brief A w_logtest_session_t instance represents a client


### PR DESCRIPTION
Hey Team!,

This PR, fix a check in logtest.

Add the check of the token field, now in addition to checking if it is a valid string, check if it is another type of data and warn the user with a warning of invalidity of the token

## Tasks
  - [x] Scan-build report
  - [x] Compile witouth warnings in linux
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] Unit Test

Regards,
Julian.