### PR TITLE
Fix VDT MSU metadata handling 

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -89,6 +89,7 @@
 #define VU_NO_SRC_NAME        "(5481): Unable to get the source '%s' name for agent '%.3d'"
 #define VU_VULN_SEND_AG_FEED  "(5482): A total of '%d' vulnerabilities have been reported for agent '%.3d' thanks to the '%s' feed."
 #define VU_NO_HOTFIX_DISABLED "(5483): No MSU data found, so the Windows hotfixes scan will be disabled for agent '%.3d'"
+#define VU_METADATA_CLEAN     "(5484): Cleaning metadata for target '%s'"
 
 /* File integrity monitoring debug messages */
 #define FIM_DIFF_SKIPPED                    "(6200): Diff execution skipped for containing insecure characters."

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -923,7 +923,6 @@ InstallLocal()
     ${INSTALL} -d -m 0660 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue/vulnerabilities
     ${INSTALL} -d -m 0440 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue/vulnerabilities/dictionaries
     ${INSTALL} -m 0440 -o root -g ${OSSEC_GROUP} wazuh_modules/vulnerability_detector/cpe_helper.json ${PREFIX}/queue/vulnerabilities/dictionaries
-    ${INSTALL} -m 0440 -o root -g ${OSSEC_GROUP} wazuh_modules/vulnerability_detector/msu.json.gz ${PREFIX}/queue/vulnerabilities/dictionaries
 
     ### Install Python
     ${MAKEBIN} wpython PREFIX=${PREFIX} TARGET=${INSTYPE}

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -16157,7 +16157,7 @@ void test_wm_vuldet_fetch_MSU_metadata_max_attempts(void **state)
 
     // Function fails attepting to download
     expect_string(__wrap_wurl_request, url, repo);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, OS_INVALID);
 
@@ -16167,7 +16167,7 @@ void test_wm_vuldet_fetch_MSU_metadata_max_attempts(void **state)
 
     // Second try
     expect_string(__wrap_wurl_request, url, repo);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, OS_INVALID);
 
@@ -16177,7 +16177,7 @@ void test_wm_vuldet_fetch_MSU_metadata_max_attempts(void **state)
 
     // Third try
     expect_string(__wrap_wurl_request, url, repo);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, OS_INVALID);
 
@@ -16187,7 +16187,7 @@ void test_wm_vuldet_fetch_MSU_metadata_max_attempts(void **state)
 
     // Fourth try
     expect_string(__wrap_wurl_request, url, repo);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, OS_INVALID);
 
@@ -16197,7 +16197,7 @@ void test_wm_vuldet_fetch_MSU_metadata_max_attempts(void **state)
 
     // Fifth try
     expect_string(__wrap_wurl_request, url, repo);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, OS_INVALID);
 
@@ -16207,7 +16207,7 @@ void test_wm_vuldet_fetch_MSU_metadata_max_attempts(void **state)
 
     // Last try
     expect_string(__wrap_wurl_request, url, repo);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, OS_INVALID);
 
@@ -16228,11 +16228,11 @@ void test_wm_vuldet_fetch_MSU_metadata_valid_attempt(void **state)
     update->timeout = 300;
 
     expect_string(__wrap_wurl_request, url, repo);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, 0);
 
-    char *path = VU_FIT_TEMP_FILE;
+    char *path = VU_TEMP_FILE;
     expect_string(__wrap_fopen, path, path);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, NULL);
@@ -16258,11 +16258,11 @@ void test_wm_vuldet_update_MSU_invalid_metadata(void **state)
 
     // download metadata
     expect_string(__wrap_wurl_request, url, repo);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, 0);
 
-    char *path = VU_FIT_TEMP_FILE;
+    char *path = VU_TEMP_FILE;
     expect_string(__wrap_fopen, path, path);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, NULL);
@@ -16285,17 +16285,17 @@ void test_wm_vuldet_update_MSU_incomplete_metadata(void **state)
 
     // download metadata
     expect_string(__wrap_wurl_request, url, repo);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, 0);
 
-    expect_string(__wrap_fopen, path, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_fopen, path, VU_TEMP_FILE);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
 
     // parse elements
     expect_value(__wrap_fgets, __stream, 1);
-    will_return(__wrap_fgets, "lastModifiedDate:12/13/13");
+    will_return(__wrap_fgets, "lastModifiedDate:2020-08-16T15:30:50-04:00");
 
     // end loop
     expect_value(__wrap_fgets, __stream, 1);
@@ -16322,17 +16322,17 @@ void test_wm_vuldet_update_MSU_valid_metadata(void **state)
 
     // download metadata
     expect_string(__wrap_wurl_request, url, repo);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, 0);
 
-    expect_string(__wrap_fopen, path, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_fopen, path, VU_TEMP_FILE);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
 
     // parse elements
     expect_value(__wrap_fgets, __stream, 1);
-    will_return(__wrap_fgets, "lastModifiedDate:12/13/13");
+    will_return(__wrap_fgets, "lastModifiedDate:2020-08-16T15:30:50-04:00");
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "sha256:abcdef");
@@ -16352,7 +16352,7 @@ void test_wm_vuldet_update_MSU_valid_metadata(void **state)
 
     // Insert
     feed_metadata msu = {0};
-    msu.last_mod = "12/13/13";
+    msu.last_mod = "2020-08-16T15:30:50-04:00";
     msu.sha256 = "abcdef";
 
     // open DB
@@ -16415,17 +16415,17 @@ void test_wm_vuldet_update_MSU_updated(void **state)
 
     // download metadata
     expect_string(__wrap_wurl_request, url, repo);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, 0);
 
-    expect_string(__wrap_fopen, path, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_fopen, path, VU_TEMP_FILE);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
 
     // parse elements
     expect_value(__wrap_fgets, __stream, 1);
-    will_return(__wrap_fgets, "lastModifiedDate:2020-06-02");
+    will_return(__wrap_fgets, "lastModifiedDate:2020-08-16T15:30:50-04:00");
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "sha256:abcdef");
@@ -16450,7 +16450,7 @@ void test_wm_vuldet_update_MSU_updated(void **state)
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
     expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020-06-02");
+    will_return(__wrap_sqlite3_column_text, "2020-08-16T15:30:50-04:00");
 
     will_return(__wrap_sqlite3_close_v2, 1);
 
@@ -16478,17 +16478,17 @@ void test_wm_vuldet_fetch_MSU_updated(void **state)
 
     // download metadata
     expect_string(__wrap_wurl_request, url, MSU_REPO_META);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, 0);
 
-    expect_string(__wrap_fopen, path, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_fopen, path, VU_TEMP_FILE);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 1);
 
     // parse elements
     expect_value(__wrap_fgets, __stream, 1);
-    will_return(__wrap_fgets, "lastModifiedDate:2020-06-02");
+    will_return(__wrap_fgets, "lastModifiedDate:2020-08-16T15:30:50-04:00");
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "sha256:abcdef");
@@ -16513,7 +16513,7 @@ void test_wm_vuldet_fetch_MSU_updated(void **state)
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
     expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020-06-02");
+    will_return(__wrap_sqlite3_column_text, "2020-08-16T15:30:50-04:00");
 
     will_return(__wrap_sqlite3_close_v2, 1);
 
@@ -16539,12 +16539,12 @@ void test_wm_vuldet_fetch_MSU_invalid_hash(void **state)
 
     // download metadata
     expect_string(__wrap_wurl_request, url, MSU_REPO_META);
-    expect_string(__wrap_wurl_request, dest, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_wurl_request, dest, VU_TEMP_FILE);
     expect_value(__wrap_wurl_request, timeout, update->timeout);
     will_return(__wrap_wurl_request, 0);
 
     // failed to open metadata file
-    expect_string(__wrap_fopen, path, VU_FIT_TEMP_FILE);
+    expect_string(__wrap_fopen, path, VU_TEMP_FILE);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, NULL);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3824,6 +3824,23 @@ int wm_vuldet_fetch_feed(update_node *update, int8_t *need_update) {
     int result;
     *need_update = 1;
 
+    // Clean metadata when set a custom location
+    if (update->url || update->multi_url || update->path || update->multi_path) {
+
+        mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_METADATA_CLEAN, vu_feed_tag[update->dist_tag_ref]);
+
+        sqlite3 *db;
+        if (sqlite3_open_v2(CVE_DB, &db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
+            return wm_vuldet_sql_error(db, NULL);
+        }
+
+        if (wm_vuldet_remove_target_table(db, METADATA_TABLE, vu_feed_tag[update->dist_tag_ref])) {
+            return OS_INVALID;
+        }
+
+        sqlite3_close_v2(db);
+    }
+
     if (!update->url && (update->path || (update->multi_path && update->dist_ref != FEED_DEBIAN))) {
         mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_LOCAL_FETCH, update->path ? update->path : update->multi_path);
         return 0;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5440,45 +5440,36 @@ feed_metadata * wm_vuldet_fetch_MSU_metadata(update_node *update) {
 feed_metadata * wm_vuldet_parse_MSU_metadata(char *path) {
     FILE *fp = NULL;
     feed_metadata *msu = NULL;
-    char *pos = NULL;
 
     if (fp = fopen(path, "r"), fp == NULL) {
         return msu;
     }
 
     char buffer[OS_MAXSTR + 1] = {0};
-    char *type = NULL;
-    char *content = NULL;
 
     os_calloc(1, sizeof(feed_metadata), msu);
 
     while (fgets(buffer, OS_MAXSTR, fp)) {
-        if (type = strtok(buffer, ":"), type == NULL) {
-            continue;
+        // Remove new line character
+        char * end;
+        if ((end = strchr(buffer, '\n')) != NULL) {
+            *end = '\0';
         }
 
-        if (content = strtok(NULL, ":"), content == NULL) {
+        char * delim;
+        if (delim = strchr(buffer, ':'), !delim) {
             continue;
         }
-
-        // Remove newline character
-        if ((pos=strchr(content, '\n')) != NULL)
-            *pos = '\0';
-
-        if (strstr("lastModifiedDate", type)) {
-            os_strdup(content, msu->last_mod);
-
-        } else if (strstr("sha256", type)) {
-            os_strdup(content, msu->sha256);
-
-        } else if (strstr("size", type)) {
-            os_strdup(content, msu->size);
-
-        } else if (strstr("gzSize", type)) {
-            os_strdup(content, msu->g_size);
-
-        } else if (strstr("version", type)) {
-            os_strdup(content, msu->version);
+        if (!strncmp(buffer, "lastModifiedDate", 16)) {
+            os_strdup(delim + 1, msu->last_mod);
+        } else if (!strncmp(buffer, "sha256", 6)) {
+            os_strdup(delim + 1, msu->sha256);
+        } else if (!strncmp(buffer, "size", 4)) {
+            os_strdup(delim + 1, msu->size);
+        } else if (!strncmp(buffer, "gzSize", 6)) {
+            os_strdup(delim + 1, msu->g_size);
+        } else if (!strncmp(buffer, "version", 7)) {
+            os_strdup(delim + 1, msu->version);
         }
     }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5497,7 +5497,7 @@ int wm_insert_MSU_metadata(feed_metadata *msu, update_node *update) {
     sqlite3_bind_text(stmt, 5, msu->last_mod, -1, NULL);
     sqlite3_bind_text(stmt, 6, msu->sha256, -1, NULL);
     sqlite3_bind_int(stmt, 7, (msu->size)? atoi(msu->size) : 0);
-    sqlite3_bind_int(stmt, 8, (msu->size)? atoi(msu->g_size) : 0);
+    sqlite3_bind_int(stmt, 8, (msu->g_size)? atoi(msu->g_size) : 0);
 
     if (wm_vuldet_step(stmt) != SQLITE_DONE) {
         return wm_vuldet_sql_error(db, stmt);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5422,7 +5422,7 @@ feed_metadata * wm_vuldet_fetch_MSU_metadata(update_node *update) {
     int res_url_request;
 
     for (int8_t attempts = 0;; attempts++) {
-        res_url_request = wurl_request(MSU_REPO_META, VU_FIT_TEMP_FILE, NULL, NULL, update->timeout);
+        res_url_request = wurl_request(MSU_REPO_META, VU_TEMP_FILE, NULL, NULL, update->timeout);
 
         if (!res_url_request) {
             break;
@@ -5434,7 +5434,7 @@ feed_metadata * wm_vuldet_fetch_MSU_metadata(update_node *update) {
         sleep(attempts);
     }
 
-    return wm_vuldet_parse_MSU_metadata(VU_FIT_TEMP_FILE);
+    return wm_vuldet_parse_MSU_metadata(VU_TEMP_FILE);
 }
 
 feed_metadata * wm_vuldet_parse_MSU_metadata(char *path) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -3865,7 +3865,7 @@ void wm_vuldet_adapt_os_cpe(cpe *ag_cpe) {
 }
 
 int wm_vuln_valid_os_cpe(vu_feed dist, cpe *ag_cpe, char *c_version) {
-    if (*ag_cpe->part != 'o') {
+    if (ag_cpe-> part && *ag_cpe->part != 'o') {
         return 1;
     }
 

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -93,7 +93,7 @@ void * wm_fluent_main(wm_fluent_t * fluent) {
     /* Listen socket */
     server_sock = OS_BindUnixDomain(fluent->sock_path, SOCK_DGRAM, OS_MAXSTR);
     if (server_sock < 0) {
-        merror("Unable to bind to socket '%s': (%d) %s.", WM_LOCAL_SOCK, errno, strerror(errno));
+        merror("Unable to bind to socket '%s': (%d) %s.", fluent->sock_path, errno, strerror(errno));
         pthread_exit(NULL);
     }
 


### PR DESCRIPTION
## Description

This PR fixes the following issues:

- https://github.com/wazuh/wazuh/commit/fc057eceaab8304091ce962b9f7a28ef3bf0e3c1: This commit fixes https://github.com/wazuh/wazuh/issues/5947. It was not only related to the MSU but all the feeds whose metadata are used to check the update status. The fix proposed consists of cleaning the metadata entry of each feed fetched from a custom location (when the metadata is not used). 

- https://github.com/wazuh/wazuh/commit/348144082b45d8d795edb578158a16439c56fcf9: Fixes https://github.com/wazuh/wazuh/issues/5965. The MSU metadata parser was failing when reading a line with more than one colon (`:`) storing only the piece of the buffer between the first and the second one.

- https://github.com/wazuh/wazuh/commit/a19fec36ded92737bc91c980c5cee32e96ec1abc: Dump the downloaded metadata file in `tmp/vuln-temp` instead of `tmp/vuln-temp-fitted` which is normally used for decompressing the feeds.

- https://github.com/wazuh/wazuh/commit/43c7512f23b7c8992b2a2c28df2d5baf60606f06: The MSU is no longer installed with the package.

- https://github.com/wazuh/wazuh/commit/46bf0a0938790642a372cff164bd90fd9aa7522d: A typo in the fluent forward module.

- https://github.com/wazuh/wazuh/commit/a507f7f8546f6a11cc33d19ae8dd7332609d11cb: Fixed two bugs reported by `scan-build`

```
wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c:3868:9: warning: Dereference of null pointer (loaded from field 'part')
    if (*ag_cpe->part != 'o') {
        ^~~~~~~~~~~~~
1 warning generated.
wazuh_modules/vulnerability_detector/wm_vuln_detector.c:5500:44: warning: Null pointer passed as an argument to a 'nonnull' parameter
    sqlite3_bind_int(stmt, 8, (msu->size)? atoi(msu->g_size) : 0);
                                           ^~~~~~~~~~~~~~~~~
1 warning generated.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- [x] Added unit tests (for new features)
