### PR TITLE
Remove rbac policies from JWT token

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -1,17 +1,17 @@
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import asyncio
 import concurrent.futures
+import copy
 import logging
 import os
+from secrets import token_urlsafe
 from shutil import chown
 from time import time
 
-import copy
 from jose import JWTError, jwt
-from secrets import token_urlsafe
 from werkzeug.exceptions import Unauthorized
 
 import api.configuration as conf

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -57,11 +57,11 @@ async def login_user(request, user: str, raw=False):
                           is_async=False,
                           logger=logger
                           )
-    data = raise_if_exc(await dapi.distribute_function())
+    roles = raise_if_exc(await dapi.distribute_function())
 
     token = None
     try:
-        token = generate_token(user_id=user, rbac_policies=data.dikt)
+        token = generate_token(user_id=user, roles=roles)
     except WazuhException as e:
         raise_if_exc(e)
 

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -20,7 +20,7 @@ from wazuh import security
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.exception import WazuhPermissionError, WazuhException
-from wazuh.core.results import AffectedItemsWazuhResult
+from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.core.security import revoke_tokens
 from wazuh.rbac import preprocessor
 
@@ -95,6 +95,27 @@ async def get_user_me(request, pretty=False, wait_for_complete=False):
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
+
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+
+
+async def get_user_me_policies(request, pretty=False, wait_for_complete=False):
+    """Return processed RBAC policies and rbac_mode for the current user.
+
+    Parameters
+    ----------
+    request : connexion.request
+    pretty : bool, optional
+        Show results in human-readable format
+    wait_for_complete : bool, optional
+        Disable timeout response
+
+    Returns
+    -------
+    Users information
+    """
+    data = WazuhResult({'data': request['token_info']['rbac_policies'],
+                       'message': "Current user processed policies information was returned"})
 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -57,11 +57,11 @@ async def login_user(request, user: str, raw=False):
                           is_async=False,
                           logger=logger
                           )
-    roles = raise_if_exc(await dapi.distribute_function())
+    data = raise_if_exc(await dapi.distribute_function())
 
     token = None
     try:
-        token = generate_token(user_id=user, roles=roles)
+        token = generate_token(user_id=user, data=data.dikt)
     except WazuhException as e:
         raise_if_exc(e)
 

--- a/api/api/spec/changes.md
+++ b/api/api/spec/changes.md
@@ -514,6 +514,12 @@ This API call expects a full valid XML file with the shared configuration tags/s
 ### GET ​   /security/users
 * New endpoint. Get user information.
 
+### GET ​   /security/users/me
+* New endpoint. Get current user information.
+
+### GET ​   /security/users/me/policies
+* New endpoint. Get current user processed policies information.
+
 ### POST ​  /security/users
 * New endpoint. Create new user.
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -14117,6 +14117,40 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
+
+  /security/users/me/policies:
+    get:
+      tags:
+        - security
+      summary: "Get current user processed policies"
+      description: "Get the processed policies information for the current user"
+      operationId: api.controllers.security_controller.get_user_me_policies
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+      responses:
+        '200':
+          description: "Information about current user processed policies"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+              example:
+                data:
+                  syscheck:run:
+                    agent:id:*: allow
+                  syscollector:read:
+                    agent:id:*: allow
+                  rbac_mode: black
+                message: "Current user processed policies information was returned"
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
   /security/users:
     get:
       tags:

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -907,7 +907,7 @@ stages:
             - <<: *user
           total_affected_items: 2
 
-  - name: Get an user by its id (invalid id)
+  - name: Get a user by its id (invalid id)
     request:
       <<: *all_users_request
       params:
@@ -915,7 +915,7 @@ stages:
     response:
       status_code: 400
 
-  - name: Get an user by its id (invalid id)
+  - name: Get a user by its id (invalid id)
     request:
       <<: *all_users_request
       params:

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -857,6 +857,24 @@ stages:
           failed_items: []
 
 ---
+test_name: GET /security/users/me/policies
+
+stages:
+
+  - name: Get information about the current user processed policies
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/me/policies"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+    response:
+      status_code: 200
+      json:
+        data: !anything
+        message: !anystr
+
+---
 test_name: GET /security/users
 
 stages:

--- a/framework/wazuh/rbac/auth_context.py
+++ b/framework/wazuh/rbac/auth_context.py
@@ -308,6 +308,12 @@ class RBAChecker:
 
         return user_roles_policies
 
+    def run_auth_context_roles(self):
+        """This function will return the roles of aun user matching the authorization context"""
+        user_roles = self.get_user_roles()
+
+        return user_roles
+
     @staticmethod
     def run_user_role_link(user_id):
         """This function will return the final policies of an user according to its roles in the RBAC database"""
@@ -321,3 +327,22 @@ class RBAChecker:
                 user_roles_policies['roles'].append(role.id)
 
         return user_roles_policies
+
+    @staticmethod
+    def run_user_role_link_roles(user_id):
+        """This function will return the roles in the RBAC database for an user"""
+        with orm.UserRolesManager() as urm:
+            user_roles = list(role for role in urm.get_all_roles_from_user(user_id=user_id))
+
+        return user_roles
+
+
+def get_policies_from_roles(roles=None):
+    """This function will return the final policies of an user according to the roles"""
+    policies = list()
+    with orm.RolesPoliciesManager() as rpm:
+        for role in roles:
+            for policy in rpm.get_all_policies_from_role(role):
+                policies.append(json.loads(policy.policy))
+
+    return policies

--- a/framework/wazuh/rbac/auth_context.py
+++ b/framework/wazuh/rbac/auth_context.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
@@ -332,7 +332,7 @@ class RBAChecker:
     def run_user_role_link_roles(user_id):
         """This function will return the roles in the RBAC database for an user"""
         with orm.UserRolesManager() as urm:
-            user_roles = list(role for role in urm.get_all_roles_from_user(user_id=user_id))
+            user_roles = list(role.id for role in urm.get_all_roles_from_user(user_id=user_id))
 
         return user_roles
 

--- a/framework/wazuh/rbac/auth_context.py
+++ b/framework/wazuh/rbac/auth_context.py
@@ -4,9 +4,9 @@
 
 import json
 import re
+from collections import defaultdict
 
 from wazuh.rbac import orm
-from collections import defaultdict
 
 
 class RBAChecker:
@@ -296,7 +296,7 @@ class RBAChecker:
         return list_roles
 
     def run_auth_context(self):
-        """This function will return the final policies of an user according to the roles matching the authorization
+        """This function will return the final policies of a user according to the roles matching the authorization
         context"""
         user_roles = self.get_user_roles()
         user_roles_policies = defaultdict(list)
@@ -316,7 +316,7 @@ class RBAChecker:
 
     @staticmethod
     def run_user_role_link(user_id):
-        """This function will return the final policies of an user according to its roles in the RBAC database"""
+        """This function will return the final policies of a user according to its roles in the RBAC database"""
         with orm.UserRolesManager() as urm:
             user_roles = list(role for role in urm.get_all_roles_from_user(user_id=user_id))
         user_roles_policies = defaultdict(list)
@@ -330,7 +330,7 @@ class RBAChecker:
 
     @staticmethod
     def run_user_role_link_roles(user_id):
-        """This function will return the roles in the RBAC database for an user"""
+        """This function will return the roles in the RBAC database for a user"""
         with orm.UserRolesManager() as urm:
             user_roles = list(role.id for role in urm.get_all_roles_from_user(user_id=user_id))
 
@@ -338,7 +338,7 @@ class RBAChecker:
 
 
 def get_policies_from_roles(roles=None):
-    """This function will return the final policies of an user according to the roles"""
+    """This function will return the final policies of a user according to its roles"""
     policies = list()
     with orm.RolesPoliciesManager() as rpm:
         for role in roles:

--- a/framework/wazuh/rbac/auth_context.py
+++ b/framework/wazuh/rbac/auth_context.py
@@ -309,7 +309,7 @@ class RBAChecker:
         return user_roles_policies
 
     def run_auth_context_roles(self):
-        """This function will return the roles of aun user matching the authorization context"""
+        """This function will return the roles of a user matching the authorization context"""
         user_roles = self.get_user_roles()
 
         return user_roles

--- a/framework/wazuh/rbac/preprocessor.py
+++ b/framework/wazuh/rbac/preprocessor.py
@@ -1,13 +1,13 @@
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import re
 
 from wazuh.core.exception import WazuhError, WazuhPermissionError
+from wazuh.core.results import WazuhResult
 from wazuh.rbac.auth_context import RBAChecker, get_policies_from_roles
 from wazuh.rbac.orm import AuthenticationManager
-from wazuh.core.results import WazuhResult
 
 
 class PreProcessor:
@@ -129,4 +129,8 @@ def get_permissions(user_id=None, auth_context=None):
         else:
             roles = get_roles(user_id=user_id)
 
-        return roles
+        result = {
+            'roles': roles
+        }
+
+        return WazuhResult(result)

--- a/framework/wazuh/rbac/preprocessor.py
+++ b/framework/wazuh/rbac/preprocessor.py
@@ -43,7 +43,7 @@ class PreProcessor:
 
     @staticmethod
     def is_combination(resource):
-        """This function checks whether a given resource is a combination or not.
+        """Check whether a given resource is a combination or not.
 
         :param resource: Resource to be checked
         :return Tuple with a flag that indicates whether it is a combination or not and if so,
@@ -56,8 +56,7 @@ class PreProcessor:
         return False, [resource]
 
     def process_policy(self, policy):
-        """Receives an unprocessed policy and transforms it into a specific format for
-        treatment in the decorator.
+        """Receive an unprocessed policy and transforms it into a specific format for treatment in the decorator.
 
         :param policy: Policy of the user
         """
@@ -80,17 +79,13 @@ class PreProcessor:
                 self.odict[action]['&'.join(resource)] = policy['effect']
 
     def get_optimize_dict(self):
-        """This function preprocess the policies of the user for a more easy treatment
-        in the decorator of the RBAC
-        """
         return self.odict
 
 
 def optimize_resources(roles=None):
-    """This function preprocess the policies of the user for a more easy treatment in the decorator of the RBAC
+    """Preprocess the policies of the user for a more easy treatment in the decorator of the RBAC
 
-    :param roles: Authorization context of the current user
-    :param user_id: Username of the current user
+    :param roles: Roles of the current user
     """
     policies = get_policies_from_roles(roles=roles)
 
@@ -102,7 +97,7 @@ def optimize_resources(roles=None):
 
 
 def get_roles(auth_context=None, user_id=None):
-    """This function preprocess the policies of the user for a more easy treatment in the decorator of the RBAC
+    """Obtain the roles of a user using auth_context or user_id
 
     :param auth_context: Authorization context of the current user
     :param user_id: Username of the current user
@@ -121,6 +116,11 @@ def get_roles(auth_context=None, user_id=None):
 
 
 def get_permissions(user_id=None, auth_context=None):
+    """Obtain the permissions of a user using auth_context or user_id
+
+    :param auth_context: Authorization context of the current user
+    :param user_id: Username of the current user
+    """
     with AuthenticationManager() as auth:
         if not auth.user_allow_run_as(user_id) and auth_context:
             raise WazuhPermissionError(code=6004)

--- a/framework/wazuh/rbac/tests/test_preprocessor.py
+++ b/framework/wazuh/rbac/tests/test_preprocessor.py
@@ -39,9 +39,8 @@ outputs = [test_case['processed_policies'] for test_case in file]
 
 @pytest.mark.parametrize('input_, output', zip(inputs, outputs))
 def test_expose_resources(db_setup, input_, output):
-    with patch('wazuh.rbac.preprocessor.RBAChecker.run_user_role_link', return_value=input_):
-        preprocessor = db_setup()
-        for policy in input_:
-            preprocessor.process_policy(policy)
-        preprocessed_policies = preprocessor.get_optimize_dict()
-        assert preprocessed_policies == output
+    preprocessor = db_setup()
+    for policy in input_:
+        preprocessor.process_policy(policy)
+    preprocessed_policies = preprocessor.get_optimize_dict()
+    assert preprocessed_policies == output


### PR DESCRIPTION
Hello team,

This PR adds a change to JWT token to eliminate full policies information. The new JWT token only shows the user, the roles and the rbac_mode, thus making the JWT token much shorter.

Regards,

David J. Iglesias