### PR TITLE
Enrollment: Checking remote events service availability

### DIFF
--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -90,9 +90,9 @@ char *get_agent_ip();
 void start_agent(int is_startup);
 
 /* Connect to the server */
-bool connect_server(int initial_id);
+bool connect_server(int initial_id, bool verbose);
 
-/** 
+/**
  * Tries to enroll to a server indicated by server_rip
  * @return 0 on success
  *         -1 on error

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -30,16 +30,18 @@ int timeout;    //timeout in seconds waiting for a server reply
 static ssize_t receive_message(char *buffer, unsigned int max_lenght);
 static void w_agentd_keys_init (void);
 static bool agent_handshake_to_server(int server_id, bool is_startup);
+static bool agent_ping_to_server(int server_id);
 static void send_msg_on_startup(void);
 
 /**
  * @brief Connects to a specified server
  * @param server_id index of the specified server from agt servers list
+ * @param verbose Be verbose or not.
  * @post The remote IP id (rip_id) is set to server_id if and only if this function succeeds.
  * @retval true on success
  * @retval false when failed
  * */
-bool connect_server(int server_id)
+bool connect_server(int server_id, bool verbose)
 {
     timeout = getDefine_Int("agent", "recv_timeout", 1, 600);
 
@@ -49,10 +51,12 @@ bool connect_server(int server_id)
         agt->sock = -1;
 
         if (agt->server[agt->rip_id].rip) {
-            minfo("Closing connection to server (%s:%d/%s).",
+            if (verbose) {
+                minfo("Closing connection to server (%s:%d/%s).",
                     agt->server[agt->rip_id].rip,
                     agt->server[agt->rip_id].port,
                     agt->server[agt->rip_id].protocol == IPPROTO_UDP ? "udp" : "tcp");
+            }
         }
     }
 
@@ -84,11 +88,12 @@ bool connect_server(int server_id)
         return false;
     }
 
-    minfo("Trying to connect to server (%s:%d/%s).",
+    if (verbose) {
+        minfo("Trying to connect to server (%s:%d/%s).",
             agt->server[server_id].rip,
             agt->server[server_id].port,
             agt->server[server_id].protocol == IPPROTO_UDP ? "udp" : "tcp");
-
+    }
     if (agt->server[server_id].protocol == IPPROTO_UDP) {
         agt->sock = OS_ConnectUDP(agt->server[server_id].port, tmp_str, strchr(tmp_str, ':') != NULL);
     } else {
@@ -97,11 +102,14 @@ bool connect_server(int server_id)
 
     if (agt->sock < 0) {
         agt->sock = -1;
-        #ifdef WIN32
-            merror(CONNS_ERROR, tmp_str, win_strerror(WSAGetLastError()));
-        #else
-            merror(CONNS_ERROR, tmp_str, strerror(errno));
-        #endif
+
+        if (verbose) {
+            #ifdef WIN32
+                merror(CONNS_ERROR, tmp_str, agt->server[server_id].port, agt->server[server_id].protocol == IPPROTO_UDP ? "udp" : "tcp", win_strerror(WSAGetLastError()));
+            #else
+                merror(CONNS_ERROR, tmp_str, agt->server[server_id].port, agt->server[server_id].protocol == IPPROTO_UDP ? "udp" : "tcp", strerror(errno));
+            #endif
+        }
     } else {
         #ifdef WIN32
             if (agt->server[server_id].protocol == IPPROTO_UDP) {
@@ -138,12 +146,18 @@ void start_agent(int is_startup)
             sleep(agt->server[current_server_id].retry_interval);
         }
 
-        if (agt->enrollment_cfg && agt->enrollment_cfg->enabled && try_enroll_to_server(agt->server[current_server_id].rip) == 0) {
-            if (agent_handshake_to_server(current_server_id, is_startup)) {
-                return;
-            }
+        if (agt->enrollment_cfg && agt->enrollment_cfg->enabled) {
+            if (agent_ping_to_server(current_server_id)) {
+                if (try_enroll_to_server(agt->server[current_server_id].rip) == 0) {
+                    if (agent_handshake_to_server(current_server_id, is_startup)) {
+                        return;
+                    }
 
-            sleep(agt->server[current_server_id].retry_interval);
+                    sleep(agt->server[current_server_id].retry_interval);
+                }
+            } else {
+                mwarn("Polling server '%s' failed. Skipping enrollment.", agt->server[current_server_id].rip);
+            }
         }
 
         /* Wait for server reply */
@@ -182,7 +196,11 @@ static void w_agentd_keys_init (void) {
 
                 /* Try to enroll to server list */
                 while (agt->server[rc].rip && (registration_status != 0)) {
-                    registration_status = try_enroll_to_server(agt->server[rc].rip);
+                    if (agent_ping_to_server(rc)) {
+                        registration_status = try_enroll_to_server(agt->server[rc].rip);
+                    } else {
+                        mwarn("Polling server '%s' failed. Skipping enrollment.", agt->server[rc].rip);
+                    }
                     rc++;
                 }
 
@@ -277,7 +295,42 @@ static ssize_t receive_message(char *buffer, unsigned int max_lenght) {
     }
     return 0;
 }
+/**
+ * @brief Check the server health using ping/pong operation.
+ * @param server_id index of the specified server from agt servers list
+ * @retval true on good health
+ * @retval false when no response
+ * */
+static bool agent_ping_to_server(int server_id) {
+    ssize_t recv_b = 0;
+    char *msg = "#ping";
+    char buffer[OS_MAXSTR + 1] = { '\0' };
 
+    if (connect_server(server_id, false)) {
+        /* Send the ping message */
+
+        if (agt->server[agt->rip_id].protocol == IPPROTO_UDP) {
+            recv_b = OS_SendUDPbySize(agt->sock, strlen(msg), msg);
+        } else {
+            recv_b = OS_SendSecureTCP(agt->sock, strlen(msg), msg);
+        }
+
+        if (recv_b != 0) {
+            return false;
+        }
+
+        /* Read until our reply comes back */
+        recv_b = receive_message(buffer, OS_MAXSTR);
+
+        if (recv_b > 0) {
+            if (strcmp(buffer, "#pong") == 0) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
 int try_enroll_to_server(const char * server_rip) {
     int enroll_result = w_enrollment_request_key(agt->enrollment_cfg, server_rip);
     if (enroll_result == 0) {
@@ -291,7 +344,6 @@ int try_enroll_to_server(const char * server_rip) {
     }
     return enroll_result;
 }
-
 /**
  * @brief Holds handshake logic for an attempt to connect to server
  * @param server_id index of the specified server from agt servers list
@@ -311,7 +363,7 @@ static bool agent_handshake_to_server(int server_id, bool is_startup) {
 
     snprintf(msg, OS_MAXSTR, "%s%s", CONTROL_HEADER, HC_STARTUP);
 
-    if (connect_server(server_id)) {
+    if (connect_server(server_id, true)) {
         /* Send start up message */
         send_msg(msg, -1);
 

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -72,7 +72,7 @@
 #define DENYIP_WARN     "(1213): Message from '%s' not allowed. Cannot find the ID of the agent."
 #define MSG_ERROR       "(1214): Problem receiving message from '%s'."
 #define CLIENT_ERROR    "(1215): No client configured. Exiting."
-#define CONNS_ERROR     "(1216): Unable to connect to '%s': '%s'."
+#define CONNS_ERROR     "(1216): Unable to connect to '%s:%d/%s': '%s'."
 #define UNABLE_CONN     "(1242): Unable to connect to server. Exhausted all options."
 #define SEC_ERROR       "(1217): Error creating encrypted message."
 #define SEND_ERROR      "(1218): Unable to send message to '%s': %s"

--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -85,7 +85,7 @@ void OS_CSyslogD(SyslogConfig **syslog_config)
         syslog_config[s]->socket = OS_ConnectUDP(syslog_config[s]->port, syslog_config[s]->server, 0);
 
         if (syslog_config[s]->socket < 0) {
-            merror(CONNS_ERROR, syslog_config[s]->server, strerror(errno));
+            merror(CONNS_ERROR, syslog_config[s]->server, syslog_config[s]->port, "udp", strerror(errno));
         } else {
             minfo("Forwarding alerts via syslog to: '%s:%d'.",
                    syslog_config[s]->server, syslog_config[s]->port);

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -340,6 +340,23 @@ static void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_in *pe
 
             return;
         }
+    } else if (strcmp(buffer, "#ping") == 0) {
+            int retval = 0;
+            char *msg = "#pong";
+            ssize_t msg_size = strlen(msg);
+
+            if (protocol == IPPROTO_UDP) {
+                retval = sendto(logr.sock, msg, msg_size, 0, (struct sockaddr *)peer_info, logr.peer_size) == msg_size ? 0 : -1;
+            } else {
+                retval = OS_SendSecureTCP(sock_client, msg_size, msg);
+            }
+
+            if (retval < 0) {
+                mwarn("Ping operation could not be delivered completely (%d)", retval);
+            }
+
+            return;
+
     } else {
         key_lock_read();
         agentid = OS_IsAllowedIP(&keys, srcip);

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -288,7 +288,7 @@ static int w_enrollment_send_message(w_enrollment_ctx *cfg) {
     int ret = SSL_write(cfg->ssl, buf, strlen(buf));
     if (ret < 0) {
         merror("SSL write error (unable to send message.)");
-        merror("If Agent verification is enabled, agent key and certifiates are required!");
+        merror("If Agent verification is enabled, agent key and certificates are required!");
         ERR_print_errors_fp(stderr);
         os_free(buf);
         if(lhostname != cfg->target_cfg->agent_name)
@@ -351,7 +351,7 @@ static int w_enrollment_process_response(SSL *ssl) {
     default:
         if(!manager_error) {
             merror("SSL read (unable to receive message)");
-            merror("If Agent verification is enabled, agent key and certifiates may be incorrect!");
+            merror("If Agent verification is enabled, agent key and certificates may be incorrect!");
         }
         break;
     }

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Generate client-agent library
-file(GLOB client-agent_files 
+file(GLOB client-agent_files
     ${SRC_FOLDER}/client-agent/*.o)
 
 list(REMOVE_ITEM client-agent_files ${SRC_FOLDER}/client-agent/main.o)
@@ -27,7 +27,8 @@ set(START_AGENT_BASE_FLAGS "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_min
                             -Wl,--wrap,w_rotate_log -Wl,--wrap,getDefine_Int -Wl,--wrap,OS_ConnectUDP \
                             -Wl,--wrap,OS_ConnectTCP -Wl,--wrap,OS_SetRecvTimeout -Wl,--wrap,resolveHostname \
                             -Wl,--wrap,send_msg -Wl,--wrap,recv -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,fseek \
-                            -Wl,--wrap,fprintf -Wl,--wrap,fflush -Wl,--wrap,ReadSecMSG -Wl,--wrap,wnet_select")
+                            -Wl,--wrap,fprintf -Wl,--wrap,fflush -Wl,--wrap,ReadSecMSG -Wl,--wrap,wnet_select \
+                            -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_SendUDPbySize")
 if(${TARGET} STREQUAL "winagent")
     list(APPEND client-agent_flags "${START_AGENT_BASE_FLAGS} -Wl,--wrap,os_random")
 else()

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -29,6 +29,7 @@
 
 extern void send_msg_on_startup(void);
 extern bool agent_handshake_to_server(int server_id, bool is_startup);
+extern bool agent_ping_to_server(int server_id);
 extern int _s_verify_counter;
 
 #ifndef TEST_WINAGENT
@@ -87,7 +88,7 @@ char SERVER_WRONG_ACK[] = {0x01,0x02,0x03,0x00};
 void add_server_config(char* address, int protocol) {
     os_realloc(agt->server, sizeof(agent_server) * (agt->rip_id + 2), agt->server);
     os_strdup(address, agt->server[agt->rip_id].rip);
-    agt->server[agt->rip_id].port = 0;
+    agt->server[agt->rip_id].port = 1514;
     agt->server[agt->rip_id].protocol = 0;
     memset(agt->server + agt->rip_id + 1, 0, sizeof(agent_server));
     agt->server[agt->rip_id].protocol = protocol;
@@ -371,11 +372,147 @@ static void test_send_msg_on_startup(void **state) {
     return;
 }
 
+// Agent ping: cannot connect
+static void test_agent_ping_to_server_no_connect(void **state) {
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_OS_ConnectUDP, -1);
+
+    assert_false(agent_ping_to_server(0));
+}
+
+// Agent ping: TCP send failure
+static void test_agent_ping_to_server_tcp_send_fail(void **state) {
+    will_return(__wrap_getDefine_Int, 5);
+
+    expect_value(__wrap_OS_ConnectTCP, _port, 1514);
+    expect_string(__wrap_OS_ConnectTCP, _ip, "127.0.0.2");
+    expect_any(__wrap_OS_ConnectTCP, ipv6);
+    will_return(__wrap_OS_ConnectTCP, 22);
+
+    expect_value(__wrap_OS_SendSecureTCP, sock, 22);
+    expect_value(__wrap_OS_SendSecureTCP, size, 5);
+    expect_string(__wrap_OS_SendSecureTCP, msg, "#ping");
+    will_return(__wrap_OS_SendSecureTCP, -1);
+
+    assert_false(agent_ping_to_server(1));
+}
+
+// Agent ping: UDP send failure
+static void test_agent_ping_to_server_udp_send_fail(void **state) {
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_OS_ConnectUDP, 24);
+
+    expect_value(__wrap_OS_SendUDPbySize, sock, 24);
+    expect_value(__wrap_OS_SendUDPbySize, size, 5);
+    expect_string(__wrap_OS_SendUDPbySize, msg, "#ping");
+    will_return(__wrap_OS_SendUDPbySize, -1);
+
+    assert_false(agent_ping_to_server(0));
+}
+
+// Agent ping: TCP receive failure
+static void test_agent_ping_to_server_tcp_receive_fail(void **state) {
+    will_return(__wrap_getDefine_Int, 5);
+
+    expect_value(__wrap_OS_ConnectTCP, _port, 1514);
+    expect_string(__wrap_OS_ConnectTCP, _ip, "127.0.0.2");
+    expect_any(__wrap_OS_ConnectTCP, ipv6);
+    will_return(__wrap_OS_ConnectTCP, 22);
+
+    expect_value(__wrap_OS_SendSecureTCP, sock, 22);
+    expect_value(__wrap_OS_SendSecureTCP, size, 5);
+    expect_string(__wrap_OS_SendSecureTCP, msg, "#ping");
+    will_return(__wrap_OS_SendSecureTCP, 0);
+
+    will_return(__wrap_wnet_select, 1);
+
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 22);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, "");
+    will_return(__wrap_OS_RecvSecureTCP, -1);
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+
+    assert_false(agent_ping_to_server(1));
+}
+
+// Agent ping: UDP receive invalid string
+static void test_agent_ping_to_server_udp_receive_invalid(void **state) {
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_OS_ConnectUDP, 24);
+
+    expect_value(__wrap_OS_SendUDPbySize, sock, 24);
+    expect_value(__wrap_OS_SendUDPbySize, size, 5);
+    expect_string(__wrap_OS_SendUDPbySize, msg, "#ping");
+    will_return(__wrap_OS_SendUDPbySize, 0);
+
+    will_return(__wrap_wnet_select, 1);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_recv, "#fail");
+#else
+    will_return(wrap_recv, "#fail");
+#endif
+
+    assert_false(agent_ping_to_server(0));
+}
+
+// Agent ping: valid ping-pong on TCP
+static void test_agent_ping_to_server_tcp_ok(void **state) {
+    will_return(__wrap_getDefine_Int, 5);
+
+    expect_value(__wrap_OS_ConnectTCP, _port, 1514);
+    expect_string(__wrap_OS_ConnectTCP, _ip, "127.0.0.2");
+    expect_any(__wrap_OS_ConnectTCP, ipv6);
+    will_return(__wrap_OS_ConnectTCP, 22);
+
+    expect_value(__wrap_OS_SendSecureTCP, sock, 22);
+    expect_value(__wrap_OS_SendSecureTCP, size, 5);
+    expect_string(__wrap_OS_SendSecureTCP, msg, "#ping");
+    will_return(__wrap_OS_SendSecureTCP, 0);
+
+    will_return(__wrap_wnet_select, 1);
+
+    expect_value(__wrap_OS_RecvSecureTCP, sock, 22);
+    expect_value(__wrap_OS_RecvSecureTCP, size, OS_MAXSTR);
+    will_return(__wrap_OS_RecvSecureTCP, "#pong");
+    will_return(__wrap_OS_RecvSecureTCP, 5);
+
+    assert_true(agent_ping_to_server(1));
+}
+
+// Agent ping: valid ping-pong on UDP
+static void test_agent_ping_to_server_udp_ok(void **state) {
+    will_return(__wrap_getDefine_Int, 5);
+    will_return(__wrap_OS_ConnectUDP, 24);
+
+    expect_value(__wrap_OS_SendUDPbySize, sock, 24);
+    expect_value(__wrap_OS_SendUDPbySize, size, 5);
+    expect_string(__wrap_OS_SendUDPbySize, msg, "#ping");
+    will_return(__wrap_OS_SendUDPbySize, 0);
+
+    will_return(__wrap_wnet_select, 1);
+#ifndef TEST_WINAGENT
+    will_return(__wrap_recv, "#pong");
+#else
+    will_return(wrap_recv, "#pong");
+#endif
+
+    assert_true(agent_ping_to_server(0));
+}
+
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_connect_server, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_agent_handshake_to_server, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_send_msg_on_startup, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_agent_ping_to_server_no_connect, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_agent_ping_to_server_tcp_send_fail, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_agent_ping_to_server_udp_send_fail, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_agent_ping_to_server_tcp_receive_fail, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_agent_ping_to_server_udp_receive_invalid, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_agent_ping_to_server_tcp_ok, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_agent_ping_to_server_udp_ok, setup_test, teardown_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -174,7 +174,7 @@ static void test_connect_server(void **state) {
 
     expect_any_count(__wrap__minfo, formatted_msg, 2);
 
-    connected = connect_server(0);
+    connected = connect_server(0, true);
     assert_int_equal(agt->rip_id, 0);
     assert_int_equal(agt->sock, 11);
     assert_true(connected);
@@ -194,7 +194,7 @@ static void test_connect_server(void **state) {
 
     expect_any_count(__wrap__minfo, formatted_msg, 2);
 
-    connected = connect_server(1);
+    connected = connect_server(1, true);
     assert_int_equal(agt->rip_id, 1);
     assert_int_equal(agt->sock, 12);
     assert_true(connected);
@@ -210,7 +210,7 @@ static void test_connect_server(void **state) {
 
     expect_any_count(__wrap__minfo, formatted_msg, 2);
 
-    connected = connect_server(2);
+    connected = connect_server(2, true);
     assert_int_equal(agt->rip_id, 2);
     assert_int_equal(agt->sock, 13);
     assert_true(connected);
@@ -226,13 +226,13 @@ static void test_connect_server(void **state) {
     expect_any(__wrap__minfo, formatted_msg);
     expect_any(__wrap__merror, formatted_msg);
 
-    connected = connect_server(3);
+    connected = connect_server(3, true);
     assert_false(connected);
 
     /* Connect to first server (UDP), simulate connection error*/
     will_return(__wrap_getDefine_Int, 5);
     will_return(__wrap_OS_ConnectUDP, -1);
-    connected = connect_server(0);
+    connected = connect_server(0, true);
     assert_false(connected);
 
     return;

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -554,7 +554,7 @@ void test_w_enrollment_send_message_fix_invalid_hostname(void **state) {
     expect_string(__wrap_SSL_write, buf, "OSSEC A:'InvalidHostname'\n");
     will_return(__wrap_SSL_write, -1);
     expect_string(__wrap__merror, formatted_msg, "SSL write error (unable to send message.)");
-    expect_string(__wrap__merror, formatted_msg, "If Agent verification is enabled, agent key and certifiates are required!");
+    expect_string(__wrap__merror, formatted_msg, "If Agent verification is enabled, agent key and certificates are required!");
     int ret = w_enrollment_send_message(cfg);
     assert_int_equal(ret, -1);
 }
@@ -573,7 +573,7 @@ void test_w_enrollment_send_message_ssl_error(void **state) {
     expect_string(__wrap_SSL_write, buf, "OSSEC A:'host.name'\n");
     will_return(__wrap_SSL_write, -1);
     expect_string(__wrap__merror, formatted_msg, "SSL write error (unable to send message.)");
-    expect_string(__wrap__merror, formatted_msg, "If Agent verification is enabled, agent key and certifiates are required!");
+    expect_string(__wrap__merror, formatted_msg, "If Agent verification is enabled, agent key and certificates are required!");
     int ret = w_enrollment_send_message(cfg);
     assert_int_equal(ret, -1);
 
@@ -722,7 +722,7 @@ void test_w_enrollment_process_response_ssl_error(void **state) {
     will_return(__wrap_SSL_get_error, SSL_ERROR_WANT_READ);
 
     expect_string(__wrap__merror, formatted_msg, "SSL read (unable to receive message)");
-    expect_string(__wrap__merror, formatted_msg, "If Agent verification is enabled, agent key and certifiates may be incorrect!");
+    expect_string(__wrap__merror, formatted_msg, "If Agent verification is enabled, agent key and certificates may be incorrect!");
 
     int ret = w_enrollment_process_response(ssl);
     assert_int_equal(ret, -1);

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -3243,7 +3243,7 @@ void test_w_get_file_permissions_GetAce_error(void **state) {
     char permissions[OS_SIZE_1024];
     int ret;
     SECURITY_DESCRIPTOR sec_desc;
-    ACL_SIZE_INFORMATION acl_size;
+    ACL_SIZE_INFORMATION acl_size = { .AceCount = 1 };
 
     expect_string(wrap_GetFileSecurity, lpFileName, "C:\\a\\path");
     will_return(wrap_GetFileSecurity, OS_SIZE_1024);

--- a/src/unit_tests/wazuh_modules/scheduling/test_wmodules_scheduling.c
+++ b/src/unit_tests/wazuh_modules/scheduling/test_wmodules_scheduling.c
@@ -80,7 +80,7 @@ static void test_day_of_the_month_mode(void **state){
     // Set day of the month
     test->scan_config.month_interval = true;
     test->scan_config.interval = 1;
-    test->scan_config.scan_time = strdup("00:00");
+    test->scan_config.scan_time = strdup("01:00");
 
     for(int i = 0; i < (sizeof(TEST_DAY_MONTHS)/ sizeof(int)); i++){
         test->scan_config.scan_day = TEST_DAY_MONTHS[i];
@@ -101,7 +101,7 @@ static void test_day_of_the_month_consecutive(void **state){
     state_structure *test = *state;
     const char *string =
         "<day>20</day>\n"
-        "<time>0:00</time>"
+        "<time>1:00</time>"
     ;
 
     expect_string(__wrap__mwarn, formatted_msg, "Interval must be a multiple of one month. New interval value: 1M");
@@ -137,7 +137,7 @@ static void test_day_of_the_week(void **state){
     state_structure *test = *state;
     const char *string =
         "<wday>tuesday</wday>\n"
-        "<time>0:00</time>\n"
+        "<time>1:00</time>\n"
         "<interval>3w</interval>\n"
     ;
     test->nodes = string_to_xml_node(string, &test->lxml);

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
@@ -21,6 +21,14 @@ int __wrap_OS_ConnectUnixDomain(const char *path, int type, int max_msg_size) {
     return mock();
 }
 
+int __wrap_OS_SendUDPbySize(int sock, int size, const char *msg) {
+    check_expected(sock);
+    check_expected(size);
+    check_expected(msg);
+
+    return mock();
+}
+
 int __wrap_OS_SendSecureTCP(int sock, uint32_t size, const void * msg) {
     check_expected(sock);
     check_expected(size);

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.h
@@ -21,6 +21,8 @@ typedef uint16_t u_int16_t;
 
 int __wrap_OS_ConnectUnixDomain(const char *path, int type, int max_msg_size);
 
+int __wrap_OS_SendUDPbySize(int sock, int size, const char *msg);
+
 int __wrap_OS_SendSecureTCP(int sock, uint32_t size, const void * msg);
 
 int __wrap_OS_RecvSecureTCP(int sock, char * ret, uint32_t size);


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/6146|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

- Modified the remote events service to be able to receive and respond to a "ping" custom request.
- Modified the agent communication service to be able to send a ping request and wait for the response.
- Modified connection error log to include both port and protocol.

The enrollment process won't continue now if the remote events service is not up and healthy (respond to ping request), the only exceptions has been cover in the related issue description.


## Logs/Alerts example

No extra logs has been added with the ping/pong operation.
Modified the `1216` error log as following:

```
2020/09/30 09:08:42 ossec-agentd: ERROR: (1216): Unable to connect to '172.28.128.4:1514/udp': 'Connection refused'.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

- [X] Request for key when 1514 tcp is down
- [X] Request for a key when 1514 udp is down
- [X] Automatic requesting when the 1514 tcp became available
- [X] Automatic requesting when the 1514 udp became available
- [X] Remove key from manager side and stop 1514
- [X] Remove key from manager side and stop 1515

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [X] Source installation
- [X] Package installation
- [X] Source upgrade
- [X] Package upgrade
- [X] Review logs syntax and correct language
- [N/A ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retro compatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
