### PR TITLE
filebeat - allow to override index_name_format and date_rounding

### DIFF
--- a/extensions/filebeat/7.x/filebeat.yml
+++ b/extensions/filebeat/7.x/filebeat.yml
@@ -5,6 +5,7 @@ filebeat.modules:
       enabled: true
     archives:
       enabled: false
+filebeat.overwrite_pipelines: true
 
 setup.template.json.enabled: true
 setup.template.json.path: '/etc/filebeat/wazuh-template.json'

--- a/extensions/filebeat/7.x/wazuh-module/alerts/config/alerts.yml
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/config/alerts.yml
@@ -1,5 +1,7 @@
 fields:
   index_prefix: {{ .index_prefix }}
+  index_format: {{ .index_format }}
+  date_rounding: {{ .date_rounding }}
 type: log
 paths:
 {{ range $i, $path := .paths }}

--- a/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
@@ -49,9 +49,9 @@
     {
       "date_index_name": {
         "field": "timestamp",
-        "date_rounding": "d",
+        "date_rounding": "{{fields.date_rounding}}",
         "index_name_prefix": "{{fields.index_prefix}}",
-        "index_name_format": "yyyy.MM.dd",
+        "index_name_format": "{{fields.index_format}}",
         "ignore_failure": false 
       }
     },

--- a/extensions/filebeat/7.x/wazuh-module/alerts/manifest.yml
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/manifest.yml
@@ -6,6 +6,10 @@ var:
       - /var/ossec/logs/alerts/alerts.json
   - name: index_prefix
     default: wazuh-alerts-3.x-
+  - name: index_format
+    default: yyyy.MM.dd
+  - name: date_rounding
+    default: d
 
 input: config/alerts.yml
 

--- a/extensions/filebeat/7.x/wazuh-module/archives/config/archives.yml
+++ b/extensions/filebeat/7.x/wazuh-module/archives/config/archives.yml
@@ -1,5 +1,7 @@
 fields:
   index_prefix: {{ .index_prefix }}
+  index_format: {{ .index_format }}
+  date_rounding: {{ .date_rounding }}
 type: log
 paths:
 {{ range $i, $path := .paths }}

--- a/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
@@ -49,9 +49,9 @@
     {
       "date_index_name": {
         "field": "timestamp",
-        "date_rounding": "d",
+        "date_rounding": "{{fields.date_rounding}}",
         "index_name_prefix": "{{fields.index_prefix}}",
-        "index_name_format": "yyyy.MM.dd",
+        "index_name_format": "{{fields.index_format}}",
         "ignore_failure": false 
       }
     },

--- a/extensions/filebeat/7.x/wazuh-module/archives/manifest.yml
+++ b/extensions/filebeat/7.x/wazuh-module/archives/manifest.yml
@@ -6,6 +6,10 @@ var:
       - /var/ossec/logs/archives/archives.json
   - name: index_prefix
     default: wazuh-archives-3.x-
+  - name: index_format
+    default: yyyy.MM.dd
+  - name: date_rounding
+    default: d
 
 input: config/archives.yml
 


### PR DESCRIPTION

|Related issue|
|---|
|6179|

## Description

Through the filebeat.yml, it is possible to override the index prefix to be used to create Elastic indices for alerts and archives. Unfortunately, there is no possibility to choose the date format, nor can you choose to create weekly or monthly indices (instead of a daily index). This change allows to pass the date format and the date rounding to the index name.

## Configuration options

The Wazuh module allows to override the index date format and the date rounding. Defaults are set to the original behaviour (daily index, format yyyy.MM.dd)

```
filebeat.modules:
  - module: wazuh
    alerts:
      enabled: true
      var.index_prefix: wazuh-alerts-3.x-
      var.index_format: yyyy.MM
      var.date_rounding: M
    archives:
      enabled: true
      var.index_prefix: wazuh-archives-3.x-
      var.index_format: yyyy.MM
      var.date_rounding: M
```
