### PR TITLE
Update agent-info insert in API integration tests

### DIFF
--- a/api/test/integration/env/base/manager/entrypoint.sh
+++ b/api/test/integration/env/base/manager/entrypoint.sh
@@ -26,7 +26,7 @@ sleep 1
 
 # Manager configuration
 for py_file in /configuration_files/*.py; do
-  /usr/bin/python3 $py_file
+  /var/ossec/framework/python/bin/python3 $py_file
 done
 
 for sh_file in /configuration_files/*.sh; do

--- a/api/test/integration/env/base/manager/manager.Dockerfile
+++ b/api/test/integration/env/base/manager/manager.Dockerfile
@@ -16,9 +16,9 @@ COPY configurations/base/manager/config/ossec.conf /aux_testing/etc/ossec.conf
 COPY configurations/base/manager/config/test.keys /aux_testing/etc/client.keys
 COPY configurations/base/manager/config/agent-groups /aux_testing/queue/agent-groups
 COPY configurations/base/manager/config/shared /aux_testing/etc/shared
-COPY configurations/base/manager/config/agent-info /aux_testing/queue/agent-info
 COPY configurations/base/manager/api.yaml /var/ossec/api/configuration/api.yaml
 COPY configurations/base/manager/security.yaml /var/ossec/api/configuration/security/security.yaml
+COPY configurations/base/manager/master_only/* /configuration_files/master_only/
 RUN chown ossec:ossec /var/ossec/api/configuration/api.yaml
 RUN chown ossec:ossec /var/ossec/api/configuration/security/security.yaml
 
@@ -26,8 +26,7 @@ ARG manager_type
 
 RUN if [ "$manager_type" = "master" ]; then \
         cp -rf /aux_testing/* /var/ossec/; \
-        # To keep last_keepalive greater than 1 day
-        touch -d "2 days ago" /var/ossec/queue/agent-info/wazuh-agent9-any && touch -d "2 days ago" /var/ossec/queue/agent-info/wazuh-agent10-any; \
+        cp -rf /configuration_files/master_only/* /configuration_files/; \
     fi
 
 COPY configurations/base/manager/security/base_security_test.sql /configuration_files/

--- a/api/test/integration/env/configurations/base/manager/config/agent-info/wazuh-agent10-any
+++ b/api/test/integration/env/configurations/base/manager/config/agent-info/wazuh-agent10-any
@@ -1,6 +1,0 @@
-Linux |wazuh-agent10 |4.18.0-16-generic |#17~18.04.1-Ubuntu SMP Tue Feb 12 13:35:51 UTC 2019 |x86_64 [Ubuntu|ubuntu: 18.04.2 LTS (Bionic Beaver)] - Wazuh v3.9.2 / e2f47d482da37c099fa1d6e4c43b523c
-5c503afb7c6a5bfafabf10ce548120f5 merged.mg
-#"_agent_ip":172.28.0.15
-
-#"_manager_hostname":wazuh-master
-#"_node_name":master-node

--- a/api/test/integration/env/configurations/base/manager/config/agent-info/wazuh-agent9-any
+++ b/api/test/integration/env/configurations/base/manager/config/agent-info/wazuh-agent9-any
@@ -1,6 +1,0 @@
-Linux |wazuh-agent9 |4.18.0-16-generic |#17~18.04.1-Ubuntu SMP Tue Feb 12 13:35:51 UTC 2019 |x86_64 [Ubuntu|ubuntu: 18.04.2 LTS (Bionic Beaver)] - Wazuh v3.9.2 / 29e0926e5a77442212e824868a2a61df
-c5c0409668664e790a295bce215b4fa2 merged.mg
-#"_agent_ip":172.28.0.14
-
-#"_manager_hostname":wazuh-master
-#"_node_name":master-node

--- a/api/test/integration/env/configurations/base/manager/master_only/agent_info.yaml
+++ b/api/test/integration/env/configurations/base/manager/master_only/agent_info.yaml
@@ -17,7 +17,7 @@
     node_name: master-node
   extra_params:
     agent_id: 9
-    last_connection_in_days: 2
+    days_from_last_connection: 2
 
 
 - new_agent_info:
@@ -38,4 +38,4 @@
     node_name: master-node
   extra_params:
     agent_id: 10
-    last_connection_in_days: 2
+    days_from_last_connection: 2

--- a/api/test/integration/env/configurations/base/manager/master_only/agent_info.yaml
+++ b/api/test/integration/env/configurations/base/manager/master_only/agent_info.yaml
@@ -1,0 +1,41 @@
+---
+- new_agent_info:
+    ip: 172.28.0.14
+    os_uname: Linux |wazuh-agent9 |4.18.0-16-generic |#17~18.04.1-Ubuntu SMP Tue Feb 12 13:35:51 UTC 2019
+    name: wazuh-agent9
+    os_arch: x86_64
+    os_name: Ubuntu
+    os_version: 18.04.2 LTS
+    os_major: 18
+    os_minor: 04
+    os_codename: Bionic Beaver
+    os_platform: ubuntu
+    version: Wazuh v3.9.2
+    config_sum: 0e013cb9c7120a83351399a83a660c20
+    merged_sum: c5c0409668664e790a295bce215b4fa2
+    manager_host: wazuh-master
+    node_name: master-node
+  extra_params:
+    agent_id: 9
+    last_connection_in_days: 2
+
+
+- new_agent_info:
+    ip: 172.28.0.15
+    os_uname: Linux |wazuh-agent10 |4.18.0-16-generic |#17~18.04.1-Ubuntu SMP Tue Feb 12 13:35:51 UTC 2019
+    name: wazuh-agent10
+    os_arch: x86_64
+    os_name: Ubuntu
+    os_version: 18.04.2 LTS
+    os_major: 18
+    os_minor: 04
+    os_codename: Bionic Beaver
+    os_platform: ubuntu
+    version: Wazuh v3.9.2
+    config_sum: e2f47d482da37c099fa1d6e4c43b523c
+    merged_sum: 5c503afb7c6a5bfafabf10ce548120f5
+    manager_host: wazuh-master
+    node_name: master-node
+  extra_params:
+    agent_id: 10
+    last_connection_in_days: 2

--- a/api/test/integration/env/configurations/base/manager/master_only/agent_info_to_wdb.sh
+++ b/api/test/integration/env/configurations/base/manager/master_only/agent_info_to_wdb.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-/var/ossec/framework/python/bin/python3 /configuration_files/update_agent_info.py

--- a/api/test/integration/env/configurations/base/manager/master_only/agent_info_to_wdb.sh
+++ b/api/test/integration/env/configurations/base/manager/master_only/agent_info_to_wdb.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+/var/ossec/framework/python/bin/python3 /configuration_files/update_agent_info.py

--- a/api/test/integration/env/configurations/base/manager/master_only/update_agent_info.py
+++ b/api/test/integration/env/configurations/base/manager/master_only/update_agent_info.py
@@ -1,0 +1,61 @@
+import socket
+import struct
+import yaml
+import json
+import time
+
+ADDR = '/var/ossec/queue/db/wdb'
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect(ADDR)
+
+
+def send_msg(msg):
+    '''Send message to wazuh-db socket
+
+    Parameters
+    ----------
+    msg : str
+        Message to be formatted and sent
+    '''
+    msg = struct.pack('<I', len(msg)) + msg.encode()
+    # Send msg
+    sock.send(msg)
+    # Receive response
+    data = sock.recv(4)
+    data_size = struct.unpack('<I', data[0:4])[0]
+    data = sock.recv(data_size).decode(encoding='utf-8', errors='ignore').split(" ", 1)
+
+    return data
+
+
+def create_and_send_query(agent_info_file):
+    with open(agent_info_file) as f:
+        agent_info = yaml.safe_load(f)
+
+    with open('/configuration_files/output_agent_info', 'w+') as f:
+        for agent in agent_info:
+            # Add last_keepalive key-value with epoch time
+            try:
+                agent['new_agent_info']['last_keepalive'] = int(time.time()) - \
+                                                            3600*24*int(agent['extra_params']['last_connection_in_days'])
+            except KeyError:
+                pass
+
+            f.write(f'GLOBAL.DB before updating agent-info: \n ' +
+                    f'{json.dumps(json.loads(send_msg("global sql select * from agent")[1]), indent=4, sort_keys=True)}')
+
+            # Prepare query with all the requested fields
+            query = "UPDATE agent SET " + \
+                    ", ".join(['{0} = {1}'.format(key, value)
+                               if isinstance(value, int) else '{0} = "{1}"'.format(key, value)
+                               for key, value in agent['new_agent_info'].items()]) + \
+                    f" WHERE id = {agent['extra_params']['agent_id']}"
+
+            # Send update query
+            f.write(str(send_msg("global sql " + query)))
+            f.write(f'GLOBAL.DB after updating agent-info: \n ' +
+                    f'{json.dumps(json.loads(send_msg("global sql select * from agent")[1]), indent=4, sort_keys=True)}')
+
+
+if __name__ == "__main__":
+    create_and_send_query('/configuration_files/agent_info.yaml')


### PR DESCRIPTION
|Related issue|
|---|
|#6101|

Hi team!

## Description

As explained in #6101, after changing the way agent-info is obtained and synchronized, it was necessary to update how the environment of our API integration tests mock that information.

Specifically, agents 9 and 10 were registered, but their information was mocked. Thus, they appeared as disconnected (without even existing).

## How it works

Now, all the agent-info is described inside a file called [agent_info.yaml](https://github.com/wazuh/wazuh/blob/develop-6101-update-agent-info-api-tests/api/test/integration/env/configurations/base/manager/master_only/agent_info.yaml). Inside, we can see something like:
https://github.com/wazuh/wazuh/blob/88df7ce035b77712932caaa0eba1799b7f6c3adf/api/test/integration/env/configurations/base/manager/master_only/agent_info.yaml#L1-L41

The script will create a query where every key of `new_agent_info` will be included, together with its value. It will update the agent whose ID is specified inside `extra_params` -> `agent_id`.

It is also possible to specify how many days it has been since the last connection, which will be transformed into epoch time and inserted as `last_keepalive` in the database.

## Output

For the master healtcheck to be correct, the agents must be like this:
```
000,wazuh-master (server),127.0.0.1,Active/Local,
001,wazuh-agent1,any,Active,
002,wazuh-agent2,any,Active,
003,wazuh-agent3,any,Active,
004,wazuh-agent4,any,Active,
005,wazuh-agent5,any,Active,
006,wazuh-agent6,any,Active,
007,wazuh-agent7,any,Active,
008,wazuh-agent8,any,Active,
009,wazuh-agent9,any,Disconnected,
010,wazuh-agent10,any,Disconnected,
011,wazuh-agent11,any,Never connected,
012,wazuh-agent12,any,Never connected,
```

And indeed, that's how they end up after this PR. However, sometimes autoenrollment does not work correctly with one or many of them, which starts to register again and again. This can be seen here:

```
/var/ossec/bin/agent_control -l

Wazuh agent_control. List of available agents:
   ID: 000, Name: wazuh-master (server), IP: 127.0.0.1, Active/Local
   ID: 001, Name: wazuh-agent1, IP: any, Active
   ID: 002, Name: wazuh-agent2, IP: any, Active
   ID: 003, Name: wazuh-agent3, IP: any, Active
   ID: 004, Name: wazuh-agent4, IP: any, Active
   ID: 005, Name: wazuh-agent5, IP: any, Active
   ID: 006, Name: wazuh-agent6, IP: any, Active
   ID: 007, Name: wazuh-agent7, IP: any, Active
   ID: 012, Name: wazuh-agent12, IP: any, Never connected
   ID: 009, Name: wazuh-agent9, IP: any, Disconnected
   ID: 010, Name: wazuh-agent10, IP: any, Disconnected
   ID: 011, Name: wazuh-agent11, IP: any, Never connected
   ID: 022, Name: wazuh-agent8, IP: any, Never connected
```

Regards,
Selu.