### PR TITLE
[API] Add data field and improve responses examples for several endpoints

### DIFF
--- a/api/api/controllers/default_controller.py
+++ b/api/api/controllers/default_controller.py
@@ -9,6 +9,7 @@ import time
 from aiohttp import web
 from api.encoder import dumps, prettify
 from api.models.basic_info import BasicInfo
+from api.models.base_model_ import Data
 from wazuh.core.security import load_spec
 
 logger = logging.getLogger('wazuh')
@@ -32,6 +33,6 @@ async def default_info(pretty=False):
         'hostname': socket.gethostname(),
         'timestamp': timestamp
     }
-    response = BasicInfo.from_dict(data)
+    response = Data(BasicInfo.from_dict(data))
 
     return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -1046,8 +1046,9 @@ async def get_security_config(request, pretty=False, wait_for_complete=False):
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
+    response = Data(data)
 
-    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def security_revoke_tokens():

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -11,11 +11,11 @@ from aiohttp import web
 from api.authentication import generate_token
 from api.configuration import default_security_configuration
 from api.encoder import dumps, prettify
-from api.models.base_model_ import Body
+from api.models.base_model_ import Body, Data
 from api.models.configuration import SecurityConfigurationModel
 from api.models.security import CreateUserModel, UpdateUserModel, RoleModel, PolicyModel, RuleModel
 from api.models.token_response import TokenResponseModel
-from api.util import remove_nones_to_dict, raise_if_exc, parse_api_param
+from api.util import remove_nones_to_dict, raise_if_exc, parse_api_param, json_response_wazuh
 from wazuh import security
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
@@ -68,7 +68,8 @@ async def login_user(request, user: str, raw=False):
     if raw:
         return web.Response(text=token, content_type='text/plain', status=200)
     else:
-        return web.json_response(data=TokenResponseModel(token=token), status=200, dumps=dumps)
+        response = Data(TokenResponseModel(token=token))
+        return web.json_response(data=response, status=200, dumps=dumps)
 
 
 async def get_user_me(request, pretty=False, wait_for_complete=False):
@@ -953,8 +954,8 @@ async def get_rbac_resources(resource: str = None, pretty: bool = False):
                           logger=logger
                           )
     data = raise_if_exc(await dapi.distribute_function())
-
-    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+    response = Data(data)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_rbac_actions(pretty: bool = False, endpoint: str = None):
@@ -982,8 +983,9 @@ async def get_rbac_actions(pretty: bool = False, endpoint: str = None):
                           logger=logger
                           )
     data = raise_if_exc(await dapi.distribute_function())
+    response = Data(data)
 
-    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
 
 
 async def revoke_all_tokens(request, pretty: bool = False):

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -15,7 +15,7 @@ from api.models.base_model_ import Body, Data
 from api.models.configuration import SecurityConfigurationModel
 from api.models.security import CreateUserModel, UpdateUserModel, RoleModel, PolicyModel, RuleModel
 from api.models.token_response import TokenResponseModel
-from api.util import remove_nones_to_dict, raise_if_exc, parse_api_param, json_response_wazuh
+from api.util import remove_nones_to_dict, raise_if_exc, parse_api_param
 from wazuh import security
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI

--- a/api/api/spec/changes.md
+++ b/api/api/spec/changes.md
@@ -508,6 +508,18 @@ This API call expects a full valid XML file with the shared configuration tags/s
 ### POST    /security/user/authenticate/run_as
 * New endpoint. Auth_context based authentication to get an access token.
 
+### GET     /security/config
+* New endpoint. Get the security configuration in JSON format.
+
+### PUT     /security/config
+* New endpoint. Update the security configuration with the data contained in the API request
+
+### DELETE     /security/config
+* New endpoint. Replaces the security configuration with the original one
+
+### GET         /security/resources
+* New endpoint. Get all the current defined RBAC resources.
+
 ### PUT ​   /security/user/revoke
 * New endpoint. Revoke all active JWT tokens.
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1761,6 +1761,12 @@ components:
         roles:
           type: array
           description: "User's roles"
+    Token:
+      type: object
+      properties:
+        token:
+          type: string
+          description: "User's token"
 
     # Cluster and manager models
     WazuhDaemonsStatus:
@@ -12788,10 +12794,12 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  token:
-                    type: string
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Token'
               example:
                 token: "<generated_token>"
             text/plain:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6482,6 +6482,16 @@ paths:
             application/xml:
               schema:
                 type: string
+              example: |
+                <agent_config>
+                  <!-- Shared agent configuration here -->
+                  <agent_config os="Linux">
+                    <localfile>
+                      <location>/var/log/linux.log</location>
+                      <log_format>syslog</log_format>
+                    </localfile>
+                  </agent_config>
+                </agent_config>
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
@@ -10461,6 +10471,57 @@ paths:
             application/xml:
               schema:
                 type: string
+              example: |
+                <!--
+                  -  Rules config
+                  -  Author: Daniel Cid.
+                  -  Updated by Wazuh, Inc.
+                  -  Copyright (C) 2015-2020, Wazuh Inc.
+                  -  Copyright (C) 2009 Trend Micro Inc.
+                  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+                -->
+                <group name="syslog,">
+                  <rule id="1" level="0" noalert="1">
+                    <category>syslog</category>
+                    <description>Generic template for all syslog rules.</description>
+                  </rule>
+                </group>
+                <group name="firewall,">
+                  <rule id="2" level="0" noalert="1">
+                    <category>firewall</category>
+                    <description>Generic template for all firewall rules.</description>
+                  </rule>
+                </group>
+                <group name="ids,">
+                  <rule id="3" level="0" noalert="1">
+                    <category>ids</category>
+                    <description>Generic template for all ids rules.</description>
+                  </rule>
+                </group>
+                <group name="web-log,">
+                  <rule id="4" level="0" noalert="1">
+                    <category>web-log</category>
+                    <description>Generic template for all web rules.</description>
+                  </rule>
+                </group>
+                <group name="squid,">
+                  <rule id="5" level="0" noalert="1">
+                    <category>squid</category>
+                    <description>Generic template for all web proxy rules.</description>
+                  </rule>
+                </group>
+                <group name="windows,">
+                  <rule id="6" level="0" noalert="1">
+                    <category>windows</category>
+                    <description>Generic template for all windows rules.</description>
+                  </rule>
+                </group>
+                <group name="ossec,">
+                  <rule id="7" level="0" noalert="1">
+                    <category>ossec</category>
+                    <description>Generic template for all ossec rules.</description>
+                  </rule>
+                </group>
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
@@ -11011,6 +11072,21 @@ paths:
             application/xml:
               schema:
                 type: string
+              example: |
+                  <!--
+                  - JSON Decoders
+                  - Copyright (C) 2015-2020, Wazuh Inc.
+                  - April 21, 2017.
+                  -
+                  - This program is a free software; you can redistribute it
+                  - and/or modify it under the terms of the GNU General Public
+                  - License (version 2) as published by the FSF - Free Software
+                  - Foundation.
+                  -->
+                  <decoder name="json">
+                    <prematch>^{\s*"</prematch>
+                    <plugin_decoder>JSON_Decoder</plugin_decoder>
+                  </decoder>
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
@@ -13003,6 +13079,12 @@ paths:
       responses:
         '200':
           description: "Tokens were successfully revoked"
+          content:
+            application/json:
+              schema:
+                type: string
+              example:
+                message: "Tokens were successfully revoked"
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
@@ -14540,6 +14622,12 @@ paths:
       responses:
         '200':
           description: 'Configuration successfully updated'
+          content:
+            application/json:
+              schema:
+                type: string
+              example:
+                message: 'Configuration successfully updated'
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
@@ -14564,7 +14652,13 @@ paths:
         - $ref: "#/components/parameters/wait_for_complete"
       responses:
         '200':
-          description: 'Configuration successfully restored'
+          description: 'Configuration successfully updated'
+          content:
+            application/json:
+              schema:
+                type: string
+              example:
+                message: 'Configuration successfully updated'
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':

--- a/api/test/integration/test_default_endpoints.tavern.yaml
+++ b/api/test/integration/test_default_endpoints.tavern.yaml
@@ -17,10 +17,11 @@ stages:
     response:
       status_code: 200
       json:
-        api_version: !anystr
-        hostname: !anystr
-        license_name: !anystr
-        license_url: !anystr
-        revision: !anyint
-        timestamp: !anystr
-        title: !anystr
+        data:
+          api_version: !anystr
+          hostname: !anystr
+          license_name: !anystr
+          license_url: !anystr
+          revision: !anyint
+          timestamp: !anystr
+          title: !anystr

--- a/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
@@ -364,8 +364,9 @@ stages:
     response:
       status_code: 200
       json:
-        auth_token_exp_timeout: !anyint
-        rbac_mode: !anystr
+        data:
+          auth_token_exp_timeout: !anyint
+          rbac_mode: !anystr
 
 ---
 test_name: UPDATE SECURITY CONFIG

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -1284,18 +1284,19 @@ stages:
     response:
       status_code: 200
       json:
-        active-response:command:
-          description: !anystr
-          resources:
-            - agent:id
-          example:
-            actions:
-              - active-response:command
+        data:
+          active-response:command:
+            description: !anystr
             resources:
-              - agent:id:001
-            effect: allow
-          related_endpoints:
-            - PUT /active-response
+              - agent:id
+            example:
+              actions:
+                - active-response:command
+              resources:
+                - agent:id:001
+              effect: allow
+            related_endpoints:
+              - PUT /active-response
 
   - name: Testing RBAC's actions catalog
     request:
@@ -1332,29 +1333,30 @@ stages:
     response:
       status_code: 200
       json:
-        "*:*":
-          description: 'Resource applied in functions which take part in the creation of a specific resource.
-          We call these functions, resourceless functions. Example: agent:create'
-        agent:id:
-          description: Reference agents via agent ID (i.e. agent:id:001)
-        group:id:
-          description: Reference agent groups via group ID (i.e. group:id:default)
-        node:id:
-          description: Reference cluster nodes via node ID (i.e. node:id:worker1)
-        file:path:
-          description: Reference files via its path (i.e. file:path:etc/rules/new_rule.xml)
-        decoder:file:
-          description: Reference decoder files via its path (i.e. decoder:file:0005-wazuh_decoders.xml)
-        list:path:
-          description: Reference list files via its path (i.e. list:path:etc/lists/audit-keys)
-        rule:file:
-          description: Reference rule files via its path (i.e. rule:file:0610-win-ms_logs_rules.xml)
-        policy:id:
-          description: Reference security policies via its id (i.e. policy:id:1)
-        role:id:
-          description: Reference security roles via its id (i.e. role:id:1)
-        user:id:
-          description: Reference security users via its id (i.e. user:id:1)
+        data:
+          "*:*":
+            description: 'Resource applied in functions which take part in the creation of a specific resource.
+            We call these functions, resourceless functions. Example: agent:create'
+          agent:id:
+            description: Reference agents via agent ID (i.e. agent:id:001)
+          group:id:
+            description: Reference agent groups via group ID (i.e. group:id:default)
+          node:id:
+            description: Reference cluster nodes via node ID (i.e. node:id:worker1)
+          file:path:
+            description: Reference files via its path (i.e. file:path:etc/rules/new_rule.xml)
+          decoder:file:
+            description: Reference decoder files via its path (i.e. decoder:file:0005-wazuh_decoders.xml)
+          list:path:
+            description: Reference list files via its path (i.e. list:path:etc/lists/audit-keys)
+          rule:file:
+            description: Reference rule files via its path (i.e. rule:file:0610-win-ms_logs_rules.xml)
+          policy:id:
+            description: Reference security policies via its id (i.e. policy:id:1)
+          role:id:
+            description: Reference security roles via its id (i.e. role:id:1)
+          user:id:
+            description: Reference security users via its id (i.e. user:id:1)
 
   - name: Testing RBAC's actions catalog
     request:
@@ -1382,5 +1384,6 @@ stages:
     response:
       status_code: 200
       json:
-        auth_token_exp_timeout: !anyint
-        rbac_mode: !anystr
+        data:
+          auth_token_exp_timeout: !anyint
+          rbac_mode: !anystr

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -865,7 +865,7 @@ def revoke_current_user_tokens():
         with AuthenticationManager() as am:
             tm.add_user_roles_rules(users={am.get_user(common.current_user.get())['id']})
 
-    return WazuhResult({'msg': f'User {common.current_user.get()} was successfully logged out'})
+    return WazuhResult({'message': f'User {common.current_user.get()} was successfully logged out'})
 
 
 @expose_resources(actions=['security:revoke'], resources=['*:*:*'],
@@ -875,7 +875,7 @@ def wrapper_revoke_tokens():
     """ Revoke all tokens """
     revoke_tokens()
 
-    return WazuhResult({'msg': 'Tokens were successfully revoked'})
+    return WazuhResult({'message': 'Tokens were successfully revoked'})
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
Hello team,

This PR closes #6196. It updates several endpoints to add them a `data` field. Here is the list of affected endpoints:

```
GET /security/user/authenticate
POST /security/user/authenticate/run_as
GET /security/actions
GET /security/config
GET /security/resources
GET /
```
The integration tests for those endpoints have been updated to support the new `data` field present in the responses.

This PR also adds redoc-compatible examples for those endpoints returning a XML instead of a JSON. The `spec.yaml` has been updated accordingly.

Finally, this PR replaces the `msg` present in security revoke endpoints with `message` to match the rest of the endpoints.

Check the issue for more details.