### PR TITLE
Allow upgrading pip to the latest version

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1669,6 +1669,7 @@ install_python:
 python_dependencies := requirements.txt
 
 install_dependencies: install_python
+	${WPYTHON_DIR}/bin/pip3 install --upgrade pip --index-url=file://${ROUTE_PATH}/${EXTERNAL_CPYTHON}/Dependencies/simple
 	LD_LIBRARY_PATH="${PREFIX}/lib" LDFLAGS="-L${PREFIX}/lib" ${WPYTHON_DIR}/bin/pip3 install -r ../framework/${python_dependencies}  --index-url=file://${ROUTE_PATH}/${EXTERNAL_CPYTHON}/Dependencies/simple
 
 install_framework: install_python


### PR DESCRIPTION
Hi team,

To solve some issues related to the installation of external dependencies, we need to upgrade `pip` package before installing any other dependency. This affects to ARM architectures, where we've compiled custom `manylinux` packages to improve the compatibility and portability of the binary packages.

Regards.