### PR TITLE
Fixing inconsistency in labels between master and workers

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -108,9 +108,9 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
     char *agent_ip = NULL;
     char manager_host[512] = "";
     char *labels = NULL;
-    const char * AGENT_IP_LABEL = "#\"_agent_ip\":";
-    const char * MANAGER_LABEL = "#\"_manager_hostname\":";
-    const char * NODE_LABEL = "#\"_node_name\":";
+    const char * agent_ip_label = "#\"_agent_ip\":";
+    const char * manager_label = "#\"_manager_hostname\":";
+    const char * node_label = "#\"_node_name\":";
     pending_data_t *data = NULL;
     int is_startup = 0;
     int agent_id = 0;
@@ -233,16 +233,16 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
                 mwarn("Unable to get hostname due to: '%s'", strerror(errno));
             }
             else {
-                wm_strcat(&labels, MANAGER_LABEL, labels ? '\n' : 0);
+                wm_strcat(&labels, manager_label, labels ? '\n' : 0);
                 wm_strcat(&labels, manager_host, 0);
             }
 
             if (agent_ip) {
-                wm_strcat(&labels, AGENT_IP_LABEL, labels ? '\n' : 0);
+                wm_strcat(&labels, agent_ip_label, labels ? '\n' : 0);
                 wm_strcat(&labels, agent_ip, 0);
             }
             if (node_name) {
-                wm_strcat(&labels, NODE_LABEL, labels ? '\n' : 0);
+                wm_strcat(&labels, node_label, labels ? '\n' : 0);
                 wm_strcat(&labels, node_name, 0);
             }
 

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -106,8 +106,11 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
     char *config_sum = NULL;
     char *merged_sum = NULL;
     char *agent_ip = NULL;
-    char *labels = NULL;
     char manager_host[512] = "";
+    char *labels = NULL;
+    const char * AGENT_IP_LABEL = "#\"_agent_ip\":";
+    const char * MANAGER_LABEL = "#\"_manager_hostname\":";
+    const char * NODE_LABEL = "#\"_node_name\":";
     pending_data_t *data = NULL;
     int is_startup = 0;
     int agent_id = 0;
@@ -188,7 +191,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
             /* Unlock mutex */
             w_mutex_unlock(&lastmsg_mutex);
             agent_id = atoi(key->id);
-            if (OS_SUCCESS != wdb_update_agent_keepalive(agent_id, logr.worker_node?WDB_SYNC_REQ:WDB_SYNCED)) {            
+            if (OS_SUCCESS != wdb_update_agent_keepalive(agent_id, logr.worker_node?WDB_SYNC_REQ:WDB_SYNCED)) {
                 mwarn("Unable to set last keepalive as pending");
             }
         } else {
@@ -224,27 +227,34 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
                 return;
             }
 
+            // Appending system labels
             /* Get manager name before chroot */
             if (gethostname(manager_host, HOST_NAME_MAX) < 0){
                 mwarn("Unable to get hostname due to: '%s'", strerror(errno));
+            }
+            else {
+                wm_strcat(&labels, MANAGER_LABEL, labels ? '\n' : 0);
+                wm_strcat(&labels, manager_host, 0);
+            }
+
+            if (agent_ip) {
+                wm_strcat(&labels, AGENT_IP_LABEL, labels ? '\n' : 0);
+                wm_strcat(&labels, agent_ip, 0);
+            }
+            if (node_name) {
+                wm_strcat(&labels, NODE_LABEL, labels ? '\n' : 0);
+                wm_strcat(&labels, node_name, 0);
             }
 
             agent_id = atoi(key->id);
 
             // Updating version and keepalive in global.db
-            result = wdb_update_agent_version(agent_id, os_name, os_version, os_major, os_minor, os_codename, os_platform,
-                                              os_build, uname, os_arch, version, config_sum, merged_sum, manager_host,
-                                              node_name, agent_ip, logr.worker_node?WDB_SYNC_REQ:WDB_SYNCED);
+            result = wdb_update_agent_data(agent_id, os_name, os_version, os_major, os_minor, os_codename, os_platform,
+                                           os_build, uname, os_arch, version, config_sum, merged_sum, manager_host,
+                                           node_name, agent_ip, labels, logr.worker_node?WDB_SYNC_REQ:WDB_SYNCED);
             
             if (OS_INVALID == result)
                 mwarn("Unable to update information in global.db for agent: %s", key->id);
-
-            if (labels) {
-                result = wdb_set_agent_labels(agent_id, labels);
-
-                if (OS_INVALID == result)
-                    mwarn("Unable to update labels information in global.db for agent: %s", key->id);
-            }
 
             os_free(version);
             os_free(os_name);

--- a/src/shared/remoted_op.c
+++ b/src/shared/remoted_op.c
@@ -194,7 +194,7 @@ int parse_agent_update_msg (char *msg,
     char *line = NULL;
     char *savedptr = NULL;
     char sdelim[] = { '\n', '\0' };
-    const char * AGENT_IP_LABEL = "#\"_agent_ip\":";
+    const char * agent_ip_label = "#\"_agent_ip\":";
 
     // Setting pointers to NULL to guarantee the return value specification
     *version = NULL;
@@ -222,8 +222,8 @@ int parse_agent_update_msg (char *msg,
         case '\"': // Regular label
             // The _agent_ip will not be appended to the labels string.
             // Instead it will be returned in the agent_ip parameter.
-            if(!strncmp(line, AGENT_IP_LABEL, strlen(AGENT_IP_LABEL))) {
-                os_strdup(line + strlen(AGENT_IP_LABEL), *agent_ip);
+            if(!strncmp(line, agent_ip_label, strlen(agent_ip_label))) {
+                os_strdup(line + strlen(agent_ip_label), *agent_ip);
             }
             else {
                 wm_strcat(labels, line, '\n');

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -951,9 +951,9 @@ void test_wdb_update_agent_name_success(void **state)
     assert_int_equal(OS_SUCCESS, ret);
 }
 
-/* Tests wdb_update_agent_version */
+/* Tests wdb_update_agent_data */
 
-void test_wdb_update_agent_version_error_json(void **state)
+void test_wdb_update_agent_data_error_json(void **state)
 {
     int ret = 0;
     int id = 1;
@@ -972,20 +972,21 @@ void test_wdb_update_agent_version_error_json(void **state)
     char *manager_host = "managerhost";
     char *node_name = "nodename";
     char *agent_ip = "agentip";
+    char *labels = "\"label1\":value1\n\"label2\":value2";
     wdb_sync_status_t sync_status = WDB_SYNC_REQ;
 
     will_return(__wrap_cJSON_CreateObject, NULL);
 
     expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
 
-    ret = wdb_update_agent_version(id, os_name, os_version, os_major, os_minor, os_codename,
+    ret = wdb_update_agent_data(id, os_name, os_version, os_major, os_minor, os_codename,
                                    os_platform, os_build, os_uname, os_arch, version, config_sum,
-                                   merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                   merged_sum, manager_host, node_name, agent_ip, labels, sync_status);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_update_agent_version_error_socket(void **state)
+void test_wdb_update_agent_data_error_socket(void **state)
 {
     int ret = 0;
     int id = 1;
@@ -1004,18 +1005,21 @@ void test_wdb_update_agent_version_error_socket(void **state)
     char *manager_host = "managerhost";
     char *node_name = "nodename";
     char *agent_ip = "agentip";
+    char *labels = "\"label1\":value1\n\"label2\":value2";
     wdb_sync_status_t sync_status = WDB_SYNC_REQ;
 
     const char *json_str = "{\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
-    const char *query_str = "global update-agent-version {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
+\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":1}";
+    const char *query_str = "global update-agent-data {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
+\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":1}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1055,6 +1059,8 @@ void test_wdb_update_agent_version_error_socket(void **state)
     expect_value(__wrap_cJSON_AddStringToObject, string, "nodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
     expect_value(__wrap_cJSON_AddStringToObject, string, "agentip");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
+    expect_value(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
     expect_string(__wrap_cJSON_AddNumberToObject, name, "sync_status");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
 
@@ -1071,21 +1077,22 @@ void test_wdb_update_agent_version_error_socket(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error in the response from socket");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-agent-version \
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-agent-data \
 {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}");
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
+\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":1}");
 
-    ret = wdb_update_agent_version(id, os_name, os_version, os_major, os_minor, os_codename,
+    ret = wdb_update_agent_data(id, os_name, os_version, os_major, os_minor, os_codename,
                                    os_platform, os_build, os_uname, os_arch, version, config_sum,
-                                   merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                   merged_sum, manager_host, node_name, agent_ip, labels, sync_status);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_update_agent_version_error_sql_execution(void **state)
+void test_wdb_update_agent_data_error_sql_execution(void **state)
 {
     int ret = 0;
     int id = 1;
@@ -1104,18 +1111,21 @@ void test_wdb_update_agent_version_error_sql_execution(void **state)
     char *manager_host = "managerhost";
     char *node_name = "nodename";
     char *agent_ip = "agentip";
+    char *labels = "\"label1\":value1\n\"label2\":value2";
     wdb_sync_status_t sync_status = WDB_SYNC_REQ;
 
     const char *json_str = "{\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
-    const char *query_str = "global update-agent-version {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
+\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":1}";
+    const char *query_str = "global update-agent-data {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
+\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":1}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1155,6 +1165,8 @@ void test_wdb_update_agent_version_error_sql_execution(void **state)
     expect_value(__wrap_cJSON_AddStringToObject, string, "nodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
     expect_value(__wrap_cJSON_AddStringToObject, string, "agentip");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
+    expect_value(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
     expect_string(__wrap_cJSON_AddNumberToObject, name, "sync_status");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
 
@@ -1171,21 +1183,22 @@ void test_wdb_update_agent_version_error_sql_execution(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-agent-version \
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-agent-data \
 {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}");
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
+\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":1}");
 
-    ret = wdb_update_agent_version(id, os_name, os_version, os_major, os_minor, os_codename,
+    ret = wdb_update_agent_data(id, os_name, os_version, os_major, os_minor, os_codename,
                                    os_platform, os_build, os_uname, os_arch, version, config_sum,
-                                   merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                   merged_sum, manager_host, node_name, agent_ip, labels, sync_status);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_update_agent_version_error_result(void **state)
+void test_wdb_update_agent_data_error_result(void **state)
 {
     int ret = 0;
     int id = 1;
@@ -1204,18 +1217,21 @@ void test_wdb_update_agent_version_error_result(void **state)
     char *manager_host = "managerhost";
     char *node_name = "nodename";
     char *agent_ip = "agentip";
+    char *labels = "\"label1\":value1\n\"label2\":value2";
     wdb_sync_status_t sync_status = WDB_SYNC_REQ;
 
     const char *json_str = "{\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
-    const char *query_str = "global update-agent-version {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
+\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":1}";
+    const char *query_str = "global update-agent-data {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
+\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":1}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1255,6 +1271,8 @@ void test_wdb_update_agent_version_error_result(void **state)
     expect_value(__wrap_cJSON_AddStringToObject, string, "nodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
     expect_value(__wrap_cJSON_AddStringToObject, string, "agentip");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
+    expect_value(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
     expect_string(__wrap_cJSON_AddNumberToObject, name, "sync_status");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
 
@@ -1274,14 +1292,14 @@ void test_wdb_update_agent_version_error_result(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error reported in the result of the query");
 
-    ret = wdb_update_agent_version(id, os_name, os_version, os_major, os_minor, os_codename,
+    ret = wdb_update_agent_data(id, os_name, os_version, os_major, os_minor, os_codename,
                                    os_platform, os_build, os_uname, os_arch, version, config_sum,
-                                   merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                   merged_sum, manager_host, node_name, agent_ip, labels, sync_status);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_update_agent_version_success(void **state)
+void test_wdb_update_agent_data_success(void **state)
 {
     int ret = 0;
     int id = 1;
@@ -1300,19 +1318,22 @@ void test_wdb_update_agent_version_success(void **state)
     char *manager_host = "managerhost";
     char *node_name = "nodename";
     char *agent_ip = "agentip";
+    char *labels = "\"label1\":value1\n\"label2\":value2";
     wdb_sync_status_t sync_status = WDB_SYNC_REQ;
 
     const char *json_str = "{\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
-    const char *query_str = "global update-agent-version {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
+\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":1}";
+    const char *query_str = "global update-agent-data {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
-    const char *response = "ok";
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
+\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":1}";
+    const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
     will_return_always(__wrap_cJSON_AddNumberToObject, 1);
@@ -1351,6 +1372,8 @@ void test_wdb_update_agent_version_success(void **state)
     expect_value(__wrap_cJSON_AddStringToObject, string, "nodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
     expect_value(__wrap_cJSON_AddStringToObject, string, "agentip");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
+    expect_value(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
     expect_string(__wrap_cJSON_AddNumberToObject, name, "sync_status");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
 
@@ -1369,9 +1392,9 @@ void test_wdb_update_agent_version_success(void **state)
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
-    ret = wdb_update_agent_version(id, os_name, os_version, os_major, os_minor, os_codename,
+    ret = wdb_update_agent_data(id, os_name, os_version, os_major, os_minor, os_codename,
                                    os_platform, os_build, os_uname, os_arch, version, config_sum,
-                                   merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                   merged_sum, manager_host, node_name, agent_ip, labels, sync_status);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
@@ -4826,12 +4849,12 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_name_error_sql_execution, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_name_error_result, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_name_success, setup_wdb_agent, teardown_wdb_agent),
-        /* Tests wdb_update_agent_version */
-        cmocka_unit_test_setup_teardown(test_wdb_update_agent_version_error_json, setup_wdb_agent, teardown_wdb_agent),
-        cmocka_unit_test_setup_teardown(test_wdb_update_agent_version_error_socket, setup_wdb_agent, teardown_wdb_agent),
-        cmocka_unit_test_setup_teardown(test_wdb_update_agent_version_error_sql_execution, setup_wdb_agent, teardown_wdb_agent),
-        cmocka_unit_test_setup_teardown(test_wdb_update_agent_version_error_result, setup_wdb_agent, teardown_wdb_agent),
-        cmocka_unit_test_setup_teardown(test_wdb_update_agent_version_success, setup_wdb_agent, teardown_wdb_agent),
+        /* Tests wdb_update_agent_data */
+        cmocka_unit_test_setup_teardown(test_wdb_update_agent_data_error_json, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_update_agent_data_error_socket, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_update_agent_data_error_sql_execution, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_update_agent_data_error_result, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_update_agent_data_success, setup_wdb_agent, teardown_wdb_agent),
         /* Tests wdb_get_agent_info */
         cmocka_unit_test_setup_teardown(test_wdb_get_agent_info_error_no_json_response, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_get_agent_info_success, setup_wdb_agent, teardown_wdb_agent),

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -555,18 +555,6 @@ void test_wdb_global_sync_agent_info_get_success(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
-    expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-
-    expect_value(__wrap_sqlite3_bind_int, index, 3);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-
-    expect_value(__wrap_sqlite3_bind_int, index, 4);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-
     // Required for wdb_global_set_sync_status()
     expect_value(__wrap_sqlite3_bind_int, index, 1);
     expect_value(__wrap_sqlite3_bind_int, value, WDB_SYNCED);
@@ -634,18 +622,6 @@ void test_wdb_global_sync_agent_info_get_sync_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
-    expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-
-    expect_value(__wrap_sqlite3_bind_int, index, 3);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-
-    expect_value(__wrap_sqlite3_bind_int, index, 4);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-
     // Required for wdb_global_set_sync_status()
     expect_value(__wrap_sqlite3_bind_int, index, 1);
     expect_value(__wrap_sqlite3_bind_int, value, WDB_SYNCED);
@@ -707,18 +683,6 @@ void test_wdb_global_sync_agent_info_get_full(void **state)
 
     // Required for wdb_get_agent_labels()
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-
-    expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-
-    expect_value(__wrap_sqlite3_bind_int, index, 3);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-
-    expect_value(__wrap_sqlite3_bind_int, index, 4);
     expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -353,31 +353,31 @@ void test_wdb_parse_global_update_agent_name_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-void test_wdb_parse_global_update_agent_version_syntax_error(void **state)
+void test_wdb_parse_global_update_agent_data_syntax_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global update-agent-version";
+    char query[OS_BUFFER_SIZE] = "global update-agent-data";
 
     will_return(__wrap_wdb_open_global, data->socket);
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-version");
-    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for update-agent-version.");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: update-agent-version");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-data");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for update-agent-data.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: update-agent-data");
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-agent-version'");
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-agent-data'");
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_global_update_agent_version_invalid_json(void **state)
+void test_wdb_parse_global_update_agent_data_invalid_json(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global update-agent-version {INVALID_JSON}";
+    char query[OS_BUFFER_SIZE] = "global update-agent-data {INVALID_JSON}";
 
     will_return(__wrap_wdb_open_global, data->socket);
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-version {INVALID_JSON}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-agent-data {INVALID_JSON}");
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when updating agent version.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
 
@@ -387,11 +387,11 @@ void test_wdb_parse_global_update_agent_version_invalid_json(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_global_update_agent_version_query_error(void **state)
+void test_wdb_parse_global_update_agent_data_query_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global update-agent-version {\"id\":1,\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
+    char query[OS_BUFFER_SIZE] = "global update-agent-data {\"id\":1,\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
@@ -399,7 +399,7 @@ void test_wdb_parse_global_update_agent_version_query_error(void **state)
 
     will_return(__wrap_wdb_open_global, data->socket);
     expect_string(__wrap__mdebug2, formatted_msg, 
-    "Global query: update-agent-version {\"id\":1,\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
+    "Global query: update-agent-data {\"id\":1,\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
@@ -434,11 +434,11 @@ void test_wdb_parse_global_update_agent_version_query_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_global_update_agent_version_invalid_data(void **state)
+void test_wdb_parse_global_update_agent_data_invalid_data(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global update-agent-version {\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
+    char query[OS_BUFFER_SIZE] = "global update-agent-data {\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
@@ -446,7 +446,7 @@ void test_wdb_parse_global_update_agent_version_invalid_data(void **state)
 
     will_return(__wrap_wdb_open_global, data->socket);
     expect_string(__wrap__mdebug2, formatted_msg, 
-    "Global query: update-agent-version {\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
+    "Global query: update-agent-data {\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
@@ -460,11 +460,11 @@ void test_wdb_parse_global_update_agent_version_invalid_data(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_global_update_agent_version_success(void **state)
+void test_wdb_parse_global_update_agent_data_success(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global update-agent-version {\"id\":1,\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
+    char query[OS_BUFFER_SIZE] = "global update-agent-data {\"id\":1,\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
@@ -472,7 +472,7 @@ void test_wdb_parse_global_update_agent_version_success(void **state)
 
     will_return(__wrap_wdb_open_global, data->socket);
     expect_string(__wrap__mdebug2, formatted_msg, 
-    "Global query: update-agent-version {\"id\":1,\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
+    "Global query: update-agent-data {\"id\":1,\"os_name\":\"test_name\",\"os_version\":\"test_version\",\
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
@@ -496,6 +496,9 @@ void test_wdb_parse_global_update_agent_version_success(void **state)
     expect_string(__wrap_wdb_global_update_agent_version, agent_ip, "test_ip");
     expect_value(__wrap_wdb_global_update_agent_version, sync_status, WDB_SYNC_REQ);
     will_return(__wrap_wdb_global_update_agent_version, OS_SUCCESS);
+
+    expect_value(__wrap_wdb_global_del_agent_labels, id, 1);
+    will_return(__wrap_wdb_global_del_agent_labels, OS_SUCCESS);
 
     ret = wdb_parse(query, data->output);
 
@@ -666,6 +669,23 @@ void test_wdb_parse_global_set_agent_labels_success(void **state)
     expect_string(__wrap_wdb_global_set_agent_label, key, "key4");
     expect_string(__wrap_wdb_global_set_agent_label, value, "test_key4");
     will_return(__wrap_wdb_global_set_agent_label, OS_SUCCESS);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_parse_global_set_agent_labels_success_only_remove(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global set-labels 1";
+
+    will_return(__wrap_wdb_open_global, data->socket);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: set-labels 1");
+    expect_value(__wrap_wdb_global_del_agent_labels, id, 1);
+    will_return(__wrap_wdb_global_del_agent_labels, OS_SUCCESS);
 
     ret = wdb_parse(query, data->output);
 
@@ -2462,11 +2482,11 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_success, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_version_syntax_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_version_invalid_json, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_version_query_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_version_invalid_data, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_version_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_data_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_data_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_data_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_data_invalid_data, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_data_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_labels_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_labels_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_labels_success, test_setup, test_teardown),
@@ -2475,6 +2495,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_labels_remove_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_labels_set_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_labels_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_labels_success_only_remove, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_keepalive_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_keepalive_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_keepalive_invalid_data, test_setup, test_teardown),

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -114,13 +114,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_UPDATE_AGENT_NAME] = "UPDATE agent SET name = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_VERSION] = "UPDATE agent SET os_name = ?, os_version = ?, os_major = ?, os_minor = ?, os_codename = ?, os_platform = ?, os_build = ?, os_uname = ?, os_arch = ?, version = ?, config_sum = ?, merged_sum = ?, manager_host = ?, node_name = ?, last_keepalive = STRFTIME('%s', 'NOW'), sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_VERSION_IP] = "UPDATE agent SET os_name = ?, os_version = ?, os_major = ?, os_minor = ?, os_codename = ?, os_platform = ?, os_build = ?, os_uname = ?, os_arch = ?, version = ?, config_sum = ?, merged_sum = ?, manager_host = ?, node_name = ?, last_keepalive = STRFTIME('%s', 'NOW'), ip = ?, sync_status = ? WHERE id = ?;",
-    [WDB_STMT_GLOBAL_LABELS_GET] = "SELECT * FROM labels WHERE id = ? \
-                                    UNION \
-                                    SELECT id, '#\"_agent_ip\"' AS key, ip AS value FROM agent WHERE id = ? \
-                                    UNION \
-                                    SELECT id, '#\"_manager_hostname\"' AS key, manager_host AS value FROM agent WHERE id = ? \
-                                    UNION \
-                                    SELECT id, '#\"_node_name\"' AS key, node_name AS value FROM agent WHERE id = ?;",
+    [WDB_STMT_GLOBAL_LABELS_GET] = "SELECT * FROM labels WHERE id = ?;",
     [WDB_STMT_GLOBAL_LABELS_DEL] = "DELETE FROM labels WHERE id = ?;",
     [WDB_STMT_GLOBAL_LABELS_SET] = "INSERT INTO labels (id, key, value) VALUES (?,?,?);",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE] = "UPDATE agent SET last_keepalive = CASE WHEN last_keepalive IS NULL THEN 0 ELSE STRFTIME('%s', 'NOW') END, sync_status = ? WHERE id = ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -168,7 +168,7 @@ typedef enum global_db_access {
     WDB_INSERT_AGENT_GROUP,
     WDB_INSERT_AGENT_BELONG,
     WDB_UPDATE_AGENT_NAME,
-    WDB_UPDATE_AGENT_VERSION,
+    WDB_UPDATE_AGENT_DATA,
     WDB_UPDATE_AGENT_KEEPALIVE,
     WDB_UPDATE_AGENT_STATUS,
     WDB_UPDATE_AGENT_GROUP,
@@ -403,7 +403,7 @@ int wdb_update_agent_belongs(int id_group, int id_agent);
 int wdb_update_agent_name(int id, const char *name);
 
 /**
- * @brief Update agent version in global.db.
+ * @brief Update agent data in global.db.
  * 
  * @param[in] id The agent ID.
  * @param[in] os_name The agent's operating system name.
@@ -421,26 +421,28 @@ int wdb_update_agent_name(int id, const char *name);
  * @param[in] manager_host The agent's manager host name.
  * @param[in] node_name The agent's manager node name.
  * @param[in] agent_ip The agent's IP address.
+ * @param[in] labels The agent labels.
  * @param[in] sync_status The agent's synchronization status in cluster.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_update_agent_version(int id, 
-                             const char *os_name,
-                             const char *os_version,
-                             const char *os_major,
-                             const char *os_minor,
-                             const char *os_codename,
-                             const char *os_platform,
-                             const char *os_build,
-                             const char *os_uname,
-                             const char *os_arch,
-                             const char *version,
-                             const char *config_sum,
-                             const char *merged_sum,
-                             const char *manager_host,
-                             const char *node_name,
-                             const char *agent_ip,
-                             wdb_sync_status_t sync_status);
+int wdb_update_agent_data(int id, 
+                          const char *os_name,
+                          const char *os_version,
+                          const char *os_major,
+                          const char *os_minor,
+                          const char *os_codename,
+                          const char *os_platform,
+                          const char *os_build,
+                          const char *os_uname,
+                          const char *os_arch,
+                          const char *version,
+                          const char *config_sum,
+                          const char *merged_sum,
+                          const char *manager_host,
+                          const char *node_name,
+                          const char *agent_ip,
+                          const char *labels,
+                          wdb_sync_status_t sync_status);
 
 /**
  * @brief Update agent's last keepalive ond modifies the cluster synchronization status.
@@ -931,14 +933,14 @@ int wdb_parse_global_insert_agent(wdb_t * wdb, char * input, char * output);
 int wdb_parse_global_update_agent_name(wdb_t * wdb, char * input, char * output);
 
 /**
- * @brief Function to parse the update agent version request.
+ * @brief Function to parse the update agent data request.
  * 
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent data in JSON format.
  * @param [out] output Response of the query.
  * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
  */
-int wdb_parse_global_update_agent_version(wdb_t * wdb, char * input, char * output);
+int wdb_parse_global_update_agent_data(wdb_t * wdb, char * input, char * output);
 
 /**
  * @brief Function to parse the labels request for a particular agent.

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -27,7 +27,7 @@ static const char *global_db_commands[] = {
     [WDB_INSERT_AGENT_GROUP] = "global insert-agent-group %s",
     [WDB_INSERT_AGENT_BELONG] = "global insert-agent-belong %s",
     [WDB_UPDATE_AGENT_NAME] = "global update-agent-name %s",
-    [WDB_UPDATE_AGENT_VERSION] = "global update-agent-version %s",
+    [WDB_UPDATE_AGENT_DATA] = "global update-agent-data %s",
     [WDB_UPDATE_AGENT_KEEPALIVE] = "global update-keepalive %s",
     [WDB_UPDATE_AGENT_STATUS] = "global update-agent-status %s",
     [WDB_UPDATE_AGENT_GROUP] = "global update-agent-group %s",
@@ -225,23 +225,24 @@ int wdb_update_agent_name(int id, const char *name) {
     return result;
 }
 
-int wdb_update_agent_version (int id,
-                              const char *os_name,
-                              const char *os_version,
-                              const char *os_major,
-                              const char *os_minor,
-                              const char *os_codename,
-                              const char *os_platform,
-                              const char *os_build,
-                              const char *os_uname,
-                              const char *os_arch,
-                              const char *version,
-                              const char *config_sum,
-                              const char *merged_sum,
-                              const char *manager_host,
-                              const char *node_name,
-                              const char *agent_ip,
-                              wdb_sync_status_t sync_status) {
+int wdb_update_agent_data (int id,
+                           const char *os_name,
+                           const char *os_version,
+                           const char *os_major,
+                           const char *os_minor,
+                           const char *os_codename,
+                           const char *os_platform,
+                           const char *os_build,
+                           const char *os_uname,
+                           const char *os_arch,
+                           const char *version,
+                           const char *config_sum,
+                           const char *merged_sum,
+                           const char *manager_host,
+                           const char *node_name,
+                           const char *agent_ip,
+                           const char *labels,
+                           wdb_sync_status_t sync_status) {
     int result = 0;
     cJSON *data_in = NULL;
     char wdbquery[WDBQUERY_SIZE] = "";
@@ -271,9 +272,10 @@ int wdb_update_agent_version (int id,
     cJSON_AddStringToObject(data_in, "manager_host", manager_host);
     cJSON_AddStringToObject(data_in, "node_name", node_name);
     cJSON_AddStringToObject(data_in, "agent_ip", agent_ip);
+    cJSON_AddStringToObject(data_in, "labels", labels);
     cJSON_AddNumberToObject(data_in, "sync_status", sync_status);
 
-    snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_UPDATE_AGENT_VERSION], cJSON_PrintUnformatted(data_in));
+    snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_UPDATE_AGENT_DATA], cJSON_PrintUnformatted(data_in));
 
     cJSON_Delete(data_in);
 

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -244,7 +244,6 @@ int wdb_global_update_agent_version(wdb_t *wdb,
 cJSON* wdb_global_get_agent_labels(wdb_t *wdb, int id) {
     sqlite3_stmt *stmt = NULL;
     cJSON * result = NULL;
-    int index = 0;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
         mdebug1("Cannot begin transaction");
@@ -258,12 +257,9 @@ cJSON* wdb_global_get_agent_labels(wdb_t *wdb, int id) {
 
     stmt = wdb->stmt[WDB_STMT_GLOBAL_LABELS_GET];
 
-    // In this statement, we must bind the agent ID four times
-    for (index = 1; index < 5; ++index) {
-        if (sqlite3_bind_int(stmt, index, id) != SQLITE_OK) {
-            merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-            return NULL;
-        }
+    if (sqlite3_bind_int(stmt, 1, id) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return NULL;
     }
 
     result = wdb_exec_stmt(stmt);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -443,14 +443,14 @@ int wdb_parse(char * input, char * output) {
             } else {
                 result = wdb_parse_global_update_agent_name(wdb, next, output);
             }
-        } else if (strcmp(query, "update-agent-version") == 0) {
+        } else if (strcmp(query, "update-agent-data") == 0) {
             if (!next) {
-                mdebug1("Global DB Invalid DB query syntax for update-agent-version.");
+                mdebug1("Global DB Invalid DB query syntax for update-agent-data.");
                 mdebug2("Global DB query error near: %s", query);
                 snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
                 result = OS_INVALID;
             } else {
-                result = wdb_parse_global_update_agent_version(wdb, next, output);
+                result = wdb_parse_global_update_agent_data(wdb, next, output);
             }
         } else if (strcmp(query, "get-labels") == 0) {
             if (!next) {
@@ -4207,7 +4207,7 @@ int wdb_parse_global_update_agent_name(wdb_t * wdb, char * input, char * output)
     return OS_SUCCESS;
 }
 
-int wdb_parse_global_update_agent_version(wdb_t * wdb, char * input, char * output) {
+int wdb_parse_global_update_agent_data(wdb_t * wdb, char * input, char * output) {
     cJSON *agent_data = NULL;
     const char *error = NULL;
     cJSON *j_id = NULL;
@@ -4227,6 +4227,7 @@ int wdb_parse_global_update_agent_version(wdb_t * wdb, char * input, char * outp
     cJSON *j_node_name = NULL;
     cJSON *j_agent_ip = NULL;
     cJSON *j_sync_status = NULL;
+    cJSON *j_labels = NULL;
 
     agent_data = cJSON_ParseWithOpts(input, &error, TRUE);
     if (!agent_data) {
@@ -4252,6 +4253,7 @@ int wdb_parse_global_update_agent_version(wdb_t * wdb, char * input, char * outp
         j_node_name = cJSON_GetObjectItem(agent_data, "node_name");
         j_agent_ip = cJSON_GetObjectItem(agent_data, "agent_ip");
         j_sync_status = cJSON_GetObjectItem(agent_data, "sync_status");
+        j_labels = cJSON_GetObjectItem(agent_data, "labels");
 
         if (cJSON_IsNumber(j_id)) {
             // Getting each field
@@ -4271,6 +4273,7 @@ int wdb_parse_global_update_agent_version(wdb_t * wdb, char * input, char * outp
             char *manager_host = cJSON_IsString(j_manager_host) ? j_manager_host->valuestring : NULL;
             char *node_name = cJSON_IsString(j_node_name) ? j_node_name->valuestring : NULL;
             char *agent_ip = cJSON_IsString(j_agent_ip) ? j_agent_ip->valuestring : NULL;
+            char *labels = cJSON_IsString(j_labels) ? j_labels->valuestring : NULL;
             wdb_sync_status_t sync_status = (cJSON_IsNumber(j_sync_status) && j_sync_status->valueint == 1) ? 
                                             WDB_SYNC_REQ : WDB_SYNCED;
 
@@ -4281,6 +4284,21 @@ int wdb_parse_global_update_agent_version(wdb_t * wdb, char * input, char * outp
                 snprintf(output, OS_MAXSTR + 1, "err Cannot execute Global database query; %s", sqlite3_errmsg(wdb->db));
                 cJSON_Delete(agent_data);
                 return OS_INVALID;
+            }
+            else {
+                // We will only add the agent's labels if the agent was successfully added to the database.
+                // We dont check for NULL because if NULL, the current labels should be removed.
+                // The output string will be filled by the labels setter method.
+                char *labels_data = NULL;
+                os_calloc(OS_MAXSTR, sizeof(char), labels_data);
+                snprintf(labels_data, OS_MAXSTR + 1, "%d", id);
+                wm_strcat(&labels_data, labels, ' ');
+
+                int result = wdb_parse_global_set_agent_labels(wdb, labels_data, output);
+
+                cJSON_Delete(agent_data);
+                os_free(labels_data);
+                return result;
             }
         } else {
             mdebug1("Global DB Invalid JSON data when updating agent version.");
@@ -4318,60 +4336,55 @@ int wdb_parse_global_get_agent_labels(wdb_t * wdb, char * input, char * output) 
 }
 
 int wdb_parse_global_set_agent_labels(wdb_t * wdb, char * input, char * output) {
-    char *next = NULL;
-    char *labels = NULL;
+    char *id = NULL;
     char *label = NULL;
     char *value = NULL;
     char *savedptr = NULL;
-    char sdelim[] = { '\n', '\0' };
+    char id_delim[] = { ' ', '\0' };
+    char label_delim[] = { '\n', '\0' };
 
-    if (next = wstr_chr(input, ' '), !next) {
+    // The input could be in the next ways
+    // "agent_id key1:value1\nkey2:value2" --> In this, case strtok_r finds a space, so we remove the
+    //                                         old labels using the agent_id and then insert the new ones.
+    // "agent_id" --> In this, case strtok_r finds the NULL character and we just remove the old
+    //                labels using the agent_id. The next strtok_r will finalize the execution.
+    if (id = strtok_r(input, id_delim, &savedptr), !id) {
         mdebug1("Invalid DB query syntax.");
         mdebug2("DB query error near: %s", input);
         snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", input);
         return OS_INVALID;
     }
-    *next++ = '\0';
 
-    int agent_id = atoi(input);
+    int agent_id = atoi(id);
 
-    if (!next) {
-        mdebug1("Global DB Invalid query syntax.");
-        mdebug2("Global DB query error near: %s", input);
-        snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", input);
+    // Removing old labels from the labels table
+    if (OS_SUCCESS != wdb_global_del_agent_labels(wdb, agent_id)) {
+        mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB2_GLOB_NAME, sqlite3_errmsg(wdb->db));
+        snprintf(output, OS_MAXSTR + 1, "err Cannot execute Global database query; %s", sqlite3_errmsg(wdb->db));
         return OS_INVALID;
-    } else {
-        // Removing old labels from the labels table
-        if (OS_SUCCESS != wdb_global_del_agent_labels(wdb, agent_id)) {
+    }
+
+    // Parsing the labes string "key1:value1\nkey2:value2"
+    for (label = strtok_r(NULL, label_delim, &savedptr); label; label = strtok_r(NULL, label_delim, &savedptr)) {
+        if (value = strstr(label, ":"), value) {
+            *value = '\0';
+            value++;
+        }
+        else {
+            continue;
+        }
+
+        // Inserting new labels in the database
+        if (OS_SUCCESS != wdb_global_set_agent_label(wdb, agent_id, label, value)) {
             mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB2_GLOB_NAME, sqlite3_errmsg(wdb->db));
             snprintf(output, OS_MAXSTR + 1, "err Cannot execute Global database query; %s", sqlite3_errmsg(wdb->db));
             return OS_INVALID;
         }
 
-        labels = next;
-
-        // Parsing the labes string "key1:value1\nkey2:value2"
-        for (label = strtok_r(labels, sdelim, &savedptr); label; label = strtok_r(NULL, sdelim, &savedptr)) {
-            if (value = strstr(label, ":"), value) {
-                *value = '\0';
-                value++;
-            }
-            else {
-                continue;
-            }
-
-            // Inserting new labels in the database
-            if (OS_SUCCESS != wdb_global_set_agent_label(wdb, agent_id, label, value)) {
-                mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB2_GLOB_NAME, sqlite3_errmsg(wdb->db));
-                snprintf(output, OS_MAXSTR + 1, "err Cannot execute Global database query; %s", sqlite3_errmsg(wdb->db));
-                return OS_INVALID;
-            }
-
-            value = NULL;
-        }
-
-        snprintf(output, OS_MAXSTR + 1, "ok");
+        value = NULL;
     }
+
+    snprintf(output, OS_MAXSTR + 1, "ok");
 
     return OS_SUCCESS;
 }

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -289,7 +289,8 @@ void wm_sync_manager() {
             }
         }
 
-        wdb_update_agent_version(0, os_name, os_version, os_major, os_minor, os_codename, os_platform, os_build, os_uname, os_arch, __ossec_name " " __ossec_version, NULL, NULL, hostname, node_name, NULL, WDB_SYNCED);
+        wdb_update_agent_data(0, os_name, os_version, os_major, os_minor, os_codename, os_platform, os_build, os_uname, os_arch, 
+                              __ossec_name " " __ossec_version, NULL, NULL, hostname, node_name, NULL, NULL, WDB_SYNCED);
 
         free(node_name);
         free(os_major);


### PR DESCRIPTION
|Related issue|
|---|
| [6024](https://github.com/wazuh/wazuh/issues/6024) |

## Description

This pull request introduces a change to fix an inconsistency that we had between workers and master node in cluster scenarios where the agents' labels were not saved in the same way.

Now, all the labels (regular, hidden, and system) are saved in the `labels` table in `global.db`. In addition, the `wdb_update_agent_version` was renamed to `wdb_update_agent_data` and modified to also update the agents' labels. With this modification, we reduce to one the number of calls to `Wazuh DB` done during the keepalive messages.

All the Unit Tests were updated in order to cover all the modifications.

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
