### PR TITLE
Change os name format to allow using special characters

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3310,7 +3310,7 @@ components:
                 properties:
                   name:
                     type: string
-                    format: alphanumeric
+                    format: alphanumeric_symbols
                   platform:
                     type: string
                     format: alphanumeric


### PR DESCRIPTION
Hi team,

When using `GET /overview/agents`, if an agent `os name` contains a special character, next error message appears:
```
{
  "error": "3013",
  "message": {
    "title": "Response body does not conform to specification",
    "detail": "'Debian GNU/Linux' is not a 'alphanumeric'. Failed validating 'format' in schema['allOf'][1]['properties']['data']['properties']['agent_os']['items']['properties']['os']['properties']['name']: {'format': 'alphanumeric', 'type': 'string'}. On instance['data']['agent_os'][1]['os']['name']: 'Debian GNU/Linux'"
  }
}
```

In this example, the cause of the error is the `os name` showed in this output (showing part of the output from `GET /agents` endpoint):
```
	
	...
        "os": {
          "arch": "x86_64",
          "codename": "stretch",
          "major": "9",
          "name": "Debian GNU/Linux",
          "platform": "debian",
          "uname": "Linux |ip-10-0-1-53 |4.9.0-9-amd64 |#1 SMP Debian 4.9.168-1+deb9u2 (2019-05-13) |x86_64",
          "version": "9"
        },
        ...
        
```

In this PR, I have modified `spec.yaml` in order to verify every `os name` with special characters like `/`, `:`, etc. I have changed `OverviewAgents` model in order to make os name format = `alphanumeric_symbols`. 

**Examples:**

With this changes, next os name strings will be accepted, among others:

```
Debian GNU/Linux
Debian /GNU:Linux
```

Changes tested by adding two entries to agent table in `global.db` and using `GET /overview/agents endpoint`.

```
sqlite3 /var/ossec/var/db/global.db

insert into agent (id,name,os_name,date_add) values (16,"wazuh-agent16","Debian GNU/Linux",1599823901);
insert into agent (id,name,os_name,date_add) values (17,"wazuh-agent17","Debian /GNU:Linux",1599823901);

select id, name, os_name from agent;
```

```
...
16|wazuh-agent16|Debian GNU/Linux
17|wazuh-agent17|Debian /GNU:Linux
```

**Using `GET /overview/agents`:**

`curl -k -X GET -H "Authorization: Bearer $TOKEN" "https://localhost:55000/overview/agents?pretty=true"
`

**Response:**
```

...
"agent_os": [
         {
            "os": {
               "name": "Ubuntu",
               "platform": "ubuntu",
               "version": "16.04.6 LTS"
            },
            "count": 3
         },
         {
            "os": {
               "name": "Ubuntu",
               "platform": "ubuntu",
               "version": "18.04.4 LTS"
            },
            "count": 6
         },
         {
            "os": {
               "name": "Ubuntu",
               "platform": "ubuntu",
               "version": "18.04.2 LTS"
            },
            "count": 2
         },
         {
            "os": {
               "name": "unknown",
               "platform": "unknown",
               "version": "unknown"
            },
            "count": 5
         },
         {
            "os": {
               "name": "Debian GNU/Linux",
               "platform": "unknown",
               "version": "unknown"
            },
            "count": 1
         },
         {
            "os": {
               "name": "Debian /GNU:Linux",
               "platform": "unknown",
               "version": "unknown"
            },
            "count": 1
         }
      ],
...


```
Regards,
Manuel.