### PR TITLE
Modify file_size, disk_quota and monitoring path log messages

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -242,5 +242,7 @@
 #define FIM_DIFF_FOLDER_SIZE                "(6348): Size of '%s' folder: %.5f KB."
 #define FIM_BIG_FILE_REPORT_CHANGES         "(6349): File '%s' is too big for configured maximum size to perform diff operation."
 #define FIM_DISK_QUOTA_LIMIT_REACHED        "(6350): The maximum configured size for the '%s' folder has been reached, the diff operation cannot be performed."
+#define FIM_DIFF_FILE_SIZE_LIMIT            "(6351): Maximum file size limit to generate diff information configured to '%d KB' for '%s'."
+#define FIM_DISK_QUOTA_LIMIT                "(6352): Maximum disk quota size limit configured to '%d KB'."
 
 #endif /* DEBUG_MESSAGES_H */

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -15,8 +15,8 @@
 #define FIM_DAEMON_STARTED                  "(6000): Starting daemon..."
 #define FIM_DISABLED                        "(6001): File integrity monitoring disabled."
 #define FIM_MONITORING_REGISTRY             "(6002): Monitoring registry entry: '%s%s'."
-#define FIM_MONITORING_DIRECTORY            "(6003): Monitoring directory/file: '%s', with options '%s'."
-#define FIM_MONITORING_LDIRECTORY           "(6003): Monitoring directory: '%s' (%s), with options '%s'."
+#define FIM_MONITORING_DIRECTORY            "(6003): Monitoring path: '%s', with options '%s'."
+#define FIM_MONITORING_LDIRECTORY           "(6003): Monitoring path: '%s' (%s), with options '%s'."
 #define FIM_NO_DIFF                         "(6004): No diff for file: '%s'"
 #define FIM_WAITING_QUEUE                   "(6005): Cannot connect to queue '%s' (%d)'%s'. Waiting %d seconds to reconnect."
 #define FIM_PRINT_IGNORE_ENTRY              "(6206): Ignore '%s' entry '%s'"
@@ -53,8 +53,8 @@
 #define FIM_DB_NORMAL_ALERT                 "(6038): Sending DB back to normal alert."
 #define FIM_DB_80_PERCENTAGE_ALERT          "(6039): Sending DB 80%% full alert."
 #define FIM_DB_90_PERCENTAGE_ALERT          "(6039): Sending DB 90%% full alert."
-#define FIM_DIFF_FILE_SIZE_LIMIT            "(6040): Maximum file size limit to generate diff information configured to '%d KB' for '%s'."
-#define FIM_DISK_QUOTA_LIMIT                "(6041): Maximum disk quota size limit configured to '%d KB'."
+
+
 #define FIM_FILE_SIZE_LIMIT_DISABLED        "(6042): File size limit disabled."
 #define FIM_DISK_QUOTA_LIMIT_DISABLED       "(6043): Disk quota limit disabled."
 

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -199,8 +199,8 @@ int main(int argc, char **argv)
                 mdebug1(FIM_TAG_ADDED, syscheck.tag[r], syscheck.dir[r]);
 
             // Print diff file size limit
-            if (syscheck.file_size_enabled) {
-                minfo(FIM_DIFF_FILE_SIZE_LIMIT, syscheck.diff_size_limit[r], syscheck.dir[r]);
+            if ((syscheck.opts[r] & CHECK_SEECHANGES) && syscheck.file_size_enabled) {
+                mdebug2(FIM_DIFF_FILE_SIZE_LIMIT, syscheck.diff_size_limit[r], syscheck.dir[r]);
             }
 
             r++;
@@ -212,7 +212,7 @@ int main(int argc, char **argv)
 
         // Print maximum disk quota to be used by the queue/diff/local folder
         if (syscheck.disk_quota_enabled) {
-            minfo(FIM_DISK_QUOTA_LIMIT, syscheck.disk_quota_limit);
+            mdebug2(FIM_DISK_QUOTA_LIMIT, syscheck.disk_quota_limit);
         }
         else {
             minfo(FIM_DISK_QUOTA_LIMIT_DISABLED);

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -180,8 +180,8 @@ int Start_win32_Syscheck()
             }
 
             // Print diff file size limit
-            if (syscheck.file_size_enabled) {
-                minfo(FIM_DIFF_FILE_SIZE_LIMIT, syscheck.diff_size_limit[r], syscheck.dir[r]);
+            if ((syscheck.opts[r] & CHECK_SEECHANGES) && syscheck.file_size_enabled) {
+                mdebug2(FIM_DIFF_FILE_SIZE_LIMIT, syscheck.diff_size_limit[r], syscheck.dir[r]);
             }
 
             r++;
@@ -193,7 +193,7 @@ int Start_win32_Syscheck()
 
         // Print maximum disk quota to be used by the queue\diff\local folder
         if (syscheck.disk_quota_enabled) {
-            minfo(FIM_DISK_QUOTA_LIMIT, syscheck.disk_quota_limit);
+            mdebug2(FIM_DISK_QUOTA_LIMIT, syscheck.disk_quota_limit);
         }
         else {
             minfo(FIM_DISK_QUOTA_LIMIT_DISABLED);

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -210,7 +210,7 @@ void test_Start_win32_Syscheck_syscheck_disabled_1(void **state)
     expect_string(__wrap__merror_exit, formatted_msg, "(6698): Creating Data Structure: sqlite3 db. Exiting.");
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
-    
+
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
 
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
@@ -255,7 +255,7 @@ void test_Start_win32_Syscheck_syscheck_disabled_2(void **state)
     expect_string(__wrap__merror_exit, formatted_msg, "(6698): Creating Data Structure: sqlite3 db. Exiting.");
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
-    
+
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
 
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
@@ -310,10 +310,10 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state)
 
     expect_string(__wrap__minfo, formatted_msg, "(6002): Monitoring registry entry: 'Entry1 [x64]'.");
 
-    expect_string(__wrap__minfo, formatted_msg, "(6003): Monitoring directory/file: 'Dir1', with options ''.");
+    expect_string(__wrap__minfo, formatted_msg, "(6003): Monitoring path: 'Dir1', with options ''.");
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
-    
+
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
 
     expect_string(__wrap__minfo, formatted_msg, "(6206): Ignore 'file' entry 'Dir1'");
@@ -373,7 +373,7 @@ void test_Start_win32_Syscheck_whodata_active(void **state)
 
     expect_string(__wrap__minfo, formatted_msg, "(6015): Real-time Whodata mode is not compatible with this version of Windows.");
 
-    expect_string(__wrap__minfo, formatted_msg, "(6003): Monitoring directory/file: 'Dir1', with options 'realtime'.");
+    expect_string(__wrap__minfo, formatted_msg, "(6003): Monitoring path: 'Dir1', with options 'realtime'.");
 
     expect_value(__wrap_fim_db_init, memory, 0);
     will_return(__wrap_fim_db_init, NULL);
@@ -381,7 +381,7 @@ void test_Start_win32_Syscheck_whodata_active(void **state)
     expect_string(__wrap__merror_exit, formatted_msg, "(6698): Creating Data Structure: sqlite3 db. Exiting.");
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);
-    
+
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
 
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());


### PR DESCRIPTION
## Description

This pull request modifies the level of the `file_size` and `disk_quota` log messages to print them in debug2 mode only when report_changes is enabled.

It also modifies the messages about which paths are monitored to make them more generic (path instead of directory/file).

## Logs/Alerts example

```
2020/09/21 15:50:48 ossec-syscheckd[122554] main.c:193 at main(): INFO: (6003): Monitoring path: '/boot', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | report_changes | scheduled'.
2020/09/21 15:50:48 ossec-syscheckd[122554] main.c:203 at main(): DEBUG: (6351): Maximum file size limit to generate diff information configured to '51200 KB' for '/boot'.
2020/09/21 15:50:48 ossec-syscheckd[122554] main.c:193 at main(): INFO: (6003): Monitoring path: '/etc', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | report_changes | scheduled'.
2020/09/21 15:50:48 ossec-syscheckd[122554] main.c:203 at main(): DEBUG: (6351): Maximum file size limit to generate diff information configured to '51200 KB' for '/etc'.
```

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation

