### PR TITLE
Remove agent files deletion in cluster.

### DIFF
--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -175,8 +175,7 @@ class WazuhDBConnection:
             status, payload = self._send(command, raw=True)
             if status == 'err':
                 raise WazuhInternalError(2007, extra_message=payload)
-            if payload != '[]':
-                response.append(payload)
+            response.append(payload)
             # Exit if there are no items left to return
             if status == 'ok':
                 break

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -175,7 +175,8 @@ class WazuhDBConnection:
             status, payload = self._send(command, raw=True)
             if status == 'err':
                 raise WazuhInternalError(2007, extra_message=payload)
-            response.append(payload)
+            if payload != '[]':
+                response.append(payload)
             # Exit if there are no items left to return
             if status == 'ok':
                 break


### PR DESCRIPTION
# Description

Hi team!

## Cluster no longer removes files from agent.
After some discussions and design decisions, it has been determined that, when deleting agents on a master node, the cluster should not be in charge of deleting the files corresponding to each of the agents on the different worker nodes.

Therefore, the remove_bulk_agents and check_remove_agents methods of the worker.py module, whose only function was precisely to remove the files and entries from the database, have been removed:
https://github.com/wazuh/wazuh/blob/5f39f8e91a78ae9f8118a03ddec3ff455ac75945/framework/wazuh/core/cluster/worker.py#L460-L561

All these actions are performed by other components when the `client.keys `file for each node is updated.

After doing tests in a local environment, I have verified that indeed, when deleting agents on the master node, the worker node updates its `client.keys` and deletes the files from `/var/ossec/var/db/agents`, `/var/ossec/queue/db/global.db`, etc., even after removing the methods above mentioned.

Best regards,
Selu.