### PR TITLE
Change limit parameter behavior in Get sca checks endpoint

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -9,7 +9,6 @@ import logging
 import os
 from secrets import token_urlsafe
 from shutil import chown
-from importlib import reload
 from time import time
 
 from jose import JWTError, jwt
@@ -110,13 +109,7 @@ def change_secret():
         jwt_secret.write(new_secret)
 
 
-def get_api_conf():
-    reload(configuration)
-    return copy.deepcopy(configuration.api_conf)
-
-
 def get_security_conf():
-    reload(configuration)
     return copy.deepcopy(configuration.security_conf)
 
 

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -19,7 +19,6 @@ from api.api_exception import APIError
 from api.constants import SECURITY_CONFIG_PATH
 from wazuh.core import common
 
-
 default_security_configuration = {
     "auth_token_exp_timeout": 3600,
     "rbac_mode": "white"
@@ -215,5 +214,5 @@ def read_yaml_config(config_file=common.api_config_path, default_conf=None) -> D
 
 
 # Configuration - global object
-api_conf = read_yaml_config()
+api_conf = dict()
 security_conf = read_yaml_config(config_file=SECURITY_CONFIG_PATH, default_conf=default_security_configuration)

--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -6,12 +6,12 @@
 import logging
 
 from aiohttp import web
-
-import wazuh.sca as sca
 from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
-from wazuh.core.common import database_limit
+
+import wazuh.sca as sca
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
+from wazuh.core.common import database_limit
 
 logger = logging.getLogger('wazuh')
 
@@ -20,20 +20,34 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
                         references=None, offset=0, limit=database_limit, sort=None, search=None, q=None):
     """Get security configuration assessment (SCA) database of an agent
 
-    :param agent_id: Agent ID. All possible values since 000 onwards.
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
-    :param name: Filters by policy name
-    :param description: Filters by policy description
-    :param references: Filters by references
-    :param offset:First element to return in the collection
-    :param limit: Maximum number of elements to return
-    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
-    ascending or descending order
-    :param search: Looks for elements with the specified string
-    :param q: Query to filter results by. This is specially useful to filter by total checks passed, failed or total
-    score (fields pass, fail, score)
-    :return: AllItemsResponseSCADatabase
+    Parameters
+    ----------
+    agent_id : str
+        Agent ID. All possible values since 000 onwards.
+    pretty : bool
+        Show results in human-readable format
+    wait_for_complete : bool
+        Disable timeout response
+    name : str
+        Filters by policy name
+    description : str
+        Filters by policy description
+    references : str
+        Filters by references
+    offset : int
+        First element to return in the collection
+    limit : int
+        Maximum number of elements to return
+    sort : str
+        Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order
+    search : str
+        Looks for elements with the specified string
+    q : str
+        Query to filter results by. This is specially useful to filter by total checks passed, failed or total score (fields pass, fail, score)
+
+    Returns
+    -------
+    AllItemsResponseSCADatabase
     """
     filters = {'name': name,
                'description': description,
@@ -65,31 +79,58 @@ async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete
                          condition=None, offset=0, limit=database_limit, sort=None, search=None, q=None):
     """Get policy monitoring alerts for a given policy
 
-    :param agent_id: Agent ID. All possible values since 000 onwards
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
-    :param policy_id: Filters by policy id
-    :param title: Filters by title
-    :param description: Filters by policy description
-    :param rationale: Filters by rationale
-    :param remediation: Filters by remediation
-    :param command: Filters by command
-    :param status: Filters by status
-    :param reason: Filters by reason
-    :param file: Filters by file
-    :param process: Filters by process
-    :param directory: Filters by directory
-    :param registry: Filters by registry
-    :param references: Filters by references
-    :param result: Filters by result
-    :param condition: Filters by condition
-    :param offset:First element to return in the collection
-    :param limit: Maximum number of elements to return
-    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
-    ascending or descending order
-    :param search: Looks for elements with the specified string
-    :param q: Query to filter results by. This is specially useful to filter by total checks passed, failed or total
-    score (fields pass, fail, score)
+    Parameters
+    ----------
+    agent_id : str
+        Agent ID. All possible values since 000 onwards
+    pretty : bool
+        Show results in human-readable format
+    wait_for_complete : bool
+        Disable timeout response
+    policy_id : str
+        Filters by policy id
+    title : str
+        Filters by title
+    description : str
+        Filters by policy description
+    rationale : str
+        Filters by rationale
+    remediation : str
+        Filters by remediation
+    command : str
+        Filters by command
+    status : str
+        Filters by status
+    reason : str
+        Filters by reason
+    file : str
+        Filters by file
+    process : str
+        Filters by process
+    directory : str
+        Filters by directory
+    registry : str
+        Filters by registry
+    references : str
+        Filters by references
+    result : str
+        Filters by result
+    condition : str
+        Filters by condition
+    offset : int
+        First element to return in the collection
+    limit : int
+        Maximum number of elements to return
+    sort : str
+        Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order
+    search : str
+        Looks for elements with the specified string
+    q : str
+        Query to filter results by. This is specially useful to filter by total checks passed, failed or total score (fields pass, fail, score)
+
+    Returns
+    -------
+    AllItemsResponseSCADatabase
     """
     filters = {'title': title,
                'description': description,

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -125,7 +125,11 @@ async def response_postprocessing(request, handler):
                                     detail=cleanup_detail_field(ex.__dict__['detail']) if 'detail' in ex.__dict__ else '',
                                     ext=ex.__dict__['ext'] if 'ext' in ex.__dict__ else None)
     except OAuthProblem:
-        problem = connexion_problem(401, "Unauthorized", type="about:blank", detail="No authorization token provided")
+        if request.path == '/security/user/authenticate' and request.method == 'GET':
+            problem = connexion_problem(401, "Unauthorized", type="about:blank", detail="Invalid credentials")
+        else:
+            problem = connexion_problem(401, "Unauthorized", type="about:blank",
+                                        detail="No authorization token provided")
     finally:
         if problem:
             remove_unwanted_fields()

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -12866,6 +12866,12 @@ paths:
           $ref: '#/components/responses/ResponseError'
         '401':
           $ref: '#/components/responses/InvalidCredentialsResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
 
   /security/actions:
     get:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3320,7 +3320,7 @@ components:
                 properties:
                   name:
                     type: string
-                    format: alphanumeric
+                    format: alphanumeric_symbols
                   platform:
                     type: string
                     format: alphanumeric

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -456,6 +456,16 @@ components:
             title: "Unauthorized"
             detail: "No authorization token provided"
 
+    InvalidCredentialsResponse:
+      description: "Response to report a problem with authentication"
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RequestError'
+          example:
+            title: "Unauthorized"
+            detail: "Invalid credentials"
+
     InvalidHTTPMethodResponse:
       description: "Response to an invalid HTTP method"
       content:
@@ -12790,7 +12800,7 @@ paths:
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
+          $ref: '#/components/responses/InvalidCredentialsResponse'
         '403':
           $ref: '#/components/responses/PermissionDeniedResponse'
         '405':
@@ -12854,6 +12864,8 @@ paths:
                 token: "<generated_token>"
         '400':
           $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/InvalidCredentialsResponse'
 
   /security/actions:
     get:

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -85,12 +85,12 @@ def test_read_configuration(mock_open, mock_exists, read_config):
 def test_read_wrong_configuration(mock_exists):
     """Verify that expected exceptions are raised when incorrect configuration"""
     with patch('api.configuration.yaml.safe_load') as m:
-        with pytest.raises(api_exception.APIError, match='.* 2004 .*'):
+        with pytest.raises(api_exception.APIError, match=r'\b2004\b'):
             configuration.read_yaml_config()
 
         with patch('builtins.open'):
             m.return_value = {'marta': 'yay'}
-            with pytest.raises(api_exception.APIError, match='.* 2000 .*'):
+            with pytest.raises(api_exception.APIError, match=r'\b2000\b'):
                 configuration.read_yaml_config()
 
 

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -826,6 +826,327 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: GET /cluster/api/config
+
+stages:
+
+  # GET /cluster/api/config
+  - name: Get API configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: "master-node"
+              node_api_config: &api_config
+                host: !anystr
+                port: !anyint
+                behind_proxy_server: !anybool
+                https:
+                  enabled: !anybool
+                  key: !anystr
+                  cert: !anystr
+                  use_ca: !anybool
+                  ca: !anystr
+                logs:
+                  level: !anystr
+                  path: !anystr
+                cors:
+                  enabled: !anybool
+                  source_route: !anystr
+                  expose_headers: !anystr
+                  allow_headers: !anystr
+                  allow_credentials: !anybool
+                cache:
+                  enabled: !anybool
+                  time: !anything
+                access:
+                  max_login_attempts: !anyint
+                  block_time: !anyint
+                  max_request_per_minute: !anyint
+                use_only_authd: !anybool
+                drop_privileges: !anybool
+                experimental_features: !anybool
+            - node_name: "worker1"
+              node_api_config:
+                <<: *api_config
+            - node_name: "worker2"
+              node_api_config:
+                <<: *api_config
+          total_affected_items: 3
+          total_failed_items: 0
+          failed_items: []
+
+  # GET /cluster/api/config/{node_list}
+  - name: Get API configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        list_nodes: 'worker1,worker2'
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: 'worker1'
+              node_api_config:
+                <<: *api_config
+            - node_name: 'worker2'
+              node_api_config:
+                <<: *api_config
+          total_affected_items: 2
+          total_failed_items: 0
+          failed_items: []
+
+---
+test_name: PUT /cluster/api/config
+
+stages:
+
+  # PUT /cluster/api/config
+  - name: Modify API configuration (some fields)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        cache:
+          enabled: false
+          time: 1
+    response:
+      status_code: 200
+      json: &update_api_config_ok
+        data:
+          affected_items: !anything
+          total_affected_items: 3
+          total_failed_items: 0
+          failed_items: []
+
+  # PUT /cluster/api/config
+  - name: Modify API configuration (all allowed fields)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        list_nodes: 'worker1,worker2'
+      method: PUT
+      json:
+        logs:
+          level: "debug"
+        cache:
+          enabled: true
+          time: 3
+        access:
+          block_time: 0
+        use_only_authd: true
+        experimental_features: true
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - worker1
+            - worker2
+          total_affected_items: 2
+          total_failed_items: 0
+          failed_items: []
+
+  # PUT /cluster/api/config
+  - name: Modify API configuration (forbidden field)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        logs:
+          path: "test"
+    response:
+      status_code: 400
+
+  # Restart nodes to apply changes
+  - name: Restart cluster
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
+  # GET /cluster/api/config
+  - name: Get API configuration that was set above
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: 'master-node'
+              node_api_config:
+                <<: *api_config
+            - node_name: 'worker1'
+              node_api_config: &modified_api_config
+                logs:
+                  level: "debug"
+                cache:
+                  enabled: true
+                  time: 3
+                use_only_authd: true
+                experimental_features: true
+            - node_name: 'worker2'
+              node_api_config:
+                <<: *modified_api_config
+          total_affected_items: 3
+          total_failed_items: 0
+          failed_items: []
+
+---
+test_name: DELETE /cluster/api/config
+
+stages:
+
+  # DELETE /cluster/api/config (worker1)
+  - name: Restore API configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        list_nodes: 'worker1'
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items: !anything
+          total_affected_items: 1
+          total_failed_items: 0
+          failed_items: []
+
+  # Restart nodes to apply changes
+  - name: Restart cluster
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
+  # GET /cluster/api/config
+  - name: Get API default configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: 'master-node'
+              node_api_config:
+                <<: *api_config
+            - node_name: 'worker1'
+              node_api_config:
+                logs:
+                  level: "info"
+                cache:
+                  enabled: true
+                  time: 0.75
+                use_only_authd: false
+                experimental_features: false
+            - node_name: 'worker2'
+              node_api_config:
+                <<: *modified_api_config
+          total_affected_items: 3
+          total_failed_items: 0
+          failed_items: []
+
+  # DELETE /cluster/api/config (all nodes)
+  - name: Restore API configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items: !anything
+          total_affected_items: 3
+          total_failed_items: 0
+          failed_items: []
+
+  # Restart nodes to apply changes
+  - name: Restart cluster
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
+  # GET /cluster/api/config
+  - name: Get API default configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: 'master-node'
+              node_api_config:
+                <<: *api_config
+            - node_name: 'worker1'
+              node_api_config:
+                <<: *api_config
+            - node_name: 'worker2'
+              node_api_config:
+                <<: *api_config
+          total_affected_items: 3
+          total_failed_items: 0
+          failed_items: []
+
+---
 test_name: GET /cluster/{node_id}/configuration/{component}/{configuration}
 
 stages:
@@ -2350,291 +2671,6 @@ stages:
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
-
----
-test_name: GET /cluster/api/config
-
-stages:
-
-  # GET /cluster/api/config
-  - name: Get API configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: "master-node"
-              node_api_config: &api_config
-                host: !anystr
-                port: !anyint
-                behind_proxy_server: !anybool
-                https:
-                  enabled: !anybool
-                  key: !anystr
-                  cert: !anystr
-                  use_ca: !anybool
-                  ca: !anystr
-                logs:
-                  level: !anystr
-                  path: !anystr
-                cors:
-                  enabled: !anybool
-                  source_route: !anystr
-                  expose_headers: !anystr
-                  allow_headers: !anystr
-                  allow_credentials: !anybool
-                cache:
-                  enabled: !anybool
-                  time: !anything
-                access:
-                  max_login_attempts: !anyint
-                  block_time: !anyint
-                  max_request_per_minute: !anyint
-                use_only_authd: !anybool
-                drop_privileges: !anybool
-                experimental_features: !anybool
-            - node_name: "worker1"
-              node_api_config:
-                <<: *api_config
-            - node_name: "worker2"
-              node_api_config:
-                <<: *api_config
-          total_affected_items: 3
-          total_failed_items: 0
-          failed_items: []
-
-  # GET /cluster/api/config/{node_list}
-  - name: Get API configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        list_nodes: 'worker1,worker2'
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: 'worker1'
-              node_api_config:
-                <<: *api_config
-            - node_name: 'worker2'
-              node_api_config:
-                <<: *api_config
-          total_affected_items: 2
-          total_failed_items: 0
-          failed_items: []
-
----
-test_name: PUT /cluster/api/config
-
-stages:
-
-  # PUT /cluster/api/config
-  - name: Modify API configuration (some fields)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-      json:
-        cache:
-          enabled: false
-          time: 1
-    response:
-      status_code: 200
-      json: &update_api_config_ok
-        data:
-          affected_items: !anything
-          total_affected_items: 3
-          total_failed_items: 0
-          failed_items: []
-
-  # PUT /cluster/api/config
-  - name: Modify API configuration (all allowed fields)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        list_nodes: 'worker1,worker2'
-      method: PUT
-      json:
-        logs:
-          level: "debug"
-        cache:
-          enabled: true
-          time: 3
-        access:
-          block_time: 0
-        use_only_authd: true
-        experimental_features: true
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - worker1
-            - worker2
-          total_affected_items: 2
-          total_failed_items: 0
-          failed_items: []
-
-  # PUT /cluster/api/config
-  - name: Modify API configuration (forbidden field)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-      json:
-        logs:
-          path: "test"
-    response:
-      status_code: 400
-
-  # GET /cluster/api/config
-  - name: Get API configuration that was set above
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: 'master-node'
-              node_api_config:
-                <<: *api_config
-            - node_name: 'worker1'
-              node_api_config: &modified_api_config
-                logs:
-                  level: "debug"
-                cache:
-                  enabled: true
-                  time: 3
-                use_only_authd: true
-                experimental_features: true
-            - node_name: 'worker2'
-              node_api_config:
-                <<: *modified_api_config
-          total_affected_items: 3
-          total_failed_items: 0
-          failed_items: []
-
----
-test_name: DELETE /cluster/api/config
-
-stages:
-
-  # DELETE /cluster/api/config (worker1)
-  - name: Restore API configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: DELETE
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        list_nodes: 'worker1'
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items: !anything
-          total_affected_items: 1
-          total_failed_items: 0
-          failed_items: []
-
-  # GET /cluster/api/config
-  - name: Get API default configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: 'master-node'
-              node_api_config:
-                <<: *api_config
-            - node_name: 'worker1'
-              node_api_config:
-                logs:
-                  level: "info"
-                cache:
-                  enabled: true
-                  time: 0.75
-                use_only_authd: false
-                experimental_features: false
-            - node_name: 'worker2'
-              node_api_config:
-                <<: *modified_api_config
-          total_affected_items: 3
-          total_failed_items: 0
-          failed_items: []
-
-  # DELETE /cluster/api/config (all nodes)
-  - name: Restore API configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: DELETE
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items: !anything
-          total_affected_items: 3
-          total_failed_items: 0
-          failed_items: []
-
-  # GET /cluster/api/config
-  - name: Get API default configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: 'master-node'
-              node_api_config:
-                <<: *api_config
-            - node_name: 'worker1'
-              node_api_config:
-                <<: *api_config
-            - node_name: 'worker2'
-              node_api_config:
-                <<: *api_config
-          total_affected_items: 3
-          total_failed_items: 0
-          failed_items: []
 
 ---
 test_name: PUT /cluster/restart

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -679,6 +679,248 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: GET /manager/api/config
+
+stages:
+
+  # GET /manager/api/config
+  - name: Get API configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: !anystr
+              node_api_config:
+                host: !anystr
+                port: !anyint
+                behind_proxy_server: !anybool
+
+                https:
+                  enabled: !anybool
+                  key: !anystr
+                  cert: !anystr
+                  use_ca: !anybool
+                  ca: !anystr
+                logs:
+                  level: !anystr
+                  path: !anystr
+                cors:
+                  enabled: !anybool
+                  source_route: !anystr
+                  expose_headers: !anystr
+                  allow_headers: !anystr
+                  allow_credentials: !anybool
+                cache:
+                  enabled: !anybool
+                  time: !anything
+                access:
+                  max_login_attempts: !anyint
+                  block_time: !anyint
+                  max_request_per_minute: !anyint
+                use_only_authd: !anybool
+                drop_privileges: !anybool
+                experimental_features: !anybool
+          total_affected_items: 1
+          total_failed_items: 0
+          failed_items: []
+
+---
+test_name: PUT /manager/api/config
+
+stages:
+
+  # PUT /manager/api/config
+  - name: Modify API configuration (some fields)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        cache:
+          enabled: false
+          time: 1
+    response:
+      status_code: 200
+      json: &update_api_config_ok
+        data:
+          affected_items: !anything
+          total_affected_items: 1
+          total_failed_items: 0
+          failed_items: []
+
+  # PUT /manager/api/config
+  - name: Modify API configuration (all allowed fields)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        behind_proxy_server: false
+        logs:
+          level: "debug"
+        cache:
+          enabled: true
+          time: 3
+        cors:
+          enabled: true
+          source_route: "*"
+          expose_headers: "*"
+          allow_headers: "*"
+          allow_credentials: false
+        use_only_authd: true
+        experimental_features: true
+    response:
+      status_code: 200
+      json:
+        <<: *update_api_config_ok
+
+  # PUT /manager/api/config
+  - name: Modify API configuration (forbidden field)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        logs:
+          path: "test"
+    response:
+      status_code: 400
+
+  # Restart manager to apply changes
+  - name: Restart manager
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
+  # GET /manager/api/config
+  - name: Get API configuration that were set above
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: !anystr
+              node_api_config: &api_response
+                host: !anystr
+                port: !anyint
+                behind_proxy_server: false
+                https:
+                  enabled: !anybool
+                  key: !anystr
+                  cert: !anystr
+                  use_ca: !anybool
+                  ca: !anystr
+                logs:
+                  level: "debug"
+                  path: !anystr
+                cors:
+                  enabled: true
+                  source_route: "*"
+                  expose_headers: "*"
+                  allow_headers: "*"
+                  allow_credentials: false
+                cache:
+                  enabled: true
+                  time: 3
+                use_only_authd: true
+                drop_privileges: !anybool
+                experimental_features: true
+          total_affected_items: 1
+          total_failed_items: 0
+          failed_items: []
+
+---
+test_name: DELETE /manager/api/config
+
+stages:
+
+  # DELETE /manager/api/config
+  - name: Restore API configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        <<: *update_api_config_ok
+
+  # Restart manager to apply changes
+  - name: Restart manager
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
+  # GET /manager/api/config
+  - name: Get API default configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - node_name: !anystr
+              node_api_config:
+                <<: *api_response
+                logs:
+                  level: "info"
+                  path: !anystr
+                cors:
+                  enabled: false
+                  source_route: "*"
+                  expose_headers: "*"
+                  allow_headers: "*"
+                  allow_credentials: false
+                cache:
+                  enabled: true
+                  time: 0.75
+                use_only_authd: false
+                drop_privileges: !anybool
+                experimental_features: false
+          total_affected_items: 1
+          total_failed_items: 0
+          failed_items: []
+
+
+---
 test_name: GET /manager/files
 
 stages:
@@ -1681,222 +1923,6 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
----
-test_name: GET /manager/api/config
-
-stages:
-
-  # GET /manager/api/config
-  - name: Get API configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: !anystr
-              node_api_config:
-                host: !anystr
-                port: !anyint
-                behind_proxy_server: !anybool
-
-                https:
-                  enabled: !anybool
-                  key: !anystr
-                  cert: !anystr
-                  use_ca: !anybool
-                  ca: !anystr
-                logs:
-                  level: !anystr
-                  path: !anystr
-                cors:
-                  enabled: !anybool
-                  source_route: !anystr
-                  expose_headers: !anystr
-                  allow_headers: !anystr
-                  allow_credentials: !anybool
-                cache:
-                  enabled: !anybool
-                  time: !anything
-                access:
-                  max_login_attempts: !anyint
-                  block_time: !anyint
-                  max_request_per_minute: !anyint
-                use_only_authd: !anybool
-                drop_privileges: !anybool
-                experimental_features: !anybool
-          total_affected_items: 1
-          total_failed_items: 0
-          failed_items: []
-
----
-test_name: PUT /manager/api/config
-
-stages:
-
-  # PUT /manager/api/config
-  - name: Modify API configuration (some fields)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-      json:
-        cache:
-          enabled: false
-          time: 1
-    response:
-      status_code: 200
-      json: &update_api_config_ok
-        data:
-          affected_items: !anything
-          total_affected_items: 1
-          total_failed_items: 0
-          failed_items: []
-
-  # PUT /manager/api/config
-  - name: Modify API configuration (all allowed fields)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-      json:
-        behind_proxy_server: false
-        logs:
-          level: "debug"
-        cache:
-          enabled: true
-          time: 3
-        cors:
-          enabled: true
-          source_route: "*"
-          expose_headers: "*"
-          allow_headers: "*"
-          allow_credentials: false
-        use_only_authd: true
-        experimental_features: true
-    response:
-      status_code: 200
-      json:
-        <<: *update_api_config_ok
-
-  # PUT /manager/api/config
-  - name: Modify API configuration (forbidden field)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-      json:
-        logs:
-          path: "test"
-    response:
-      status_code: 400
-
-  # GET /manager/api/config
-  - name: Get API configuration that were set above
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: !anystr
-              node_api_config: &api_response
-                host: !anystr
-                port: !anyint
-                behind_proxy_server: false
-                https:
-                  enabled: !anybool
-                  key: !anystr
-                  cert: !anystr
-                  use_ca: !anybool
-                  ca: !anystr
-                logs:
-                  level: "debug"
-                  path: !anystr
-                cors:
-                  enabled: true
-                  source_route: "*"
-                  expose_headers: "*"
-                  allow_headers: "*"
-                  allow_credentials: false
-                cache:
-                  enabled: true
-                  time: 3
-                use_only_authd: true
-                drop_privileges: !anybool
-                experimental_features: true
-          total_affected_items: 1
-          total_failed_items: 0
-          failed_items: []
-
----
-test_name: DELETE /manager/api/config
-
-stages:
-
-  # DELETE /manager/api/config
-  - name: Restore API configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      method: DELETE
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        <<: *update_api_config_ok
-
-  # GET /manager/api/config
-  - name: Get API default configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - node_name: !anystr
-              node_api_config:
-                <<: *api_response
-                logs:
-                  level: "info"
-                  path: !anystr
-                cors:
-                  enabled: false
-                  source_route: "*"
-                  expose_headers: "*"
-                  allow_headers: "*"
-                  allow_credentials: false
-                cache:
-                  enabled: true
-                  time: 0.75
-                use_only_authd: false
-                drop_privileges: !anybool
-                experimental_features: false
-          total_affected_items: 1
-          total_failed_items: 0
-          failed_items: []
 
 ---
 test_name: PUT /manager/restart

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -933,6 +933,8 @@ stages:
           affected_items:
             - <<: *sca_check_result_002
             - <<: *sca_check_result_002
+            - <<: *sca_agent_result_002
+            - <<: *sca_agent_result_002
           failed_items: []
           total_failed_items: 0
 
@@ -953,6 +955,7 @@ stages:
           total_affected_items: !anyint
           affected_items:
             - <<: *sca_check_result_002
+            - <<: *sca_agent_result_002
           failed_items: []
           total_failed_items: 0
 
@@ -1480,6 +1483,8 @@ stages:
           affected_items:
             - <<: *sca_check_result_003
             - <<: *sca_check_result_003
+            - <<: *sca_check_result_003
+            - <<: *sca_check_result_003
           failed_items: []
           total_failed_items: 0
 
@@ -1499,6 +1504,7 @@ stages:
         data:
           total_affected_items: !anyint
           affected_items:
+            - <<: *sca_check_result_003
             - <<: *sca_check_result_003
           failed_items: []
           total_failed_items: 0

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -289,6 +289,8 @@ stages:
           affected_items:
             - <<: *sca_check_result_001
             - <<: *sca_check_result_001
+            - <<: *sca_check_result_001
+            - <<: *sca_check_result_001
           failed_items: []
           total_failed_items: 0
 
@@ -308,6 +310,7 @@ stages:
         data:
           total_affected_items: !anyint
           affected_items:
+            - <<: *sca_check_result_001
             - <<: *sca_check_result_001
           failed_items: []
           total_failed_items: 0

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -933,8 +933,8 @@ stages:
           affected_items:
             - <<: *sca_check_result_002
             - <<: *sca_check_result_002
-            - <<: *sca_agent_result_002
-            - <<: *sca_agent_result_002
+            - <<: *sca_check_result_002
+            - <<: *sca_check_result_002
           failed_items: []
           total_failed_items: 0
 

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -955,7 +955,7 @@ stages:
           total_affected_items: !anyint
           affected_items:
             - <<: *sca_check_result_002
-            - <<: *sca_agent_result_002
+            - <<: *sca_check_result_002
           failed_items: []
           total_failed_items: 0
 

--- a/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
@@ -758,6 +758,23 @@ stages:
       status_code: 200
 
 ---
+test_name: PUT /cluster/restart
+
+stages:
+
+  # Restart nodes to apply changes
+  - name: Restart cluster
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
+---
 test_name: CHECK /security/config
 
 stages:

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -532,6 +532,18 @@ test_name: PUT /security/config (Check)
 
 stages:
 
+  # Restart nodes to apply changes
+  - name: Restart cluster
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+    delay_after: !float "{restart_delay}"
+
   - name: Get security configuration to check if PUT method worked correctly
     request:
       verify: False

--- a/etc/rules/0230-ms-se_rules.xml
+++ b/etc/rules/0230-ms-se_rules.xml
@@ -231,7 +231,7 @@
   <rule id="20177" level="8">
     <if_sid>20168</if_sid>
     <field name="win.system.eventID">^2004$</field>
-    <group>pci_dss_10.6.1,gpg13_4.14,gpg13_4.4,gpg13_,gdpr_IV_35.7.d,</group>
+    <group>pci_dss_10.6.1,gpg13_4.14,gpg13_4.4,gdpr_IV_35.7.d,</group>
     <description>Microsoft Security Essentials - Loading definitions failed. Using last good set</description>
     <options>no_full_log</options>
   </rule>

--- a/framework/scripts/update_ruleset.py
+++ b/framework/scripts/update_ruleset.py
@@ -11,27 +11,27 @@
 #  root privileges
 # http://wazuh-documentation.readthedocs.io/en/latest/wazuh_ruleset.html
 
-import contextlib
 import os
 import sys
-from datetime import datetime
-from filecmp import cmp
-from getopt import GetoptError, getopt
-from glob import glob
-from grp import getgrnam
-from json import dumps
-from pwd import getpwnam
-from re import sub, search
-from shutil import copyfile, copytree, rmtree
-from signal import signal, SIGINT
-from time import time
-from zipfile import ZipFile
-
 import requests
+import contextlib
+from glob import glob
+from zipfile import ZipFile
+from getopt import GetoptError, getopt
+from signal import signal, SIGINT
+from datetime import datetime, date
+from pwd import getpwnam
+from grp import getgrnam
+from shutil import copyfile, copytree, rmtree
+from re import sub, search
+from filecmp import cmp
+from time import time
+from json import dumps
 
 # Set framework path
-from wazuh.core import common
-from wazuh.core.cluster.utils import read_config
+from wazuh import Wazuh
+from wazuh import common
+from wazuh.cluster.cluster import read_config
 
 
 class RulesetLogger:
@@ -259,7 +259,7 @@ def get_new_ruleset(source, url, branch_name=None):
 
         ruleset_zip = "{0}/ruleset.zip".format(update_downloads)
 
-        logger.debug("Downloading ruleset from {0}.".format(url_ruleset, ))
+        logger.debug("Downloading ruleset from {0}.".format(url_ruleset,))
 
         # Download
         try:
@@ -307,7 +307,8 @@ def get_new_ruleset(source, url, branch_name=None):
         else:
             copy("{0}/update_ruleset.py".format(update_ruleset), ossec_update_script, 0o750)
     except Exception as e:
-        exit(2, "Upgrade aborted: Update ruleset not found.")
+        exit(2,"Upgrade aborted: Update ruleset not found.")
+
 
     return get_ruleset_version()
 
@@ -359,6 +360,7 @@ def get_ruleset_to_update(no_checks=False):
 
 
 def upgrade_ruleset(ruleset):
+
     rm(update_backups)
     mkdir(update_backups)
     mkdir(update_backups_rules)
@@ -394,6 +396,7 @@ def upgrade_ruleset(ruleset):
             if os.path.exists(dst_file):
                 copy(dst_file, dst_backup, perm)
             copy(src_file, dst_file, perm)
+
 
     msg = ""
     for type_r in deprecated.keys():
@@ -473,27 +476,28 @@ def main():
     else:
         # version temporary backup
 
-        copy(ossec_ruleset_version_path, ossec_ruleset_version_path + '-old')
+        copy(ossec_ruleset_version_path, ossec_ruleset_version_path+'-old')
         try:
-            copy(ossec_update_script, ossec_update_script + '-old', 0o750)
+            copy(ossec_update_script, ossec_update_script+'-old', 0o750)
         except:
-            copy(ossec_update_script + ".py", ossec_update_script + '-old', 0o750)
+            copy(ossec_update_script + ".py", ossec_update_script+'-old', 0o750)
         # Get ruleset
         status['old_version'] = get_ruleset_version()
         status['new_version'] = get_new_ruleset(arguments['source'], arguments['url'], arguments['branch-name'])
-        # Compare major
-        old_version = ossec_version.replace('"', '')
+        #Compare major
+        old_version = ossec_version.replace('"','')
         if not same_major_minor(old_version, status['new_version']):
-            copy(ossec_ruleset_version_path + '-old', ossec_ruleset_version_path)
-            copy(ossec_update_script + '-old', ossec_update_script, 0o750)
-            os.remove(ossec_update_script + '-old')
-            os.remove(ossec_ruleset_version_path + '-old')
-            exit(2, "Upgrade aborted: Unexpected version in the new ruleset. " + \
-                 "Expected version {0}. Found version {1}".format(old_version[:-1] + 'x',
-                                                                  status['new_version']))
+            copy(ossec_ruleset_version_path+'-old', ossec_ruleset_version_path)
+            copy(ossec_update_script+'-old', ossec_update_script, 0o750)
+            os.remove(ossec_update_script+'-old')
+            os.remove(ossec_ruleset_version_path+'-old')
+            exit(2,"Upgrade aborted: Unexpected version in the new ruleset. " + \
+                "Expected version {0}. Found version {1}".format(old_version[:-1]+'x',
+                status['new_version']))
         # remove temporary files
-        os.remove(ossec_update_script + '-old')
-        os.remove(ossec_ruleset_version_path + '-old')
+        os.remove(ossec_update_script+'-old')
+        os.remove(ossec_ruleset_version_path+'-old')
+
 
         ruleset_to_update, status['restart_required'] = get_ruleset_to_update(arguments['force'])
 
@@ -502,8 +506,7 @@ def main():
             status['msg'] = "\nYou already have the latest version of ruleset."
         else:
             upgrade_ruleset(ruleset_to_update)
-            status['msg'] = "\nRuleset {0} updated to {1} successfully".format(status['old_version'],
-                                                                               status['new_version'])
+            status['msg'] = "\nRuleset {0} updated to {1} successfully".format(status['old_version'], status['new_version'])
 
         rm(update_downloads)
 
@@ -537,7 +540,6 @@ def main():
     if arguments['json']:
         print(dumps({'error': 0, 'data': status}))
 
-
 def same_major_minor(old_version, new_version):
     old_major, old_minor, old_patch = old_version.split(".")
     new_major, new_minor, new_patch = new_version.split(".")
@@ -548,7 +550,6 @@ def same_major_minor(old_version, new_version):
         return True
     else:
         return False
-
 
 def usage():
     branch = get_branch()  # 'stable' 'master' 'development'
@@ -586,8 +587,7 @@ if __name__ == "__main__":
         executable_name = "update_ruleset"
         master_ip = cluster_config['nodes'][0]
         print("Wazuh is running in cluster mode: {EXECUTABLE_NAME} is not available in worker nodes. "
-              "Please, try again in the master node: {MASTER_IP}".format(EXECUTABLE_NAME=executable_name,
-                                                                         MASTER_IP=master_ip))
+            "Please, try again in the master node: {MASTER_IP}".format(EXECUTABLE_NAME=executable_name, MASTER_IP=master_ip))
         sys.exit(1)
 
     if os.geteuid() != 0:
@@ -601,14 +601,11 @@ if __name__ == "__main__":
         sys.exit(1)
 
     # Arguments
-    arguments = {'source': 'download', 'restart': 'ask', 'backups': False, 'force': False, 'debug': False,
-                 'json': False, 'branch-name': False, 'url': False}
+    arguments = {'source': 'download', 'restart': 'ask', 'backups': False, 'force': False, 'debug': False, 'json': False, 'branch-name': False, 'url': False}
     restart_args = 0
 
     try:
-        opts, args = getopt(sys.argv[1:], "s:o:n:u:brRfdjh",
-                            ["backups", "source=", "ossec_path=", "restart", "no-restart", "force-update", "debug",
-                             "json", "help", "branch-name=", "url="])
+        opts, args = getopt(sys.argv[1:], "s:o:n:u:brRfdjh", ["backups", "source=", "ossec_path=", "restart", "no-restart", "force-update", "debug", "json", "help", "branch-name=", "url="])
         if len(opts) > 6:
             print("Incorrect number of arguments.\nTry './update_ruleset --help' for more information.")
             sys.exit(1)
@@ -687,17 +684,12 @@ if __name__ == "__main__":
     update_backups_rules = "{0}/rules".format(update_backups)
     update_backups_rootchecks = "{0}/rootchecks".format(update_backups)
 
-    deprecated = {'rules': ['0355-amazon-ec2_rules.xml', '0370-amazon-iam_rules.xml', '0465-amazon-s3_rules.xml',
-                            '0470-suricata_rules.xml', '0520-vulnerability-detector.xml',
-                            '0565-ms_ipsec_rules_json.xml'],
-                  'decoders': ['0020-amazon_decoders.xml', '0005-json_decoders.xml']}
+    deprecated = {'rules': ['0355-amazon-ec2_rules.xml', '0370-amazon-iam_rules.xml', '0465-amazon-s3_rules.xml', '0470-suricata_rules.xml', '0520-vulnerability-detector.xml', '0565-ms_ipsec_rules_json.xml'], 'decoders': ['0020-amazon_decoders.xml', '0005-json_decoders.xml'] }
 
     if arguments['json']:
-        logger = RulesetLogger(tag="Wazuh-Ruleset", filename=ossec_ruleset_log, flag=RulesetLogger.O_FILE,
-                               debug=arguments['debug'])
+        logger = RulesetLogger(tag="Wazuh-Ruleset", filename=ossec_ruleset_log, flag=RulesetLogger.O_FILE, debug=arguments['debug'])
     else:
-        logger = RulesetLogger(tag="Wazuh-Ruleset", filename=ossec_ruleset_log, flag=RulesetLogger.O_ALL,
-                               debug=arguments['debug'])
+        logger = RulesetLogger(tag="Wazuh-Ruleset", filename=ossec_ruleset_log, flag=RulesetLogger.O_ALL, debug=arguments['debug'])
 
     logger.debug("Arguments: {0}".format(arguments))
 

--- a/framework/scripts/wazuh-clusterd.py
+++ b/framework/scripts/wazuh-clusterd.py
@@ -3,6 +3,9 @@
 # Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+from api import configuration
+configuration.api_conf.update(configuration.read_yaml_config())
+
 import argparse
 import asyncio
 import logging

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -2,6 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import copy
 import fcntl
 import json
 import random
@@ -16,9 +17,9 @@ from os.path import exists, join
 from pyexpat import ExpatError
 from shutil import Error
 from typing import Dict
+from xml.dom.minidom import parseString
 
 import yaml
-from xml.dom.minidom import parseString
 
 from api import configuration
 from wazuh import WazuhInternalError, WazuhError
@@ -355,12 +356,12 @@ def replace_in_comments(original_content, to_be_replaced, replacement):
 
 
 def get_api_conf():
-    """Returns current API configuration."""
-    return configuration.api_conf
+    """Return current API configuration."""
+    return copy.deepcopy(configuration.api_conf)
 
 
 def update_api_conf(new_config):
-    """Update dict and subdicts without overriding unspecified keys and write it in the API.yaml file.
+    """Update the API.yaml file.
 
     Parameters
     ----------
@@ -368,16 +369,9 @@ def update_api_conf(new_config):
         Dictionary with the new configuration.
     """
     if new_config:
-        for key in new_config:
-            if key in configuration.api_conf:
-                if isinstance(configuration.api_conf[key], dict) and isinstance(new_config[key], dict):
-                    configuration.api_conf[key].update(new_config[key])
-                else:
-                    configuration.api_conf[key] = new_config[key]
-
         try:
             with open(common.api_config_path, 'w+') as f:
-                yaml.dump(configuration.api_conf, f)
+                yaml.dump(new_config, f)
         except IOError:
             raise WazuhInternalError(1005)
     else:

--- a/framework/wazuh/core/security.py
+++ b/framework/wazuh/core/security.py
@@ -30,12 +30,10 @@ def update_security_conf(new_config):
     new_config : dict
         Dictionary with the new configuration.
     """
-    configuration.security_conf.update(new_config)
-
     if new_config:
         try:
             with open(SECURITY_CONFIG_PATH, 'w+') as f:
-                yaml.dump(configuration.security_conf, f)
+                yaml.dump(new_config, f)
         except IOError:
             raise WazuhInternalError(1005)
     else:

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -461,9 +461,8 @@ def test_update_api_conf(mock_open, mock_yaml):
     with patch('wazuh.core.manager.configuration.api_conf', new=old_config):
         update_api_conf(new_config=new_config)
 
-        assert old_config == {'experimental_features': True, 'cache': {'enabled': True, 'time': 0.75}}
         mock_open.assert_called_once(), '"Open" should be called, but it was not.'
-        mock_yaml.assert_called_once_with(old_config, ANY), '"Yaml.dump" should be called with updated config.'
+        mock_yaml.assert_called_once_with(new_config, ANY), '"Yaml.dump" should be called with updated config.'
 
 
 def test_update_api_conf_ko():

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -247,9 +247,9 @@ def get_api_config():
 
 _update_config_default_result_kwargs = {
     'all_msg': f"API configuration was successfully updated{' in all specified nodes' if node_id != 'manager' else '' }. "
-               f"Some settings may require restarting the API to be applied",
-    'some_msg': 'Not all API configuration could be updated',
-    'none_msg': f"API configuration could not be updated{' in any node' if node_id != 'manager' else ''}",
+               f"Settings require restarting the API to be applied.",
+    'some_msg': 'Not all API configuration could be updated.',
+    'none_msg': f"API configuration could not be updated{' in any node' if node_id != 'manager' else ''}.",
     'sort_casting': ['str']
 }
 

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -82,8 +82,8 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
                            list(fields_translation_sca_check_rule.keys())
                            )
 
-            db_query = WazuhDBQuerySCA(agent_id=agent_list[0], offset=offset, limit=limit, sort=sort, search=search,
-                                       select=full_select, count=True, get_data=True,
+            db_query = WazuhDBQuerySCA(agent_id=agent_list[0], offset=offset, limit=common.database_limit, sort=sort,
+                                       search=search, select=full_select, count=True, get_data=True,
                                        query=f"policy_id={policy_id}" if q == "" else f"policy_id={policy_id};{q}",
                                        filters=filters, default_query=default_query_sca_check,
                                        default_sort_field='policy_id', fields=fields_translation, count_field='id')
@@ -100,7 +100,7 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
             select_fields = set([field if field != 'compliance' else 'compliance'
                                  for field in select_fields if field in fields_translation_sca_check])
             # Rearrange check and compliance fields
-            for _, group in groups:
+            for idx, (_, group) in zip(range(0, limit), groups):
                 group_list = list(group)
                 check_dict = {k: v for k, v in group_list[0].items()
                               if k in select_fields
@@ -113,7 +113,6 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
                         check_dict[extra_field] = [dict(zip(field_translations.values(), x))
                                                    for x in set((map(itemgetter(*field_translations.keys()),
                                                                      group_list)))]
-
                 result.affected_items.append(check_dict)
             result.total_affected_items = result_dict['totalItems']
         else:

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -12,7 +12,8 @@ from wazuh.core.agent import get_agents_info
 from wazuh.core.exception import WazuhInternalError, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.sca import WazuhDBQuerySCA, fields_translation_sca, fields_translation_sca_check, \
-    fields_translation_sca_check_compliance, fields_translation_sca_check_rule, default_query_sca_check
+    fields_translation_sca_check_compliance, fields_translation_sca_check_rule, default_query_sca_check, \
+    WazuhDBQuerySCACheck
 from wazuh.rbac.decorators import expose_resources
 
 
@@ -82,11 +83,11 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
                            list(fields_translation_sca_check_rule.keys())
                            )
 
-            db_query = WazuhDBQuerySCA(agent_id=agent_list[0], offset=offset, limit=common.database_limit, sort=sort,
-                                       search=search, select=full_select, count=True, get_data=True,
-                                       query=f"policy_id={policy_id}" if q == "" else f"policy_id={policy_id};{q}",
-                                       filters=filters, default_query=default_query_sca_check,
-                                       default_sort_field='policy_id', fields=fields_translation, count_field='id')
+            db_query = WazuhDBQuerySCACheck(agent_id=agent_list[0], offset=offset, limit=limit, sort=sort,
+                                            search=search, select=full_select, count=True, get_data=True,
+                                            query=f"policy_id={policy_id}" if q == "" else f"policy_id={policy_id};{q}",
+                                            filters=filters, default_query=default_query_sca_check,
+                                            default_sort_field='policy_id', fields=fields_translation, count_field='id')
 
             result_dict = db_query.run()
 
@@ -100,7 +101,7 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
             select_fields = set([field if field != 'compliance' else 'compliance'
                                  for field in select_fields if field in fields_translation_sca_check])
             # Rearrange check and compliance fields
-            for idx, (_, group) in zip(range(0, limit), groups):
+            for _, group in groups:
                 group_list = list(group)
                 check_dict = {k: v for k, v in group_list[0].items()
                               if k in select_fields

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -22,15 +22,28 @@ def get_sca_list(agent_list=None, q="", offset=0, limit=common.database_limit, s
                  filters=None):
     """ Get a list of policies analyzed in the configuration assessment for a given agent
 
-    :param agent_list: agent id to get policies from
-    :param q: Defines query to filter in DB.
-    :param offset: First item to return.
-    :param limit: Maximum number of items to return.
-    :param sort: Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
-    :param search: Looks for items with the specified string. Format: {"fields": ["field1","field2"]}
-    :param select: Select fields to return. Format: {"fields":["field1","field2"]}.
-    :param filters: Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
-    :return: AffectedItemsWazuhResult
+    Parameters
+    ----------
+    agent_list : list
+        Agent ids to get policies from.
+    q : str
+        Defines query to filter in DB.
+    offset : int
+        First item to return.
+    limit : int
+        Maximum number of items to return.
+    sort : str
+        Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
+    search : str
+        Looks for items with the specified string. Format: {"fields": ["field1","field2"]}
+    select : str
+        Select fields to return. Format: {"fields":["field1","field2"]}.
+    filters : str
+        Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
+
+    Returns
+    -------
+    AffectedItemsWazuhResult
     """
     result = AffectedItemsWazuhResult(all_msg='All selected sca information was returned',
                                       some_msg='Some sca information was not returned',
@@ -57,16 +70,30 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
                    select=None, filters=None):
     """ Get a list of checks analyzed for a policy
 
-    :param policy_id: policy id to get the checks from
-    :param agent_list: agent id to get the policies from
-    :param q: Defines query to filter in DB.
-    :param offset: First item to return.
-    :param limit: Maximum number of items to return.
-    :param sort: Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
-    :param search: Looks for items with the specified string. Format: {"fields": ["field1","field2"]}
-    :param select: Select fields to return. Format: {"fields":["field1","field2"]}.
-    :param filters: Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
-    :return: AffectedItemsWazuhResult
+    Parameters
+    ----------
+    policy_id : str
+        Policy id to get the checks from.
+    agent_list : list
+        Agent id to get the policies from
+    q : str
+        Defines query to filter in DB.
+    offset : int
+        First item to return.
+    limit : int
+        Maximum number of items to return.
+    sort : str
+        Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
+    search : str
+        Looks for items with the specified string. Format: {"fields": ["field1","field2"]}
+    select : str
+        Select fields to return. Format: {"fields":["field1","field2"]}.
+    filters : str
+        Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
+
+    Returns
+    -------
+    AffectedItemsWazuhResult
     """
     result = AffectedItemsWazuhResult(all_msg='All selected sca/policy information was returned',
                                       some_msg='Some sca/policy information was not returned',

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -5,7 +5,7 @@
 import os
 import socket
 import sys
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock, mock_open, ANY
 import json
 
 import pytest
@@ -263,7 +263,7 @@ def test_get_api_config():
     assert result['data']['affected_items'][0]['node_name'] == 'manager', 'Not expected node name'
 
 
-@patch('wazuh.core.manager.yaml')
+@patch('wazuh.core.manager.yaml.dump')
 @patch('wazuh.core.manager.open')
 def test_update_api_config(mock_open, mock_yaml):
     """Checks that update_api_config method is updating current api_conf dict and returning expected result."""
@@ -275,7 +275,8 @@ def test_update_api_config(mock_open, mock_yaml):
 
         assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type.'
         assert result.render()['data']['total_failed_items'] == 0, 'Total_failed_items should be 0.'
-        assert old_config == new_config, 'Old configuration should be equal to new configuration.'
+        assert old_config != new_config, 'Old configuration should be equal to new configuration.'
+        mock_yaml.assert_called_once_with(new_config, ANY)
 
 
 def test_update_api_config_ko():

--- a/framework/wazuh/tests/test_sca.py
+++ b/framework/wazuh/tests/test_sca.py
@@ -223,6 +223,6 @@ def test_sca_response_without_result():
     """
     with patch('wazuh.core.sca.WazuhDBBackend') as mock_wdb:
         mock_wdb.return_value.connect_to_db.return_value.execute.side_effect = get_fake_sca_data
-        with patch('wazuh.core.sca.WazuhDBQuerySCA.run', return_value={}):
+        with patch('wazuh.core.sca.WazuhDBQuerySCACheck.run', return_value={}):
             with pytest.raises(exception.WazuhException, match=".* 2007 .*"):
                 get_sca_checks('not_exists', agent_list=['000'])

--- a/src/Makefile
+++ b/src/Makefile
@@ -981,6 +981,9 @@ wrappers_externals_audit_o := $(wrappers_externals_audit_c:.c=.o)
 wrappers_externals_bzip2_c := $(wildcard unit_tests/wrappers/externals/bzip2/*.c)
 wrappers_externals_bzip2_o := $(wrappers_externals_bzip2_c:.c=.o)
 
+wrappers_externals_zlib_c := $(wildcard unit_tests/wrappers/externals/zlib/*.c)
+wrappers_externals_zlib_o := $(wrappers_externals_zlib_c:.c=.o)
+
 wrappers_externals_cJSON_c := $(wildcard unit_tests/wrappers/externals/cJSON/*.c)
 wrappers_externals_cJSON_o := $(wrappers_externals_cJSON_c:.c=.o)
 
@@ -1053,6 +1056,7 @@ ifneq (,$(filter ${TEST},YES yes y Y 1))
 	UNIT_TEST_WRAPPERS:=${wrappers_common_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_bzip2_o}
+	UNIT_TEST_WRAPPERS+=${wrappers_externals_zlib_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_cJSON_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_openssl_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_sqlite_o}
@@ -1968,6 +1972,7 @@ clean-unit-tests:
 	rm -f ${wrappers_externals_o}
 	rm -f ${wrappers_externals_audit_o}
 	rm -f ${wrappers_externals_bzip2_o}
+	rm -f ${wrappers_externals_zlib_o}
 	rm -f ${wrappers_externals_cJSON_o}
 	rm -f ${wrappers_externals_openssl_o}
 	rm -f ${wrappers_externals_procpc_o}

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -131,7 +131,7 @@ cJSON *getClientConfig(void) {
         if (agt->enrollment_cfg->cert_cfg->agent_key)    
             cJSON_AddStringToObject(enrollment_cfg, "agent_key_path", agt->enrollment_cfg->cert_cfg->agent_key);
         if(agt->enrollment_cfg->cert_cfg->authpass)
-            cJSON_AddStringToObject(enrollment_cfg, "authorization_pass_path", agt->enrollment_cfg->cert_cfg->authpass);
+            cJSON_AddStringToObject(enrollment_cfg, "authorization_pass_path", agt->enrollment_cfg->cert_cfg->authpass_file);
         
         cJSON_AddStringToObject(enrollment_cfg,"auto_method",agt->enrollment_cfg->cert_cfg->auto_method ? "yes": "no");
         cJSON_AddItemToObject(client,"enrollment",enrollment_cfg);

--- a/src/client-agent/sendmsg.c
+++ b/src/client-agent/sendmsg.c
@@ -53,13 +53,20 @@ int send_msg(const char *msg, ssize_t msg_length)
     } else {
 #ifdef WIN32
         error = WSAGetLastError();
-        merror(SEND_ERROR, "server", win_strerror(error));
+        mwarn(SEND_ERROR, "server", win_strerror(error));
 #else
-        if(error == EPIPE) {
+        switch (error) {
+        case EPIPE:
             mdebug2(TCP_EPIPE);
-        } else {
-            merror(SEND_ERROR, "server", strerror(error));
+            break;
+        case ECONNREFUSED:
+            mdebug2(CONN_REF);
+            break;
+        default:
+            mwarn(SEND_ERROR, "server", strerror(error));
+            break;
         }
+
 #endif
         sleep(1);
     }

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -328,7 +328,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
     const char *xml_server_ca_path = "server_ca_path";
     const char *xml_agent_certif_path = "agent_certificate_path";
     const char *xml_agent_key_path = "agent_key_path";
-    const char *xml_auth_password = "authorization_pass_path";
+    const char *xml_auth_password_path = "authorization_pass_path";
     const char *xml_auto_method = "auto_method";
     const char *xml_delay_after_enrollment = "delay_after_enrollment";
     const char *xml_use_source_ip = "use_source_ip";
@@ -420,7 +420,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
         } else if (strcmp(node[j]->element, xml_agent_key_path) == 0) {
             os_free(cert_cfg->agent_key);
             os_strdup(node[j]->content, cert_cfg->agent_key);
-        } else if (strcmp(node[j]->element, xml_auth_password) == 0) {
+        } else if (strcmp(node[j]->element, xml_auth_password_path) == 0) {
             os_free(cert_cfg->authpass_file);
             os_strdup(node[j]->content, cert_cfg->authpass_file);
         } else if (strcmp(node[j]->element, xml_auto_method) == 0) {

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -59,6 +59,6 @@ void Free_Client(agent * config);
 bool Validate_Address(agent_server *servers);
 
 #define DEFAULT_MAX_RETRIES 5
-#define DEFAULT_RETRY_INTERVAL 5
+#define DEFAULT_RETRY_INTERVAL 10
 
 #endif /* CAGENTD_H */

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -30,8 +30,6 @@ typedef struct provider_options {
     char *multi_url;
     int multi_url_start;
     int multi_url_end;
-    char **multi_allowed_os_name;
-    char **multi_allowed_os_ver;
     int port;
     time_t update_interval;
     int update_since;
@@ -46,8 +44,7 @@ static int wm_vuldet_provider_enable(xml_node **node);
 static char *wm_vuldet_provider_name(xml_node *node);
 static int wm_vuldet_provider_os_list(xml_node **node, vu_os_feed **feeds, char *pr_name);
 static void wm_vuldet_set_port_to_url(char **url, int port);
-static int wm_vuldet_add_allow_os(update_node *update, char *os_tags, char old_config);
-static int wm_vuldet_add_multi_allow_os(update_node *update, char **src_os, char **dst_os);
+static int wm_vuldet_add_allow_os(update_node *update, char *os_tags);
 static int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_provider, provider_options *options);
 static char wm_vuldet_provider_type(char *pr_name);
 static void wm_vuldet_remove_os_feed(vu_os_feed *feed, char full_r);
@@ -71,7 +68,6 @@ static const char *XML_PORT = "port";
 static const char *XML_ALLOW = "allow";
 static const char *XML_UPDATE_FROM_YEAR = "update_from_year";
 static const char *XML_PROVIDER = "provider";
-static const char *XML_REPLACED_OS = "replaced_os";
 static const char *XML_TIMEOUT = "download_timeout";
 
 static const char *XML_START = "start";
@@ -529,7 +525,7 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
                 continue;
             }
 
-            if (os_list->allow && wm_vuldet_add_allow_os(updates[os_index], os_list->allow, 0)) {
+            if (os_list->allow && wm_vuldet_add_allow_os(updates[os_index], os_list->allow)) {
                 goto end;
             }
 
@@ -565,7 +561,7 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
     }
 
     /**
-    *  multi_provider = NVD, RedHat and MSU.
+    *  multi_provider = NVD, RedHat JSON and MSU.
     *  Those which use <path> or <url> tags.
     **/
     if (multi_provider || (p_options.multi_path || p_options.multi_url)) {
@@ -591,12 +587,6 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
         updates[os_index]->multi_url_end = p_options.multi_url_end;
         updates[os_index]->port = p_options.port;
         updates[os_index]->timeout = p_options.timeout;
-
-        if (p_options.multi_allowed_os_name) {
-            if (wm_vuldet_add_multi_allow_os(updates[os_index], p_options.multi_allowed_os_name, p_options.multi_allowed_os_ver)) {
-                goto end;
-            }
-        }
 
         p_options.multi_path = NULL;
         p_options.multi_url = NULL;
@@ -731,7 +721,7 @@ int wm_vuldet_provider_os_list(xml_node **node, vu_os_feed **feeds, char *pr_nam
                 tmp_list = feeds_it;
             }
         } else {
-            merror("'%s' tag required for '%s' provider", XML_OS, pr_name);
+            merror("'%s' tag required for '%s' provider.", XML_OS, pr_name);
             return OS_INVALID;
         }
     }
@@ -783,19 +773,6 @@ void wm_vuldet_free_update_node(update_node *update) {
         free(update->allowed_os_name);
         w_FreeArray(update->allowed_os_ver);
         free(update->allowed_os_ver);
-    } else if (update->dist_ref == FEED_REDHAT) {
-        int section, i;
-
-        for (section = 0; section < 2; section++) {
-            char ***multios_src = !section ? update->allowed_multios_src_name : update->allowed_multios_src_ver;
-            char **multios_dst = !section ? update->allowed_multios_dst_name : update->allowed_multios_dst_ver;
-            for (i = 0; multios_src && multios_src[i]; i++) {
-                w_FreeArray(multios_src[i]);
-                free(multios_src[i]);
-            }
-            w_FreeArray(multios_dst);
-            free(multios_dst);
-        }
     }
 }
 
@@ -837,82 +814,38 @@ void wm_vuldet_set_port_to_url(char **url, int port) {
     }
 }
 
-int wm_vuldet_add_allow_os(update_node *update, char *os_tags, char old_config) {
+int wm_vuldet_add_allow_os(update_node *update, char *os_tags) {
     char *found;
     size_t size;
 
-    if (wm_vuldet_is_single_provider(update->dist_ref) || old_config) {
-        os_calloc(1, sizeof(char *), update->allowed_os_name);
-        os_calloc(1, sizeof(char *), update->allowed_os_ver);
+    os_calloc(1, sizeof(char *), update->allowed_os_name);
+    os_calloc(1, sizeof(char *), update->allowed_os_ver);
 
-        for (size = 0; (found = strchr(os_tags, ',')); size++) {
-            *(found++) = '\0';
-            os_realloc(update->allowed_os_name, (size + 2)*sizeof(char *), update->allowed_os_name);
-            os_realloc(update->allowed_os_ver, (size + 2)*sizeof(char *), update->allowed_os_ver);
-            if (format_os_version(os_tags, &update->allowed_os_name[size], &update->allowed_os_ver[size])) {
-                merror("Invalid OS entered in %s: %s", WM_VULNDETECTOR_CONTEXT.name, os_tags);
-                return OS_INVALID;
-            }
-            update->allowed_os_name[size + 1] = NULL;
-            os_tags = found;
-        }
+    for (size = 0; (found = strchr(os_tags, ',')); size++) {
+        *(found++) = '\0';
         os_realloc(update->allowed_os_name, (size + 2)*sizeof(char *), update->allowed_os_name);
+        os_realloc(update->allowed_os_ver, (size + 2)*sizeof(char *), update->allowed_os_ver);
         if (format_os_version(os_tags, &update->allowed_os_name[size], &update->allowed_os_ver[size])) {
             merror("Invalid OS entered in %s: %s", WM_VULNDETECTOR_CONTEXT.name, os_tags);
             return OS_INVALID;
         }
+        mdebug1("'%s' successfully added to the monitored OS list.", os_tags);
         update->allowed_os_name[size + 1] = NULL;
-    } else {
-        merror("The 'allow' option can only be used with single-providers.");
+        os_tags = found;
+    }
+    os_realloc(update->allowed_os_name, (size + 2)*sizeof(char *), update->allowed_os_name);
+    if (format_os_version(os_tags, &update->allowed_os_name[size], &update->allowed_os_ver[size])) {
+        merror("Invalid OS entered in %s: %s", WM_VULNDETECTOR_CONTEXT.name, os_tags);
         return OS_INVALID;
     }
-
-    return 0;
-}
-
-int wm_vuldet_add_multi_allow_os(update_node *update, char **src_os, char **dst_os) {
-    int i, j;
-    char *version;
-
-    for (i = 0; src_os[i]; i++) {
-        os_realloc(update->allowed_multios_src_name, (i + 2) * sizeof(char **), update->allowed_multios_src_name);
-        memset(&update->allowed_multios_src_name[i], '\0', 2 * sizeof(char **));
-        os_realloc(update->allowed_multios_src_ver, (i + 2) * sizeof(char **), update->allowed_multios_src_ver);
-        memset(&update->allowed_multios_src_ver[i], '\0', 2 * sizeof(char **));
-
-        os_realloc(update->allowed_multios_dst_name, (i + 2) * sizeof(char *), update->allowed_multios_dst_name);
-        memset(&update->allowed_multios_dst_name[i], '\0', 2 * sizeof(char *));
-        os_realloc(update->allowed_multios_dst_ver, (i + 2) * sizeof(char *), update->allowed_multios_dst_ver);
-        memset(&update->allowed_multios_dst_ver[i], '\0', 2 * sizeof(char *));
-
-        // Set the allowed names
-        wstr_split(src_os[i], ",", NULL, 1, &update->allowed_multios_src_name[i]);
-        os_strdup(dst_os[i], update->allowed_multios_dst_name[i]);
-
-        // Set the allowed versions
-        for (j = 0; update->allowed_multios_src_name[i][j]; j++) {
-            if (version = strchr(update->allowed_multios_src_name[i][j], '-'), !version) {
-                merror("Invalid '%s' content. Use: 'OS-version'", XML_ALLOW);
-                return OS_INVALID;
-            }
-            *(version++) = '\0';
-            os_realloc(update->allowed_multios_src_ver[i], (j + 2) * sizeof(char *), update->allowed_multios_src_ver[i]);
-            os_strdup(version, update->allowed_multios_src_ver[i][j]);
-        }
-        if (version = strchr(update->allowed_multios_dst_name[i], '-'), !version) {
-            merror("Invalid '%s' content. Use: 'OS-version'", XML_REPLACED_OS);
-            return OS_INVALID;
-        }
-        *(version++) = '\0';
-        os_strdup(version, update->allowed_multios_dst_ver[i]);
-    }
+    mdebug1("'%s' successfully added to the monitored OS list.", os_tags);
+    update->allowed_os_name[size + 1] = NULL;
 
     return 0;
 }
 
 int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_provider, provider_options *options) {
     int i, j;
-    int elements;
     int8_t rhel_enabled = (strcasestr(name, vu_feed_tag[FEED_REDHAT])) ? 1 : 0;
     int8_t msu_enabled = (strcasestr(name, vu_feed_tag[FEED_MSU])) ? 1 : 0;
 
@@ -939,7 +872,7 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
                     return OS_INVALID;
                 }
             } else {
-                mwarn("'%s' option can only be used in a multi-provider.", node[i]->element);
+                mwarn("Invalid option '%s' for '%s' provider at '%s'", node[i]->element, name, WM_VULNDETECTOR_CONTEXT.name);
             }
         } else if (!strcmp(node[i]->element, XML_UPDATE_INTERVAL)) {
             if (wm_vuldet_get_interval(node[i]->content, &options->update_interval)) {
@@ -981,25 +914,14 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
                 }
             }
         } else if (!strcmp(node[i]->element, XML_ALLOW)) {
-            if (multi_provider || rhel_enabled) {
-                if (!node[i]->attributes || !*node[i]->attributes || strcmp(*node[i]->attributes, XML_REPLACED_OS) ||
-                    !node[i]->values || !*node[i]->values || !**node[i]->values) {
-                    merror("Invalid '%s' value.", XML_REPLACED_OS);
-                    return OS_INVALID;
-                }
-                for (elements = 0; options->multi_allowed_os_name && options->multi_allowed_os_name[elements]; elements++);
-                os_realloc(options->multi_allowed_os_name, (elements + 2) * sizeof(char *), options->multi_allowed_os_name);
-                os_realloc(options->multi_allowed_os_ver, (elements + 2) * sizeof(char *), options->multi_allowed_os_ver);
-                os_strdup(node[i]->content, options->multi_allowed_os_name[elements]);
-                os_strdup(*node[i]->values, options->multi_allowed_os_ver[elements]);
-                options->multi_allowed_os_name[elements + 1] = NULL;
-                options->multi_allowed_os_ver[elements + 1] = NULL;
+            if (rhel_enabled) {
+                mwarn("Deprecated option '%s' for '%s' provider. Use it as attribute <os %s> instead.", node[i]->element, name, node[i]->element);
             } else {
-                mwarn("'%s' option can only be used in a multi-provider.", node[i]->element);
+                mwarn("Invalid option '%s' for '%s' provider at '%s'", node[i]->element, name, WM_VULNDETECTOR_CONTEXT.name);
             }
         } else if (!strcmp(node[i]->element, XML_OS)) {
             if (multi_provider) {
-                mwarn("'%s' option can only be used in a single-provider.", node[i]->element);
+                mwarn("Invalid option '%s' for '%s' provider at '%s'", node[i]->element, name, WM_VULNDETECTOR_CONTEXT.name);
             }
         } else if (strcmp(node[i]->element, XML_ENABLED)) {
             merror("Invalid option in %s section for module '%s': '%s'", XML_PROVIDER, WM_VULNDETECTOR_CONTEXT.name, node[i]->element);
@@ -1048,8 +970,6 @@ void wm_vuldet_init_provider_options(provider_options *options) {
     options->multi_url = NULL;
     options->multi_url_start = 0;
     options->multi_url_end = 0;
-    options->multi_allowed_os_name = NULL;
-    options->multi_allowed_os_ver = NULL;
     options->port = 0;
     options->update_interval = 0;
     options->update_since = 0;
@@ -1059,10 +979,6 @@ void wm_vuldet_init_provider_options(provider_options *options) {
 void wm_vuldet_clear_provider_options(provider_options options) {
     os_free(options.multi_path);
     os_free(options.multi_url);
-    w_FreeArray(options.multi_allowed_os_name);
-    w_FreeArray(options.multi_allowed_os_ver);
-    os_free(options.multi_allowed_os_name);
-    os_free(options.multi_allowed_os_ver);
 }
 
 #endif

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -104,6 +104,7 @@
 #define SHARED_ERROR    "(1246): Unable to send file '%s' to agent ID '%s'."
 #define TCP_NOT_SUPPORT "(1247): TCP not supported for this operating system."
 #define TCP_EPIPE       "(1248): Unable to send message. Connection has been closed by remote server."
+#define CONN_REF        "(1249): Unable to send message. Connection with remote server refused."
 
 #define MAILQ_ERROR     "(1221): No Mail queue at %s"
 #define IMSG_ERROR      "(1222): Invalid msg: %s"

--- a/src/init/darwin-init.sh
+++ b/src/init/darwin-init.sh
@@ -12,6 +12,8 @@ LAUNCHER_SCRIPT=/Library/StartupItems/WAZUH/launcher.sh
 STARTUP_SCRIPT=/Library/StartupItems/WAZUH/WAZUH
 
 launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist 2> /dev/null
+mkdir -p /Library/StartupItems/WAZUH
+chown root:wheel /Library/StartupItems/WAZUH
 rm -f $STARTUP $STARTUP_SCRIPT $SERVICE
 echo > $LAUNCHER_SCRIPT
 chown root:wheel $LAUNCHER_SCRIPT
@@ -35,9 +37,6 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
 chown root:wheel $SERVICE
 chmod u=rw-,go=r-- $SERVICE
 launchctl load $SERVICE
-
-mkdir -p /Library/StartupItems/WAZUH
-chown root:wheel /Library/StartupItems/WAZUH
 
 echo '
 #!/bin/sh

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -189,7 +189,7 @@ w_err_t w_auth_validate_data (char *response, const char *ip, const char *agentn
         if (index = OS_IsAllowedIP(&keys, ip), index >= 0) {
             if (config.flags.force_insert && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= config.force_time || antiquity < 0)) {
                 id_exist = keys.keyentries[index]->id;
-                minfo("Duplicated IP '%s' (%s). Saving backup.", ip, id_exist);
+                minfo("Duplicated IP '%s' (%s). Removing old agent.", ip, id_exist);
 
                 add_remove(keys.keyentries[index]);
                 OS_DeleteKey(&keys, id_exist, 0);
@@ -214,7 +214,7 @@ w_err_t w_auth_validate_data (char *response, const char *ip, const char *agentn
     if (index = OS_IsAllowedName(&keys, agentname), index >= 0) {
         if (config.flags.force_insert && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= config.force_time || antiquity < 0)) {
             id_exist = keys.keyentries[index]->id;
-            minfo("Duplicated name '%s' (%s). Saving backup.", agentname, id_exist);
+            minfo("Duplicated name '%s' (%s). Removing old agent.", agentname, id_exist);
 
             add_remove(keys.keyentries[index]);
             OS_DeleteKey(&keys, id_exist, 0);

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -316,7 +316,7 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
     if (id && (index = OS_IsAllowedID(&keys, id), index >= 0)) {
         if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
             id_exist = keys.keyentries[index]->id;
-            minfo("Duplicated ID '%s' (%s). Saving backup.", id, id_exist);
+            minfo("Duplicated ID '%s' (%s). Removing old agent.", id, id_exist);
             add_remove(keys.keyentries[index]);
             OS_DeleteKey(&keys, id_exist, 0);
         } else {
@@ -331,7 +331,7 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
         if (index = OS_IsAllowedIP(&keys, ip), index >= 0) {
             if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
                 id_exist = keys.keyentries[index]->id;
-                minfo("Duplicated IP '%s' (%s). Saving backup.", ip, id_exist);
+                minfo("Duplicated IP '%s' (%s). Removing old agent.", ip, id_exist);
                 add_remove(keys.keyentries[index]);
                 OS_DeleteKey(&keys, id_exist, 0);
             } else {
@@ -353,7 +353,7 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
     if (index = OS_IsAllowedName(&keys, name), index >= 0) {
         if (force >= 0 && (antiquity = OS_AgentAntiquity(keys.keyentries[index]->name, keys.keyentries[index]->ip->ip), antiquity >= force || antiquity < 0)) {
             id_exist = keys.keyentries[index]->id;
-            minfo("Duplicated name '%s' (%s). Saving backup.", name, id_exist);
+            minfo("Duplicated name '%s' (%s). Removing old agent.", name, id_exist);
             add_remove(keys.keyentries[index]);
             OS_DeleteKey(&keys, id_exist, 0);
         } else {

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2761,24 +2761,23 @@ int w_uncompress_gzfile(const char *gzfilesrc, const char *gzfiledst) {
     os_calloc(OS_SIZE_8192, sizeof(char), buf);
     do {
         len = gzread(gz_fd, buf, OS_SIZE_8192);
-        fwrite(buf, 1, len, fd);
-        buf[0] = '\0';
-        if (len < OS_SIZE_8192) {
-            if (gzeof(gz_fd)) {
-                break;
-            } else {
-                const char * gzerr;
-                gzerr = gzerror(gz_fd, &err);
-                if (err) {
-                    merror("in w_uncompress_gzfile(): gzread error: '%s'", gzerr);
-                    fclose(fd);
-                    gzclose(gz_fd);
-                    os_free(buf);
-                    return -1;
-                }
-            }
+
+        if (len > 0) {
+            fwrite(buf, 1, len, fd);
+            buf[0] = '\0';
         }
-    } while (true);
+    } while (len == OS_SIZE_8192);
+
+    if (!gzeof(gz_fd)) {
+        const char * gzerr = gzerror(gz_fd, &err);
+        if (err) {
+            merror("in w_uncompress_gzfile(): gzread error: '%s'", gzerr);
+            fclose(fd);
+            gzclose(gz_fd);
+            os_free(buf);
+            return -1;
+        }
+    }
 
     os_free(buf);
     fclose(fd);

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -188,14 +188,14 @@ static void test_w_auth_validate_data_force_insert(void **state) {
 
     /* Duplicated IP*/
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicated IP '"EXISTENT_IP1"' (001). Saving backup.");
+    expect_string(__wrap__minfo, formatted_msg, "Duplicated IP '"EXISTENT_IP1"' (001). Removing old agent.");
     err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");
 
      /* Duplicated Name*/
     response[0] = '\0';
-    expect_string(__wrap__minfo, formatted_msg, "Duplicated name '"EXISTENT_AGENT2"' (002). Saving backup.");
+    expect_string(__wrap__minfo, formatted_msg, "Duplicated name '"EXISTENT_AGENT2"' (002). Removing old agent.");
     err = w_auth_validate_data(response, NEW_IP2, EXISTENT_AGENT2, NULL);
     assert_int_equal(err, OS_SUCCESS);
     assert_string_equal(response, "");

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -7,7 +7,9 @@ if(NOT ${TARGET} STREQUAL "winagent")
                             -Wl,--wrap,fopen,--wrap,_mferror,--wrap,fflush,--wrap,fclose \
                             -Wl,--wrap,fread,--wrap,fseek,--wrap,fwrite,--wrap,remove \
                             -Wl,--wrap,fprintf,--wrap,fgets,--wrap,File_DateofChange \
-                            -Wl,--wrap,bzip2_uncompress,--wrap,mdebug1")
+                            -Wl,--wrap,bzip2_uncompress,--wrap,mdebug1,--wrap,lstat \
+                            -Wl,--wrap,gzopen,--wrap,gzread,--wrap,gzclose \
+                            -Wl,--wrap,gzeof,--wrap,gzerror,--wrap,gzwrite")
     list(APPEND shared_tests_flags "${FILE_OP_BASE_FLAGS}")
 endif()
 

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -15,23 +15,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include "headers/defs.h"
-
+#include "../headers/file_op.h"
 #include "../wrappers/common.h"
 #include "../wrappers/posix/stat_wrappers.h"
 #include "../wrappers/posix/unistd_wrappers.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/shared/file_op_wrappers.h"
-#include "../headers/file_op.h"
-
-
-#ifdef TEST_SERVER
-int __wrap_bzip2_uncompress(const char *filebz2, const char *file) {
-
-    check_expected_ptr(filebz2);
-    check_expected_ptr(file);
-    return mock();
-}
-#endif
+#include "../wrappers/externals/zlib/zlib_wrappers.h"
 
 
 /* setups/teardowns */
@@ -246,6 +236,316 @@ void test_w_uncompress_bz2_gz_file_bz2(void **state) {
 
 #endif
 
+// w_compress_gzfile
+
+void test_w_compress_gzfile_wfopen_fail(void **state){
+
+    int ret;
+    char *srcfile = "testfilesrc";
+    char *dstfile = "testfiledst.gz";
+
+    expect_string(__wrap_fopen, path, srcfile);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "in w_compress_gzfile(): fopen error testfilesrc (0):'Success'");
+
+    ret = w_compress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_compress_gzfile_gzopen_fail(void **state){
+
+    int ret;
+    char *srcfile = "testfilesrc";
+    char *dstfile = "testfiledst.gz";
+
+    expect_string(__wrap_fopen, path, srcfile);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, dstfile);
+    expect_string(__wrap_gzopen, mode, "w");
+    will_return(__wrap_gzopen, NULL);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    expect_string(__wrap__merror, formatted_msg, "in w_compress_gzfile(): gzopen error testfiledst.gz (0):'Success'");
+
+    ret = w_compress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_compress_gzfile_write_error(void **state){
+
+    int ret;
+    char *srcfile = "testfilesrc";
+    char *dstfile = "testfiledst.gz";
+
+    expect_string(__wrap_fopen, path, srcfile);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, dstfile);
+    expect_string(__wrap_gzopen, mode, "w");
+    will_return(__wrap_gzopen, 2);
+
+    will_return(__wrap_fread, "teststring");
+    will_return(__wrap_fread, 10);
+
+    expect_value(__wrap_gzwrite, file, 2);
+    expect_string(__wrap_gzwrite, buf, "teststring");
+    expect_value(__wrap_gzwrite, len, 10);
+    will_return(__wrap_gzwrite, Z_ERRNO);
+
+    expect_value(__wrap_gzerror, file, 2);
+    will_return(__wrap_gzerror, Z_ERRNO);
+    will_return(__wrap_gzerror, "Test error");
+    expect_string(__wrap__merror, formatted_msg, "in w_compress_gzfile(): Compression error: Test error");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+    expect_value(__wrap_gzclose, file, 2);
+    will_return(__wrap_gzclose, 1);
+
+    ret = w_compress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_compress_gzfile_success(void **state){
+
+    int ret;
+    char *srcfile = "testfilesrc";
+    char *dstfile = "testfiledst.gz";
+
+    expect_string(__wrap_fopen, path, srcfile);
+    expect_string(__wrap_fopen, mode, "rb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, dstfile);
+    expect_string(__wrap_gzopen, mode, "w");
+    will_return(__wrap_gzopen, 2);
+
+    will_return(__wrap_fread, "teststring");
+    will_return(__wrap_fread, 10);
+
+    expect_value(__wrap_gzwrite, file, 2);
+    expect_string(__wrap_gzwrite, buf, "teststring");
+    expect_value(__wrap_gzwrite, len, 10);
+    will_return(__wrap_gzwrite, 10);
+
+    will_return(__wrap_fread, "");
+    will_return(__wrap_fread, 0);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+    expect_value(__wrap_gzclose, file, 2);
+    will_return(__wrap_gzclose, 1);
+
+    ret = w_compress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, 0);
+
+}
+
+// w_uncompress_gzfile
+
+void test_w_uncompress_gzfile_lstat_fail(void **state) {
+
+    int ret;
+    char *srcfile = "testfile.gz";
+    char *dstfile = "testfiledst";
+
+    expect_string(__wrap_lstat, filename, srcfile);
+    will_return(__wrap_lstat, S_IFREG);
+    will_return(__wrap_lstat, -1);
+
+    ret = w_uncompress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_uncompress_gzfile_fopen_fail(void **state) {
+
+    int ret;
+    char *srcfile = "testfile.gz";
+    char *dstfile = "testfiledst";
+
+    expect_string(__wrap_lstat, filename, srcfile);
+    will_return(__wrap_lstat, S_IFREG);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "in w_uncompress_gzfile(): fopen error testfiledst (0):'Success'");
+
+    ret = w_uncompress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_uncompress_gzfile_gzopen_fail(void **state) {
+
+    int ret;
+    char *srcfile = "testfile.gz";
+    char *dstfile = "testfiledst";
+
+    expect_string(__wrap_lstat, filename, srcfile);
+    will_return(__wrap_lstat, S_IFREG);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, srcfile);
+    expect_string(__wrap_gzopen, mode, "rb");
+    will_return(__wrap_gzopen, NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "in w_uncompress_gzfile(): gzopen error testfile.gz (0):'Success'");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+
+    ret = w_uncompress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_uncompress_gzfile_first_read_fail(void **state) {
+
+    int ret;
+    char *srcfile = "testfile.gz";
+    char *dstfile = "testfiledst";
+
+    expect_string(__wrap_lstat, filename, srcfile);
+    will_return(__wrap_lstat, S_IFREG);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, srcfile);
+    expect_string(__wrap_gzopen, mode, "rb");
+    will_return(__wrap_gzopen, 2);
+
+    expect_value(__wrap_gzread, gz_fd, 2);
+    will_return(__wrap_gzread, 0);
+    will_return(__wrap_gzread, "failstring");
+
+    will_return(__wrap_fwrite, 0);
+
+    expect_value(__wrap_gzeof, file, 2);
+    will_return(__wrap_gzeof, 0);
+
+    expect_value(__wrap_gzerror, file, 2);
+    will_return(__wrap_gzerror, Z_BUF_ERROR);
+    will_return(__wrap_gzerror, "Test error");
+
+    expect_string(__wrap__merror, formatted_msg, "in w_uncompress_gzfile(): gzread error: 'Test error'");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+    expect_value(__wrap_gzclose, file, 2);
+    will_return(__wrap_gzclose, 1);
+
+    ret = w_uncompress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_uncompress_gzfile_first_read_success(void **state) {
+
+    int ret;
+    char *srcfile = "testfile.gz";
+    char *dstfile = "testfiledst";
+
+    expect_string(__wrap_lstat, filename, srcfile);
+    will_return(__wrap_lstat, S_IFREG);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, srcfile);
+    expect_string(__wrap_gzopen, mode, "rb");
+    will_return(__wrap_gzopen, 2);
+
+    expect_value(__wrap_gzread, gz_fd, 2);
+    will_return(__wrap_gzread, OS_SIZE_8192);
+    will_return(__wrap_gzread, "teststring");
+
+    will_return(__wrap_fwrite, OS_SIZE_8192);
+
+    expect_value(__wrap_gzread, gz_fd, 2);
+    will_return(__wrap_gzread, 0);
+    will_return(__wrap_gzread, "failstring");
+
+    will_return(__wrap_fwrite, 0);
+
+    expect_value(__wrap_gzeof, file, 2);
+    will_return(__wrap_gzeof, 0);
+
+    expect_value(__wrap_gzerror, file, 2);
+    will_return(__wrap_gzerror, Z_BUF_ERROR);
+    will_return(__wrap_gzerror, "Test error");
+
+    expect_string(__wrap__merror, formatted_msg, "in w_uncompress_gzfile(): gzread error: 'Test error'");
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+    expect_value(__wrap_gzclose, file, 2);
+    will_return(__wrap_gzclose, 1);
+
+    ret = w_uncompress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, -1);
+
+}
+
+void test_w_uncompress_gzfile_success(void **state) {
+
+    int ret;
+    char *srcfile = "testfile.gz";
+    char *dstfile = "testfiledst";
+
+    expect_string(__wrap_lstat, filename, srcfile);
+    will_return(__wrap_lstat, S_IFREG);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_fopen, path, dstfile);
+    expect_string(__wrap_fopen, mode, "wb");
+    will_return(__wrap_fopen, 1);
+
+    expect_string(__wrap_gzopen, path, srcfile);
+    expect_string(__wrap_gzopen, mode, "rb");
+    will_return(__wrap_gzopen, 2);
+
+    expect_value(__wrap_gzread, gz_fd, 2);
+    will_return(__wrap_gzread, 10);
+    will_return(__wrap_gzread, "teststring");
+
+    will_return(__wrap_fwrite, 10);
+
+    expect_value(__wrap_gzeof, file, 2);
+    will_return(__wrap_gzeof, 1);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 1);
+    expect_value(__wrap_gzclose, file, 2);
+    will_return(__wrap_gzclose, 1);
+
+    ret = w_uncompress_gzfile(srcfile, dstfile);
+    assert_int_equal(ret, 0);
+
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_CreatePID_success),
@@ -257,8 +557,20 @@ int main(void) {
         cmocka_unit_test(test_w_is_compressed_bz2_file_compressed),
         cmocka_unit_test(test_w_is_compressed_bz2_file_uncompressed),
 #ifdef TEST_SERVER
-        cmocka_unit_test(test_w_uncompress_bz2_gz_file_bz2)
+        cmocka_unit_test(test_w_uncompress_bz2_gz_file_bz2),
 #endif
+        // w_compress_gzfile
+        cmocka_unit_test(test_w_compress_gzfile_wfopen_fail),
+        cmocka_unit_test(test_w_compress_gzfile_gzopen_fail),
+        cmocka_unit_test(test_w_compress_gzfile_write_error),
+        cmocka_unit_test(test_w_compress_gzfile_success),
+        // w_uncompress_gzfile
+        cmocka_unit_test(test_w_uncompress_gzfile_lstat_fail),
+        cmocka_unit_test(test_w_uncompress_gzfile_fopen_fail),
+        cmocka_unit_test(test_w_uncompress_gzfile_gzopen_fail),
+        cmocka_unit_test(test_w_uncompress_gzfile_first_read_fail),
+        cmocka_unit_test(test_w_uncompress_gzfile_first_read_success),
+        cmocka_unit_test(test_w_uncompress_gzfile_success)
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -439,8 +439,6 @@ void test_w_uncompress_gzfile_first_read_fail(void **state) {
     will_return(__wrap_gzread, 0);
     will_return(__wrap_gzread, "failstring");
 
-    will_return(__wrap_fwrite, 0);
-
     expect_value(__wrap_gzeof, file, 2);
     will_return(__wrap_gzeof, 0);
 
@@ -487,8 +485,6 @@ void test_w_uncompress_gzfile_first_read_success(void **state) {
     expect_value(__wrap_gzread, gz_fd, 2);
     will_return(__wrap_gzread, 0);
     will_return(__wrap_gzread, "failstring");
-
-    will_return(__wrap_fwrite, 0);
 
     expect_value(__wrap_gzeof, file, 2);
     will_return(__wrap_gzeof, 0);

--- a/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.c
+++ b/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.c
@@ -76,3 +76,13 @@ BZFILE* __wrap_BZ2_bzWriteOpen(int* bzerror,
 
     return mock_type(BZFILE*);
 }
+
+#ifndef TEST_WINAGENT
+int __wrap_bzip2_uncompress(const char *filebz2,
+                            const char *file) {
+
+    check_expected_ptr(filebz2);
+    check_expected_ptr(file);
+    return mock();
+}
+#endif

--- a/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.h
+++ b/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.h
@@ -47,4 +47,9 @@ BZFILE* __wrap_BZ2_bzWriteOpen(int* bzerror,
                                int verbosity,
                                int workFactor);
 
+#ifndef TEST_WINAGENT
+int __wrap_bzip2_uncompress(const char *filebz2,
+                            const char *file);
+#endif
+
 #endif

--- a/src/unit_tests/wrappers/externals/zlib/zlib_wrappers.c
+++ b/src/unit_tests/wrappers/externals/zlib/zlib_wrappers.c
@@ -1,0 +1,62 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "zlib_wrappers.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+
+
+int __wrap_gzread(gzFile gz_fd,
+                  void* buf,
+                  int len) {
+    check_expected_ptr(gz_fd);
+    int n = mock();
+    if(n <= len) {
+        memcpy(buf, mock_type(void*), n);
+    }
+    return n;
+}
+
+gzFile __wrap_gzopen(const char * path,
+                     const char * mode) {
+    check_expected(path);
+    check_expected(mode);
+
+    return mock_type(gzFile);
+}
+
+int __wrap_gzclose(gzFile file) {
+    check_expected_ptr(file);
+    return mock();
+}
+
+int __wrap_gzeof(gzFile file) {
+    check_expected_ptr(file);
+    return mock();
+}
+
+const char * __wrap_gzerror(gzFile file,
+                            int *errnum) {
+    check_expected_ptr(file);
+    *errnum = mock();
+    return mock_type(char*);
+}
+
+int __wrap_gzwrite(gzFile file,
+                   voidpc buf,
+                   unsigned int len) {
+    check_expected_ptr(file);
+    check_expected(buf);
+    check_expected(len);
+    return mock();
+
+}

--- a/src/unit_tests/wrappers/externals/zlib/zlib_wrappers.h
+++ b/src/unit_tests/wrappers/externals/zlib/zlib_wrappers.h
@@ -1,0 +1,34 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef ZLIB_WRAPPERS_H
+#define ZLIB_WRAPPERS_H
+
+#include "../../../../external/zlib/zlib.h"
+
+int __wrap_gzread(gzFile gz_fd,
+                  void* buf,
+                  int len);
+
+gzFile __wrap_gzopen(const char * file,
+                     const char * mode);
+
+int __wrap_gzclose(gzFile file);
+
+int __wrap_gzeof(gzFile file);
+
+const char * __wrap_gzerror(gzFile file,
+                            __attribute__((unused)) int *errnum);
+
+int __wrap_gzwrite(gzFile file,
+                   voidpc buf,
+                   unsigned int len);
+
+#endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -265,7 +265,6 @@ STATIC void wm_vuldet_get_package_os(const char *version, const char **os_major,
 STATIC void wm_vuldet_set_subversion(char *version, char **os_minor);
 STATIC cJSON *wm_vuldet_json_fread(char *json_file);
 STATIC cJSON *wm_vuldet_get_cvss(const char *scoring_vector);
-STATIC int wm_vuldet_get_dist_ref(const char *dist_name, const char *dist_ver, int *dist_ref, int *dist_ver_ref);
 STATIC int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_field, char **condition);
 STATIC void wm_vuldet_run_scan(wm_vuldet_t *vuldet);
 STATIC void wm_vuldet_run_sleep(wm_vuldet_t *vuldet);
@@ -457,11 +456,11 @@ const char *vu_cpe_dic_option[] = {
 
 vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_version, update_node **updates, vu_feed *agent_dist) {
     vu_feed retval = FEED_UNKNOWN;
-    int i, j, k;
+    int i;
 
     for (i = 0; i < OS_SUPP_SIZE; i++) {
         if (updates[i]) {
-            if (wm_vuldet_is_single_provider(updates[i]->dist_ref) || updates[i]->old_config) {
+            if (wm_vuldet_is_single_provider(updates[i]->dist_ref)) {
                 if (updates[i]->allowed_os_name) {
                     int j;
                     char *allowed_os;
@@ -477,33 +476,10 @@ vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_version, 
                         allowed_ver = updates[i]->allowed_os_ver[j];
                     }
                 }
-            } else {
-                if (updates[i]->allowed_multios_src_name) {
-                    for (j = 0; updates[i]->allowed_multios_src_name[j]; j++) {
-                        for (k = 0; updates[i]->allowed_multios_src_name[j][k]; k++) {
-                            if (strcasestr(os_name, updates[i]->allowed_multios_src_name[j][k]) &&
-                                    strcasestr(os_version, updates[i]->allowed_multios_src_ver[j][k])) {
-                                int dist_tag_ref;
-                                int dist_ref;
-
-                                if (wm_vuldet_get_dist_ref(updates[i]->allowed_multios_dst_name[j], updates[i]->allowed_multios_dst_ver[j],
-                                        &dist_ref, &dist_tag_ref)) {
-                                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_INVALID_TRANSLATION_OS, updates[i]->allowed_multios_dst_name[j], updates[i]->allowed_multios_dst_ver[j]);
-                                    goto end;
-                                }
-
-                                retval = dist_tag_ref;
-                                *agent_dist = dist_ref;
-                                goto end;
-                            }
-                        }
-                    }
-                }
             }
         }
     }
 
-end:
     return retval;
 }
 
@@ -4702,14 +4678,14 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
 void wm_vuldet_destroy(wm_vuldet_t * vuldet) {
     agent_software *agent;
     update_node **update;
-    int i, j, k;
+    int i, j;
 
     for (i = 0, update = vuldet->updates; i < OS_SUPP_SIZE; i++) {
         if (update[i]) {
-            free(update[i]->dist);
-            free(update[i]->version);
-            free(update[i]->url);
-            free(update[i]->path);
+            os_free(update[i]->dist);
+            os_free(update[i]->version);
+            os_free(update[i]->url);
+            os_free(update[i]->path);
             if (wm_vuldet_is_single_provider(update[i]->dist_ref)) {
                 if (update[i]->allowed_os_name) {
                     for (j = 0; update[i]->allowed_os_name[j]; j++) {
@@ -4719,28 +4695,8 @@ void wm_vuldet_destroy(wm_vuldet_t * vuldet) {
                     free(update[i]->allowed_os_name);
                     free(update[i]->allowed_os_ver);
                 }
-            } else {
-                if (update[i]->allowed_multios_src_name) {
-                    for (j = 0; update[i]->allowed_multios_src_name[j]; j++) {
-                        for (k = 0; update[i]->allowed_multios_src_name[j][k]; k++) {
-                            free(update[i]->allowed_multios_src_name[j][k]);
-                            free(update[i]->allowed_multios_src_ver[j][k]);
-                        }
-                        free(update[i]->allowed_multios_src_name[j]);
-                        free(update[i]->allowed_multios_src_ver[j]);
-                    }
-                    free(update[i]->allowed_multios_src_name);
-                    free(update[i]->allowed_multios_src_ver);
-
-                    for (j = 0; update[i]->allowed_os_name[j]; j++) {
-                        free(update[i]->allowed_multios_dst_name[j]);
-                        free(update[i]->allowed_multios_dst_ver[j]);
-                    }
-                    free(update[i]->allowed_multios_dst_name);
-                    free(update[i]->allowed_multios_dst_ver);
-                }
             }
-            free(update[i]);
+            os_free(update[i]);
         }
     }
 
@@ -4828,39 +4784,6 @@ cJSON *wm_vuldet_dump(const wm_vuldet_t * vuldet){
                     cJSON_AddItemToArray(allow, allowed);
                     cJSON_AddItemToObject(provider,"allow",allow);
                 }
-            } else if (vuldet->updates[i]->allowed_multios_src_name) {
-                int j = 0;
-                cJSON *allow = cJSON_CreateArray();
-                for (j = 0; vuldet->updates[i]->allowed_multios_src_name[j]; j++) {
-                    cJSON *allowed = cJSON_CreateObject();
-                    if (vuldet->updates[i]->allowed_multios_dst_name && vuldet->updates[i]->allowed_multios_dst_name[j]) {
-                        char * dst_os;
-                        os_calloc(OS_SIZE_128, sizeof(char), dst_os);
-                        if (vuldet->updates[i]->allowed_multios_dst_ver && vuldet->updates[i]->allowed_multios_dst_ver[j]) {
-                            snprintf(dst_os, OS_SIZE_128 - 1, "%s-%s", vuldet->updates[i]->allowed_multios_dst_name[j], vuldet->updates[i]->allowed_multios_dst_ver[j]);
-                        } else {
-                            snprintf(dst_os, OS_SIZE_128 - 1, "%s", vuldet->updates[i]->allowed_multios_dst_name[j]);
-                        }
-                        cJSON_AddStringToObject(allowed,"replaced_os",dst_os);
-                        os_free(dst_os);
-                    }
-                    int k = 0;
-                    cJSON *src = cJSON_CreateArray();
-                    for (k = 0; vuldet->updates[i]->allowed_multios_src_name[j][k]; k++) {
-                        char * src_os;
-                        os_calloc(OS_SIZE_128, sizeof(char), src_os);
-                        if (vuldet->updates[i]->allowed_multios_src_ver && vuldet->updates[i]->allowed_multios_src_ver[j] && vuldet->updates[i]->allowed_multios_src_ver[j][k]) {
-                            snprintf(src_os, OS_SIZE_128 - 1, "%s-%s", vuldet->updates[i]->allowed_multios_src_name[j][k], vuldet->updates[i]->allowed_multios_src_ver[j][k]);
-                        } else {
-                            snprintf(src_os, OS_SIZE_128 - 1, "%s", vuldet->updates[i]->allowed_multios_src_name[j][k]);
-                        }
-                        cJSON_AddItemToArray(src, cJSON_CreateString(src_os));
-                        os_free(src_os);
-                    }
-                    cJSON_AddItemToObject(allowed, "src", src);
-                    cJSON_AddItemToArray(allow, allowed);
-                }
-                cJSON_AddItemToObject(provider,"allow",allow);
             }
 
             cJSON_AddItemToArray(providers, provider);
@@ -6732,31 +6655,6 @@ cJSON *wm_vuldet_get_cvss(const char *scoring_vector) {
     os_free(vector);
 
     return cvss_json;
-}
-
-int wm_vuldet_get_dist_ref(const char *dist_name, const char *dist_ver, int *dist_ref, int *dist_ver_ref) {
-    if (strcasestr(dist_name, vu_feed_tag[FEED_REDHAT]) || strcasestr(dist_name, "red hat")) {
-        switch (*dist_ver) {
-            case '5':
-                *dist_ver_ref = FEED_RHEL5;
-                break;
-            case '6':
-                *dist_ver_ref = FEED_RHEL6;
-                break;
-            case '7':
-                *dist_ver_ref = FEED_RHEL7;
-                break;
-            case '8':
-                *dist_ver_ref = FEED_RHEL8;
-                break;
-            default:
-                return OS_INVALID;
-        }
-        *dist_ref = FEED_REDHAT;
-        return 0;
-    }
-
-    return OS_INVALID;;
 }
 
 int wm_vuldet_get_term_condition(char *i_term, char **term, char **comp_field, char **condition) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -385,21 +385,12 @@ typedef struct update_node {
     char *path;
     char *multi_path;
     long timeout; // Timeout for download requests
-    union { // Supported operating systems
-        struct { // Single providers (Debian and Canonical)
-            char **allowed_os_name;
-            char **allowed_os_ver;
-        };
-        struct { // Multi providers (Red Hat)
-            char ***allowed_multios_src_name;
-            char ***allowed_multios_src_ver;
-            char **allowed_multios_dst_name;
-            char **allowed_multios_dst_ver;
-        };
+    struct { // Supported operating systems
+        char **allowed_os_name;
+        char **allowed_os_ver;
     };
     unsigned int attempted:1;
     unsigned int json_format:1;
-    unsigned int old_config:1;
 } update_node;
 
 typedef struct wm_vuldet_t {
@@ -752,7 +743,7 @@ struct vu_msu_vul_entry {
 };
 
 // Macros
-#define wm_vuldet_is_single_provider(x) (x == FEED_UBUNTU || x == FEED_DEBIAN)
+#define wm_vuldet_is_single_provider(x) (x == FEED_UBUNTU || x == FEED_DEBIAN || x == FEED_REDHAT)
 #define wm_vuldet_silent_feed(x) (x == FEED_CPEW)
 #define wm_vuldet_get_json_value(obj, key) ({void *ret = NULL; cJSON *it = cJSON_GetObjectItem(obj, key); \
                                             if (it) ret = it->valuestring; ret;})

--- a/src/win32/ui/os_win32ui.c
+++ b/src/win32/ui/os_win32ui.c
@@ -345,8 +345,7 @@ BOOL CALLBACK DlgProc(HWND hwnd, UINT Message, WPARAM wParam,
                     break;
                 case UI_MENU_MANAGE_RESTART:
 
-                    if ((strcmp(config_inst.key, FL_NOKEY) == 0) ||
-                            (strcmp(config_inst.server, FL_NOSERVER) == 0)) {
+                    if (strcmp(config_inst.server, FL_NOSERVER) == 0) {
                         MessageBox(hwnd, "Unable to restart agent (check config)",
                                    "Error -- Unable to Restart Agent", MB_OK);
                         break;


### PR DESCRIPTION
|Related issue|
|---|
|#5878|

Hi team,

This PR is related to the issue https://github.com/wazuh/wazuh/issues/5878. I have changed the `limit` parameter behavior in `GET /sca/{agent_id}/checks/{policy_id}` endpoint.

**Before the changes**, the `limit` parameter was not working as expected, when you set the `limit` to 3 (as an instance), the `rules` and `compliances` of every check were counted to reach to that limit.
**New behavior**, different than the one proposed in the issue, when you set the `limit` to 3, you will get 3 different checks and all the `rules` and `compliances` corresponding to these 3 checks. 

API integration test cases also added/updated.

**Test results:**
- API integration tests:
```
test_sca_endpoints.tavern.yaml 
	 6 passed, 8 warnings
```

- Unit tests:
```
pytest framework/wazuh/tests/test_sca.py 
============================== 7 passed in 0.31s ===============================
```

**Example of the new behavior:**

- Request:
`curl -X GET "https://localhost:55000/sca/000/checks/cis_debian9_L2?limit=3" -H "accept: application/json" -H "Authorization: Bearer $TOKEN" -k`

- Response:
```
{
   "data": {
      "affected_items": [
         {
            "reason": "",
            "file": "/etc/ssh/sshd_config",
            "result": "failed",
            "description": "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections.",
            "title": "Ensure SSH X11 forwarding is disabled",
            "condition": "all",
            "remediation": "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders.",
            "id": 3528,
            "policy_id": "cis_debian9_L2",
            "status": "",
            "rationale": "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders.",
            "compliance": [
               {
                  "key": "cis_csc",
                  "value": "9.2"
               },
               {
                  "key": "cis",
                  "value": "5.2.6"
               }
            ],
            "rules": [
               {
                  "type": "file",
                  "rule": "f:/etc/ssh/sshd_config -> !r:^# && r:X11Forwarding\\s+no"
               }
            ]
         },
         {
            "reason": "",
            "result": "failed",
            "description": "Set system audit so that audit rules cannot be modified with auditctl. Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot.",
            "title": "Ensure the audit configuration is immutable",
            "directory": "/etc/audit",
            "condition": "all",
            "remediation": "Add the following line to the end of the /etc/audit/audit.rules file: -e 2. Notes: This setting will ensure reloading the auditd config to set active settings requires a system reboot.",
            "id": 3527,
            "policy_id": "cis_debian9_L2",
            "status": "",
            "rationale": "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes.",
            "compliance": [
               {
                  "key": "cis_csc",
                  "value": "6.2,6.3"
               },
               {
                  "key": "cis",
                  "value": "4.1.18"
               }
            ],
            "rules": [
               {
                  "type": "directory",
                  "rule": "d:/etc/audit"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^\\s*\\t*-e 2$"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules"
               }
            ]
         },
         {
            "reason": "",
            "result": "failed",
            "description": "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\".",
            "title": "Ensure kernel module loading and unloading is collected",
            "directory": "/etc/audit",
            "condition": "all",
            "remediation": "For 32 bit systems add the following lines to the /etc/audit/audit.rules file: -w /sbin/insmod -p x -k modules | -w /sbin/rmmod -p x -k modules | -w /sbin/modprobe -p x -k modules | -a always,exit -F arch=b32 -S init_module -S delete_module -k modules. For 64 bit systems add the following lines to the /etc/audit/audit.rules file: -w /sbin/insmod -p x -k modules | -w /sbin/rmmod -p x -k modules | -w /sbin/modprobe -p x -k modules | -a always,exit -F arch=b64 -S init_module -S delete_module -k modules. Notes: Reloading the auditd config to set active settings may require a system reboot.",
            "id": 3526,
            "policy_id": "cis_debian9_L2",
            "status": "",
            "rationale": "Monitoring the use of insmod, rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules.",
            "compliance": [
               {
                  "key": "cis",
                  "value": "4.1.17"
               },
               {
                  "key": "cis_csc",
                  "value": "5.1"
               }
            ],
            "rules": [
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S init_module && r:-S delete_module && r:-k modules"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-w && r:/sbin/modprobe && r:-p x && r:-k modules"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-w && r:/sbin/insmod && r:-p x && r:-k modules"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-w && r:/sbin/rmmod && r:-p x && r:-k modules"
               },
               {
                  "type": "directory",
                  "rule": "d:/etc/audit"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules"
               }
            ]
         }
      ],
      "total_affected_items": 29,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All selected sca/policy information was returned"
}
```

Regards,
Manuel.