### PR TITLE
[6235] Adding dbsync and rsync in server target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -635,6 +635,7 @@ ifeq (${MAKECMDGOALS},server)
 $(error Do not use 'server' directly, use 'TARGET=server')
 endif
 server: external
+	${MAKE} build_syscollector
 	${MAKE} ${BUILD_SERVER}
 
 ifeq (${MAKECMDGOALS},local)
@@ -1707,11 +1708,7 @@ wmodulesd_c := wazuh_modules/main.c
 wmodulesd_o := $(wmodulesd_c:.c=.o)
 
 wazuh-modulesd: ${wmodulesd_o} ${syscollector_o}
-ifeq (${TARGET}, agent)
 	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${SHARED_MODULES_LDFLAGS} -o $@
-else
-	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
-endif
 
 ### wazuh-framework ##
 ifneq (,$(filter ${USE_FRAMEWORK_LIB},YES yes y Y 1))


### PR DESCRIPTION
|Related issue|
|---|
|[6235](https://github.com/wazuh/wazuh/issues/6235)|

## Description

This issue suggests that we incorporate DBSync and RSync into the manager's compilation steps, since syscollector is part of the Wazuh server compilation.

## DoD
- [X] Modify Makefile steps
- [X] Test manager compilation in Debian/Ubuntu, CentOS -> CI pipeline will inform this from different OSes

- **Local compilation with** `-j4` **option:**
![image](https://user-images.githubusercontent.com/22640902/95462203-9745d500-094d-11eb-95dd-a71d4b88e6fa.png)
