### PR TITLE
Fix diff_file_size on-demand configuration

### DIFF
--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -240,7 +240,7 @@ cJSON *getSyscheckConfig(void) {
                 cJSON_AddStringToObject(pair,"tags",syscheck.tag[i]);
             }
 
-            if (syscheck.file_limit_enabled && syscheck.diff_size_limit[i]) {
+            if (syscheck.file_size_enabled && syscheck.diff_size_limit[i]) {
                 cJSON_AddNumberToObject(pair, "diff_size_limit", syscheck.diff_size_limit[i]);
             }
 


### PR DESCRIPTION
| Related issue  |
|---------------|
| #6152              |

## Description

In the on-demand configuration, the `file_limit_enabled` variable was used instead of the `file_size_enabled` variable when sending the configuration of the `diff_file_size` option.

This pull request closes #6152.

## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X

