### PR TITLE
Fix compilation issue in ARM architecture

### DIFF
--- a/src/shared_modules/rsync/CMakeLists.txt
+++ b/src/shared_modules/rsync/CMakeLists.txt
@@ -57,7 +57,7 @@ endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_link_libraries(rsync cjson dbsync crypto gcov)
+  target_link_libraries(rsync cjson dbsync crypto gcov pthread)
   if(UNIT_TEST)
     include_directories(${SRC_FOLDER}/external/googletest/googletest/include/)
     include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
@@ -68,7 +68,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_subdirectory(integrationTests)
   endif(UNIT_TEST)
 else()
-    target_link_libraries(rsync dbsync cjson crypto)
+    target_link_libraries(rsync dbsync cjson crypto pthread)
 endif(CMAKE_BUILD_TYPE STREQUAL "Debug")
 
 if(NOT DEFINED COVERITY)

--- a/src/shared_modules/rsync/testtool/CMakeLists.txt
+++ b/src/shared_modules/rsync/testtool/CMakeLists.txt
@@ -30,7 +30,6 @@ else()
 	target_link_libraries(rsync_test_tool
 	    rsync
 	    dbsync
-	    pthread
 	    dl
 	)
 


### PR DESCRIPTION
|Related issue|
|---|
|#6068|

Fix compilation issue, which only occurs in ARM architectures, because of the place where the pthread is located.

Before:
![image](https://user-images.githubusercontent.com/14300208/94862964-1d26c500-0410-11eb-9f98-35ad1a73bd97.png)

After:
![image](https://user-images.githubusercontent.com/14300208/94863070-40517480-0410-11eb-91f7-6cb5704997c9.png)



