### PR TITLE
Add pending logic on update-agent-keepalive query

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -187,6 +187,10 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
         if (is_startup) {
             /* Unlock mutex */
             w_mutex_unlock(&lastmsg_mutex);
+            agent_id = atoi(key->id);
+            if (OS_SUCCESS != wdb_update_agent_keepalive(agent_id, logr.worker_node?WDB_SYNC_REQ:WDB_SYNCED)) {            
+                mwarn("Unable to set last keepalive as pending");
+            }
         } else {
             /* Update message */
             mdebug2("save_controlmsg(): inserting '%s'", msg);

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -123,7 +123,7 @@ static const char *SQL_STMT[] = {
                                     SELECT id, '#\"_node_name\"' AS key, node_name AS value FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_LABELS_DEL] = "DELETE FROM labels WHERE id = ?;",
     [WDB_STMT_GLOBAL_LABELS_SET] = "INSERT INTO labels (id, key, value) VALUES (?,?,?);",
-    [WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE] = "UPDATE agent SET last_keepalive = STRFTIME('%s', 'NOW'), sync_status = ? WHERE id = ?;",
+    [WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE] = "UPDATE agent SET last_keepalive = CASE WHEN last_keepalive IS NULL THEN 0 ELSE STRFTIME('%s', 'NOW') END, sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_DELETE_AGENT] = "DELETE FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_SELECT_AGENT_NAME] = "SELECT name FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_SELECT_AGENT_GROUP] = "SELECT `group` FROM agent WHERE id = ?;",


### PR DESCRIPTION
|Related issue|
|---|
|6004|

## Description

This PR changes the update-agent-keepalive query to set last_keepalive value to 0 the first time is set.
This will reflect the PENDING status of the agent.
When HC_STARTUP arrives, remoted call this query to update last_keepalive and then, set it as 0.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [ ] Source installation

