### PR TITLE
5958 openssl wrapper class

### DIFF
--- a/src/shared_modules/utils/hashHelper.h
+++ b/src/shared_modules/utils/hashHelper.h
@@ -1,0 +1,120 @@
+/*
+ * Wazuh DBSYNC
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * June 11, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HASH_HELPER_H
+#define _HASH_HELPER_H
+
+#include <openssl/evp.h>
+#include <vector>
+#include <memory>
+
+namespace Utils
+{
+    enum class HashType
+    {
+        Sha1,
+        Sha256,
+    };
+    class HashData
+    {
+    public:
+        HashData(const HashType hashType = HashType::Sha1)
+        : m_spCtx{createContext()}
+        {
+            initializeContext(hashType, m_spCtx);
+        }
+        ~HashData() = default;
+
+        void update(const void* data, const size_t size)
+        {
+            const auto ret
+            {
+                EVP_DigestUpdate(m_spCtx.get(), data, size)
+            };
+            // LCOV_EXCL_START
+            if (!ret)
+            {
+                throw std::runtime_error
+                {
+                    "Error getting digest final."
+                };
+            }
+            // LCOV_EXCL_START
+        }
+        std::vector<unsigned char> hash()
+        {
+            unsigned char digest[EVP_MAX_MD_SIZE]{0};
+            unsigned int digestSize{0};
+            const auto ret
+            {
+                EVP_DigestFinal_ex(m_spCtx.get(), digest, &digestSize)
+            };
+            // LCOV_EXCL_START
+            if (!ret)
+            {
+                throw std::runtime_error
+                {
+                    "Error getting digest final."
+                };
+            }
+            // LCOV_EXCL_STOP
+            return {digest, digest+digestSize};
+        }
+    private:
+        struct EvpContextDeleter
+        {
+            void operator()(EVP_MD_CTX* ctx)
+            {
+                EVP_MD_CTX_destroy(ctx);
+            }
+        };
+
+        static EVP_MD_CTX* createContext()
+        {
+            auto ctx{ EVP_MD_CTX_create() };
+            // LCOV_EXCL_START
+            if (!ctx)
+            {
+                throw std::runtime_error
+                {
+                    "Error creating EVP_MD_CTX."
+                };
+            }
+            // LCOV_EXCL_STOP
+            return ctx;
+        }
+        static void initializeContext(const HashType hashType, std::unique_ptr<EVP_MD_CTX, EvpContextDeleter>& spCtx)
+        {
+            auto ret{0};
+            switch(hashType)
+            {
+                case HashType::Sha1:
+                    ret = EVP_DigestInit(spCtx.get(), EVP_sha1());
+                    break;
+                case HashType::Sha256:
+                    ret = EVP_DigestInit(spCtx.get(), EVP_sha256());
+                    break;
+            }
+            if (!ret)
+            {
+                throw std::runtime_error
+                {
+                    "Error initializing EVP_MD_CTX."
+                };
+            }
+        }
+        std::unique_ptr<EVP_MD_CTX, EvpContextDeleter> m_spCtx;
+    };
+
+
+}
+
+#endif // _HASH_HELPER_H

--- a/src/shared_modules/utils/hashHelper.h
+++ b/src/shared_modules/utils/hashHelper.h
@@ -1,7 +1,7 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
- * June 11, 2020.
+ * Sep 8, 2020.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
@@ -47,7 +47,7 @@ namespace Utils
                     "Error getting digest final."
                 };
             }
-            // LCOV_EXCL_START
+            // LCOV_EXCL_STOP
         }
         std::vector<unsigned char> hash()
         {
@@ -69,7 +69,7 @@ namespace Utils
             return {digest, digest+digestSize};
         }
     private:
-        struct EvpContextDeleter
+        struct EvpContextDeleter final
         {
             void operator()(EVP_MD_CTX* ctx)
             {

--- a/src/shared_modules/utils/hashHelper.h
+++ b/src/shared_modules/utils/hashHelper.h
@@ -12,9 +12,9 @@
 #ifndef _HASH_HELPER_H
 #define _HASH_HELPER_H
 
-#include <openssl/evp.h>
 #include <vector>
 #include <memory>
+#include "openssl/evp.h"
 
 namespace Utils
 {

--- a/src/shared_modules/utils/makeUnique.h
+++ b/src/shared_modules/utils/makeUnique.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *

--- a/src/shared_modules/utils/msgDispatcher.h
+++ b/src/shared_modules/utils/msgDispatcher.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * August 28, 2020.
  *

--- a/src/shared_modules/utils/pipelineNodesImp.h
+++ b/src/shared_modules/utils/pipelineNodesImp.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *

--- a/src/shared_modules/utils/pipelinePattern.h
+++ b/src/shared_modules/utils/pipelinePattern.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * June 11, 2020.
  *

--- a/src/shared_modules/utils/tests/CMakeLists.txt
+++ b/src/shared_modules/utils/tests/CMakeLists.txt
@@ -10,11 +10,13 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage")
 include_directories(${SRC_FOLDER}/shared_modules/utils/)
 include_directories(${SRC_FOLDER}/external/googletest/googletest/include/)
 include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
+include_directories(${SRC_FOLDER}/external/openssl/include/)
 
 file(GLOB UTIL_CXX_UNITTEST_SRC
     "*.cpp")
 
 link_directories(${SRC_FOLDER}/external/googletest/lib/)
+link_directories(${SRC_FOLDER}/external/openssl/)
 
 add_executable(utils_unit_test 
     "${UTIL_CXX_UNITTEST_SRC}")
@@ -31,7 +33,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         optimized gmock_maind
         pthread
         gcov
+        crypto
+        ssl
         -static-libgcc -static-libstdc++
+        ws2_32
+        crypt32
     )
 else()
     target_link_libraries(utils_unit_test
@@ -45,6 +51,8 @@ else()
         optimized gmock_maind
         gcov
         pthread
+        crypto
+        dl
     )
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 

--- a/src/shared_modules/utils/tests/hashHelper_test.cpp
+++ b/src/shared_modules/utils/tests/hashHelper_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * Sep 8, 2020.
  *

--- a/src/shared_modules/utils/tests/hashHelper_test.cpp
+++ b/src/shared_modules/utils/tests/hashHelper_test.cpp
@@ -1,0 +1,79 @@
+/*
+ * Wazuh DBSYNC
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * Sep 8, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "hashHelper_test.h"
+#include "hashHelper.h"
+
+
+void HashHelperTest::SetUp() {};
+
+void HashHelperTest::TearDown() {};
+
+using ::testing::_;
+using ::testing::Return;
+using namespace Utils;
+
+TEST_F(HashHelperTest, UnsupportedHashType)
+{
+    EXPECT_THROW(HashData hash{static_cast<HashType>(15)}, std::runtime_error);
+}
+
+TEST_F(HashHelperTest, HashHelperHashBufferSha1)
+{
+    const unsigned char expected[]{0x2d, 0x53, 0x3b, 0x9d, 0x9f, 0x0f, 0x06, 0xef, 0x4e, 0x3c, 0x23, 0xfd, 0x49, 0x6c, 0xfe, 0xb2, 0x78, 0x0e, 0xda, 0x7f};
+    const std::string data{"HASH"};
+    HashData hash;
+    hash.update(data.c_str(), data.size());
+    const auto result{ hash.hash() };
+    EXPECT_EQ(sizeof(expected), result.size());
+    EXPECT_TRUE(!memcmp(expected, result.data(), result.size()));
+}
+
+TEST_F(HashHelperTest, HashHelperHashIterativeSha1)
+{
+    const unsigned char expected[]{0x2d, 0x53, 0x3b, 0x9d, 0x9f, 0x0f, 0x06, 0xef, 0x4e, 0x3c, 0x23, 0xfd, 0x49, 0x6c, 0xfe, 0xb2, 0x78, 0x0e, 0xda, 0x7f};
+    const std::string data{"HASH"};
+    HashData hash;
+    for (const auto& value : data)
+    {
+        hash.update(&value, sizeof(value));
+    }
+    const auto result{ hash.hash() };
+    EXPECT_EQ(sizeof(expected), result.size());
+    EXPECT_TRUE(!memcmp(expected, result.data(), result.size()));
+}
+
+TEST_F(HashHelperTest, HashHelperHashBufferSha256)
+{
+    const unsigned char expected[]{0xc1, 0xfb, 0x44, 0xc7, 0x26, 0x28, 0xea, 0xe4, 0x91, 0x32, 0x06, 0x2f, 0xe5, 0x10, 0x9f, 0x65,
+                                   0x0b, 0x6a, 0x7a, 0xb9, 0x03, 0x33, 0x6e, 0x7f, 0xcd, 0x2e, 0xf8, 0xf5, 0xeb, 0xa0, 0x41, 0x51};
+    const std::string data{"HASH"};
+    HashData hash{HashType::Sha256};
+    hash.update(data.c_str(), data.size());
+    const auto result{ hash.hash() };
+    EXPECT_EQ(sizeof(expected), result.size());
+    EXPECT_TRUE(!memcmp(expected, result.data(), result.size()));
+}
+
+TEST_F(HashHelperTest, HashHelperHashIterativeSha256)
+{
+    const unsigned char expected[]{0xc1, 0xfb, 0x44, 0xc7, 0x26, 0x28, 0xea, 0xe4, 0x91, 0x32, 0x06, 0x2f, 0xe5, 0x10, 0x9f, 0x65,
+                                   0x0b, 0x6a, 0x7a, 0xb9, 0x03, 0x33, 0x6e, 0x7f, 0xcd, 0x2e, 0xf8, 0xf5, 0xeb, 0xa0, 0x41, 0x51};
+    const std::string data{"HASH"};
+    HashData hash{HashType::Sha256};
+    for (const auto& value : data)
+    {
+        hash.update(&value, sizeof(value));
+    }
+    const auto result{ hash.hash() };
+    EXPECT_EQ(sizeof(expected), result.size());
+    EXPECT_TRUE(!memcmp(expected, result.data(), result.size()));
+}

--- a/src/shared_modules/utils/tests/hashHelper_test.h
+++ b/src/shared_modules/utils/tests/hashHelper_test.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * Sep 8, 2020.
  *

--- a/src/shared_modules/utils/tests/hashHelper_test.h
+++ b/src/shared_modules/utils/tests/hashHelper_test.h
@@ -1,0 +1,27 @@
+/*
+ * Wazuh DBSYNC
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * Sep 8, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef HASH_HELPER_TESTS_H
+#define HASH_HELPER_TESTS_H
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+class HashHelperTest : public ::testing::Test
+{
+protected:
+
+    HashHelperTest() = default;
+    virtual ~HashHelperTest() = default;
+
+    void SetUp() override;
+    void TearDown() override;
+};
+#endif //HASH_HELPER_TESTS_H

--- a/src/shared_modules/utils/tests/msgDispatcher_test.cpp
+++ b/src/shared_modules/utils/tests/msgDispatcher_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * Sep 1, 2020.
  *

--- a/src/shared_modules/utils/tests/msgDispatcher_test.h
+++ b/src/shared_modules/utils/tests/msgDispatcher_test.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * Sep 1, 2020.
  *

--- a/src/shared_modules/utils/tests/pipelineNodes_test.cpp
+++ b/src/shared_modules/utils/tests/pipelineNodes_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *

--- a/src/shared_modules/utils/tests/pipelineNodes_test.h
+++ b/src/shared_modules/utils/tests/pipelineNodes_test.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *

--- a/src/shared_modules/utils/tests/stringHelper_test.h
+++ b/src/shared_modules/utils/tests/stringHelper_test.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *

--- a/src/shared_modules/utils/tests/threadDispatcher_test.cpp
+++ b/src/shared_modules/utils/tests/threadDispatcher_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *

--- a/src/shared_modules/utils/tests/threadDispatcher_test.h
+++ b/src/shared_modules/utils/tests/threadDispatcher_test.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *

--- a/src/shared_modules/utils/tests/threadSafeQueue_test.cpp
+++ b/src/shared_modules/utils/tests/threadSafeQueue_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *

--- a/src/shared_modules/utils/tests/threadSafeQueue_test.h
+++ b/src/shared_modules/utils/tests/threadSafeQueue_test.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *

--- a/src/shared_modules/utils/threadDispatcher.h
+++ b/src/shared_modules/utils/threadDispatcher.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *

--- a/src/shared_modules/utils/threadSafeQueue.h
+++ b/src/shared_modules/utils/threadSafeQueue.h
@@ -1,5 +1,5 @@
 /*
- * Wazuh DBSYNC
+ * Wazuh shared modules utils
  * Copyright (C) 2015-2020, Wazuh Inc.
  * July 14, 2020.
  *


### PR DESCRIPTION
|Related issue|
|---|
|5958|
# OpenSSL helper to hash data.

## Description
This issue aims to create a helper class to wrap open ssl APIs to hash data.

## DoD / Tasks
- [X] Implementation
- [X] RTR
![image](https://user-images.githubusercontent.com/54002291/92596462-39ee3380-f27c-11ea-8613-2bf860b8c981.png)

![image](https://user-images.githubusercontent.com/54002291/92596503-47a3b900-f27c-11ea-9cb1-01f57e245e7b.png)
