### PR TITLE
Fix compilation erros in macOS (clang 9.0.0)

### DIFF
--- a/src/shared_modules/rsync/testtool/oneTimeSync.cpp
+++ b/src/shared_modules/rsync/testtool/oneTimeSync.cpp
@@ -22,10 +22,10 @@ struct SmartDeleterJson final
 
 DBSYNC_HANDLE getDbsyncHandle(const nlohmann::json& config)
 {
-    const std::string dbName{ config.at("db_name") };
-    const std::string dbType{ config.at("db_type") };
-    const std::string hostType{ config.at("host_type") };        
-    const std::string sqlStmt{ config.at("sql_statement") };
+    const std::string dbName{ config.at("db_name").get_ref<const std::string&>() };
+    const std::string dbType{ config.at("db_type").get_ref<const std::string&>() };
+    const std::string hostType{ config.at("host_type").get_ref<const std::string&>() };
+    const std::string sqlStmt{ config.at("sql_statement").get_ref<const std::string&>() };
     auto handle 
     { 
         dbsync_create((hostType.compare("0") == 0) ? HostType::MANAGER : HostType::AGENT,


### PR DESCRIPTION
|Related issue|
|---|
|#6068|

## Description
Invalid implicit type conversion, when compile RSync project in macOS, using clang 9.0

![image](https://user-images.githubusercontent.com/14300208/94717539-ddd07980-0326-11eb-9a5f-c45a6ebf39b9.png)


