### PR TITLE
Fixing errors discovered in exploratory testing

### DIFF
--- a/src/headers/read-agents.h
+++ b/src/headers/read-agents.h
@@ -22,6 +22,7 @@ typedef struct _agent_info {
     char *rootcheck_endtime;
     char *os;
     char *version;
+    char *config_sum;
     char *merged_sum;
 } agent_info;
 

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -240,7 +240,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
 
             // Updating version and keepalive in global.db
             result = wdb_update_agent_data(agent_data);
-            
+
             if (OS_INVALID == result)
                 mwarn("Unable to update information in global.db for agent: %s", key->id);
 

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -1112,7 +1112,7 @@ agent_info *get_agent_info(const char *agent_name, const char *agent_ip, const c
     /* Allocate memory for the info structure */   
     os_calloc(1, sizeof(agent_info), agt_info);
 
-    json_field = cJSON_GetObjectItem(json_agt_info->child, "os_name");
+    json_field = cJSON_GetObjectItem(json_agt_info->child, "os_uname");
     if(cJSON_IsString(json_field) && json_field->valuestring != NULL){
         os_strdup(json_field->valuestring, agt_info->os);
     }
@@ -1120,6 +1120,11 @@ agent_info *get_agent_info(const char *agent_name, const char *agent_ip, const c
     json_field = cJSON_GetObjectItem(json_agt_info->child, "version");
     if(cJSON_IsString(json_field) && json_field->valuestring != NULL){
         os_strdup(json_field->valuestring, agt_info->version);
+    }
+
+    json_field = cJSON_GetObjectItem(json_agt_info->child, "config_sum");
+    if(cJSON_IsString(json_field) && json_field->valuestring != NULL){
+        os_strdup(json_field->valuestring, agt_info->config_sum);
     }
 
     json_field = cJSON_GetObjectItem(json_agt_info->child, "merged_sum");

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -1986,6 +1986,24 @@ void test_wdb_remove_agent_error_socket(void **state)
 {
     int ret = 0;
     int id = 1;
+    cJSON *root = NULL;
+    cJSON *row = NULL;
+    cJSON *str = NULL;
+
+    root = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str = __real_cJSON_CreateString("agent1");
+    __real_cJSON_AddItemToObject(row, "name", str);
+    __real_cJSON_AddItemToArray(root, row);
+
+    // Calling Wazuh DB in select-agent-name
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, root);
+
+    // Getting JSON data
+    will_return(__wrap_cJSON_GetObjectItem, str);
+
+    expect_function_call(__wrap_cJSON_Delete);
 
     char *query_str = "global delete-agent 1";
     const char *response = "err";
@@ -2004,12 +2022,32 @@ void test_wdb_remove_agent_error_socket(void **state)
     ret = wdb_remove_agent(id);
 
     assert_int_equal(OS_INVALID, ret);
+
+    __real_cJSON_Delete(root);
 }
 
 void test_wdb_remove_agent_error_sql_execution(void **state)
 {
     int ret = 0;
     int id = 1;
+    cJSON *root = NULL;
+    cJSON *row = NULL;
+    cJSON *str = NULL;
+
+    root = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str = __real_cJSON_CreateString("agent1");
+    __real_cJSON_AddItemToObject(row, "name", str);
+    __real_cJSON_AddItemToArray(root, row);
+
+    // Calling Wazuh DB in select-agent-name
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, root);
+
+    // Getting JSON data
+    will_return(__wrap_cJSON_GetObjectItem, str);
+
+    expect_function_call(__wrap_cJSON_Delete);
 
     char *query_str = "global delete-agent 1";
     const char *response = "err";
@@ -2028,12 +2066,32 @@ void test_wdb_remove_agent_error_sql_execution(void **state)
     ret = wdb_remove_agent(id);
 
     assert_int_equal(OS_INVALID, ret);
+
+    __real_cJSON_Delete(root);
 }
 
 void test_wdb_remove_agent_error_result(void **state)
 {
     int ret = 0;
     int id = 1;
+    cJSON *root = NULL;
+    cJSON *row = NULL;
+    cJSON *str = NULL;
+
+    root = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str = __real_cJSON_CreateString("agent1");
+    __real_cJSON_AddItemToObject(row, "name", str);
+    __real_cJSON_AddItemToArray(root, row);
+
+    // Calling Wazuh DB in select-agent-name
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, root);
+
+    // Getting JSON data
+    will_return(__wrap_cJSON_GetObjectItem, str);
+
+    expect_function_call(__wrap_cJSON_Delete);
 
     char *query_str = "global delete-agent 1";
     const char *response = "err";
@@ -2053,6 +2111,8 @@ void test_wdb_remove_agent_error_result(void **state)
     ret = wdb_remove_agent(id);
 
     assert_int_equal(OS_INVALID, ret);
+
+    __real_cJSON_Delete(root);
 }
 
 void test_wdb_remove_agent_error_delete_belongs_and_name(void **state)

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -399,7 +399,7 @@ int main(int argc, char **argv)
                 printf("   Agent Name: %s\n", keys.keyentries[agt_id]->name);
                 printf("   IP address: %s\n", final_ip);
                 printf("   Status:     %s\n\n", print_agent_status(agt_status));
-            }else if(json_output){
+            } else if (json_output) {
                 cJSON_AddStringToObject(json_data, "id", keys.keyentries[agt_id]->id);
                 cJSON_AddStringToObject(json_data, "name", keys.keyentries[agt_id]->name);
                 cJSON_AddStringToObject(json_data, "ip", final_ip);
@@ -420,7 +420,7 @@ int main(int argc, char **argv)
                 printf("   Agent Name: %s\n", shost);
                 printf("   IP address: 127.0.0.1\n");
                 printf("   Status:     %s/Local\n\n", print_agent_status(agt_status));
-            }else if(json_output){
+            } else if (json_output) {
                 cJSON_AddStringToObject(json_data, "id", "000");
                 cJSON_AddStringToObject(json_data, "name", shost);
                 cJSON_AddStringToObject(json_data, "ip", "127.0.0.1");
@@ -435,6 +435,7 @@ int main(int argc, char **argv)
         if (!csv_output && !json_output) {
             printf("   Operating system:    %s\n", agt_info->os);
             printf("   Client version:      %s\n", agt_info->version);
+            printf("   Configuration hash:  %s\n", agt_info->config_sum);
             printf("   Shared file hash:    %s\n", agt_info->merged_sum);
             printf("   Last keep alive:     %s\n\n", agt_info->last_keepalive);
 
@@ -447,18 +448,19 @@ int main(int argc, char **argv)
             } else {
                 printf("   Rootcheck last started at: %s\n", agt_info->rootcheck_time);
             }
-        }else if(json_output){
-                cJSON_AddStringToObject(json_data, "os", agt_info->os);
-                cJSON_AddStringToObject(json_data, "version", agt_info->version);
-                cJSON_AddStringToObject(json_data, "mergedSum", agt_info->merged_sum);
-                cJSON_AddStringToObject(json_data, "lastKeepAlive", agt_info->last_keepalive);
-                cJSON_AddStringToObject(json_data, "syscheckTime", agt_info->syscheck_time);
-                cJSON_AddStringToObject(json_data, "syscheckEndTime", agt_info->syscheck_endtime);
-                cJSON_AddStringToObject(json_data, "rootcheckTime", agt_info->rootcheck_time);
+        } else if (json_output) {
+            cJSON_AddStringToObject(json_data, "os", agt_info->os);
+            cJSON_AddStringToObject(json_data, "version", agt_info->version);
+            cJSON_AddStringToObject(json_data, "configSum", agt_info->config_sum);
+            cJSON_AddStringToObject(json_data, "mergedSum", agt_info->merged_sum);
+            cJSON_AddStringToObject(json_data, "lastKeepAlive", agt_info->last_keepalive);
+            cJSON_AddStringToObject(json_data, "syscheckTime", agt_info->syscheck_time);
+            cJSON_AddStringToObject(json_data, "syscheckEndTime", agt_info->syscheck_endtime);
+            cJSON_AddStringToObject(json_data, "rootcheckTime", agt_info->rootcheck_time);
 
-                if (end_time) {
-                    cJSON_AddStringToObject(json_data, "rootcheckEndTime", agt_info->rootcheck_endtime);
-                }
+            if (end_time) {
+                cJSON_AddStringToObject(json_data, "rootcheckEndTime", agt_info->rootcheck_endtime);
+            }
         } else {
             printf("%s,%s,%s,%s,%s,\n",
                    agt_info->os,
@@ -467,12 +469,16 @@ int main(int argc, char **argv)
                    agt_info->syscheck_time,
                    agt_info->rootcheck_time);
         }
+
         if(json_output){
             cJSON_AddNumberToObject(root, "error", 0);
             cJSON_AddItemToObject(root, "data", json_data);
             printf("%s",cJSON_PrintUnformatted(root));
             cJSON_Delete(root);
         }
+
+        os_free(agt_info);
+
         exit(0);
     }
 

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -936,6 +936,9 @@ int wdb_remove_agent(int id) {
     char *payload = NULL;
     char *name = NULL;
 
+    // Getting the agent's name before removing it from global.db
+    name = wdb_get_agent_name(id);
+
     snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_DELETE_AGENT], id);
     result = wdbc_query_ex(&wdb_sock_agent, wdbquery, wdboutput, sizeof(wdboutput));
 
@@ -943,7 +946,6 @@ int wdb_remove_agent(int id) {
         case OS_SUCCESS:
             if (WDBC_OK == wdbc_parse_result(wdboutput, &payload)) {
                 result = wdb_delete_agent_belongs(id);
-                name = wdb_get_agent_name(id);
 
                 result = ((OS_SUCCESS == result) && name) ? wdb_remove_agent_db(id, name) : OS_INVALID;
 


### PR DESCRIPTION
|Related issue|
|---|
| [Pull 5541](https://github.com/wazuh/wazuh/pull/5541) |

## Description

This PR fixes some errors and inconsistencies discovered during the exploratory testing over the `dev-agent-info` branch.

1. The first error was caused because of a bad order of actions taken during an agent removal. The logic was trying to get the agent's name from the database after removing the entry.

2. The second error was an inconsistency on the output of the `agent_control` tool between `master` and `dev-agent-info`. Now we display the OS uname as the Operating System information, and also the configuration sum in a separated item.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade