### PR TITLE
Disable response checking strict

### DIFF
--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -125,7 +125,7 @@ def start(foreground, root, config_file):
                            'port': api_conf['port']
                            },
                 strict_validation=True,
-                validate_responses=True,
+                validate_responses=False,
                 pass_context_arg_name='request',
                 options={"middlewares": [response_postprocessing, set_user_name, security_middleware]})
 

--- a/api/test/integration/env/base/manager/entrypoint.sh
+++ b/api/test/integration/env/base/manager/entrypoint.sh
@@ -6,6 +6,7 @@
 sed -i "s:<key>key</key>:<key>9d273b53510fef702b54a92e9cffc82e</key>:g" /var/ossec/etc/ossec.conf
 sed -i "s:<node>NODE_IP</node>:<node>$1</node>:g" /var/ossec/etc/ossec.conf
 sed -i "s:<node_name>node01</node_name>:<node_name>$2</node_name>:g" /var/ossec/etc/ossec.conf
+sed -i "s:validate_responses=False:validate_responses=True:g" /var/ossec/api/scripts/wazuh-apid.py
 
 if [ "$3" != "master" ]; then
     sed -i "s:<node_type>master</node_type>:<node_type>worker</node_type>:g" /var/ossec/etc/ossec.conf


### PR DESCRIPTION
Hello team,

This PR closes #6228. It disables strict validation for production and adds it to test environments.

Regards,

David J. Iglesias