### PR TITLE
Fixing missing node_name field in global.db - agent table

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -233,6 +233,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
             if (node_name) {
                 wm_strcat(&agent_data->labels, node_label, agent_data->labels ? '\n' : 0);
                 wm_strcat(&agent_data->labels, node_name, 0);
+                os_strdup(node_name, agent_data->node_name);
             }
 
             agent_data->id = atoi(key->id);


### PR DESCRIPTION
## Description

During the testing done for the Wazuh cluster, it was discovered that the field `node_name` of the `agent` table in `global.db` was never set. Suspiciously, this information was properly set in the `labels` table but not in the `agent` table.

With this PR we fix the issue by including the information in the data structure that is created in `remoted` when the agent's keepalive is received and the call to `Wazuh DB` is done.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation