### PR TITLE
Fixing warning generated when no data is provided to set in global.db

### DIFF
--- a/src/headers/remoted_op.h
+++ b/src/headers/remoted_op.h
@@ -19,7 +19,7 @@
  *        be de-allocated by the caller.
  *
  * @param[in] os_header String that contains the architecture. Usually uname.
- * @retval A string pointer to the architecture.
+ * @retval A string pointer to the architecture. NULL if not found.
  */
 char * get_os_arch(char * os_header);
 

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -242,7 +242,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length)
             result = wdb_update_agent_data(agent_data);
 
             if (OS_INVALID == result)
-                mwarn("Unable to update information in global.db for agent: %s", key->id);
+                mdebug1("Unable to update information in global.db for agent: %s", key->id);
 
             wdb_free_agent_info_data(agent_data);
         }

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1128,7 +1128,7 @@ const char *getuname()
                      uts_buf.machine,
                      __ossec_name, __ossec_version);
         } else {
-            snprintf(muname, 512, "No system info available -  %s %s",
+            snprintf(muname, 512, "No system info available - %s %s",
                      __ossec_name, __ossec_version);
         }
     }

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -1042,6 +1042,22 @@ void test_wdb_update_agent_data_error_socket(void **state)
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "config_sum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "csum");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "merged_sum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "msum");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "manager_host");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "managerhost");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "node_name");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "nodename");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_name");
     expect_string(__wrap_cJSON_AddStringToObject, string, "osname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_version");
@@ -1060,22 +1076,6 @@ void test_wdb_update_agent_data_error_socket(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "osuname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_arch");
     expect_string(__wrap_cJSON_AddStringToObject, string, "osarch");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "version");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "version");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "config_sum");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "csum");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "merged_sum");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "msum");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "manager_host");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "managerhost");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "node_name");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "nodename");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1155,6 +1155,22 @@ void test_wdb_update_agent_data_error_sql_execution(void **state)
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "config_sum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "csum");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "merged_sum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "msum");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "manager_host");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "managerhost");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "node_name");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "nodename");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_name");
     expect_string(__wrap_cJSON_AddStringToObject, string, "osname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_version");
@@ -1173,22 +1189,6 @@ void test_wdb_update_agent_data_error_sql_execution(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "osuname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_arch");
     expect_string(__wrap_cJSON_AddStringToObject, string, "osarch");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "version");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "version");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "config_sum");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "csum");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "merged_sum");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "msum");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "manager_host");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "managerhost");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "node_name");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "nodename");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1268,6 +1268,22 @@ void test_wdb_update_agent_data_error_result(void **state)
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "config_sum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "csum");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "merged_sum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "msum");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "manager_host");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "managerhost");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "node_name");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "nodename");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_name");
     expect_string(__wrap_cJSON_AddStringToObject, string, "osname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_version");
@@ -1286,22 +1302,6 @@ void test_wdb_update_agent_data_error_result(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "osuname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_arch");
     expect_string(__wrap_cJSON_AddStringToObject, string, "osarch");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "version");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "version");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "config_sum");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "csum");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "merged_sum");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "msum");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "manager_host");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "managerhost");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "node_name");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "nodename");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1375,6 +1375,22 @@ void test_wdb_update_agent_data_success(void **state)
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "version");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "config_sum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "csum");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "merged_sum");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "msum");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "manager_host");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "managerhost");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "node_name");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "nodename");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_name");
     expect_string(__wrap_cJSON_AddStringToObject, string, "osname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_version");
@@ -1393,22 +1409,6 @@ void test_wdb_update_agent_data_success(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "osuname");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_arch");
     expect_string(__wrap_cJSON_AddStringToObject, string, "osarch");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "version");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "version");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "config_sum");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "csum");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "merged_sum");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "msum");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "manager_host");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "managerhost");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "node_name");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "nodename");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "agent_ip");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -225,14 +225,14 @@ int wdb_update_agent_name(int id, const char *name) {
     return result;
 }
 
-int wdb_update_agent_data (agent_info_data *agent_data) {
+int wdb_update_agent_data(agent_info_data *agent_data) {
     int result = 0;
     cJSON *data_in = NULL;
     char wdbquery[WDBQUERY_SIZE] = "";
     char wdboutput[WDBOUTPUT_SIZE] = "";
     char *payload = NULL;
 
-    if (!agent_data || !agent_data->osd) {
+    if (!agent_data) {
         mdebug1("Invalid data provided to set in global.db.");
         return OS_INVALID;
     }
@@ -245,15 +245,6 @@ int wdb_update_agent_data (agent_info_data *agent_data) {
     }
 
     cJSON_AddNumberToObject(data_in, "id", agent_data->id);
-    cJSON_AddStringToObject(data_in, "os_name", agent_data->osd->os_name);
-    cJSON_AddStringToObject(data_in, "os_version", agent_data->osd->os_version);
-    cJSON_AddStringToObject(data_in, "os_major", agent_data->osd->os_major);
-    cJSON_AddStringToObject(data_in, "os_minor", agent_data->osd->os_minor);
-    cJSON_AddStringToObject(data_in, "os_codename", agent_data->osd->os_codename);
-    cJSON_AddStringToObject(data_in, "os_platform", agent_data->osd->os_platform);
-    cJSON_AddStringToObject(data_in, "os_build", agent_data->osd->os_build);
-    cJSON_AddStringToObject(data_in, "os_uname", agent_data->osd->os_uname);
-    cJSON_AddStringToObject(data_in, "os_arch", agent_data->osd->os_arch);
     cJSON_AddStringToObject(data_in, "version", agent_data->version);
     cJSON_AddStringToObject(data_in, "config_sum", agent_data->config_sum);
     cJSON_AddStringToObject(data_in, "merged_sum", agent_data->merged_sum);
@@ -262,6 +253,18 @@ int wdb_update_agent_data (agent_info_data *agent_data) {
     cJSON_AddStringToObject(data_in, "agent_ip", agent_data->agent_ip);
     cJSON_AddStringToObject(data_in, "labels", agent_data->labels);
     cJSON_AddStringToObject(data_in, "sync_status", agent_data->sync_status);
+
+    if (agent_data->osd) {
+        cJSON_AddStringToObject(data_in, "os_name", agent_data->osd->os_name);
+        cJSON_AddStringToObject(data_in, "os_version", agent_data->osd->os_version);
+        cJSON_AddStringToObject(data_in, "os_major", agent_data->osd->os_major);
+        cJSON_AddStringToObject(data_in, "os_minor", agent_data->osd->os_minor);
+        cJSON_AddStringToObject(data_in, "os_codename", agent_data->osd->os_codename);
+        cJSON_AddStringToObject(data_in, "os_platform", agent_data->osd->os_platform);
+        cJSON_AddStringToObject(data_in, "os_build", agent_data->osd->os_build);
+        cJSON_AddStringToObject(data_in, "os_uname", agent_data->osd->os_uname);
+        cJSON_AddStringToObject(data_in, "os_arch", agent_data->osd->os_arch);
+    }
 
     snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_UPDATE_AGENT_DATA], cJSON_PrintUnformatted(data_in));
 


### PR DESCRIPTION
## Description

During the testing done for Wazuh `4.0`, we found some `WARNING` logs generated by `remoted` when the keepalive messages are parsed and it tries to set the agent data in `Wazuh DB`. After doing some testing and analyzing the code of the agent when the keepalive messages are generated (see [run_notify()](https://github.com/wazuh/wazuh/blob/4.0/src/client-agent/notify.c#L80) function), we identify some information that couldn't be present in the keepalive messages.

Some of the information that could not be in the message are, `uname`, `config_sum`, `merged_sum` and `agent_ip`. As a result, we could get messages like this one for Solaris as an example:

```
2020/09/29 16:11:20 ossec-remoted[83087] manager.c:186 at save_controlmsg(): DEBUG: save_controlmsg(): inserting 'SunOS |solaris10 |5.10 |Generic_147148-26 |i86pc [SunOS|sunos: 10] - Wazuh v3.13.2
x merged.mg

'
```

In this pull request, we improve the `uname` parsing taking into account all the possible scenarios. In addition, we improve the agent's data set logic in order to avoid generating warnings when some part of the data is missed.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation