### PR TITLE
Read user, group, permissions and modification time information from registries

### DIFF
--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -280,7 +280,7 @@ const char *get_group(int gid);
 #else
 
 /**
- * @brief Retrieves the user name of the owner of a file in Windows.
+ * @brief Retrieves the user name of the owner of a file or registry in Windows.
  * Also sets the user ID associated to that user.
  *
  * @param path File or registry path to check the owner of.
@@ -324,6 +324,18 @@ int w_get_file_permissions(const char *file_path, char *permissions, int perm_si
  * @return The group name on success, an empty string on failure
  */
 const char *get_group(__attribute__((unused)) int gid);
+
+/**
+ * @brief Retrieves the group name and gid of a registry key.
+ * Also sets the group ID associated to that group.
+ *
+ * @param path Path of the registry key.
+ * @param sid The user ID associated to the user.
+ * @param hdnl Handle for the registry to check the owner of (NULL for files).
+ *
+ * @return The user name on success, NULL on failure.
+*/
+char *get_registry_group(const char *path, char **sid, HANDLE hdnl);
 
 /**
  * @brief Copy ACE information into buffer

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -280,14 +280,17 @@ const char *get_group(int gid);
 #else
 
 /**
- * @brief Retrieves the user name of the owner of a file in Windows
- * Also sets the user ID associated to that user
+ * @brief Retrieves the user name of the owner of a file in Windows.
+ * Also sets the user ID associated to that user.
  *
- * @param [in] path File path to check the owner of
- * @param [out] sid The user ID associated to the user
- * @return The user name on success, NULL on failure
+ * @param path File or registry path to check the owner of.
+ * @param sid The user ID associated to the user.
+ * @param hdnl Handle for the registry to check the owner of (NULL for files).
+ * @param entry_type Type of the entry to check the owner of (FIM_TYPE_FILE or FIM_TYPE_REGISTRY).
+ *
+ * @return The user name on success, NULL on failure.
  */
-char *get_user(const char *path, char **sid);
+char *get_user(const char *path, char **sid, HANDLE hdnl, fim_type entry_type);
 
 /**
  * @brief Check if a directory exists

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -280,17 +280,40 @@ const char *get_group(int gid);
 #else
 
 /**
+ * @brief Retrieves the user name of the owner of a registry in Windows.
+ * Also sets the user ID associated to that user.
+ *
+ * @param path Registry path to check the owner of.
+ * @param sid The user ID associated to the user.
+ * @param hndl Handle for the registry to check the owner of.
+ *
+ * @return The user name on success, NULL on failure.
+ */
+char *get_registry_user(const char *path, char **sid, HANDLE hndl);
+
+/**
+ * @brief Retrieves the user name of the owner of a file in Windows.
+ * Also sets the user ID associated to that user.
+ *
+ * @param path File path to check the owner of.
+ * @param sid The user ID associated to the user.
+ *
+ * @return The user name on success, NULL on failure.
+ */
+char *get_file_user(const char *path, char **sid);
+
+/**
  * @brief Retrieves the user name of the owner of a file or registry in Windows.
  * Also sets the user ID associated to that user.
  *
  * @param path File or registry path to check the owner of.
  * @param sid The user ID associated to the user.
- * @param hdnl Handle for the registry to check the owner of (NULL for files).
+ * @param hndl Handle of the file or registry to check the owner of (NULL for files).
  * @param entry_type Type of the entry to check the owner of (FIM_TYPE_FILE or FIM_TYPE_REGISTRY).
  *
  * @return The user name on success, NULL on failure.
  */
-char *get_user(const char *path, char **sid, HANDLE hdnl, fim_type entry_type);
+char *get_user(const char *path, char **sid, HANDLE hndl, fim_type entry_type);
 
 /**
  * @brief Check if a directory exists
@@ -329,24 +352,22 @@ const char *get_group(__attribute__((unused)) int gid);
  * @brief Retrieves the group name and gid of a registry key.
  * Also sets the group ID associated to that group.
  *
- * @param path Path of the registry key.
  * @param sid The user ID associated to the group.
- * @param hdnl Handle for the registry to check the group of.
+ * @param hndl Handle for the registry to check the group of.
  *
  * @return The user name on success, NULL on failure.
 */
-char *get_registry_group(const char *path, char **sid, HANDLE hdnl);
+char *get_registry_group(char **sid, HANDLE hndl);
 
 /**
  * @brief Retrieves the permissions of a registry key.
  *
- * @param path Path to the registry key.
- * @param hdnl Handle for the registry key to check the permissions of.
+ * @param hndl Handle for the registry key to check the permissions of.
  * @param perm_key Permissions associated to the registry key.
  *
- * @return Permissions in perm_key. -1 on failure, 0 on sucess.
+ * @return Permissions in perm_key. ERROR_SUCCESS on success, different otherwise
 */
-int get_registry_permissions(const char *path, HKEY hdnl, char *perm_key);
+DWORD get_registry_permissions(HKEY hndl, char *perm_key);
 
 /**
  * @brief Copy ACE information into buffer

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -309,11 +309,11 @@ char *get_file_user(const char *path, char **sid);
  * @param path File or registry path to check the owner of.
  * @param sid The user ID associated to the user.
  * @param hndl Handle of the file or registry to check the owner of (NULL for files).
- * @param entry_type Type of the entry to check the owner of (FIM_TYPE_FILE or FIM_TYPE_REGISTRY).
+ * @param object_type Type of the object to check the owner of (SE_FILE_OBJECT or SE_REGISTRY_KEY).
  *
  * @return The user name on success, NULL on failure.
  */
-char *get_user(const char *path, char **sid, HANDLE hndl, fim_type entry_type);
+char *get_user(const char *path, char **sid, HANDLE hndl, SE_OBJECT_TYPE object_type);
 
 /**
  * @brief Check if a directory exists

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -370,15 +370,6 @@ char *get_registry_group(char **sid, HANDLE hndl);
 DWORD get_registry_permissions(HKEY hndl, char *perm_key);
 
 /**
- * @brief Convert FILETIME time format to POSIX.
- *
- * @param ft Time in FILETIME format.
- *
- * @return Time in POSIX format.
-*/
-unsigned int FILETIME_to_POSIX(FILETIME ft);
-
-/**
  * @brief Get last modification time from registry key.
  *
  * @param hndl Handle for the registry key to check the permissions of.

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -330,12 +330,23 @@ const char *get_group(__attribute__((unused)) int gid);
  * Also sets the group ID associated to that group.
  *
  * @param path Path of the registry key.
- * @param sid The user ID associated to the user.
- * @param hdnl Handle for the registry to check the owner of (NULL for files).
+ * @param sid The user ID associated to the group.
+ * @param hdnl Handle for the registry to check the group of.
  *
  * @return The user name on success, NULL on failure.
 */
 char *get_registry_group(const char *path, char **sid, HANDLE hdnl);
+
+/**
+ * @brief Retrieves the permissions of a registry key.
+ *
+ * @param path Path to the registry key.
+ * @param hdnl Handle for the registry key to check the permissions of.
+ * @param perm_key Permissions associated to the registry key.
+ *
+ * @return Permissions in perm_key. -1 on failure, 0 on sucess.
+*/
+int get_registry_permissions(const char *path, HKEY hdnl, char *perm_key);
 
 /**
  * @brief Copy ACE information into buffer

--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -370,6 +370,24 @@ char *get_registry_group(char **sid, HANDLE hndl);
 DWORD get_registry_permissions(HKEY hndl, char *perm_key);
 
 /**
+ * @brief Convert FILETIME time format to POSIX.
+ *
+ * @param ft Time in FILETIME format.
+ *
+ * @return Time in POSIX format.
+*/
+unsigned int FILETIME_to_POSIX(FILETIME ft);
+
+/**
+ * @brief Get last modification time from registry key.
+ *
+ * @param hndl Handle for the registry key to check the permissions of.
+ *
+ * @return Last modification time of registry key in POSIX format.
+*/
+unsigned int get_registry_mtime(HKEY hndl);
+
+/**
  * @brief Copy ACE information into buffer
  *
  * @param [in] ace ACE structure

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -703,7 +703,7 @@ fim_file_data * fim_get_data(const char *file, fim_element *item) {
 
 #ifdef WIN32
     if (item->configuration & CHECK_OWNER) {
-        data->user_name = get_user(file, &data->uid, NULL, FIM_TYPE_FILE);
+        data->user_name = get_file_user(file, &data->uid);
     }
 #else
     if (item->configuration & CHECK_OWNER) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -703,7 +703,7 @@ fim_file_data * fim_get_data(const char *file, fim_element *item) {
 
 #ifdef WIN32
     if (item->configuration & CHECK_OWNER) {
-        data->user_name = get_user(file, &data->uid);
+        data->user_name = get_user(file, &data->uid, NULL, FIM_TYPE_FILE);
     }
 #else
     if (item->configuration & CHECK_OWNER) {

--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -197,6 +197,17 @@ fim_registry_key *fim_registry_get_key_data(HKEY key_handle, const char *path, c
         key->group_name = get_registry_group(path, &key->gid, key_handle);
     }
 
+    if (configuration->opts & CHECK_PERM) {
+        char permissions[OS_SIZE_6144 + 1];
+
+        if (get_registry_permissions(path, key_handle, permissions) == -1) {
+            mwarn(FIM_EXTRACT_PERM_FAIL, path, -1);
+        }
+        else {
+            key->perm = decode_win_permissions(permissions);
+        }
+    }
+
     return key;
 }
 

--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -190,20 +190,22 @@ fim_registry_key *fim_registry_get_key_data(HKEY key_handle, const char *path, c
     os_calloc(1, sizeof(fim_registry_key), key);
 
     if (configuration->opts & CHECK_OWNER) {
-        key->user_name = get_user(path, &key->uid, key_handle, FIM_TYPE_REGISTRY);
+        key->user_name = get_registry_user(path, &key->uid, key_handle);
     }
 
     if (configuration->opts & CHECK_GROUP) {
-        key->group_name = get_registry_group(path, &key->gid, key_handle);
+        key->group_name = get_registry_group(&key->gid, key_handle);
     }
 
     if (configuration->opts & CHECK_PERM) {
         char permissions[OS_SIZE_6144 + 1];
+        int retval = 0;
 
-        if (get_registry_permissions(path, key_handle, permissions) == -1) {
-            mwarn(FIM_EXTRACT_PERM_FAIL, path, -1);
-        }
-        else {
+        retval = get_registry_permissions(key_handle, permissions);
+
+        if (retval != ERROR_SUCCESS) {
+            mwarn(FIM_EXTRACT_PERM_FAIL, path, retval);
+        } else {
             key->perm = decode_win_permissions(permissions);
         }
     }

--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -189,7 +189,12 @@ fim_registry_key *fim_registry_get_key_data(HKEY key_handle, const char *path, c
 
     os_calloc(1, sizeof(fim_registry_key), key);
 
-    if (configuration->opts & CHECK_OWNER) {
+    os_calloc(MAX_KEY, sizeof(char), key->path);
+    snprintf(key->path, MAX_KEY, "%s", path);
+
+    key->arch = configuration->arch;
+
+     if (configuration->opts & CHECK_OWNER) {
         key->user_name = get_registry_user(path, &key->uid, key_handle);
     }
 
@@ -226,8 +231,18 @@ void fim_registry_free_key(fim_registry_key *key) {
     if (key) {
         os_free(key->path);
         os_free(key->perm);
-        os_free(key->uid);
-        os_free(key->gid);
+
+        // UID and GID need to be freed with the LocalFree function according to ConvertSidToStringSid documentation
+        if (key->uid) {
+            LocalFree(key->uid);
+            key->uid = NULL;
+        }
+
+        if (key->gid) {
+            LocalFree(key->gid);
+            key->gid = NULL;
+        }
+
         os_free(key->user_name);
         os_free(key->group_name);
         free(key);

--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -193,6 +193,10 @@ fim_registry_key *fim_registry_get_key_data(HKEY key_handle, const char *path, c
         key->user_name = get_user(path, &key->uid, key_handle, FIM_TYPE_REGISTRY);
     }
 
+    if (configuration->opts & CHECK_GROUP) {
+        key->group_name = get_registry_group(path, &key->gid, key_handle);
+    }
+
     return key;
 }
 

--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -185,7 +185,15 @@ int fim_registry_validate_path(const char *entry_path, const registry *configura
  * @return A fim_registry_key object holding the information from the queried key, NULL on error.
  */
 fim_registry_key *fim_registry_get_key_data(HKEY key_handle, const char *path, const registry *configuration) {
-    return NULL;
+    fim_registry_key *key;
+
+    os_calloc(1, sizeof(fim_registry_key), key);
+
+    if (configuration->opts & CHECK_OWNER) {
+        key->user_name = get_user(path, &key->uid, key_handle, FIM_TYPE_REGISTRY);
+    }
+
+    return key;
 }
 
 /**

--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -210,6 +210,10 @@ fim_registry_key *fim_registry_get_key_data(HKEY key_handle, const char *path, c
         }
     }
 
+    if (configuration->opts & CHECK_MTIME) {
+        key->mtime = get_registry_mtime(key_handle);
+    }
+
     return key;
 }
 


### PR DESCRIPTION
| Related issue  |
|---------------|
| #4223             |

## Description

This pull request adds the functionality of reading user name, user id, group name, group id and permissions to Windows registries.

The reading of the user name and id is done in the already present `get_user` function. I have modified it to read information from both files and registries:
https://github.com/wazuh/wazuh/blob/5375f4ae6f29c91dff2bfef46a993f2fef9efc14/src/headers/syscheck_op.h#L293

The reading of the group name and id is done in a new function: `get_registry_group`. This function, in the case that the group name is returned as `"None"`, will change it to an empty string (`""`):
https://github.com/wazuh/wazuh/blob/5375f4ae6f29c91dff2bfef46a993f2fef9efc14/src/headers/syscheck_op.h#L338

Finally, for the permissions, I have added another new function, `get_registry_permissions`:
https://github.com/wazuh/wazuh/blob/5375f4ae6f29c91dff2bfef46a993f2fef9efc14/src/headers/syscheck_op.h#L349

The three functions return the values they obtain into a `fim_registry_key` structure in the `fim_registry_get_key_data` function.

This pull request closes #4223.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [x] Scan-build report
