### PR TITLE
[API] Improve API response post-processing

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -518,7 +518,7 @@ components:
           example:
             title: "Resource Not Found"
             detail: "The group does not exist"
-            remediation: "Please, use `GET /agents/groups` to find all available groups://documentation.wazuh.com/current/user-manual/api/rbac/configuration.html"
+            remediation: "Please, use `GET /groups` to find all available groups://documentation.wazuh.com/current/user-manual/api/rbac/configuration.html"
             code: 1710
             dapi_errors:
               unknown-node:


### PR DESCRIPTION
Hello team,

This PR updates the api response postprocessing middleware to ensure HTTP `4xx` responses have the `type` and `status` fields removed.

Before the fix:
```
{
  "type": "about:blank",
  "title": "Unauthorized",
  "detail": "The server could not verify that you are authorized to access the URL requested. You either supplied the wrong credentials (e.g. a bad password), or your browser doesn't understand how to supply the credentials required.",
  "status": 401
}
```

After the fix:
```
{
  "title": "Unauthorized",
  "detail": "The server could not verify that you are authorized to access the URL requested. You either supplied the wrong credentials (e.g. a bad password), or your browser doesn't understand how to supply the credentials required.",
}
```