### PR TITLE
Fixing issues found during exploratory testing

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -271,7 +271,7 @@ monitord.size_rotate=512
 # Maximum number of rotations per day for internal logs [1..256]
 monitord.daily_rotations=12
 
-# Number of minutes for deleting an disconnected agent [0..120]. (0=disabled)
+# Number of minutes for deleting a disconnected agent [0..9600]. (0=disabled)
 monitord.delete_old_agents=0
 
 # Syscheck perform a delay when dispatching real-time notifications so it avoids

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -185,6 +185,10 @@ int OS_RemoveAgent(const char *u_id) {
 
     os_free(wdboutput);
 
+    if (wdb_remove_agent(atoi(u_id)) != OS_SUCCESS) {
+        mdebug1("Could not remove the information stored in Wazuh DB of the agent %s.", u_id);
+    }
+
     /* Remove counter for ID */
     OS_RemoveCounter(u_id);
     OS_RemoveAgentTimestamp(u_id);

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -182,11 +182,8 @@ int OS_RemoveAgent(const char *u_id) {
     if (sock >= 0) {
         close(sock);
     }
-    os_free(wdboutput);
 
-    if (wdb_remove_agent(atoi(u_id)) != OS_SUCCESS) {
-        merror("Could not remove the information stored in Wazuh DB of the agent %s.", u_id);
-    }
+    os_free(wdboutput);
 
     /* Remove counter for ID */
     OS_RemoveCounter(u_id);

--- a/src/monitord/monitor_agents.c
+++ b/src/monitord/monitor_agents.c
@@ -20,7 +20,7 @@ void monitor_agents()
     char **cr_agents;
     char **av_agents;
 
-    av_agents = get_agents_by_last_keepalive(GA_ACTIVE,mond.delete_old_agents > 0 ? mond.delete_old_agents * 60 : DISCON_TIME);
+    av_agents = get_agents_by_last_keepalive(GA_ACTIVE, mond.delete_old_agents > 0 ? mond.delete_old_agents * 60 : DISCON_TIME);
 
     /* No agent saved */
     if (!mond.agents) {

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -29,6 +29,7 @@
 #include <sys/wait.h>
 #include "check_cert.h"
 #include "os_crypto/md5/md5_op.h"
+#include "wazuh_db/wdb.h"
 #include "wazuhdb_op.h"
 #include "os_err.h"
 
@@ -809,6 +810,10 @@ void* run_writer(__attribute__((unused)) void *arg) {
             OS_RemoveCounter(cur->id);
             OS_RemoveAgentTimestamp(cur->id);
             OS_RemoveAgentGroup(cur->id);
+
+            if (wdb_remove_agent(atoi(cur->id)) != OS_SUCCESS) {
+                mdebug1("Could not remove the information stored in Wazuh DB of the agent %s.", cur->id);
+            }
 
             snprintf(wdbquery, OS_SIZE_128, "agent %s remove", cur->id);
             wdbc_query_ex(&wdb_sock, wdbquery, wdboutput, sizeof(wdboutput));

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -31,7 +31,6 @@
 #include "os_crypto/md5/md5_op.h"
 #include "wazuhdb_op.h"
 #include "os_err.h"
-#include "wazuh_db/wdb.h"
 
 /* Prototypes */
 static void help_authd(void) __attribute((noreturn));
@@ -810,10 +809,6 @@ void* run_writer(__attribute__((unused)) void *arg) {
             OS_RemoveCounter(cur->id);
             OS_RemoveAgentTimestamp(cur->id);
             OS_RemoveAgentGroup(cur->id);
-
-            if(wdb_remove_agent(atoi(cur->id)) != OS_SUCCESS){
-                merror("Could not remove the information stored in Wazuh DB of the agent %s.", cur->id);
-            }
 
             snprintf(wdbquery, OS_SIZE_128, "agent %s remove", cur->id);
             wdbc_query_ex(&wdb_sock, wdbquery, wdboutput, sizeof(wdboutput));

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -843,7 +843,7 @@ void delete_diff(const char *name)
     snprintf(tmp_folder, 512, "%s/%s",
              DIFF_DIR,
              name);
-    
+
     rmdir_ex(tmp_folder);
 }
 
@@ -1314,18 +1314,17 @@ char **get_agents_by_last_keepalive(int flag, int delta){
         if(cJSON_IsString(json_name) && json_name->valuestring != NULL && 
             cJSON_IsString(json_ip) && json_ip->valuestring != NULL){
             snprintf(agent_name_ip, sizeof(agent_name_ip), "%s-%s", json_name->valuestring, json_ip->valuestring);
+            os_realloc(agents_array, (array_size + 2) * sizeof(char *), agents_array);
+            os_strdup(agent_name_ip, agents_array[array_size]);
+            agents_array[array_size + 1] = NULL;
+            array_size++;
         }
 
         cJSON_Delete(json_agt_info);
-        os_realloc(agents_array, (array_size + 2) * sizeof(char *), agents_array);
-        os_strdup(agent_name_ip, agents_array[array_size]);
-
-        agents_array[array_size + 1] = NULL;
-        array_size++;
     }
 
     os_free(id_array);
-    return (agents_array);
+    return agents_array;
 }
 
 #ifndef WIN32

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -2156,8 +2156,6 @@ void test_wdb_remove_agent_error_delete_belongs_and_name(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Error querying Wazuh DB to get the agent's 1 name.");
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Unable to remove agent DB: 1 - (null)");
-
     ret = wdb_remove_agent(id);
 
     assert_int_equal(OS_INVALID, ret);

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -69,5 +69,3 @@ CREATE TABLE IF NOT EXISTS metadata (
 );
 
 INSERT INTO metadata (key, value) VALUES ('db_version', '1');
-
-PRAGMA journal_mode=WAL;

--- a/src/wazuh_db/schema_global_upgrade_v1.sql
+++ b/src/wazuh_db/schema_global_upgrade_v1.sql
@@ -10,6 +10,8 @@
 
 BEGIN;
 
+PRAGMA journal_mode=DELETE;
+
 CREATE TABLE IF NOT EXISTS labels (
     id INTEGER,
     key TEXT NOT NULL,

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -947,10 +947,9 @@ int wdb_remove_agent(int id) {
             if (WDBC_OK == wdbc_parse_result(wdboutput, &payload)) {
                 result = wdb_delete_agent_belongs(id);
 
-                result = ((OS_SUCCESS == result) && name) ? wdb_remove_agent_db(id, name) : OS_INVALID;
-
-                if(OS_INVALID == result){
-                    mdebug1("Unable to remove agent DB: %d - %s", id, name);
+                if ((OS_SUCCESS == result) && name &&
+                     OS_INVALID == wdb_remove_agent_db(id, name)) {
+                     mdebug1("Unable to remove agent DB: %d - %s", id, name);
                 }
             }
             else {


### PR DESCRIPTION
|Related issue|
|---|
| [Pull 5541](https://github.com/wazuh/wazuh/pull/5541) |

## Description

This PR fixes two issues found during the exploratory testing done over the `dev-agent-info` branch. The issues are:

1. A duplicated attempt to remove an agent from Wazuh DB when using `manage_agents`.

2. A bad memory allocation was done when getting agents by keepalive to evaluate if they had to be removed.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade