### PR TITLE
Refactor and update agent-info synchronization process in cluster.

### DIFF
--- a/framework/scripts/cluster_control.py
+++ b/framework/scripts/cluster_control.py
@@ -111,10 +111,8 @@ async def print_health(config, more, filter_node):
             msg2 += "                Last synchronization: {0} - {1}.\n".format(
                 node_info['status']['last_sync_agentinfo']['date_start_master'],
                 node_info['status']['last_sync_agentinfo']['date_end_master'])
-            msg2 += "                Synchronized files: {}.\n".format(
+            msg2 += "                Number of synchronized chunks: {}.\n".format(
                 str(node_info['status']['last_sync_agentinfo']['total_agentinfo']))
-            msg2 += "                Permission to synchronize: {}.\n".format(
-                str(node_info['status']['sync_agentinfo_free']))
 
             # Agent groups
             msg2 += "            Agents-group\n"

--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -66,19 +66,6 @@
             "description": "user CDB lists"
         },
 
-        "/queue/agent-info/": {
-            "permissions": "0o660",
-            "source": "worker",
-            "files": [
-                "agent-info.merged"
-            ],
-            "recursive": false,
-            "restart": false,
-            "remove_subdirs_if_empty": false,
-            "extra_valid": false,
-            "description": "agent status"
-        },
-
         "/queue/agent-groups/": {
             "permissions": "0o660",
             "source": "master",

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -627,10 +627,10 @@ class SendSyncRequestQueue(WazuhRequestQueue):
             node = self.server.clients[names[0]]
             try:
                 request = json.loads(request, object_hook=c_common.as_wazuh_object)
-                self.logger.info("Receiving SendSync request ({}) from {} ({})".format(
+                self.logger.debug("Receiving SendSync request ({}) from {} ({})".format(
                     request['daemon_name'], names[0], names[1]))
                 result = await wazuh_sendsync(**request)
-                task_id = await node.send_string(json.dumps(result, cls=c_common.WazuhJSONEncoder).encode())
+                task_id = await node.send_string(result.encode())
             except Exception as e:
                 self.logger.error("Error in SendSync: {}".format(e), exc_info=True)
                 task_id = b'Error in SendSync: ' + str(e).encode()

--- a/framework/wazuh/core/cluster/local_client.py
+++ b/framework/wazuh/core/cluster/local_client.py
@@ -124,7 +124,7 @@ class LocalClient(client.AbstractClientManager):
                                                                                          fernet_key='', manager=self,
                                                                                          cluster_items=self.cluster_items),
                                              path='{}/queue/cluster/c-internal.sock'.format(common.ossec_path))
-        except ConnectionRefusedError:
+        except (ConnectionRefusedError, FileNotFoundError):
             raise exception.WazuhInternalError(3012)
         except MemoryError:
             raise exception.WazuhInternalError(1119)

--- a/framework/wazuh/core/cluster/local_client.py
+++ b/framework/wazuh/core/cluster/local_client.py
@@ -52,6 +52,12 @@ class LocalClientHandler(client.AbstractClient):
             self.response = self.in_str[data].payload
             self.response_available.set()
             return b'ok', b'Distributed api response received'
+        elif command == b'ok':
+            if data.startswith(b'Error'):
+                return b'err', self.process_error_from_peer(data)
+            self.response = data
+            self.response_available.set()
+            return b'ok', b'Sendsync response received'
         elif command == b'control_res':
             if data.startswith(b'Error'):
                 return b'err', self.process_error_from_peer(data)
@@ -62,6 +68,10 @@ class LocalClientHandler(client.AbstractClient):
             self.response = data
             self.response_available.set()
             return b'ok', b'Response received'
+        elif command == b'err':
+            self.response = data
+            self.response_available.set()
+            return b'ok', b'Error response received'
         else:
             return super().process_request(command, data)
 
@@ -114,7 +124,7 @@ class LocalClient(client.AbstractClientManager):
                                                                                          fernet_key='', manager=self,
                                                                                          cluster_items=self.cluster_items),
                                              path='{}/queue/cluster/c-internal.sock'.format(common.ossec_path))
-        except (ConnectionRefusedError, FileNotFoundError):
+        except ConnectionRefusedError:
             raise exception.WazuhInternalError(3012)
         except MemoryError:
             raise exception.WazuhInternalError(1119)
@@ -134,8 +144,8 @@ class LocalClient(client.AbstractClientManager):
         if result == 'There are no connected worker nodes':
             request_result = {}
         else:
-            if command == b'dapi' or command == b'dapi_forward' or command == b'send_file' or \
-                    result == 'Sent request to master node':
+            if command == b'dapi' or command == b'dapi_forward' or command == b'send_file' or command == b'sendasync' \
+                    or result == 'Sent request to master node':
                 try:
                     timeout = None if wait_for_complete \
                         else self.cluster_items['intervals']['communication']['timeout_api_request']

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -32,7 +32,7 @@ class LocalServerHandler(server.AbstractServerHandler):
         self.tag = "Local " + self.name
         # modify filter tags with context vars
         context_tag.set(self.tag)
-        self.logger.info('Connection received in local server.')
+        self.logger.debug('Connection received in local server.')
 
     def process_request(self, command: bytes, data: bytes) -> Tuple[bytes, bytes]:
         """
@@ -254,6 +254,11 @@ class LocalServerHandlerWorker(LocalServerHandler):
                 raise WazuhClusterError(3023)
             asyncio.create_task(self.server.node.client.send_request(b'sendsync', self.name.encode() + b' ' + data))
             return None, None
+        elif command == b'sendasync':
+            if self.server.node.client is None:
+                raise WazuhClusterError(3023)
+            asyncio.create_task(self.server.node.client.send_request(b'sendsync', self.name.encode() + b' ' + data))
+            return b'ok', b'Added request to sendsync requests queue'
         else:
             return super().process_request(command, data)
 

--- a/framework/wazuh/core/cluster/server.py
+++ b/framework/wazuh/core/cluster/server.py
@@ -126,7 +126,7 @@ class AbstractServerHandler(c_common.Handler):
         """
         if self.name:
             if exc is None:
-                self.logger.info("Disconnected.".format(self.name))
+                self.logger.debug("Disconnected.".format(self.name))
             else:
                 self.logger.error(f"Error during connection with '{self.name}': {exc}.\n"
                                   f"{''.join(traceback.format_tb(exc.__traceback__))}")

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -6,7 +6,7 @@ import logging
 import os
 import subprocess
 import sys
-from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import patch, mock_open, MagicMock, call
 
 import pytest
 import uvloop
@@ -114,8 +114,7 @@ def test_remove_bulk_agents(isdir_mock, connection_mock, agents_mock, glob_mock,
     """
     agents_mock.return_value = {'totalItems': len(agents_to_remove),
                                 'items': [{'id': a_id, 'ip': '0.0.0.0', 'name': 'test'} for a_id in agents_to_remove]}
-    files_to_remove = [common.ossec_path + '/queue/agent-info/{name}-{ip}',
-                       common.ossec_path + '/queue/rootcheck/({name}) {ip}->rootcheck',
+    files_to_remove = [common.ossec_path + '/queue/rootcheck/({name}) {ip}->rootcheck',
                        common.ossec_path + '/queue/diff/{name}', common.ossec_path + '/queue/agent-groups/{id}',
                        common.ossec_path + '/queue/rids/{id}', common.ossec_path + '/var/db/agents/{name}-{id}.db',
                        'global.db']
@@ -139,7 +138,7 @@ asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 loop = asyncio.new_event_loop()
 current_path_logger = os.path.join(os.path.dirname(__file__), 'testing.log')
 logging.basicConfig(filename=current_path_logger, level=logging.DEBUG)
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('test')
 
 
 def get_worker_handler():
@@ -167,14 +166,12 @@ def test_ReceiveIntegrityTask():
 
 
 @pytest.mark.asyncio
-async def test_SyncWorker():
-    def get_last_logger_line():
-        return subprocess.check_output(['tail', '-1', current_path_logger])
-
+async def test_SyncWorker(caplog):
     async def check_message(mock, expected_message):
         with patch('wazuh.core.cluster.common.Handler.send_request', new=AsyncMock(return_value=mock)):
-            await sync_worker.sync()
-            assert get_last_logger_line().decode() == expected_message
+            with caplog.at_level(logging.DEBUG):
+                await sync_worker.sync()
+                assert caplog.records[-1].message == expected_message
 
     worker_handler = get_worker_handler()
 
@@ -182,24 +179,84 @@ async def test_SyncWorker():
                                     logger=logger, worker=worker_handler)
 
     send_request_mock = KeyError(1)
-    await check_message(mock=send_request_mock, expected_message=f"ERROR:wazuh:Error asking for permission: "
-                                                                 f"{str(send_request_mock)}\n")
-    await check_message(mock=b'False', expected_message="INFO:wazuh:Master didnt grant permission to synchronize\n")
-    await check_message(mock=b'True', expected_message="INFO:wazuh:Worker files sent to master\n")
+    await check_message(mock=send_request_mock, expected_message=f"Error asking for permission: 1")
+    await check_message(mock=b'False', expected_message="Master didnt grant permission to synchronize")
+    await check_message(mock=b'True', expected_message="Worker files sent to master")
 
     error = WazuhException(1001)
     with patch('wazuh.core.cluster.common.Handler.send_request', new=AsyncMock(return_value=b'True')):
         with patch('wazuh.core.cluster.common.Handler.send_file', new=AsyncMock(side_effect=error)):
             await sync_worker.sync()
-            assert b'ERROR:wazuh:Error sending files information' in get_last_logger_line()
+            assert 'Error sending files information' in caplog.records[-1].message
 
     error = KeyError(1)
     with patch('wazuh.core.cluster.common.Handler.send_request', new=AsyncMock(return_value=b'True')):
         with patch('wazuh.core.cluster.common.Handler.send_file', new=AsyncMock(side_effect=error)):
             await sync_worker.sync()
-            assert b'ERROR:wazuh:Error sending files information' in get_last_logger_line()
+            assert 'Error sending files information' in caplog.records[-1].message
 
-    os.remove(current_path_logger)
+
+@pytest.mark.asyncio
+async def test_SyncInfo(caplog):
+    async def check_message(expected_messages, *args, **kwargs):
+        with caplog.at_level(logging.DEBUG):
+            await sync_worker.sync(*args, **kwargs)
+            for i, expected_message in enumerate(expected_messages):
+                assert caplog.records[-(i+1)].message == expected_message
+
+    worker_handler = get_worker_handler()
+
+    # Test if data_retriever exceptions are handled
+    sync_worker = worker.SyncInfo(worker=worker_handler, daemon='test', logger=logger,
+                                  data_retriever=lambda: exec('raise(WazuhException(1000))'))
+    await check_message(expected_messages=["Error obtaining data: Error 1000 - Wazuh Internal Error",
+                                           "Obtaining data to be sent to master's test."])
+
+    # Test params used in data_retriever are correct
+    data_mock = MagicMock()
+    sync_worker = worker.SyncInfo(worker=worker_handler, daemon='test', logger=logger, data_retriever=data_mock)
+    await check_message(expected_messages=[], command='global sql test')
+    data_mock.assert_called_once_with(command='global sql test')
+
+    # Test expected exception is raised when calling LocalClient.execute().
+    sync_worker = worker.SyncInfo(worker=worker_handler, daemon='test', logger=logger, data_retriever=lambda: ['test'])
+    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=WazuhException(1000)):
+        await check_message(expected_messages=["Finished sending information to test (0 chunks sent).",
+                                               "Error sending information to test: Error 1000 - Wazuh Internal Error"])
+
+    # Test successful workflow for 2 chunks
+    sync_worker = worker.SyncInfo(worker=worker_handler, daemon='test', logger=logger,
+                                  msg_format='test_format {payload}', data_retriever=lambda: ['test1', 'test2'])
+    with patch('wazuh.core.cluster.local_client.LocalClient.execute', return_value='ok') as mock_lc:
+        await check_message(expected_messages=["Finished sending information to test (2 chunks sent).",
+                                               "Master's test response: ok.",
+                                               "Master's test response: ok.",
+                                               "Starting sending information to test."])
+        calls = [call(command=b'sendasync', data=b'{"daemon_name": "test", "message": "test_format test1"}',
+                      wait_for_complete=False),
+                 call(command=b'sendasync', data=b'{"daemon_name": "test", "message": "test_format test2"}',
+                      wait_for_complete=False)]
+        mock_lc.assert_has_calls(calls)
+
+    # Test unsuccessful workflow for 1 chunks
+    sync_worker = worker.SyncInfo(worker=worker_handler, daemon='test', logger=logger, expected_res='test_res',
+                                  n_retries=1, data_retriever=lambda: ['test1'], cmd=b'sync_a_m_w')
+    with patch('wazuh.core.cluster.local_client.LocalClient.execute', return_value='ok') as mock_lc:
+        with patch('wazuh.core.cluster.common.Handler.send_request', return_value='ok'):
+            await check_message(expected_messages=["Finished sending information to test (0 chunks sent).",
+                                                   "Master response for b'sync_a_m_w_e' command: ok",
+                                                   "Master's test response: ok.",
+                                                   "Response does not start with test_res. Retrying... 0.",
+                                                   "Master's test response: ok.",
+                                                   "Starting sending information to test.",
+                                                   "Master response for b'sync_a_m_w_s' command: ok",
+                                                   "Obtained 1 chunks of data to be sent.",
+                                                   "Obtaining data to be sent to master's test."])
+            calls = [
+                call(command=b'sendasync', data=b'{"daemon_name": "test", "message": "test1"}', wait_for_complete=False),
+                call(command=b'sendasync', data=b'{"daemon_name": "test", "message": "test1"}', wait_for_complete=False)
+            ]
+            mock_lc.assert_has_calls(calls)
 
 
 def test_WorkerHandler():

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -16,6 +16,7 @@ import wazuh.core.cluster.cluster
 from wazuh.core import cluster as metadata, common, exception, utils
 from wazuh.core.agent import Agent
 from wazuh.core.cluster import client, common as c_common
+from wazuh.core.cluster import local_client
 from wazuh.core.cluster.dapi import dapi
 from wazuh.core.database import Connection
 from wazuh.core.exception import WazuhClusterError, WazuhInternalError
@@ -38,7 +39,7 @@ class ReceiveIntegrityTask(c_common.ReceiveFileTask):
 
 class SyncWorker:
     """
-    Defines methods to synchronize files with master
+    Define methods to synchronize files with master
     """
     def __init__(self, cmd: bytes, files_to_sync: Dict, checksums: Dict, logger, worker):
         """
@@ -59,7 +60,7 @@ class SyncWorker:
 
     async def sync(self):
         """
-        Starts synchronization process with the master and sends necessary information
+        Start synchronization process with the master and send necessary information
         """
         result = await self.worker.send_request(command=self.cmd+b'_p', data=b'')
         if isinstance(result, Exception):
@@ -96,6 +97,123 @@ class SyncWorker:
             result = await self.worker.send_request(command=self.cmd+b'_r', data=task_id + b' ' + exc_info)
         finally:
             os.unlink(compressed_data_path)
+
+
+class RetrieveAndSendToMaster:
+    """
+    Define methods to send information to self.daemon in the master through sendsync command.
+    """
+
+    def __init__(self, worker, destination_daemon, data_retriever: callable, logger=None, msg_format='{payload}',
+                 n_retries=3, max_retry_time_allowed=10, cmd=None, expected_res='ok'):
+        """Class constructor
+
+        Parameters
+        ----------
+        worker : WorkerHandler object
+            Instance of worker object
+        destination_daemon : str
+            Daemon name on the master node to which send information.
+        cmd : bytes
+            Command to inform the master when the synchronization process starts and ends.
+        data_retriever : Callable
+            Function to be called to obtain chunks of data. It must return a list of chunks.
+        logger : Logging object
+             Logger to use during synchronization process.
+        msg_format : str
+            Format of the message to be executed in the master's daemon. It must
+            contain the label '{payload}', which will be replaced with every chunk of data.
+            I. e: 'global sync-agent-info-set {payload}'
+        n_retries : int
+            Number of times a chunk has to be resent when it fails.
+        max_retry_time_allowed : int
+            Maximum total time allowed to retry failed requests. If this time has already been
+            elapsed, no new attempts will be made to resend all the chunks which response
+            does not begin with {expected_res}.
+        expected_res : str
+            Master's response that will be interpreted as correct. If it doesn't match,
+            send retries will be made.
+        """
+        self.worker = worker
+        self.daemon = destination_daemon
+        self.msg_format = msg_format
+        self.data_retriever = data_retriever
+        self.logger = logger if logger is not None else self.worker.setup_task_logger('Default logger')
+        self.n_retries = n_retries
+        self.max_retry_time_allowed = max_retry_time_allowed
+        self.cmd = cmd
+        self.expected_res = expected_res
+        self.lc = local_client.LocalClient()
+
+    async def retrieve_and_send(self, *args, **kwargs):
+        """Start synchronization process with the master and send necessary information
+
+        This method retrieves a list of payloads/chunks from self.data_retriever(*args, **kwargs).
+        The chunks are sent one by one through sendsync command.
+
+        Parameters
+        ----------
+        *args
+            Variable length argument list to be sent as parameter to data_retriever callable
+        **kwargs
+            Arbitrary keyword arguments to be sent as parameter to data_retriever callable.
+        """
+        self.logger.info(f"Obtaining data to be sent to master's {self.daemon}.")
+        try:
+            chunks_to_send = self.data_retriever(*args, **kwargs)
+            self.logger.debug(f"Obtained {len(chunks_to_send)} chunks of data to be sent.")
+        except exception.WazuhException as e:
+            self.logger.error(f"Error obtaining data: {e}")
+            return
+
+        if self.cmd:
+            # Send command to master so it knows when the task starts
+            result = await self.worker.send_request(command=self.cmd + b'_s', data=b'')
+            self.logger.debug(f"Master response for {self.cmd+b'_s'} command: {result}")
+
+        chunks_sent = 0
+        start_time = time.time()
+
+        self.logger.info(f"Starting to send information to {self.daemon}.")
+        for chunk in chunks_to_send:
+            data = json.dumps({
+                'daemon_name': self.daemon,
+                'message': self.msg_format.format(payload=chunk)
+            }).encode()
+
+            try:
+                # Send chunk of data to self.daemon of the master
+                result = await self.lc.execute(command=b'sendasync', data=data, wait_for_complete=False)
+                self.logger.debug(f"Master's {self.daemon} response: {result}.")
+
+                # Retry self.n_retries if result was not ok
+                if not result.startswith(self.expected_res):
+                    if (time.time() - start_time) < self.max_retry_time_allowed:
+                        for i in range(self.n_retries):
+                            await asyncio.sleep(i * (len(chunks_to_send)/self.max_retry_time_allowed))
+                            self.logger.error(f"Error sending chunk to master's {self.daemon}. Response does not start "
+                                              f"with {self.expected_res}. Retrying... {i}.")
+                            result = await self.lc.execute(command=b'sendasync', data=data, wait_for_complete=False)
+                            self.logger.debug(f"Master's {self.daemon} response: {result}.")
+                            if result.startswith(self.expected_res):
+                                chunks_sent += 1
+                                break
+                    else:
+                        self.logger.error(f"Error sending chunk to master's {self.daemon}. Response does not start "
+                                          f"with {self.expected_res}. Not retrying because total time exceeded "
+                                          f"{self.max_retry_time_allowed} seconds.")
+                else:
+                    chunks_sent += 1
+
+            except exception.WazuhException as e:
+                self.logger.error(f"Error sending information to {self.daemon}: {e}")
+
+        if self.cmd:
+            # Send command to master so it knows when the task stops
+            result = await self.worker.send_request(command=self.cmd + b'_e', data=str(chunks_sent).encode())
+            self.logger.debug(f"Master response for {self.cmd+b'_e'} command: {result}")
+
+        self.logger.info(f"Finished sending information to {self.daemon} ({chunks_sent} chunks sent).")
 
 
 class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
@@ -249,25 +367,21 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         :return: None
         """
         agent_info_logger = self.task_loggers["Agent info"]
+        wdb_conn = WazuhDBConnection()
+        agent_info = RetrieveAndSendToMaster(worker=self, destination_daemon='wazuh-db', logger=agent_info_logger,
+                                             msg_format='global sync-agent-info-set {payload}', cmd=b'sync_a_w_m',
+                                             data_retriever=wdb_conn.run_wdb_command, max_retry_time_allowed=
+                                             self.cluster_items['intervals']['worker']['sync_files'])
+
         while True:
             try:
                 if self.connected:
+                    agent_info_logger.info("Starting agent-info sync process.")
                     before = time.time()
-                    agent_info_logger.info("Starting to send agent status files")
-                    worker_files = wazuh.core.cluster.cluster.get_files_status('worker', self.name, get_md5=False)
-                    await SyncWorker(cmd=b'sync_a_w_m', files_to_sync=worker_files, checksums=worker_files,
-                                     logger=agent_info_logger, worker=self).sync()
-                    after = time.time()
-                    agent_info_logger.debug2("Time synchronizing agent statuses: {} s".format(after - before))
-            except exception.WazuhException as e:
-                agent_info_logger.error("Error synchronizing agent status files: {}".format(e))
-                res = await self.send_request(command=b'sync_a_w_m_r',
-                                              data=json.dumps(e, cls=c_common.WazuhJSONEncoder).encode())
+                    await agent_info.retrieve_and_send('global sync-agent-info-get ')
+                    agent_info_logger.debug2("Time synchronizing agent statuses: {} s".format(time.time() - before))
             except Exception as e:
-                agent_info_logger.error("Error synchronizing agent status files: {}".format(e))
-                exc_info = json.dumps(exception.WazuhClusterError(code=1000, extra_message=str(e)),
-                                      cls=c_common.WazuhJSONEncoder)
-                res = await self.send_request(command=b'sync_a_w_m_r', data=exc_info.encode())
+                agent_info_logger.error("Error synchronizing agent info: {}".format(e))
 
             await asyncio.sleep(self.cluster_items['intervals']['worker']['sync_files'])
 
@@ -377,17 +491,15 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
 
         logger.info("Removing files from {} agents".format(len(agent_ids_list)))
         logger.debug("Agents to remove: {}".format(', '.join(agent_ids_list)))
-        # the agents must be removed in groups of 997: 999 is the limit of SQL variables per query. Limit and offset are
-        # always included in the SQL query, so that leaves 997 variables as limit.
-        for agents_ids_sublist in itertools.zip_longest(*itertools.repeat(iter(agent_ids_list), 997), fillvalue='0'):
+        # Remove agents in group of 500 elements (so wazuh-db socket is not saturated)
+        for agents_ids_sublist in itertools.zip_longest(*itertools.repeat(iter(agent_ids_list), 500), fillvalue='0'):
             agents_ids_sublist = list(filter(lambda x: x != '0', agents_ids_sublist))
             # Get info from DB
             agent_info = Agent.get_agents_overview(q=",".join(["id={}".format(i) for i in agents_ids_sublist]),
                                                    select=['ip', 'id', 'name'], limit=None)['items']
             logger.debug2("Removing files from agents {}".format(', '.join(agents_ids_sublist)))
 
-            files_to_remove = ['{ossec_path}/queue/agent-info/{name}-{ip}',
-                               '{ossec_path}/queue/rootcheck/({name}) {ip}->rootcheck',
+            files_to_remove = ['{ossec_path}/queue/rootcheck/({name}) {ip}->rootcheck',
                                '{ossec_path}/queue/diff/{name}', '{ossec_path}/queue/agent-groups/{id}',
                                '{ossec_path}/queue/rids/{id}',
                                '{ossec_path}/var/db/agents/{name}-{id}.db']
@@ -395,19 +507,12 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
 
             logger.debug2("Removing agent group assigments from database")
             # remove agent from groups
-            db_global = glob.glob(common.database_path_global)
-            if not db_global:
-                raise WazuhInternalError(1600)
-
-            conn = Connection(db_global[0])
-            agent_ids_db = {'id_agent{}'.format(i): int(i) for i in agents_ids_sublist}
-            conn.execute('delete from belongs where {}'.format(
-                ' or '.join(['id_agent = :{}'.format(i) for i in agent_ids_db.keys()])), agent_ids_db)
-            conn.commit()
-
-            # Tell wazuhbd to delete agent database
             wdb_conn = WazuhDBConnection()
-            wdb_conn.delete_agents_db(agents_ids_sublist)
+
+            query_to_execute = 'global sql delete from belongs where {}'.format(' or '.join([
+                'id_agent = {}'.format(agent_id) for agent_id in agents_ids_sublist
+            ]))
+            wdb_conn.run_wdb_command(query_to_execute)
 
         logger.info("Agent files removed")
 

--- a/framework/wazuh/core/tests/test_wdb.py
+++ b/framework/wazuh/core/tests/test_wdb.py
@@ -2,11 +2,17 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+from struct import pack
 from unittest.mock import patch
+
 import pytest
 
 from wazuh.core import exception
 from wazuh.core.wdb import WazuhDBConnection
+
+
+def format_msg(msg):
+    return pack('<I', len(bytes(msg)))
 
 
 def test_failed_connection():
@@ -32,7 +38,7 @@ def test_wrong_character_encodings_wdb(send_mock, connect_mock):
     """
     def recv_mock(size_to_receive):
         bad_string = b' {"bad": "\x96bad"}'
-        return bytes(len(bad_string)) if size_to_receive == 4 else bad_string
+        return format_msg(bad_string) if size_to_receive == 4 else bad_string
 
     with patch('socket.socket.recv', side_effect=recv_mock):
         mywdb = WazuhDBConnection()
@@ -48,7 +54,7 @@ def test_null_values_are_removed(send_mock, connect_mock):
     """
     def recv_mock(size_to_receive):
         nulls_string = b' {"a": "a", "b": "(null)", "c": [1, 2, 3], "d": {"e": "(null)"}}'
-        return bytes(len(nulls_string)) if size_to_receive == 4 else nulls_string
+        return format_msg(nulls_string) if size_to_receive == 4 else nulls_string
 
     with patch('socket.socket.recv', side_effect=recv_mock):
         mywdb = WazuhDBConnection()
@@ -64,7 +70,7 @@ def test_failed_send_private(send_mock, connect_mock):
     """
     def recv_mock(size_to_receive):
         error_string = b'err {"agents": {"001": "Error"}}'
-        return bytes(len(error_string)) if size_to_receive == 4 else error_string
+        return format_msg(error_string) if size_to_receive == 4 else error_string
 
     with patch('socket.socket.recv', side_effect=recv_mock):
         mywdb = WazuhDBConnection()
@@ -85,7 +91,7 @@ def test_remove_agents_database(send_mock, connect_mock, content):
     Tests delete_agents_db method handle exceptions properly
     """
     def recv_mock(size_to_receive):
-        return bytes(len(content)) if size_to_receive == 4 else content
+        return format_msg(content) if size_to_receive == 4 else content
 
     with patch('socket.socket.recv', side_effect=recv_mock):
         mywdb = WazuhDBConnection()
@@ -114,6 +120,24 @@ def test_query_lower_private(send_mock, connect_mock):
     mywdb = WazuhDBConnection()
     with pytest.raises(exception.WazuhException, match=".* 2004 .*"):
         mywdb.execute("Agent sql select 'test'")
+
+
+@patch("socket.socket.connect")
+def test_run_wdb_command(connect_mock):
+    with patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=[['due', 'chunk1'], ['due', 'chunk2'],
+                                                                      ['ok', 'chunk3'], ['due', 'chunk4']]):
+        mywdb = WazuhDBConnection()
+        result = mywdb.run_wdb_command("global sync-agent-info-get ")
+        assert result == ['chunk1', 'chunk2', 'chunk3']
+
+
+@patch("socket.socket.connect")
+def test_run_wdb_command_ko(connect_mock):
+    with patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=[['due', 'chunk1'], ['err', 'chunk2'],
+                                                                      ['ok', 'chunk3'], ['due', 'chunk4']]):
+        mywdb = WazuhDBConnection()
+        with pytest.raises(exception.WazuhInternalError, match=".* 2007 .* chunk2"):
+            mywdb.run_wdb_command("global sync-agent-info-get ")
 
 
 @patch("socket.socket.connect")


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5585|

## Description
Hi team!

This PR adds a new class called `SyncInfo`, which allows a worker to communicate with any daemon on the master using the `sendsync` protocol.

The class needs a callable as a parameter from which it will get a list of chunks. After that, it will send the chunks one by one to the desired daemon of the master, along with a command (if needed).

```PYTHON
await SyncInfo(worker=self, daemon='wazuh-db', msg_format='global sync-agent-info-set {payload}', 
                        logger=agent_info_logger, data_retriever=wdb_conn.run_wdb_command
).sync('global sync-agent-info-get ')
```

In this case, we are using this class to synchronize the agent-info data from the worker to the master. The workflow is as follows: 

1. The function `data_retriever` (`wdb_conn.run_wdb_command`) is called with the parameters inside sync() (`global sync-agent-info-get `). It returns a list of payloads/chunks of the agents whose sync_status is `not_synced`. 
2. The list of chunks is iterated. For each of them, a JSON is prepared in which the target daemon and the message are set. The message is formed by adding the chunk to the `msg_format` command.
3. Each JSON is sent through sendsync. It waits for a response or an error.

## Performance tests
We have yet to test in more realistic environments, with inter-node latency, on AWS.

However, the latest results carried out on 4 simultaneous workers, each of them with 10,000 registered agents that contain this information:

```PYTHON
{
    "id": 18,
    "name": "wazuh-agent18",
    "os_name": "Ubuntu",
    "os_version": "18.04.4 LTS",
    "os_major": "18",
    "os_minor": "04",
    "os_codename": "Bionic Beaver",
    "os_platform": "ubuntu",
    "node_name": "worker1",
    "labels": [
        {
            "id": 18,
            "key": "#\\"_agent_ip\\""
        },
        {
            "id": 18,
            "key": "#\\"_manager_hostname\\""
        },
        {
            "id": 18,
            "key": "#\\"_node_name\\"",
            "value": "worker1"
        }
    ]
}
```

They provide the following results:
- It requires about **53 chunks**, each **~64KiB**, to send the complete information of the 10,000 agents to the master.
- The whole process (obtaining agent-info from wazuh-db, sending it, setting it in the master's wazuh-db and responding), takes between 1 and 3 seconds in each worker. Below is a real trace of one of the workers.

```
2020/09/07 12:15:42 DEBUG: [Local Client] [Main] AGENTINFO Obtained 53 chunks of data to be sent.
2020/09/07 12:15:43 DEBUG2: [Client worker3] [Main] AGENTINFO Time synchronizing agent statuses: 1.6099236011505127 s
2020/09/07 12:15:54 DEBUG: [Local Client] [Main] AGENTINFO Obtained 53 chunks of data to be sent.
2020/09/07 12:15:55 DEBUG2: [Client worker3] [Main] AGENTINFO Time synchronizing agent statuses: 1.545175313949585 s
2020/09/07 12:16:05 DEBUG: [Local Client] [Main] AGENTINFO Obtained 53 chunks of data to be sent.
2020/09/07 12:16:07 DEBUG2: [Client worker3] [Main] AGENTINFO Time synchronizing agent statuses: 2.005589485168457 s
2020/09/07 12:16:17 DEBUG: [Local Client] [Main] AGENTINFO Obtained 53 chunks of data to be sent.
2020/09/07 12:16:19 DEBUG2: [Client worker3] [Main] AGENTINFO Time synchronizing agent statuses: 1.6432416439056396 s
2020/09/07 12:16:29 DEBUG: [Local Client] [Main] AGENTINFO Obtained 53 chunks of data to be sent.
2020/09/07 12:16:30 DEBUG2: [Client worker3] [Main] AGENTINFO Time synchronizing agent statuses: 1.533736228942871 s
2020/09/07 12:16:40 DEBUG: [Local Client] [Main] AGENTINFO Obtained 53 chunks of data to be sent.
2020/09/07 12:16:42 DEBUG2: [Client worker3] [Main] AGENTINFO Time synchronizing agent statuses: 1.7118175029754639 s
2020/09/07 12:16:52 DEBUG: [Local Client] [Main] AGENTINFO Obtained 53 chunks of data to be sent.
2020/09/07 12:16:54 DEBUG2: [Client worker3] [Main] AGENTINFO Time synchronizing agent statuses: 1.7678701877593994 s
2020/09/07 12:17:04 DEBUG: [Local Client] [Main] AGENTINFO Obtained 53 chunks of data to be sent.
2020/09/07 12:17:06 DEBUG2: [Client worker3] [Main] AGENTINFO Time synchronizing agent statuses: 1.943708896636963 s
```

**PD:** The results of multiple performance tests have been reported in https://github.com/wazuh/wazuh/issues/5585. Check it out for more information.

## To-do
This part is "optional" and is projected for Wazuh 4.2 or future iterations of this development. 

Currently, since the message sent to wazuh-db through `sendsync` is not only a JSON but is needs also a command, it is necessary to perform `json.dumps()` on the entire dictionary as seen below:
https://github.com/wazuh/wazuh/blob/273aef9159b534edd5170197f5ae163f631d559e/framework/wazuh/core/cluster/worker.py#L162-L165

However, the payload was already in JSON format but needs to be re-encoded as this cannot be sent this way:

```JSON
{
    "daemon_name": "",
    "message": "global sync-agent-info-set {"key1": "value1", "key2": "value2"}",
}
```

but this:
```JSON
{
    "daemon_name": "",
    "message": "global sync-agent-info-set {\"key1\": \"value1\", \"key2\": \"value2\"}",
}
```

It could be solved when the request of this issue https://github.com/wazuh/wazuh/issues/5937 is implemented, which will reduce the size of the information to send (by not adding `\`) and will slightly reduce the processing by not needing to convert the message to JSON (since it already is when it is received from wazuh-db). 

Kind regards,
Selu.