### PR TITLE
Improve error handling when uncompressing gz files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -981,6 +981,9 @@ wrappers_externals_audit_o := $(wrappers_externals_audit_c:.c=.o)
 wrappers_externals_bzip2_c := $(wildcard unit_tests/wrappers/externals/bzip2/*.c)
 wrappers_externals_bzip2_o := $(wrappers_externals_bzip2_c:.c=.o)
 
+wrappers_externals_zlib_c := $(wildcard unit_tests/wrappers/externals/zlib/*.c)
+wrappers_externals_zlib_o := $(wrappers_externals_zlib_c:.c=.o)
+
 wrappers_externals_cJSON_c := $(wildcard unit_tests/wrappers/externals/cJSON/*.c)
 wrappers_externals_cJSON_o := $(wrappers_externals_cJSON_c:.c=.o)
 
@@ -1053,6 +1056,7 @@ ifneq (,$(filter ${TEST},YES yes y Y 1))
 	UNIT_TEST_WRAPPERS:=${wrappers_common_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_bzip2_o}
+	UNIT_TEST_WRAPPERS+=${wrappers_externals_zlib_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_cJSON_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_openssl_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_sqlite_o}
@@ -1968,6 +1972,7 @@ clean-unit-tests:
 	rm -f ${wrappers_externals_o}
 	rm -f ${wrappers_externals_audit_o}
 	rm -f ${wrappers_externals_bzip2_o}
+	rm -f ${wrappers_externals_zlib_o}
 	rm -f ${wrappers_externals_cJSON_o}
 	rm -f ${wrappers_externals_openssl_o}
 	rm -f ${wrappers_externals_procpc_o}

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2761,24 +2761,23 @@ int w_uncompress_gzfile(const char *gzfilesrc, const char *gzfiledst) {
     os_calloc(OS_SIZE_8192, sizeof(char), buf);
     do {
         len = gzread(gz_fd, buf, OS_SIZE_8192);
-        fwrite(buf, 1, len, fd);
-        buf[0] = '\0';
-        if (len < OS_SIZE_8192) {
-            if (gzeof(gz_fd)) {
-                break;
-            } else {
-                const char * gzerr;
-                gzerr = gzerror(gz_fd, &err);
-                if (err) {
-                    merror("in w_uncompress_gzfile(): gzread error: '%s'", gzerr);
-                    fclose(fd);
-                    gzclose(gz_fd);
-                    os_free(buf);
-                    return -1;
-                }
-            }
+
+        if (len > 0) {
+            fwrite(buf, 1, len, fd);
+            buf[0] = '\0';
         }
-    } while (true);
+    } while (len == OS_SIZE_8192);
+
+    if (!gzeof(gz_fd)) {
+        const char * gzerr = gzerror(gz_fd, &err);
+        if (err) {
+            merror("in w_uncompress_gzfile(): gzread error: '%s'", gzerr);
+            fclose(fd);
+            gzclose(gz_fd);
+            os_free(buf);
+            return -1;
+        }
+    }
 
     os_free(buf);
     fclose(fd);

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -7,7 +7,9 @@ if(NOT ${TARGET} STREQUAL "winagent")
                             -Wl,--wrap,fopen,--wrap,_mferror,--wrap,fflush,--wrap,fclose \
                             -Wl,--wrap,fread,--wrap,fseek,--wrap,fwrite,--wrap,remove \
                             -Wl,--wrap,fprintf,--wrap,fgets,--wrap,File_DateofChange \
-                            -Wl,--wrap,bzip2_uncompress,--wrap,mdebug1")
+                            -Wl,--wrap,bzip2_uncompress,--wrap,mdebug1,--wrap,lstat \
+                            -Wl,--wrap,gzopen,--wrap,gzread,--wrap,gzclose \
+                            -Wl,--wrap,gzeof,--wrap,gzerror,--wrap,gzwrite")
     list(APPEND shared_tests_flags "${FILE_OP_BASE_FLAGS}")
 endif()
 

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -15,23 +15,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include "headers/defs.h"
-
+#include "../headers/file_op.h"
 #include "../wrappers/common.h"
 #include "../wrappers/posix/stat_wrappers.h"
 #include "../wrappers/posix/unistd_wrappers.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/shared/file_op_wrappers.h"
-#include "../headers/file_op.h"
-
-
-#ifdef TEST_SERVER
-int __wrap_bzip2_uncompress(const char *filebz2, const char *file) {
-
-    check_expected_ptr(filebz2);
-    check_expected_ptr(file);
-    return mock();
-}
-#endif
+#include "../wrappers/externals/zlib/zlib_wrappers.h"
 
 
 /* setups/teardowns */
@@ -246,6 +236,316 @@ void test_w_uncompress_bz2_gz_file_bz2(void **state) {
 
 #endif
 
+// w_compress_gzfile
+
+void test_w_compress_gzfile_wfopen_fail(void **state){
+
+    int ret;
+    char *srcfile = "testfilesrc";
+    char *dstfile = "testfiledst.gz";
+
+    expect_string(__wrap_fopen, path, srcfile);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "in w_compress_gzfile(): fopen error testfilesrc (0):'Success'");
+
+    ret = w_compress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_compress_gzfile_gzopen_fail(void **state){
+
+    int ret;
+    char *srcfile = "testfilesrc";
+    char *dstfile = "testfiledst.gz";
+
+    expect_string(__wrap_fopen, path, srcfile);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, dstfile);
+    expect_string(__wrap_gzopen, mode, "w");
+    will_return(__wrap_gzopen, NULL);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    expect_string(__wrap__merror, formatted_msg, "in w_compress_gzfile(): gzopen error testfiledst.gz (0):'Success'");
+
+    ret = w_compress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_compress_gzfile_write_error(void **state){
+
+    int ret;
+    char *srcfile = "testfilesrc";
+    char *dstfile = "testfiledst.gz";
+
+    expect_string(__wrap_fopen, path, srcfile);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, dstfile);
+    expect_string(__wrap_gzopen, mode, "w");
+    will_return(__wrap_gzopen, 2);
+
+    will_return(__wrap_fread, "teststring");
+    will_return(__wrap_fread, 10);
+
+    expect_value(__wrap_gzwrite, file, 2);
+    expect_string(__wrap_gzwrite, buf, "teststring");
+    expect_value(__wrap_gzwrite, len, 10);
+    will_return(__wrap_gzwrite, Z_ERRNO);
+
+    expect_value(__wrap_gzerror, file, 2);
+    will_return(__wrap_gzerror, Z_ERRNO);
+    will_return(__wrap_gzerror, "Test error");
+    expect_string(__wrap__merror, formatted_msg, "in w_compress_gzfile(): Compression error: Test error");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+    expect_value(__wrap_gzclose, file, 2);
+    will_return(__wrap_gzclose, 1);
+
+    ret = w_compress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_compress_gzfile_success(void **state){
+
+    int ret;
+    char *srcfile = "testfilesrc";
+    char *dstfile = "testfiledst.gz";
+
+    expect_string(__wrap_fopen, path, srcfile);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, dstfile);
+    expect_string(__wrap_gzopen, mode, "w");
+    will_return(__wrap_gzopen, 2);
+
+    will_return(__wrap_fread, "teststring");
+    will_return(__wrap_fread, 10);
+
+    expect_value(__wrap_gzwrite, file, 2);
+    expect_string(__wrap_gzwrite, buf, "teststring");
+    expect_value(__wrap_gzwrite, len, 10);
+    will_return(__wrap_gzwrite, 10);
+
+    will_return(__wrap_fread, "");
+    will_return(__wrap_fread, 0);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+    expect_value(__wrap_gzclose, file, 2);
+    will_return(__wrap_gzclose, 1);
+
+    ret = w_compress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, 0);
+
+}
+
+// w_uncompress_gzfile
+
+void test_w_uncompress_gzfile_lstat_fail(void **state) {
+
+    int ret;
+    char *srcfile = "testfile.gz";
+    char *dstfile = "testfiledst";
+
+    expect_string(__wrap_lstat, filename, srcfile);
+    will_return(__wrap_lstat, S_IFREG);
+    will_return(__wrap_lstat, -1);
+
+    ret = w_uncompress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_uncompress_gzfile_fopen_fail(void **state) {
+
+    int ret;
+    char *srcfile = "testfile.gz";
+    char *dstfile = "testfiledst";
+
+    expect_string(__wrap_lstat, filename, srcfile);
+    will_return(__wrap_lstat, S_IFREG);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "in w_uncompress_gzfile(): fopen error testfiledst (0):'Success'");
+
+    ret = w_uncompress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_uncompress_gzfile_gzopen_fail(void **state) {
+
+    int ret;
+    char *srcfile = "testfile.gz";
+    char *dstfile = "testfiledst";
+
+    expect_string(__wrap_lstat, filename, srcfile);
+    will_return(__wrap_lstat, S_IFREG);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, srcfile);
+    expect_string(__wrap_gzopen, mode, "rb");
+    will_return(__wrap_gzopen, NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "in w_uncompress_gzfile(): gzopen error testfile.gz (0):'Success'");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = w_uncompress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_uncompress_gzfile_first_read_fail(void **state) {
+
+    int ret;
+    char *srcfile = "testfile.gz";
+    char *dstfile = "testfiledst";
+
+    expect_string(__wrap_lstat, filename, srcfile);
+    will_return(__wrap_lstat, S_IFREG);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, srcfile);
+    expect_string(__wrap_gzopen, mode, "rb");
+    will_return(__wrap_gzopen, 2);
+
+    expect_value(__wrap_gzread, gz_fd, 2);
+    will_return(__wrap_gzread, 0);
+    will_return(__wrap_gzread, "failstring");
+
+    will_return(__wrap_fwrite, 0);
+
+    expect_value(__wrap_gzeof, file, 2);
+    will_return(__wrap_gzeof, 0);
+
+    expect_value(__wrap_gzerror, file, 2);
+    will_return(__wrap_gzerror, Z_BUF_ERROR);
+    will_return(__wrap_gzerror, "Test error");
+
+    expect_string(__wrap__merror, formatted_msg, "in w_uncompress_gzfile(): gzread error: 'Test error'");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+    expect_value(__wrap_gzclose, file, 2);
+    will_return(__wrap_gzclose, 1);
+
+    ret = w_uncompress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_uncompress_gzfile_first_read_success(void **state) {
+
+    int ret;
+    char *srcfile = "testfile.gz";
+    char *dstfile = "testfiledst";
+
+    expect_string(__wrap_lstat, filename, srcfile);
+    will_return(__wrap_lstat, S_IFREG);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, srcfile);
+    expect_string(__wrap_gzopen, mode, "rb");
+    will_return(__wrap_gzopen, 2);
+
+    expect_value(__wrap_gzread, gz_fd, 2);
+    will_return(__wrap_gzread, OS_SIZE_8192);
+    will_return(__wrap_gzread, "teststring");
+
+    will_return(__wrap_fwrite, OS_SIZE_8192);
+
+    expect_value(__wrap_gzread, gz_fd, 2);
+    will_return(__wrap_gzread, 0);
+    will_return(__wrap_gzread, "failstring");
+
+    will_return(__wrap_fwrite, 0);
+
+    expect_value(__wrap_gzeof, file, 2);
+    will_return(__wrap_gzeof, 0);
+
+    expect_value(__wrap_gzerror, file, 2);
+    will_return(__wrap_gzerror, Z_BUF_ERROR);
+    will_return(__wrap_gzerror, "Test error");
+
+    expect_string(__wrap__merror, formatted_msg, "in w_uncompress_gzfile(): gzread error: 'Test error'");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+    expect_value(__wrap_gzclose, file, 2);
+    will_return(__wrap_gzclose, 1);
+
+    ret = w_uncompress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_uncompress_gzfile_success(void **state) {
+
+    int ret;
+    char *srcfile = "testfile.gz";
+    char *dstfile = "testfiledst";
+
+    expect_string(__wrap_lstat, filename, srcfile);
+    will_return(__wrap_lstat, S_IFREG);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, srcfile);
+    expect_string(__wrap_gzopen, mode, "rb");
+    will_return(__wrap_gzopen, 2);
+
+    expect_value(__wrap_gzread, gz_fd, 2);
+    will_return(__wrap_gzread, 10);
+    will_return(__wrap_gzread, "teststring");
+
+    will_return(__wrap_fwrite, 10);
+
+    expect_value(__wrap_gzeof, file, 2);
+    will_return(__wrap_gzeof, 1);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+    expect_value(__wrap_gzclose, file, 2);
+    will_return(__wrap_gzclose, 1);
+
+    ret = w_uncompress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, 0);
+
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_CreatePID_success),
@@ -257,8 +557,20 @@ int main(void) {
         cmocka_unit_test(test_w_is_compressed_bz2_file_compressed),
         cmocka_unit_test(test_w_is_compressed_bz2_file_uncompressed),
 #ifdef TEST_SERVER
-        cmocka_unit_test(test_w_uncompress_bz2_gz_file_bz2)
+        cmocka_unit_test(test_w_uncompress_bz2_gz_file_bz2),
 #endif
+        // w_compress_gzfile
+        cmocka_unit_test(test_w_compress_gzfile_wfopen_fail),
+        cmocka_unit_test(test_w_compress_gzfile_gzopen_fail),
+        cmocka_unit_test(test_w_compress_gzfile_write_error),
+        cmocka_unit_test(test_w_compress_gzfile_success),
+        // w_uncompress_gzfile
+        cmocka_unit_test(test_w_uncompress_gzfile_lstat_fail),
+        cmocka_unit_test(test_w_uncompress_gzfile_fopen_fail),
+        cmocka_unit_test(test_w_uncompress_gzfile_gzopen_fail),
+        cmocka_unit_test(test_w_uncompress_gzfile_first_read_fail),
+        cmocka_unit_test(test_w_uncompress_gzfile_first_read_success),
+        cmocka_unit_test(test_w_uncompress_gzfile_success)
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -439,8 +439,6 @@ void test_w_uncompress_gzfile_first_read_fail(void **state) {
     will_return(__wrap_gzread, 0);
     will_return(__wrap_gzread, "failstring");
 
-    will_return(__wrap_fwrite, 0);
-
     expect_value(__wrap_gzeof, file, 2);
     will_return(__wrap_gzeof, 0);
 
@@ -487,8 +485,6 @@ void test_w_uncompress_gzfile_first_read_success(void **state) {
     expect_value(__wrap_gzread, gz_fd, 2);
     will_return(__wrap_gzread, 0);
     will_return(__wrap_gzread, "failstring");
-
-    will_return(__wrap_fwrite, 0);
 
     expect_value(__wrap_gzeof, file, 2);
     will_return(__wrap_gzeof, 0);

--- a/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.c
+++ b/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.c
@@ -76,3 +76,13 @@ BZFILE* __wrap_BZ2_bzWriteOpen(int* bzerror,
 
     return mock_type(BZFILE*);
 }
+
+#ifndef TEST_WINAGENT
+int __wrap_bzip2_uncompress(const char *filebz2,
+                            const char *file) {
+
+    check_expected_ptr(filebz2);
+    check_expected_ptr(file);
+    return mock();
+}
+#endif

--- a/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.h
+++ b/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.h
@@ -47,4 +47,9 @@ BZFILE* __wrap_BZ2_bzWriteOpen(int* bzerror,
                                int verbosity,
                                int workFactor);
 
+#ifndef TEST_WINAGENT
+int __wrap_bzip2_uncompress(const char *filebz2,
+                            const char *file);
+#endif
+
 #endif

--- a/src/unit_tests/wrappers/externals/zlib/zlib_wrappers.c
+++ b/src/unit_tests/wrappers/externals/zlib/zlib_wrappers.c
@@ -1,0 +1,62 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "zlib_wrappers.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+
+
+int __wrap_gzread(gzFile gz_fd,
+                  void* buf,
+                  int len) {
+    check_expected_ptr(gz_fd);
+    int n = mock();
+    if(n <= len) {
+        memcpy(buf, mock_type(void*), n);
+    }
+    return n;
+}
+
+gzFile __wrap_gzopen(const char * path,
+                     const char * mode) {
+    check_expected(path);
+    check_expected(mode);
+
+    return mock_type(gzFile);
+}
+
+int __wrap_gzclose(gzFile file) {
+    check_expected_ptr(file);
+    return mock();
+}
+
+int __wrap_gzeof(gzFile file) {
+    check_expected_ptr(file);
+    return mock();
+}
+
+const char * __wrap_gzerror(gzFile file,
+                            int *errnum) {
+    check_expected_ptr(file);
+    *errnum = mock();
+    return mock_type(char*);
+}
+
+int __wrap_gzwrite(gzFile file,
+                   voidpc buf,
+                   unsigned int len) {
+    check_expected_ptr(file);
+    check_expected(buf);
+    check_expected(len);
+    return mock();
+
+}

--- a/src/unit_tests/wrappers/externals/zlib/zlib_wrappers.h
+++ b/src/unit_tests/wrappers/externals/zlib/zlib_wrappers.h
@@ -1,0 +1,34 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef ZLIB_WRAPPERS_H
+#define ZLIB_WRAPPERS_H
+
+#include "../../../../external/zlib/zlib.h"
+
+int __wrap_gzread(gzFile gz_fd,
+                  void* buf,
+                  int len);
+
+gzFile __wrap_gzopen(const char * file,
+                     const char * mode);
+
+int __wrap_gzclose(gzFile file);
+
+int __wrap_gzeof(gzFile file);
+
+const char * __wrap_gzerror(gzFile file,
+                            __attribute__((unused)) int *errnum);
+
+int __wrap_gzwrite(gzFile file,
+                   voidpc buf,
+                   unsigned int len);
+
+#endif


### PR DESCRIPTION
## Description

This PR prevents an infinity loop during the uncompress process when the source file is corrupted, as reported at https://github.com/wazuh/wazuh/issues/5928.

Now the uncompression loop is adapted to the `zlib` documentation:

```
gzread returns the number of uncompressed bytes actually read, less than len for end of file, or -1 for error.
```

So, when the uncompressed bytes are less than the buffer length, we check if the EOF has been reached, otherwise an error is raised.

It has been also included unit tests for both compressing and uncompressing functions.

## Logs/Alerts example

Manual testing has been performed by downloading the compresses feeds by Vulnerability Detector:

```
2020/09/10 06:51:09 wazuh-modulesd[19613] url.c:346 at wurl_request_uncompress_bz2_gz(): DEBUG: File from URL 'https://feed.wazuh.com/vulnerability-detector/windows/msu-updates.json.gz' was successfully uncompressed into 'tmp/vuln-temp-fitted'
```

Unit tests output:

```
# ./test_file_op
[==========] tests: Running 19 test(s).
[ RUN      ] test_CreatePID_success
[       OK ] test_CreatePID_success
[ RUN      ] test_CreatePID_failure_chmod
[       OK ] test_CreatePID_failure_chmod
[ RUN      ] test_CreatePID_failure_fopen
[       OK ] test_CreatePID_failure_fopen
[ RUN      ] test_DeletePID_success
[       OK ] test_DeletePID_success
[ RUN      ] test_DeletePID_failure
[       OK ] test_DeletePID_failure
[ RUN      ] test_w_is_compressed_gz_file_uncompressed
[       OK ] test_w_is_compressed_gz_file_uncompressed
[ RUN      ] test_w_is_compressed_bz2_file_compressed
[       OK ] test_w_is_compressed_bz2_file_compressed
[ RUN      ] test_w_is_compressed_bz2_file_uncompressed
[       OK ] test_w_is_compressed_bz2_file_uncompressed
[ RUN      ] test_w_uncompress_bz2_gz_file_bz2
[       OK ] test_w_uncompress_bz2_gz_file_bz2
[ RUN      ] test_w_compress_gzfile_wfopen_fail
[       OK ] test_w_compress_gzfile_wfopen_fail
[ RUN      ] test_w_compress_gzfile_gzopen_fail
[       OK ] test_w_compress_gzfile_gzopen_fail
[ RUN      ] test_w_compress_gzfile_write_error
[       OK ] test_w_compress_gzfile_write_error
[ RUN      ] test_w_compress_gzfile_success
[       OK ] test_w_compress_gzfile_success
[ RUN      ] test_w_uncompress_gzfile_lstat_fail
[       OK ] test_w_uncompress_gzfile_lstat_fail
[ RUN      ] test_w_uncompress_gzfile_fopen_fail
[       OK ] test_w_uncompress_gzfile_fopen_fail
[ RUN      ] test_w_uncompress_gzfile_gzopen_fail
[       OK ] test_w_uncompress_gzfile_gzopen_fail
[ RUN      ] test_w_uncompress_gzfile_first_read_fail
[       OK ] test_w_uncompress_gzfile_first_read_fail
[ RUN      ] test_w_uncompress_gzfile_first_read_success
[       OK ] test_w_uncompress_gzfile_first_read_success
[ RUN      ] test_w_uncompress_gzfile_success
[       OK ] test_w_uncompress_gzfile_success
[==========] tests: 19 test(s) run.
[  PASSED  ] 19 test(s).
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- [x] Added unit tests (for new features)
