### PR TITLE
Let syscheck ignore the subkeys of an ignored registry

### DIFF
--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -130,7 +130,7 @@ int fim_registry_validate_path(const char *entry_path, const registry *configura
                 continue;
             }
 
-            if (strcasecmp(syscheck.registry_ignore[ign_it].entry, entry_path) == 0) {
+            if (strncasecmp(syscheck.registry_ignore[ign_it].entry, entry_path, strlen(syscheck.registry_ignore[ign_it].entry)) == 0) {
                 mdebug2(FIM_IGNORE_ENTRY, "registry", entry_path, syscheck.registry_ignore[ign_it].entry);
                 return -1;
             }
@@ -412,7 +412,6 @@ void fim_open_key(HKEY root_key_handle, const char *full_key, const char *sub_ke
         /* Open sub_key */
         fim_open_key(root_key_handle, new_full_key, new_sub_key, arch, mode);
     }
-
     // Done scanning sub_keys, trigger an alert on the current key if required.
     new.type = FIM_TYPE_REGISTRY;
     new.registry_entry.key = fim_registry_get_key_data(current_key_handle, full_key, configuration);


### PR DESCRIPTION
|Related issue|
|---|
|#5251|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to fix #5251 by changing the call to `strcasecmp` by `strncasecmp` using the length of the ignored registry. 

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```xml
  <syscheck>
    <!-- By default it is disabled. In the Install you must choose to enable it. -->
    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>5</frequency>
		
    <windows_registry>HKEY_LOCAL_MACHINE\System\CurrentControlSet\test</windows_registry>
    <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet</registry_ignore>
  </syscheck>
```

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
```DEBUG: (6204): Ignoring 'registry' 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\test' due to HKEY_LOCAL_MACHINE\System\CurrentControlSet'```
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
