### PR TITLE
[5777] RSYNC push message implementation

### DIFF
--- a/src/shared_modules/rsync/include/rsync.h
+++ b/src/shared_modules/rsync/include/rsync.h
@@ -84,12 +84,14 @@ EXPORTED int rsync_register_sync_id(const RSYNC_HANDLE handle,
  *
  * @param handle  Current rsync handle being used.
  * @param payload Message to be queued and processed.
+ * @param size    Size of the message to be queued and processed.
  *
  * @return 0 if succeeded,
  *         specific error code (OS dependent) otherwise.
  */
 EXPORTED int rsync_push_message(const RSYNC_HANDLE handle,
-                                const char* payload);
+                                const void* payload,
+                                const size_t size);
 
 /**
  * @brief Turns off an specific rsync instance.

--- a/src/shared_modules/rsync/src/rsync.cpp
+++ b/src/shared_modules/rsync/src/rsync.cpp
@@ -79,10 +79,35 @@ EXPORTED int rsync_register_sync_id(const RSYNC_HANDLE /*handle*/,
     return 0;    
 }
 
-EXPORTED int rsync_push_message(const RSYNC_HANDLE /*handle*/,
-                                const char* /*payload*/)
+EXPORTED int rsync_push_message(const RSYNC_HANDLE handle,
+                                const void* payload,
+                                const size_t size)
 {
-    return 0;    
+    auto retVal { -1 };
+    std::string errorMessage;
+    if (!handle || !payload || !size)
+    {
+        errorMessage += "Invalid Parameters.";
+    }
+    else
+    {
+        try
+        {
+            const auto first{reinterpret_cast<const unsigned char*>(payload)};
+            const auto last{first + size};
+            const std::vector<unsigned char> data{first, last};
+            RSyncImplementation::instance().push(handle, data);
+            retVal = 0;
+        }
+        // LCOV_EXCL_START
+        catch(...)
+        {
+            errorMessage += "Unrecognized error.";
+        }
+    }
+    // LCOV_EXCL_STOP
+    log_message(errorMessage);
+    return retVal;
 }
 
 EXPORTED int rsync_close(const RSYNC_HANDLE handle)

--- a/src/shared_modules/rsync/src/rsync.cpp
+++ b/src/shared_modules/rsync/src/rsync.cpp
@@ -104,8 +104,8 @@ EXPORTED int rsync_push_message(const RSYNC_HANDLE handle,
         {
             errorMessage += "Unrecognized error.";
         }
+        // LCOV_EXCL_STOP
     }
-    // LCOV_EXCL_STOP
     log_message(errorMessage);
     return retVal;
 }

--- a/src/shared_modules/rsync/src/rsync_implementation.cpp
+++ b/src/shared_modules/rsync/src/rsync_implementation.cpp
@@ -47,3 +47,12 @@ std::shared_ptr<RSyncImplementation::RSyncContext> RSyncImplementation::remoteSy
     }
     return it->second;
 }
+
+void RSyncImplementation::push(const RSYNC_HANDLE handle, const std::vector<unsigned char>& data)
+{
+    const auto spRSyncContext
+    {
+        remoteSyncContext(handle)
+    };
+    //spRSyncContext->m_msgDispatcher.push(data);
+}

--- a/src/shared_modules/rsync/src/rsync_implementation.h
+++ b/src/shared_modules/rsync/src/rsync_implementation.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <vector>
 #include "typedef.h"
 
 namespace RSync
@@ -30,6 +31,7 @@ namespace RSync
         void release();
         bool releaseContext(const RSYNC_HANDLE handle);
         RSYNC_HANDLE create();
+        void push(const RSYNC_HANDLE handle, const std::vector<unsigned char>& data);
     private:
 
         class RSyncContext final

--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -52,8 +52,11 @@ TEST_F(RSyncTest, registerSyncId)
 
 TEST_F(RSyncTest, pushMessage)
 {
+    const std::string buffer{"test buffer"};
     const auto handle { rsync_create() };
-    ASSERT_EQ(0, rsync_push_message(handle, nullptr));
+    ASSERT_NE(0, rsync_push_message(handle, nullptr, 1000));
+    ASSERT_NE(0, rsync_push_message(handle, reinterpret_cast<const void*>(0x1000), 0));
+    ASSERT_EQ(0, rsync_push_message(handle, reinterpret_cast<const void*>(buffer.data()), buffer.size()));
 }
 
 TEST_F(RSyncTest, CloseWithoutInitialization)

--- a/src/shared_modules/rsync/testtool/agentEmulator.cpp
+++ b/src/shared_modules/rsync/testtool/agentEmulator.cpp
@@ -128,8 +128,8 @@ void AgentEmulator::updateData()
 void AgentEmulator::syncData(const void* buffer, size_t bufferSize)
 {
     std::cout << "AGENT: sync." << std::endl;
-    const char* first{reinterpret_cast<const char*>(buffer)};
-    const char* last{first + bufferSize};
+    const auto first{reinterpret_cast<const unsigned char*>(buffer)};
+    const auto last{first + bufferSize};
     const auto data
     {
         std::make_pair<SyncId, SyncData>(RSYNC_HANDLE{m_rsyncHandle}, SyncData{first, last})

--- a/src/shared_modules/rsync/testtool/agentEmulator.h
+++ b/src/shared_modules/rsync/testtool/agentEmulator.h
@@ -22,7 +22,7 @@
 
 
 using SyncId = RSYNC_HANDLE;
-using SyncData = std::vector<char>;
+using SyncData = std::vector<unsigned char>;
 using SyncMessage = std::pair<SyncId, SyncData>;
 using SyncQueue = Utils::SafeQueue<SyncMessage>;
 

--- a/src/shared_modules/rsync/testtool/managerEmulator.cpp
+++ b/src/shared_modules/rsync/testtool/managerEmulator.cpp
@@ -36,7 +36,7 @@ void ManagerEmulator::syncData()
         {
             std::cout << "MGR: syncData: " << msg.first << std::endl;
             //TODO: check received data and apply changes to local db.
-            rsync_push_message(msg.first, msg.second.data());
+            rsync_push_message(msg.first, msg.second.data(), msg.second.size());
         }
         std::this_thread::yield();
     }


### PR DESCRIPTION
# Rsync push message implementation.

## **Related Issue**
[5777](https://github.com/wazuh/wazuh/issues/5777)

## Description
This issue aims that after receiving a message from the manager, this message is redirected to remote sync, to process it according to the characteristics established by the callback or synchronization register #5773 .

This will dispatch the processing of these actions in dispatch threads according to the configuration.

## DoD / Tasks
- [X] Implementation
- [X] RTR
![image](https://user-images.githubusercontent.com/54002291/92928303-435ed380-f415-11ea-9a2b-8f9b30a2bcd4.png)

