### PR TITLE
Add new configuration for windows registries

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -315,7 +315,7 @@ void dump_syscheck_registry(syscheck_config *syscheck,
         } else {
             if (syscheck->registry[pl].filerestrict) {
                 OSMatch_FreePattern(syscheck->registry[pl].filerestrict);
-                free(syscheck->registry[pl].filerestrict);
+                os_free(syscheck->registry[pl].filerestrict);
             }
             os_free(syscheck->registry[pl].tag);
         }
@@ -324,7 +324,6 @@ void dump_syscheck_registry(syscheck_config *syscheck,
     syscheck->registry[pl].arch = arch;
     syscheck->registry[pl].opts = opts;
     syscheck->registry[pl].diff_size_limit = diff_size;
-
     if (tag) {
         os_strdup(tag, syscheck->registry[pl].tag);
     }
@@ -471,10 +470,12 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
     const char *xml_check_perm = "check_perm";
     const char *xml_check_mtime = "check_mtime";
     const char *xml_check_type = "check_type";
+    const char *xml_restrict = "restrict";
 
     int i;
     char **entry;
     char *tag = NULL;
+    char *restrictfile = NULL;
     int arch = ARCH_32BIT;
     int recursion_level = MAX_REGISTRY_DEPTH;
     int opts = REGISTRY_CHECK_ALL;
@@ -490,7 +491,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                 os_free(tag);
 
                 if (tag = os_strip_char(values[i], ' '), !tag) {
-                    merror("Processing tag '%s' for registry entry '%s'.", tag, entries);
+                    merror("Processing tag for registry entry '%s'.", entries);
                 }
             } else if (strcmp(attributes[i], xml_arch) == 0) {
                 if (strcmp(values[i], xml_32bit) == 0) {
@@ -522,7 +523,10 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                     mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
                     goto clean_reg;
                 }
-            } else if (strcmp(attributes[i], xml_check_all)) {
+            } else if (strcmp(attributes[i], xml_restrict) == 0) {
+                os_free(restrictfile);
+                os_strdup(values[i], restrictfile);
+            } else if (strcmp(attributes[i], xml_check_all) == 0) {
                 if (strcmp(values[i], "yes") == 0) {
                     opts |= REGISTRY_CHECK_ALL;
                 } else if (strcmp(values[i], "no") == 0) {
@@ -531,7 +535,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                     mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
                     goto clean_reg;
                 }
-            } else if (strcmp(attributes[i], xml_check_sum)) {
+            } else if (strcmp(attributes[i], xml_check_sum) == 0) {
                 if (strcmp(values[i], "yes") == 0) {
                     opts |= CHECK_SUM;
                 } else if (strcmp(values[i], "no") == 0) {
@@ -540,7 +544,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                     mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
                     goto clean_reg;
                 }
-            } else if (strcmp(attributes[i], xml_check_md5sum)) {
+            } else if (strcmp(attributes[i], xml_check_md5sum) == 0) {
                 if (strcmp(values[i], "yes") == 0) {
                     opts |= CHECK_MD5SUM;
                 } else if (strcmp(values[i], "no") == 0) {
@@ -549,7 +553,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                     mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
                     goto clean_reg;
                 }
-            } else if (strcmp(attributes[i], xml_check_sha1sum)) {
+            } else if (strcmp(attributes[i], xml_check_sha1sum) == 0) {
                 if (strcmp(values[i], "yes") == 0) {
                     opts |= CHECK_SHA1SUM;
                 } else if (strcmp(values[i], "no") == 0) {
@@ -558,7 +562,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                     mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
                     goto clean_reg;
                 }
-            } else if (strcmp(attributes[i], xml_check_sha256sum)) {
+            } else if (strcmp(attributes[i], xml_check_sha256sum) == 0) {
                 if (strcmp(values[i], "yes") == 0) {
                     opts |= CHECK_SHA256SUM;
                 } else if (strcmp(values[i], "no") == 0) {
@@ -567,7 +571,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                     mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
                     goto clean_reg;
                 }
-            } else if (strcmp(attributes[i], xml_check_size)) {
+            } else if (strcmp(attributes[i], xml_check_size) == 0) {
                 if (strcmp(values[i], "yes") == 0) {
                     opts |= CHECK_SIZE;
                 } else if (strcmp(values[i], "no") == 0) {
@@ -576,7 +580,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                     mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
                     goto clean_reg;
                 }
-            } else if (strcmp(attributes[i], xml_check_owner)) {
+            } else if (strcmp(attributes[i], xml_check_owner) == 0) {
                 if (strcmp(values[i], "yes") == 0) {
                     opts |= CHECK_OWNER;
                 } else if (strcmp(values[i], "no") == 0) {
@@ -585,7 +589,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                     mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
                     goto clean_reg;
                 }
-            } else if (strcmp(attributes[i], xml_check_group)) {
+            } else if (strcmp(attributes[i], xml_check_group) == 0) {
                 if (strcmp(values[i], "yes") == 0) {
                     opts |= CHECK_GROUP;
                 } else if (strcmp(values[i], "no") == 0) {
@@ -594,7 +598,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                     mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
                     goto clean_reg;
                 }
-            } else if (strcmp(attributes[i], xml_check_perm)) {
+            } else if (strcmp(attributes[i], xml_check_perm) == 0) {
                 if (strcmp(values[i], "yes") == 0) {
                     opts |= CHECK_PERM;
                 } else if (strcmp(values[i], "no") == 0) {
@@ -603,7 +607,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                     mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
                     goto clean_reg;
                 }
-            } else if (strcmp(attributes[i], xml_check_mtime)) {
+            } else if (strcmp(attributes[i], xml_check_mtime) == 0) {
                 if (strcmp(values[i], "yes") == 0) {
                     opts |= CHECK_MTIME;
                 } else if (strcmp(values[i], "no") == 0) {
@@ -612,7 +616,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                     mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
                     goto clean_reg;
                 }
-            } else if (strcmp(attributes[i], xml_check_type)) {
+            } else if (strcmp(attributes[i], xml_check_type) == 0) {
                 if (strcmp(values[i], "yes") == 0) {
                     opts |= CHECK_TYPE;
                 } else if (strcmp(values[i], "no") == 0) {
@@ -632,7 +636,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
     entry = OS_StrBreak(',', entries, MAX_DIR_SIZE + 1); /* Max number */
 
     if (entry == NULL) {
-        return (0);
+        goto clean_reg;
     }
 
     for (i = 0; entry[i]; i++) {
@@ -667,10 +671,10 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
 
         /* Add new entry */
         if (arch == ARCH_BOTH) {
-            dump_syscheck_registry(syscheck, tmp_entry, opts, NULL, recursion_level, tag, ARCH_64BIT, -1);
-            dump_syscheck_registry(syscheck, tmp_entry, opts, NULL, recursion_level, tag, ARCH_32BIT, -1);
+            dump_syscheck_registry(syscheck, tmp_entry, opts, restrictfile, recursion_level, tag, ARCH_64BIT, -1);
+            dump_syscheck_registry(syscheck, tmp_entry, opts, restrictfile, recursion_level, tag, ARCH_32BIT, -1);
         } else {
-            dump_syscheck_registry(syscheck, tmp_entry, opts, NULL, recursion_level, tag, arch, -1);
+            dump_syscheck_registry(syscheck, tmp_entry, opts, restrictfile, recursion_level, tag, arch, -1);
         }
 
         /* Next entry */
@@ -681,7 +685,7 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
     retval = 1;
 clean_reg:
     os_free(tag);
-
+    os_free(restrictfile);
     return retval;
 }
 #endif /* WIN32 */

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -459,13 +459,24 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
     const char *xml_tag = "tags";
     const char *xml_recursion_level = "recursion_level";
     const char *xml_report_changes = "report_changes";
+    const char *xml_check_all = "check_all";
+    const char *xml_check_sum = "check_sum";
+    const char *xml_check_md5sum = "check_md5sum";
+    const char *xml_check_sha1sum = "check_sha1sum";
+    const char *xml_check_sha256sum = "check_sha256sum";
+    const char *xml_check_size = "check_size";
+    const char *xml_check_owner = "check_owner";
+    const char *xml_check_group = "check_group";
+    const char *xml_check_perm = "check_perm";
+    const char *xml_check_mtime = "check_mtime";
+    const char *xml_check_type = "check_type";
 
     int i;
     char **entry;
     char *tag = NULL;
     int arch = ARCH_32BIT;
     int recursion_level = MAX_REGISTRY_DEPTH;
-    int opts = 0;
+    int opts = REGISTRY_CHECK_ALL;
     int retval = 0;
 
     if (attributes && values) {
@@ -502,6 +513,105 @@ int read_reg(syscheck_config *syscheck, const char *entries, char **attributes, 
                     opts |= CHECK_SEECHANGES;
                 } else if (strcmp(values[i], "no") == 0) {
                     opts &= ~CHECK_SEECHANGES;
+                } else {
+                    mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
+                    goto clean_reg;
+                }
+            } else if (strcmp(attributes[i], xml_check_all)) {
+                if (strcmp(values[i], "yes") == 0) {
+                    opts |= REGISTRY_CHECK_ALL;
+                } else if (strcmp(values[i], "no") == 0) {
+                    opts &= ~REGISTRY_CHECK_ALL;
+                } else {
+                    mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
+                    goto clean_reg;
+                }
+            } else if (strcmp(attributes[i], xml_check_sum)) {
+                if (strcmp(values[i], "yes") == 0) {
+                    opts |= CHECK_SUM;
+                } else if (strcmp(values[i], "no") == 0) {
+                    opts &= ~CHECK_SUM;
+                } else {
+                    mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
+                    goto clean_reg;
+                }
+            } else if (strcmp(attributes[i], xml_check_md5sum)) {
+                if (strcmp(values[i], "yes") == 0) {
+                    opts |= CHECK_MD5SUM;
+                } else if (strcmp(values[i], "no") == 0) {
+                    opts &= ~CHECK_MD5SUM;
+                } else {
+                    mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
+                    goto clean_reg;
+                }
+            } else if (strcmp(attributes[i], xml_check_sha1sum)) {
+                if (strcmp(values[i], "yes") == 0) {
+                    opts |= CHECK_SHA1SUM;
+                } else if (strcmp(values[i], "no") == 0) {
+                    opts &= ~CHECK_SHA1SUM;
+                } else {
+                    mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
+                    goto clean_reg;
+                }
+            } else if (strcmp(attributes[i], xml_check_sha256sum)) {
+                if (strcmp(values[i], "yes") == 0) {
+                    opts |= CHECK_SHA256SUM;
+                } else if (strcmp(values[i], "no") == 0) {
+                    opts &= ~CHECK_SHA256SUM;
+                } else {
+                    mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
+                    goto clean_reg;
+                }
+            } else if (strcmp(attributes[i], xml_check_size)) {
+                if (strcmp(values[i], "yes") == 0) {
+                    opts |= CHECK_SIZE;
+                } else if (strcmp(values[i], "no") == 0) {
+                    opts &= ~CHECK_SIZE;
+                } else {
+                    mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
+                    goto clean_reg;
+                }
+            } else if (strcmp(attributes[i], xml_check_owner)) {
+                if (strcmp(values[i], "yes") == 0) {
+                    opts |= CHECK_OWNER;
+                } else if (strcmp(values[i], "no") == 0) {
+                    opts &= ~CHECK_OWNER;
+                } else {
+                    mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
+                    goto clean_reg;
+                }
+            } else if (strcmp(attributes[i], xml_check_group)) {
+                if (strcmp(values[i], "yes") == 0) {
+                    opts |= CHECK_GROUP;
+                } else if (strcmp(values[i], "no") == 0) {
+                    opts &= ~CHECK_GROUP;
+                } else {
+                    mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
+                    goto clean_reg;
+                }
+            } else if (strcmp(attributes[i], xml_check_perm)) {
+                if (strcmp(values[i], "yes") == 0) {
+                    opts |= CHECK_PERM;
+                } else if (strcmp(values[i], "no") == 0) {
+                    opts &= ~CHECK_PERM;
+                } else {
+                    mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
+                    goto clean_reg;
+                }
+            } else if (strcmp(attributes[i], xml_check_mtime)) {
+                if (strcmp(values[i], "yes") == 0) {
+                    opts |= CHECK_MTIME;
+                } else if (strcmp(values[i], "no") == 0) {
+                    opts &= ~CHECK_MTIME;
+                } else {
+                    mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
+                    goto clean_reg;
+                }
+            } else if (strcmp(attributes[i], xml_check_type)) {
+                if (strcmp(values[i], "yes") == 0) {
+                    opts |= CHECK_TYPE;
+                } else if (strcmp(values[i], "no") == 0) {
+                    opts &= ~CHECK_TYPE;
                 } else {
                     mwarn(FIM_INVALID_REG_OPTION_SKIP, values[i], attributes[i], entries);
                     goto clean_reg;

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -105,6 +105,11 @@ typedef enum fdb_stmt {
 #define SCHEDULED_ACTIVE    00400000
 #ifdef WIN32
 #define CHECK_TYPE          01000000
+
+#define REGISTRY_CHECK_ALL                                                                                  \
+    (CHECK_MD5SUM | CHECK_SHA1SUM | CHECK_SHA256SUM | CHECK_SIZE | CHECK_OWNER | CHECK_GROUP | CHECK_PERM | \
+     CHECK_MTIME | CHECK_TYPE)
+#define CHECK_SUM (CHECK_MD5SUM | CHECK_SHA1SUM | CHECK_SHA256SUM)
 #endif
 
 #define ARCH_32BIT          0

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -446,20 +446,20 @@ void dump_syscheck_file(syscheck_config *syscheck, char *entry, int vals, const 
  *
  * @param syscheck Syscheck configuration structure
  * @param entry Entry to be dumped
- * @param vals Indicates the attributes for folders or registries to be set
+ * @param opts Indicates the attributes for registries to be set
  * @param restrictfile The restrict regex to be set
  * @param recursion_level The recursion level to be set
  * @param tag The tag to be set
- * @param link If the added entry is pointed by a symbolic link for folders and arch for registries
+ * @param arch Indicates whether to monitor the 64 or 32 version of the registry
  * @param diff_size Maximum size to calculate diff for files in the directory
  */
 void dump_syscheck_registry(syscheck_config *syscheck,
                             char *entry,
-                            int vals,
+                            int opts,
                             const char *restrictfile,
                             int recursion_level,
                             const char *tag,
-                            const char *link,
+                            int arch,
                             int diff_size) __attribute__((nonnull(1, 2)));
 #endif
 

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -430,16 +430,38 @@ void parse_diff(const OS_XML *xml, syscheck_config * syscheck, XML_NODE node);
  * @param syscheck Syscheck configuration structure
  * @param entry Entry to be dumped
  * @param vals Indicates the attributes for folders or registries to be set
- * @param reg 1 if it's a registry, 0 if not
  * @param restrictfile The restrict regex to be set
  * @param recursion_level The recursion level to be set
  * @param tag The tag to be set
  * @param link If the added entry is pointed by a symbolic link for folders and arch for registries
  * @param diff_size Maximum size to calculate diff for files in the directory
  */
-void dump_syscheck_entry(syscheck_config *syscheck, char *entry, int vals, int reg, const char *restrictfile,
+void dump_syscheck_file(syscheck_config *syscheck, char *entry, int vals, const char *restrictfile,
                             int recursion_level, const char *tag, const char *link,
                             int diff_size) __attribute__((nonnull(1, 2)));
+
+#ifdef WIN32
+/**
+ * @brief Adds (or overwrite if exists) an entry to the syscheck configuration structure
+ *
+ * @param syscheck Syscheck configuration structure
+ * @param entry Entry to be dumped
+ * @param vals Indicates the attributes for folders or registries to be set
+ * @param restrictfile The restrict regex to be set
+ * @param recursion_level The recursion level to be set
+ * @param tag The tag to be set
+ * @param link If the added entry is pointed by a symbolic link for folders and arch for registries
+ * @param diff_size Maximum size to calculate diff for files in the directory
+ */
+void dump_syscheck_registry(syscheck_config *syscheck,
+                            char *entry,
+                            int vals,
+                            const char *restrictfile,
+                            int recursion_level,
+                            const char *tag,
+                            const char *link,
+                            int diff_size) __attribute__((nonnull(1, 2)));
+#endif
 
 /**
  * @brief Converts a bit mask with syscheck options to a human readable format

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -244,5 +244,6 @@
 #define FIM_DISK_QUOTA_ESTIMATION           "(6351): The estimate of the file size '%s' exceeds the disk_quota. Operation discarded. "
 #define FIM_DIFF_IDENTICAL_MD5_FILES        "(6352): The files are identical, don't compute differences"
 #define FIM_DIFF_COMMAND_OUTPUT_EQUAL       "(6353): Command diff/fc output 0, files are the same"
+#define FIM_EMPTY_REGISTRY_CONFIG           "(6354): Empty windows_registry tag found in the configuration."
 
 #endif /* DEBUG_MESSAGES_H */

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -14,7 +14,7 @@
 /* File integrity monitoring info messages*/
 #define FIM_DAEMON_STARTED                  "(6000): Starting daemon..."
 #define FIM_DISABLED                        "(6001): File integrity monitoring disabled."
-#define FIM_MONITORING_REGISTRY             "(6002): Monitoring registry entry: '%s%s'."
+#define FIM_MONITORING_REGISTRY             "(6002): Monitoring registry entry: '%s%s', with options '%s'"
 #define FIM_MONITORING_DIRECTORY            "(6003): Monitoring directory/file: '%s', with options '%s'."
 #define FIM_MONITORING_LDIRECTORY           "(6003): Monitoring directory: '%s' (%s), with options '%s'."
 #define FIM_NO_DIFF                         "(6004): No diff for file: '%s'"

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -138,6 +138,14 @@ int Read_Syscheck_Config(const char *cfgfile)
     }
     if (!syscheck.registry) {
             syscheck.registry = REGISTRY_EMPTY;
+    } else {
+        it = 0;
+        while (syscheck.registry[it].entry) {
+            if (syscheck.registry[it].diff_size_limit == -1) {
+                syscheck.registry[it].diff_size_limit = syscheck.file_size_limit;
+            }
+            it++;
+        }
     }
     if ((syscheck.dir[0] == NULL) && (syscheck.registry[0].entry == NULL)) {
         return (1);

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
             if (!test_config) {
                 minfo(FIM_DIRECTORY_NOPROVIDED);
             }
-            dump_syscheck_entry(&syscheck, "", 0, 0, NULL, 0, NULL, NULL, -1);
+            dump_syscheck_file(&syscheck, "", 0, NULL, 0, NULL, NULL, -1);
         } else if (!syscheck.dir[0]) {
             if (!test_config) {
                 minfo(FIM_DIRECTORY_NOPROVIDED);

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -131,7 +131,7 @@ int Start_win32_Syscheck()
         }
 
         if (!syscheck.registry) {
-            dump_syscheck_registry(&syscheck, "", 0, NULL, 0, NULL, NULL, -1);
+            dump_syscheck_registry(&syscheck, "", 0, NULL, 0, NULL, 0, -1);
         }
         os_free(syscheck.registry[0].entry);
 
@@ -165,7 +165,10 @@ int Start_win32_Syscheck()
         r = 0;
         // TODO: allow sha256 sum on registries
         while (syscheck.registry[r].entry != NULL) {
-            minfo(FIM_MONITORING_REGISTRY, syscheck.registry[r].entry, syscheck.registry[r].arch == ARCH_64BIT ? " [x64]" : "");
+            char optstr[1024];
+            minfo(FIM_MONITORING_REGISTRY, syscheck.registry[r].entry,
+                  syscheck.registry[r].arch == ARCH_64BIT ? " [x64]" : "",
+                  syscheck_opts2str(optstr, sizeof(optstr), syscheck.registry[r].opts));
             r++;
         }
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -117,7 +117,7 @@ int Start_win32_Syscheck()
         /* Disabled */
         if (!syscheck.dir) {
             minfo(FIM_DIRECTORY_NOPROVIDED);
-            dump_syscheck_entry(&syscheck, "", 0, 0, NULL, 0, NULL, NULL, -1);
+            dump_syscheck_file(&syscheck, "", 0, NULL, 0, NULL, NULL, -1);
         } else if (!syscheck.dir[0]) {
             minfo(FIM_DIRECTORY_NOPROVIDED);
         }
@@ -131,7 +131,7 @@ int Start_win32_Syscheck()
         }
 
         if (!syscheck.registry) {
-            dump_syscheck_entry(&syscheck, "", 0, 1, NULL, 0, NULL, NULL, -1);
+            dump_syscheck_registry(&syscheck, "", 0, NULL, 0, NULL, NULL, -1);
         }
         os_free(syscheck.registry[0].entry);
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -169,6 +169,9 @@ int Start_win32_Syscheck()
             minfo(FIM_MONITORING_REGISTRY, syscheck.registry[r].entry,
                   syscheck.registry[r].arch == ARCH_64BIT ? " [x64]" : "",
                   syscheck_opts2str(optstr, sizeof(optstr), syscheck.registry[r].opts));
+            if (syscheck.file_size_enabled){
+                minfo(FIM_DIFF_FILE_SIZE_LIMIT, syscheck.registry[r].diff_size_limit, syscheck.registry[r].entry);
+            }
             r++;
         }
 


### PR DESCRIPTION
|Related issue|
|---|
|#6157|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to split the commits that read the configuration into a separate branch. It also checks that if there is a duplicated entry in the configuration, the configuration is overwritten using the last entry.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```xml
	<windows_registry arch="32bit" check_all="no" recursion_level="3" report_changes="yes">HKEY_LOCAL_MACHINE\Software\Policies</windows_registry>
	<windows_registry arch="32bit" check_all="yes" recursion_level="3" report_changes="no">HKEY_LOCAL_MACHINE\Software\Policies</windows_registry>

	<windows_registry arch="64bit" check_all="yes" recursion_level="3" report_changes="no">HKEY_LOCAL_MACHINE\Software\Policies</windows_registry>
	<windows_registry arch="64bit" check_all="no" recursion_level="3" report_changes="yes">HKEY_LOCAL_MACHINE\Software\Policies</windows_registry>

```

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
```
2020/10/01 16:08:11 ossec-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Policies', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2020/10/01 16:08:11 ossec-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Policies [x64]', with options 'report_changes'
```

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Windows
- [X] Source installation
- [X] Source upgrade

- Memory tests for Windows
  - [X] Scan-build report