### PR TITLE
Fix queue_op hang on system time decrement

### DIFF
--- a/src/headers/pthreads_op.h
+++ b/src/headers/pthreads_op.h
@@ -24,6 +24,9 @@
 #define w_cond_wait(x, y) { int error = pthread_cond_wait(x, y); if (error) merror_exit("At pthread_cond_wait(): %s", strerror(error)); }
 #define w_cond_signal(x) { int error = pthread_cond_signal(x); if (error) merror_exit("At pthread_cond_signal(): %s", strerror(error)); }
 #define w_cond_destroy(x) { int error = pthread_cond_destroy(x); if (error) merror_exit("At pthread_cond_destroy(): %s", strerror(error)); }
+#define w_condattr_init(x) { int error = pthread_condattr_init(x); if (error) merror_exit("At pthread_condattr_init(): %s", strerror(error)); }
+#define w_condattr_setclock(x, y) { int error = pthread_condattr_setclock(x, y); if (error) merror_exit("At pthread_condattr_setclock(): %s", strerror(error)); }
+#define w_condattr_destroy(x) { int error = pthread_condattr_destroy(x); if (error) merror_exit("At pthread_condattr_destroy(): %s", strerror(error)); }
 #define w_rwlock_init(x, y) { int error = pthread_rwlock_init(x, y); if (error) merror_exit("At pthread_rwlock_init(): %s", strerror(error)); }
 #define w_rwlock_rdlock(x) { int error = pthread_rwlock_rdlock(x); if (error) merror_exit("At pthread_rwlock_rdlock(): %s", strerror(error)); }
 #define w_rwlock_wrlock(x) { int error = pthread_rwlock_wrlock(x); if (error) merror_exit("At pthread_rwlock_wrlock(): %s", strerror(error)); }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -614,9 +614,10 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
     mdebug1("Dispatch thread ready");
 
     while (running) {
-        const struct timespec timeout = { .tv_sec = time(NULL) + 1 };
+        struct timespec timeout;
+        clock_gettime(CLOCK_MONOTONIC, &timeout);
+        timeout.tv_sec += 1;
         struct client *client = queue_pop_ex_timedwait(client_queue, &timeout);
-
 
         if (!client)
             continue;

--- a/src/shared/queue_op.c
+++ b/src/shared/queue_op.c
@@ -13,13 +13,17 @@
 
 w_queue_t * queue_init(size_t size) {
     w_queue_t * queue;
+    pthread_condattr_t attr;
     os_calloc(1, sizeof(w_queue_t), queue);
     os_malloc(size * sizeof(void *), queue->data);
     queue->size = size;
     queue->elements = 0;
     w_mutex_init(&queue->mutex, NULL);
-    w_cond_init(&queue->available, NULL);
-    w_cond_init(&queue->available_not_empty, NULL);
+    w_condattr_init(&attr);
+    w_condattr_setclock(&attr, CLOCK_MONOTONIC);
+    w_cond_init(&queue->available, &attr);
+    w_cond_init(&queue->available_not_empty, &attr);
+    w_condattr_destroy(&attr);
     return queue;
 }
 

--- a/src/syscheckd/fim_sync.c
+++ b/src/syscheckd/fim_sync.c
@@ -60,13 +60,17 @@ void * fim_run_integrity(void * args) {
 
         mdebug2("Finished calculating FIM integrity. Time: %.3f seconds.", time_diff(&start, &end));
 
-        struct timespec timeout = { .tv_sec = time(NULL) + sync_interval };
+        struct timespec timeout;
+        clock_gettime(CLOCK_MONOTONIC, &timeout);
+        timeout.tv_sec += sync_interval;
 
         // Get messages until timeout
         char * msg;
 
         while ((msg = queue_pop_ex_timedwait(fim_sync_queue, &timeout))) {
-            long margin = time(NULL) + syscheck.sync_response_timeout;
+            struct timespec margin_time;
+            clock_gettime(CLOCK_MONOTONIC, &margin_time);
+            long margin = margin_time.tv_sec + syscheck.sync_response_timeout;
 
             fim_sync_dispatch(msg);
             free(msg);


### PR DESCRIPTION
|Related issue|
|---|
|6175|

## Description
This PR fixes a hang occured when system time is decreased caused by **pthread_cond_t**  using the system time as timeout.
The solution was to change the initialization of **pthread_cond_t** to use a custom attribute with **CLOCK_MONOTONIC** and adapt the usage of **queue_op** to cope with this change. 

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [X] Source installation
- [ ] Package installation
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)



