### PR TITLE
Add new error message when invalid credentials are detected

### DIFF
--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -125,7 +125,11 @@ async def response_postprocessing(request, handler):
                                     detail=cleanup_detail_field(ex.__dict__['detail']) if 'detail' in ex.__dict__ else '',
                                     ext=ex.__dict__['ext'] if 'ext' in ex.__dict__ else None)
     except OAuthProblem:
-        problem = connexion_problem(401, "Unauthorized", type="about:blank", detail="No authorization token provided")
+        if request.path == '/security/user/authenticate' and request.method == 'GET':
+            problem = connexion_problem(401, "Unauthorized", type="about:blank", detail="Invalid credentials")
+        else:
+            problem = connexion_problem(401, "Unauthorized", type="about:blank",
+                                        detail="No authorization token provided")
     finally:
         if problem:
             remove_unwanted_fields()

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -12866,6 +12866,12 @@ paths:
           $ref: '#/components/responses/ResponseError'
         '401':
           $ref: '#/components/responses/InvalidCredentialsResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
 
   /security/actions:
     get:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -456,6 +456,16 @@ components:
             title: "Unauthorized"
             detail: "No authorization token provided"
 
+    InvalidCredentialsResponse:
+      description: "Response to report a problem with authentication"
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RequestError'
+          example:
+            title: "Unauthorized"
+            detail: "Invalid credentials"
+
     InvalidHTTPMethodResponse:
       description: "Response to an invalid HTTP method"
       content:
@@ -12790,7 +12800,7 @@ paths:
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
+          $ref: '#/components/responses/InvalidCredentialsResponse'
         '403':
           $ref: '#/components/responses/PermissionDeniedResponse'
         '405':
@@ -12854,6 +12864,8 @@ paths:
                 token: "<generated_token>"
         '400':
           $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/InvalidCredentialsResponse'
 
   /security/actions:
     get:


### PR DESCRIPTION
Hi team,

In this PR we have added a new error message when the user tries to get a token with invalid credentials.

```
{
  "title": "Unauthorized",
  "detail": "Invalid credentials"
}
```

Regards