### PR TITLE
General framework fixes for dev-agent-info

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -13,8 +13,7 @@ from wazuh.core.agent import WazuhDBQueryAgents, WazuhDBQueryGroupByAgents, \
     WazuhDBQueryMultigroups, Agent, WazuhDBQueryGroup, get_agents_info, get_groups, get_rbac_filters
 from wazuh.core.cluster.cluster import get_node
 from wazuh.core.cluster.utils import read_cluster_config
-from wazuh.core.exception import WazuhError, WazuhInternalError, WazuhException, WazuhPermissionError, \
-    WazuhResourceNotFound
+from wazuh.core.exception import WazuhError, WazuhInternalError, WazuhException, WazuhResourceNotFound
 from wazuh.core.results import WazuhResult, AffectedItemsWazuhResult
 from wazuh.core.utils import chmod_r, chown_r, get_hash, mkdir_with_mode, md5, process_array
 from wazuh.rbac.decorators import expose_resources

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -139,12 +139,12 @@ def check_agent(test_data, agent):
 
 @pytest.mark.parametrize('value', [
     True,
-    False
+    OSError
 ])
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
+@patch("wazuh.core.agent.WazuhDBBackend")
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryAgents__init__(mock_socket_conn, mock_isfile, mock_sqli_conn, value):
+def test_WazuhDBQueryAgents__init__(socket_mock, send_mock, backend_mock, value):
     """Tests if method __init__ of WazuhDBQueryAgents works properly.
 
     Parameters
@@ -154,13 +154,13 @@ def test_WazuhDBQueryAgents__init__(mock_socket_conn, mock_isfile, mock_sqli_con
     value : boolean
         Boolean to be returned by the method glob.glob().
     """
-    with patch('wazuh.core.utils.glob.glob', return_value=value):
-        if value:
+    socket_mock.side_effect = value
+    if value:
+        WazuhDBQueryAgents()
+        backend_mock.assert_called_once()
+    else:
+        with pytest.raises(WazuhException, match=".* 2005 .*"):
             WazuhDBQueryAgents()
-            mock_sqli_conn.assert_called_once()
-        else:
-            with pytest.raises(WazuhException, match=".* 1600 .*"):
-                WazuhDBQueryAgents()
 
 
 @pytest.mark.parametrize('value, expected_query', [
@@ -169,12 +169,8 @@ def test_WazuhDBQueryAgents__init__(mock_socket_conn, mock_isfile, mock_sqli_con
     ('never_connected', 'last_keepalive IS NULL AND id != 0'),
     ('pending', 'last_keepalive IS NOT NULL AND version IS NULL')
 ])
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryAgents_filter_status(mock_socket_conn, mock_isfile, mock_sqli_conn, mock_glob, value,
-                                          expected_query):
+def test_WazuhDBQueryAgents_filter_status(mock_socket_conn, value, expected_query):
     """Tests _filter_status of WazuhDBQueryAgents returns expected query
 
     Parameters
@@ -191,31 +187,22 @@ def test_WazuhDBQueryAgents_filter_status(mock_socket_conn, mock_isfile, mock_sq
     query_agent._filter_status({'value': value, 'operator': '!='})
     assert ('NOT ' + expected_query) in query_agent.query, 'Query returned does not match the expected one'
 
-    mock_sqli_conn.assert_called_once()
 
-
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryAgents_filter_status_ko(mock_socket_conn, mock_isfile, mock_sqli_conn, mock_glob):
+def test_WazuhDBQueryAgents_filter_status_ko(mock_socket_conn):
     """Tests _filter_status of WazuhDBQueryAgents raises expected exception"""
     with pytest.raises(WazuhException, match=f'.* 1729 .*'):
         query_agent = WazuhDBQueryAgents()
         query_agent._filter_status({'value': 'unknown', 'operator': '=='})
 
 
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryAgents_filter_date(mock_socket_conn, mock_isfile, mock_sqli_conn, mock_glob):
+def test_WazuhDBQueryAgents_filter_date(mock_socket_conn):
     """Tests _filter_date of WazuhDBQueryAgents returns expected query"""
     query_agent = WazuhDBQueryAgents()
     query_agent._filter_date({'value': '7d', 'operator': '<', 'field': 'time'}, 'os.name')
 
     assert ' AND id != 0' in query_agent.query, 'Query returned does not match the expected one'
-    mock_sqli_conn.assert_called_once()
 
 
 @pytest.mark.parametrize('field, expected_query', [
@@ -223,12 +210,8 @@ def test_WazuhDBQueryAgents_filter_date(mock_socket_conn, mock_isfile, mock_sqli
     ('os.version', 'CAST(os_major AS INTEGER) asc, CAST(os_minor AS INTEGER) asc'),
     ('id', 'id asc'),
 ])
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryAgents_sort_query(mock_socket_conn, mock_isfile, mock_sqli_conn, mock_glob,
-                                       field, expected_query):
+def test_WazuhDBQueryAgents_sort_query(mock_socket_conn, field, expected_query):
     """Tests _sort_query of WazuhDBQueryAgents returns expected result
 
     Parameters
@@ -242,27 +225,19 @@ def test_WazuhDBQueryAgents_sort_query(mock_socket_conn, mock_isfile, mock_sqli_
     result = query_agent._sort_query(field)
 
     assert expected_query in result, 'Result does not match the expected one'
-    mock_sqli_conn.assert_called_once()
 
 
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryAgents_add_search_to_query(mock_socket_conn, mock_isfile, mock_sqli_conn, mock_glob):
+def test_WazuhDBQueryAgents_add_search_to_query(mock_socket_conn):
     """Tests _add_search_to_query of WazuhDBQueryAgents returns expected query"""
     query_agent = WazuhDBQueryAgents(search={'value': 'test', 'negation': True})
     query_agent._add_search_to_query()
 
     assert 'OR id LIKE :search_id)' in query_agent.query, 'Query returned does not match the expected one'
-    mock_sqli_conn.assert_called_once()
 
 
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryAgents_format_data_into_dictionary(mock_socket_conn, mock_isfile, mock_sqli_conn, mock_glob):
+def test_WazuhDBQueryAgents_format_data_into_dictionary(mock_socket_conn):
     """Tests _format_data_into_dictionary of WazuhDBQueryAgents returns expected data"""
     data = [{'id': 0, 'status': 'updated', 'group': 'default,group1,group2', 'manager': 'master',
              'dateAdd': 1000000000}]
@@ -285,18 +260,14 @@ def test_WazuhDBQueryAgents_format_data_into_dictionary(mock_socket_conn, mock_i
     assert result['items'][0]['manager'] == 'master'
 
 
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryAgents_parse_legacy_filters(mock_socket_conn, mock_isfile, mock_sqli_conn, mock_glob):
+def test_WazuhDBQueryAgents_parse_legacy_filters(mock_socket_conn):
     """Tests _parse_legacy_filters of WazuhDBQueryAgents returns expected query"""
     query_agent = WazuhDBQueryAgents(filters={'older_than': 'test'})
     query_agent._parse_legacy_filters()
 
     assert '(lastKeepAlive>test;status!=never_connected,dateAdd>test;status=never_connected)' in query_agent.q, \
         'Query returned does not match the expected one'
-    mock_sqli_conn.assert_called_once()
 
 
 @pytest.mark.parametrize('field_name, field_filter, q_filter', [
@@ -304,12 +275,8 @@ def test_WazuhDBQueryAgents_parse_legacy_filters(mock_socket_conn, mock_isfile, 
     ('group', 'test', {'value': '1', 'operator': 'LIKE'}),
     ('os.name', 'field', {'value': '1', 'operator': 'LIKE', 'field': 'status$0'}),
 ])
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryAgents_process_filter(mock_socket_conn, mock_isfile, mock_sqli_conn, mock_glob,
-                                           field_name, field_filter, q_filter):
+def test_WazuhDBQueryAgents_process_filter(mock_socket_conn, field_name, field_filter, q_filter):
     """Tests _process_filter of WazuhDBQueryAgents returns expected query
 
     Parameters
@@ -332,17 +299,15 @@ def test_WazuhDBQueryAgents_process_filter(mock_socket_conn, mock_isfile, mock_s
         assert 'agentos_name LIKE :field COLLATE NOCASE' in query_agent.query, \
             'Query returned does not match the expected one'
 
-    mock_sqli_conn.assert_called_once()
-
 
 @pytest.mark.parametrize('value', [
     True,
-    False
+    OSError
 ])
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
+@patch("wazuh.core.agent.WazuhDBBackend")
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryGroup__init__(mock_socket_conn, mock_isfile, mock_sqli_conn, value):
+def test_WazuhDBQueryGroup__init__(socket_mock, send_mock, backend_mock, value):
     """Test if method __init__ of WazuhDBQueryGroup works properly.
 
     Parameters
@@ -352,21 +317,22 @@ def test_WazuhDBQueryGroup__init__(mock_socket_conn, mock_isfile, mock_sqli_conn
     value : boolean
         Boolean to be returned by the method glob.glob().
     """
-    with patch('wazuh.core.utils.glob.glob', return_value=value):
-        if value:
+    socket_mock.side_effect = value
+    if value:
+        WazuhDBQueryGroup()
+        backend_mock.assert_called_once()
+    else:
+        with pytest.raises(WazuhException, match=".* 2005 .*"):
             WazuhDBQueryGroup()
-            mock_sqli_conn.assert_called_once()
-        else:
-            with pytest.raises(WazuhException, match=".* 1600 .*"):
-                WazuhDBQueryGroup()
 
 
 @pytest.mark.parametrize('filters', [
     {'name': 'group-1'},
     {'name': 'group-2'}
 ])
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_WazuhDBQueryGroup_filters(filters):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_WazuhDBQueryGroup_filters(socket_mock, send_mock, filters):
     """Test if parameter filters of WazuhDBQueryGroup works properly.
 
         Parameters
@@ -381,26 +347,18 @@ def test_WazuhDBQueryGroup_filters(filters):
         assert (item[key] == value for key, value in filters.items())
 
 
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryGroupByAgents__init__(mock_socket_conn, mock_isfile, mock_glob, mock_sqli_conn):
+def test_WazuhDBQueryGroupByAgents__init__(mock_socket_conn):
     """Tests if method __init__ of WazuhDBQueryGroupByAgents works properly."""
     query_group = WazuhDBQueryGroupByAgents(filter_fields=['name', 'os.name'], offset=0, limit=1, sort={'order': 'asc'},
                                             search={'value': 'test', 'negation': True},
                                             select={'os.name'}, query=None, count=5, get_data=None)
 
     assert query_group.remove_extra_fields, 'Query returned does not match the expected one'
-    mock_sqli_conn.assert_called_once()
 
 
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryGroupByAgents_format_data_into_dictionary(mock_socket_conn, mock_isfile, mock_glob,
-                                                               mock_sqli_conn):
+def test_WazuhDBQueryGroupByAgents_format_data_into_dictionary(mock_socket_conn):
     """Tests if method _format_data_into_dictionary of WazuhDBQueryGroupByAgents works properly."""
     query_group = WazuhDBQueryGroupByAgents(filter_fields=['name', 'os.name'], offset=0, limit=1, sort={'order': 'asc'},
                                             search={'value': 'test', 'negation': True},
@@ -414,12 +372,8 @@ def test_WazuhDBQueryGroupByAgents_format_data_into_dictionary(mock_socket_conn,
     assert all(x['os']['name'] == 'unknown' for x in result['items'])
 
 
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryGroupByAgents_format_data_into_dictionary_status(mock_socket_conn, mock_isfile, mock_glob,
-                                                                      mock_sqli_conn):
+def test_WazuhDBQueryGroupByAgents_format_data_into_dictionary_status(mock_socket_conn):
     """Tests if method _format_data_into_dictionary of WazuhDBQueryGroupByAgents works properly."""
     query_group = WazuhDBQueryGroupByAgents(filter_fields=['status', 'os.name'], offset=0, limit=1, sort=None,
                                             search=None, select=None, query=None, count=5, get_data=None)
@@ -434,27 +388,20 @@ def test_WazuhDBQueryGroupByAgents_format_data_into_dictionary_status(mock_socke
     assert result == {'items': [{'os': {'name': 'Ubuntu'}, 'status': 'disconnected', 'count': 4}], 'totalItems': 0}
 
 
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryMultigroups__init__(mock_socket_conn, mock_isfile, mock_glob, mock_sqli_conn):
+def test_WazuhDBQueryMultigroups__init__(mock_socket_conn):
     """Tests if method __init__ of WazuhDBQueryMultigroups works properly."""
     query_multigroups = WazuhDBQueryMultigroups(group_id='test')
 
     assert 'group=test' in query_multigroups.q, 'Query returned does not match the expected one'
-    mock_sqli_conn.assert_called_once()
 
 
 @pytest.mark.parametrize('group_id', [
     'null',
     'test'
 ])
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryMultigroups_default_query(mock_socket_conn, mock_isfile, mock_glob, mock_sqli_conn, group_id):
+def test_WazuhDBQueryMultigroups_default_query(mock_socket_conn, group_id):
     """Tests if method _default_query of WazuhDBQueryMultigroups works properly.
 
     Parameters
@@ -471,33 +418,24 @@ def test_WazuhDBQueryMultigroups_default_query(mock_socket_conn, mock_isfile, mo
         assert 'SELECT {0} FROM agent a LEFT JOIN belongs b ON a.id = b.id_agent' in result, \
             'Query returned does not match the expected one'
 
-    mock_sqli_conn.assert_called_once()
 
-
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryMultigroups_default_count_query(mock_socket_conn, mock_isfile, mock_glob, mock_sqli_conn):
+def test_WazuhDBQueryMultigroups_default_count_query(mock_socket_conn):
     """Tests if method _default_count_query of WazuhDBQueryMultigroups works properly."""
     query_multigroups = WazuhDBQueryMultigroups(group_id='test')
     result = query_multigroups._default_count_query()
 
     assert 'COUNT(DISTINCT a.id)' in result, 'Query returned does not match the expected one'
-    mock_sqli_conn.assert_called_once()
 
 
-@patch('wazuh.core.utils.glob.glob', return_value=True)
-@patch('sqlite3.connect')
-@patch("wazuh.core.database.isfile", return_value=True)
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_WazuhDBQueryMultigroups_get_total_items(mock_socket_conn, mock_isfile, mock_glob, mock_sqli_conn):
+def test_WazuhDBQueryMultigroups_get_total_items(mock_socket_conn, send_mock):
     """Tests if method _get_total_items of WazuhDBQueryMultigroups works properly."""
     query_multigroups = WazuhDBQueryMultigroups(group_id='test')
     query_multigroups._get_total_items()
 
     assert 'GROUP BY a.id' in query_multigroups.query, 'Query returned does not match the expected one'
-    mock_sqli_conn.assert_called_once()
 
 
 @pytest.mark.parametrize('id, ip, name, key', [
@@ -524,26 +462,18 @@ def test_agent__init__(mock_add, id, ip, name, key):
         'Query returned does not match the expected one'
 
 
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
 def test_agent__str__():
     """Tests if method __str__ of Agent returns a string type."""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
+    agent = Agent()
 
-        agent = Agent()
-
-        assert isinstance(str(agent), str)
+    assert isinstance(str(agent), str)
 
 
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
 def test_agent_to_dict():
     """Tests if method to_dict() of Agent returns a dict type."""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
+    agent = Agent()
 
-        agent = Agent()
-
-        assert isinstance(agent.to_dict(), dict), 'Result is not a dict'
+    assert isinstance(agent.to_dict(), dict), 'Result is not a dict'
 
 
 @pytest.mark.parametrize('id, expected_ip, expected_name, expected_codename', [
@@ -551,8 +481,9 @@ def test_agent_to_dict():
     ('001', '172.17.0.202', 'agent-1', 'Bionic Beaver'),
     ('002', '172.17.0.201', 'agent-2', 'Xenial'),
 ])
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_load_info_from_db(id, expected_ip, expected_name, expected_codename):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_load_info_from_db(socket_mock, send_mock, id, expected_ip, expected_name, expected_codename):
     """Tests if method load_info_from_db of Agent returns a correct info.
 
     Parameters
@@ -566,26 +497,21 @@ def test_agent_load_info_from_db(id, expected_ip, expected_name, expected_codena
     expected_codename : str
         OS codename expected on the returned agent.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
+    agent = Agent(id=id)
+    agent.load_info_from_db()
+    result = agent.to_dict()
 
-        agent = Agent(id=id)
-        agent.load_info_from_db()
-        result = agent.to_dict()
-
-        assert result['id'] == id and result['name'] == expected_name and result['ip'] == expected_ip and \
-               result['os']['codename'] == expected_codename
+    assert result['id'] == id and result['name'] == expected_name and result['ip'] == expected_ip and \
+           result['os']['codename'] == expected_codename
 
 
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_load_info_from_db_ko():
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_load_info_from_db_ko(socket_mock, send_mock):
     """Tests if method load_info_from_db raises expected exception"""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        with pytest.raises(WazuhResourceNotFound, match='.* 1701 .*'):
-            agent = Agent(id=11250)
-            agent.load_info_from_db()
+    with pytest.raises(WazuhResourceNotFound, match='.* 1701 .*'):
+        agent = Agent(id=11250)
+        agent.load_info_from_db()
 
 
 @pytest.mark.parametrize('id, select', [
@@ -596,8 +522,9 @@ def test_agent_load_info_from_db_ko():
     (0, {'status', 'manager', 'node_name', 'dateAdd', 'lastKeepAlive'}),
     (2, {'status', 'manager', 'node_name', 'dateAdd', 'lastKeepAlive'})
 ])
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_basic_information(id, select):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_basic_information(socket_mock, send_mock, id, select):
     """Tests if method get_basic_information returns expected data
 
     Parameters
@@ -607,16 +534,13 @@ def test_agent_get_basic_information(id, select):
     select : set
         Fields to return.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
+    agent = Agent(id)
+    result = agent.get_basic_information(select)
 
-        agent = Agent(id)
-        result = agent.get_basic_information(select)
-
-        assert isinstance(result, dict), 'Result is not a dict'
-        if select is not None:
-            assert all((x in select for x in result.keys())) and len(result.keys()) == len(select), \
-                'Result does not contain expected keys.'
+    assert isinstance(result, dict), 'Result is not a dict'
+    if select is not None:
+        assert all((x in select for x in result.keys())) and len(result.keys()) == len(select), \
+            'Result does not contain expected keys.'
 
 
 @pytest.mark.parametrize('id, expected_key', [
@@ -654,8 +578,9 @@ def test_agent_compute_key(id, expected_key):
     (5,
      'MDA1IGFnZW50LTUgMTcyLjE3LjAuMzAwIGIzNjUwZTExZWJhMmYyN2VyNGQxNjBjNjlkZTUzM2VlN2VlZDYwMTYzNmE0MmJhMjQ1NWQ1M2E5MDkyNzc0N2Y='),
 ])
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_key(id, expected_key):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_key(socket_mock, send_mock, id, expected_key):
     """Tests if method get_key returns expected key for each agent
 
     Parameters
@@ -665,60 +590,51 @@ def test_agent_get_key(id, expected_key):
     expected_key :
         Key that should be returned for given ID.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
+    agent = Agent(id)
+    result = agent.get_key()
 
-        agent = Agent(id)
-        result = agent.get_key()
-
-        assert result == expected_key, 'Result does not match with expected key'
+    assert result == expected_key, 'Result does not match with expected key'
 
 
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_key_ko():
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_key_ko(socket_mock, send_mock):
     """Tests if method get_key raises exception when ID is 0"""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        with pytest.raises(WazuhError, match='.* 1703 .*'):
-            agent = Agent(0)
-            agent.get_key()
+    with pytest.raises(WazuhError, match='.* 1703 .*'):
+        agent = Agent(0)
+        agent.get_key()
 
 
 @patch('wazuh.core.agent.OssecQueue')
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_restart(mock_queue):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_restart(socket_mock, send_mock, mock_queue):
     """Tests if method restart calls other methods with correct params"""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
+    with patch('wazuh.core.agent.Agent.getconfig', return_value={'active-response': {'disabled': 'no'}}) as \
+            mock_config:
+        agent = Agent(0)
+        agent.restart()
 
-        with patch('wazuh.core.agent.Agent.getconfig', return_value={'active-response': {'disabled': 'no'}}) as \
-                mock_config:
-            agent = Agent(0)
+        # Assert methods are called with correct params
+        mock_config.assert_called_once_with('com', 'active-response')
+        mock_queue.assert_called_once()
+
+
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_restart_ko(socket_mock, send_mock):
+    """Tests if method restart raises exception"""
+    # Assert exception is raised when status of agent is not 'active'
+    with patch('wazuh.core.agent.Agent.getconfig', return_value={'active-response': {'disabled': 'no'}}):
+        with pytest.raises(WazuhError, match='.* 1707 .*'):
+            agent = Agent(3)
             agent.restart()
 
-            # Assert methods are called with correct params
-            mock_config.assert_called_once_with('com', 'active-response')
-            mock_queue.assert_called_once()
-
-
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_restart_ko():
-    """Tests if method restart raises exception"""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        # Assert exception is raised when status of agent is not 'active'
-        with patch('wazuh.core.agent.Agent.getconfig', return_value={'active-response': {'disabled': 'no'}}):
-            with pytest.raises(WazuhError, match='.* 1707 .*'):
-                agent = Agent(3)
-                agent.restart()
-
-        # Assert exception is raised when active-response is disabled
-        with patch('wazuh.core.agent.Agent.getconfig', return_value={'active-response': {'disabled': 'yes'}}):
-            with pytest.raises(WazuhException, match='.* 1750 .*'):
-                agent = Agent(0)
-                agent.restart()
+    # Assert exception is raised when active-response is disabled
+    with patch('wazuh.core.agent.Agent.getconfig', return_value={'active-response': {'disabled': 'yes'}}):
+        with pytest.raises(WazuhException, match='.* 1750 .*'):
+            agent = Agent(0)
+            agent.restart()
 
 
 @pytest.mark.parametrize('status', [
@@ -790,10 +706,11 @@ def test_agent_remove_authd(mock_ossec_socket):
 @freeze_time('1975-01-01')
 @patch("wazuh.common.ossec_uid", return_value=getpwnam("root"))
 @patch("wazuh.common.ossec_gid", return_value=getgrnam("root"))
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_remove_manual(grp_mock, pwd_mock, chmod_r_mock, makedirs_mock, safe_move_mock, isdir_mock, isfile_mock,
-                             exists_mock, glob_mock, stat_mock, chmod_mock, chown_mock, rmtree_mock, remove_mock,
-                             wdb_mock, backup, exists_backup_dir):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_remove_manual(socket_mock, send_mock, grp_mock, pwd_mock, chmod_r_mock, makedirs_mock, safe_move_mock,
+                             isdir_mock, isfile_mock, exists_mock, glob_mock, stat_mock, chmod_mock, chown_mock,
+                             rmtree_mock, remove_mock, wdb_mock, backup, exists_backup_dir):
     """Test the _remove_manual function
 
     Parameters
@@ -806,13 +723,11 @@ def test_agent_remove_manual(grp_mock, pwd_mock, chmod_r_mock, makedirs_mock, sa
             'select id, name, register_ip, internal_key from agent where id > 0')])
 
     with patch('wazuh.core.agent.open', mock_open(read_data=client_keys_text)) as m:
-        with patch('sqlite3.connect') as mock_db:
-            mock_db.return_value = test_data.global_db
-            if exists_backup_dir:
-                exists_mock.side_effect = [True, True, True] + [False] * 10
-            else:
-                exists_mock.side_effect = lambda x: not (common.backup_path in x)
-            Agent('001')._remove_manual(backup=backup)
+        if exists_backup_dir:
+            exists_mock.side_effect = [True, True, True] + [False] * 10
+        else:
+            exists_mock.side_effect = lambda x: not (common.backup_path in x)
+        Agent('001')._remove_manual(backup=backup)
 
         m.assert_any_call(common.client_keys)
         m.assert_any_call(common.client_keys + '.tmp', 'w')
@@ -1072,8 +987,9 @@ def test_agent_delete_single_group(mock_remove_manual, mock_time, mock_safe_move
     (2, 'register_ip', '172.17.0.201'),
     (1, 'os_arch', 'x86_64')
 ])
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_agent_attr(id, attr, expected_result):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agent_attr(socket_mock, send_mock, id, attr, expected_result):
     """Tests if method get_agent_attr() returns expected value for the given attribute
 
     Parameters
@@ -1085,38 +1001,34 @@ def test_agent_get_agent_attr(id, attr, expected_result):
     expected_result : str
         Expected value to be obtained.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        agent = Agent(id)
-        result = agent.get_agent_attr(attr)
-        assert result == expected_result
+    agent = Agent(id)
+    result = agent.get_agent_attr(attr)
+    assert result == expected_result
 
 
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'var', 'db', 'test'))
-def test_agent_get_agent_attr_ko():
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agent_attr_ko(socket_mock, send_mock):
     """Tests if method get_agent_attr() raises expected exception when there is no path to DB"""
-
     with pytest.raises(WazuhInternalError, match='.* 1600 .*'):
         agent = Agent(0)
         agent.get_agent_attr('name')
 
 
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_agents_overview_default():
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_overview_default(socket_mock, send_mock):
     """Test to get all agents using default parameters"""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
 
-        agents = Agent.get_agents_overview()
+    agents = Agent.get_agents_overview()
 
-        # check number of agents
-        assert agents['totalItems'] == 9
-        # check the return dictionary has all necessary fields
+    # check number of agents
+    assert agents['totalItems'] == 9
+    # check the return dictionary has all necessary fields
 
-        for agent in agents['items']:
-            # check no values are returned as None
-            check_agent(test_data, agent)
+    for agent in agents['items']:
+        # check no values are returned as None
+        check_agent(test_data, agent)
 
 
 @pytest.mark.parametrize("select, status, older_than, offset", [
@@ -1132,8 +1044,9 @@ def test_agent_get_agents_overview_default():
     ({'id', 'ip', 'lastKeepAlive'}, 'pending', '15m', 1),
     ({'id', 'ip', 'lastKeepAlive'}, ['active', 'pending'], '15m', 1)
 ])
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_agents_overview_select(select, status, older_than, offset):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_overview_select(socket_mock, send_mock, select, status, older_than, offset):
     """Test get_agents_overview function with multiple select parameters
 
     Parameters
@@ -1147,12 +1060,9 @@ def test_agent_get_agents_overview_select(select, status, older_than, offset):
     offset : int
         First item to return.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        agents = Agent.get_agents_overview(select=select, filters={'status': status, 'older_than': older_than},
-                                           offset=offset)
-        assert all(map(lambda x: x.keys() == select, agents['items']))
+    agents = Agent.get_agents_overview(select=select, filters={'status': status, 'older_than': older_than},
+                                       offset=offset)
+    assert all(map(lambda x: x.keys() == select, agents['items']))
 
 
 @pytest.mark.parametrize("search, totalItems", [
@@ -1162,8 +1072,9 @@ def test_agent_get_agents_overview_select(select, status, older_than, offset):
     ({'value': '202', 'negation': 1}, 8),
     ({'value': 'master', 'negation': 1}, 2)
 ])
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_agents_overview_search(search, totalItems):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_overview_search(socket_mock, send_mock, search, totalItems):
     """Test searching by IP and Register IP
 
     Parameters
@@ -1173,11 +1084,8 @@ def test_agent_get_agents_overview_search(search, totalItems):
     totalItems : int
         Expected number of items to be returned.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        agents = Agent.get_agents_overview(search=search)
-        assert len(agents['items']) == totalItems
+    agents = Agent.get_agents_overview(search=search)
+    assert len(agents['items']) == totalItems
 
 
 @pytest.mark.parametrize("query, totalItems", [
@@ -1187,8 +1095,9 @@ def test_agent_get_agents_overview_search(search, totalItems):
     ("status=disconnected;lastKeepAlive>34m", 1),
     ("(status=active,status=pending);lastKeepAlive>5m", 4)
 ])
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_agents_overview_query(query, totalItems):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_overview_query(socket_mock, send_mock, query, totalItems):
     """
 
     Parameters
@@ -1198,11 +1107,8 @@ def test_agent_get_agents_overview_query(query, totalItems):
     totalItems : int
         Expected number of items to be returned.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        agents = Agent.get_agents_overview(q=query)
-        assert len(agents['items']) == totalItems
+    agents = Agent.get_agents_overview(q=query)
+    assert len(agents['items']) == totalItems
 
 
 @pytest.mark.parametrize("status, older_than, totalItems, exception", [
@@ -1211,8 +1117,9 @@ def test_agent_get_agents_overview_query(query, totalItems):
     ('never_connected', '30m', 1, None),
     (55, '30m', 0, 1729)
 ])
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_agents_overview_status_olderthan(status, older_than, totalItems, exception):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_overview_status_olderthan(socket_mock, send_mock, status, older_than, totalItems, exception):
     """Test filtering by status
 
     Parameters
@@ -1226,25 +1133,24 @@ def test_agent_get_agents_overview_status_olderthan(status, older_than, totalIte
     exception : int
         Error code of expected exception.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-        kwargs = {'filters': {'status': status, 'older_than': older_than},
-                  'select': {'name', 'id', 'status', 'lastKeepAlive', 'dateAdd'}}
+    kwargs = {'filters': {'status': status, 'older_than': older_than},
+              'select': {'name', 'id', 'status', 'lastKeepAlive', 'dateAdd'}}
 
-        if exception is None:
-            agents = Agent.get_agents_overview(**kwargs)
-            assert agents['totalItems'] == totalItems
-        else:
-            with pytest.raises(WazuhException, match=f'.* {exception} .*'):
-                Agent.get_agents_overview(**kwargs)
+    if exception is None:
+        agents = Agent.get_agents_overview(**kwargs)
+        assert agents['totalItems'] == totalItems
+    else:
+        with pytest.raises(WazuhException, match=f'.* {exception} .*'):
+            Agent.get_agents_overview(**kwargs)
 
 
 @pytest.mark.parametrize("sort, first_id", [
     ({'fields': ['dateAdd'], 'order': 'asc'}, '000'),
     ({'fields': ['dateAdd'], 'order': 'desc'}, '004')
 ])
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_agents_overview_sort(sort, first_id):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_overview_sort(socket_mock, send_mock, sort, first_id):
     """Test sorting.
 
     Parameters
@@ -1254,11 +1160,8 @@ def test_agent_get_agents_overview_sort(sort, first_id):
     first_id : str
         First expected ID.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        agents = Agent.get_agents_overview(sort=sort, select={'dateAdd'})
-        assert agents['items'][0]['id'] == first_id
+    agents = Agent.get_agents_overview(sort=sort, select={'dateAdd'})
+    assert agents['items'][0]['id'] == first_id
 
 
 @pytest.mark.parametrize("agent_id, group_id, force, replace, replace_list", [
@@ -1268,8 +1171,9 @@ def test_agent_get_agents_overview_sort(sort, first_id):
 ])
 @patch('wazuh.common.groups_path', new=test_data_path)
 @patch('wazuh.common.shared_path', new=test_data_path)
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_agent_add_group_to_agent(agent_id, group_id, force, replace, replace_list):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_add_group_to_agent(socket_mock, send_mock, agent_id, group_id, force, replace, replace_list):
     """Test if add_group_to_agent() works as expected when adding an existing group to agent
 
     Parameters
@@ -1316,50 +1220,49 @@ def test_agent_add_group_to_agent(agent_id, group_id, force, replace, replace_li
 
 @patch('wazuh.common.groups_path', new=os.path.join(test_data_path, 'etc', 'shared'))
 @patch('wazuh.common.shared_path', new=os.path.join(test_data_path, 'etc', 'shared'))
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_agent_add_group_to_agent_ko():
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_add_group_to_agent_ko(socket_mock, send_mock):
     """Test if add_group_to_agent() raises expected exceptions"""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
+    # Master cannot be added to a conf group
+    with pytest.raises(WazuhError, match='.* 1703 .*'):
+        Agent.add_group_to_agent('test_group', '000')
 
-        # Master cannot be added to a conf group
-        with pytest.raises(WazuhError, match='.* 1703 .*'):
-            Agent.add_group_to_agent('test_group', '000')
+    # Group does not exists
+    with pytest.raises(WazuhResourceNotFound, match='.* 1710 .*'):
+        Agent.add_group_to_agent('test_group', '002')
 
-        # Group does not exists
-        with pytest.raises(WazuhResourceNotFound, match='.* 1710 .*'):
+    with patch('os.path.exists', return_value=True):
+        # Agent status is never_connected
+        with pytest.raises(WazuhError, match='.* 1753 .*'):
+            Agent.add_group_to_agent('test_group', '003')
+
+        # Agent file does not exists
+        with pytest.raises(WazuhInternalError, match='.* 1005 .*'):
             Agent.add_group_to_agent('test_group', '002')
 
-        with patch('os.path.exists', return_value=True):
-            # Agent status is never_connected
-            with pytest.raises(WazuhError, match='.* 1753 .*'):
-                Agent.add_group_to_agent('test_group', '003')
+        with patch('builtins.open', mock_open(read_data='default')):
+            # Group cannot be replaced because it is not in replace_list (not enough permissions in rbac)
+            with pytest.raises(WazuhError, match='.* 1752 .*'):
+                Agent.add_group_to_agent('test_group', '002', replace=True, replace_list=['other'])
 
-            # Agent file does not exists
-            with pytest.raises(WazuhInternalError, match='.* 1005 .*'):
-                Agent.add_group_to_agent('test_group', '002')
+            # The group already belongs to the agent
+            with pytest.raises(WazuhError, match='.* 1751 .*'):
+                Agent.add_group_to_agent('default', '002')
 
-            with patch('builtins.open', mock_open(read_data='default')):
-                # Group cannot be replaced because it is not in replace_list (not enough permissions in rbac)
-                with pytest.raises(WazuhError, match='.* 1752 .*'):
-                    Agent.add_group_to_agent('test_group', '002', replace=True, replace_list=['other'])
-
-                # The group already belongs to the agent
-                with pytest.raises(WazuhError, match='.* 1751 .*'):
-                    Agent.add_group_to_agent('default', '002')
-
-                with patch('wazuh.common.max_groups_per_multigroup', new=0):
-                    # Multigroup limit exceeded.
-                    with pytest.raises(WazuhError, match='.* 1737 .*'):
-                        Agent.add_group_to_agent('test_group', '002')
+            with patch('wazuh.common.max_groups_per_multigroup', new=0):
+                # Multigroup limit exceeded.
+                with pytest.raises(WazuhError, match='.* 1737 .*'):
+                    Agent.add_group_to_agent('test_group', '002')
 
 
 @pytest.mark.parametrize("agent_id, seconds, expected_result", [
     ('002', 10, True),
     ('002', 700, False)
 ])
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_check_if_delete_agent(agent_id, seconds, expected_result):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_check_if_delete_agent(socket_mock, send_mock, agent_id, seconds, expected_result):
     """Test if check_if_delete_agent() returns True when time from last connection is greater than <seconds>
 
     Parameters
@@ -1371,11 +1274,8 @@ def test_agent_check_if_delete_agent(agent_id, seconds, expected_result):
     expected_result : bool
         Result that check_if_delete_agent() should return with given params.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        result = Agent.check_if_delete_agent(agent_id, seconds)
-        assert result == expected_result, f'Result is {result} but should be {expected_result}'
+    result = Agent.check_if_delete_agent(agent_id, seconds)
+    assert result == expected_result, f'Result is {result} but should be {expected_result}'
 
 
 @patch("wazuh.core.agent.Agent.get_basic_information")
@@ -1484,8 +1384,9 @@ def test_agent_check_multigroup_limit(groups, expected_result):
 ])
 @patch('wazuh.common.groups_path', new=test_data_path)
 @patch('wazuh.common.shared_path', new=test_data_path)
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_agent_unset_single_group_agent(agent_id, group_id, force, previous_groups, set_default):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_unset_single_group_agent(socket_mock, send_mock, agent_id, group_id, force, previous_groups, set_default):
     """Test if unset_single_group_agent() returns expected message and removes group from agent
 
     Parameters
@@ -1533,30 +1434,28 @@ def test_agent_unset_single_group_agent(agent_id, group_id, force, previous_grou
 
 @patch('wazuh.common.groups_path', new=os.path.join(test_data_path, 'etc', 'shared'))
 @patch('wazuh.common.shared_path', new=os.path.join(test_data_path, 'etc', 'shared'))
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_agent_unset_single_group_agent_ko():
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_unset_single_group_agent_ko(socket_mock, send_mock):
     """Test if unset_single_group_agent() raises expected exceptions"""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
+    # Master cannot be added to a conf group
+    with pytest.raises(WazuhError, match='.* 1703 .*'):
+        Agent.unset_single_group_agent('000', 'test_group')
 
-        # Master cannot be added to a conf group
-        with pytest.raises(WazuhError, match='.* 1703 .*'):
-            Agent.unset_single_group_agent('000', 'test_group')
+    # Group does not exists
+    with pytest.raises(WazuhResourceNotFound, match='.* 1710 .*'):
+        Agent.unset_single_group_agent('002', 'test_group')
 
-        # Group does not exists
-        with pytest.raises(WazuhResourceNotFound, match='.* 1710 .*'):
-            Agent.unset_single_group_agent('002', 'test_group')
+    with patch('os.path.exists', return_value=True):
+        with patch('wazuh.core.agent.Agent.get_agents_group_file', return_value='new_group,new_group2'):
+            # Group_id is not within group_list
+            with pytest.raises(WazuhError, match='.* 1734 .*'):
+                Agent.unset_single_group_agent('002', 'test_group')
 
-        with patch('os.path.exists', return_value=True):
-            with patch('wazuh.core.agent.Agent.get_agents_group_file', return_value='new_group,new_group2'):
-                # Group_id is not within group_list
-                with pytest.raises(WazuhError, match='.* 1734 .*'):
-                    Agent.unset_single_group_agent('002', 'test_group')
-
-            with patch('wazuh.core.agent.Agent.get_agents_group_file', return_value='default'):
-                # Agent file does not exists
-                with pytest.raises(WazuhError, match='.* 1745 .*'):
-                    Agent.unset_single_group_agent('002', 'default')
+        with patch('wazuh.core.agent.Agent.get_agents_group_file', return_value='default'):
+            # Agent file does not exists
+            with pytest.raises(WazuhError, match='.* 1745 .*'):
+                Agent.unset_single_group_agent('002', 'default')
 
 
 @pytest.mark.parametrize('wpk_repo, use_http, protocol', [
@@ -1587,8 +1486,9 @@ def test_agent_get_protocol(wpk_repo, use_http, protocol):
     ('002', 'debian', 'v3.3.0', 'https://packages.wazuh.com/wpk/debian/16/x86_64/versions')
 ])
 @patch('wazuh.core.agent.requests.get')
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_versions(requests_mock, agent_id, platform, version, expected_url):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_versions(socket_mock, send_mock, requests_mock, agent_id, platform, version, expected_url):
     """Test if _get_versions() returns correct message.
 
     Parameters
@@ -1605,42 +1505,38 @@ def test_agent_get_versions(requests_mock, agent_id, platform, version, expected
     # regex for checking SHA-1 hash
     regex_sha1 = re.compile(r'^[0-9a-f]{40}$')
 
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
+    agent = Agent(agent_id)
+    agent.load_info_from_db()
+    agent.os['platform'] = platform
+    # mock request with available versions from server
+    requests_mock.return_value.text = '\n'.join(' '.join(x) for x in wpk_versions)
+    requests_mock.return_value.ok = True
+    available_versions = agent._get_versions(version=version)
 
-        agent = Agent(agent_id)
-        agent.load_info_from_db()
-        agent.os['platform'] = platform
-        # mock request with available versions from server
-        requests_mock.return_value.text = '\n'.join(' '.join(x) for x in wpk_versions)
-        requests_mock.return_value.ok = True
-        available_versions = agent._get_versions(version=version)
-
-        requests_mock.assert_called_once_with(expected_url)
-        for i, version in enumerate(available_versions):
-            assert version == wpk_versions[i]
-            assert re.search(regex_sha1, version[1])
+    requests_mock.assert_called_once_with(expected_url)
+    for i, version in enumerate(available_versions):
+        assert version == wpk_versions[i]
+        assert re.search(regex_sha1, version[1])
 
 
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_versions_ko():
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_versions_ko(socket_mock, send_mock):
     """Test if _get_versions() raises expected exceptions"""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
 
-        agent = Agent('002')
-        agent.load_info_from_db()
+    agent = Agent('002')
+    agent.load_info_from_db()
 
-        # Request.get returns code over 400
-        with patch('wazuh.core.agent.requests.get') as requests_mock:
-            requests_mock.return_value.ok = False
-            with pytest.raises(WazuhInternalError, match='.* 1713 .*'):
-                agent._get_versions()
-
-        # Platform is not valid
-        agent.os['platform'] = 'solaris'
+    # Request.get returns code over 400
+    with patch('wazuh.core.agent.requests.get') as requests_mock:
+        requests_mock.return_value.ok = False
         with pytest.raises(WazuhInternalError, match='.* 1713 .*'):
             agent._get_versions()
+
+    # Platform is not valid
+    agent.os['platform'] = 'solaris'
+    with pytest.raises(WazuhInternalError, match='.* 1713 .*'):
+        agent._get_versions()
 
 
 @pytest.mark.parametrize('agent_id, version, platform, force, already_downloaded', [
@@ -1658,9 +1554,11 @@ def test_agent_get_versions_ko():
 @patch('wazuh.core.agent.open')
 @patch('wazuh.core.agent.requests.get')
 @patch('wazuh.core.agent.Agent._get_versions')
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_wpk_file(versions_mock, get_req_mock, open_mock, sha1_mock, mock_ossec_gid, mock_ossec_uid,
-                            mock_chown, mock_chmod, agent_id, version, platform, force, already_downloaded):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_wpk_file(socket_mock, send_mock, versions_mock, get_req_mock, open_mock, sha1_mock, mock_ossec_gid,
+                            mock_ossec_uid, mock_chown, mock_chmod, agent_id, version, platform, force,
+                            already_downloaded):
     """Test _get_wpk_file() method returns the correct wpk file and hash.
 
     Parameters
@@ -1695,22 +1593,20 @@ def test_agent_get_wpk_file(versions_mock, get_req_mock, open_mock, sha1_mock, m
     get_req_mock.return_value.ok = True
     get_req_mock.return_value.iter_content.side_effect = 'a'
 
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-        agent = Agent(agent_id)
-        agent.load_info_from_db()
-        agent.os['platform'] = platform
-        # mock return value of hexdigest function
-        manager_version, hash_manager_version = get_manager_info(wpk_versions)
-        sha1_mock.return_value.hexdigest.return_value = hash_manager_version
+    agent = Agent(agent_id)
+    agent.load_info_from_db()
+    agent.os['platform'] = platform
+    # mock return value of hexdigest function
+    manager_version, hash_manager_version = get_manager_info(wpk_versions)
+    sha1_mock.return_value.hexdigest.return_value = hash_manager_version
 
-        with patch('wazuh.core.agent.path.isfile', return_value=already_downloaded):
-            result = agent._get_wpk_file(debug=True, version=version, force=force)
+    with patch('wazuh.core.agent.path.isfile', return_value=already_downloaded):
+        result = agent._get_wpk_file(debug=True, version=version, force=force)
 
-        assert result[1] == hash_manager_version
-        # get_req_mock.return_value.iter_content.assert_called_once_with('a')
-        if not force:
-            assert get_package_version(result[0]) == manager_version
+    assert result[1] == hash_manager_version
+    # get_req_mock.return_value.iter_content.assert_called_once_with('a')
+    if not force:
+        assert get_package_version(result[0]) == manager_version
 
 
 @patch('wazuh.core.agent.chmod')
@@ -1720,46 +1616,45 @@ def test_agent_get_wpk_file(versions_mock, get_req_mock, open_mock, sha1_mock, m
 @patch('wazuh.core.agent.hashlib.sha1')
 @patch('wazuh.core.agent.open')
 @patch('wazuh.core.agent.Agent._get_versions')
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_get_wpk_file_ko(versions_mock, open_mock, sha1_mock, mock_ossec_gid, mock_ossec_uid,
-                               mock_chown, mock_chmod):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_wpk_file_ko(socket_mock, send_mock, versions_mock, open_mock, sha1_mock, mock_ossec_gid,
+                               mock_ossec_uid, mock_chown, mock_chmod):
     """Test _get_wpk_file() method raises the expected exceptions"""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-        agent = Agent('002')
-        agent.load_info_from_db()
+    agent = Agent('002')
+    agent.load_info_from_db()
 
-        # mock _get_versions method with a list of available versions
-        versions_mock.return_value = wpk_versions
+    # mock _get_versions method with a list of available versions
+    versions_mock.return_value = wpk_versions
 
-        with patch('wazuh.core.agent.requests.get') as request_mock:
-            request_mock.return_value.ok = True
+    with patch('wazuh.core.agent.requests.get') as request_mock:
+        request_mock.return_value.ok = True
 
-            # Version not in _ger_versions list
-            with pytest.raises(WazuhInternalError, match='.* 1718 .*'):
-                agent._get_wpk_file(version='v3.8.5')
+        # Version not in _ger_versions list
+        with pytest.raises(WazuhInternalError, match='.* 1718 .*'):
+            agent._get_wpk_file(version='v3.8.5')
 
-            # Manager version lower than agent new version without force=True
-            with pytest.raises(WazuhError, match='.* 1717 .*'):
-                agent._get_wpk_file(version='v3.10.0')
+        # Manager version lower than agent new version without force=True
+        with pytest.raises(WazuhError, match='.* 1717 .*'):
+            agent._get_wpk_file(version='v3.10.0')
 
-            # Current agent version greater than version specified in get_wpk_file
-            with pytest.raises(WazuhError, match='.* 1749 .*'):
-                agent._get_wpk_file(version='v3.6.1')
+        # Current agent version greater than version specified in get_wpk_file
+        with pytest.raises(WazuhError, match='.* 1749 .*'):
+            agent._get_wpk_file(version='v3.6.1')
 
-            with pytest.raises(WazuhInternalError, match='.* 1714 .*'):
-                agent._get_wpk_file(debug=True, version='v3.8.3')
+        with pytest.raises(WazuhInternalError, match='.* 1714 .*'):
+            agent._get_wpk_file(debug=True, version='v3.8.3')
 
-            # status_code over 400 when calling requests API
-            request_mock.return_value.ok = False
-            with pytest.raises(WazuhInternalError, match='.* 1714 .*'):
-                agent._get_wpk_file(debug=True)
+        # status_code over 400 when calling requests API
+        request_mock.return_value.ok = False
+        with pytest.raises(WazuhInternalError, match='.* 1714 .*'):
+            agent._get_wpk_file(debug=True)
 
-            # Hash doesn't match
-            with pytest.raises(WazuhInternalError, match=".* 1714 .*"):
-                with patch('wazuh.core.agent.path.isfile', return_value=True):
-                    sha1_mock.return_value.hexdigest.return_value = 'random'
-                    agent._get_wpk_file(debug=True, version='3.3.9', force=True)
+        # Hash doesn't match
+        with pytest.raises(WazuhInternalError, match=".* 1714 .*"):
+            with patch('wazuh.core.agent.path.isfile', return_value=True):
+                sha1_mock.return_value.hexdigest.return_value = 'random'
+                agent._get_wpk_file(debug=True, version='3.3.9', force=True)
 
         # Requests API raises exception
         agent.os['platform'] = 'noexists'
@@ -1777,8 +1672,9 @@ def test_agent_get_wpk_file_ko(versions_mock, open_mock, sha1_mock, mock_ossec_g
 @patch('wazuh.core.agent.requests.get')
 @patch('wazuh.core.agent.Agent._get_wpk_file')
 @patch('wazuh.common.open_sleep', new=0)
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_send_wpk_file(_get_wpk_mock, get_req_mock, stat_mock, ossec_socket_mock,
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_send_wpk_file(socket_mock, send_mock, _get_wpk_mock, get_req_mock, stat_mock, ossec_socket_mock,
                              open_mock, agent_id):
     """Test _send_wpk_file method returns expected message and call socket.send with correct params
 
@@ -1787,30 +1683,28 @@ def test_agent_send_wpk_file(_get_wpk_mock, get_req_mock, stat_mock, ossec_socke
     agent_id : str
         Id of the agent.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-        agent = Agent(agent_id)
+    agent = Agent(agent_id)
 
-        for version in wpk_versions:
-            _get_wpk_mock.return_value = version
-            # mock return value of OssecSocket.receive method with a binary string
-            ossec_socket_mock.return_value.receive.side_effect = [f'ok {version[1]}'.encode(),
-                                                                  f'err {version[1]}'.encode()] + \
-                                                                 [f'ok {version[1]}'.encode()] * 5
-            # mock return value of open.read to avoid infinite loop
-            open_mock.return_value.read.side_effect = [b'test', b'']
+    for version in wpk_versions:
+        _get_wpk_mock.return_value = version
+        # mock return value of OssecSocket.receive method with a binary string
+        ossec_socket_mock.return_value.receive.side_effect = [f'ok {version[1]}'.encode(),
+                                                              f'err {version[1]}'.encode()] + \
+                                                             [f'ok {version[1]}'.encode()] * 5
+        # mock return value of open.read to avoid infinite loop
+        open_mock.return_value.read.side_effect = [b'test', b'']
 
-            result = agent._send_wpk_file(wpk_repo='packages.wazuh.com/4.x/wpk', debug=True, show_progress=Mock())
+        result = agent._send_wpk_file(wpk_repo='packages.wazuh.com/4.x/wpk', debug=True, show_progress=Mock())
 
-            assert result == ["WPK file sent", version[0]]
-            calls = [call(bytes(f'{agent_id} com lock_restart -1', encoding='ascii')),
-                     call(bytes(f'{agent_id} com open wb {version[0]}', encoding='ascii')),
-                     call(bytes(f'{agent_id} com open wb {version[0]}', encoding='ascii')),
-                     call(bytes(f'{agent_id} com lock_restart -1', encoding='ascii')),
-                     call(bytes(f'{agent_id} com write 4 {version[0]} test', encoding='ascii')),
-                     call(bytes(f'{agent_id} com close {version[0]}', encoding='ascii')),
-                     call(bytes(f'{agent_id} com sha1 {version[0]}', encoding='ascii'))]
-            ossec_socket_mock.return_value.send.assert_has_calls(calls)
+        assert result == ["WPK file sent", version[0]]
+        calls = [call(bytes(f'{agent_id} com lock_restart -1', encoding='ascii')),
+                 call(bytes(f'{agent_id} com open wb {version[0]}', encoding='ascii')),
+                 call(bytes(f'{agent_id} com open wb {version[0]}', encoding='ascii')),
+                 call(bytes(f'{agent_id} com lock_restart -1', encoding='ascii')),
+                 call(bytes(f'{agent_id} com write 4 {version[0]} test', encoding='ascii')),
+                 call(bytes(f'{agent_id} com close {version[0]}', encoding='ascii')),
+                 call(bytes(f'{agent_id} com sha1 {version[0]}', encoding='ascii'))]
+        ossec_socket_mock.return_value.send.assert_has_calls(calls)
 
 
 @patch('wazuh.core.agent.open')
@@ -1819,63 +1713,63 @@ def test_agent_send_wpk_file(_get_wpk_mock, get_req_mock, stat_mock, ossec_socke
 @patch('wazuh.core.agent.requests.get')
 @patch('wazuh.core.agent.Agent._get_wpk_file')
 @patch('wazuh.common.open_sleep', new=0)
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_send_wpk_file_ko(_get_wpk_mock, get_req_mock, stat_mock, ossec_socket_mock, open_mock):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_send_wpk_file_ko(socket_mock, send_mock, _get_wpk_mock, get_req_mock, stat_mock, ossec_socket_mock,
+                                open_mock):
     """Test _send_wpk_file raises expected exceptions"""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-        agent = Agent('001')
-        wpk_version = wpk_versions[0]
-        _get_wpk_mock.return_value = wpk_version
+    agent = Agent('001')
+    wpk_version = wpk_versions[0]
+    _get_wpk_mock.return_value = wpk_version
 
-        # 1er 'receive' method returns err
-        with pytest.raises(WazuhException, match=".* 1715 .*"):
-            ossec_socket_mock.return_value.receive.side_effect = [f'err {wpk_version}'.encode()]
-            agent._send_wpk_file(debug=True)
+    # 1er 'receive' method returns err
+    with pytest.raises(WazuhException, match=".* 1715 .*"):
+        ossec_socket_mock.return_value.receive.side_effect = [f'err {wpk_version}'.encode()]
+        agent._send_wpk_file(debug=True)
 
-        # 2nd 'receive' method returns err all the time in the loop
-        with pytest.raises(WazuhException, match=".* 1715 .*"):
-            ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] + \
-                                                                 [f'err {wpk_version}'.encode()] * 11
-            agent._send_wpk_file(wpk_repo='packages.wazuh.com/4.x/wpk', debug=True)
+    # 2nd 'receive' method returns err all the time in the loop
+    with pytest.raises(WazuhException, match=".* 1715 .*"):
+        ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] + \
+                                                             [f'err {wpk_version}'.encode()] * 11
+        agent._send_wpk_file(wpk_repo='packages.wazuh.com/4.x/wpk', debug=True)
 
-        # 3rd 'receive' method returns err all the time in the loop
-        with pytest.raises(WazuhException, match=".* 1715 .*"):
-            ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] * 2 + \
-                                                                 [f'err {wpk_version}'.encode()]
-            agent._send_wpk_file(debug=True)
+    # 3rd 'receive' method returns err all the time in the loop
+    with pytest.raises(WazuhException, match=".* 1715 .*"):
+        ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] * 2 + \
+                                                             [f'err {wpk_version}'.encode()]
+        agent._send_wpk_file(debug=True)
 
-        # 4th 'receive' method returns err
-        with pytest.raises(WazuhException, match=".* 1715 .*"):
-            ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] * 3 + \
-                                                                 [f'err {wpk_version}'.encode()]
-            agent._send_wpk_file(debug=True)
+    # 4th 'receive' method returns err
+    with pytest.raises(WazuhException, match=".* 1715 .*"):
+        ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] * 3 + \
+                                                             [f'err {wpk_version}'.encode()]
+        agent._send_wpk_file(debug=True)
 
-        open_mock.return_value.read.return_value = b''
+    open_mock.return_value.read.return_value = b''
 
-        # 5th 'receive' method returns err
-        with pytest.raises(WazuhException, match=".* 1715 .*"):
-            ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] * 3 + \
-                                                                 [f'err {wpk_version}'.encode()]
-            agent._send_wpk_file(debug=True)
+    # 5th 'receive' method returns err
+    with pytest.raises(WazuhException, match=".* 1715 .*"):
+        ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] * 3 + \
+                                                             [f'err {wpk_version}'.encode()]
+        agent._send_wpk_file(debug=True)
 
-        # 6th 'receive' method returns err
-        with pytest.raises(WazuhException, match=".* 1715 .*"):
-            ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] * 4 + \
-                                                                 [f'err {wpk_version}'.encode()]
-            agent._send_wpk_file(debug=True)
+    # 6th 'receive' method returns err
+    with pytest.raises(WazuhException, match=".* 1715 .*"):
+        ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] * 4 + \
+                                                             [f'err {wpk_version}'.encode()]
+        agent._send_wpk_file(debug=True)
 
-        # Hash doesn't match
-        with pytest.raises(WazuhException, match=".* 1715 .*"):
-            ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] * 4 + \
-                                                                 ['ok random'.encode()]
-            agent._send_wpk_file(debug=True)
+    # Hash doesn't match
+    with pytest.raises(WazuhException, match=".* 1715 .*"):
+        ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] * 4 + \
+                                                             ['ok random'.encode()]
+        agent._send_wpk_file(debug=True)
 
-        # open returns None
-        with pytest.raises(WazuhException, match=".* 1715 .*"):
-            ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] * 20
-            open_mock.return_value = None
-            agent._send_wpk_file(debug=True)
+    # open returns None
+    with pytest.raises(WazuhException, match=".* 1715 .*"):
+        ossec_socket_mock.return_value.receive.side_effect = [f'ok {wpk_version}'.encode()] * 20
+        open_mock.return_value = None
+        agent._send_wpk_file(debug=True)
 
 
 @pytest.mark.parametrize('agent_id, platform, version, wpk_repo, used_repo', [
@@ -1886,8 +1780,10 @@ def test_agent_send_wpk_file_ko(_get_wpk_mock, get_req_mock, stat_mock, ossec_so
 @patch('wazuh.core.agent.OssecSocket')
 @patch('wazuh.core.agent.Agent._send_wpk_file')
 @patch('socket.socket.sendto', return_value=1)
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_upgrade(socket_sendto, _send_wpk_file, ossec_socket_mock, agent_id, platform, version, wpk_repo, used_repo):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_upgrade(socket_mock, send_mock, socket_sendto, _send_wpk_file, ossec_socket_mock, agent_id, platform,
+                       version, wpk_repo, used_repo):
     """Test upgrade method returns expected message and call socket.sendto with correct params
     Parameters
     ----------
@@ -1895,55 +1791,51 @@ def test_agent_upgrade(socket_sendto, _send_wpk_file, ossec_socket_mock, agent_i
         Id of the agent.
     """
     ossec_socket_mock.return_value.receive.return_value = b'ok'
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-        agent = Agent(agent_id)
-        result = agent.upgrade(version=version, wpk_repo=wpk_repo, debug=True)
-        assert result == 'Upgrade procedure started'
-        ossec_socket_mock.return_value.send.assert_called_once()
-        _send_wpk_file.assert_called_with(wpk_repo=used_repo, debug=True, version=version, force=False,
-                                          show_progress=None, chunk_size=None, rl_timeout=-1, use_http=False)
-        socket_sendto.assert_called_with(f'1:wazuh-upgrade:wazuh: Upgrade procedure on agent {agent_id} ({agent.name}):'
-                                         f' started. Current version: {agent.version}'.encode(),
-                                         path.join(test_data_path, 'queue', 'ossec', 'queue'))
+    agent = Agent(agent_id)
+    result = agent.upgrade(version=version, wpk_repo=wpk_repo, debug=True)
+    assert result == 'Upgrade procedure started'
+    ossec_socket_mock.return_value.send.assert_called_once()
+    _send_wpk_file.assert_called_with(wpk_repo=used_repo, debug=True, version=version, force=False,
+                                      show_progress=None, chunk_size=None, rl_timeout=-1, use_http=False)
+    socket_sendto.assert_called_with(f'1:wazuh-upgrade:wazuh: Upgrade procedure on agent {agent_id} ({agent.name}):'
+                                     f' started. Current version: {agent.version}'.encode(),
+                                     path.join(test_data_path, 'queue', 'ossec', 'queue'))
 
 
 @patch('socket.socket.sendto', return_value=1)
 @patch('wazuh.core.agent.Agent._send_wpk_file')
 @patch('wazuh.core.agent.OssecSocket')
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_agent_upgrade_ko(ossec_socket_mock, _send_wpk_file, socket_sendto):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_upgrade_ko(socket_mock, send_mock, ossec_socket_mock, _send_wpk_file, socket_sendto):
     """Test upgrade method raises expected exceptions."""
     ossec_socket_mock.return_value.receive.return_value = b'ok'
 
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
+    # Try to upgrade master
+    agent = Agent('000')
+    with pytest.raises(WazuhException, match=".* 1703 .*"):
+        agent.upgrade(debug=True)
 
-        # Try to upgrade master
-        agent = Agent('000')
-        with pytest.raises(WazuhException, match=".* 1703 .*"):
-            agent.upgrade(debug=True)
+    # Agent is not active
+    agent = Agent('005')
+    with pytest.raises(WazuhException, match=".* 1720 .*"):
+        agent.upgrade(debug=True)
 
-        # Agent is not active
-        agent = Agent('005')
-        with pytest.raises(WazuhException, match=".* 1720 .*"):
-            agent.upgrade(debug=True)
+    # Wazuh version is < 3.0.0-alpha4
+    agent = Agent('007')
+    with pytest.raises(WazuhError, match=".* 1719 .*"):
+        agent.upgrade(debug=True)
 
-        # Wazuh version is < 3.0.0-alpha4
-        agent = Agent('007')
-        with pytest.raises(WazuhError, match=".* 1719 .*"):
-            agent.upgrade(debug=True)
+    # Agent is Windows and os_version < 6
+    agent = Agent('006')
+    with pytest.raises(WazuhInternalError, match=".* 1721 .*"):
+        agent.upgrade(debug=True)
 
-        # Agent is Windows and os_version < 6
-        agent = Agent('006')
-        with pytest.raises(WazuhInternalError, match=".* 1721 .*"):
-            agent.upgrade(debug=True)
-
-        # Socket.receive returns 'err'
-        ossec_socket_mock.return_value.receive.return_value = b'err'
-        agent = Agent('001')
-        with pytest.raises(WazuhError, match=".* 1716 .*"):
-            agent.upgrade(debug=True)
+    # Socket.receive returns 'err'
+    ossec_socket_mock.return_value.receive.return_value = b'err'
+    agent = Agent('001')
+    with pytest.raises(WazuhError, match=".* 1716 .*"):
+        agent.upgrade(debug=True)
 
 
 @pytest.mark.parametrize('agent_id', [
@@ -1954,8 +1846,10 @@ def test_agent_upgrade_ko(ossec_socket_mock, _send_wpk_file, socket_sendto):
 @patch('wazuh.core.agent.Agent._send_wpk_file')
 @patch('socket.socket.sendto', return_value=1)
 @patch('wazuh.core.agent.sleep')
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_upgrade_result(mock_sleep, socket_sendto, _send_wpk_file, ossec_socket_mock, agent_id):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_upgrade_result(socket_mock, send_mock, mock_sleep, socket_sendto, _send_wpk_file, ossec_socket_mock,
+                              agent_id):
     """Test upgrade_result method returns expected message and call socket with correct params
 
     Parameters
@@ -1965,47 +1859,44 @@ def test_agent_upgrade_result(mock_sleep, socket_sendto, _send_wpk_file, ossec_s
     """
     ossec_socket_mock.return_value.receive.side_effect = [b'err', b'ok 0']
 
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-        agent = Agent(agent_id)
-        result = agent.upgrade_result(debug=True)
+    agent = Agent(agent_id)
+    result = agent.upgrade_result(debug=True)
 
-        assert result == 'Agent was successfully upgraded', 'Message is not as expected.'
-        calls = [call(bytes(f'{agent_id} com upgrade_result', encoding='ascii')),
-                 call(bytes(f'{agent_id} com upgrade_result', encoding='ascii'))]
-        ossec_socket_mock.return_value.send.assert_has_calls(calls)
-        socket_sendto.assert_called_with(f'1:wazuh-upgrade:wazuh: Upgrade procedure on agent {agent_id} ({agent.name}):'
-                                         f' succeeded. New version: {agent.version}'.encode(),
-                                         path.join(test_data_path, 'queue', 'ossec', 'queue'))
+    assert result == 'Agent was successfully upgraded', 'Message is not as expected.'
+    calls = [call(bytes(f'{agent_id} com upgrade_result', encoding='ascii')),
+             call(bytes(f'{agent_id} com upgrade_result', encoding='ascii'))]
+    ossec_socket_mock.return_value.send.assert_has_calls(calls)
+    socket_sendto.assert_called_with(f'1:wazuh-upgrade:wazuh: Upgrade procedure on agent {agent_id} ({agent.name}):'
+                                     f' succeeded. New version: {agent.version}'.encode(),
+                                     path.join(test_data_path, 'queue', 'ossec', 'queue'))
 
 
 @patch('wazuh.core.agent.OssecSocket')
 @patch('wazuh.core.agent.Agent._send_wpk_file')
 @patch('socket.socket.sendto', return_value=1)
 @patch('wazuh.core.agent.sleep')
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_upgrade_result_ko(mock_sleep, socket_sendto, _send_wpk_file, ossec_socket_mock):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_upgrade_result_ko(socket_mock, send_mock, mock_sleep, socket_sendto, _send_wpk_file, ossec_socket_mock):
     """Test upgrade_result method raises expected exceptions"""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-        ossec_socket_mock.return_value.receive.side_effect = [b'err', b'ok 0']
+    ossec_socket_mock.return_value.receive.side_effect = [b'err', b'ok 0']
 
-        # Try to upgrade master
-        agent = Agent('000')
-        with pytest.raises(WazuhException, match=".* 1703 .*"):
-            agent.upgrade_result(debug=True)
+    # Try to upgrade master
+    agent = Agent('000')
+    with pytest.raises(WazuhException, match=".* 1703 .*"):
+        agent.upgrade_result(debug=True)
 
-        # Message received is 'ok 2' (agent restored to previous version)
-        ossec_socket_mock.return_value.receive.side_effect = [b'err', b'ok 2']
-        agent = Agent('001')
-        with pytest.raises(WazuhException, match=".* 1716 .*"):
-            agent.upgrade_result(debug=True)
+    # Message received is 'ok 2' (agent restored to previous version)
+    ossec_socket_mock.return_value.receive.side_effect = [b'err', b'ok 2']
+    agent = Agent('001')
+    with pytest.raises(WazuhException, match=".* 1716 .*"):
+        agent.upgrade_result(debug=True)
 
-        # Message received is not 'ok'
-        ossec_socket_mock.return_value.receive.side_effect = [b'ok', b'err']
-        agent = Agent('001')
-        with pytest.raises(WazuhException, match=".* 1716 .*"):
-            agent.upgrade_result(debug=True)
+    # Message received is not 'ok'
+    ossec_socket_mock.return_value.receive.side_effect = [b'ok', b'err']
+    agent = Agent('001')
+    with pytest.raises(WazuhException, match=".* 1716 .*"):
+        agent.upgrade_result(debug=True)
 
 
 @pytest.mark.parametrize('agent_id', [
@@ -2018,8 +1909,9 @@ def test_agent_upgrade_result_ko(mock_sleep, socket_sendto, _send_wpk_file, osse
 @patch('wazuh.core.agent.requests.get')
 @patch('wazuh.core.agent.path.isfile', return_value=True)
 @patch('wazuh.common.open_sleep', new=0)
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_send_custom_wpk_file(mock_isfile, mock_requests, mock_stat, ossec_socket_mock,
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_send_custom_wpk_file(socket_mock, send_mock, mock_isfile, mock_requests, mock_stat, ossec_socket_mock,
                                     open_mock, agent_id):
     """Test _send_custom_wpk_file method returns expected message and call socket.send with correct params
 
@@ -2031,28 +1923,26 @@ def test_agent_send_custom_wpk_file(mock_isfile, mock_requests, mock_stat, ossec
     wpk_name = 'test.wpk'
     sha1 = 'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3'
 
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-        agent = Agent(agent_id)
+    agent = Agent(agent_id)
 
-        # mock return value of OssecSocket.receive method with a binary string
-        ossec_socket_mock.return_value.receive.side_effect = [f'ok {sha1}'.encode(),
-                                                              f'err {sha1}'.encode()] + \
-                                                             [f'ok {sha1}'.encode()] * 5
-        # mock return value of open.read to avoid infinite loop
-        open_mock.return_value.read.side_effect = [b'test', b'']
+    # mock return value of OssecSocket.receive method with a binary string
+    ossec_socket_mock.return_value.receive.side_effect = [f'ok {sha1}'.encode(),
+                                                          f'err {sha1}'.encode()] + \
+                                                         [f'ok {sha1}'.encode()] * 5
+    # mock return value of open.read to avoid infinite loop
+    open_mock.return_value.read.side_effect = [b'test', b'']
 
-        result = agent._send_custom_wpk_file(file_path=os.path.join(test_data_path, wpk_name), debug=True,
-                                             show_progress=Mock())
+    result = agent._send_custom_wpk_file(file_path=os.path.join(test_data_path, wpk_name), debug=True,
+                                         show_progress=Mock())
 
-        assert result == ['WPK file sent', 'test.wpk'], 'Result message is not as expected.'
-        calls = [call(bytes(f'{agent_id} com lock_restart -1', encoding='ascii')),
-                 call(bytes(f'{agent_id} com open wb {wpk_name}', encoding='ascii')),
-                 call(bytes(f'{agent_id} com open wb {wpk_name}', encoding='ascii')),
-                 call(bytes(f'{agent_id} com write 4 {wpk_name} test', encoding='ascii')),
-                 call(bytes(f'{agent_id} com close {wpk_name}', encoding='ascii')),
-                 call(bytes(f'{agent_id} com sha1 {wpk_name}', encoding='ascii'))]
-        ossec_socket_mock.return_value.send.assert_has_calls(calls)
+    assert result == ['WPK file sent', 'test.wpk'], 'Result message is not as expected.'
+    calls = [call(bytes(f'{agent_id} com lock_restart -1', encoding='ascii')),
+             call(bytes(f'{agent_id} com open wb {wpk_name}', encoding='ascii')),
+             call(bytes(f'{agent_id} com open wb {wpk_name}', encoding='ascii')),
+             call(bytes(f'{agent_id} com write 4 {wpk_name} test', encoding='ascii')),
+             call(bytes(f'{agent_id} com close {wpk_name}', encoding='ascii')),
+             call(bytes(f'{agent_id} com sha1 {wpk_name}', encoding='ascii'))]
+    ossec_socket_mock.return_value.send.assert_has_calls(calls)
 
 
 @patch('wazuh.core.agent.hashlib.sha1')
@@ -2060,74 +1950,74 @@ def test_agent_send_custom_wpk_file(mock_isfile, mock_requests, mock_stat, ossec
 @patch('wazuh.core.agent.sleep')
 @patch('wazuh.core.agent.stat')
 @patch('wazuh.core.agent.OssecSocket')
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_send_custom_wpk_file_ko(ossec_socket_mock, mock_stat, mock_sleep, mock_open, mock_sha1):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_send_custom_wpk_file_ko(socket_mock, send_mock, ossec_socket_mock, mock_stat, mock_sleep, mock_open,
+                                       mock_sha1):
     """Test _send_custom_wpk_file method returns expected message and call socket.send with correct params"""
 
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-        mock_sha1.return_value.hexdigest.return_value = 'random'
-        agent = Agent('002')
+    mock_sha1.return_value.hexdigest.return_value = 'random'
+    agent = Agent('002')
 
-        # WPK file does not exist
-        with pytest.raises(WazuhError, match=".* 1006 .*"):
-            agent._send_custom_wpk_file(file_path='/noexists', debug=True)
+    # WPK file does not exist
+    with pytest.raises(WazuhError, match=".* 1006 .*"):
+        agent._send_custom_wpk_file(file_path='/noexists', debug=True)
 
-        with patch('wazuh.core.agent.path.isfile', return_value=True):
-            # Get error code from receive method
-            with pytest.raises(WazuhInternalError, match=".* 1715 .*"):
-                ossec_socket_mock.return_value.receive.side_effect = [f'err '.encode()]
-                agent._send_custom_wpk_file(file_path='wpk', debug=True)
+    with patch('wazuh.core.agent.path.isfile', return_value=True):
+        # Get error code from receive method
+        with pytest.raises(WazuhInternalError, match=".* 1715 .*"):
+            ossec_socket_mock.return_value.receive.side_effect = [f'err '.encode()]
+            agent._send_custom_wpk_file(file_path='wpk', debug=True)
 
-            # Get error code from second receive method
-            with pytest.raises(WazuhInternalError, match=".* 1715 .*"):
-                ossec_socket_mock.return_value.receive.side_effect = [f'ok '.encode()] + \
-                                                                     [f'err '.encode()] * 11
-                agent._send_custom_wpk_file(file_path='wpk', debug=True)
+        # Get error code from second receive method
+        with pytest.raises(WazuhInternalError, match=".* 1715 .*"):
+            ossec_socket_mock.return_value.receive.side_effect = [f'ok '.encode()] + \
+                                                                 [f'err '.encode()] * 11
+            agent._send_custom_wpk_file(file_path='wpk', debug=True)
 
-            mock_open.return_value.read.side_effect = [b'a']
+        mock_open.return_value.read.side_effect = [b'a']
 
-            # Get error code from third receive method
-            with pytest.raises(WazuhException, match=".* 1715 .*"):
-                ossec_socket_mock.return_value.receive.side_effect = [f'ok '.encode()] * 2 + \
-                                                                     [f'err '.encode()]
-                agent._send_custom_wpk_file(file_path='wpk', debug=True)
+        # Get error code from third receive method
+        with pytest.raises(WazuhException, match=".* 1715 .*"):
+            ossec_socket_mock.return_value.receive.side_effect = [f'ok '.encode()] * 2 + \
+                                                                 [f'err '.encode()]
+            agent._send_custom_wpk_file(file_path='wpk', debug=True)
 
-            # Get error code from fourth receive method
-            with pytest.raises(WazuhException, match=".* 1715 .*"):
-                mock_open.return_value.read.side_effect = [b'a', None]
-                ossec_socket_mock.return_value.receive.side_effect = [f'ok '.encode()] * 3 + \
-                                                                     [f'err '.encode()]
-                agent._send_custom_wpk_file(file_path='wpk', debug=True)
+        # Get error code from fourth receive method
+        with pytest.raises(WazuhException, match=".* 1715 .*"):
+            mock_open.return_value.read.side_effect = [b'a', None]
+            ossec_socket_mock.return_value.receive.side_effect = [f'ok '.encode()] * 3 + \
+                                                                 [f'err '.encode()]
+            agent._send_custom_wpk_file(file_path='wpk', debug=True)
 
-            # File does not exists
-            with pytest.raises(WazuhInternalError, match=".* 1715 .*"):
-                mock_open.return_value = None
-                ossec_socket_mock.return_value.receive.side_effect = [f'ok '.encode()] * 5
-                agent._send_custom_wpk_file(file_path='wpk', debug=True)
+        # File does not exists
+        with pytest.raises(WazuhInternalError, match=".* 1715 .*"):
+            mock_open.return_value = None
+            ossec_socket_mock.return_value.receive.side_effect = [f'ok '.encode()] * 5
+            agent._send_custom_wpk_file(file_path='wpk', debug=True)
 
-            # Get error code from fifth receive method
-            with pytest.raises(WazuhException, match=".* 1715 .*"):
-                mock_open.return_value = Mock()
-                mock_open.return_value.read.side_effect = [b'a', None]
-                ossec_socket_mock.return_value.receive.side_effect = [f'ok '.encode()] * 3 + \
-                                                                     [f'err '.encode()]
-                agent._send_custom_wpk_file(file_path='wpk', debug=True)
+        # Get error code from fifth receive method
+        with pytest.raises(WazuhException, match=".* 1715 .*"):
+            mock_open.return_value = Mock()
+            mock_open.return_value.read.side_effect = [b'a', None]
+            ossec_socket_mock.return_value.receive.side_effect = [f'ok '.encode()] * 3 + \
+                                                                 [f'err '.encode()]
+            agent._send_custom_wpk_file(file_path='wpk', debug=True)
 
-            # Get error code from sixth receive method
-            with pytest.raises(WazuhException, match=".* 1715 .*"):
-                mock_open.return_value = Mock()
-                mock_open.return_value.read.side_effect = [b'a', None]
-                ossec_socket_mock.return_value.receive.side_effect = [f'ok '.encode()] * 4 + \
-                                                                     [f'err '.encode()]
-                agent._send_custom_wpk_file(file_path='wpk', debug=True)
+        # Get error code from sixth receive method
+        with pytest.raises(WazuhException, match=".* 1715 .*"):
+            mock_open.return_value = Mock()
+            mock_open.return_value.read.side_effect = [b'a', None]
+            ossec_socket_mock.return_value.receive.side_effect = [f'ok '.encode()] * 4 + \
+                                                                 [f'err '.encode()]
+            agent._send_custom_wpk_file(file_path='wpk', debug=True)
 
-            # Get error code from fifth receive method
-            with pytest.raises(WazuhException, match=".* 1715 .*"):
-                mock_open.return_value = Mock()
-                mock_open.return_value.read.side_effect = [b'a', None]
-                ossec_socket_mock.return_value.receive.side_effect = [f'ok 1234'.encode()] * 5
-                agent._send_custom_wpk_file(file_path='wpk', debug=True)
+        # Get error code from fifth receive method
+        with pytest.raises(WazuhException, match=".* 1715 .*"):
+            mock_open.return_value = Mock()
+            mock_open.return_value.read.side_effect = [b'a', None]
+            ossec_socket_mock.return_value.receive.side_effect = [f'ok 1234'.encode()] * 5
+            agent._send_custom_wpk_file(file_path='wpk', debug=True)
 
 
 @pytest.mark.parametrize('agent_id', [
@@ -2140,9 +2030,10 @@ def test_agent_send_custom_wpk_file_ko(ossec_socket_mock, mock_stat, mock_sleep,
 @patch('socket.socket.sendto', return_value=1)
 @patch('wazuh.core.agent.stat')
 @patch('wazuh.core.agent.path.isfile', return_value=True)
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_upgrade_custom(mock_is_file, mock_stat, mock_sendto, mock_send_wpk, mock_ossec_socket, mock_open,
-                              agent_id):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_upgrade_custom(socket_mock, send_mock, mock_is_file, mock_stat, mock_sendto, mock_send_wpk,
+                              mock_ossec_socket, mock_open, agent_id):
     """Test upgrade_custom method returns expected message and call socket.sendto with correct params
 
     Parameters
@@ -2150,72 +2041,65 @@ def test_agent_upgrade_custom(mock_is_file, mock_stat, mock_sendto, mock_send_wp
     agent_id : str
         Id of the agent.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-        mock_ossec_socket.return_value.receive.return_value = b'ok'
+    mock_ossec_socket.return_value.receive.return_value = b'ok'
 
-        agent = Agent(agent_id)
-        result = agent.upgrade_custom(file_path='test.wpk', installer='installer')
+    agent = Agent(agent_id)
+    result = agent.upgrade_custom(file_path='test.wpk', installer='installer')
 
-        assert result == 'Installation started', 'Result message is not as expected.'
-        mock_sendto.assert_called_with(f'1:wazuh-upgrade:wazuh: Custom installation on agent {agent_id} ({agent.name}):'
-                                       f' started.'.encode(), path.join(test_data_path, 'queue', 'ossec', 'queue'))
+    assert result == 'Installation started', 'Result message is not as expected.'
+    mock_sendto.assert_called_with(f'1:wazuh-upgrade:wazuh: Custom installation on agent {agent_id} ({agent.name}):'
+                                   f' started.'.encode(), path.join(test_data_path, 'queue', 'ossec', 'queue'))
 
 
 @patch('socket.socket.sendto', return_value=1)
 @patch('wazuh.core.agent.Agent._send_custom_wpk_file')
 @patch('wazuh.core.agent.OssecSocket')
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_agent_upgrade_custom_ko(ossec_socket_mock, _send_wpk_file, socket_sendto):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_upgrade_custom_ko(socket_mock, send_mock, ossec_socket_mock, _send_wpk_file, socket_sendto):
     """Test upgrade_custom method raises expected exceptions."""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
+    # Try to upgrade master
+    agent = Agent('000')
+    with pytest.raises(WazuhException, match=".* 1703 .*"):
+        agent.upgrade_custom(file_path='test.wpk', installer='installer', debug=True)
 
-        # Try to upgrade master
-        agent = Agent('000')
-        with pytest.raises(WazuhException, match=".* 1703 .*"):
-            agent.upgrade_custom(file_path='test.wpk', installer='installer', debug=True)
+    # Agent is not active
+    agent = Agent('005')
+    with pytest.raises(WazuhException, match=".* 1720 .*"):
+        agent.upgrade_custom(file_path='test.wpk', installer='installer', debug=True)
 
-        # Agent is not active
-        agent = Agent('005')
-        with pytest.raises(WazuhException, match=".* 1720 .*"):
-            agent.upgrade_custom(file_path='test.wpk', installer='installer', debug=True)
-
-        # Socket.receive returns 'err'
-        ossec_socket_mock.return_value.receive.return_value = b'err'
-        agent = Agent('001')
-        with pytest.raises(WazuhError, match=".* 1716 .*"):
-            agent.upgrade_custom(file_path='test.wpk', installer='installer', debug=True)
+    # Socket.receive returns 'err'
+    ossec_socket_mock.return_value.receive.return_value = b'err'
+    agent = Agent('001')
+    with pytest.raises(WazuhError, match=".* 1716 .*"):
+        agent.upgrade_custom(file_path='test.wpk', installer='installer', debug=True)
 
 
 @patch('wazuh.core.configuration.OssecSocket')
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_agent_getconfig(mock_ossec_socket):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_getconfig(socket_mock, send_mock, mock_ossec_socket):
     """Test getconfig method returns expected message."""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-        agent = Agent('001')
-        mock_ossec_socket.return_value.receive.return_value = b'ok {"test": "conf"}'
-        result = agent.getconfig('com', 'active-response')
-        assert result == {"test": "conf"}, 'Result message is not as expected.'
+    agent = Agent('001')
+    mock_ossec_socket.return_value.receive.return_value = b'ok {"test": "conf"}'
+    result = agent.getconfig('com', 'active-response')
+    assert result == {"test": "conf"}, 'Result message is not as expected.'
 
 
 @patch('wazuh.core.configuration.OssecSocket')
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_agent_getconfig_ko(mock_ossec_socket):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_getconfig_ko(socket_mock, send_mock, mock_ossec_socket):
     """Test getconfig method raises expected exceptions."""
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
+    # Agent version is null
+    agent = Agent('004')
+    with pytest.raises(WazuhInternalError, match=".* 1015 .*"):
+        agent.getconfig('com', 'active-response')
 
-        # Agent version is null
-        agent = Agent('004')
-        with pytest.raises(WazuhInternalError, match=".* 1015 .*"):
-            agent.getconfig('com', 'active-response')
-
-        # Agent Wazuh version is lower than v3.7.0
-        agent = Agent('002')
-        with pytest.raises(WazuhInternalError, match=".* 1735 .*"):
-            agent.getconfig('com', 'active-response')
+    # Agent Wazuh version is lower than v3.7.0
+    agent = Agent('002')
+    with pytest.raises(WazuhInternalError, match=".* 1735 .*"):
+        agent.getconfig('com', 'active-response')
 
 
 @pytest.mark.parametrize('last_keep_alive, pending, expected_status', [
@@ -2246,28 +2130,24 @@ def test_send_restart_command(mock_ossec_queue):
     mock_ossec_queue.return_value.send_msg_to_agent.assert_called_once_with(ANY, '001')
 
 
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_get_agents_info():
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_get_agents_info(socket_mock, send_mock):
     """Test that get_agents_info() returns expected agent IDs"""
     expected_result = {'005', '003', '008', '000', '004', '001', '006', '002', '007'}
 
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        result = get_agents_info()
-        assert result == expected_result
+    result = get_agents_info()
+    assert result == expected_result
 
 
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_get_groups():
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_get_groups(socket_mock, send_mock):
     """Test that get_groups() returns expected agent groups"""
     expected_result = {'group-1', 'group-2'}
 
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        result = get_groups()
-        assert result == expected_result
+    result = get_groups()
+    assert result == expected_result
 
 
 @pytest.mark.parametrize('group, expected_agents', [
@@ -2275,8 +2155,9 @@ def test_get_groups():
     ('group-2', {'001'}),
     ('*', {'006', '008', '000', '002', '005', '007', '001'})
 ])
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_expand_group(group, expected_agents):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_expand_group(socket_mock, send_mock, group, expected_agents):
     """Test that expand_group() returns expected agent IDs
 
     Parameters
@@ -2286,11 +2167,8 @@ def test_expand_group(group, expected_agents):
     expected_agents : set
         Expected agent IDs for the selected group
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        result = expand_group(group)
-        assert result == expected_agents
+    result = expand_group(group)
+    assert result == expected_agents
 
 
 @pytest.mark.parametrize('agent_id, expected_exception', [
@@ -2308,8 +2186,6 @@ def test_expand_group(group, expected_agents):
 @patch('wazuh.core.agent.stat')
 @patch('wazuh.core.agent.glob')
 @patch("wazuh.common.client_keys", new=os.path.join(test_data_path, 'etc', 'client.keys'))
-@patch('wazuh.core.agent.path.exists', side_effect=lambda x: not (common.backup_path in x))
-@patch('wazuh.core.database.isfile', return_value=True)
 @patch('wazuh.core.agent.path.isdir', return_value=True)
 @patch('wazuh.core.agent.safe_move')
 @patch('wazuh.core.agent.makedirs')
@@ -2317,10 +2193,11 @@ def test_expand_group(group, expected_agents):
 @freeze_time('1975-01-01')
 @patch("wazuh.common.ossec_uid", return_value=getpwnam("root"))
 @patch("wazuh.common.ossec_gid", return_value=getgrnam("root"))
-@patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db'))
-def test_agent_remove_manual_ko(grp_mock, pwd_mock, chmod_r_mock, makedirs_mock, safe_move_mock, isdir_mock,
-                                isfile_mock, exists_mock, glob_mock, stat_mock, chmod_mock, chown_mock, rmtree_mock,
-                                remove_mock, wdb_mock, agent_id, expected_exception):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_remove_manual_ko(socket_mock, send_mock, grp_mock, pwd_mock, chmod_r_mock, makedirs_mock, safe_move_mock,
+                                isdir_mock, glob_mock, stat_mock, chmod_mock, chown_mock, rmtree_mock, remove_mock,
+                                wdb_mock, agent_id, expected_exception):
     """Test the _remove_manual function error cases.
 
     Parameters
@@ -2341,10 +2218,6 @@ def test_agent_remove_manual_ko(grp_mock, pwd_mock, chmod_r_mock, makedirs_mock,
     rmtree_mock.side_effect = Exception("Boom!")
 
     with patch('wazuh.core.agent.open', mock_open(read_data=client_keys_text)) as m:
-        with patch('sqlite3.connect') as mock_db:
-            mock_db.return_value = test_data.global_db
-            if expected_exception == 1747:
-                mock_db.return_value.execute("drop table belongs")
             with pytest.raises(WazuhException, match=f".* {expected_exception} .*"):
                 Agent(agent_id)._remove_manual()
 
@@ -2372,11 +2245,8 @@ def test_get_rbac_filters(system_resources, permitted_resources, filters, expect
     permitted_resources : int
         Error code that is expected.
     """
-    with patch('sqlite3.connect') as mock_db:
-        mock_db.return_value = test_data.global_db
-
-        result = get_rbac_filters(system_resources=system_resources,
-                                  permitted_resources=permitted_resources, filters=filters)
-        result['filters']['rbac_ids'] = set(result['filters']['rbac_ids'])
-        expected_result['filters']['rbac_ids'] = set(expected_result['filters']['rbac_ids'])
-        assert result == expected_result
+    result = get_rbac_filters(system_resources=system_resources,
+                              permitted_resources=permitted_resources, filters=filters)
+    result['filters']['rbac_ids'] = set(result['filters']['rbac_ids'])
+    expected_result['filters']['rbac_ids'] = set(expected_result['filters']['rbac_ids'])
+    assert result == expected_result

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -18,6 +18,7 @@ with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         from wazuh.core.utils import *
         from wazuh.core import exception
+        from wazuh.core.agent import WazuhDBQueryAgents
 
 # all necessary params
 
@@ -1078,38 +1079,41 @@ def test_WazuhDBQuery_protected_filter_date(mock_socket_conn, mock_isfile, mock_
         mock_conn_db.assert_called_once_with()
 
 
-@patch('wazuh.core.utils.glob.glob', return_value=True)
+@pytest.mark.parametrize('execute_value, expected_result', [
+    ([{'id': 99}, {'id': 100}], {'items': [{'id': '099'}, {'id': '100'}], 'totalItems': 0}),
+    ([{'id': 1}], {'items': [{'id': '001'}], 'totalItems': 0}),
+    ([{'id': i} for i in range(30000)], {'items': [{'id': str(i).zfill(3)} for i in range(30000)], 'totalItems': 0})
+])
 @patch("wazuh.core.database.isfile", return_value=True)
-@patch('sqlite3.connect')
-@patch('wazuh.core.utils.WazuhDBQuery._add_select_to_query')
-@patch('wazuh.core.utils.WazuhDBQuery._add_filters_to_query')
-@patch('wazuh.core.utils.WazuhDBQuery._add_search_to_query')
-@patch('wazuh.core.utils.WazuhDBQuery._get_total_items')
-@patch('wazuh.core.utils.WazuhDBQuery._add_sort_to_query')
-@patch('wazuh.core.utils.WazuhDBQuery._add_limit_to_query')
-@patch('wazuh.core.utils.WazuhDBQuery._format_data_into_dictionary')
-@patch('wazuh.core.utils.SQLiteBackend._get_data')
-def test_WazuhDBQuery_run(mock_data, mock_dict, mock_limit, mock_sort, mock_items, mock_search, mock_filters,
-                          mock_select, mock_sqli_conn, mock_isfile, mock_glob):
-    """Test WazuhDBQuery.run function."""
-    query = WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
-                         search=None, select={'os.name'},
-                         fields={'os.name': 'ubuntu', 'os.version': '18.04'},
-                         default_sort_field=None, query=None, count=5,
-                         backend=SQLiteBackend(common.database_path),
-                         get_data=True, min_select_fields={'os.version'})
+@patch('socket.socket.connect')
+def test_WazuhDBQuery_general_run(mock_socket_conn, mock_isfile, execute_value, expected_result):
+    """Test WazuhDBQuery.general_run function."""
+    with patch('wazuh.core.utils.WazuhDBBackend.execute', return_value=execute_value):
+        query = WazuhDBQueryAgents(offset=0, limit=None, sort=None, search=None, select={'id'},
+                                   query=None, count=False, get_data=True, remove_extra_fields=False)
 
-    query.run()
+        assert query.general_run() == expected_result
 
-    mock_sqli_conn.assert_called_once()
-    mock_select.assert_called_once_with()
-    mock_filters.assert_called_once_with()
-    mock_search.assert_called_once_with()
-    mock_items.assert_called_once_with()
-    mock_sort.assert_called_once_with()
-    mock_limit.assert_called_once_with()
-    mock_data.assert_called_once_with()
-    mock_dict.assert_called_once_with()
+
+@pytest.mark.parametrize('execute_value, rbac_ids, negate, final_rbac_ids, expected_result', [
+    ([{'id': 99}, {'id': 100}], ['001', '099', '101'], False, [{'id': 99}], {'items': [{'id': '099'}], 'totalItems': 1}),
+    ([{'id': 1}], [], True, [{'id': 1}], {'items': [{'id': '001'}], 'totalItems': 1}),
+    ([{'id': i} for i in range(30000)], [str(i).zfill(3) for i in range(15001)], True,
+     [{'id': i} for i in range(15001, 30000)],
+     {'items': [{'id': str(i).zfill(3)} for i in range(15001, 30000)], 'totalItems': 14999})
+])
+@patch("wazuh.core.database.isfile", return_value=True)
+@patch('socket.socket.connect')
+def test_WazuhDBQuery_oversized_run(mock_socket_conn, mock_isfile, execute_value, rbac_ids, negate,
+                                    final_rbac_ids, expected_result):
+    """Test WazuhDBQuery.oversized_run function."""
+    with patch('wazuh.core.utils.WazuhDBBackend.execute', side_effect=[execute_value, final_rbac_ids]):
+        query = WazuhDBQueryAgents(offset=0, limit=None, sort=None, search=None, select={'id'},
+                                   query=None, count=True, get_data=True, remove_extra_fields=False)
+        query.legacy_filters['rbac_ids'] = rbac_ids
+        query.rbac_negate = negate
+
+        assert query.oversized_run() == expected_result
 
 
 @patch('wazuh.core.utils.glob.glob', return_value=True)

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1152,7 +1152,7 @@ class WazuhDBQuery(object):
             # If it matches the same format as DB (timestamp integer), filter directly by value (next if cond).
             self._filter_date(q_filter, field_name)
         elif 'rbac' in field_name:
-            self.query += f"{field_name.lstrip('rbac_')} IN (:{field_filter})"
+            self.query += f"{field_name.lstrip('rbac_')} {q_filter['operator']} (:{field_filter})"
             self.request[field_filter] = q_filter['value']
         else:
             if q_filter['value'] is not None:

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1259,7 +1259,7 @@ class WazuhDBQuery(object):
         self._add_select_to_query()
         self._execute_data_query()
         try:
-            resources = list(map(lambda d: str(d[resource]), self._data))
+            resources = list(map(lambda d: str(d[resource]).zfill(3), self._data))
             maximum_value = min(self.limit, len(resources)) if self.limit is not None else len(resources)
             for item in resources:
                 if self.rbac_negate:
@@ -1279,9 +1279,11 @@ class WazuhDBQuery(object):
         self.select = original_select
         self.reset()
         self.legacy_filters['rbac_ids'] = final_ids
+        original_count = self.count
         self.count = False
         result = self.general_run()
-        result['totalItems'] = count
+        if original_count:
+            result['totalItems'] = count
 
         return result
 

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from api.util import remove_nones_to_dict
 from wazuh.core.exception import WazuhResourceNotFound
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../..'))
@@ -29,7 +30,7 @@ with patch('wazuh.common.ossec_uid'):
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
 
         from wazuh.agent import add_agent, assign_agents_to_group, create_group, delete_agents, delete_groups, \
-            get_agent_by_name, get_agent_conf, get_agent_config, get_agent_groups, get_agents, get_agents_in_group, \
+            get_agent_conf, get_agent_config, get_agent_groups, get_agents, get_agents_in_group, \
             get_agents_keys, get_agents_summary_os, get_agents_summary_status, get_agents_sync_group, \
             get_distinct_agents, get_file_conf, get_full_overview, get_group_files, get_outdated_agents, \
             get_upgrade_result, remove_agent_from_group, remove_agent_from_groups, remove_agents_from_group, \
@@ -50,6 +51,12 @@ full_agent_list = ['000', '001', '002', '003', '004', '005', '006', '007', '008'
 short_agent_list = ['000', '001', '002', '003', '004', '005']
 
 
+def send_msg_to_wdb(msg, raw=False):
+    query = ' '.join(msg.split(' ')[2:])
+    result = test_data.cur.execute(query).fetchall()
+    return list(map(remove_nones_to_dict, map(dict, result)))
+
+
 @pytest.mark.parametrize('fields, expected_items', [
     (['os.platform'], [{'os': {'platform': 'ubuntu'}, 'count': 4}, {'os': {'platform': 'unknown'}, 'count': 2}]),
     (['version'], [{'version': 'Wazuh v3.9.0', 'count': 1}, {'version': 'Wazuh v3.8.2', 'count': 2},
@@ -63,9 +70,9 @@ short_agent_list = ['000', '001', '002', '003', '004', '005']
         {'os': {'name': 'Ubuntu', 'platform': 'ubuntu', 'version': '16.04.1 LTS'}, 'count': 1},
         {'os': {'name': 'unknown', 'platform': 'unknown', 'version': 'unknown'}, 'count': 2}]),
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_distinct_agents(sqlite_mock, fields, expected_items):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_distinct_agents(socket_mock, send_mock, fields, expected_items):
     """Test `get_distinct_agents` function from agent module.
 
     Parameters
@@ -80,9 +87,9 @@ def test_agent_get_distinct_agents(sqlite_mock, fields, expected_items):
     assert distinct.affected_items == expected_items, f'"Affected_items" does not match. Should be "{expected_items}".'
 
 
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_agents_summary_status(sqlite_mock):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_summary_status(socket_mock, send_mock):
     """Test `get_agents_summary` function from agent module."""
     summary = get_agents_summary_status(short_agent_list)
     assert isinstance(summary, WazuhResult), 'The returned object is not an "WazuhResult" instance.'
@@ -96,9 +103,9 @@ def test_agent_get_agents_summary_status(sqlite_mock):
     assert summary['total'] == expected_results['total']
 
 
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_agents_summary_os(sqlite_mock):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_summary_os(connect_mock, send_mock):
     """Tests `get_os_summary function`."""
     summary = get_agents_summary_os(short_agent_list)
     assert isinstance(summary, AffectedItemsWazuhResult), 'The returned object is not an "WazuhResult" instance.'
@@ -110,11 +117,11 @@ def test_agent_get_agents_summary_os(sqlite_mock):
     (['000'], [], 1703),
     (['001', '500'], ['001'], 1701)
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.core.agent.Agent.restart')
 @patch('wazuh.agent.get_agents_info', return_value=short_agent_list)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_restart_agents(sqlite_mock, agents_info_mock, restart_mock, agent_list, expected_items, error_code):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_restart_agents(socket_mock, send_mock, agents_info_mock, restart_mock, agent_list, expected_items, error_code):
     """Test `restart_agents` function from agent module.
 
     Parameters
@@ -138,11 +145,11 @@ def test_agent_restart_agents(sqlite_mock, agents_info_mock, restart_mock, agent
     (['000', '001', '002'], ['001', '002'], None),
     (['001', '500'], ['001'], 1701)
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.core.agent.Agent.restart')
 @patch('wazuh.agent.get_agents_info', return_value=short_agent_list)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_restart_agents_by_node(sqlite_mock, agents_info_mock, restart_mock, agent_list, expected_items,
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_restart_agents_by_node(socket_mock, send_mock, agents_info_mock, restart_mock, agent_list, expected_items,
                                       error_code):
     """Test `restart_agents_by_node` function from agent module.
 
@@ -167,9 +174,9 @@ def test_agent_restart_agents_by_node(sqlite_mock, agents_info_mock, restart_moc
     (['001', '002', '003'], ['001', '002', '003']),
     (['001', '400', '002', '500'], ['001', '002'])
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_agents(sqlite_mock, agent_list, expected_items):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents(socket_mock, send_mock, agent_list, expected_items):
     """Test `get_agents` function from agent module.
 
     Parameters
@@ -188,47 +195,15 @@ def test_agent_get_agents(sqlite_mock, agent_list, expected_items):
         assert (failed_item.message == 'Agent does not exist' for failed_item in result.failed_items.keys())
 
 
-@pytest.mark.parametrize('name, expected_id', [
-    ('agent-1', '001'),
-    ('nc-agent', '003'),
-    ('master', '000'),
-    ('invalid-agent', False),
-    ('master', 4000),
-    ('master', 1000)
-])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_agent_by_name(sqlite_mock, name, expected_id):
-    """Test `get_agent_by_name` function from agent module.
-
-    Parameters
-    ----------
-    name : str
-        Name of the agent.
-    expected_id : str
-        ID of the agent whose name is the specified one.
-    """
-    if isinstance(expected_id, str):
-        agent_by_name = get_agent_by_name(name=name, select=['id'])
-        assert next(iter(agent_by_name.affected_items[0].values())) == expected_id
-    elif not expected_id:
-        with pytest.raises(WazuhResourceNotFound, match='.* 1754 .*'):
-            get_agent_by_name(name=name)
-    else:
-        with patch('wazuh.agent.get_agents', side_effect=WazuhError(expected_id)):
-            with pytest.raises(WazuhException, match=f'.* (1754|{expected_id}) .*'):
-                get_agent_by_name(name=name)
-
-
 @pytest.mark.parametrize('group, group_exists, expected_agents', [
     ('default', True, ['001', '002', '005']),
     ('not_exists_group', False, None)
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.agent.get_agents')
 @patch('wazuh.agent.get_groups')
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_agents_in_group(sqlite_mock, mock_get_groups, mock_get_agents, group, group_exists,
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_in_group(socket_mock, send_mock, mock_get_groups, mock_get_agents, group, group_exists,
                                    expected_agents):
     """Test `get_agents_in_group` from agent module.
 
@@ -261,9 +236,9 @@ def test_agent_get_agents_in_group(sqlite_mock, mock_get_groups, mock_get_agents
     (['001', '002', '003'], ['001', '002', '003']),
     (['001', '400', '002', '500'], ['001', '002'])
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_agents_keys(sqlite_mock, agent_list, expected_items):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_keys(socket_mock, send_mock, agent_list, expected_items):
     """Test `get_agents_keys` from agent module.
 
     Parameters
@@ -289,9 +264,10 @@ def test_agent_get_agents_keys(sqlite_mock, agent_list, expected_items):
     (['001', '500'], "1s", 'Agent was successfully deleted', 1701, ['001']),
     (['001', '002'], "1s", WazuhException(1700), 1700, []),
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.agent.Agent.remove')
-def test_agent_delete_agents(mock_remove, agent_list, older_than, remove_msg, error_code, expected_items):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_delete_agents(socket_mock, send_mock, mock_remove, agent_list, older_than, remove_msg, error_code, expected_items):
     """Test `delete_agents` function from agent module.
 
     Parameters
@@ -314,8 +290,9 @@ def test_agent_delete_agents(mock_remove, agent_list, older_than, remove_msg, er
     assert result['older_than'] == older_than
 
 
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-def test_agent_delete_agents_different_status():
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_delete_agents_different_status(socket_mock, send_mock):
     """Test `delete_agents` function from agent module.
 
     It will force a failed item due to agent not eligible (different status).
@@ -333,7 +310,6 @@ def test_agent_delete_agents_different_status():
     ('agent-1', '001', 'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f'),
     ('a' * 129, '002', 'f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d')
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.core.agent.fcntl.lockf')
 @patch('wazuh.common.client_keys', new=os.path.join(test_agent_path, 'client.keys'))
 @patch('wazuh.core.agent.chown')
@@ -343,8 +319,10 @@ def test_agent_delete_agents_different_status():
 @patch('wazuh.core.agent.common.ossec_gid')
 @patch('wazuh.core.agent.safe_move')
 @patch('builtins.open')
-def test_agent_add_agent(open_mock, safe_move_mock, common_gid_mock, common_uid_mock, copyfile_mock, chmod_mock,
-                         chown_mock, fcntl_mock, name, agent_id, key):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_add_agent(socket_mock, send_mock, open_mock, safe_move_mock, common_gid_mock, common_uid_mock,
+                         copyfile_mock, chmod_mock, chown_mock, fcntl_mock, name, agent_id, key):
     """Test `add_agent` from agent module.
 
     Parameters
@@ -368,11 +346,11 @@ def test_agent_add_agent(open_mock, safe_move_mock, common_gid_mock, common_uid_
     (['group-1', 'group-2'], ['group-1', 'group-2']),
     (['invalid_group'], [])
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.common.client_keys', new=os.path.join(test_agent_path, 'client.keys'))
 @patch('wazuh.common.shared_path', new=test_shared_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_agent_groups(sqlite_mock, group_list, expected_result):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agent_groups(socket_mock, send_mock, group_list, expected_result):
     """Test `get_agent_groups` from agent module.
 
     This will check if the provided groups exists.
@@ -393,11 +371,12 @@ def test_agent_get_agent_groups(sqlite_mock, group_list, expected_result):
 
 
 @pytest.mark.parametrize('db_global, system_groups, error_code', [
-    ('Invalid path', 'valid-group', 1600),
     (test_global_bd_path, 'invalid_group', 1710)
 ])
 @patch('wazuh.agent.get_groups')
-def test_agent_get_agent_groups_exceptions(mock_get_groups, db_global, system_groups, error_code):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agent_groups_exceptions(socket_mock, send_mock, mock_get_groups, db_global, system_groups, error_code):
     """Test `get_agent_groups` function from agent module raises the expected exceptions if an invalid 'global.db' path
     or group is specified.
 
@@ -545,8 +524,9 @@ def test_create_group_exceptions(group_id, exception, exception_code):
 @patch('wazuh.agent.get_groups')
 @patch('wazuh.agent.remove_agents_from_group', return_value=AffectedItemsWazuhResult())
 @patch('wazuh.agent.Agent.delete_single_group')
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-def test_agent_delete_groups(mock_delete, mock_remove_agent, mock_get_groups, group_list):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_delete_groups(socket_mock, send_mock, mock_delete, mock_remove_agent, mock_get_groups, group_list):
     """Test `delete_groups` function from agent module.
 
     Parameters
@@ -571,10 +551,12 @@ def test_agent_delete_groups(mock_delete, mock_remove_agent, mock_get_groups, gr
 
 
 @pytest.mark.parametrize('group_name', ['test_group'])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.agent.remove_agents_from_group')
 @patch('wazuh.agent.get_groups')
-def test_agent_delete_groups_permission_exception(mock_get_groups, mock_remove_agents, group_name):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_delete_groups_permission_exception(socket_mock, send_mock, mock_get_groups, mock_remove_agents,
+                                                  group_name):
     """Test delete_group function when trying to delete an existant group but without enough privileges.
 
     Parameters
@@ -634,10 +616,11 @@ def test_agent_delete_groups_other_exceptions(mock_get_groups, group_list, expec
     (['group-1'], ['001', '002', '003'], 0),
     (['group-1'], ['001', '002', '003', '100'], 1),
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.common.shared_path', new=test_shared_path)
 @patch('wazuh.agent.Agent.add_group_to_agent')
-def test_assign_agents_to_group(add_group_mock, group_list, agent_list, num_failed):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_assign_agents_to_group(socket_mock, send_mock, add_group_mock, group_list, agent_list, num_failed):
     """Test `assign_agents_to_group` function from agent module. Does not check its raised exceptions.
 
     Parameters
@@ -665,11 +648,12 @@ def test_assign_agents_to_group(add_group_mock, group_list, agent_list, num_fail
     (['group-1'], ['100'], WazuhResourceNotFound(1701), False),
     (['default'], ['000'], WazuhError(1703), False)
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.agent.Agent.group_exists')
 @patch('wazuh.agent.Agent.add_group_to_agent')
-def test_agent_assign_agents_to_group_exceptions(mock_add_group, mock_group_exists, group_list, agent_list,
-                                                 expected_error, catch_exception):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_assign_agents_to_group_exceptions(socket_mock, send_mock, mock_add_group, mock_group_exists, group_list,
+                                                 agent_list, expected_error, catch_exception):
     """Test `assign_agents_to_group` function from agent module raises the expected exceptions when using invalid groups.
 
     Parameters
@@ -916,9 +900,9 @@ def test_agent_remove_agents_from_group_exceptions(group_mock, agents_info_mock,
 @pytest.mark.parametrize('agent_list, outdated_agents', [
     (short_agent_list, ['001', '002', '005'])
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_outdated_agents(sqlite_mock, agent_list, outdated_agents):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_outdated_agents(socket_mock, send_mock, agent_list, outdated_agents):
     """Test get_oudated_agents function from agent module.
 
     Parameters
@@ -956,9 +940,9 @@ def test_agent_get_outdated_agents(sqlite_mock, agent_list, outdated_agents):
 @patch('wazuh.core.agent.OssecSocket')
 @patch('wazuh.core.agent.Agent._send_wpk_file')
 @patch('socket.socket.sendto', return_value=1)
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_upgrade_agents(sqlite_mock, socket_sendto, _send_wpk_file, ossec_socket_mock, agent_list):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_upgrade_agents(socket_mock, send_mock, socket_sendto, _send_wpk_file, ossec_socket_mock, agent_list):
     """Test `upgrade_agents` function from agent module.
 
     Parameters
@@ -975,9 +959,9 @@ def test_agent_upgrade_agents(sqlite_mock, socket_sendto, _send_wpk_file, ossec_
 @patch('wazuh.core.agent.OssecSocket')
 @patch('wazuh.core.agent.Agent._send_wpk_file')
 @patch('socket.socket.sendto', return_value=1)
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_upgrade_result(sqlite_mock, socket_sendto, _send_wpk_file, ossec_socket_mock, agent_list):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_upgrade_result(socket_mock, send_mock, socket_sendto, _send_wpk_file, ossec_socket_mock, agent_list):
     """Test `get_upgrade_result` function from agent module.
 
     Parameters
@@ -994,9 +978,9 @@ def test_agent_get_upgrade_result(sqlite_mock, socket_sendto, _send_wpk_file, os
 @patch('wazuh.core.agent.OssecSocket')
 @patch('wazuh.core.agent.Agent._send_custom_wpk_file')
 @patch('socket.socket.sendto', return_value=1)
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_upgrade_agents_custom(sqlite_mock, socket_sendto, _send_wpk_file, ossec_socket_mock, agent_list):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_upgrade_agents_custom(socket_mock, send_mock, socket_sendto, _send_wpk_file, ossec_socket_mock, agent_list):
     """Test `upgrade_agents_custom` function from agent module.
 
     Parameters
@@ -1014,9 +998,9 @@ def test_agent_upgrade_agents_custom(sqlite_mock, socket_sendto, _send_wpk_file,
     ("any-path", None),
     (None, None)
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_upgrade_agents_custom_exceptions(sqlite_mock, file_path, installer):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_upgrade_agents_custom_exceptions(socket_mock, send_mock, file_path, installer):
     """Test `upgrade_agents_custom` function from agent module raises the expected `WazuhInternalError` exception when
     using invalid parameters.
 
@@ -1040,9 +1024,9 @@ def test_agent_upgrade_agents_custom_exceptions(sqlite_mock, file_path, installe
     (['001'], 'logcollector', 'internal')
 ])
 @patch('wazuh.core.configuration.OssecSocket')
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_agent_config(sqlite_mock, ossec_socket_mock, agent_list, component, configuration):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agent_config(socket_mock, send_mock, ossec_socket_mock, agent_list, component, configuration):
     """Test `get_agent_config` function from agent module.
 
     Parameters
@@ -1064,9 +1048,9 @@ def test_agent_get_agent_config(sqlite_mock, ossec_socket_mock, agent_list, comp
 @pytest.mark.parametrize('agent_list', [
     ['005']
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_agent_config_exceptions(sqlite_mock, agent_list):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agent_config_exceptions(socket_mock, send_mock, agent_list):
     """Test `get_agent_config` function from agent module raises the expected exceptions when using invalid parameters.
 
     Parameters
@@ -1084,12 +1068,12 @@ def test_agent_get_agent_config_exceptions(sqlite_mock, agent_list):
 @pytest.mark.parametrize('agent_list', [
     full_agent_list[1:]
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.common.shared_path', new=test_shared_path)
 @patch('wazuh.common.multi_groups_path', new=test_multigroup_path)
 @patch('wazuh.agent.get_agents_info', return_value=full_agent_list)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_agents_sync_group(sqlite_mock, get_agent_mock, agent_list):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_sync_group(socket_mock, send_mock, get_agent_mock, agent_list):
     """Test `get_agents_sync_group` function from agent module.
 
     Parameters
@@ -1108,9 +1092,9 @@ def test_agent_get_agents_sync_group(sqlite_mock, get_agent_mock, agent_list):
     (['000'], WazuhError(1703)),
     (['100'], WazuhResourceNotFound(1701))
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_agents_sync_group_exceptions(sqlite_mock, agent_list, expected_error):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agents_sync_group_exceptions(socket_mock, send_mock, agent_list, expected_error):
     """Test `get_agents_sync_group` function from agent module returns the expected exceptions when using invalid
     parameters.
 
@@ -1199,15 +1183,15 @@ def test_agent_upload_group_file(mock_upload, group_list):
     (full_agent_list, ['group-1'], False, '004'),
     (full_agent_list, ['group-1'], True, None)
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.common.shared_path', new=test_shared_path)
 @patch('wazuh.agent.get_distinct_agents')
 @patch('wazuh.agent.get_agent_groups')
 @patch('wazuh.agent.get_agents_summary_status')
 @patch('wazuh.agent.get_agents')
-@patch('sqlite3.connect', return_value=test_data.global_db)
-def test_agent_get_full_overview(sqlite_mock, get_mock, summary_mock, group_mock, distinct_mock, agent_list, group_list,
-                                 index_error, last_agent):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_full_overview(socket_mock, send_mock, get_mock, summary_mock, group_mock, distinct_mock, agent_list,
+                                 group_list, index_error, last_agent):
     """Test `get_full_overview` function from agent module.
 
     Parameters


### PR DESCRIPTION
Hello team,

This PR fixes some bugs we detected in the `WazuhDBQuery` and `wdb.py` modules after the integration with the `wazuh-db` socket. In addition, affected unit tests have been updated and improved.

## Tests performed
- SDK agents
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0
collected 89 items                                                                                                                                                                          

wazuh/tests/test_agent.py .......................F.................................................................                                                                   [100%]

========================================================================= 1 failed, 88 passed, 11 warnings in 3.05s =========================================================================

```
 
- Core agents
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0
collected 191 items                                                                                                                                                                         

wazuh/core/tests/test_agent.py ............................................................FFF......................FFFFF............................................................ [ 78%]
................................F.FFF....                                                                                                                                             [100%]

======================================================================== 12 failed, 179 passed, 11 warnings in 2.05s ========================================================================

```

- Core utils
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0
collected 204 items                                                                                                                                                                         

wazuh/core/tests/test_utils.py ...................................................................................................................................................... [ 73%]
......................................................                                                                                                                                [100%]

==================================================================================== 204 passed in 0.66s ====================================================================================

```

Some tests are failing because of the `Agent` class. There are a few methods that keep using `sqlite` to connect to `global.db` instead of using `WazuhDBQuery`. These tests are updated to expect the use of `WazuhDBQuery` so they should pass once we refactor these methods.

Regards.