### PR TITLE
Fix message error output when fails load cbdlist

### DIFF
--- a/src/analysisd/lists.c
+++ b/src/analysisd/lists.c
@@ -19,7 +19,7 @@ void Lists_OP_CreateLists()
     return;
 }
 
-int Lists_OP_LoadList(char *listfile, ListNode **cdblists)
+int Lists_OP_LoadList(char *listfile, ListNode **cdblists, OSList* log_msg)
 {
     char *holder;
     char a_filename[OS_MAXSTR];
@@ -51,7 +51,7 @@ int Lists_OP_LoadList(char *listfile, ListNode **cdblists)
     FILE *txt_fd = fopen(a_filename, "r");
     if (!txt_fd)
     {
-        merror(FOPEN_ERROR, a_filename, errno, strerror(errno));
+        smerror(log_msg, FOPEN_ERROR, a_filename, errno, strerror(errno));
         free(tmp_listnode_pt);
         return -1;
     }

--- a/src/analysisd/lists.h
+++ b/src/analysisd/lists.h
@@ -67,9 +67,10 @@ void OS_AddList( ListNode *new_listnode, ListNode **cdblists);
  * @brief Load cdb list
  * @param listfile file name where find cdb list
  * @param cdblists ListNode where save cdb list
+ * @param log_msg list to save log messages
  * @return 0 on success, otherwise -1
  */
-int Lists_OP_LoadList(char *listfile, ListNode **cdblists);
+int Lists_OP_LoadList(char *listfile, ListNode **cdblists, OSList* log_msg);
 
 /**
  * @brief Search a key in a cdb list

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -403,7 +403,7 @@ w_logtest_session_t *w_logtest_initialize_session(char *token, OSList* list_msg)
     files = Config.lists;
 
     while (files && *files) {
-        if (Lists_OP_LoadList(*files, &session->cdblistnode) < 0) {
+        if (Lists_OP_LoadList(*files, &session->cdblistnode, list_msg) < 0) {
             goto cleanup;
         }
         files++;

--- a/src/analysisd/makelists.c
+++ b/src/analysisd/makelists.c
@@ -165,8 +165,23 @@ int main(int argc, char **argv)
     {
         char **listfiles;
         listfiles = Config.lists;
+        OSList * list_msg = OSList_Create();
+        OSList_SetMaxSize(list_msg, ERRORLIST_MAXSIZE);
+
         while (listfiles && *listfiles) {
-            if (Lists_OP_LoadList(*listfiles, &os_analysisd_cdblists) < 0) {
+            if (Lists_OP_LoadList(*listfiles, &os_analysisd_cdblists, list_msg) < 0) {
+                char * msg;
+                OSListNode * node_log_msg;
+                node_log_msg = OSList_GetFirstNode(list_msg);
+                while (node_log_msg) {
+                    os_analysisd_log_msg_t * data_msg = node_log_msg->data;
+                    msg = os_analysisd_string_log_msg(data_msg);
+                    merror("%s", msg);
+                    os_free(msg);
+                    os_analysisd_free_log_msg(&data_msg);
+                    OSList_DeleteCurrentlyNode(list_msg);
+                    node_log_msg = OSList_GetFirstNode(list_msg);
+                }
                 merror_exit(LISTS_ERROR, *listfiles);
             }
             free(*listfiles);
@@ -174,6 +189,7 @@ int main(int argc, char **argv)
         }
         free(Config.lists);
         Config.lists = NULL;
+        os_free(list_msg);
     }
 
     printf(" Since Wazuh v3.11.0, this binary is deprecated\n");

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -250,7 +250,7 @@ int __wrap_SetDecodeXML(OSList* log_msg, OSStore **decoder_list,
     return mock_type(int);
 }
 
-int __wrap_Lists_OP_LoadList(char * files, ListNode ** cdblistnode) {
+int __wrap_Lists_OP_LoadList(char * files, ListNode ** cdblistnode, OSList * msg) {
     return mock_type(int);
 }
 
@@ -258,7 +258,7 @@ void __wrap_Lists_OP_MakeAll(int force, int show_message, ListNode **lnode) {
     return;
 }
 
-int __wrap_Rules_OP_ReadRules(char * file, RuleNode ** rule_list, ListNode ** cbd , EventList ** evet , OSList * msg) {
+int __wrap_Rules_OP_ReadRules(char * file, RuleNode ** rule_list, ListNode ** cbd , EventList ** evet, OSList * msg) {
     return mock_type(int);
 }
 


### PR DESCRIPTION
Hey Team!,

This PR, fix a error msg whens fail load cdb list.

Currently the error message when loading the cbd list is only written to the ossec log, this PR changes that, it only writes to the log if it fails to load the list from analysisd and in case the error occurred when the user tries to start session by logtest informs it returns the message through the socket.

## Tasks
  - [x] Scan-build report
  - [x] Compile witouth warnings in linux
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] Unit Test

Regards,
Julian.