### PR TITLE
Fix/6145 framework integration tests

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -7,6 +7,7 @@ import concurrent.futures
 import copy
 import logging
 import os
+from importlib import reload
 from secrets import token_urlsafe
 from shutil import chown
 from time import time
@@ -110,6 +111,7 @@ def change_secret():
 
 
 def get_security_conf():
+    reload(configuration)
     return copy.deepcopy(configuration.security_conf)
 
 

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -7,7 +7,6 @@ import concurrent.futures
 import copy
 import logging
 import os
-from importlib import reload
 from secrets import token_urlsafe
 from shutil import chown
 from time import time
@@ -15,7 +14,8 @@ from time import time
 from jose import JWTError, jwt
 from werkzeug.exceptions import Unauthorized
 
-import api.configuration as configuration
+import api.configuration as conf
+from api.constants import SECURITY_CONFIG_PATH
 from api.constants import SECURITY_PATH
 from api.util import raise_if_exc
 from wazuh import WazuhInternalError
@@ -111,8 +111,9 @@ def change_secret():
 
 
 def get_security_conf():
-    reload(configuration)
-    return copy.deepcopy(configuration.security_conf)
+    conf.security_conf.update(conf.read_yaml_config(config_file=SECURITY_CONFIG_PATH,
+                                                    default_conf=conf.default_security_configuration))
+    return copy.deepcopy(conf.security_conf)
 
 
 def generate_token(user_id=None, rbac_policies=None):

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2239,6 +2239,7 @@ components:
           type: string
           description: "Wazuh component that logged the event"
           enum:
+            - agent_control
             - ossec-agentlessd
             - ossec-analysisd
             - ossec-authd

--- a/api/test/integration/env/base/manager/entrypoint.sh
+++ b/api/test/integration/env/base/manager/entrypoint.sh
@@ -18,7 +18,7 @@ else
     chown -R ossec:ossec /var/ossec/queue/agent-groups
     chown -R ossec:ossec /var/ossec/etc/shared
     chmod --reference=/var/ossec/etc/shared/default /var/ossec/etc/shared/group*
-    cd /var/ossec/etc/shared && find -name merged.mg -exec chown ossecr:ossec {} \;
+    cd /var/ossec/etc/shared && find -name merged.mg -exec chown ossecr:ossec {} \; && cd /
     chown root:ossec /var/ossec/etc/shared/ar.conf
     chown -R ossecr:ossec /var/ossec/queue/agent-info
 fi

--- a/api/test/integration/env/base/manager/entrypoint.sh
+++ b/api/test/integration/env/base/manager/entrypoint.sh
@@ -17,6 +17,8 @@ else
     chown root:ossec /var/ossec/etc/client.keys
     chown -R ossec:ossec /var/ossec/queue/agent-groups
     chown -R ossec:ossec /var/ossec/etc/shared
+    chmod --reference=/var/ossec/etc/shared/default /var/ossec/etc/shared/group*
+    cd /var/ossec/etc/shared && find -name merged.mg -exec chown ossecr:ossec {} \;
     chown root:ossec /var/ossec/etc/shared/ar.conf
     chown -R ossecr:ossec /var/ossec/queue/agent-info
 fi

--- a/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
@@ -88,13 +88,13 @@ stages:
             - error:
                 code: 1601
               id:
-                - '011'
-                - '012'
+                - '009'
+                - '010'
             - error:
                 code: 1601
               id:
-                - '009'
-                - '010'
+                - '011'
+                - '012'
           total_affected_items: 5
           total_failed_items: 4
         

--- a/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
@@ -758,23 +758,6 @@ stages:
       status_code: 200
 
 ---
-test_name: PUT /cluster/restart
-
-stages:
-
-  # Restart nodes to apply changes
-  - name: Restart cluster
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
-      method: PUT
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-    delay_after: !float "{restart_delay}"
-
----
 test_name: CHECK /security/config
 
 stages:

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -532,18 +532,6 @@ test_name: PUT /security/config (Check)
 
 stages:
 
-  # Restart nodes to apply changes
-  - name: Restart cluster
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
-      method: PUT
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-    delay_after: !float "{restart_delay}"
-
   - name: Get security configuration to check if PUT method worked correctly
     request:
       verify: False

--- a/api/test/integration/test_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscheck_endpoints.tavern.yaml
@@ -538,11 +538,11 @@ stages:
             - error:
                 code: 1601
               id:
-                - '012'
+                - '010'
             - error:
                 code: 1601
               id:
-                - '010'
+                - '012'
           total_affected_items: 5
           total_failed_items: 2
 
@@ -1035,12 +1035,12 @@ stages:
             - error:
                 code: 1601
               id:
-                - '011'
-                - '012'
+                - '009'
+                - '010'
             - error:
                 code: 1601
               id:
-                - '009'
-                - '010'
+                - '011'
+                - '012'
           total_affected_items: 9
           total_failed_items: 4

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -851,12 +851,12 @@ class Agent:
     def get_agent_attr(self, attr):
         """Returns a string with an agent's attribute value
         """
-        wdb_conn = WazuhDBBackend(query_format='global')
-        query = "SELECT {0} FROM agent WHERE id = {1}".format(attr, self.id)
-        request = {'attr': attr, 'id': self.id}
-        query_value = wdb_conn.execute(query=query, request=request)[0][attr]
+        query = WazuhDBQueryAgents(select=[attr.replace('_', '.')], filters={'id': [self.id]})
 
-        return query_value
+        try:
+            return query.run()['items'][0]['os']['name']
+        except KeyError:
+            return 'null'
 
     @staticmethod
     def get_agents_overview(offset=0, limit=common.database_limit, sort=None, search=None, select=None,

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -257,6 +257,8 @@ class WazuhDBConnection:
                     send_request_to_wdb(query_lower, step, off, response)
             except ValueError as e:
                 raise WazuhError(2006, str(e))
+            except WazuhError as e:
+                raise e
             except Exception as e:
                 raise WazuhInternalError(2007, str(e))
 


### PR DESCRIPTION
|Related issue|
|---|
|#6145|

Hi team!

## Description

This PR updates some of the API integration tests, as well as fixes different errors in Wazuh framework after all the changes that using `wazuh-db` instead of `SQLite` has entailed for querying and executing agent's related queries.

Some of the changes performed can be found in the issue updates. For example, as explained here https://github.com/wazuh/wazuh/issues/6145#issuecomment-702687753, the security configuration has recovered its hot-changes feature. Now, it is not necessary to restart the manager in order to apply the last configuration.

Best regards,
Selu.
