### PR TITLE
Remove hot-changes in API configuration

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -9,7 +9,6 @@ import logging
 import os
 from secrets import token_urlsafe
 from shutil import chown
-from importlib import reload
 from time import time
 
 from jose import JWTError, jwt
@@ -110,13 +109,7 @@ def change_secret():
         jwt_secret.write(new_secret)
 
 
-def get_api_conf():
-    reload(configuration)
-    return copy.deepcopy(configuration.api_conf)
-
-
 def get_security_conf():
-    reload(configuration)
     return copy.deepcopy(configuration.security_conf)
 
 

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -19,7 +19,6 @@ from api.api_exception import APIError
 from api.constants import SECURITY_CONFIG_PATH
 from wazuh.core import common
 
-
 default_security_configuration = {
     "auth_token_exp_timeout": 3600,
     "rbac_mode": "white"
@@ -215,5 +214,5 @@ def read_yaml_config(config_file=common.api_config_path, default_conf=None) -> D
 
 
 # Configuration - global object
-api_conf = read_yaml_config()
+api_conf = dict()
 security_conf = read_yaml_config(config_file=SECURITY_CONFIG_PATH, default_conf=default_security_configuration)

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -826,6 +826,327 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: GET /cluster/api/config
+
+stages:
+
+  # GET /cluster/api/config
+  - name: Get API configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: "master-node"
+              node_api_config: &api_config
+                host: !anystr
+                port: !anyint
+                behind_proxy_server: !anybool
+                https:
+                  enabled: !anybool
+                  key: !anystr
+                  cert: !anystr
+                  use_ca: !anybool
+                  ca: !anystr
+                logs:
+                  level: !anystr
+                  path: !anystr
+                cors:
+                  enabled: !anybool
+                  source_route: !anystr
+                  expose_headers: !anystr
+                  allow_headers: !anystr
+                  allow_credentials: !anybool
+                cache:
+                  enabled: !anybool
+                  time: !anything
+                access:
+                  max_login_attempts: !anyint
+                  block_time: !anyint
+                  max_request_per_minute: !anyint
+                use_only_authd: !anybool
+                drop_privileges: !anybool
+                experimental_features: !anybool
+            - node_name: "worker1"
+              node_api_config:
+                <<: *api_config
+            - node_name: "worker2"
+              node_api_config:
+                <<: *api_config
+          total_affected_items: 3
+          total_failed_items: 0
+          failed_items: []
+
+  # GET /cluster/api/config/{node_list}
+  - name: Get API configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        list_nodes: 'worker1,worker2'
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: 'worker1'
+              node_api_config:
+                <<: *api_config
+            - node_name: 'worker2'
+              node_api_config:
+                <<: *api_config
+          total_affected_items: 2
+          total_failed_items: 0
+          failed_items: []
+
+---
+test_name: PUT /cluster/api/config
+
+stages:
+
+  # PUT /cluster/api/config
+  - name: Modify API configuration (some fields)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        cache:
+          enabled: false
+          time: 1
+    response:
+      status_code: 200
+      json: &update_api_config_ok
+        data:
+          affected_items: !anything
+          total_affected_items: 3
+          total_failed_items: 0
+          failed_items: []
+
+  # PUT /cluster/api/config
+  - name: Modify API configuration (all allowed fields)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        list_nodes: 'worker1,worker2'
+      method: PUT
+      json:
+        logs:
+          level: "debug"
+        cache:
+          enabled: true
+          time: 3
+        access:
+          block_time: 0
+        use_only_authd: true
+        experimental_features: true
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - worker1
+            - worker2
+          total_affected_items: 2
+          total_failed_items: 0
+          failed_items: []
+
+  # PUT /cluster/api/config
+  - name: Modify API configuration (forbidden field)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        logs:
+          path: "test"
+    response:
+      status_code: 400
+
+  # Restart nodes to apply changes
+  - name: Restart cluster
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
+  # GET /cluster/api/config
+  - name: Get API configuration that was set above
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: 'master-node'
+              node_api_config:
+                <<: *api_config
+            - node_name: 'worker1'
+              node_api_config: &modified_api_config
+                logs:
+                  level: "debug"
+                cache:
+                  enabled: true
+                  time: 3
+                use_only_authd: true
+                experimental_features: true
+            - node_name: 'worker2'
+              node_api_config:
+                <<: *modified_api_config
+          total_affected_items: 3
+          total_failed_items: 0
+          failed_items: []
+
+---
+test_name: DELETE /cluster/api/config
+
+stages:
+
+  # DELETE /cluster/api/config (worker1)
+  - name: Restore API configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        list_nodes: 'worker1'
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items: !anything
+          total_affected_items: 1
+          total_failed_items: 0
+          failed_items: []
+
+  # Restart nodes to apply changes
+  - name: Restart cluster
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
+  # GET /cluster/api/config
+  - name: Get API default configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: 'master-node'
+              node_api_config:
+                <<: *api_config
+            - node_name: 'worker1'
+              node_api_config:
+                logs:
+                  level: "info"
+                cache:
+                  enabled: true
+                  time: 0.75
+                use_only_authd: false
+                experimental_features: false
+            - node_name: 'worker2'
+              node_api_config:
+                <<: *modified_api_config
+          total_affected_items: 3
+          total_failed_items: 0
+          failed_items: []
+
+  # DELETE /cluster/api/config (all nodes)
+  - name: Restore API configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items: !anything
+          total_affected_items: 3
+          total_failed_items: 0
+          failed_items: []
+
+  # Restart nodes to apply changes
+  - name: Restart cluster
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
+  # GET /cluster/api/config
+  - name: Get API default configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: 'master-node'
+              node_api_config:
+                <<: *api_config
+            - node_name: 'worker1'
+              node_api_config:
+                <<: *api_config
+            - node_name: 'worker2'
+              node_api_config:
+                <<: *api_config
+          total_affected_items: 3
+          total_failed_items: 0
+          failed_items: []
+
+---
 test_name: GET /cluster/{node_id}/configuration/{component}/{configuration}
 
 stages:
@@ -2350,291 +2671,6 @@ stages:
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
-
----
-test_name: GET /cluster/api/config
-
-stages:
-
-  # GET /cluster/api/config
-  - name: Get API configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: "master-node"
-              node_api_config: &api_config
-                host: !anystr
-                port: !anyint
-                behind_proxy_server: !anybool
-                https:
-                  enabled: !anybool
-                  key: !anystr
-                  cert: !anystr
-                  use_ca: !anybool
-                  ca: !anystr
-                logs:
-                  level: !anystr
-                  path: !anystr
-                cors:
-                  enabled: !anybool
-                  source_route: !anystr
-                  expose_headers: !anystr
-                  allow_headers: !anystr
-                  allow_credentials: !anybool
-                cache:
-                  enabled: !anybool
-                  time: !anything
-                access:
-                  max_login_attempts: !anyint
-                  block_time: !anyint
-                  max_request_per_minute: !anyint
-                use_only_authd: !anybool
-                drop_privileges: !anybool
-                experimental_features: !anybool
-            - node_name: "worker1"
-              node_api_config:
-                <<: *api_config
-            - node_name: "worker2"
-              node_api_config:
-                <<: *api_config
-          total_affected_items: 3
-          total_failed_items: 0
-          failed_items: []
-
-  # GET /cluster/api/config/{node_list}
-  - name: Get API configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        list_nodes: 'worker1,worker2'
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: 'worker1'
-              node_api_config:
-                <<: *api_config
-            - node_name: 'worker2'
-              node_api_config:
-                <<: *api_config
-          total_affected_items: 2
-          total_failed_items: 0
-          failed_items: []
-
----
-test_name: PUT /cluster/api/config
-
-stages:
-
-  # PUT /cluster/api/config
-  - name: Modify API configuration (some fields)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-      json:
-        cache:
-          enabled: false
-          time: 1
-    response:
-      status_code: 200
-      json: &update_api_config_ok
-        data:
-          affected_items: !anything
-          total_affected_items: 3
-          total_failed_items: 0
-          failed_items: []
-
-  # PUT /cluster/api/config
-  - name: Modify API configuration (all allowed fields)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        list_nodes: 'worker1,worker2'
-      method: PUT
-      json:
-        logs:
-          level: "debug"
-        cache:
-          enabled: true
-          time: 3
-        access:
-          block_time: 0
-        use_only_authd: true
-        experimental_features: true
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - worker1
-            - worker2
-          total_affected_items: 2
-          total_failed_items: 0
-          failed_items: []
-
-  # PUT /cluster/api/config
-  - name: Modify API configuration (forbidden field)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-      json:
-        logs:
-          path: "test"
-    response:
-      status_code: 400
-
-  # GET /cluster/api/config
-  - name: Get API configuration that was set above
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: 'master-node'
-              node_api_config:
-                <<: *api_config
-            - node_name: 'worker1'
-              node_api_config: &modified_api_config
-                logs:
-                  level: "debug"
-                cache:
-                  enabled: true
-                  time: 3
-                use_only_authd: true
-                experimental_features: true
-            - node_name: 'worker2'
-              node_api_config:
-                <<: *modified_api_config
-          total_affected_items: 3
-          total_failed_items: 0
-          failed_items: []
-
----
-test_name: DELETE /cluster/api/config
-
-stages:
-
-  # DELETE /cluster/api/config (worker1)
-  - name: Restore API configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: DELETE
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        list_nodes: 'worker1'
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items: !anything
-          total_affected_items: 1
-          total_failed_items: 0
-          failed_items: []
-
-  # GET /cluster/api/config
-  - name: Get API default configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: 'master-node'
-              node_api_config:
-                <<: *api_config
-            - node_name: 'worker1'
-              node_api_config:
-                logs:
-                  level: "info"
-                cache:
-                  enabled: true
-                  time: 0.75
-                use_only_authd: false
-                experimental_features: false
-            - node_name: 'worker2'
-              node_api_config:
-                <<: *modified_api_config
-          total_affected_items: 3
-          total_failed_items: 0
-          failed_items: []
-
-  # DELETE /cluster/api/config (all nodes)
-  - name: Restore API configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: DELETE
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items: !anything
-          total_affected_items: 3
-          total_failed_items: 0
-          failed_items: []
-
-  # GET /cluster/api/config
-  - name: Get API default configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: 'master-node'
-              node_api_config:
-                <<: *api_config
-            - node_name: 'worker1'
-              node_api_config:
-                <<: *api_config
-            - node_name: 'worker2'
-              node_api_config:
-                <<: *api_config
-          total_affected_items: 3
-          total_failed_items: 0
-          failed_items: []
 
 ---
 test_name: PUT /cluster/restart

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -679,6 +679,248 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: GET /manager/api/config
+
+stages:
+
+  # GET /manager/api/config
+  - name: Get API configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: !anystr
+              node_api_config:
+                host: !anystr
+                port: !anyint
+                behind_proxy_server: !anybool
+
+                https:
+                  enabled: !anybool
+                  key: !anystr
+                  cert: !anystr
+                  use_ca: !anybool
+                  ca: !anystr
+                logs:
+                  level: !anystr
+                  path: !anystr
+                cors:
+                  enabled: !anybool
+                  source_route: !anystr
+                  expose_headers: !anystr
+                  allow_headers: !anystr
+                  allow_credentials: !anybool
+                cache:
+                  enabled: !anybool
+                  time: !anything
+                access:
+                  max_login_attempts: !anyint
+                  block_time: !anyint
+                  max_request_per_minute: !anyint
+                use_only_authd: !anybool
+                drop_privileges: !anybool
+                experimental_features: !anybool
+          total_affected_items: 1
+          total_failed_items: 0
+          failed_items: []
+
+---
+test_name: PUT /manager/api/config
+
+stages:
+
+  # PUT /manager/api/config
+  - name: Modify API configuration (some fields)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        cache:
+          enabled: false
+          time: 1
+    response:
+      status_code: 200
+      json: &update_api_config_ok
+        data:
+          affected_items: !anything
+          total_affected_items: 1
+          total_failed_items: 0
+          failed_items: []
+
+  # PUT /manager/api/config
+  - name: Modify API configuration (all allowed fields)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        behind_proxy_server: false
+        logs:
+          level: "debug"
+        cache:
+          enabled: true
+          time: 3
+        cors:
+          enabled: true
+          source_route: "*"
+          expose_headers: "*"
+          allow_headers: "*"
+          allow_credentials: false
+        use_only_authd: true
+        experimental_features: true
+    response:
+      status_code: 200
+      json:
+        <<: *update_api_config_ok
+
+  # PUT /manager/api/config
+  - name: Modify API configuration (forbidden field)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        logs:
+          path: "test"
+    response:
+      status_code: 400
+
+  # Restart manager to apply changes
+  - name: Restart manager
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
+  # GET /manager/api/config
+  - name: Get API configuration that were set above
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: !anystr
+              node_api_config: &api_response
+                host: !anystr
+                port: !anyint
+                behind_proxy_server: false
+                https:
+                  enabled: !anybool
+                  key: !anystr
+                  cert: !anystr
+                  use_ca: !anybool
+                  ca: !anystr
+                logs:
+                  level: "debug"
+                  path: !anystr
+                cors:
+                  enabled: true
+                  source_route: "*"
+                  expose_headers: "*"
+                  allow_headers: "*"
+                  allow_credentials: false
+                cache:
+                  enabled: true
+                  time: 3
+                use_only_authd: true
+                drop_privileges: !anybool
+                experimental_features: true
+          total_affected_items: 1
+          total_failed_items: 0
+          failed_items: []
+
+---
+test_name: DELETE /manager/api/config
+
+stages:
+
+  # DELETE /manager/api/config
+  - name: Restore API configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        <<: *update_api_config_ok
+
+  # Restart manager to apply changes
+  - name: Restart manager
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
+  # GET /manager/api/config
+  - name: Get API default configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: !anystr
+              node_api_config:
+                <<: *api_response
+                logs:
+                  level: "info"
+                  path: !anystr
+                cors:
+                  enabled: false
+                  source_route: "*"
+                  expose_headers: "*"
+                  allow_headers: "*"
+                  allow_credentials: false
+                cache:
+                  enabled: true
+                  time: 0.75
+                use_only_authd: false
+                drop_privileges: !anybool
+                experimental_features: false
+          total_affected_items: 1
+          total_failed_items: 0
+          failed_items: []
+
+
+---
 test_name: GET /manager/files
 
 stages:
@@ -1681,222 +1923,6 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
----
-test_name: GET /manager/api/config
-
-stages:
-
-  # GET /manager/api/config
-  - name: Get API configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: !anystr
-              node_api_config:
-                host: !anystr
-                port: !anyint
-                behind_proxy_server: !anybool
-
-                https:
-                  enabled: !anybool
-                  key: !anystr
-                  cert: !anystr
-                  use_ca: !anybool
-                  ca: !anystr
-                logs:
-                  level: !anystr
-                  path: !anystr
-                cors:
-                  enabled: !anybool
-                  source_route: !anystr
-                  expose_headers: !anystr
-                  allow_headers: !anystr
-                  allow_credentials: !anybool
-                cache:
-                  enabled: !anybool
-                  time: !anything
-                access:
-                  max_login_attempts: !anyint
-                  block_time: !anyint
-                  max_request_per_minute: !anyint
-                use_only_authd: !anybool
-                drop_privileges: !anybool
-                experimental_features: !anybool
-          total_affected_items: 1
-          total_failed_items: 0
-          failed_items: []
-
----
-test_name: PUT /manager/api/config
-
-stages:
-
-  # PUT /manager/api/config
-  - name: Modify API configuration (some fields)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-      json:
-        cache:
-          enabled: false
-          time: 1
-    response:
-      status_code: 200
-      json: &update_api_config_ok
-        data:
-          affected_items: !anything
-          total_affected_items: 1
-          total_failed_items: 0
-          failed_items: []
-
-  # PUT /manager/api/config
-  - name: Modify API configuration (all allowed fields)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-      json:
-        behind_proxy_server: false
-        logs:
-          level: "debug"
-        cache:
-          enabled: true
-          time: 3
-        cors:
-          enabled: true
-          source_route: "*"
-          expose_headers: "*"
-          allow_headers: "*"
-          allow_credentials: false
-        use_only_authd: true
-        experimental_features: true
-    response:
-      status_code: 200
-      json:
-        <<: *update_api_config_ok
-
-  # PUT /manager/api/config
-  - name: Modify API configuration (forbidden field)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-      json:
-        logs:
-          path: "test"
-    response:
-      status_code: 400
-
-  # GET /manager/api/config
-  - name: Get API configuration that were set above
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: !anystr
-              node_api_config: &api_response
-                host: !anystr
-                port: !anyint
-                behind_proxy_server: false
-                https:
-                  enabled: !anybool
-                  key: !anystr
-                  cert: !anystr
-                  use_ca: !anybool
-                  ca: !anystr
-                logs:
-                  level: "debug"
-                  path: !anystr
-                cors:
-                  enabled: true
-                  source_route: "*"
-                  expose_headers: "*"
-                  allow_headers: "*"
-                  allow_credentials: false
-                cache:
-                  enabled: true
-                  time: 3
-                use_only_authd: true
-                drop_privileges: !anybool
-                experimental_features: true
-          total_affected_items: 1
-          total_failed_items: 0
-          failed_items: []
-
----
-test_name: DELETE /manager/api/config
-
-stages:
-
-  # DELETE /manager/api/config
-  - name: Restore API configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      method: DELETE
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        <<: *update_api_config_ok
-
-  # GET /manager/api/config
-  - name: Get API default configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: !anystr
-              node_api_config:
-                <<: *api_response
-                logs:
-                  level: "info"
-                  path: !anystr
-                cors:
-                  enabled: false
-                  source_route: "*"
-                  expose_headers: "*"
-                  allow_headers: "*"
-                  allow_credentials: false
-                cache:
-                  enabled: true
-                  time: 0.75
-                use_only_authd: false
-                drop_privileges: !anybool
-                experimental_features: false
-          total_affected_items: 1
-          total_failed_items: 0
-          failed_items: []
 
 ---
 test_name: PUT /manager/restart

--- a/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
@@ -758,6 +758,23 @@ stages:
       status_code: 200
 
 ---
+test_name: PUT /cluster/restart
+
+stages:
+
+  # Restart nodes to apply changes
+  - name: Restart cluster
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
+---
 test_name: CHECK /security/config
 
 stages:

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -532,6 +532,18 @@ test_name: PUT /security/config (Check)
 
 stages:
 
+  # Restart nodes to apply changes
+  - name: Restart cluster
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
   - name: Get security configuration to check if PUT method worked correctly
     request:
       verify: False

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -3,6 +3,9 @@
 # Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+from api import configuration
+configuration.api_conf.update(configuration.read_yaml_config())
+
 import argparse
 import asyncio
 import logging

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import copy
 import fcntl
 import json
 import random
@@ -16,9 +17,9 @@ from os.path import exists, join
 from pyexpat import ExpatError
 from shutil import Error
 from typing import Dict
+from xml.dom.minidom import parseString
 
 import yaml
-from xml.dom.minidom import parseString
 
 from api import configuration
 from wazuh import WazuhInternalError, WazuhError
@@ -355,12 +356,12 @@ def replace_in_comments(original_content, to_be_replaced, replacement):
 
 
 def get_api_conf():
-    """Returns current API configuration."""
-    return configuration.api_conf
+    """Return current API configuration."""
+    return copy.deepcopy(configuration.api_conf)
 
 
 def update_api_conf(new_config):
-    """Update dict and subdicts without overriding unspecified keys and write it in the API.yaml file.
+    """Update the API.yaml file.
 
     Parameters
     ----------
@@ -368,16 +369,9 @@ def update_api_conf(new_config):
         Dictionary with the new configuration.
     """
     if new_config:
-        for key in new_config:
-            if key in configuration.api_conf:
-                if isinstance(configuration.api_conf[key], dict) and isinstance(new_config[key], dict):
-                    configuration.api_conf[key].update(new_config[key])
-                else:
-                    configuration.api_conf[key] = new_config[key]
-
         try:
             with open(common.api_config_path, 'w+') as f:
-                yaml.dump(configuration.api_conf, f)
+                yaml.dump(new_config, f)
         except IOError:
             raise WazuhInternalError(1005)
     else:

--- a/framework/wazuh/core/security.py
+++ b/framework/wazuh/core/security.py
@@ -30,12 +30,10 @@ def update_security_conf(new_config):
     new_config : dict
         Dictionary with the new configuration.
     """
-    configuration.security_conf.update(new_config)
-
     if new_config:
         try:
             with open(SECURITY_CONFIG_PATH, 'w+') as f:
-                yaml.dump(configuration.security_conf, f)
+                yaml.dump(new_config, f)
         except IOError:
             raise WazuhInternalError(1005)
     else:

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -461,9 +461,8 @@ def test_update_api_conf(mock_open, mock_yaml):
     with patch('wazuh.core.manager.configuration.api_conf', new=old_config):
         update_api_conf(new_config=new_config)
 
-        assert old_config == {'experimental_features': True, 'cache': {'enabled': True, 'time': 0.75}}
         mock_open.assert_called_once(), '"Open" should be called, but it was not.'
-        mock_yaml.assert_called_once_with(old_config, ANY), '"Yaml.dump" should be called with updated config.'
+        mock_yaml.assert_called_once_with(new_config, ANY), '"Yaml.dump" should be called with updated config.'
 
 
 def test_update_api_conf_ko():

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -247,9 +247,9 @@ def get_api_config():
 
 _update_config_default_result_kwargs = {
     'all_msg': f"API configuration was successfully updated{' in all specified nodes' if node_id != 'manager' else '' }. "
-               f"Some settings may require restarting the API to be applied",
-    'some_msg': 'Not all API configuration could be updated',
-    'none_msg': f"API configuration could not be updated{' in any node' if node_id != 'manager' else ''}",
+               f"Settings require restarting the API to be applied.",
+    'some_msg': 'Not all API configuration could be updated.',
+    'none_msg': f"API configuration could not be updated{' in any node' if node_id != 'manager' else ''}.",
     'sort_casting': ['str']
 }
 

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -5,7 +5,7 @@
 import os
 import socket
 import sys
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock, mock_open, ANY
 import json
 
 import pytest
@@ -263,7 +263,7 @@ def test_get_api_config():
     assert result['data']['affected_items'][0]['node_name'] == 'manager', 'Not expected node name'
 
 
-@patch('wazuh.core.manager.yaml')
+@patch('wazuh.core.manager.yaml.dump')
 @patch('wazuh.core.manager.open')
 def test_update_api_config(mock_open, mock_yaml):
     """Checks that update_api_config method is updating current api_conf dict and returning expected result."""
@@ -275,7 +275,8 @@ def test_update_api_config(mock_open, mock_yaml):
 
         assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type.'
         assert result.render()['data']['total_failed_items'] == 0, 'Total_failed_items should be 0.'
-        assert old_config == new_config, 'Old configuration should be equal to new configuration.'
+        assert old_config != new_config, 'Old configuration should be equal to new configuration.'
+        mock_yaml.assert_called_once_with(new_config, ANY)
 
 
 def test_update_api_config_ko():


### PR DESCRIPTION
|Related issue|
|---|
|#5993|

# Description

Hi team!

To increase the consistency in the behaviour of different configurations, and avoid entangling the user, we have decided to remove those settings that until now were hot applied when modified through API endpoints.

Therefore, now it will be necessary to restart the manager, or failing that the API, to apply the changes made to any of these endpoints:
- PUT /cluster/api/config
- PUT /manager/api/config
- PUT /security/config

As long as Wazuh is not restarted, each node will show the current active configuration when using the GET method of the mentioned endpoints.

# Tests

## Integration tests

### Manager

```
pytest -vv test_manager_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-47-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 35 items                                                                                                                                                                                           

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                                         [  2%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                           [  5%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                                                                                                                [  8%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                                                                                                  [ 11%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                                                                                               [ 14%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                                                                                               [ 17%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                                                                                               [ 20%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                                                                                                [ 22%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                                                                                             [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                                                                                               [ 28%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                                                                                                [ 31%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                                                                                             [ 34%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                                                                                               [ 37%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                                                                                                   [ 40%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                                                                                              [ 42%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                                                                                                          [ 45%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detector] PASSED                                                                                                [ 48%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                                  [ 51%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                                          [ 54%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                                   [ 57%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                                   [ 60%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                                [ 62%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                                  [ 65%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                           [ 68%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                                   [ 71%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                                                     [ 74%]
test_manager_endpoints.tavern.yaml::PUT /manager/api/config PASSED                                                                                                                                     [ 77%]
test_manager_endpoints.tavern.yaml::DELETE /manager/api/config PASSED                                                                                                                                  [ 80%]
test_manager_endpoints.tavern.yaml::GET /manager/files PASSED                                                                                                                                          [ 82%]
test_manager_endpoints.tavern.yaml::PUT /manager/files PASSED                                                                                                                                          [ 85%]
test_manager_endpoints.tavern.yaml::DELETE /manager/files PASSED                                                                                                                                       [ 88%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                                                                                                  [ 91%]
test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED                                                                                                                                [ 94%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                                      [ 97%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                                        [100%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 21 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.base_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:182: 15 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:182: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item_new = YamlItem(spec_new["test_name"], self, spec_new, self.fspath)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================ 35 passed, 38 warnings in 159.71s (0:02:39) =================================================================================
```

```
pytest -vv test_rbac_black_manager_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-47-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 19 items                                                                                                                                                                                           

test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                       [  5%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration/validation PASSED                                                                                                            [ 10%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                           [ 15%]
test_rbac_black_manager_endpoints.tavern.yaml::DELETE /manager/files PASSED                                                                                                                            [ 21%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/files PASSED                                                                                                                               [ 26%]
test_rbac_black_manager_endpoints.tavern.yaml::PUT /manager/files PASSED                                                                                                                               [ 31%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                [ 36%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                [ 42%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                        [ 47%]
test_rbac_black_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                             [ 52%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                               [ 57%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                     [ 63%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                        [ 68%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                       [ 73%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                        [ 78%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                              [ 84%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                                          [ 89%]
test_rbac_black_manager_endpoints.tavern.yaml::PUT /manager/api/config PASSED                                                                                                                          [ 94%]
test_rbac_black_manager_endpoints.tavern.yaml::DELETE /manager/api/config PASSED                                                                                                                       [100%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 19 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.rbac_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================ 19 passed, 21 warnings in 108.22s (0:01:48) =================================================================================
```

```
pytest -vv test_rbac_white_manager_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-47-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 19 items                                                                                                                                                                                           

test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                       [  5%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration/validation PASSED                                                                                                            [ 10%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                           [ 15%]
test_rbac_white_manager_endpoints.tavern.yaml::DELETE /manager/files PASSED                                                                                                                            [ 21%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/files PASSED                                                                                                                               [ 26%]
test_rbac_white_manager_endpoints.tavern.yaml::PUT /manager/files PASSED                                                                                                                               [ 31%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                [ 36%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                [ 42%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                        [ 47%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                               [ 52%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                     [ 57%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                        [ 63%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                       [ 68%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                        [ 73%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                              [ 78%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                                          [ 84%]
test_rbac_white_manager_endpoints.tavern.yaml::PUT /manager/api/config PASSED                                                                                                                          [ 89%]
test_rbac_white_manager_endpoints.tavern.yaml::DELETE /manager/api/config PASSED                                                                                                                       [ 94%]
test_rbac_white_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                             [100%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 19 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.rbac_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================= 19 passed, 21 warnings in 66.88s (0:01:06) =================================================================================
```

### Cluster

```
pytest -vv test_cluster_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-47-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 56 items                                                                                                                                                                                           

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                                                                   [  1%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                                                    [  3%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                                                     [  5%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                                                          [  7%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                                                                                             [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                                                                                                 [ 10%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                                                                                                 [ 12%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                                                                                               [ 14%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                                                                                             [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                                                                                             [ 17%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                                                                                                          [ 19%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                                                         [ 21%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                                                        [ 23%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                                                       [ 25%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                                                     [ 26%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/api/config PASSED                                                                                                                                     [ 28%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/api/config PASSED                                                                                                                                  [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                                                            [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[master-node] PASSED                                                                                                                   [ 33%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[worker1] PASSED                                                                                                                       [ 35%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[worker2] PASSED                                                                                                                       [ 37%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[master-node] PASSED                                                                                                                [ 39%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[worker1] PASSED                                                                                                                    [ 41%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[worker2] PASSED                                                                                                                    [ 42%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[master-node] PASSED                                                                                                                   [ 44%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[worker1] PASSED                                                                                                                       [ 46%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[worker2] PASSED                                                                                                                       [ 48%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/wrong_node/files PASSED                                                                                                                               [ 50%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                                                                                                    [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                                                                                                        [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                                                                                                        [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                                                                                                    [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                                                                                                        [ 58%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                                                                                                        [ 60%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                                                                                                [ 62%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                                                                                                [ 64%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                                                                                                   [ 66%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                                                                                                       [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                                                                                                       [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                                                                                               [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                                                                                                         [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                                                                                                             [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                                                                                                             [ 76%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                                                                                            [ 78%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                                                                                                [ 80%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                                                                                                [ 82%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                                                                                                           [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                                                                                               [ 85%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                                                                                               [ 87%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                                                                                            [ 89%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                                                                                                [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                                                                                                [ 92%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                                                                                                  [ 94%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                                                                                                      [ 96%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                                                                                                      [ 98%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                                                        [100%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 28 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.base_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:182: 42 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:182: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item_new = YamlItem(spec_new["test_name"], self, spec_new, self.fspath)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================ 56 passed, 72 warnings in 293.57s (0:04:53) =================================================================================
```

```
pytest -vv test_rbac_black_cluster_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-47-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 21 items                                                                                                                                                                                           

test_rbac_black_cluster_endpoints.tavern.yaml::/cluster/local/config PASSED                                                                                                                            [  4%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                                         [  9%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                                          [ 14%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                                               [ 19%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/nodes/{node_id} PASSED                                                                                                                     [ 23%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                                              [ 28%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                                             [ 33%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                                            [ 38%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                                                 [ 42%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info PASSED                                                                                                                      [ 47%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs PASSED                                                                                                                      [ 52%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary PASSED                                                                                                              [ 57%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats PASSED                                                                                                                     [ 61%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status PASSED                                                                                                                    [ 66%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files PASSED                                                                                                                     [ 71%]
test_rbac_black_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files PASSED                                                                                                                     [ 76%]
test_rbac_black_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files PASSED                                                                                                                  [ 80%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                                          [ 85%]
test_rbac_black_cluster_endpoints.tavern.yaml::PUT /cluster/api/config PASSED                                                                                                                          [ 90%]
test_rbac_black_cluster_endpoints.tavern.yaml::DELETE /cluster/api/config PASSED                                                                                                                       [ 95%]
test_rbac_black_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                                             [100%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 21 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.rbac_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================= 21 passed, 23 warnings in 93.86s (0:01:33) =================================================================================
```
```
pytest -vv test_rbac_white_cluster_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-47-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 21 items                                                                                                                                                                                           

test_rbac_white_cluster_endpoints.tavern.yaml::/cluster/local/config PASSED                                                                                                                            [  4%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                                         [  9%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                                          [ 14%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                                               [ 19%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/nodes/{node_id} PASSED                                                                                                                     [ 23%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                                              [ 28%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                                             [ 33%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                                            [ 38%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                                                 [ 42%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info PASSED                                                                                                                      [ 47%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs PASSED                                                                                                                      [ 52%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary PASSED                                                                                                              [ 57%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats PASSED                                                                                                                     [ 61%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status PASSED                                                                                                                    [ 66%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                                          [ 71%]
test_rbac_white_cluster_endpoints.tavern.yaml::PUT /cluster/api/config PASSED                                                                                                                          [ 76%]
test_rbac_white_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                                             [ 80%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files PASSED                                                                                                                     [ 85%]
test_rbac_white_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files PASSED                                                                                                                     [ 90%]
test_rbac_white_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files PASSED                                                                                                                  [ 95%]
test_rbac_white_cluster_endpoints.tavern.yaml::DELETE /cluster/api/config PASSED                                                                                                                       [100%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 21 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.rbac_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================ 21 passed, 23 warnings in 176.40s (0:02:56) =================================================================================
```

### Security 


```
pytest -vv test_security_GET_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-47-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 17 items                                                                                                                                                                                           

test_security_GET_endpoints.tavern.yaml::GET /security/roles PASSED                                                                                                                                    [  5%]
test_security_GET_endpoints.tavern.yaml::GET /security/policies PASSED                                                                                                                                 [ 11%]
test_security_GET_endpoints.tavern.yaml::GET /security/rules PASSED                                                                                                                                    [ 17%]
test_security_GET_endpoints.tavern.yaml::GET /security/roles PASSED                                                                                                                                    [ 17%]
test_security_GET_endpoints.tavern.yaml::GET /security/rules/{rule_id} PASSED                                                                                                                          [ 23%]
test_security_GET_endpoints.tavern.yaml::GET /security/policies/{policy_id} PASSED                                                                                                                     [ 29%]
test_security_GET_endpoints.tavern.yaml::GET /security/user/authenticate PASSED                                                                                                                        [ 35%]
test_security_GET_endpoints.tavern.yaml::GET /security/users PASSED                                                                                                                                    [ 41%]
test_security_GET_endpoints.tavern.yaml::GET /security/users/me PASSED                                                                                                                                 [ 47%]
test_security_GET_endpoints.tavern.yaml::GET /security/users PASSED                                                                                                                                    [ 47%]
test_security_GET_endpoints.tavern.yaml::GET /security/users/?search[wazuh-wui] PASSED                                                                                                                 [ 52%]
test_security_GET_endpoints.tavern.yaml::GET /security/users/?search[normal] PASSED                                                                                                                    [ 58%]
test_security_GET_endpoints.tavern.yaml::GET /security/users/?sort PASSED                                                                                                                              [ 64%]
test_security_GET_endpoints.tavern.yaml::GET /security/users/?limit,offset PASSED                                                                                                                      [ 70%]
test_security_GET_endpoints.tavern.yaml::GET /security/actions PASSED                                                                                                                                  [ 76%]
test_security_GET_endpoints.tavern.yaml::GET /security/resources PASSED                                                                                                                                [ 82%]
test_security_GET_endpoints.tavern.yaml::GET /security/config PASSED                                                                                                                                   [ 88%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 16 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.base_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:182
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:182
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:182: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item_new = YamlItem(spec_new["test_name"], self, spec_new, self.fspath)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================= 17 passed, 20 warnings in 97.36s (0:01:37) =================================================================================
```
```
pytest -vv test_security_DELETE_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-47-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 15 items                                                                                                                                                                                           

test_security_DELETE_endpoints.tavern.yaml::DELETE /security/roles/{role_id} PASSED                                                                                                                    [  6%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/roles/{role_id}/policies/{policy_id} PASSED                                                                                               [ 13%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/roles/{role_id}/rules PASSED                                                                                                              [ 20%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/user/{user_id}/roles/{role_id} PASSED                                                                                                     [ 26%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/policies/{policy_id} PASSED                                                                                                               [ 33%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/roles PASSED                                                                                                                              [ 40%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/policies PASSED                                                                                                                           [ 46%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/users PASSED                                                                                                                              [ 53%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/rules PASSED                                                                                                                              [ 60%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/rules (invalid) PASSED                                                                                                                    [ 66%]
test_security_DELETE_endpoints.tavern.yaml::PUT /security/config PASSED                                                                                                                                [ 73%]
test_security_DELETE_endpoints.tavern.yaml::RESTORE /security/config PASSED                                                                                                                            [ 80%]
test_security_DELETE_endpoints.tavern.yaml::CHECK /security/config PASSED                                                                                                                              [ 86%]
test_security_DELETE_endpoints.tavern.yaml::CLEANER DELETE /security/{policies} PASSED                                                                                                                 [ 93%]
test_security_DELETE_endpoints.tavern.yaml::CLEANER DELETE /security/{roles} PASSED                                                                                                                    [100%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 15 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.base_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================ 15 passed, 17 warnings in 112.43s (0:01:52) =================================================================================
```
```
pytest -vv test_security_DELETE_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.2', 'Platform': 'Linux-5.4.0-47-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 16 items                                                                                                                                                                                           

test_security_DELETE_endpoints.tavern.yaml::DELETE /security/roles/{role_id} PASSED                                                                                                                    [  6%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/roles/{role_id}/policies/{policy_id} PASSED                                                                                               [ 12%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/roles/{role_id}/rules PASSED                                                                                                              [ 18%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/user/{user_id}/roles/{role_id} PASSED                                                                                                     [ 25%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/policies/{policy_id} PASSED                                                                                                               [ 31%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/roles PASSED                                                                                                                              [ 37%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/policies PASSED                                                                                                                           [ 43%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/users PASSED                                                                                                                              [ 50%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/rules PASSED                                                                                                                              [ 56%]
test_security_DELETE_endpoints.tavern.yaml::DELETE /security/rules (invalid) PASSED                                                                                                                    [ 62%]
test_security_DELETE_endpoints.tavern.yaml::PUT /security/config PASSED                                                                                                                                [ 68%]
test_security_DELETE_endpoints.tavern.yaml::RESTORE /security/config PASSED                                                                                                                            [ 75%]
test_security_DELETE_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                                                [ 81%]
test_security_DELETE_endpoints.tavern.yaml::CHECK /security/config PASSED                                                                                                                              [ 87%]
test_security_DELETE_endpoints.tavern.yaml::CLEANER DELETE /security/{policies} PASSED                                                                                                                 [ 93%]
test_security_DELETE_endpoints.tavern.yaml::CLEANER DELETE /security/{roles} PASSED                                                                                                                    [100%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: 16 tests with warnings
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.base_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================ 16 passed, 18 warnings in 153.73s (0:02:33) =================================================================================
```

## Unit tests
### Manager
```
pytest wazuh/tests/test_manager.py -x
================================================================= test session starts ==================================================================
platform linux -- Python 3.8.2, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: trio-0.6.0, asyncio-0.14.0
collected 40 items                                                                                                                                     

wazuh/tests/test_manager.py ........................................                                                                             [100%]

================================================================== 40 passed in 0.37s ==================================================================
```

```
pytest wazuh/core/tests/test_manager.py 
================================================= test session starts =================================================
platform linux -- Python 3.8.2, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: trio-0.6.0, asyncio-0.14.0
collected 32 items                                                                                                    

wazuh/core/tests/test_manager.py ................................                                               [100%]

================================================= 32 passed in 0.28s ==================================================
```

Kind regards,
Selu.
