### PR TITLE
Fix undefined behavior in the network library

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -659,14 +659,8 @@ int OS_RecvSecureTCP(int sock, char * ret,uint32_t size) {
     /* Get header */
     recvval = os_recv_waitall(sock, &msgsize, sizeof(msgsize));
 
-    switch(recvval) {
-        case -1:
-            return recvval;
-            break;
-
-        case 0:
-            return recvval;
-            break;
+    if (recvval != sizeof(msgsize)) {
+        return (recvval == -1) ? -1 : 0;
     }
 
     msgsize = wnet_order(msgsize);
@@ -815,7 +809,7 @@ int OS_RecvSecureClusterTCP(int sock, char * ret, size_t length) {
                 return -1;
             }
     }
-   
+
     if (strncmp(buffer+8, "err --------", CMD_SIZE) == 0) {
         return -2;
     }


### PR DESCRIPTION
This PR is related to #5862 but does not fix it.


## Description

`os_recv_waitall()` must return sizeof(uint32_t) to read the message header.

In the current implementation, the function `OS_RecvSecureTCP()` waits for a 4-byte message header.

- If the receiving operation result is `-1` (error), return `-1`.
- If it's `0`, return `0` as the communication is broken.
- Otherwise, the function assumes that the operation result was `4`, letting values `1`, `2` and `3` produce undefined behavior.

This bug was causing the agent to sometimes print this log when the manager got disconnected:

```
ERROR: Corrupt payload (exceeding size) received
```

## Fix

Check the values mentioned above and return `0` as that would mean that the communication is closed.

## Tests

- [X] Compile manager and agent on Linux.
- [X] Connect an agent to the manager.