### PR TITLE
Avoid unrequired changes on ossec.conf when upgrading Windows Agents

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -75,19 +75,6 @@ If objFSO.fileExists(home_dir & "ossec.conf") Then
     strText = objFile.ReadAll
     objFile.Close
 
-    ' Enable syscheck in a fresh installation
-    strNewText = Replace(strText, "<teststring>", "<teststring>")
-    If InStr(strText,"<address>0.0.0.0</address>") > 0 Then
-        Set re = new regexp
-        re.Pattern = "<disabled>yes</disabled>"
-        re.Global = False
-        strNewText = re.Replace(strNewText, "<disabled>no</disabled>")
-        Set re = new regexp
-        re.Pattern = "<!-- By default it is disabled. In the Install you must choose to enable it. -->"
-        re.Global = True
-        strNewText = re.Replace(strNewText, "")
-    End If
-
     If address <> "" or server_port <> "" or protocol <> "" or notify_time <> "" or time_reconnect <> "" Then
         If address <> "" and InStr(address,";") > 0 Then 'list of address
             ip_list=Split(address,";")

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -155,14 +155,13 @@ If objFSO.fileExists(home_dir & "ossec.conf") Then
             End If
         End If
 
+         ' Writing the ossec.conf file
+          const ForWriting = 2
+          Set objFile = objFSO.OpenTextFile(home_dir & "ossec.conf", ForWriting)
+          objFile.WriteLine strNewText
+          objFile.Close
 
     End If
-
-    ' Writing the ossec.conf file
-    const ForWriting = 2
-    Set objFile = objFSO.OpenTextFile(home_dir & "ossec.conf", ForWriting)
-    objFile.WriteLine strNewText
-    objFile.Close
 
 	If Not objFSO.fileExists(home_dir & "local_internal_options.conf") Then
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -67,7 +67,7 @@
 
   <!-- File integrity monitoring -->
   <syscheck>
-    <!-- By default it is disabled. In the Install you must choose to enable it. -->
+
     <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -68,7 +68,7 @@
   <!-- File integrity monitoring -->
   <syscheck>
     <!-- By default it is disabled. In the Install you must choose to enable it. -->
-    <disabled>yes</disabled>
+    <disabled>no</disabled>
 
     <!-- Frequency that syscheck is executed default every 12 hours -->
     <frequency>43200</frequency>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5085|

## Description

There is a script called `src/win32/InstallerScripts.vbs` which makes some modifications to the default ossec.conf on certain circumstances. In it, there is a block of code that was intended to enable syscheck bu default in a fresh installation. Nevertheless, the way to check if it isn't being executed on an upgrade was tricky and could produce weird behaviors.

We have removed that code block. Instead of using it, we will just enable syscheck in the default configuration used for both install and upgrade. Also, we will avoid unnecessarily writes to the file. Another block that writes the changes required to ossec.conf (even if there are no required changes at all) have been moved into a conditional structure so te ossec.conf is only written when there are any required changes to do.

## Configuration options

None.

## Logs/Alerts example

![image](https://user-images.githubusercontent.com/15269938/94568043-57eff800-026c-11eb-988c-1026ebf78c6f.png)


## Tests

Jenkins test: packages building, installation, etc...

Manually tested: 
- Fresh install on Windows agent.
- Upgrade from the previous version to 4.0
- Check that syscheck is enabled by default

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [ ] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities


