### PR TITLE
[RBAC] - Update position values when removing role-policy relationships

### DIFF
--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -1810,11 +1810,23 @@ class RolesPoliciesManager:
                 policy = self.session.query(Policies).filter_by(id=policy_id).first()
                 if policy is None:
                     return SecurityError.POLICY_NOT_EXIST
-                if self.session.query(RolesPolicies).filter_by(role_id=role_id,
-                                                               policy_id=policy_id).first() is not None:
+
+                role_policy = self.session.query(RolesPolicies).filter_by(role_id=role_id,
+                                                                          policy_id=policy_id).first()
+
+                if role_policy is not None:
                     role = self.session.query(Roles).get(role_id)
                     policy = self.session.query(Policies).get(policy_id)
                     role.policies.remove(policy)
+
+                    # Update position value
+                    relationships_to_update = [row for row in self.session.query(
+                        RolesPolicies).filter(RolesPolicies.role_id == role_id, RolesPolicies.level >= role_policy.level
+                                              )]
+
+                    for relation in relationships_to_update:
+                        relation.level -= 1
+
                     self.session.commit()
                     return True
                 else:


### PR DESCRIPTION
Hello team, this closes #6247 .

As it was reported in the issue, the ORM was not updating the `position` value of the affected entries when removing a relationship between role and policy. It is now fixed and working properly:

### Status before
```sql
sqlite> select * from roles_policies where role_id=100;
48|100|100|0|2020-10-09 08:04:27.927098
51|100|101|1|2020-10-09 08:04:27.927098
50|100|102|3|2020-10-09 08:04:27.927098
49|100|103|2|2020-10-09 08:04:27.927098

```

### Status after removing relationship between role 100 and policy 101
```sql
sqlite> select * from roles_policies where role_id=100;
48|100|100|0|2020-10-09 08:04:27.927098
50|100|102|2|2020-10-09 08:04:27.927098
49|100|103|1|2020-10-09 08:04:27.927098
```

## Tests results
### Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0
collected 53 items                                                                                                                                                                          

wazuh/rbac/tests/test_orm.py .....................................................                                                                                                    [100%]

==================================================================================== 53 passed in 42.41s ====================================================================================

```

Regards,
Víctor.