### PR TITLE
Fix sending [] to master

### DIFF
--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -175,7 +175,8 @@ class WazuhDBConnection:
             status, payload = self._send(command, raw=True)
             if status == 'err':
                 raise WazuhInternalError(2007, extra_message=payload)
-            response.append(payload)
+            if payload != '[]':
+                response.append(payload)
             # Exit if there are no items left to return
             if status == 'ok':
                 break


### PR DESCRIPTION
## Description
Hi team!

In one of the latest changes, a check was lost that prevented, in `run_wdb_command`, from returning a list whose only element was [].

This caused that item to be sent to master every 10 seconds, which was useless. Now no chunk is sent if there is nothing to update:
```
2020/09/29 12:42:32 INFO: [Local Client] [Main] Starting to send information to wazuh-db.
2020/09/29 12:42:32 INFO: [Local Client] [Main] Finished sending information to wazuh-db (0 chunks sent).
```

The agent-info synchronization can still be queried in cluster_control binary:
```
/var/ossec/bin/cluster_control -i more
Cluster name: wazuh

Connected nodes (2):

    master-node (wazuh-master)
        Version: 4.0.0
        Type: master
        Active agents: 0

    worker1 (172.24.0.4)
        Version: 4.0.0
        Type: worker
        Active agents: 0
        Status:
            Last keep Alive:
                Last received: 2020-09-29 15:20:12.645374.
            Integrity
                Last synchronization: 2020-09-29 15:20:17.184038 - 2020-09-29 15:20:17.198059.
                Synchronized files: Shared: 0 | Missing: 0 | Extra: 0 | Extra valid: 0.
                Permission to synchronize: True.
            Agents-info
                Last synchronization: 2020-09-29 15:20:13.989306 - 2020-09-29 15:20:13.993237.
                Number of synchronized chunks: 0.
            Agents-group
                Last synchronization: n/a - n/a.
                Synchronized files: 0.
                Permission to synchronize: True.
 
```

Best regards,
Selu.