### PR TITLE
Fix API unit test

### DIFF
--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -85,12 +85,12 @@ def test_read_configuration(mock_open, mock_exists, read_config):
 def test_read_wrong_configuration(mock_exists):
     """Verify that expected exceptions are raised when incorrect configuration"""
     with patch('api.configuration.yaml.safe_load') as m:
-        with pytest.raises(api_exception.APIError, match='.* 2004 .*'):
+        with pytest.raises(api_exception.APIError, match=r'\b2004\b'):
             configuration.read_yaml_config()
 
         with patch('builtins.open'):
             m.return_value = {'marta': 'yay'}
-            with pytest.raises(api_exception.APIError, match='.* 2000 .*'):
+            with pytest.raises(api_exception.APIError, match=r'\b2000\b'):
                 configuration.read_yaml_config()
 
 


### PR DESCRIPTION
## Description

Hi team! There were a failure in one of the API unit tests due to a small change. It is fixed in this PR.

## Tests
```
======================================================= test session starts ========================================================
platform linux -- Python 3.8.2, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /home/selu/venv/unittest-env/bin/python3
cachedir: .pytest_cache
rootdir: /home/selu/Git/wazuh/api
plugins: trio-0.6.0, asyncio-0.14.0
collected 7 items                                                                                                                  

test/test_configuration.py::test_read_configuration[read_config0] PASSED                                                     [ 14%]
test/test_configuration.py::test_read_configuration[read_config1] PASSED                                                     [ 28%]
test/test_configuration.py::test_read_configuration[read_config2] PASSED                                                     [ 42%]
test/test_configuration.py::test_read_configuration[read_config3] PASSED                                                     [ 57%]
test/test_configuration.py::test_read_wrong_configuration PASSED                                                             [ 71%]
test/test_configuration.py::test_generate_private_key PASSED                                                                 [ 85%]
test/test_configuration.py::test_generate_self_signed_certificate PASSED                                                     [100%]

======================================================== 7 passed in 0.29s ==
=======================================================
```

Kind regards,
Selu.
