### PR TITLE
Migrate syncstatus to TEXT

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -164,7 +164,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
 
         agent_id = atoi(key->id);
 
-        result = wdb_update_agent_keepalive(agent_id, logr.worker_node?WDB_SYNC_REQ:WDB_SYNCED);
+        result = wdb_update_agent_keepalive(agent_id, logr.worker_node?"syncreq":"synced");
 
         if (OS_SUCCESS != result)
             mwarn("Unable to save agent last keepalive in global.db");
@@ -188,7 +188,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
             /* Unlock mutex */
             w_mutex_unlock(&lastmsg_mutex);
             agent_id = atoi(key->id);
-            if (OS_SUCCESS != wdb_update_agent_keepalive(agent_id, logr.worker_node?WDB_SYNC_REQ:WDB_SYNCED)) {            
+            if (OS_SUCCESS != wdb_update_agent_keepalive(agent_id, logr.worker_node?"syncreq":"synced")) {            
                 mwarn("Unable to set last keepalive as pending");
             }
         } else {
@@ -234,7 +234,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
             // Updating version and keepalive in global.db
             result = wdb_update_agent_version(agent_id, os_name, os_version, os_major, os_minor, os_codename, os_platform,
                                               os_build, uname, os_arch, version, config_sum, merged_sum, manager_host,
-                                              node_name, agent_ip, logr.worker_node?WDB_SYNC_REQ:WDB_SYNCED);
+                                              node_name, agent_ip, logr.worker_node?"syncreq":"synced");
             
             if (OS_INVALID == result)
                 mwarn("Unable to update information in global.db for agent: %s", key->id);

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -413,15 +413,15 @@ void test_wdb_insert_agent_error_socket(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agent1");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agent1");
     expect_string(__wrap_cJSON_AddStringToObject, name, "ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "192.168.0.101");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "192.168.0.101");
     expect_string(__wrap_cJSON_AddStringToObject, name, "register_ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "any");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "any");
     expect_string(__wrap_cJSON_AddStringToObject, name, "internal_key");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "e6ecef1698e21e8fb160e81c722a0523d72554dc1fc3e4374e247f4baac52301");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "e6ecef1698e21e8fb160e81c722a0523d72554dc1fc3e4374e247f4baac52301");
     expect_string(__wrap_cJSON_AddStringToObject, name, "group");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "default");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "default");
     expect_string(__wrap_cJSON_AddNumberToObject, name, "date_add");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
 
@@ -472,15 +472,15 @@ void test_wdb_insert_agent_error_sql_execution(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agent1");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agent1");
     expect_string(__wrap_cJSON_AddStringToObject, name, "ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "192.168.0.101");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "192.168.0.101");
     expect_string(__wrap_cJSON_AddStringToObject, name, "register_ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "any");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "any");
     expect_string(__wrap_cJSON_AddStringToObject, name, "internal_key");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "e6ecef1698e21e8fb160e81c722a0523d72554dc1fc3e4374e247f4baac52301");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "e6ecef1698e21e8fb160e81c722a0523d72554dc1fc3e4374e247f4baac52301");
     expect_string(__wrap_cJSON_AddStringToObject, name, "group");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "default");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "default");
     expect_string(__wrap_cJSON_AddNumberToObject, name, "date_add");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
 
@@ -531,15 +531,15 @@ void test_wdb_insert_agent_error_result(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agent1");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agent1");
     expect_string(__wrap_cJSON_AddStringToObject, name, "ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "192.168.0.101");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "192.168.0.101");
     expect_string(__wrap_cJSON_AddStringToObject, name, "register_ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "any");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "any");
     expect_string(__wrap_cJSON_AddStringToObject, name, "internal_key");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "e6ecef1698e21e8fb160e81c722a0523d72554dc1fc3e4374e247f4baac52301");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "e6ecef1698e21e8fb160e81c722a0523d72554dc1fc3e4374e247f4baac52301");
     expect_string(__wrap_cJSON_AddStringToObject, name, "group");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "default");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "default");
     expect_string(__wrap_cJSON_AddNumberToObject, name, "date_add");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
 
@@ -589,15 +589,15 @@ void test_wdb_insert_agent_success(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agent1");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agent1");
     expect_string(__wrap_cJSON_AddStringToObject, name, "ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "192.168.0.101");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "192.168.0.101");
     expect_string(__wrap_cJSON_AddStringToObject, name, "register_ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "any");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "any");
     expect_string(__wrap_cJSON_AddStringToObject, name, "internal_key");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "e6ecef1698e21e8fb160e81c722a0523d72554dc1fc3e4374e247f4baac52301");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "e6ecef1698e21e8fb160e81c722a0523d72554dc1fc3e4374e247f4baac52301");
     expect_string(__wrap_cJSON_AddStringToObject, name, "group");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "default");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "default");
     expect_string(__wrap_cJSON_AddNumberToObject, name, "date_add");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
 
@@ -707,15 +707,15 @@ void test_wdb_insert_agent_success_keep_date(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agent1");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agent1");
     expect_string(__wrap_cJSON_AddStringToObject, name, "ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "192.168.0.101");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "192.168.0.101");
     expect_string(__wrap_cJSON_AddStringToObject, name, "register_ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "any");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "any");
     expect_string(__wrap_cJSON_AddStringToObject, name, "internal_key");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "e6ecef1698e21e8fb160e81c722a0523d72554dc1fc3e4374e247f4baac52301");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "e6ecef1698e21e8fb160e81c722a0523d72554dc1fc3e4374e247f4baac52301");
     expect_string(__wrap_cJSON_AddStringToObject, name, "group");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "default");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "default");
     expect_string(__wrap_cJSON_AddNumberToObject, name, "date_add");
     expect_value(__wrap_cJSON_AddNumberToObject, number, date_returned);
 
@@ -808,7 +808,7 @@ void test_wdb_update_agent_name_error_socket(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agent1");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agent1");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -848,7 +848,7 @@ void test_wdb_update_agent_name_error_sql_execution(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agent1");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agent1");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -888,7 +888,7 @@ void test_wdb_update_agent_name_error_result(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agent1");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agent1");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -929,7 +929,7 @@ void test_wdb_update_agent_name_success(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agent1");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agent1");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1031,39 +1031,39 @@ void test_wdb_update_agent_data_error_socket(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osname");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_version");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osversion");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osversion");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_major");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osmajor");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osmajor");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_minor");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osminor");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osminor");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_codename");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "oscodename");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "oscodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_platform");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osplatform");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osplatform");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_build");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osbuild");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osbuild");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_uname");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osuname");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osuname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_arch");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osarch");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osarch");
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "version");
     expect_string(__wrap_cJSON_AddStringToObject, name, "config_sum");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "csum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "csum");
     expect_string(__wrap_cJSON_AddStringToObject, name, "merged_sum");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "msum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "msum");
     expect_string(__wrap_cJSON_AddStringToObject, name, "manager_host");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "managerhost");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "managerhost");
     expect_string(__wrap_cJSON_AddStringToObject, name, "node_name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "nodename");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "nodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agentip");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
     expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "syncreq");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1138,39 +1138,39 @@ void test_wdb_update_agent_data_error_sql_execution(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osname");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_version");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osversion");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osversion");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_major");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osmajor");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osmajor");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_minor");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osminor");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osminor");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_codename");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "oscodename");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "oscodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_platform");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osplatform");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osplatform");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_build");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osbuild");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osbuild");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_uname");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osuname");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osuname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_arch");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osarch");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osarch");
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "version");
     expect_string(__wrap_cJSON_AddStringToObject, name, "config_sum");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "csum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "csum");
     expect_string(__wrap_cJSON_AddStringToObject, name, "merged_sum");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "msum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "msum");
     expect_string(__wrap_cJSON_AddStringToObject, name, "manager_host");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "managerhost");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "managerhost");
     expect_string(__wrap_cJSON_AddStringToObject, name, "node_name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "nodename");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "nodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agentip");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
     expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "syncreq");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1245,39 +1245,39 @@ void test_wdb_update_agent_data_error_result(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osname");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_version");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osversion");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osversion");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_major");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osmajor");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osmajor");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_minor");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osminor");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osminor");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_codename");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "oscodename");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "oscodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_platform");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osplatform");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osplatform");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_build");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osbuild");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osbuild");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_uname");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osuname");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osuname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_arch");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osarch");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osarch");
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "version");
     expect_string(__wrap_cJSON_AddStringToObject, name, "config_sum");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "csum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "csum");
     expect_string(__wrap_cJSON_AddStringToObject, name, "merged_sum");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "msum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "msum");
     expect_string(__wrap_cJSON_AddStringToObject, name, "manager_host");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "managerhost");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "managerhost");
     expect_string(__wrap_cJSON_AddStringToObject, name, "node_name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "nodename");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "nodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agentip");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
     expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "syncreq");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1346,39 +1346,39 @@ void test_wdb_update_agent_data_success(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osname");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_version");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osversion");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osversion");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_major");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osmajor");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osmajor");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_minor");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osminor");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osminor");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_codename");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "oscodename");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "oscodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_platform");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osplatform");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osplatform");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_build");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osbuild");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osbuild");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_uname");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osuname");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osuname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_arch");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "osarch");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "osarch");
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "version");
     expect_string(__wrap_cJSON_AddStringToObject, name, "config_sum");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "csum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "csum");
     expect_string(__wrap_cJSON_AddStringToObject, name, "merged_sum");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "msum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "msum");
     expect_string(__wrap_cJSON_AddStringToObject, name, "manager_host");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "managerhost");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "managerhost");
     expect_string(__wrap_cJSON_AddStringToObject, name, "node_name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "nodename");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "nodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "agentip");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
     expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "syncreq");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1600,7 +1600,7 @@ void test_wdb_update_agent_keepalive_error_socket(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "synced");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "synced");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1640,7 +1640,7 @@ void test_wdb_update_agent_keepalive_error_sql_execution(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "synced");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "synced");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1680,7 +1680,7 @@ void test_wdb_update_agent_keepalive_error_result(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "synced");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "synced");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1721,7 +1721,7 @@ void test_wdb_update_agent_keepalive_success(void **state)
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddStringToObject, string, "synced");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "synced");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -2303,9 +2303,9 @@ void test_wdb_find_agent_error_json_output(void **state)
 
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, name_str);
+    expect_string(__wrap_cJSON_AddStringToObject, string, name_str);
     expect_string(__wrap_cJSON_AddStringToObject, name, "ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, ip_str);
+    expect_string(__wrap_cJSON_AddStringToObject, string, ip_str);
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -2343,9 +2343,9 @@ void test_wdb_find_agent_success(void **state)
 
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_value(__wrap_cJSON_AddStringToObject, string, name_str);
+    expect_string(__wrap_cJSON_AddStringToObject, string, name_str);
     expect_string(__wrap_cJSON_AddStringToObject, name, "ip");
-    expect_value(__wrap_cJSON_AddStringToObject, string, ip_str);
+    expect_string(__wrap_cJSON_AddStringToObject, string, ip_str);
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -972,7 +972,7 @@ void test_wdb_update_agent_version_error_json(void **state)
     char *manager_host = "managerhost";
     char *node_name = "nodename";
     char *agent_ip = "agentip";
-    wdb_sync_status_t sync_status = WDB_SYNC_REQ;
+    const char *sync_status = "syncreq";
 
     will_return(__wrap_cJSON_CreateObject, NULL);
 
@@ -1004,18 +1004,18 @@ void test_wdb_update_agent_version_error_socket(void **state)
     char *manager_host = "managerhost";
     char *node_name = "nodename";
     char *agent_ip = "agentip";
-    wdb_sync_status_t sync_status = WDB_SYNC_REQ;
+    const char *sync_status = "syncreq";
 
     const char *json_str = "{\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":\"syncreq\"}";
     const char *query_str = "global update-agent-version {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":\"syncreq\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1055,8 +1055,8 @@ void test_wdb_update_agent_version_error_socket(void **state)
     expect_value(__wrap_cJSON_AddStringToObject, string, "nodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
     expect_value(__wrap_cJSON_AddStringToObject, string, "agentip");
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_value(__wrap_cJSON_AddStringToObject, string, "syncreq");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1076,7 +1076,7 @@ void test_wdb_update_agent_version_error_socket(void **state)
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}");
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":\"syncreq\"}");
 
     ret = wdb_update_agent_version(id, os_name, os_version, os_major, os_minor, os_codename,
                                    os_platform, os_build, os_uname, os_arch, version, config_sum,
@@ -1104,18 +1104,18 @@ void test_wdb_update_agent_version_error_sql_execution(void **state)
     char *manager_host = "managerhost";
     char *node_name = "nodename";
     char *agent_ip = "agentip";
-    wdb_sync_status_t sync_status = WDB_SYNC_REQ;
+    const char *sync_status = "syncreq";
 
     const char *json_str = "{\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":\"syncreq\"}";
     const char *query_str = "global update-agent-version {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":\"syncreq\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1155,8 +1155,8 @@ void test_wdb_update_agent_version_error_sql_execution(void **state)
     expect_value(__wrap_cJSON_AddStringToObject, string, "nodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
     expect_value(__wrap_cJSON_AddStringToObject, string, "agentip");
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_value(__wrap_cJSON_AddStringToObject, string, "syncreq");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1176,7 +1176,7 @@ void test_wdb_update_agent_version_error_sql_execution(void **state)
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}");
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":\"syncreq\"}");
 
     ret = wdb_update_agent_version(id, os_name, os_version, os_major, os_minor, os_codename,
                                    os_platform, os_build, os_uname, os_arch, version, config_sum,
@@ -1204,18 +1204,18 @@ void test_wdb_update_agent_version_error_result(void **state)
     char *manager_host = "managerhost";
     char *node_name = "nodename";
     char *agent_ip = "agentip";
-    wdb_sync_status_t sync_status = WDB_SYNC_REQ;
+    const char *sync_status = "syncreq";
 
     const char *json_str = "{\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":\"syncreq\"}";
     const char *query_str = "global update-agent-version {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":\"syncreq\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1255,8 +1255,8 @@ void test_wdb_update_agent_version_error_result(void **state)
     expect_value(__wrap_cJSON_AddStringToObject, string, "nodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
     expect_value(__wrap_cJSON_AddStringToObject, string, "agentip");
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_value(__wrap_cJSON_AddStringToObject, string, "syncreq");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1300,18 +1300,18 @@ void test_wdb_update_agent_version_success(void **state)
     char *manager_host = "managerhost";
     char *node_name = "nodename";
     char *agent_ip = "agentip";
-    wdb_sync_status_t sync_status = WDB_SYNC_REQ;
+    const char *sync_status = "syncreq";
 
     const char *json_str = "{\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":\"syncreq\"}";
     const char *query_str = "global update-agent-version {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
-\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":1}";
+\"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"sync_status\":\"syncreq\"}";
     const char *response = "ok";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1351,8 +1351,8 @@ void test_wdb_update_agent_version_success(void **state)
     expect_value(__wrap_cJSON_AddStringToObject, string, "nodename");
     expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
     expect_value(__wrap_cJSON_AddStringToObject, string, "agentip");
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_value(__wrap_cJSON_AddStringToObject, string, "syncreq");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1545,7 +1545,7 @@ void test_wdb_update_agent_keepalive_error_json(void **state)
 {
     int ret = 0;
     int id = 1;
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_cJSON_CreateObject, NULL);
 
@@ -1560,20 +1560,21 @@ void test_wdb_update_agent_keepalive_error_socket(void **state)
 {
     int ret = 0;
     int id = 1;
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
-    const char *json_str = "{\"id\":1,\"sync_status\":0}";
-    const char *query_str = "global update-keepalive {\"id\":1,\"sync_status\":0}";
+    const char *json_str = "{\"id\":1,\"sync_status\":\"synced\"}";
+    const char *query_str = "global update-keepalive {\"id\":1,\"sync_status\":\"synced\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
     will_return_always(__wrap_cJSON_AddNumberToObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
 
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_value(__wrap_cJSON_AddStringToObject, string, "synced");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1588,7 +1589,7 @@ void test_wdb_update_agent_keepalive_error_socket(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error in the response from socket");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-keepalive {\"id\":1,\"sync_status\":0}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-keepalive {\"id\":1,\"sync_status\":\"synced\"}");
 
     ret = wdb_update_agent_keepalive(id, sync_status);
 
@@ -1599,20 +1600,21 @@ void test_wdb_update_agent_keepalive_error_sql_execution(void **state)
 {
     int ret = 0;
     int id = 1;
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
-    const char *json_str = "{\"id\":1,\"sync_status\":0}";
-    const char *query_str = "global update-keepalive {\"id\":1,\"sync_status\":0}";
+    const char *json_str = "{\"id\":1,\"sync_status\":\"synced\"}";
+    const char *query_str = "global update-keepalive {\"id\":1,\"sync_status\":\"synced\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
     will_return_always(__wrap_cJSON_AddNumberToObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
 
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_value(__wrap_cJSON_AddStringToObject, string, "synced");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1627,7 +1629,7 @@ void test_wdb_update_agent_keepalive_error_sql_execution(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-keepalive {\"id\":1,\"sync_status\":0}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-keepalive {\"id\":1,\"sync_status\":\"synced\"}");
 
     ret = wdb_update_agent_keepalive(id, sync_status);
 
@@ -1638,20 +1640,21 @@ void test_wdb_update_agent_keepalive_error_result(void **state)
 {
     int ret = 0;
     int id = 1;
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
-    const char *json_str = "{\"id\":1,\"sync_status\":0}";
-    const char *query_str = "global update-keepalive {\"id\":1,\"sync_status\":0}";
+    const char *json_str = "{\"id\":1,\"sync_status\":\"synced\"}";
+    const char *query_str = "global update-keepalive {\"id\":1,\"sync_status\":\"synced\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
     will_return_always(__wrap_cJSON_AddNumberToObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
 
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_value(__wrap_cJSON_AddStringToObject, string, "synced");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1678,20 +1681,21 @@ void test_wdb_update_agent_keepalive_success(void **state)
 {
     int ret = 0;
     int id = 1;
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
-    const char *json_str = "{\"id\":1,\"sync_status\":0}";
-    const char *query_str = "global update-keepalive {\"id\":1,\"sync_status\":0}";
+    const char *json_str = "{\"id\":1,\"sync_status\":\"synced\"}";
+    const char *query_str = "global update-keepalive {\"id\":1,\"sync_status\":\"synced\"}";
     const char *response = "ok";
 
     will_return(__wrap_cJSON_CreateObject, 1);
     will_return_always(__wrap_cJSON_AddNumberToObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
 
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "sync_status");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_value(__wrap_cJSON_AddStringToObject, string, "synced");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -341,7 +341,7 @@ void test_wdb_global_set_sync_status_transaction_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    wdb_sync_status_t status = WDB_SYNCED;
+    const char *status = "synced";
  
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
@@ -354,7 +354,7 @@ void test_wdb_global_set_sync_status_cache_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    wdb_sync_status_t status = WDB_SYNCED;
+    const char *status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
@@ -368,15 +368,15 @@ void test_wdb_global_set_sync_status_bind1_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    wdb_sync_status_t status = WDB_SYNCED;
+    const char *status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, status);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_set_sync_status(data->socket, atoi(data->socket->id), status);
     assert_int_equal(result, OS_INVALID);
@@ -386,13 +386,13 @@ void test_wdb_global_set_sync_status_bind2_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    wdb_sync_status_t status = WDB_SYNCED;
+    const char *status = "synced";
  
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, status);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->socket->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
@@ -407,13 +407,13 @@ void test_wdb_global_set_sync_status_step_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    wdb_sync_status_t status = WDB_SYNCED;
+    const char *status = "synced";
   
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, status);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->socket->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
@@ -429,13 +429,13 @@ void test_wdb_global_set_sync_status_success(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    wdb_sync_status_t status = WDB_SYNCED;
+    const char *status = "synced";
    
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, status);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->socket->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
@@ -568,9 +568,9 @@ void test_wdb_global_sync_agent_info_get_success(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     // Required for wdb_global_set_sync_status()
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, WDB_SYNCED);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "synced");
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
@@ -647,9 +647,9 @@ void test_wdb_global_sync_agent_info_get_sync_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     // Required for wdb_global_set_sync_status()
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, WDB_SYNCED);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "synced");
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
@@ -855,12 +855,12 @@ void test_wdb_global_sync_agent_info_set_bind3_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, index, 1);
     expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, WDB_SYNCED);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "synced");
+    will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_sync_agent_info_set(data->socket, json_agent);
     __real_cJSON_Delete(json_agent);
@@ -890,9 +890,9 @@ void test_wdb_global_sync_agent_info_set_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, index, 1);
     expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, WDB_SYNCED);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "synced");
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
@@ -926,9 +926,9 @@ void test_wdb_global_sync_agent_info_set_success(void **state)
     expect_value(__wrap_sqlite3_bind_int, index, 1);
     expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, WDB_SYNCED);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "synced");
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
     result = wdb_global_sync_agent_info_set(data->socket, json_agent);
@@ -1438,7 +1438,7 @@ void test_wdb_global_update_agent_version_transaction_fail(void **state)
     const char *manager_host = NULL;
     const char *node_name = NULL;
     const char *agent_ip = NULL;
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
@@ -1469,7 +1469,7 @@ void test_wdb_global_update_agent_version_cache_fail(void **state)
     const char *manager_host = NULL;
     const char *node_name = NULL;
     const char *agent_ip = NULL;
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
@@ -1502,7 +1502,7 @@ void test_wdb_global_update_agent_version_bind1_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -1540,7 +1540,7 @@ void test_wdb_global_update_agent_version_bind2_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -1581,7 +1581,7 @@ void test_wdb_global_update_agent_version_bind3_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -1626,7 +1626,7 @@ void test_wdb_global_update_agent_version_bind4_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -1674,7 +1674,7 @@ void test_wdb_global_update_agent_version_bind5_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -1725,7 +1725,7 @@ void test_wdb_global_update_agent_version_bind6_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -1779,7 +1779,7 @@ void test_wdb_global_update_agent_version_bind7_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -1836,7 +1836,7 @@ void test_wdb_global_update_agent_version_bind8_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -1896,7 +1896,7 @@ void test_wdb_global_update_agent_version_bind9_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -1959,7 +1959,7 @@ void test_wdb_global_update_agent_version_bind10_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -2025,7 +2025,7 @@ void test_wdb_global_update_agent_version_bind11_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -2094,7 +2094,7 @@ void test_wdb_global_update_agent_version_bind12_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -2166,7 +2166,7 @@ void test_wdb_global_update_agent_version_bind13_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -2241,7 +2241,7 @@ void test_wdb_global_update_agent_version_bind14_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -2319,7 +2319,7 @@ void test_wdb_global_update_agent_version_bind15_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -2400,7 +2400,7 @@ void test_wdb_global_update_agent_version_bind16_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -2450,13 +2450,13 @@ void test_wdb_global_update_agent_version_bind16_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 15);
     expect_value(__wrap_sqlite3_bind_text, buffer, agent_ip);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 16);
-    expect_value(__wrap_sqlite3_bind_int, value, sync_status);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    expect_value(__wrap_sqlite3_bind_text, pos, 16);
+    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->socket, atoi(data->socket->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2484,7 +2484,7 @@ void test_wdb_global_update_agent_version_bind17_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -2534,9 +2534,9 @@ void test_wdb_global_update_agent_version_bind17_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 15);
     expect_value(__wrap_sqlite3_bind_text, buffer, agent_ip);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 16);
-    expect_value(__wrap_sqlite3_bind_int, value, sync_status);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 16);
+    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 17);
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->socket->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
@@ -2571,7 +2571,7 @@ void test_wdb_global_update_agent_version_step_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -2621,9 +2621,9 @@ void test_wdb_global_update_agent_version_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 15);
     expect_value(__wrap_sqlite3_bind_text, buffer, agent_ip);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 16);
-    expect_value(__wrap_sqlite3_bind_int, value, sync_status);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 16);
+    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 17);
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->socket->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
@@ -2658,7 +2658,7 @@ void test_wdb_global_update_agent_version_success(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
-    wdb_sync_status_t sync_status = WDB_SYNCED;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -2708,9 +2708,9 @@ void test_wdb_global_update_agent_version_success(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 15);
     expect_value(__wrap_sqlite3_bind_text, buffer, agent_ip);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 16);
-    expect_value(__wrap_sqlite3_bind_int, value, sync_status);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 16);
+    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 17);
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->socket->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
@@ -2728,7 +2728,7 @@ void test_wdb_global_update_agent_keepalive_transaction_fail(void **state)
     int result = 0;
     int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    wdb_sync_status_t status = WDB_SYNCED;
+    const char *status = "synced";
 
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
@@ -2743,7 +2743,7 @@ void test_wdb_global_update_agent_keepalive_cache_fail(void **state)
     int result = 0;
     int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    wdb_sync_status_t status = WDB_SYNCED;
+    const char *status = "synced";
    
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
@@ -2759,16 +2759,16 @@ void test_wdb_global_update_agent_keepalive_bind1_fail(void **state)
     int result = 0;
     int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    wdb_sync_status_t status = WDB_SYNCED;
+    const char *status = "synced";
    
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
 
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, status);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");   
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_keepalive(data->socket, atoi(data->socket->id), status);
 
@@ -2780,14 +2780,14 @@ void test_wdb_global_update_agent_keepalive_bind2_fail(void **state)
     int result = 0;
     int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    wdb_sync_status_t status = WDB_SYNCED;
+    const char *status = "synced";
    
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1); 
 
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, status);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->socket->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
@@ -2804,14 +2804,14 @@ void test_wdb_global_update_agent_keepalive_step_fail(void **state)
     int result = 0;
     int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    wdb_sync_status_t status = WDB_SYNCED;
+    const char *status = "synced";
    
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1); 
 
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, status);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->socket->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
@@ -2830,14 +2830,14 @@ void test_wdb_global_update_agent_keepalive_success(void **state)
     int result = 0;
     int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    wdb_sync_status_t status = WDB_SYNCED;
+    const char *status = "synced";
    
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1); 
 
-    expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, status);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->socket->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -395,7 +395,7 @@ void test_wdb_parse_global_update_agent_version_query_error(void **state)
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
-    \"sync_status\":1}";
+    \"sync_status\":\"syncreq\"}";
 
     will_return(__wrap_wdb_open_global, data->socket);
     expect_string(__wrap__mdebug2, formatted_msg, 
@@ -403,7 +403,7 @@ void test_wdb_parse_global_update_agent_version_query_error(void **state)
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
-    \"sync_status\":1}");
+    \"sync_status\":\"syncreq\"}");
 
     expect_value(__wrap_wdb_global_update_agent_version, id, 1);
     expect_string(__wrap_wdb_global_update_agent_version, os_name, "test_name");
@@ -421,7 +421,7 @@ void test_wdb_parse_global_update_agent_version_query_error(void **state)
     expect_string(__wrap_wdb_global_update_agent_version, manager_host, "test_manager");
     expect_string(__wrap_wdb_global_update_agent_version, node_name, "test_node");
     expect_string(__wrap_wdb_global_update_agent_version, agent_ip, "test_ip");
-    expect_value(__wrap_wdb_global_update_agent_version, sync_status, WDB_SYNC_REQ);
+    expect_string(__wrap_wdb_global_update_agent_version, sync_status, "syncreq");
 
     will_return(__wrap_wdb_global_update_agent_version, OS_INVALID);
 
@@ -442,7 +442,7 @@ void test_wdb_parse_global_update_agent_version_invalid_data(void **state)
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
-    \"sync_status\":1}";
+    \"sync_status\":\"syncreq\"}";
 
     will_return(__wrap_wdb_open_global, data->socket);
     expect_string(__wrap__mdebug2, formatted_msg, 
@@ -450,7 +450,7 @@ void test_wdb_parse_global_update_agent_version_invalid_data(void **state)
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
-    \"sync_status\":1}");
+    \"sync_status\":\"syncreq\"}");
 
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when updating agent version.");
 
@@ -468,7 +468,7 @@ void test_wdb_parse_global_update_agent_version_success(void **state)
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
-    \"sync_status\":1}";
+    \"sync_status\":\"syncreq\"}";
 
     will_return(__wrap_wdb_open_global, data->socket);
     expect_string(__wrap__mdebug2, formatted_msg, 
@@ -476,7 +476,7 @@ void test_wdb_parse_global_update_agent_version_success(void **state)
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
-    \"sync_status\":1}");
+    \"sync_status\":\"syncreq\"}");
 
     expect_value(__wrap_wdb_global_update_agent_version, id, 1);
     expect_string(__wrap_wdb_global_update_agent_version, os_name, "test_name");
@@ -494,7 +494,7 @@ void test_wdb_parse_global_update_agent_version_success(void **state)
     expect_string(__wrap_wdb_global_update_agent_version, manager_host, "test_manager");
     expect_string(__wrap_wdb_global_update_agent_version, node_name, "test_node");
     expect_string(__wrap_wdb_global_update_agent_version, agent_ip, "test_ip");
-    expect_value(__wrap_wdb_global_update_agent_version, sync_status, WDB_SYNC_REQ);
+    expect_string(__wrap_wdb_global_update_agent_version, sync_status, "syncreq");
     will_return(__wrap_wdb_global_update_agent_version, OS_SUCCESS);
 
     ret = wdb_parse(query, data->output);
@@ -727,14 +727,14 @@ void test_wdb_parse_global_update_agent_keepalive_query_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global update-keepalive {\"id\":1,\"sync_status\":1}";
+    char query[OS_BUFFER_SIZE] = "global update-keepalive {\"id\":1,\"sync_status\":\"syncreq\"}";
 
     will_return(__wrap_wdb_open_global, data->socket);
     expect_value(__wrap_wdb_global_update_agent_keepalive, id, 1);
-    expect_value(__wrap_wdb_global_update_agent_keepalive, status, WDB_SYNC_REQ);
+    expect_string(__wrap_wdb_global_update_agent_keepalive, status, "syncreq");
     will_return(__wrap_wdb_global_update_agent_keepalive, OS_INVALID);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-keepalive {\"id\":1,\"sync_status\":1}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-keepalive {\"id\":1,\"sync_status\":\"syncreq\"}");
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
@@ -748,14 +748,14 @@ void test_wdb_parse_global_update_agent_keepalive_success(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global update-keepalive {\"id\":1,\"sync_status\":1}";
+    char query[OS_BUFFER_SIZE] = "global update-keepalive {\"id\":1,\"sync_status\":\"syncreq\"}";
 
     will_return(__wrap_wdb_open_global, data->socket);
     expect_value(__wrap_wdb_global_update_agent_keepalive, id, 1);
-    expect_value(__wrap_wdb_global_update_agent_keepalive, status, WDB_SYNC_REQ);
+    expect_string(__wrap_wdb_global_update_agent_keepalive, status, "syncreq");
     will_return(__wrap_wdb_global_update_agent_keepalive, OS_SUCCESS);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-keepalive {\"id\":1,\"sync_status\":1}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-keepalive {\"id\":1,\"sync_status\":\"syncreq\"}");
 
     ret = wdb_parse(query, data->output);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -58,7 +58,7 @@ int __wrap_wdb_global_update_agent_version( __attribute__((unused)) wdb_t *wdb,
                                             const char *manager_host,
                                             const char *node_name,
                                             const char *agent_ip,
-                                            wdb_sync_status_t sync_status) {
+                                            const char *sync_status) {
     check_expected(id);
     check_expected(os_name);
     check_expected(os_version);
@@ -104,7 +104,7 @@ int __wrap_wdb_global_set_agent_label(  __attribute__((unused)) wdb_t *wdb,
 
 int __wrap_wdb_global_update_agent_keepalive(__attribute__((unused)) wdb_t *wdb,
                                             int id,
-                                            wdb_sync_status_t status) {
+                                            char* status) {
     check_expected(id);
     check_expected(status);
     return mock();

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -34,7 +34,7 @@ int __wrap_wdb_global_update_agent_version(wdb_t *wdb,
                                     const char *manager_host,
                                     const char *node_name,
                                     const char *agent_ip,
-                                    wdb_sync_status_t sync_status);
+                                    const char *sync_status);
 
 cJSON* __wrap_wdb_global_get_agent_labels(wdb_t *wdb, int id);
 
@@ -42,7 +42,7 @@ int __wrap_wdb_global_del_agent_labels(wdb_t *wdb, int id);
 
 int __wrap_wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value);
 
-int __wrap_wdb_global_update_agent_keepalive(wdb_t *wdb, int id, wdb_sync_status_t status);
+int __wrap_wdb_global_update_agent_keepalive(wdb_t *wdb, int id, char* status);
 
 int __wrap_wdb_global_delete_agent(wdb_t *wdb, int id);
 

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS agent (
     fim_offset INTEGER NOT NULL DEFAULT 0,
     reg_offset INTEGER NOT NULL DEFAULT 0,
     `group` TEXT DEFAULT 'default',
-    sync_status INTEGER NOT NULL DEFAULT 0
+    sync_status TEXT NOT NULL CHECK (sync_status IN ('synced', 'syncreq')) DEFAULT 'synced'
 );
 
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);

--- a/src/wazuh_db/schema_global_upgrade_v1.sql
+++ b/src/wazuh_db/schema_global_upgrade_v1.sql
@@ -17,8 +17,7 @@ CREATE TABLE IF NOT EXISTS labels (
     PRIMARY KEY (id,key)
 );
 
-ALTER TABLE agent ADD COLUMN sync_status INTEGER NOT NULL DEFAULT 0;
-
+ALTER TABLE agent ADD COLUMN sync_status TEXT NOT NULL CHECK (sync_status IN ('synced', 'syncreq')) DEFAULT 'synced';
 CREATE TABLE IF NOT EXISTS metadata (
     key TEXT PRIMARY KEY,
     value TEXT

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -143,7 +143,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_DELETE_GROUP] = "DELETE FROM `group` WHERE name = ?;",
     [WDB_STMT_GLOBAL_SELECT_GROUPS] = "SELECT name FROM `group`;",
     [WDB_STMT_GLOBAL_SELECT_AGENT_KEEPALIVE] = "SELECT last_keepalive FROM agent WHERE name = ? AND (register_ip = ? OR register_ip LIKE ? || '/_%');",
-    [WDB_STMT_GLOBAL_SYNC_REQ_GET] = "SELECT id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, last_keepalive FROM agent WHERE id > ? AND sync_status = 1 LIMIT 1;", 
+    [WDB_STMT_GLOBAL_SYNC_REQ_GET] = "SELECT id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, last_keepalive FROM agent WHERE id > ? AND sync_status = 'syncreq' LIMIT 1;", 
     [WDB_STMT_GLOBAL_SYNC_SET] = "UPDATE agent SET sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_INFO] = "UPDATE agent SET config_sum = :config_sum, ip = :ip, manager_host = :manager_host, merged_sum = :merged_sum, name = :name, node_name = :node_name, os_arch = :os_arch, os_build = :os_build, os_codename = :os_codename, os_major = :os_major, os_minor = :os_minor, os_name = :os_name, os_platform = :os_platform, os_uname = :os_uname, os_version = :os_version, version = :version, last_keepalive = :last_keepalive, sync_status = :sync_status WHERE id = :id;",
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ? LIMIT 1;", 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1402,7 +1402,7 @@ int wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value);
  * @param [in] status The value of sync_status
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, char *sync_status);
+int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, const char *sync_status);
 
 /**
  * @brief Function to delete an agent from the agent table.
@@ -1589,7 +1589,7 @@ cJSON* wdb_global_select_agent_keepalive(wdb_t *wdb, char* name, char* ip);
  * @param [in] status The value of sync_status
  * @return 0 On success. -1 On error.
  */
-int wdb_global_set_sync_status(wdb_t *wdb, int id, char *sync_status);
+int wdb_global_set_sync_status(wdb_t *wdb, int id, const char *sync_status);
 
 /**
  * @brief Gets and parses agents with 'syncreq' sync_status and sets them to 'synced'.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -219,12 +219,6 @@ typedef enum {
     WDB_FIM         ///< File integrity monitoring.
 } wdb_component_t;
 
-/// Enumeration of sync-status.
-typedef enum {
-    WDB_SYNCED,
-    WDB_SYNC_REQ
-} wdb_sync_status_t;
-
 extern char *schema_global_sql;
 extern char *schema_agents_sql;
 extern char *schema_upgrade_v1_sql;
@@ -441,16 +435,16 @@ int wdb_update_agent_version(int id,
                              const char *manager_host,
                              const char *node_name,
                              const char *agent_ip,
-                             wdb_sync_status_t sync_status);
+                             const char *sync_status);
 
 /**
  * @brief Update agent's last keepalive ond modifies the cluster synchronization status.
  * 
  * @param[in] id Id of the agent for whom the keepalive must be updated.
- * @param[in] sync_status Enumeration with the cluster synchronization status to be set.
+ * @param[in] sync_status String with the cluster synchronization status to be set.
  * @return OS_SUCCESS on success or OS_INVALID on failure.
  */
-int wdb_update_agent_keepalive(int id, wdb_sync_status_t sync_status);
+int wdb_update_agent_keepalive(int id, const char *sync_status);
 
 /**
  * @brief Set agent updating status.
@@ -1369,7 +1363,7 @@ int wdb_global_update_agent_version(wdb_t *wdb,
                                     const char *manager_host,
                                     const char *node_name,
                                     const char *agent_ip,
-                                    wdb_sync_status_t sync_status);
+                                    const char *sync_status);
 
 /**
  * @brief Function to get the labels of a particular agent.
@@ -1408,7 +1402,7 @@ int wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value);
  * @param [in] status The value of sync_status
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, wdb_sync_status_t status);
+int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, char *sync_status);
 
 /**
  * @brief Function to delete an agent from the agent table.
@@ -1595,10 +1589,10 @@ cJSON* wdb_global_select_agent_keepalive(wdb_t *wdb, char* name, char* ip);
  * @param [in] status The value of sync_status
  * @return 0 On success. -1 On error.
  */
-int wdb_global_set_sync_status(wdb_t *wdb, int id, wdb_sync_status_t status);
+int wdb_global_set_sync_status(wdb_t *wdb, int id, char *sync_status);
 
 /**
- * @brief Gets and parses agents with WDB_SYNC_REQ sync_status and sets them to WDB_SYNCED.
+ * @brief Gets and parses agents with 'syncreq' sync_status and sets them to 'synced'.
  *        Response is prepared in one chunk, 
  *        if the size of the chunk exceeds WDB_MAX_RESPONSE_SIZE parsing stops and reports the amount of agents obtained.
  *        Multiple calls to this function can be required to fully obtain all agents.

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -241,7 +241,7 @@ int wdb_update_agent_version (int id,
                               const char *manager_host,
                               const char *node_name,
                               const char *agent_ip,
-                              wdb_sync_status_t sync_status) {
+                              const char *sync_status) {
     int result = 0;
     cJSON *data_in = NULL;
     char wdbquery[WDBQUERY_SIZE] = "";
@@ -271,7 +271,7 @@ int wdb_update_agent_version (int id,
     cJSON_AddStringToObject(data_in, "manager_host", manager_host);
     cJSON_AddStringToObject(data_in, "node_name", node_name);
     cJSON_AddStringToObject(data_in, "agent_ip", agent_ip);
-    cJSON_AddNumberToObject(data_in, "sync_status", sync_status);
+    cJSON_AddStringToObject(data_in, "sync_status", sync_status);
 
     snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_UPDATE_AGENT_VERSION], cJSON_PrintUnformatted(data_in));
 
@@ -299,7 +299,7 @@ int wdb_update_agent_version (int id,
     return result;
 }
 
-int wdb_update_agent_keepalive(int id, wdb_sync_status_t sync_status) {
+int wdb_update_agent_keepalive(int id, const char *sync_status) {
     int result = 0;
     cJSON *data_in = NULL;
     char wdbquery[WDBQUERY_SIZE] = "";
@@ -314,7 +314,7 @@ int wdb_update_agent_keepalive(int id, wdb_sync_status_t sync_status) {
     }
 
     cJSON_AddNumberToObject(data_in, "id", id);
-    cJSON_AddNumberToObject(data_in, "sync_status", sync_status);
+    cJSON_AddStringToObject(data_in, "sync_status", sync_status);
 
     snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_UPDATE_AGENT_KEEPALIVE], cJSON_PrintUnformatted(data_in));
 

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -345,7 +345,7 @@ int wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value) {
     }
 }
 
-int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, char* sync_status) {
+int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, const char* sync_status) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
@@ -991,7 +991,7 @@ int wdb_global_delete_agent_belong(wdb_t *wdb, int id) {
     }
 }
 
-int wdb_global_set_sync_status(wdb_t *wdb, int id, char* sync_status) {
+int wdb_global_set_sync_status(wdb_t *wdb, int id, const char* sync_status) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -142,7 +142,7 @@ int wdb_global_update_agent_version(wdb_t *wdb,
                                     const char *manager_host,
                                     const char *node_name,
                                     const char *agent_ip,
-                                    wdb_sync_status_t sync_status)
+                                    const char *sync_status)
 {
     sqlite3_stmt *stmt = NULL;
     int index = 1;
@@ -221,8 +221,8 @@ int wdb_global_update_agent_version(wdb_t *wdb,
             return OS_INVALID;
         }
     }
-    if (sqlite3_bind_int(stmt, index++, sync_status) != SQLITE_OK) {
-        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+    if (sqlite3_bind_text(stmt, index++, sync_status, -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }
     if (sqlite3_bind_int(stmt, index++, id) != SQLITE_OK) {
@@ -345,7 +345,7 @@ int wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value) {
     }
 }
 
-int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, wdb_sync_status_t status) {
+int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, char* sync_status) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
@@ -360,8 +360,8 @@ int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, wdb_sync_status_t stat
 
     stmt = wdb->stmt[WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE];
 
-    if (sqlite3_bind_int(stmt, 1, status) != SQLITE_OK) {
-        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+    if (sqlite3_bind_text(stmt, 1, sync_status, -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }
     if (sqlite3_bind_int(stmt, 2, id) != SQLITE_OK) {
@@ -991,7 +991,7 @@ int wdb_global_delete_agent_belong(wdb_t *wdb, int id) {
     }
 }
 
-int wdb_global_set_sync_status(wdb_t *wdb, int id, wdb_sync_status_t status) {
+int wdb_global_set_sync_status(wdb_t *wdb, int id, char* sync_status) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
@@ -1006,8 +1006,8 @@ int wdb_global_set_sync_status(wdb_t *wdb, int id, wdb_sync_status_t status) {
 
     stmt = wdb->stmt[WDB_STMT_GLOBAL_SYNC_SET];
 
-    if (sqlite3_bind_int(stmt, 1, status) != SQLITE_OK) {
-        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+    if (sqlite3_bind_text(stmt, 1, sync_status, -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }
     if (sqlite3_bind_int(stmt, 2, id) != SQLITE_OK) {
@@ -1094,7 +1094,7 @@ wdbc_result wdb_global_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char 
                     response_size += agent_len+1;
                     *last_agent_id = agent_id;
                     //Set sync status as synced
-                    if (OS_SUCCESS != wdb_global_set_sync_status(wdb, agent_id, WDB_SYNCED)) {
+                    if (OS_SUCCESS != wdb_global_set_sync_status(wdb, agent_id, "synced")) {
                         merror("Cannot set sync_status for agent %d", agent_id);
                         snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s %d", "Cannot set sync_status for agent", agent_id);
                         status = WDBC_ERROR;
@@ -1162,8 +1162,8 @@ int wdb_global_sync_agent_info_set(wdb_t *wdb,cJSON * json_agent){
     }
 
     index = sqlite3_bind_parameter_index(stmt, ":sync_status");
-    if (sqlite3_bind_int(stmt, index, WDB_SYNCED) != SQLITE_OK) {
-        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+    if (sqlite3_bind_text(stmt, index, "synced", -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -4271,8 +4271,7 @@ int wdb_parse_global_update_agent_version(wdb_t * wdb, char * input, char * outp
             char *manager_host = cJSON_IsString(j_manager_host) ? j_manager_host->valuestring : NULL;
             char *node_name = cJSON_IsString(j_node_name) ? j_node_name->valuestring : NULL;
             char *agent_ip = cJSON_IsString(j_agent_ip) ? j_agent_ip->valuestring : NULL;
-            wdb_sync_status_t sync_status = (cJSON_IsNumber(j_sync_status) && j_sync_status->valueint == 1) ? 
-                                            WDB_SYNC_REQ : WDB_SYNCED;
+            char *sync_status = cJSON_IsString(j_sync_status) ? j_sync_status->valuestring : "synced";
 
             if (OS_SUCCESS != wdb_global_update_agent_version(wdb, id, os_name, os_version, os_major, os_minor, os_codename,
                                                               os_platform, os_build, os_uname, os_arch, version, config_sum,
@@ -4392,10 +4391,10 @@ int wdb_parse_global_update_agent_keepalive(wdb_t * wdb, char * input, char * ou
         j_id = cJSON_GetObjectItem(agent_data, "id");
         j_sync_status = cJSON_GetObjectItem(agent_data, "sync_status");
 
-        if (cJSON_IsNumber(j_id) && cJSON_IsNumber(j_sync_status)) {
+        if (cJSON_IsNumber(j_id) && cJSON_IsString(j_sync_status)) {
             // Getting each field
             int id = j_id->valueint;
-            wdb_sync_status_t sync_status = (j_sync_status->valueint == 1) ? WDB_SYNC_REQ : WDB_SYNCED;
+            char *sync_status = j_sync_status->valuestring;
 
             if (OS_SUCCESS != wdb_global_update_agent_keepalive(wdb, id, sync_status)) {
                 mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB_GLOB_NAME, sqlite3_errmsg(wdb->db));

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -289,7 +289,7 @@ void wm_sync_manager() {
             }
         }
 
-        wdb_update_agent_version(0, os_name, os_version, os_major, os_minor, os_codename, os_platform, os_build, os_uname, os_arch, __ossec_name " " __ossec_version, NULL, NULL, hostname, node_name, NULL, WDB_SYNCED);
+        wdb_update_agent_version(0, os_name, os_version, os_major, os_minor, os_codename, os_platform, os_build, os_uname, os_arch, __ossec_name " " __ossec_version, NULL, NULL, hostname, node_name, NULL, "synced");
 
         free(node_name);
         free(os_major);


### PR DESCRIPTION
|Related issue|
|---|
|6023|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR migrates syncstatus columns of global.db from integer to TEXT with check constraints.
Adapts:
- Database difinition.
- Methods using it.
- Upgrade tasks.
- Unitests. 

## Tests
- [x] Integration tests for WazuhDB

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Valgrind (memcheck and descriptor leaks check)
