### PR TITLE
Add a backslash to devices names.

### DIFF
--- a/src/syscheckd/win_whodata.c
+++ b/src/syscheckd/win_whodata.c
@@ -1216,6 +1216,8 @@ int get_volume_names() {
 
         // Convert device name
         wcstombs(convert_device, device_name, ARRAYSIZE(device_name));
+        /* Add a backslash to the device name */
+        strncat(convert_device, "\\", MAX_PATH);
         // Get all drive letters
         get_drive_names(volume_name, convert_device);
 
@@ -1251,6 +1253,7 @@ int get_drive_names(wchar_t *volume_name, char *device) {
     unsigned int device_it;
     size_t success = -1;
     size_t retval = -1;
+    unsigned int name_len = 0;
 
     while (1) {
         // Allocate a buffer to hold the paths.
@@ -1278,9 +1281,9 @@ int get_drive_names(wchar_t *volume_name, char *device) {
     if (success) {
         // Save information in FIM whodata structure
         char convert_name[MAX_PATH] = "";
-
-        for (nameit = names; nameit[0] != L'\0'; nameit += wcslen(nameit) + 1) {
-            wcstombs(convert_name, nameit, wcslen(nameit));
+        for (nameit = names; nameit[0] != L'\0'; nameit += name_len + 1) {
+            name_len = wcslen(nameit);
+            wcstombs(convert_name, nameit, name_len);
             mdebug1(FIM_WHODATA_DEVICE_LETTER, device, convert_name);
 
             if(syscheck.wdata.device) {

--- a/src/unit_tests/syscheckd/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/test_win_whodata.c
@@ -3287,9 +3287,9 @@ void test_get_volume_names_error_on_next_volume(void **state) {
         will_return(wrap_GetVolumePathNamesForVolumeNameW, volume_paths);
         will_return(wrap_GetVolumePathNamesForVolumeNameW, 1);
 
-        expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C' associated with the mounting point 'A'");
-        expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C' associated with the mounting point 'C'");
-        expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C' associated with the mounting point '\\Some\\path'");
+        expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C\\' associated with the mounting point 'A'");
+        expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C\\' associated with the mounting point 'C'");
+        expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C\\' associated with the mounting point '\\Some\\path'");
     }
 
     expect_value(wrap_FindNextVolumeW, hFindVolume, (HANDLE)123456);
@@ -3331,9 +3331,9 @@ void test_get_volume_names_no_more_files(void **state) {
         will_return(wrap_GetVolumePathNamesForVolumeNameW, volume_paths);
         will_return(wrap_GetVolumePathNamesForVolumeNameW, 1);
 
-        expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C' associated with the mounting point 'A'");
-        expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C' associated with the mounting point 'C'");
-        expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C' associated with the mounting point '\\Some\\path'");
+        expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C\\' associated with the mounting point 'A'");
+        expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C\\' associated with the mounting point 'C'");
+        expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C\\' associated with the mounting point '\\Some\\path'");
     }
 
     expect_value(wrap_FindNextVolumeW, hFindVolume, (HANDLE)123456);
@@ -7307,9 +7307,9 @@ void test_whodata_audit_start_success(void **state) {
             will_return(wrap_GetVolumePathNamesForVolumeNameW, volume_paths);
             will_return(wrap_GetVolumePathNamesForVolumeNameW, 1);
 
-            expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C' associated with the mounting point 'A'");
-            expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C' associated with the mounting point 'C'");
-            expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C' associated with the mounting point '\\Some\\path'");
+            expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C\\' associated with the mounting point 'A'");
+            expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C\\' associated with the mounting point 'C'");
+            expect_string(__wrap__mdebug1, formatted_msg, "(6303): Device 'C\\' associated with the mounting point '\\Some\\path'");
         }
 
         expect_value(wrap_FindNextVolumeW, hFindVolume, (HANDLE)123456);


### PR DESCRIPTION
|Related issue|
|---|
|#6177|

## Description

This PR aims to fix the failure described in #6177, where an incorrect concatenation of the drive name and the path was causing that FIM could not find the path associated with a drive name.

## Configuration options

```xml
 <syscheck>
    <disabled>no</disabled>
    <frequency>43200</frequency>

    <directories whodata="yes">a:\test\test_file.txt</directories>
</syscheck>
```
## Logs/Alerts example
```
2020/10/06 09:35:28 ossec-agent[2288] win_whodata.c:1336 at replace_device_path(): DEBUG: (6304): Find device '\Device\HarddiskVolume4\' in path '\Device\HarddiskVolume4\test\test_file.txt'
2020/10/06 09:35:28 ossec-agent[2288] win_whodata.c:1344 at replace_device_path(): DEBUG: (6305): Replacing '\Device\HarddiskVolume4\test\test_file.txt' to 'A:\test\test_file.txt'
2020/10/06 09:35:32 ossec-agent[2288] state.c:67 at write_state(): DEBUG: Updating state file.
```
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Windows
- [X] Source installation
- [X] Source upgrade
- Memory tests for Windows
  - [X] Scan-build report
