### PR TITLE
Fix agent_groups framework script - NoneType  Error

### DIFF
--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -11,6 +11,7 @@ from signal import signal, SIGINT
 from sys import exit, argv
 
 from wazuh import agent
+from wazuh.agent import remove_agent_from_groups
 from wazuh.core import agent as core_agent
 from wazuh.core.cluster.utils import read_config
 from wazuh.core.exception import WazuhError
@@ -98,7 +99,14 @@ def unset_group(agent_id, group_id=None, quiet=False):
         ans = 'y'
 
     if ans.lower() == 'y':
-        msg = core_agent.Agent.unset_single_group_agent(agent_id, group_id)
+        if group_id:
+            msg = core_agent.Agent.unset_single_group_agent(agent_id, group_id)
+        else:
+            groups_agent_removed = remove_agent_from_groups(agent_list=[agent_id])._affected_items
+            if len(groups_agent_removed) == 0:
+                msg = f"Agent '{agent_id}' is only assigned to group default."
+            else:
+                msg = f"Agent '{agent_id}' removed from '{', '.join(groups_agent_removed)}'. Agent reassigned to group default."
     else:
         msg = "Cancelled."
 
@@ -162,7 +170,7 @@ def create_group(group_id, quiet=False):
 
 def usage():
     msg = """
-    {0} [ -l [ -g group_id ] | -c -g group_id | -a (-i agent_id -g groupd_id | -g group_id) [-q] [-f] | -s -i agent_id | -S -i agent_id | -r (-g group_id | -i agent_id) [-q] | -ap -i agent_id -g group_id [-q] ]
+    {0} [ -l [ -g group_id ] | -c -g group_id | -a (-i agent_id -g groupd_id | -g group_id) [-q] [-f] | -s -i agent_id | -S -i agent_id | -r (-g group_id | -i agent_id) [-q] ]
 
     Usage:
     \t-l                                    # List all groups


### PR DESCRIPTION
|Related issue|
|---|
| #6226 |

Hi team,

This PR is related to the issue #6226 . I have fixed the `agent_groups.py` framework script. As reported in the issue, there was an error when trying to remove all groups of an agent when using `-r` parameter with the `id` and without a specific group (NoneType() error).

For instance, `/var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_groups.py -r -i 001` should remove all groups but `default` of the agent with id 001. With the fixes it is working as expected.

**Minor change:** deleted -ap parameter when showing usage of the script. Unused parameter.

- Example of adding 001 to groups 1,2 and 3 and then using this command:

```
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_groups.py -a -i 001 -g group1
Do you want to add the group 'group1' to the agent '001'? [y/N]: y
Group 'group1' added to agent '001'.

root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_groups.py -a -i 001 -g group2 -q
Group 'group2' added to agent '001'.

root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_groups.py -a -i 001 -g group3 -q
Group 'group3' added to agent '001'.

root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_groups.py -r -i 001             
Do you want to delete all groups of agent '001'? [y/N]: y
Agent '001' removed from 'group1, group2, group3'. Agent reassigned to group default.

root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_groups.py -r -i 001
Do you want to delete all groups of agent '001'? [y/N]: y
Agent '001' is only assigned to group default.
```

Regards, 
Manuel.