### PR TITLE
Vulnerability Detector: Changed NVD feed version in URL

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -909,9 +909,9 @@ int wm_vuldet_fill_report_nvd_scoring(sqlite3 *db, sqlite3_stmt *stmt, int cve_t
             continue;
         }
 
-        if (!strcmp(cvss_ver, "2.0") && !report->cvss2) {
+        if (strstr(cvss_ver, "2.") && !report->cvss2) {
             cvss = &report->cvss2;
-        } else if (!strcmp(cvss_ver, "3.0") && !report->cvss3) {
+        } else if (strstr(cvss_ver, "3.") && !report->cvss3) {
             cvss = &report->cvss3;
         } else {
             continue;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -52,8 +52,8 @@
 #define RED_HAT_REPO_REQ_SIZE 1000
 #define RED_HAT_REPO "https://access.redhat.com/labs/securitydataapi/cve.json?after=%d-01-01&per_page=%d&page=%d"
 #define NVD_CPE_REPO "https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz"
-#define NVD_CVE_REPO_META "https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-%d.meta"
-#define NVD_CVE_REPO "https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-%d.json.gz"
+#define NVD_CVE_REPO_META "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.meta"
+#define NVD_CVE_REPO "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz"
 #define NVD_CVE_URL "https://nvd.nist.gov/vuln/detail/"
 #define NVD_REPO_MAX_ATTEMPTS 3
 #define DOWNLOAD_SLEEP_FACTOR 5

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -1244,9 +1244,9 @@ int wm_vuldet_parse_nvd_impact(cJSON *nvd_item, nvd_vulnerability *data) {
     cJSON *impact_element;
     cJSON *cvss_data;
     cv_scoring_system * scoring = NULL;
-    static char *cvss3_vector_tag = "CVSS:3.0/";
-    static char *JSON_V20 = "2.0";
-    static char *JSON_V30 = "3.0";
+    static char *cvss3_vector_tag = "CVSS";
+    static char *JSON_V20 = "2.";
+    static char *JSON_V30 = "3.";
     static char *JSON_VECT_STR = "vectorString";
     static char *JSON_BASE_SCORE = "baseScore";
     static char *JSON_EXP_SCORE = "exploitabilityScore";
@@ -1258,19 +1258,19 @@ int wm_vuldet_parse_nvd_impact(cJSON *nvd_item, nvd_vulnerability *data) {
             os_calloc(1, sizeof(cv_scoring_system), scoring);
             for (cvss_data = impact_element->child; json_tagged_obj(cvss_data); cvss_data = cvss_data->next) {
                 if (!strcmp(cvss_data->string, vu_cpe_tags[CPE_VERSION]) && cvss_data->valuestring) {
-                    if (!strcmp(cvss_data->valuestring, JSON_V20)) {
+                    if (strstr(cvss_data->valuestring, JSON_V20)) {
                         score_added = 1;
                         data->cvss2 = scoring;
-                    } else if (!strcmp(cvss_data->valuestring, JSON_V30)) {
+                    } else if (strstr(cvss_data->valuestring, JSON_V30)) {
                         score_added = 1;
                         data->cvss3 = scoring;
                     }
                     os_strdup(cvss_data->valuestring, scoring->version);
                 } else if (!strcmp(cvss_data->string, JSON_VECT_STR) && cvss_data->valuestring) {
                     if (strstr(cvss_data->valuestring, cvss3_vector_tag)) {
-                        os_strdup(cvss_data->valuestring + strlen(cvss3_vector_tag), scoring->vector_string);
+                        w_strdup(strstr(cvss_data->valuestring, "/"), scoring->vector_string);
                     } else {
-                        os_strdup(cvss_data->valuestring, scoring->vector_string);
+                        w_strdup(cvss_data->valuestring, scoring->vector_string);
                     }
                 } else if (!strcmp(cvss_data->string, JSON_BASE_SCORE)) {
                     scoring->base_score = cvss_data->valuedouble;
@@ -2128,9 +2128,9 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
                 continue;
             }
 
-            if (!strcmp(cvss_ver, "2.0") && !report->cvss2) {
+            if (strstr(cvss_ver, "2.") && !report->cvss2) {
                 cvss = &report->cvss2;
-            } else if (!strcmp(cvss_ver, "3.0") && !report->cvss3) {
+            } else if (strstr(cvss_ver, "3.") && !report->cvss3) {
                 cvss = &report->cvss3;
             } else {
                 continue;

--- a/tools/vulnerability-detector/nvd-generator.sh
+++ b/tools/vulnerability-detector/nvd-generator.sh
@@ -34,7 +34,7 @@ fi
 
 while [ true ]
 do
-    link="https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-$year.json.gz"
+    link="https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-$year.json.gz"
     file=$directory/nvd-feed$year.json
 
     if [ $last_year -ne $year ]


### PR DESCRIPTION
|Related issue|
|---|
|#6053|

## Description

We've modified the NVD JSON feed version so that the new feeds can be downloaded automatically or manually using `wazuh/tools/vulnerability-detector/nvd-generator.sh` script. In addition, we've added support for `CVSS 3.1`, which is the new standard used by the `NVD`.

## Logs/Alerts example

```
2020/09/18 12:43:07 wazuh-modulesd:vulnerability-detector[118038] wm_vuln_detector.c:3784 at wm_vuldet_check_feed(): INFO: (5400): Starting 'National Vulnerability Database' database update.
2020/09/18 12:43:07 wazuh-modulesd:vulnerability-detector[118038] wm_vuln_detector.c:2090 at wm_vuldet_update_feed(): DEBUG: (5401): Synchronizing the year '2010' of the vulnerability database.
2020/09/18 12:43:07 wazuh-modulesd:download[118038] wm_download.c:226 at wm_download_dispatch(): DEBUG: Downloading 'https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2010.meta' to '/var/ossec/tmp/vuln-temp'
2020/09/18 12:43:08 wazuh-modulesd:download[118038] wm_download.c:246 at wm_download_dispatch(): DEBUG: Download of 'https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2010.meta' finished.
2020/09/18 12:43:08 wazuh-modulesd:vulnerability-detector[118038] wm_vuln_detector_nvd.c:917 at wm_vuldet_fetch_nvd_cve(): DEBUG: (5407): The feed 'National Vulnerability Database (2010)' is outdated. Fetching the last version.
2020/09/18 12:43:08 wazuh-modulesd:download[118038] wm_download.c:226 at wm_download_dispatch(): DEBUG: Downloading 'https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2010.json.gz' to '/var/ossec/tmp/req-513412643'
2020/09/18 12:43:14 wazuh-modulesd:download[118038] wm_download.c:246 at wm_download_dispatch(): DEBUG: Download of 'https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2010.json.gz' finished.
2020/09/18 12:43:22 wazuh-modulesd:vulnerability-detector[118038] wm_vuln_detector.c:3373 at wm_vuldet_index_feed(): DEBUG: (5414): Refreshing 'National Vulnerability Database' databases.
2020/09/18 12:43:22 wazuh-modulesd:vulnerability-detector[118038] wm_vuln_detector.c:2288 at wm_vuldet_insert(): DEBUG: (5415): Inserting vulnerabilities.
2020/09/18 12:43:22 wazuh-modulesd:vulnerability-detector[118038] wm_vuln_detector.c:2323 at wm_vuldet_insert(): DEBUG: (5419): Inserting NVD vulnerabilities section.
2020/09/18 12:43:51 wazuh-modulesd:vulnerability-detector[118038] wm_vuln_detector.c:6272 at wm_vuldet_index_nvd(): DEBUG: (5421): It took '29' seconds to 'index the NVD' vulnerabilities.
2020/09/18 12:43:51 wazuh-modulesd:vulnerability-detector[118038] wm_vuln_detector.c:3379 at wm_vuldet_index_feed(): DEBUG: (5427): Refresh of 'National Vulnerability Database' database finished.
2020/09/18 12:43:51 wazuh-modulesd:vulnerability-detector[118038] wm_vuln_detector.c:3390 at wm_vuldet_index_feed(): DEBUG: remove(tmp/vuln-temp.bz2): No such file or directory
2020/09/18 12:43:51 wazuh-modulesd:vulnerability-detector[118038] wm_vuln_detector.c:2090 at wm_vuldet_update_feed(): DEBUG: (5401): Synchronizing the year '2011' of the vulnerability database.
```
```
{"timestamp":"2020-09-18T12:54:51.753+0200","rule":{"level":7,"description":"CVE-2015-0848 affects libwmf0.2-7","id":"23504","firedtimes":2,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"000","name":"host","ip":"127.0.0.1"},"manager":{"name":"host"},"id":"1600426491.332348","decoder":{"name":"json"},"data":{"vulnerability":{"package":{"name":"libwmf0.2-7","source":"libwmf","version":"0.2.8.4-17ubuntu1","architecture":"amd64","condition":"Package matches a vulnerable version"},"cvss":{"cvss2":{"vector":{"attack_vector":"network","access_complexity":"medium","authentication":"none","confidentiality_impact":"partial","integrity_impact":"partial","availability":"partial"},"base_score":"6.800000"}},"cve":"CVE-2015-0848","title":"Heap-based buffer overflow in libwmf 0.2.8.4 allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted BMP image.","severity":"Medium","published":"2015-07-01","updated":"2018-10-30","cwe_reference":"CWE-119","references":["http://lists.fedoraproject.org/pipermail/package-announce/2015-June/160668.html","http://lists.fedoraproject.org/pipermail/package-announce/2015-October/168507.html","http://lists.fedoraproject.org/pipermail/package-announce/2015-September/165547.html","http://lists.opensuse.org/opensuse-updates/2015-06/msg00051.html","http://lists.opensuse.org/opensuse-updates/2015-06/msg00053.html","http://lists.opensuse.org/opensuse-updates/2015-07/msg00018.html","http://rhn.redhat.com/errata/RHSA-2015-1917.html","http://www.debian.org/security/2015/dsa-3302","http://www.openwall.com/lists/oss-security/2015/06/01/2","http://www.oracle.com/technetwork/topics/security/linuxbulletinoct2015-2719645.html","http://www.securityfocus.com/bid/74923","http://www.securitytracker.com/id/1032771","http://www.ubuntu.com/usn/USN-2670-1","https://security.gentoo.org/glsa/201602-03","https://nvd.nist.gov/vuln/detail/CVE-2015-0848"],"assigner":"cve@mitre.org","cve_version":"4.0"}},"location":"vulnerability-detector"}


{"timestamp":"2020-09-18T13:44:19.325+0200","rule":{"level":7,"description":"CVE-2017-11849 affects Windows 10","id":"23504","firedtimes":548,"mail":false,"groups":["vulnerability-detector"],"gdpr":["IV_35.7.d"],"pci_dss":["11.2.1","11.2.3"],"tsc":["CC7.1","CC7.2"]},"agent":{"id":"002","name":"Windows10","ip":"10.0.2.15"},"manager":{"name":"host"},"id":"1600429459.5497856","decoder":{"name":"json"},"data":{"vulnerability":{"package":{"name":"Windows 10","generated_cpe":"o:microsoft:windows_10:1709:::::::","condition":"4048955 patch is not installed."},"cvss":{"cvss2":{"vector":{"attack_vector":"local","access_complexity":"medium","authentication":"none","confidentiality_impact":"partial","integrity_impact":"none","availability":"none"},"base_score":"1.900000"},"cvss3":{"vector":{"attack_vector":"local","access_complexity":"high","privileges_required":"low","user_interaction":"none","scope":"unchanged","confidentiality_impact":"high","integrity_impact":"none","availability":"none"},"base_score":"4.700000"}},"cve":"CVE-2017-11849","title":"Windows kernel in Windows 7 SP1, Windows Server 2008 SP2 and R2 SP1, Windows 8.1 and RT 8.1, Server 2012 and R2, Windows 10 Gold, 1511, 1607, 1703, and 1709, Windows Server 2016, and Windows Server, version 1709 allows an attacker to log in and run a specially crafted application due to the Windows kernel improperly initializing a memory address, aka \"Windows Kernel Information Disclosure Vulnerability\". This CVE ID is unique from CVE-2017-11842, CVE-2017-11851, and CVE-2017-11853.","severity":"Medium","published":"2017-11-15","updated":"2017-12-01","cwe_reference":"CWE-200","references":["http://www.securityfocus.com/bid/101762","http://www.securitytracker.com/id/1039782","https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-11849","https://nvd.nist.gov/vuln/detail/CVE-2017-11849"],"assigner":"cve@mitre.org","cve_version":"4.0"}},"location":"vulnerability-detector"}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

