### PR TITLE
adapt wazuh-logtest to new api communication protocol

### DIFF
--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -719,8 +719,8 @@ int w_logtest_check_input_remove_session(cJSON * root, char ** msg) {
     if (!cJSON_IsString(token) || (cJSON_IsString(token) && token->valuestring == NULL)) {
 
         mdebug1(LOGTEST_ERROR_TOKEN_INVALID_TYPE);
-        int size_msg = strlen(LOGTEST_ERROR_TOKEN_INVALID_TYPE);
-        os_calloc(size_msg + 1, sizeof(char), *msg);
+        int size_msg = strlen(LOGTEST_ERROR_TOKEN_INVALID_TYPE) + 1;
+        os_calloc(size_msg, sizeof(char), *msg);
         snprintf(*msg, size_msg, LOGTEST_ERROR_TOKEN_INVALID_TYPE);
 
         return W_LOGTEST_CODE_INVALID_TOKEN;
@@ -731,8 +731,8 @@ int w_logtest_check_input_remove_session(cJSON * root, char ** msg) {
                && strlen(token->valuestring) != W_LOGTEST_TOKEN_LENGH) {
 
         mdebug1(LOGTEST_ERROR_TOKEN_INVALID, token->valuestring);
-        int size_msg = strlen(LOGTEST_ERROR_TOKEN_INVALID) + strlen(token->valuestring);
-        os_calloc(size_msg + 1, sizeof(char), *msg);
+        int size_msg = strlen(LOGTEST_ERROR_TOKEN_INVALID) + strlen(token->valuestring) + 1;
+        os_calloc(size_msg, sizeof(char), *msg);
         snprintf(*msg, size_msg, LOGTEST_ERROR_TOKEN_INVALID, token->valuestring);
 
         return W_LOGTEST_CODE_INVALID_TOKEN;

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -69,7 +69,7 @@
 #define W_LOGTEST_CODE_INVALID_JSON         2   ///< Unabled to process JSON request (Fields not found or they aren't valid)
 #define W_LOGTEST_CODE_COMMAND_NOT_ALLOWED  3   ///< Unabled to process the command
 #define W_LOGTEST_CODE_INVALID_TOKEN        4   ///< Invalid client id
-
+#define W_LOGTEST_CODE_MSG_TOO_LARGE        5   ///< Message too big to be processed
 
 #define valid_str_session(x,y) (cJSON_IsString(x) && x->valuestring && strlen(x->valuestring) == y) ? 1 : 0)
 

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -45,6 +45,7 @@ __attribute__((noreturn))
 static void help_logtest(void)
 {
     print_header();
+    print_out("\nSince Wazuh v4.0.0 this binary is deprecated. Use wazuh-logtest instead\n");
     print_out("  %s: -[Vhdtva] [-c config] [-D dir] [-U rule:alert:decoder]", ARGV0);
     print_out("    -V          Version and license message");
     print_out("    -h          This help message");
@@ -471,6 +472,9 @@ int main(int argc, char **argv)
 
     /* Start up message */
     minfo(STARTUP_MSG, (int)getpid());
+
+    /* Inform that binary is deprecated */
+    print_out("\nSince Wazuh v4.0.0 this binary is deprecated. Use wazuh-logtest instead\n");
 
     /* Going to main loop */
     OS_ReadMSG(ut_str);

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -503,18 +503,18 @@
 #define LOGTEST_ERROR_INIT_HASH                     "(7303): Failure to initialize all_sessions hash"
 #define LOGTEST_ERROR_INV_CONF                      "(7304): Invalid wazuh-logtest configuration"
 #define LOGTEST_ERROR_SIZE_HASH                     "(7305): Failure to resize all_sessions hash"
-#define LOGTEST_ERROR_JSON_PARSE                    "(7306): Error parsing JSON"
-#define LOGTEST_ERROR_JSON_PARSE_POS                "(7307): Error in position %i, ... %s ..."
+#define LOGTEST_ERROR_COMMAND_NOT_ALLOWED           "(7306): Unable to process command"
+#define LOGTEST_ERROR_JSON_PARSE_POS                "(7307): Error parsing JSON in position %i, ... %s ..."
 #define LOGTEST_ERROR_JSON_REQUIRED_SFIELD          "(7308): '%s' JSON field is required and must be a string"
 #define LOGTEST_ERROR_TOKEN_INVALID                 "(7309): '%s' is not a valid token"
 #define LOGTEST_ERROR_RESPONSE                      "(7310): Failure to sending response to client [%i] %s."
 #define LOGTEST_ERROR_INITIALIZE_SESSION            "(7311): Failure to initializing session '%s'"
 #define LOGTEST_ERROR_PROCESS_EVENT                 "(7312): Failed to process the event"
-#define LOGTEST_ERROR_FIELD_NOT_FOUND               "(7313): '%s' JSON field not found or is empty"
+#define LOGTEST_ERROR_FIELD_NOT_FOUND               "(7313): '%s' JSON field not found"
 #define LOGTEST_ERROR_RECV_MSG_EMPTY_TO             "(7314): Failure to receive message: empty or reception timeout"
 #define LOGTEST_ERROR_RECV_MSG_OVERSIZE             "(7315): Failure to receive message: size is bigger than expected"
 #define LOGTEST_ERROR_TOKEN_INVALID_TYPE            "(7316): Failure to remove session. remove_session JSON field must be a string"
-
+#define LOGTEST_ERROR_FIELD_NOT_VALID               "(7317): '%s' JSON field value is not valid"
 
 /* Verbose messages */
 #define STARTUP_MSG "Started (pid: %d)."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -513,7 +513,7 @@
 #define LOGTEST_ERROR_FIELD_NOT_FOUND               "(7313): '%s' JSON field not found"
 #define LOGTEST_ERROR_RECV_MSG_EMPTY_TO             "(7314): Failure to receive message: empty or reception timeout"
 #define LOGTEST_ERROR_RECV_MSG_OVERSIZE             "(7315): Failure to receive message: size is bigger than expected"
-#define LOGTEST_ERROR_TOKEN_INVALID_TYPE            "(7316): Failure to remove session. remove_session JSON field must be a string"
+#define LOGTEST_ERROR_TOKEN_INVALID_TYPE            "(7316): Failure to remove session. token JSON field must be a string"
 #define LOGTEST_ERROR_FIELD_NOT_VALID               "(7317): '%s' JSON field value is not valid"
 
 /* Verbose messages */

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -2800,19 +2800,18 @@ void test_w_logtest_process_request_type_remove_session_ok(void ** state) {
     OSList * list_msg;
     os_calloc(1, sizeof(OSList), list_msg);
 
-
     /* w_logtest_process_request */
     will_return(__wrap_OSList_Create, list_msg);
     will_return(__wrap_OSList_SetMaxSize, 0);
+    will_return(__wrap_cJSON_CreateObject, (cJSON *) 1);
+    will_return(__wrap_cJSON_CreateObject, (cJSON *) 1);
 
-    will_return(__wrap_cJSON_CreateObject, (cJSON *) 1);
-    will_return(__wrap_cJSON_CreateObject, (cJSON *) 1);
+    /* w_logtest_check_input */
     will_return(__wrap_cJSON_ParseWithOpts, (cJSON *) 1);
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_IsObject, true);
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_GetStringValue, "remove_session");
-
 
     // w_logtest_check_input_remove_session ok
     cJSON token = {0};
@@ -2826,7 +2825,9 @@ void test_w_logtest_process_request_type_remove_session_ok(void ** state) {
     /* w_logtest_process_request_remove_session_fail */
     w_logtest_connection_t connection = {0};
     connection.active_client = 5;
+    cJSON parameters = {0};
 
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &parameters);
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
 
     expect_string(__wrap__mdebug1, formatted_msg, "(7316): Failure to remove session. token JSON field must be a string");
@@ -2937,6 +2938,10 @@ void test_w_logtest_process_request_type_log_processing(void ** state) {
     will_return(__wrap_cJSON_IsString, true);
     will_return(__wrap_cJSON_IsString, true);
 
+    /* w_logtest_process_request */
+    cJSON parameters = {0};
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &parameters);
+
     /* log processing fail get session*/
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, NULL);
 
@@ -3028,14 +3033,13 @@ void test_w_logtest_generate_error_response_ok(void ** state) {
     cJSON response = {0};
 
     will_return(__wrap_cJSON_CreateObject, &response);
-    will_return(__wrap_cJSON_CreateArray, (cJSON *) 1);
     will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
 
     expect_value(__wrap_cJSON_AddItemToObject, object, &response);
-    expect_string(__wrap_cJSON_AddItemToObject, string, "messages");
+    expect_string(__wrap_cJSON_AddItemToObject, string, "message");
 
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "codemsg");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, -2);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "error");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 5);
     will_return(__wrap_cJSON_AddNumberToObject, NULL);
 
     will_return(__wrap_cJSON_PrintUnformatted, "{json response}");
@@ -4220,14 +4224,13 @@ void test_w_logtest_clients_handler_recv_msg_oversize(void ** state)
     // w_logtest_generate_error_response
     cJSON response = {0};
     will_return(__wrap_cJSON_CreateObject, &response);
-    will_return(__wrap_cJSON_CreateArray, (cJSON *) 1);
     will_return(__wrap_cJSON_CreateString, (cJSON *) 1);
 
     expect_value(__wrap_cJSON_AddItemToObject, object, &response);
-    expect_string(__wrap_cJSON_AddItemToObject, string, "messages");
+    expect_string(__wrap_cJSON_AddItemToObject, string, "message");
 
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "codemsg");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, -2);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "error");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 5);
     will_return(__wrap_cJSON_AddNumberToObject, NULL);
 
     will_return(__wrap_cJSON_PrintUnformatted, strdup("{json response}"));
@@ -4246,16 +4249,11 @@ void test_w_logtest_clients_handler_ok(void ** state)
     w_logtest_connection_t conection = {0};
 
     will_return(__wrap_FOREVER, 1);
-
     will_return(__wrap_pthread_mutex_lock, 0);
-
     will_return(__wrap_accept, 5);
-
     will_return(__wrap_pthread_mutex_unlock, 0);
-
     will_return(__wrap_OS_RecvSecureTCP, 100);
 
-    // w_logtest_process_request_type_remove_session_ok
     /* w_logtest_process_request */
     OSList * list_msg;
     os_calloc(1, sizeof(OSList), list_msg);
@@ -4270,8 +4268,7 @@ void test_w_logtest_clients_handler_ok(void ** state)
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_GetStringValue, "remove_session");
 
-
-    // w_logtest_check_input_remove_session ok
+    /* w_logtest_check_input_remove_session ok */
     cJSON token = {0};
     token.valuestring = strdup("12345678");
 
@@ -4279,6 +4276,10 @@ void test_w_logtest_clients_handler_ok(void ** state)
     will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
     will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
     will_return(__wrap_cJSON_IsString, (cJSON_bool) 1);
+
+    /* w_logtest_process_request */
+    cJSON parameter = {0};
+    will_return(__wrap_cJSON_GetObjectItemCaseSensitive, &parameter);
 
     /* w_logtest_process_request_remove_session_fail */
     w_logtest_connection_t connection = {0};


### PR DESCRIPTION
|Related issue|
|---|
|[6033](https://github.com/wazuh/wazuh/issues/6033)|



## Description

This PR modify the communication protocol according to the new specification (defined on issue number [5934](https://github.com/wazuh/wazuh/issues/5934))

## Socket messages examples

```json
{
    "version":1,
    "command":"log_processing",
    "origin":{
        "name":"worker1",
        "module":"api"
    },
    "parameters":{
        "token":"e1b71e1a",
        "event":"Oct 15 21:07:56 master sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928",
        "log_format":"syslog",
        "location":"master->/var/log/syslog"
    }
}
```

## Tests

- [x] Compilation without warnings
- [x] Scan-build
- [x] Memory tests
- [x] Integration test
- [x] Unit test
