### PR TITLE
Allow unsopported OS be monitored with Redhat feeds

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -30,8 +30,6 @@ typedef struct provider_options {
     char *multi_url;
     int multi_url_start;
     int multi_url_end;
-    char **multi_allowed_os_name;
-    char **multi_allowed_os_ver;
     int port;
     time_t update_interval;
     int update_since;
@@ -46,8 +44,7 @@ static int wm_vuldet_provider_enable(xml_node **node);
 static char *wm_vuldet_provider_name(xml_node *node);
 static int wm_vuldet_provider_os_list(xml_node **node, vu_os_feed **feeds, char *pr_name);
 static void wm_vuldet_set_port_to_url(char **url, int port);
-static int wm_vuldet_add_allow_os(update_node *update, char *os_tags, char old_config);
-static int wm_vuldet_add_multi_allow_os(update_node *update, char **src_os, char **dst_os);
+static int wm_vuldet_add_allow_os(update_node *update, char *os_tags);
 static int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_provider, provider_options *options);
 static char wm_vuldet_provider_type(char *pr_name);
 static void wm_vuldet_remove_os_feed(vu_os_feed *feed, char full_r);
@@ -71,7 +68,6 @@ static const char *XML_PORT = "port";
 static const char *XML_ALLOW = "allow";
 static const char *XML_UPDATE_FROM_YEAR = "update_from_year";
 static const char *XML_PROVIDER = "provider";
-static const char *XML_REPLACED_OS = "replaced_os";
 static const char *XML_TIMEOUT = "download_timeout";
 
 static const char *XML_START = "start";
@@ -529,7 +525,7 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
                 continue;
             }
 
-            if (os_list->allow && wm_vuldet_add_allow_os(updates[os_index], os_list->allow, 0)) {
+            if (os_list->allow && wm_vuldet_add_allow_os(updates[os_index], os_list->allow)) {
                 goto end;
             }
 
@@ -565,7 +561,7 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
     }
 
     /**
-    *  multi_provider = NVD, RedHat and MSU.
+    *  multi_provider = NVD, RedHat JSON and MSU.
     *  Those which use <path> or <url> tags.
     **/
     if (multi_provider || (p_options.multi_path || p_options.multi_url)) {
@@ -591,12 +587,6 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
         updates[os_index]->multi_url_end = p_options.multi_url_end;
         updates[os_index]->port = p_options.port;
         updates[os_index]->timeout = p_options.timeout;
-
-        if (p_options.multi_allowed_os_name) {
-            if (wm_vuldet_add_multi_allow_os(updates[os_index], p_options.multi_allowed_os_name, p_options.multi_allowed_os_ver)) {
-                goto end;
-            }
-        }
 
         p_options.multi_path = NULL;
         p_options.multi_url = NULL;
@@ -731,7 +721,7 @@ int wm_vuldet_provider_os_list(xml_node **node, vu_os_feed **feeds, char *pr_nam
                 tmp_list = feeds_it;
             }
         } else {
-            merror("'%s' tag required for '%s' provider", XML_OS, pr_name);
+            merror("'%s' tag required for '%s' provider.", XML_OS, pr_name);
             return OS_INVALID;
         }
     }
@@ -783,19 +773,6 @@ void wm_vuldet_free_update_node(update_node *update) {
         free(update->allowed_os_name);
         w_FreeArray(update->allowed_os_ver);
         free(update->allowed_os_ver);
-    } else if (update->dist_ref == FEED_REDHAT) {
-        int section, i;
-
-        for (section = 0; section < 2; section++) {
-            char ***multios_src = !section ? update->allowed_multios_src_name : update->allowed_multios_src_ver;
-            char **multios_dst = !section ? update->allowed_multios_dst_name : update->allowed_multios_dst_ver;
-            for (i = 0; multios_src && multios_src[i]; i++) {
-                w_FreeArray(multios_src[i]);
-                free(multios_src[i]);
-            }
-            w_FreeArray(multios_dst);
-            free(multios_dst);
-        }
     }
 }
 
@@ -837,82 +814,38 @@ void wm_vuldet_set_port_to_url(char **url, int port) {
     }
 }
 
-int wm_vuldet_add_allow_os(update_node *update, char *os_tags, char old_config) {
+int wm_vuldet_add_allow_os(update_node *update, char *os_tags) {
     char *found;
     size_t size;
 
-    if (wm_vuldet_is_single_provider(update->dist_ref) || old_config) {
-        os_calloc(1, sizeof(char *), update->allowed_os_name);
-        os_calloc(1, sizeof(char *), update->allowed_os_ver);
+    os_calloc(1, sizeof(char *), update->allowed_os_name);
+    os_calloc(1, sizeof(char *), update->allowed_os_ver);
 
-        for (size = 0; (found = strchr(os_tags, ',')); size++) {
-            *(found++) = '\0';
-            os_realloc(update->allowed_os_name, (size + 2)*sizeof(char *), update->allowed_os_name);
-            os_realloc(update->allowed_os_ver, (size + 2)*sizeof(char *), update->allowed_os_ver);
-            if (format_os_version(os_tags, &update->allowed_os_name[size], &update->allowed_os_ver[size])) {
-                merror("Invalid OS entered in %s: %s", WM_VULNDETECTOR_CONTEXT.name, os_tags);
-                return OS_INVALID;
-            }
-            update->allowed_os_name[size + 1] = NULL;
-            os_tags = found;
-        }
+    for (size = 0; (found = strchr(os_tags, ',')); size++) {
+        *(found++) = '\0';
         os_realloc(update->allowed_os_name, (size + 2)*sizeof(char *), update->allowed_os_name);
+        os_realloc(update->allowed_os_ver, (size + 2)*sizeof(char *), update->allowed_os_ver);
         if (format_os_version(os_tags, &update->allowed_os_name[size], &update->allowed_os_ver[size])) {
             merror("Invalid OS entered in %s: %s", WM_VULNDETECTOR_CONTEXT.name, os_tags);
             return OS_INVALID;
         }
+        mdebug1("'%s' successfully added to the monitored OS list.", os_tags);
         update->allowed_os_name[size + 1] = NULL;
-    } else {
-        merror("The 'allow' option can only be used with single-providers.");
+        os_tags = found;
+    }
+    os_realloc(update->allowed_os_name, (size + 2)*sizeof(char *), update->allowed_os_name);
+    if (format_os_version(os_tags, &update->allowed_os_name[size], &update->allowed_os_ver[size])) {
+        merror("Invalid OS entered in %s: %s", WM_VULNDETECTOR_CONTEXT.name, os_tags);
         return OS_INVALID;
     }
-
-    return 0;
-}
-
-int wm_vuldet_add_multi_allow_os(update_node *update, char **src_os, char **dst_os) {
-    int i, j;
-    char *version;
-
-    for (i = 0; src_os[i]; i++) {
-        os_realloc(update->allowed_multios_src_name, (i + 2) * sizeof(char **), update->allowed_multios_src_name);
-        memset(&update->allowed_multios_src_name[i], '\0', 2 * sizeof(char **));
-        os_realloc(update->allowed_multios_src_ver, (i + 2) * sizeof(char **), update->allowed_multios_src_ver);
-        memset(&update->allowed_multios_src_ver[i], '\0', 2 * sizeof(char **));
-
-        os_realloc(update->allowed_multios_dst_name, (i + 2) * sizeof(char *), update->allowed_multios_dst_name);
-        memset(&update->allowed_multios_dst_name[i], '\0', 2 * sizeof(char *));
-        os_realloc(update->allowed_multios_dst_ver, (i + 2) * sizeof(char *), update->allowed_multios_dst_ver);
-        memset(&update->allowed_multios_dst_ver[i], '\0', 2 * sizeof(char *));
-
-        // Set the allowed names
-        wstr_split(src_os[i], ",", NULL, 1, &update->allowed_multios_src_name[i]);
-        os_strdup(dst_os[i], update->allowed_multios_dst_name[i]);
-
-        // Set the allowed versions
-        for (j = 0; update->allowed_multios_src_name[i][j]; j++) {
-            if (version = strchr(update->allowed_multios_src_name[i][j], '-'), !version) {
-                merror("Invalid '%s' content. Use: 'OS-version'", XML_ALLOW);
-                return OS_INVALID;
-            }
-            *(version++) = '\0';
-            os_realloc(update->allowed_multios_src_ver[i], (j + 2) * sizeof(char *), update->allowed_multios_src_ver[i]);
-            os_strdup(version, update->allowed_multios_src_ver[i][j]);
-        }
-        if (version = strchr(update->allowed_multios_dst_name[i], '-'), !version) {
-            merror("Invalid '%s' content. Use: 'OS-version'", XML_REPLACED_OS);
-            return OS_INVALID;
-        }
-        *(version++) = '\0';
-        os_strdup(version, update->allowed_multios_dst_ver[i]);
-    }
+    mdebug1("'%s' successfully added to the monitored OS list.", os_tags);
+    update->allowed_os_name[size + 1] = NULL;
 
     return 0;
 }
 
 int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_provider, provider_options *options) {
     int i, j;
-    int elements;
     int8_t rhel_enabled = (strcasestr(name, vu_feed_tag[FEED_REDHAT])) ? 1 : 0;
     int8_t msu_enabled = (strcasestr(name, vu_feed_tag[FEED_MSU])) ? 1 : 0;
 
@@ -939,7 +872,7 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
                     return OS_INVALID;
                 }
             } else {
-                mwarn("'%s' option can only be used in a multi-provider.", node[i]->element);
+                mwarn("Invalid option '%s' for '%s' provider at '%s'", node[i]->element, name, WM_VULNDETECTOR_CONTEXT.name);
             }
         } else if (!strcmp(node[i]->element, XML_UPDATE_INTERVAL)) {
             if (wm_vuldet_get_interval(node[i]->content, &options->update_interval)) {
@@ -981,25 +914,14 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
                 }
             }
         } else if (!strcmp(node[i]->element, XML_ALLOW)) {
-            if (multi_provider || rhel_enabled) {
-                if (!node[i]->attributes || !*node[i]->attributes || strcmp(*node[i]->attributes, XML_REPLACED_OS) ||
-                    !node[i]->values || !*node[i]->values || !**node[i]->values) {
-                    merror("Invalid '%s' value.", XML_REPLACED_OS);
-                    return OS_INVALID;
-                }
-                for (elements = 0; options->multi_allowed_os_name && options->multi_allowed_os_name[elements]; elements++);
-                os_realloc(options->multi_allowed_os_name, (elements + 2) * sizeof(char *), options->multi_allowed_os_name);
-                os_realloc(options->multi_allowed_os_ver, (elements + 2) * sizeof(char *), options->multi_allowed_os_ver);
-                os_strdup(node[i]->content, options->multi_allowed_os_name[elements]);
-                os_strdup(*node[i]->values, options->multi_allowed_os_ver[elements]);
-                options->multi_allowed_os_name[elements + 1] = NULL;
-                options->multi_allowed_os_ver[elements + 1] = NULL;
+            if (rhel_enabled) {
+                mwarn("Deprecated option '%s' for '%s' provider. Use it as attribute <os %s> instead.", node[i]->element, name, node[i]->element);
             } else {
-                mwarn("'%s' option can only be used in a multi-provider.", node[i]->element);
+                mwarn("Invalid option '%s' for '%s' provider at '%s'", node[i]->element, name, WM_VULNDETECTOR_CONTEXT.name);
             }
         } else if (!strcmp(node[i]->element, XML_OS)) {
             if (multi_provider) {
-                mwarn("'%s' option can only be used in a single-provider.", node[i]->element);
+                mwarn("Invalid option '%s' for '%s' provider at '%s'", node[i]->element, name, WM_VULNDETECTOR_CONTEXT.name);
             }
         } else if (strcmp(node[i]->element, XML_ENABLED)) {
             merror("Invalid option in %s section for module '%s': '%s'", XML_PROVIDER, WM_VULNDETECTOR_CONTEXT.name, node[i]->element);
@@ -1048,8 +970,6 @@ void wm_vuldet_init_provider_options(provider_options *options) {
     options->multi_url = NULL;
     options->multi_url_start = 0;
     options->multi_url_end = 0;
-    options->multi_allowed_os_name = NULL;
-    options->multi_allowed_os_ver = NULL;
     options->port = 0;
     options->update_interval = 0;
     options->update_since = 0;
@@ -1059,10 +979,6 @@ void wm_vuldet_init_provider_options(provider_options *options) {
 void wm_vuldet_clear_provider_options(provider_options options) {
     os_free(options.multi_path);
     os_free(options.multi_url);
-    w_FreeArray(options.multi_allowed_os_name);
-    w_FreeArray(options.multi_allowed_os_ver);
-    os_free(options.multi_allowed_os_name);
-    os_free(options.multi_allowed_os_ver);
 }
 
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -265,7 +265,6 @@ STATIC void wm_vuldet_get_package_os(const char *version, const char **os_major,
 STATIC void wm_vuldet_set_subversion(char *version, char **os_minor);
 STATIC cJSON *wm_vuldet_json_fread(char *json_file);
 STATIC cJSON *wm_vuldet_get_cvss(const char *scoring_vector);
-STATIC int wm_vuldet_get_dist_ref(const char *dist_name, const char *dist_ver, int *dist_ref, int *dist_ver_ref);
 STATIC int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_field, char **condition);
 STATIC void wm_vuldet_run_scan(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_run_sleep(wm_vuldet_t *vuldet);
@@ -457,11 +456,11 @@ const char *vu_cpe_dic_option[] = {
 
 vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_version, update_node **updates, vu_feed *agent_dist) {
     vu_feed retval = FEED_UNKNOWN;
-    int i, j, k;
+    int i;
 
     for (i = 0; i < OS_SUPP_SIZE; i++) {
         if (updates[i]) {
-            if (wm_vuldet_is_single_provider(updates[i]->dist_ref) || updates[i]->old_config) {
+            if (wm_vuldet_is_single_provider(updates[i]->dist_ref)) {
                 if (updates[i]->allowed_os_name) {
                     int j;
                     char *allowed_os;
@@ -477,33 +476,10 @@ vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_version, 
                         allowed_ver = updates[i]->allowed_os_ver[j];
                     }
                 }
-            } else {
-                if (updates[i]->allowed_multios_src_name) {
-                    for (j = 0; updates[i]->allowed_multios_src_name[j]; j++) {
-                        for (k = 0; updates[i]->allowed_multios_src_name[j][k]; k++) {
-                            if (strcasestr(os_name, updates[i]->allowed_multios_src_name[j][k]) &&
-                                    strcasestr(os_version, updates[i]->allowed_multios_src_ver[j][k])) {
-                                int dist_tag_ref;
-                                int dist_ref;
-
-                                if (wm_vuldet_get_dist_ref(updates[i]->allowed_multios_dst_name[j], updates[i]->allowed_multios_dst_ver[j],
-                                        &dist_ref, &dist_tag_ref)) {
-                                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_INVALID_TRANSLATION_OS, updates[i]->allowed_multios_dst_name[j], updates[i]->allowed_multios_dst_ver[j]);
-                                    goto end;
-                                }
-
-                                retval = dist_tag_ref;
-                                *agent_dist = dist_ref;
-                                goto end;
-                            }
-                        }
-                    }
-                }
             }
         }
     }
 
-end:
     return retval;
 }
 
@@ -4702,14 +4678,14 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
 void wm_vuldet_destroy(wm_vuldet_t * vuldet) {
     agent_software *agent;
     update_node **update;
-    int i, j, k;
+    int i, j;
 
     for (i = 0, update = vuldet->updates; i < OS_SUPP_SIZE; i++) {
         if (update[i]) {
-            free(update[i]->dist);
-            free(update[i]->version);
-            free(update[i]->url);
-            free(update[i]->path);
+            os_free(update[i]->dist);
+            os_free(update[i]->version);
+            os_free(update[i]->url);
+            os_free(update[i]->path);
             if (wm_vuldet_is_single_provider(update[i]->dist_ref)) {
                 if (update[i]->allowed_os_name) {
                     for (j = 0; update[i]->allowed_os_name[j]; j++) {
@@ -4719,28 +4695,8 @@ void wm_vuldet_destroy(wm_vuldet_t * vuldet) {
                     free(update[i]->allowed_os_name);
                     free(update[i]->allowed_os_ver);
                 }
-            } else {
-                if (update[i]->allowed_multios_src_name) {
-                    for (j = 0; update[i]->allowed_multios_src_name[j]; j++) {
-                        for (k = 0; update[i]->allowed_multios_src_name[j][k]; k++) {
-                            free(update[i]->allowed_multios_src_name[j][k]);
-                            free(update[i]->allowed_multios_src_ver[j][k]);
-                        }
-                        free(update[i]->allowed_multios_src_name[j]);
-                        free(update[i]->allowed_multios_src_ver[j]);
-                    }
-                    free(update[i]->allowed_multios_src_name);
-                    free(update[i]->allowed_multios_src_ver);
-
-                    for (j = 0; update[i]->allowed_os_name[j]; j++) {
-                        free(update[i]->allowed_multios_dst_name[j]);
-                        free(update[i]->allowed_multios_dst_ver[j]);
-                    }
-                    free(update[i]->allowed_multios_dst_name);
-                    free(update[i]->allowed_multios_dst_ver);
-                }
             }
-            free(update[i]);
+            os_free(update[i]);
         }
     }
 
@@ -4828,39 +4784,6 @@ cJSON *wm_vuldet_dump(const wm_vuldet_t * vuldet){
                     cJSON_AddItemToArray(allow, allowed);
                     cJSON_AddItemToObject(provider,"allow",allow);
                 }
-            } else if (vuldet->updates[i]->allowed_multios_src_name) {
-                int j = 0;
-                cJSON *allow = cJSON_CreateArray();
-                for (j = 0; vuldet->updates[i]->allowed_multios_src_name[j]; j++) {
-                    cJSON *allowed = cJSON_CreateObject();
-                    if (vuldet->updates[i]->allowed_multios_dst_name && vuldet->updates[i]->allowed_multios_dst_name[j]) {
-                        char * dst_os;
-                        os_calloc(OS_SIZE_128, sizeof(char), dst_os);
-                        if (vuldet->updates[i]->allowed_multios_dst_ver && vuldet->updates[i]->allowed_multios_dst_ver[j]) {
-                            snprintf(dst_os, OS_SIZE_128 - 1, "%s-%s", vuldet->updates[i]->allowed_multios_dst_name[j], vuldet->updates[i]->allowed_multios_dst_ver[j]);
-                        } else {
-                            snprintf(dst_os, OS_SIZE_128 - 1, "%s", vuldet->updates[i]->allowed_multios_dst_name[j]);
-                        }
-                        cJSON_AddStringToObject(allowed,"replaced_os",dst_os);
-                        os_free(dst_os);
-                    }
-                    int k = 0;
-                    cJSON *src = cJSON_CreateArray();
-                    for (k = 0; vuldet->updates[i]->allowed_multios_src_name[j][k]; k++) {
-                        char * src_os;
-                        os_calloc(OS_SIZE_128, sizeof(char), src_os);
-                        if (vuldet->updates[i]->allowed_multios_src_ver && vuldet->updates[i]->allowed_multios_src_ver[j] && vuldet->updates[i]->allowed_multios_src_ver[j][k]) {
-                            snprintf(src_os, OS_SIZE_128 - 1, "%s-%s", vuldet->updates[i]->allowed_multios_src_name[j][k], vuldet->updates[i]->allowed_multios_src_ver[j][k]);
-                        } else {
-                            snprintf(src_os, OS_SIZE_128 - 1, "%s", vuldet->updates[i]->allowed_multios_src_name[j][k]);
-                        }
-                        cJSON_AddItemToArray(src, cJSON_CreateString(src_os));
-                        os_free(src_os);
-                    }
-                    cJSON_AddItemToObject(allowed, "src", src);
-                    cJSON_AddItemToArray(allow, allowed);
-                }
-                cJSON_AddItemToObject(provider,"allow",allow);
             }
 
             cJSON_AddItemToArray(providers, provider);
@@ -6732,31 +6655,6 @@ cJSON *wm_vuldet_get_cvss(const char *scoring_vector) {
     os_free(vector);
 
     return cvss_json;
-}
-
-int wm_vuldet_get_dist_ref(const char *dist_name, const char *dist_ver, int *dist_ref, int *dist_ver_ref) {
-    if (strcasestr(dist_name, vu_feed_tag[FEED_REDHAT]) || strcasestr(dist_name, "red hat")) {
-        switch (*dist_ver) {
-            case '5':
-                *dist_ver_ref = FEED_RHEL5;
-                break;
-            case '6':
-                *dist_ver_ref = FEED_RHEL6;
-                break;
-            case '7':
-                *dist_ver_ref = FEED_RHEL7;
-                break;
-            case '8':
-                *dist_ver_ref = FEED_RHEL8;
-                break;
-            default:
-                return OS_INVALID;
-        }
-        *dist_ref = FEED_REDHAT;
-        return 0;
-    }
-
-    return OS_INVALID;;
 }
 
 int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_field, char **condition) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -385,21 +385,12 @@ typedef struct update_node {
     char *path;
     char *multi_path;
     long timeout; // Timeout for download requests
-    union { // Supported operating systems
-        struct { // Single providers (Debian and Canonical)
-            char **allowed_os_name;
-            char **allowed_os_ver;
-        };
-        struct { // Multi providers (Red Hat)
-            char ***allowed_multios_src_name;
-            char ***allowed_multios_src_ver;
-            char **allowed_multios_dst_name;
-            char **allowed_multios_dst_ver;
-        };
+    struct { // Supported operating systems
+        char **allowed_os_name;
+        char **allowed_os_ver;
     };
     unsigned int attempted:1;
     unsigned int json_format:1;
-    unsigned int old_config:1;
 } update_node;
 
 typedef struct wm_vuldet_t {
@@ -752,7 +743,7 @@ struct vu_msu_vul_entry {
 };
 
 // Macros
-#define wm_vuldet_is_single_provider(x) (x == FEED_UBUNTU || x == FEED_DEBIAN)
+#define wm_vuldet_is_single_provider(x) (x == FEED_UBUNTU || x == FEED_DEBIAN || x == FEED_REDHAT)
 #define wm_vuldet_silent_feed(x) (x == FEED_CPEW)
 #define wm_vuldet_get_json_value(obj, key) ({void *ret = NULL; cJSON *it = cJSON_GetObjectItem(obj, key); \
                                             if (it) ret = it->valuestring; ret;})


### PR DESCRIPTION
## Description

This PR closes #5994 

Since the Redhat provider downloads one feed per supported OS, the option `allow replaced_os` is no longer used by any provider, so it has been deprecated. Now, to associate unsupported OS to Redhat feeds, the attribute `allow` should be used.
## Configuration options

**Deprecated option**

```xml
<allow replaced_os="Red Hat-7">Oracle Linux-7</allow>
```

**New option for Redhat**

```xml
<os allow="Oracle Linux-7">7</os>
```

## Logs/Alerts example

A warning has been added when read a deprecated tag:

```
2020/09/11 03:56:23 wazuh-modulesd[9195] wmodules-vuln-detector.c:918 at wm_vuldet_read_provider_content(): WARNING: Deprecated option 'allow' for 'redhat' provider. Use it as attribute <os allow> instead.
```

In addition, a debug message has been added to know if the unsupported OS was added correctly:

```
2020/09/11 03:56:23 wazuh-modulesd[9195] wmodules-vuln-detector.c:841 at wm_vuldet_add_allow_os(): DEBUG: 'Oracle Linux-7' successfully added to the monitored OS list.
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

- [x] Added unit tests (for new features)
- [x] Stress test for affected components
