### PR TITLE
Turning ERROR message to debug when multiple daemons attempt to remove an agent simultaneously

### DIFF
--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -430,7 +430,7 @@ cJSON* local_get(const char *id) {
     w_mutex_lock(&mutex_keys);
 
     if (index = OS_IsAllowedID(&keys, id), index < 0) {
-        merror("ERROR %d: %s.", ERRORS[ENOAGENT].code, ERRORS[ENOAGENT].message);
+        mdebug1("Error %d: %s.", ERRORS[ENOAGENT].code, ERRORS[ENOAGENT].message);
         response = local_create_error_response(ERRORS[ENOAGENT].code, ERRORS[ENOAGENT].message);
     }
     else {

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -405,7 +405,7 @@ cJSON* local_remove(const char *id, int purge) {
     w_mutex_lock(&mutex_keys);
 
     if (index = OS_IsAllowedID(&keys, id), index < 0) {
-        merror("ERROR %d: %s.", ERRORS[ENOAGENT].code, ERRORS[ENOAGENT].message);
+        mdebug1("Error %d: %s.", ERRORS[ENOAGENT].code, ERRORS[ENOAGENT].message);
         response = local_create_error_response(ERRORS[ENOAGENT].code, ERRORS[ENOAGENT].message);
     } else {
         minfo("Agent '%s' (%s) deleted (requested locally)", id, keys.keyentries[index]->name);


### PR DESCRIPTION
## Description

It was found that Wazuh Manager v4.0 prints an **ERROR** message like the following one due to a race condition trying to delete an agent:

`2020/10/02 20:11:00 ossec-authd[23049] local-server.c:414 at local_remove(): ERROR: ERROR 9011: Agent ID not found.`

It happens because the **auth** daemon received a message from **remoted** to remove an agent, but it can't find it because it was already erased before. 
This situation isn't considered an error, and a double try to delete the agent will be printed only as a debug message.

## How to reproduce it

If we activate the **mond.delete_old_agents** option and after the selected time expires, the old disconnected agents will be removed. Then, we can find that error log.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation