### PR TITLE
Fix segfault when windows file has no permissions.

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -981,15 +981,16 @@ char *decode_win_permissions(char *raw_perm) {
     char *base_it = NULL;
     char *account_name = NULL;
     char a_type;
+    char *decoded_perm;
     long mask;
 
     if (*raw_perm != '|') {
         // It is trying to convert to the new format
         // a permissions that have already been transformed
-        return 0;
+        os_strdup("", decoded_perm);
+        return decoded_perm;
     }
 
-    char *decoded_perm;
     os_calloc(MAX_WIN_PERM_SIZE, sizeof(char), decoded_perm);
 
     int perm_size = MAX_WIN_PERM_SIZE;

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -2340,7 +2340,7 @@ static void test_decode_win_permissions_fail_wrong_format(void **state) {
     free(raw_perm);
     *state = output;
 
-    assert_null(output);
+    assert_string_equal("", output);
 }
 
 /* attrs_to_json tests */


### PR DESCRIPTION
|Related issue|
|---|
|#6055|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims to fix the issue #6055 by not returning NULL when a file in Windows has no permissions. This was happening using scheduled, realtime, and whodata monitoring modes.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```xml
 <syscheck>
    <!-- By default it is disabled. In the Install you must choose to enable it. -->
    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>2</frequency>

    <directories check_all="yes">C:\testdir1</directories>
    <!-- Frequency for ACL checking (seconds) -->
    <windows_audit_interval>60</windows_audit_interval>
```
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
```
2020/09/29 12:22:13 ossec-agent[684] run_check.c:98 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"scan_start","data":{"timestamp":1601378533}}
2020/09/29 12:22:13 ossec-agent[684] create_db.c:68 at fim_scan(): DEBUG: (6348): Size of 'queue/diff' folder: 0.00000 KB.
2020/09/29 12:22:13 ossec-agent[684] syscheck_op.c:689 at get_user(): DEBUG: At get_user(c:\testdir1\nuevo documento de texto.txt): CreateFile(): Acceso denegado. (5)
2020/09/29 12:22:13 ossec-agent[684] fim_db.c:457 at fim_db_check_transaction(): DEBUG: Database transaction completed.
2020/09/29 12:22:13 ossec-agent[684] win-registry.c:307 at os_winreg_check(): DEBUG: (6031): Registry integrity monitoring scan started
2020/09/29 12:22:13 ossec-agent[684] win-registry.c:335 at os_winreg_check(): DEBUG: (6032): Registry integrity monitoring scan ended
2020/09/29 12:22:13 ossec-agent[684] syscheck_op.c:689 at get_user(): DEBUG: At get_user(c:\testdir1\nuevo documento de texto.txt): CreateFile(): Acceso denegado. (5)
2020/09/29 12:22:13 ossec-agent[684] win-registry.c:307 at os_winreg_check(): DEBUG: (6031): Registry integrity monitoring scan started
2020/09/29 12:22:13 ossec-agent[684] win-registry.c:335 at os_winreg_check(): DEBUG: (6032): Registry integrity monitoring scan ended
2020/09/29 12:22:13 ossec-agent[684] create_db.c:141 at fim_scan(): DEBUG: (6342): Maximum number of files to be monitored: '100000'
2020/09/29 12:22:13 ossec-agent[684] create_db.c:154 at fim_scan(): DEBUG: (6345): Folders monitored with real-time engine: 0
2020/09/29 12:22:13 ossec-agent[684] create_db.c:157 at fim_scan(): INFO: (6009): File integrity monitoring scan ended.
```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Windows
- [X] Source installation
- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [X] Scan-build report
