### PR TITLE
Fix 4.0 scan-build errors

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -2235,7 +2235,7 @@ void test_wdb_get_agent_keepalive_error_no_name_nor_ip(void **state) {
     char *name = NULL;
     char *ip = NULL;
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Empty agent name or ip when trying to get last keepalive. Agent: ((null)) IP: ((null))");
+    expect_string(__wrap__mdebug1, formatted_msg, "Empty agent name or ip when trying to get last keepalive.");
 
     keepalive = wdb_get_agent_keepalive(name, ip);
 
@@ -2356,7 +2356,7 @@ void test_wdb_find_agent_error_invalid_parameters(void **state)
     char *name = NULL;
     char *ip = NULL;
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Empty agent name or ip when trying to get agent name. Agent: ((null)) IP: ((null))");
+    expect_string(__wrap__mdebug1, formatted_msg, "Empty agent name or ip when trying to get agent ID.");
 
     ret = wdb_find_agent(name, ip);
 
@@ -2404,7 +2404,7 @@ void test_wdb_find_agent_error_json_output(void **state)
     will_return(__wrap_wdbc_query_parse_json, NULL);
 
     // Handling result
-    expect_string(__wrap__merror, formatted_msg, "Error querying Wazuh DB for agent name.");
+    expect_string(__wrap__merror, formatted_msg, "Error querying Wazuh DB for agent ID.");
 
     ret = wdb_find_agent(name_str, ip_str);
 

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -549,9 +549,9 @@ int* wdb_get_all_agents(bool include_manager) {
                 char *savedptr = NULL;
                 for (agent_id = strtok_r(payload, sdelim, &savedptr); agent_id; agent_id = strtok_r(NULL, sdelim, &savedptr)) {
                     array[len] = atoi(agent_id);
+                    last_id = array[len];
                     len++;
                 }
-                last_id = array[len-1];
             }
         }
         else {
@@ -594,9 +594,9 @@ int* wdb_get_agents_by_keepalive(const char* condition, int keepalive, bool incl
                 char *savedptr = NULL;
                 for (agent_id = strtok_r(payload, sdelim, &savedptr); agent_id; agent_id = strtok_r(NULL, sdelim, &savedptr)) {
                     array[len] = atoi(agent_id);
+                    last_id = array[len];
                     len++;
                 }
-                last_id = array[len-1];
             }
         }
         else {
@@ -623,7 +623,7 @@ int wdb_find_agent(const char *name, const char *ip) {
     cJSON *json_id = NULL;
 
     if (!name || !ip) {
-        mdebug1("Empty agent name or ip when trying to get agent name. Agent: (%s) IP: (%s)", name, ip);
+        mdebug1("Empty agent name or ip when trying to get agent ID.");
         return OS_INVALID;
     }
 
@@ -644,7 +644,7 @@ int wdb_find_agent(const char *name, const char *ip) {
     root = wdbc_query_parse_json(&wdb_sock_agent, wdbquery, wdboutput, sizeof(wdboutput));
 
     if (!root) {
-        merror("Error querying Wazuh DB for agent name.");
+        merror("Error querying Wazuh DB for agent ID.");
         return OS_INVALID;
     }
 
@@ -771,7 +771,7 @@ time_t wdb_get_agent_keepalive(const char *name, const char *ip){
     cJSON *json_keepalive = NULL;
 
     if (!name || !ip) {
-        mdebug1("Empty agent name or ip when trying to get last keepalive. Agent: (%s) IP: (%s)", name, ip);
+        mdebug1("Empty agent name or ip when trying to get last keepalive.");
         return OS_INVALID;
     }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4589,7 +4589,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
             }
             continue;
         } else if (!os_version) {
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_UNSOPPORTED, id, name);
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_UNSOPPORTED, id, name?name:"");
             continue;
         }
 
@@ -4653,7 +4653,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
             // Check if the agent OS can be matched with a OVAL
             if (agent_dist_ver = wm_vuldet_set_allowed_feed(os_name, os_version, updates, &agent_dist), agent_dist_ver == FEED_UNKNOWN) {
                 if (dist_error == -2) {
-                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_UNSOPPORTED, id, name);
+                    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_UNSOPPORTED, id, name?name:"");
                     continue;
                 } else {
                     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, id, vu_feed_ext[dist_error]);
@@ -4693,7 +4693,9 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
         snprintf(str_id, sizeof(str_id), "%d", id);
         os_strdup(str_id, agents->agent_id);
 
-        os_strdup(name, agents->agent_name);
+        if (name) {
+            os_strdup(name, agents->agent_name);
+        }        
         if (arch) {
             os_strdup(arch, agents->arch);
         }


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR fixes different minimal issues reported by scan-build

- Garbage on variables of **wdb_get_all_agents()** and **wdb_get_agents_by_keepalive()** if WazuhDB sends a valid response with no payload (not possible scenario)
- Wrong logs using null pointer.
- Non null-check on **wm_vuldet_set_agents_info()**. This is a legacy issue, but fixed here.


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
 
- Integration tests
  - [x] WazuhDB integration tests 
