### PR TITLE
Fix fts list conflict between analysisd and logtest sessions

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1931,7 +1931,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
 
             /* Check each rule */
             else if (t_currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, &os_analysisd_cdblists,
-                     rulenode_pt, &rule_match, &os_analysisd_fts_list, &os_analysisd_fts_store), !t_currently_rule) {
+                     rulenode_pt, &rule_match, &os_analysisd_fts_list, &os_analysisd_fts_store, true), !t_currently_rule) {
 
                 continue;
             }

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -303,7 +303,7 @@ int w_logtest_rulesmatching_phase(Eventinfo * lf, w_logtest_session_t * session,
 
         /* Search the rule that match */
         if (ruleinformation = OS_CheckIfRuleMatch(lf, session->eventlist, &session->cdblistnode,
-            rulenode, &session->rule_match, &session->fts_list, &session->fts_store), !ruleinformation) {
+            rulenode, &session->rule_match, &session->fts_list, &session->fts_store, false), !ruleinformation) {
             continue;
         }
 

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -628,6 +628,8 @@ int w_logtest_fts_init(OSList **fts_list, OSHash **fts_store) {
         return 0;
     }
 
+    OSHash_SetFreeDataPointer(*fts_store, &free);
+    
     return 1;
 }
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -2874,7 +2874,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events, Lis
 
         while (child_node) {
             child_rule = OS_CheckIfRuleMatch(lf, last_events, cdblists, child_node, rule_match,
-                                             &os_analysisd_fts_list, &os_analysisd_fts_store);
+                                             fts_list, fts_store);
             if (child_rule != NULL) {
                 if (!child_rule->prev_rule) {
                     child_rule->prev_rule = rule;

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -247,11 +247,13 @@ RuleInfo *zerorulemember(int id, int level, int maxsize, int frequency,
  * @param cdblists list of cdbs
  * @param curr_node rule to compare with the event "lf"
  * @param rule_match stores the regex of the rule
+ * @param save_fts_value determine if fts value can be saved in fts-queue file
  * @return the rule information if it matches, otherwise null
  */
-RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events, ListNode **cdblists,
-                              RuleNode *curr_node, regex_matching *rule_match,
-                              OSList **fts_list, OSHash **fts_store);
+RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
+                              ListNode **cdblists, RuleNode *curr_node,
+                              regex_matching *rule_match, OSList **fts_list,
+                              OSHash **fts_store, const bool save_fts_value);
 
 /**
  * @brief Set os_analysisd_rulelist to null

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -639,7 +639,7 @@ void OS_ReadMSG(char *ut_str)
 
                 /* Check each rule */
                 else if (currently_rule = OS_CheckIfRuleMatch(lf, os_analysisd_last_events, &os_analysisd_cdblists,
-                         rulenode_pt, &rule_match, &os_analysisd_fts_list, &os_analysisd_fts_store), !currently_rule) {
+                         rulenode_pt, &rule_match, &os_analysisd_fts_list, &os_analysisd_fts_store, false), !currently_rule) {
                     continue;
                 }
 

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -71,7 +71,8 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap
                              -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,CreateThreadJoinable -Wl,--wrap,_merror_exit \
                              -Wl,--wrap,CreateThread -Wl,--wrap,pthread_join -Wl,--wrap,unlink \
                              -Wl,--wrap,Eventinfo_to_jsonstr -Wl,--wrap,cJSON_Parse -Wl,--wrap,ParseRuleComment \
-                             -Wl,--wrap,Accumulate -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddBoolToObject")
+                             -Wl,--wrap,Accumulate -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddBoolToObject \
+                             -Wl,--wrap,OSHash_SetFreeDataPointer")
 
 LIST(APPEND analysisd_names "test_logtest-config")
 LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nproc -Wl,--wrap,cJSON_CreateObject \

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -137,6 +137,10 @@ int __wrap_OSHash_setSize(OSHash *self, unsigned int new_size) {
     return mock();
 }
 
+int __wrap_OSHash_SetFreeDataPointer(OSHash *self, void (free_data_function)(void *)) {
+    return mock_type(int);
+}
+
 OSList *__wrap_OSList_Create() {
     return mock_type(OSList *);
 }
@@ -801,6 +805,7 @@ void test_w_logtest_fts_init_success(void **state)
 
     expect_value(__wrap_OSHash_setSize, new_size, 2048);
     will_return(__wrap_OSHash_setSize, 1);
+    will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
     int ret = w_logtest_fts_init(&fts_list, &fts_store);
     assert_int_equal(ret, 1);
@@ -1403,6 +1408,7 @@ void test_w_logtest_initialize_session_error_accumulate_init(void ** state) {
     will_return(__wrap_OSHash_Create, hash);
     expect_value(__wrap_OSHash_setSize, new_size, 2048);
     will_return(__wrap_OSHash_setSize, 1);
+    will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
     will_return(__wrap_Accumulate_Init, 0);
 
@@ -1467,6 +1473,7 @@ void test_w_logtest_initialize_session_success(void ** state) {
     will_return(__wrap_OSHash_Create, hash);
     expect_value(__wrap_OSHash_setSize, new_size, 2048);
     will_return(__wrap_OSHash_setSize, 1);
+    will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
     will_return(__wrap_Accumulate_Init, 1);
 
@@ -1671,6 +1678,7 @@ void test_w_logtest_get_session_expired_token(void ** state) {
     will_return(__wrap_OSHash_Create, hash);
     expect_value(__wrap_OSHash_setSize, new_size, 2048);
     will_return(__wrap_OSHash_setSize, 1);
+    will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
     will_return(__wrap_Accumulate_Init, 1);
 
@@ -1761,6 +1769,7 @@ void test_w_logtest_get_session_new(void ** state) {
     will_return(__wrap_OSHash_Create, hash);
     expect_value(__wrap_OSHash_setSize, new_size, 2048);
     will_return(__wrap_OSHash_setSize, 1);
+    will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
     will_return(__wrap_Accumulate_Init, 1);
 


### PR DESCRIPTION
## Description

Hi Team,

This PR fix the conflict of the fts list between logtest session and analysisd

Regards,
Julian

Checks
- [x] Scan-build report
- [x] Without warnings
- [x] Valgrind (memcheck and descriptor leaks check)
- [x] Tests