### PR TITLE
Fix agent unittests for new get_agent_os_name method.

### DIFF
--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -851,9 +851,12 @@ class Agent:
     def get_agent_os_name(self):
         """Returns a string with an agent's os name
         """
-        query = WazuhDBQueryAgents(select='os.name', filters={'id': [self.id]})
+        query = WazuhDBQueryAgents(select=['os.name'], filters={'id': [self.id]})
 
-        return query.run()['items'][0]['os'].get('name', 'null')
+        try:
+            return query.run()['items'][0]['os'].get('name', 'null')
+        except KeyError:
+            return 'null'
 
     @staticmethod
     def get_agents_overview(offset=0, limit=common.database_limit, sort=None, search=None, select=None,

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -984,39 +984,33 @@ def test_agent_delete_single_group(mock_remove_manual, mock_time, mock_safe_move
                                            permissions=0o660), 'Safe_move not called with expected params'
 
 
-@pytest.mark.parametrize("id, attr, expected_result", [
-    (0, 'os_name', 'Ubuntu'),
-    (7, 'os_name', 'Windows'),
-    (5, 'status', 'updated'),
-    (2, 'register_ip', '172.17.0.201'),
-    (1, 'os_arch', 'x86_64')
+@pytest.mark.parametrize("agent_id, expected_result", [
+    (0, 'Ubuntu'),
+    (7, 'Windows'),
 ])
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_agent_get_agent_attr(socket_mock, send_mock, id, attr, expected_result):
-    """Tests if method get_agent_attr() returns expected value for the given attribute
+def test_agent_get_agent_os_name(socket_mock, send_mock, agent_id, expected_result):
+    """Tests if method get_agent_os_name() returns expected value
 
     Parameters
     ----------
-    id : int
+    agent_id : int
         ID of the agent to return the attribute from.
-    attr : str
-        Attribute to get value from.
     expected_result : str
         Expected value to be obtained.
     """
-    agent = Agent(id)
-    result = agent.get_agent_attr(attr)
+    agent = Agent(agent_id)
+    result = agent.get_agent_os_name()
     assert result == expected_result
 
 
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_agent_get_agent_attr_ko(socket_mock, send_mock):
-    """Tests if method get_agent_attr() raises expected exception when there is no attribute in the DB"""
-    with pytest.raises(WazuhInternalError, match='.* 2007 .*'):
-        agent = Agent(0)
-        agent.get_agent_attr('wrong_column')
+def test_agent_get_agent_os_name_ko(socket_mock, send_mock):
+    """Tests if method get_agent_os_name() returns expected value when there is no attribute in the DB"""
+    agent = Agent(4)
+    assert 'null' == agent.get_agent_os_name()
 
 
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)

--- a/framework/wazuh/core/tests/test_syscollector.py
+++ b/framework/wazuh/core/tests/test_syscollector.py
@@ -34,14 +34,14 @@ def test_get_valid_fields(mock_info, os_name):
     os_name : str
         Request information of this OS.
     """
-    with patch('wazuh.core.agent.Agent.get_agent_attr', return_value=os_name):
+    with patch('wazuh.core.agent.Agent.get_agent_os_name', return_value=os_name):
         response = get_valid_fields(Type.OS, '0')
         assert isinstance(response, tuple) and isinstance(response[1], dict), 'Data type not expected'
         assert 'sys_osinfo' in response[0], f'"sys_osinfo" not contained in {response}'
 
 
 @patch("wazuh.core.agent.Agent.get_basic_information", return_value=None)
-@patch('wazuh.core.agent.Agent.get_agent_attr', return_value='Linux')
+@patch('wazuh.core.agent.Agent.get_agent_os_name', return_value='Linux')
 def test_WazuhDBQuerySyscollector(mock_basic_info, mock_agents_info):
     """Verify that the method connects correctly to the database and returns the correct type."""
     with patch('wazuh.core.utils.WazuhDBConnection') as mock_wdb:

--- a/framework/wazuh/tests/test_syscollector.py
+++ b/framework/wazuh/tests/test_syscollector.py
@@ -34,7 +34,7 @@ with patch('wazuh.common.ossec_uid'):
 ])
 @patch("wazuh.syscollector.get_agents_info", return_value=['000', '001'])
 @patch("wazuh.core.agent.Agent.get_basic_information", return_value=None)
-@patch('wazuh.core.agent.Agent.get_agent_attr', return_value='Linux')
+@patch('wazuh.core.agent.Agent.get_agent_os_name', return_value='Linux')
 def test_get_item_agent(mock_agent_attr, mock_basic_info, mock_agents_info, select, search):
     """Test get_item_agent method.
 
@@ -66,7 +66,7 @@ def test_get_item_agent(mock_agent_attr, mock_basic_info, mock_agents_info, sele
 ])
 @patch("wazuh.syscollector.get_agents_info", return_value=['000', '001'])
 @patch("wazuh.core.agent.Agent.get_basic_information", return_value=None)
-@patch('wazuh.core.agent.Agent.get_agent_attr', return_value='Linux')
+@patch('wazuh.core.agent.Agent.get_agent_os_name', return_value='Linux')
 def test_failed_get_item_agent(mock_agent_attr, mock_basic_info, mock_agents_info, agent_list, expected_exception):
     """Test if get_item_agent method handle exceptions properly.
 
@@ -97,7 +97,7 @@ def test_failed_get_item_agent(mock_agent_attr, mock_basic_info, mock_agents_inf
 ])
 @patch("wazuh.syscollector.get_agents_info", return_value=['000', '001'])
 @patch("wazuh.core.agent.Agent.get_basic_information", return_value=None)
-@patch('wazuh.core.agent.Agent.get_agent_attr', return_value='Linux')
+@patch('wazuh.core.agent.Agent.get_agent_os_name', return_value='Linux')
 def test_agent_elements(mock_agent_attr, mock_basic_info, mock_agents_info, element_type):
     """Tests every possible type of agent element
 


### PR DESCRIPTION
|Related issue|
|---|
|#6144|

Hi team!

## Description

This PR updates the unit tests of `wazuh/core/agent.py` module after the method `get_agent_attr(attr)` has been replaced by get_agent_os_name(). 

A small fix was also made in the mentioned method to prevent an error in certain circumstances (agent without `os` field, for example).

## Tests
### Tests framework
```
wazuh/core/cluster/dapi/tests/test_dapi.py
	22 passed
wazuh/core/cluster/tests/test_cluster.py
	18 passed
wazuh/core/cluster/tests/test_common.py
	7 passed
wazuh/core/cluster/tests/test_control.py
	5 passed
wazuh/core/cluster/tests/test_local_client.py
	1 passed
wazuh/core/cluster/tests/test_utils.py
	7 passed
wazuh/core/cluster/tests/test_worker.py
	16 passed
wazuh/core/tests/test_active_response.py
	12 passed
wazuh/core/tests/test_agent.py
	12 passed
wazuh/core/tests/test_cdb_list.py
	33 passed
wazuh/core/tests/test_common.py
	7 passed
wazuh/core/tests/test_configuration.py
	34 passed
wazuh/core/tests/test_decoder.py
	15 passed
wazuh/core/tests/test_input_validator.py
	3 passed
wazuh/core/tests/test_manager.py
	32 passed
wazuh/core/tests/test_ossec_queue.py
	19 passed
wazuh/core/tests/test_pyDaemonModule.py
	6 passed
wazuh/core/tests/test_results.py
	40 passed
wazuh/core/tests/test_rule.py
	21 passed
wazuh/core/tests/test_syscollector.py
	3 passed
wazuh/core/tests/test_utils.py
	204 passed
wazuh/core/tests/test_wazuh_socket.py
	15 passed
wazuh/core/tests/test_wdb.py
	21 passed
wazuh/rbac/tests/test_auth_context.py
	2 passed
wazuh/rbac/tests/test_decorators.py
	105 passed
wazuh/rbac/tests/test_default_configuration.py
	47 passed
wazuh/rbac/tests/test_orm.py
	53 passed
wazuh/rbac/tests/test_preprocessor.py
	11 passed
wazuh/tests/test_active_response.py
	9 passed
wazuh/tests/test_agent.py
	1 failed, 88 passed, 11 warnings
wazuh/tests/test_cdb_list.py
	47 passed
wazuh/tests/test_ciscat.py
	2 passed
wazuh/tests/test_cluster.py
	7 passed
wazuh/tests/test_decoders.py
	31 passed
wazuh/tests/test_group.py
	8 passed
wazuh/tests/test_manager.py
	40 passed
wazuh/tests/test_mitre.py
	180 passed
wazuh/tests/test_rule.py
	52 passed
wazuh/tests/test_sca.py
	7 passed
wazuh/tests/test_security.py
	65 passed
wazuh/tests/test_stats.py
	13 passed
wazuh/tests/test_syscheck.py
	18 passed
wazuh/tests/test_syscollector.py
	12 passed
```
### Tests API
```
PYTHONPATH=/home/selu/Git/wazuh/api:/home/selu/Git/wazuh/framework python3 -m pytest test/
======================================================= test session starts ========================================================
platform linux -- Python 3.8.2, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/api
plugins: trio-0.6.0, asyncio-0.14.0
collected 195 items                                                                                                                

test/test_alogging.py ........                                                                                               [  4%]
test/test_authentication.py ..........                                                                                       [  9%]
test/test_configuration.py .......                                                                                           [ 12%]
test/test_util.py ...................................                                                                        [ 30%]
test/test_validator.py ..................................................................................................... [ 82%]
..................................                                                                                           [100%]

========================================================= warnings summary =========================================================
/home/selu/venv/unittest-env/lib/python3.8/site-packages/aiohttp/helpers.py:107
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/aiohttp/helpers.py:107: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def noop(*args, **kwargs):  # type: ignore

/home/selu/venv/unittest-env/lib/python3.8/site-packages/jose/jwt.py:5
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/jose/jwt.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping

/home/selu/venv/unittest-env/lib/python3.8/site-packages/jose/jws.py:6
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/jose/jws.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping, Iterable

/home/selu/venv/unittest-env/lib/python3.8/site-packages/jsonschema/compat.py:6
/home/selu/venv/unittest-env/lib/python3.8/site-packages/jsonschema/compat.py:6
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import MutableMapping, Sequence  # noqa

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:48
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:48: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def problems_middleware(request, handler):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:169
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:169: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_json(self, request):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:177
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:177: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_yaml(self, request):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:236
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:236: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_home(self, req):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:246
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:246: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_config(self, req):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:295
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:295: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_request(cls, req):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:324
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:324: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_response(cls, response, mimetype=None, request=None):

test/test_util.py:15
  /home/selu/Git/wazuh/api/api/test/test_util.py:15: PytestCollectionWarning: cannot collect test class 'TestClass' because it has a __init__ constructor (from: api/test/test_util.py)
    class TestClass:

api/test/test_authentication.py::test_generate_secret
  /usr/lib/python3.8/unittest/mock.py:2098: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    self.name = name

api/test/test_authentication.py::test_check_token
  /usr/lib/python3.8/unittest/mock.py:1095: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    self.call_args = _call

api/test/test_configuration.py::test_read_configuration[read_config2]
  /usr/lib/python3.8/unittest/mock.py:2052: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    setattr(_type, entry, MagicProxy(entry, self))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================= 195 passed, 16 warnings in 0.93s =================================================

```

Best regards,
Selu.