### PR TITLE
Check patches and other values are not null before inserting into the MSU DB

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -7204,7 +7204,9 @@ int wm_vulndet_insert_msu_vul_entry(sqlite3 *db, vu_msu_vul_entry *vul) {
 
         sqlite3_bind_text(stmt, 1, vul->cveid, -1, NULL);
         sqlite3_bind_text(stmt, 2, vul->product, -1, NULL);
-        sqlite3_bind_text(stmt, 3, strncmp(vul->patch, "KB", 2) ? vul->patch : vul->patch + 2, -1, NULL);
+        if (vul->patch) {
+            sqlite3_bind_text(stmt, 3, strncmp(vul->patch, "KB", 2) ? vul->patch : vul->patch + 2, -1, NULL);
+        }
         sqlite3_bind_text(stmt, 4, vul->title, -1, NULL);
         sqlite3_bind_text(stmt, 5, vul->url, -1, NULL);
         sqlite3_bind_text(stmt, 6, vul->subtype, -1, NULL);
@@ -7232,13 +7234,16 @@ int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_dep_entry *dep) {
             if (wm_vuldet_prepare(db, vu_queries[VU_INSERT_MSU_SUPER], -1, &stmt, NULL) != SQLITE_OK) {
                 return wm_vuldet_sql_error(db, stmt);
             }
+            if (dep->patch) {
+                sqlite3_bind_text(stmt, 1, strncmp(dep->patch, "KB", 2) ? dep->patch : dep->patch + 2, -1, NULL);
+            }
+            if (dep->supers[i]) {
+                sqlite3_bind_text(stmt, 2, strncmp(dep->supers[i], "KB", 2) ? dep->supers[i] : dep->supers[i] + 2, -1, NULL);
 
-            sqlite3_bind_text(stmt, 1, strncmp(dep->patch, "KB", 2) ? dep->patch : dep->patch + 2, -1, NULL);
-            sqlite3_bind_text(stmt, 2, strncmp(dep->supers[i], "KB", 2) ? dep->supers[i] : dep->supers[i] + 2, -1, NULL);
-
-            // A super can be a patch too, so non-duplicated ones will be added as rows
-            sqlite3_bind_text(stmt, 3, strncmp(dep->supers[i], "KB", 2) ? dep->supers[i] : dep->supers[i] + 2, -1, NULL);
-            sqlite3_bind_text(stmt, 4, strncmp(dep->supers[i], "KB", 2) ? dep->supers[i] : dep->supers[i] + 2, -1, NULL);
+                // A super can be a patch too, so non-duplicated ones will be added as rows
+                sqlite3_bind_text(stmt, 3, strncmp(dep->supers[i], "KB", 2) ? dep->supers[i] : dep->supers[i] + 2, -1, NULL);
+                sqlite3_bind_text(stmt, 4, strncmp(dep->supers[i], "KB", 2) ? dep->supers[i] : dep->supers[i] + 2, -1, NULL);
+            }
 
             if (result = wm_vuldet_step(stmt), result != SQLITE_DONE) {
                 return wm_vuldet_sql_error(db, stmt);


### PR DESCRIPTION
## Description
This PR is related to PR #5717 and it checks the patches and other values are not null before inserting into the MSU DB. In that way, we avoid the wazuh-modulesd fails when MSU JSON has invalid values.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Check unit tests (for new features)
