### PR TITLE
[API] Remove error field from data field in API responses

### DIFF
--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -12,7 +12,7 @@ from api import configuration
 from api.encoder import dumps, prettify
 from api.models.agent_added import AgentAddedModel
 from api.models.agent_inserted import AgentInsertedModel
-from api.models.base_model_ import Data, Body
+from api.models.base_model_ import Body
 from api.util import parse_api_param, remove_nones_to_dict, raise_if_exc
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
@@ -153,9 +153,8 @@ async def add_agent(request, pretty=False, wait_for_complete=False):
                           )
 
     data = raise_if_exc(await dapi.distribute_function())
-    response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def restart_agents(request, pretty=False, wait_for_complete=False, list_agents='*'):
@@ -243,9 +242,8 @@ async def get_agent_config(request, pretty=False, wait_for_complete=False, agent
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
-    response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def delete_single_agent_multiple_groups(request, agent_id, list_groups=None, pretty=False, wait_for_complete=False):
@@ -485,9 +483,8 @@ async def post_new_agent(request, agent_name, pretty=False, wait_for_complete=Fa
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
-    response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agent_upgrade(request, agent_id, timeout=3, pretty=False, wait_for_complete=False):
@@ -722,7 +719,7 @@ async def get_group_config(request, group_id, pretty=False, wait_for_complete=Fa
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=Data(data), status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def put_group_config(request, body, group_id, pretty=False, wait_for_complete=False):
@@ -817,9 +814,8 @@ async def get_group_file_json(request, group_id, file_name, pretty=False, wait_f
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
-    response = Data(data['data']['affected_items'])
 
-    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=data['data']['affected_items'], status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_group_file_xml(request, group_id, file_name, pretty=False, wait_for_complete=False):
@@ -907,9 +903,8 @@ async def insert_agent(request, pretty=False, wait_for_complete=False):
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
-    response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agent_no_group(request, pretty=False, wait_for_complete=False, offset=0, limit=database_limit,
@@ -1038,9 +1033,8 @@ async def get_agent_summary_status(request, pretty=False, wait_for_complete=Fals
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
-    response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_agent_summary_os(request, pretty=False, wait_for_complete=False):

--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -13,7 +13,7 @@ import wazuh.manager as manager
 import wazuh.stats as stats
 from api import configuration
 from api.encoder import dumps, prettify
-from api.models.base_model_ import Data, Body
+from api.models.base_model_ import Body
 from api.models.configuration import APIConfigurationModel
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deserialize_date
 from wazuh.core.cluster.control import get_system_nodes
@@ -133,9 +133,8 @@ async def get_status(request, pretty=False, wait_for_complete=False):
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
-    response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_config(request, pretty=False, wait_for_complete=False):

--- a/api/api/controllers/default_controller.py
+++ b/api/api/controllers/default_controller.py
@@ -9,7 +9,7 @@ import time
 from aiohttp import web
 from api.encoder import dumps, prettify
 from api.models.basic_info import BasicInfo
-from api.models.base_model_ import Data
+from wazuh.core.results import WazuhResult
 from wazuh.core.security import load_spec
 
 logger = logging.getLogger('wazuh')
@@ -33,6 +33,6 @@ async def default_info(pretty=False):
         'hostname': socket.gethostname(),
         'timestamp': timestamp
     }
-    response = Data(BasicInfo.from_dict(data))
+    response = WazuhResult({'data': BasicInfo.from_dict(data)})
 
     return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -13,7 +13,7 @@ import wazuh.stats as stats
 from api import configuration
 from api.api_exception import APIError
 from api.encoder import dumps, prettify
-from api.models.base_model_ import Data, Body
+from api.models.base_model_ import Body
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deserialize_date
 from wazuh.core import common
 from wazuh.core.cluster.dapi.dapi import DistributedAPI

--- a/api/api/controllers/overview_controller.py
+++ b/api/api/controllers/overview_controller.py
@@ -7,7 +7,6 @@ import logging
 from aiohttp import web
 
 from api.encoder import dumps, prettify
-from api.models.base_model_ import Data
 from api.util import raise_if_exc, remove_nones_to_dict
 from wazuh.agent import get_full_overview
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
@@ -33,6 +32,5 @@ async def get_overview_agents(request, pretty=False, wait_for_complete=False):
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
-    response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -11,7 +11,7 @@ from aiohttp import web
 from api.authentication import generate_token
 from api.configuration import default_security_configuration
 from api.encoder import dumps, prettify
-from api.models.base_model_ import Body, Data
+from api.models.base_model_ import Body
 from api.models.configuration import SecurityConfigurationModel
 from api.models.security import CreateUserModel, UpdateUserModel, RoleModel, PolicyModel, RuleModel
 from api.models.token_response import TokenResponseModel
@@ -68,8 +68,7 @@ async def login_user(request, user: str, raw=False):
     if raw:
         return web.Response(text=token, content_type='text/plain', status=200)
     else:
-        response = Data(TokenResponseModel(token=token))
-        return web.json_response(data=response, status=200, dumps=dumps)
+        return web.json_response(data=WazuhResult({'data': TokenResponseModel(token=token)}), status=200, dumps=dumps)
 
 
 async def get_user_me(request, pretty=False, wait_for_complete=False):
@@ -975,8 +974,8 @@ async def get_rbac_resources(resource: str = None, pretty: bool = False):
                           logger=logger
                           )
     data = raise_if_exc(await dapi.distribute_function())
-    response = Data(data)
-    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
+
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_rbac_actions(pretty: bool = False, endpoint: str = None):
@@ -1004,9 +1003,8 @@ async def get_rbac_actions(pretty: bool = False, endpoint: str = None):
                           logger=logger
                           )
     data = raise_if_exc(await dapi.distribute_function())
-    response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def revoke_all_tokens(request, pretty: bool = False):
@@ -1067,9 +1065,8 @@ async def get_security_config(request, pretty=False, wait_for_complete=False):
                           rbac_permissions=request['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
-    response = Data(data)
 
-    return web.json_response(data=response, status=200, dumps=prettify if pretty else dumps)
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def security_revoke_tokens():

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -65,7 +65,7 @@ def get_agents_summary_status(agent_list=None):
     :param agent_list: List of agents ID's.
     :return: WazuhResult.
     """
-    result = WazuhResult({'data': {'active': 0, 'disconnected': 0, 'never_connected': 0, 'pending': 0, 'total': 0}})
+    summary = {'active': 0, 'disconnected': 0, 'never_connected': 0, 'pending': 0, 'total': 0}
     if len(agent_list) != 0:
         rbac_filters = get_rbac_filters(system_resources=get_agents_info(), permitted_resources=agent_list)
 
@@ -73,10 +73,10 @@ def get_agents_summary_status(agent_list=None):
         data = db_query.run()
 
         for agent in data['items']:
-            result['data'][agent['status']] += 1
-            result['data']['total'] += 1
+            summary[agent['status']] += 1
+            summary['total'] += 1
 
-    return result
+    return WazuhResult({'data': summary})
 
 
 @expose_resources(actions=["agent:read"], resources=["agent:id:{agent_list}"], post_proc_func=None)
@@ -862,7 +862,7 @@ def get_full_overview() -> WazuhResult:
     except IndexError:  # an IndexError could happen if there are not registered agents
         last_registered_agent = []
     # combine results in an unique dictionary
-    result = {'data': {'nodes': stats_distinct_node, 'groups': groups, 'agent_os': stats_distinct_os, 'agent_status': summary,
-              'agent_version': stats_version, 'last_registered_agent': last_registered_agent}}
+    result = {'nodes': stats_distinct_node, 'groups': groups, 'agent_os': stats_distinct_os, 'agent_status': summary,
+              'agent_version': stats_version, 'last_registered_agent': last_registered_agent}
 
-    return WazuhResult(result)
+    return WazuhResult({'data': result})

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -65,7 +65,7 @@ def get_agents_summary_status(agent_list=None):
     :param agent_list: List of agents ID's.
     :return: WazuhResult.
     """
-    result = WazuhResult({'active': 0, 'disconnected': 0, 'never_connected': 0, 'pending': 0, 'total': 0})
+    result = WazuhResult({'data': {'active': 0, 'disconnected': 0, 'never_connected': 0, 'pending': 0, 'total': 0}})
     if len(agent_list) != 0:
         rbac_filters = get_rbac_filters(system_resources=get_agents_info(), permitted_resources=agent_list)
 
@@ -73,8 +73,8 @@ def get_agents_summary_status(agent_list=None):
         data = db_query.run()
 
         for agent in data['items']:
-            result[agent['status']] += 1
-            result['total'] += 1
+            result['data'][agent['status']] += 1
+            result['data']['total'] += 1
 
     return result
 
@@ -314,7 +314,7 @@ def add_agent(name=None, agent_id=None, key=None, ip='any', force_time=-1, use_o
 
     new_agent = Agent(name=name, ip=ip, id=agent_id, key=key, force=force_time, use_only_authd=use_only_authd)
 
-    return WazuhResult({'id': new_agent.id, 'key': new_agent.key})
+    return WazuhResult({'data': {'id': new_agent.id, 'key': new_agent.key}})
 
 
 @expose_resources(actions=["group:read"], resources=["group:id:{group_list}"],
@@ -745,7 +745,7 @@ def get_agent_config(agent_list=None, component=None, config=None):
     if my_agent.status != "active":
         raise WazuhError(1740)
 
-    return WazuhResult(my_agent.getconfig(component=component, config=config))
+    return WazuhResult({'data': my_agent.getconfig(component=component, config=config)})
 
 
 @expose_resources(actions=["agent:read"], resources=["agent:id:{agent_list}"],
@@ -823,7 +823,8 @@ def get_agent_conf(group_list=None, filename='agent.conf', offset=0, limit=commo
     # a list of groups
     group_id = group_list[0]
 
-    return WazuhResult(configuration.get_agent_conf(group_id=group_id, filename=filename, offset=offset, limit=limit))
+    return WazuhResult(
+        {'data': configuration.get_agent_conf(group_id=group_id, filename=filename, offset=offset, limit=limit)})
 
 
 @expose_resources(actions=["group:update_config"], resources=["group:id:{group_list}"], post_proc_func=None)
@@ -861,7 +862,7 @@ def get_full_overview() -> WazuhResult:
     except IndexError:  # an IndexError could happen if there are not registered agents
         last_registered_agent = []
     # combine results in an unique dictionary
-    result = {'nodes': stats_distinct_node, 'groups': groups, 'agent_os': stats_distinct_os, 'agent_status': summary,
-              'agent_version': stats_version, 'last_registered_agent': last_registered_agent}
+    result = {'data': {'nodes': stats_distinct_node, 'groups': groups, 'agent_os': stats_distinct_os, 'agent_status': summary,
+              'agent_version': stats_version, 'last_registered_agent': last_registered_agent}}
 
     return WazuhResult(result)

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -57,7 +57,7 @@ def get_status_json():
 
     :return: Dictionary with the cluster status.
     """
-    return get_cluster_status()
+    return {'data': get_cluster_status(), 'error': 0}
 
 
 @expose_resources(actions=['cluster:read'], resources=['node:id:{filter_node}'], post_proc_func=async_list_handler)

--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -7,7 +7,7 @@ from wazuh.core.cluster.cluster import get_node
 from wazuh.core.cluster.control import get_health, get_nodes
 from wazuh.core.cluster.utils import get_cluster_status, read_cluster_config, read_config
 from wazuh.core.exception import WazuhError, WazuhResourceNotFound
-from wazuh.core.results import AffectedItemsWazuhResult
+from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.rbac.decorators import expose_resources, async_list_handler
 
 cluster_enabled = not read_cluster_config()['disabled']
@@ -57,7 +57,7 @@ def get_status_json():
 
     :return: Dictionary with the cluster status.
     """
-    return {'data': get_cluster_status(), 'error': 0}
+    return WazuhResult({'data': get_cluster_status()})
 
 
 @expose_resources(actions=['cluster:read'], resources=['node:id:{filter_node}'], post_proc_func=async_list_handler)

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -961,7 +961,7 @@ def get_rbac_actions(endpoint: str = None):
 @expose_resources(actions=['security:read_config'], resources=['*:*:*'])
 def get_security_config():
     """Returns current security configuration."""
-    return {'data': configuration.security_conf }
+    return WazuhResult({'data': configuration.security_conf})
 
 
 @expose_resources(actions=['security:update_config'], resources=['*:*:*'])

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -911,11 +911,11 @@ def get_rbac_resources(resource: str = None):
         RBAC resources
     """
     if not resource:
-        return WazuhResult(load_spec()['x-rbac-catalog']['resources'])
+        return WazuhResult({'data': load_spec()['x-rbac-catalog']['resources']})
     else:
         if resource not in load_spec()['x-rbac-catalog']['resources'].keys():
             raise WazuhError(4019)
-        return WazuhResult({resource: load_spec()['x-rbac-catalog']['resources'][resource]})
+        return WazuhResult({'data': {resource: load_spec()['x-rbac-catalog']['resources'][resource]}})
 
 
 @lru_cache(maxsize=None)
@@ -955,13 +955,13 @@ def get_rbac_actions(endpoint: str = None):
             except KeyError:
                 pass
 
-    return WazuhResult(data)
+    return WazuhResult({'data': data})
 
 
 @expose_resources(actions=['security:read_config'], resources=['*:*:*'])
 def get_security_config():
     """Returns current security configuration."""
-    return configuration.security_conf
+    return {'data': configuration.security_conf }
 
 
 @expose_resources(actions=['security:update_config'], resources=['*:*:*'])

--- a/framework/wazuh/tests/test_cluster.py
+++ b/framework/wazuh/tests/test_cluster.py
@@ -20,6 +20,7 @@ with patch('wazuh.common.ossec_uid'):
         from wazuh import cluster
         from wazuh.core.exception import WazuhError, WazuhResourceNotFound
         from wazuh.core.cluster.local_client import LocalClient
+        from wazuh.core.results import WazuhResult
 
 default_config = {'disabled': True, 'node_type': 'master', 'name': 'wazuh', 'node_name': 'node01',
                   'key': '', 'port': 1516, 'bind_addr': '0.0.0.0', 'nodes': ['NODE_IP'], 'hidden': 'no'}
@@ -58,7 +59,7 @@ def test_node_wrapper_exception(mock_get_node):
 def test_get_status_json():
     """Verify that get_status_json returns the default status information."""
     result = cluster.get_status_json()
-    expected = {"enabled": "no" if default_config['disabled'] else "yes", "running": "no"}
+    expected = WazuhResult({'data': {"enabled": "no" if default_config['disabled'] else "yes", "running": "no"}})
     assert result == expected
 
 


### PR DESCRIPTION
Hello team,

This PR updates the API endpoints to avoid having the newly-added `error` field inside the `data` field, if present.

Here are the list of affected endpoints and an example of their response after this fix:

**POST /agents**
```
{
  "data": {
    "id": "001",
    "key": "MDAxIENhcmxvcyAxMC4wLjAuOSAxMzViNmRjZWJiOTQ5NzM1YjVlOGI1OGQwZGMwNTRlY2VmYWM3ODhhMWYyOWQ1YTUxMTVjMDdjMTZmN2IwY2E5"
  },
  "error": 0
}
```

**GET  /agents/{agent_id}/config/{component}/{configuration}**
```
{
  "data": {
    "global": {
      "email_notification": "no",
      "logall": "no",
      "logall_json": "no",
      "integrity_checking": 8,
      "rootkit_detection": 8,
      "host_information": 8,
      "prelude_output": "no",
      "zeromq_output": "no",
      "jsonout_output": "yes",
      "alerts_log": "yes",
      "stats": 4,
      "memory_size": 8192,
      "white_list": [
        "127.0.0.1",
        "212.230.135.1",
        "212.230.135.2",
        "localhost.localdomain"
      ],
      "rotate_interval": 0,
      "max_output_size": 0
    }
  },
  "error": 0
}
```

**POST /agents/insert/quick**
```
{
  "data": {
    "id": "003",
    "key": "MDAzIHN0cmluZyBhbnkgNGFhYzBjZjNiZWRmOGE4MzAxOWE3ZDU0OTk2OWM1N2M1YzVlZmY4Yzk2MzEwMmUxOWY1MDUyNDEwZTU4NDViMg=="
  },
  "error": 0
}
```

**GET /groups/{group_id}/configuration**
```
{
  "data": {
    "total_affected_items": 1,
    "affected_items": [
      {
        "filters": {},
        "config": {}
      }
    ]
  },
  "error": 0
}
```

**GET /groups/{group_id}/files/{file_name}/json**
```
[
  {
    "filters": {},
    "config": {}
  }
]
```

**POST /agents/insert**
```
{
  "data": {
    "id": "123",
    "key": "MTIzIE5ld0hvc3RfMiAxMC4wLjEwLjExIDFhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5emFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpNjQ="
  },
  "error": 0
}
```

**GET /agents/summary/status**
```
{
  "data": {
    "active": 1,
    "disconnected": 0,
    "never_connected": 4,
    "pending": 0,
    "total": 5
  },
  "error": 0
}
```

**GET /cluster/status**
```
{
  "data": {
    "enabled": "yes",
    "running": "yes"
  },
  "error": 0
}
```

**GET /**
```
{
  "data": {
    "title": "Wazuh API REST",
    "api_version": "4.0.0",
    "revision": 4000,
    "license_name": "GPL 2.0",
    "license_url": "https://github.com/wazuh/wazuh/blob/master/LICENSE",
    "hostname": "wazuh-master",
    "timestamp": "2020-10-07T08:32:11+0000"
  },
  "error": 0
}
```

**GET /overview/agents**
```
{
  "data": {
    "nodes": [
      {
        "count": 1,
        "node_name": "master-node"
      },
      {
        "count": 4,
        "node_name": "unknown"
      }
    ],
    "groups": [
      {
        "name": "default",
        "count": 0,
        "mergedSum": "fd756ba04d9c32c8848d4608bec41251",
        "configSum": "ab73af41699f13fdd81903b5f23d8d00"
      }
    ],
    "agent_os": [
      {
        "os": {
          "name": "Ubuntu",
          "platform": "ubuntu",
          "version": "18.04.5 LTS"
        },
        "count": 1
      },
      {
        "os": {
          "name": "unknown",
          "platform": "unknown",
          "version": "unknown"
        },
        "count": 4
      }
    ],
    "agent_status": {
      "data": {
        "active": 1,
        "disconnected": 0,
        "never_connected": 4,
        "pending": 0,
        "total": 5
      },
      "error": 0
    },
    "agent_version": [
      {
        "count": 1,
        "version": "Wazuh v4.0.0"
      },
      {
        "count": 4,
        "version": "unknown"
      }
    ],
    "last_registered_agent": [
      {
        "status": "never_connected",
        "dateAdd": "2020-10-07T08:21:22Z",
        "name": "NewHost_2",
        "registerIP": "10.0.10.11",
        "id": "123",
        "node_name": "unknown",
        "ip": "10.0.10.11"
      }
    ]
  },
  "error": 0
}
```

**GET /security/user/authenticate**
```
{
  "data": {
    "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjAyMDYxMDY4LCJleHAiOjE2MDIwNjQ2NjgsInN1YiI6IndhenVoIiwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.f_GmCHcPNCT2HP4vXJzLT5h9BXTcT7zauVn0gwBQaIU"
  },
  "error": 0
}
```

**GET /security/resources**
```
{
  "data": {
    "*:*": {
      "description": "Resource applied in functions which take part in the creation of a specific resource. We call these functions, resourceless functions. Example: agent:create"
    },
    "agent:id": {
      "description": "Reference agents via agent ID (i.e. agent:id:001)"
    },
    "group:id": {
      "description": "Reference agent groups via group ID (i.e. group:id:default)"
    },
    "node:id": {
      "description": "Reference cluster nodes via node ID (i.e. node:id:worker1)"
    },
    "file:path": {
      "description": "Reference files via its path (i.e. file:path:etc/rules/new_rule.xml)"
    },
    "decoder:file": {
      "description": "Reference decoder files via its path (i.e. decoder:file:0005-wazuh_decoders.xml)"
    },
    "list:path": {
      "description": "Reference list files via its path (i.e. list:path:etc/lists/audit-keys)"
    },
    "rule:file": {
      "description": "Reference rule files via its path (i.e. rule:file:0610-win-ms_logs_rules.xml)"
    },
    "policy:id": {
      "description": "Reference security policies via its id (i.e. policy:id:1)"
    },
    "role:id": {
      "description": "Reference security roles via its id (i.e. role:id:1)"
    },
    "user:id": {
      "description": "Reference security users via its id (i.e. user:id:1)"
    },
    "rule:id": {
      "description": "Reference security rules via its id (i.e. rule:id:1)"
    }
  },
  "error": 0
}
```

GET /security/actions**
```
{
  "data": {
    "active-response:command": {
      "description": "Allow to execute active response commands in the agents",
      "resources": [
        "agent:id"
      ],
      "example": {
        "actions": [
          "active-response:command"
        ],
        "resources": [
          "agent:id:001"
        ],
        "effect": "allow"
      },
      "related_endpoints": [
        "PUT /active-response"
      ]
    },
    
    · · ·

    "security:update_config": {
      "description": "Update current security configuration",
      "resources": [
        "*:*"
      ],
      "example": {
        "actions": [
          "security:update_config"
        ],
        "resources": [
          "*:*:*"
        ],
        "effect": "allow"
      },
      "related_endpoints": [
        "PUT /security/config",
        "DELETE /security/config"
      ]
    }
  },
  "error": 0
}
```

**GET /security/config**
```
{
  "data": {
    "auth_token_exp_timeout": 3600,
    "rbac_mode": "white"
  },
  "error": 0
}
```