### PR TITLE
Avoid the cleaning of the VDT metadata when a custom location is not set

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -551,6 +551,11 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
                         updates[os_index]->timeout);
             flags->update = 1;
 
+            if (updates[os_index]->path || updates[os_index]->url) {
+                // The feed is fetched from a custom location
+                updates[os_index]->custom_location = 1;
+            }
+
             if (updates[os_index]->path && updates[os_index]->url) {
                 os_free(updates[os_index]->url);
             }
@@ -603,6 +608,11 @@ int wm_vuldet_read_provider(const OS_XML *xml, xml_node *node, update_node **upd
             updates[os_index]->update_from_year,
             updates[os_index]->timeout);
         flags->update = 1;
+
+        if (updates[os_index]->multi_path || updates[os_index]->multi_url) {
+                // The feed is fetched from a custom location
+                updates[os_index]->custom_location = 1;
+            }
 
         if (updates[os_index]->multi_path && updates[os_index]->multi_url) {
             os_free(updates[os_index]->multi_url);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -3801,7 +3801,7 @@ int wm_vuldet_fetch_feed(update_node *update, int8_t *need_update) {
     *need_update = 1;
 
     // Clean metadata when set a custom location
-    if (update->url || update->multi_url || update->path || update->multi_path) {
+    if (update->custom_location) {
 
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_METADATA_CLEAN, vu_feed_tag[update->dist_tag_ref]);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -391,6 +391,7 @@ typedef struct update_node {
     };
     unsigned int attempted:1;
     unsigned int json_format:1;
+    unsigned int custom_location:1;
 } update_node;
 
 typedef struct wm_vuldet_t {


### PR DESCRIPTION
## Description

This PR closes #6060.

Since https://github.com/wazuh/wazuh/pull/5971 the `metadata` table is cleaning when set a custom location to fetch a feed, following this condition:

```
if (update->url || update->multi_url || update->path || update->multi_path)
```

However, in further iterations of the update, the `update->url` variable is overwritten with the default repository, so the metadata is clean for those cases.

To avoid that situation, a flag `custom_location` is enabled when reading the configuration and a custom location is set. That flag is now used to trigger the cleaning.

## Configuration options

N/A

## Logs/Alerts example

Now it is detected when the feed is already updated.

```
2020/09/21 04:54:07 wazuh-modulesd:vulnerability-detector[126656] wm_vuln_detector.c:3668 at wm_vuldet_fetch_oval(): DEBUG: (5406): The feed 'Ubuntu Trusty' is in its latest version.
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- [x] Added unit tests (for new features)
