### PR TITLE
6068 solaris 11.4 11.3 compilation fix

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1027,6 +1027,9 @@ wrappers_externals_audit_o := $(wrappers_externals_audit_c:.c=.o)
 wrappers_externals_bzip2_c := $(wildcard unit_tests/wrappers/externals/bzip2/*.c)
 wrappers_externals_bzip2_o := $(wrappers_externals_bzip2_c:.c=.o)
 
+wrappers_externals_zlib_c := $(wildcard unit_tests/wrappers/externals/zlib/*.c)
+wrappers_externals_zlib_o := $(wrappers_externals_zlib_c:.c=.o)
+
 wrappers_externals_cJSON_c := $(wildcard unit_tests/wrappers/externals/cJSON/*.c)
 wrappers_externals_cJSON_o := $(wrappers_externals_cJSON_c:.c=.o)
 
@@ -1099,6 +1102,7 @@ ifneq (,$(filter ${TEST},YES yes y Y 1))
 	UNIT_TEST_WRAPPERS:=${wrappers_common_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_bzip2_o}
+	UNIT_TEST_WRAPPERS+=${wrappers_externals_zlib_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_cJSON_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_openssl_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_sqlite_o}
@@ -1160,7 +1164,7 @@ config/%.o: config/%.c
 
 build_shared_modules:
 	cd ${DBSYNC} && mkdir -p build && cd build && cmake ${WIN_CMAKE_OPTS} ${DBSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} .. && make
-	cd ${RSYNC} && mkdir -p build && cd build && cmake ${WIN_CMAKE_OPTS} ${SOLARIS_CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && make
+	cd ${RSYNC} && mkdir -p build && cd build && cmake ${WIN_CMAKE_OPTS} ${RSYNC_TEST} ${SOLARIS_CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && make
 ifneq (,$(filter ${TEST},YES yes y Y 1))
 ifneq (,$(filter ${DEBUG},YES yes y Y 1))
 	cd ${SHARED_UTILS_TEST} &&  mkdir -p build && cd build && cmake ${WIN_CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && make
@@ -1725,6 +1729,7 @@ install_python:
 python_dependencies := requirements.txt
 
 install_dependencies: install_python
+	${WPYTHON_DIR}/bin/pip3 install --upgrade pip --index-url=file://${ROUTE_PATH}/${EXTERNAL_CPYTHON}/Dependencies/simple
 	LD_LIBRARY_PATH="${PREFIX}/lib" LDFLAGS="-L${PREFIX}/lib" ${WPYTHON_DIR}/bin/pip3 install -r ../framework/${python_dependencies}  --index-url=file://${ROUTE_PATH}/${EXTERNAL_CPYTHON}/Dependencies/simple
 
 install_framework: install_python
@@ -2036,6 +2041,7 @@ clean-unit-tests:
 	rm -f ${wrappers_externals_o}
 	rm -f ${wrappers_externals_audit_o}
 	rm -f ${wrappers_externals_bzip2_o}
+	rm -f ${wrappers_externals_zlib_o}
 	rm -f ${wrappers_externals_cJSON_o}
 	rm -f ${wrappers_externals_openssl_o}
 	rm -f ${wrappers_externals_procpc_o}

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,6 +12,7 @@
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_P := $(shell sh -c 'uname -p 2>/dev/null || echo not')
 uname_R := $(shell sh -c 'uname -r 2>/dev/null || echo not')
+uname_V := $(shell sh -c 'uname -v 2>/dev/null || echo not')
 HAS_CHECKMODULE = $(shell command -v checkmodule > /dev/null && echo YES)
 HAS_SEMODULE_PACKAGE = $(shell command -v semodule_package > /dev/null && echo YES)
 CHECK_ARCHLINUX := $(shell sh -c 'grep "Arch Linux" /etc/os-release > /dev/null && echo YES || echo not')
@@ -134,6 +135,14 @@ ifeq (${uname_S},AIX)
 		CC=gcc
 else
 ifeq (${uname_S},SunOS)
+SOLARIS_CMAKE_OPTS=-DSOLARIS=ON
+ifneq ($(uname_R),5.10)
+		DEFINES+=-DSUN_MAJOR_VERSION=$(word 1, $(subst ., ,$(uname_V)))
+		DEFINES+=-DSUN_MINOR_VERSION=$(word 2, $(subst ., ,$(uname_V)))
+else
+		DEFINES+=-DSUN_MAJOR_VERSION=10
+		DEFINES+=-DSUN_MINOR_VERSION=0
+endif
 		DEFINES+=-DSOLARIS
 		DEFINES+=-DHIGHFIRST
 		DEFINES+=-D_REENTRANT
@@ -1018,9 +1027,6 @@ wrappers_externals_audit_o := $(wrappers_externals_audit_c:.c=.o)
 wrappers_externals_bzip2_c := $(wildcard unit_tests/wrappers/externals/bzip2/*.c)
 wrappers_externals_bzip2_o := $(wrappers_externals_bzip2_c:.c=.o)
 
-wrappers_externals_zlib_c := $(wildcard unit_tests/wrappers/externals/zlib/*.c)
-wrappers_externals_zlib_o := $(wrappers_externals_zlib_c:.c=.o)
-
 wrappers_externals_cJSON_c := $(wildcard unit_tests/wrappers/externals/cJSON/*.c)
 wrappers_externals_cJSON_o := $(wrappers_externals_cJSON_c:.c=.o)
 
@@ -1093,7 +1099,6 @@ ifneq (,$(filter ${TEST},YES yes y Y 1))
 	UNIT_TEST_WRAPPERS:=${wrappers_common_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_bzip2_o}
-	UNIT_TEST_WRAPPERS+=${wrappers_externals_zlib_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_cJSON_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_openssl_o}
 	UNIT_TEST_WRAPPERS+=${wrappers_externals_sqlite_o}
@@ -1155,7 +1160,7 @@ config/%.o: config/%.c
 
 build_shared_modules:
 	cd ${DBSYNC} && mkdir -p build && cd build && cmake ${WIN_CMAKE_OPTS} ${DBSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} .. && make
-	cd ${RSYNC} && mkdir -p build && cd build && cmake ${WIN_CMAKE_OPTS} ${RSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} .. && make
+	cd ${RSYNC} && mkdir -p build && cd build && cmake ${WIN_CMAKE_OPTS} ${SOLARIS_CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && make
 ifneq (,$(filter ${TEST},YES yes y Y 1))
 ifneq (,$(filter ${DEBUG},YES yes y Y 1))
 	cd ${SHARED_UTILS_TEST} &&  mkdir -p build && cd build && cmake ${WIN_CMAKE_OPTS} ${SHARED_MODULES_RELEASE_TYPE} .. && make
@@ -1720,7 +1725,6 @@ install_python:
 python_dependencies := requirements.txt
 
 install_dependencies: install_python
-	${WPYTHON_DIR}/bin/pip3 install --upgrade pip --index-url=file://${ROUTE_PATH}/${EXTERNAL_CPYTHON}/Dependencies/simple
 	LD_LIBRARY_PATH="${PREFIX}/lib" LDFLAGS="-L${PREFIX}/lib" ${WPYTHON_DIR}/bin/pip3 install -r ../framework/${python_dependencies}  --index-url=file://${ROUTE_PATH}/${EXTERNAL_CPYTHON}/Dependencies/simple
 
 install_framework: install_python
@@ -2032,7 +2036,6 @@ clean-unit-tests:
 	rm -f ${wrappers_externals_o}
 	rm -f ${wrappers_externals_audit_o}
 	rm -f ${wrappers_externals_bzip2_o}
-	rm -f ${wrappers_externals_zlib_o}
 	rm -f ${wrappers_externals_cJSON_o}
 	rm -f ${wrappers_externals_openssl_o}
 	rm -f ${wrappers_externals_procpc_o}

--- a/src/headers/privsep_op.h
+++ b/src/headers/privsep_op.h
@@ -15,7 +15,9 @@
 
 #include "shared.h"
 
-#ifdef SOLARIS
+#if defined(SUN_MAJOR_VERSION) && defined(SUN_MINOR_VERSION)  && \
+    (SUN_MAJOR_VERSION < 11) || \
+    ((SUN_MAJOR_VERSION == 11) && (SUN_MINOR_VERSION < 4))
 #define w_ctime(x,y,z) ctime_r(x,y,z)
 #else
 #define w_ctime(x,y,z) ctime_r(x,y)

--- a/src/shared/privsep_op.c
+++ b/src/shared/privsep_op.c
@@ -22,7 +22,9 @@
 #include "headers/os_err.h"
 
 struct passwd *w_getpwnam(const char *name, struct passwd *pwd, char *buf, size_t buflen) {
-#ifdef SOLARIS
+#if defined(SUN_MAJOR_VERSION) && defined(SUN_MINOR_VERSION)  && \
+    (SUN_MAJOR_VERSION < 11) || \
+    ((SUN_MAJOR_VERSION == 11) && (SUN_MINOR_VERSION < 4))
     return getpwnam_r(name, pwd, buf, buflen);
 #else
     struct passwd *result = NULL;
@@ -37,7 +39,9 @@ struct passwd *w_getpwnam(const char *name, struct passwd *pwd, char *buf, size_
 }
 
 struct passwd *w_getpwuid(uid_t uid, struct  passwd  *pwd, char *buf, int  buflen) {
-#ifdef SOLARIS
+#if defined(SUN_MAJOR_VERSION) && defined(SUN_MINOR_VERSION)  && \
+    (SUN_MAJOR_VERSION < 11) || \
+    ((SUN_MAJOR_VERSION == 11) && (SUN_MINOR_VERSION < 4))
     return getpwuid_r(uid, pwd, buf, buflen);
 #else
     struct passwd *result = NULL;
@@ -52,7 +56,9 @@ struct passwd *w_getpwuid(uid_t uid, struct  passwd  *pwd, char *buf, int  bufle
 }
 
 struct group *w_getgrnam(const  char  *name,  struct group *grp, char *buf, int buflen) {
-#ifdef SOLARIS
+#if defined(SUN_MAJOR_VERSION) && defined(SUN_MINOR_VERSION)  && \
+    (SUN_MAJOR_VERSION < 11) || \
+    ((SUN_MAJOR_VERSION == 11) && (SUN_MINOR_VERSION < 4))
     return getgrnam_r(name, grp, buf, buflen);
 #else
     struct group *result = NULL;
@@ -67,7 +73,9 @@ struct group *w_getgrnam(const  char  *name,  struct group *grp, char *buf, int 
 }
 
 struct group *w_getgrgid(gid_t gid, struct group *grp,  char *buf, int buflen) {
-#ifdef SOLARIS
+#if defined(SUN_MAJOR_VERSION) && defined(SUN_MINOR_VERSION)  && \
+    (SUN_MAJOR_VERSION < 11) || \
+    ((SUN_MAJOR_VERSION == 11) && (SUN_MINOR_VERSION < 4))
     return getgrgid_r(gid, grp, buf, buflen);
 #else
     struct group *result = NULL;

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -603,7 +603,9 @@ char *get_user(int uid) {
 
     os_calloc(bufsize, sizeof(char), buf);
 
-#ifdef SOLARIS
+#if defined(SUN_MAJOR_VERSION) && defined(SUN_MINOR_VERSION)  && \
+    (SUN_MAJOR_VERSION < 11) || \
+    ((SUN_MAJOR_VERSION == 11) && (SUN_MINOR_VERSION < 4))
     result = getpwuid_r(uid, &pwd, buf, bufsize);
 #else
     errno = getpwuid_r(uid, &pwd, buf, bufsize, &result);

--- a/src/shared_modules/rsync/testtool/CMakeLists.txt
+++ b/src/shared_modules/rsync/testtool/CMakeLists.txt
@@ -33,4 +33,11 @@ else()
 	    pthread
 	    dl
 	)
+
+	if(SOLARIS)
+		target_link_libraries(rsync_test_tool
+			nsl
+			socket
+		)
+	endif(SOLARIS)
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")


### PR DESCRIPTION
|Related issue|
|---|
|#6068|

Changes that solve compilation problems in Solaris 11.3 and Solaris 11.4, apparently the gclib library is more similar to the C standard library.

RTR:
![image](https://user-images.githubusercontent.com/14300208/94667704-8b229d80-02e5-11eb-82ee-dd5e4120bd0f.png)
![image](https://user-images.githubusercontent.com/14300208/94667992-e48acc80-02e5-11eb-8858-af90220000de.png)


Compilation Success:
![image](https://user-images.githubusercontent.com/14300208/94709081-b45e2080-031b-11eb-98a8-caee9ed57e7a.png)

