### PR TITLE
Fix global variable in ossec-control script

### DIFF
--- a/src/init/ossec-client.sh
+++ b/src/init/ossec-client.sh
@@ -152,7 +152,7 @@ start()
                     fi
                     sleep 1;
                     j=`expr $j + 1`;
-                    if [ "$j" = "${MAX_ITERATION}" ]; then
+                    if [ "$j" -ge "${MAX_ITERATION}" ]; then
                         failed=true
                     fi
                 done
@@ -185,15 +185,15 @@ pstatus()
 
     ls ${DIR}/var/run/${pfile}*.pid > /dev/null 2>&1
     if [ $? = 0 ]; then
-        for j in `cat ${DIR}/var/run/${pfile}*.pid 2>/dev/null`; do
-            ps -p $j > /dev/null 2>&1
+        for k in `cat ${DIR}/var/run/${pfile}*.pid 2>/dev/null`; do
+            ps -p $k > /dev/null 2>&1
             if [ ! $? = 0 ]; then
-                echo "${pfile}: Process $j not used by Wazuh, removing .."
-                rm -f ${DIR}/var/run/${pfile}-$j.pid
+                echo "${pfile}: Process $k not used by Wazuh, removing .."
+                rm -f ${DIR}/var/run/${pfile}-$k.pid
                 continue;
             fi
 
-            kill -0 $j > /dev/null 2>&1
+            kill -0 $k > /dev/null 2>&1
             if [ $? = 0 ]; then
                 return 1;
             fi

--- a/src/init/ossec-client.sh
+++ b/src/init/ossec-client.sh
@@ -185,15 +185,15 @@ pstatus()
 
     ls ${DIR}/var/run/${pfile}*.pid > /dev/null 2>&1
     if [ $? = 0 ]; then
-        for k in `cat ${DIR}/var/run/${pfile}*.pid 2>/dev/null`; do
-            ps -p $k > /dev/null 2>&1
+        for pid in `cat ${DIR}/var/run/${pfile}*.pid 2>/dev/null`; do
+            ps -p ${pid} > /dev/null 2>&1
             if [ ! $? = 0 ]; then
-                echo "${pfile}: Process $k not used by Wazuh, removing .."
-                rm -f ${DIR}/var/run/${pfile}-$k.pid
+                echo "${pfile}: Process ${pid} not used by Wazuh, removing .."
+                rm -f ${DIR}/var/run/${pfile}-${pid}.pid
                 continue;
             fi
 
-            kill -0 $k > /dev/null 2>&1
+            kill -0 ${pid} > /dev/null 2>&1
             if [ $? = 0 ]; then
                 return 1;
             fi

--- a/src/init/ossec-local.sh
+++ b/src/init/ossec-local.sh
@@ -278,15 +278,15 @@ pstatus()
 
     ls ${DIR}/var/run/${pfile}*.pid > /dev/null 2>&1
     if [ $? = 0 ]; then
-        for j in `cat ${DIR}/var/run/${pfile}*.pid 2>/dev/null`; do
-            ps -p $j > /dev/null 2>&1
+        for k in `cat ${DIR}/var/run/${pfile}*.pid 2>/dev/null`; do
+            ps -p $k > /dev/null 2>&1
             if [ ! $? = 0 ]; then
-                echo "${pfile}: Process $j not used by Wazuh, removing..."
-                rm -f ${DIR}/var/run/${pfile}-$j.pid
+                echo "${pfile}: Process $k not used by Wazuh, removing..."
+                rm -f ${DIR}/var/run/${pfile}-$k.pid
                 continue;
             fi
 
-            kill -0 $j > /dev/null 2>&1
+            kill -0 $k > /dev/null 2>&1
             if [ $? = 0 ]; then
                 return 1;
             fi

--- a/src/init/ossec-local.sh
+++ b/src/init/ossec-local.sh
@@ -278,15 +278,15 @@ pstatus()
 
     ls ${DIR}/var/run/${pfile}*.pid > /dev/null 2>&1
     if [ $? = 0 ]; then
-        for k in `cat ${DIR}/var/run/${pfile}*.pid 2>/dev/null`; do
-            ps -p $k > /dev/null 2>&1
+        for pid in `cat ${DIR}/var/run/${pfile}*.pid 2>/dev/null`; do
+            ps -p ${pid} > /dev/null 2>&1
             if [ ! $? = 0 ]; then
-                echo "${pfile}: Process $k not used by Wazuh, removing..."
-                rm -f ${DIR}/var/run/${pfile}-$k.pid
+                echo "${pfile}: Process ${pid} not used by Wazuh, removing..."
+                rm -f ${DIR}/var/run/${pfile}-${pid}.pid
                 continue;
             fi
 
-            kill -0 $k > /dev/null 2>&1
+            kill -0 ${pid} > /dev/null 2>&1
             if [ $? = 0 ]; then
                 return 1;
             fi

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -346,7 +346,7 @@ start()
                         fi
                         sleep 1;
                         j=`expr $j + 1`;
-                        if [ "$j" = "${MAX_ITERATION}" ]; then
+                        if [ "$j" -ge "${MAX_ITERATION}" ]; then
                             failed=true
                         fi
                     done
@@ -413,17 +413,17 @@ pstatus()
 
     ls ${DIR}/var/run/${pfile}*.pid > /dev/null 2>&1
     if [ $? = 0 ]; then
-        for j in `cat ${DIR}/var/run/${pfile}*.pid 2>/dev/null`; do
-            ps -p $j > /dev/null 2>&1
+        for k in `cat ${DIR}/var/run/${pfile}*.pid 2>/dev/null`; do
+            ps -p $k > /dev/null 2>&1
             if [ ! $? = 0 ]; then
                 if [ $USE_JSON = false ]; then
-                    echo "${pfile}: Process $j not used by Wazuh, removing..."
+                    echo "${pfile}: Process $k not used by Wazuh, removing..."
                 fi
-                rm -f ${DIR}/var/run/${pfile}-$j.pid
+                rm -f ${DIR}/var/run/${pfile}-$k.pid
                 continue;
             fi
 
-            kill -0 $j > /dev/null 2>&1
+            kill -0 $k > /dev/null 2>&1
             if [ $? = 0 ]; then
                 return 1;
             fi

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -413,17 +413,17 @@ pstatus()
 
     ls ${DIR}/var/run/${pfile}*.pid > /dev/null 2>&1
     if [ $? = 0 ]; then
-        for k in `cat ${DIR}/var/run/${pfile}*.pid 2>/dev/null`; do
-            ps -p $k > /dev/null 2>&1
+        for pid in `cat ${DIR}/var/run/${pfile}*.pid 2>/dev/null`; do
+            ps -p ${pid} > /dev/null 2>&1
             if [ ! $? = 0 ]; then
                 if [ $USE_JSON = false ]; then
-                    echo "${pfile}: Process $k not used by Wazuh, removing..."
+                    echo "${pfile}: Process ${pid} not used by Wazuh, removing..."
                 fi
-                rm -f ${DIR}/var/run/${pfile}-$k.pid
+                rm -f ${DIR}/var/run/${pfile}-${pid}.pid
                 continue;
             fi
 
-            kill -0 $k > /dev/null 2>&1
+            kill -0 ${pid} > /dev/null 2>&1
             if [ $? = 0 ]; then
                 return 1;
             fi


### PR DESCRIPTION
|Related issue|
|---|
|#5987|

This PR aims to apply the changes requested in #5987:

- Refactor `j` to `pid` in `pstatus()`, preventing `j` from affecting the same variable in `start()`.
- Change "equal" condition to "greater or equal" in `start()`.

## How to reproduce

The related issue seems to be due to a missing `ps` command in the host running the manager.

1. Start the manager:
```sh
$ ossec-control start
```
2. Remove `ps`:
```
$ mv /bin/ps /bin/ps.bak
```
3. Try to start the manager again:
```
$ ossec-control start
```

### Output

When adding `set -x` to _/var/ossec/bin/ossec-control_, we see that the variable `j` is right now:
```
+ expr 6 + 1
+ j=7
+ [ 7 -ge 10 ]
```

On the other hand, the manager cannot start if `ps` is not available:
```
Starting Wazuh v4.0.0...
wazuh-apid: Process 28255 not used by Wazuh, removing...
wazuh-apid did not start correctly.
```

## Tests

- [X] Run the steps above on Linux, without `ps`: the manager cannot start.
- [X] Run the steps above having `ps`: the manager starts correctly.