### PR TITLE
Add external dependency in windows build of dbsync and rsync

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -679,7 +679,7 @@ winagent: external win32/shared_modules win32/libwinpthread-1.dll wazuh_modules/
 	cd win32/ && makensis ossec-installer.nsi
 
 
-win32/shared_modules:
+win32/shared_modules: external
 	cd ${DBSYNC} && mkdir -p build && cd build && cmake ${WIN_CMAKE_OPTS} ${DBSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} .. && make
 	cd ${RSYNC} &&  mkdir -p build && cd build && cmake ${WIN_CMAKE_OPTS} ${RSYNC_TEST} ${SHARED_MODULES_RELEASE_TYPE} .. && make
 ifneq (,$(filter ${TEST},YES yes y Y 1))


### PR DESCRIPTION
|Related issue|
|---|
|#6068|

Windows compilation failed when concurrent, since compilation of rsync and dbsync did not wait for openssl, cjson and sqlite to be compiled.

With this change, wait for the completion of the external to compile shared modules.