### PR TITLE
Remove custom wpk from tests

### DIFF
--- a/api/test/integration/env/configurations/agents/manager/agents_config.sh
+++ b/api/test/integration/env/configurations/agents/manager/agents_config.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-cp -f configuration_files/test_custom_upgrade_3.12.2.wpk /var/ossec/test_custom_upgrade_3.12.2.wpk
+wget https://packages.wazuh.com/wpk/linux/x86_64/wazuh_agent_v3.12.2_linux_x86_64.wpk
+mv ./wazuh_agent_v3.12.2_linux_x86_64.wpk /var/ossec/test_custom_upgrade_3.12.2.wpk


### PR DESCRIPTION
Hello team,

This PR removes a large wpk binary file from the repository and instead downloads it inside the docker container when testing.

Best regards,

David J. Iglesias