### PR TITLE
Change Saving Backup log message

### DIFF
--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -189,8 +189,8 @@ w_err_t w_auth_validate_data (char *response, const char *ip, const char *agentn
         if (index = OS_IsAllowedIP(&keys, ip), index >= 0) {
             if (config.flags.force_insert && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= config.force_time || antiquity < 0)) {
                 id_exist = keys.keyentries[index]->id;
-                minfo("Duplicated IP '%s' (%s). Saving backup.", ip, id_exist);
-
+                minfo("Duplicated IP '%s' (%s). Removing old agent.", ip, id_exist);
+                
                 add_remove(keys.keyentries[index]);
                 OS_DeleteKey(&keys, id_exist, 0);
             } else {
@@ -214,7 +214,7 @@ w_err_t w_auth_validate_data (char *response, const char *ip, const char *agentn
     if (index = OS_IsAllowedName(&keys, agentname), index >= 0) {
         if (config.flags.force_insert && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= config.force_time || antiquity < 0)) {
             id_exist = keys.keyentries[index]->id;
-            minfo("Duplicated name '%s' (%s). Saving backup.", agentname, id_exist);
+            minfo("Duplicated name '%s' (%s). Removing old agent.", agentname, id_exist);
 
             add_remove(keys.keyentries[index]);
             OS_DeleteKey(&keys, id_exist, 0);

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -190,7 +190,7 @@ w_err_t w_auth_validate_data (char *response, const char *ip, const char *agentn
             if (config.flags.force_insert && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= config.force_time || antiquity < 0)) {
                 id_exist = keys.keyentries[index]->id;
                 minfo("Duplicated IP '%s' (%s). Removing old agent.", ip, id_exist);
-                
+
                 add_remove(keys.keyentries[index]);
                 OS_DeleteKey(&keys, id_exist, 0);
             } else {

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -316,7 +316,7 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
     if (id && (index = OS_IsAllowedID(&keys, id), index >= 0)) {
         if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
             id_exist = keys.keyentries[index]->id;
-            minfo("Duplicated ID '%s' (%s). Saving backup.", id, id_exist);
+            minfo("Duplicated ID '%s' (%s). Removing old agent.", id, id_exist);
             add_remove(keys.keyentries[index]);
             OS_DeleteKey(&keys, id_exist, 0);
         } else {
@@ -331,7 +331,7 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
         if (index = OS_IsAllowedIP(&keys, ip), index >= 0) {
             if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
                 id_exist = keys.keyentries[index]->id;
-                minfo("Duplicated IP '%s' (%s). Saving backup.", ip, id_exist);
+                minfo("Duplicated IP '%s' (%s). Removing old agent.", ip, id_exist);
                 add_remove(keys.keyentries[index]);
                 OS_DeleteKey(&keys, id_exist, 0);
             } else {
@@ -353,7 +353,7 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
     if (index = OS_IsAllowedName(&keys, name), index >= 0) {
         if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
             id_exist = keys.keyentries[index]->id;
-            minfo("Duplicated name '%s' (%s). Saving backup.", name, id_exist);
+            minfo("Duplicated name '%s' (%s). Removing old agent.", name, id_exist);
             add_remove(keys.keyentries[index]);
             OS_DeleteKey(&keys, id_exist, 0);
         } else {

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -188,15 +188,15 @@ static void test_w_auth_validate_data_force_insert(void **state) {
 
     /* Duplicated IP*/
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicated IP '"EXISTENT_IP1"' (001). Removing old agent.");            
-    err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL);  
+    expect_string(__wrap__minfo, formatted_msg, "Duplicated IP '"EXISTENT_IP1"' (001). Removing old agent.");
+    err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 
      /* Duplicated Name*/
     response[0] = '\0';
     expect_string(__wrap__minfo, formatted_msg, "Duplicated name '"EXISTENT_AGENT2"' (002). Removing old agent.");
-    err = w_auth_validate_data(response, NEW_IP2, EXISTENT_AGENT2, NULL);  
+    err = w_auth_validate_data(response, NEW_IP2, EXISTENT_AGENT2, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -188,15 +188,15 @@ static void test_w_auth_validate_data_force_insert(void **state) {
 
     /* Duplicated IP*/
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicated IP '"EXISTENT_IP1"' (001). Saving backup.");
-    err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL);
+    expect_string(__wrap__minfo, formatted_msg, "Duplicated IP '"EXISTENT_IP1"' (001). Removing old agent.");            
+    err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL);  
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 
      /* Duplicated Name*/
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicated name '"EXISTENT_AGENT2"' (002). Saving backup.");
-    err = w_auth_validate_data(response, NEW_IP2, EXISTENT_AGENT2, NULL);
+    expect_string(__wrap__minfo, formatted_msg, "Duplicated name '"EXISTENT_AGENT2"' (002). Removing old agent.");
+    err = w_auth_validate_data(response, NEW_IP2, EXISTENT_AGENT2, NULL);  
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 


### PR DESCRIPTION
## Description
This PR fixes the log when a new registered agent is duplicated. Previously, it was saved as backup, now is removed.