### PR TITLE
Fix verify agent configuration tool using patterns in FIM directories.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to this project will be documented in this file.
   - Fixed an error with `/groups/{group_id}/config` endpoints (GET and PUT) when using complex `localfile` configurations. ([#6276](https://github.com/wazuh/wazuh/pull/6383))
 - **Core:**
   - Fix error in Analysisd when getting the ossec group ID ([#6688](https://github.com/wazuh/wazuh/pull/6688))
+  - Prevent FIM from reporting configuration error when setting patterns that match no files. ([#6187](https://github.com/wazuh/wazuh/pull/6187))
 
 ### Removed
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -964,7 +964,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 mdebug2(GLOB_NO_MATCH, tmp_dir);
                 dir++;
                 continue;
-            } else if (gstatus = GLOB_NOSPACE | GLOB_ABORTED) {
+            } else if (gstatus != 0) {
                 merror(GLOB_ERROR, tmp_dir);
                 dir++;
                 continue;

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -956,9 +956,14 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                 strchr(tmp_dir, '?') ||
                 strchr(tmp_dir, '[')) {
             int gindex = 0;
+            int gstatus;
             glob_t g;
 
-            if (glob(tmp_dir, 0, NULL, &g) != 0) {
+            if (gstatus = glob(tmp_dir, 0, NULL, &g), gstatus == GLOB_NOMATCH) {
+                mdebug2(GLOB_NO_MATCH, tmp_dir);
+                dir++;
+                continue;
+            } else if (gstatus = GLOB_NOSPACE | GLOB_ABORTED) {
                 merror(GLOB_ERROR, tmp_dir);
                 dir++;
                 continue;

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -959,7 +959,8 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             int gstatus;
             glob_t g;
 
-            if (gstatus = glob(tmp_dir, 0, NULL, &g), gstatus == GLOB_NOMATCH) {
+            gstatus = glob(tmp_dir, 0, NULL, &g);
+            if (gstatus == GLOB_NOMATCH) {
                 mdebug2(GLOB_NO_MATCH, tmp_dir);
                 dir++;
                 continue;

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -276,5 +276,6 @@
 #define MOD_TASK_RESPONSE_MESSAGE           "(8205): Response to message: '%s'"
 #define MOD_TASK_RUNNING_CLEAN              "(8206): Running daily clean DB thread."
 #define MOD_TASK_DISABLED_WORKER            "(8207): Module Task Manager only runs on Master nodes in cluster configuration."
+#define GLOB_NO_MATCH                       "(6351): No matches found for the glob pattern: '%s'"
 
 #endif /* DEBUG_MESSAGES_H */


### PR DESCRIPTION
|Related issue|
|---|
|#167|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR solves a problem when checking the configuration with the verify-agent-conf tool on the manager side. 

In case of setting up a directory with a wildcard in agent.conf and verifying this configuration an error message is displayed if the directory does not exist. The provided solution shows a debug message when expanding there is no directory that matches the pattern.

<!--
Add a clear description of how the problem has been solved.
-->

## Logs/Alerts example

```
syscheck-config.c:954 at read_attr(): DEBUG: (6351): No matches found for the glob pattern: '/test/*/globpattern'
```

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language


<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
