### PR TITLE
Allow negation in rules

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1083,7 +1083,8 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             return (NULL);
         }
 
-        if (strcmp(rule->action->string, lf->action) != 0) {
+        bool diff_act = strcmp(rule->action->string, lf->action) ? true : false;
+        if (diff_act != rule->action->negate) {
             return (NULL);
         }
     }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1071,8 +1071,8 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
 
     /* Check if exist any regex for this rule */
     if (rule->regex) {
-        const char *result = OSRegex_Execute_ex(lf->log, rule->regex->regex, rule_match);
-        if ((result && rule->regex->negate) || (!result && !rule->regex->negate)) {
+        bool matches = OSRegex_Execute_ex(lf->log, rule->regex->regex, rule_match) ? true : false;
+        if (matches == rule->regex->negate) {
             return NULL;
         }
     }
@@ -1118,8 +1118,8 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             return NULL;
         }
 
-        const char * result = OSRegex_Execute_ex(field, rule->fields[i]->regex, rule_match);
-        if ((result && rule->fields[i]->negate) || (!result && !rule->fields[i]->negate)) {
+        bool matches = OSRegex_Execute_ex(field, rule->fields[i]->regex, rule_match) ? true : false;
+        if (matches == rule->fields[i]->negate) {
             return NULL;
         }
     }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1023,9 +1023,8 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             return (NULL);
         }
 
-        if (!OSMatch_Execute(lf->program_name,
-                             lf->p_name_size,
-                             rule->program_name)) {
+        if (OSMatch_Execute(lf->program_name, lf->p_name_size, rule->program_name->match)
+            == rule->program_name->negate) {
             return (NULL);
         }
     }
@@ -1036,9 +1035,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             return (NULL);
         }
 
-        if (!OSMatch_Execute(lf->id,
-                             strlen(lf->id),
-                             rule->id)) {
+        if (OSMatch_Execute(lf->id, strlen(lf->id), rule->id->match) == rule->id->negate) {
             return (NULL);
         }
     }
@@ -1049,7 +1046,8 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             return (NULL);
         }
 
-        if (!OSMatch_Execute(lf->systemname, strlen(lf->systemname), rule->system_name)) {
+        if (OSMatch_Execute(lf->systemname, strlen(lf->systemname), rule->system_name->match)
+            == rule->system_name->negate) {
             return (NULL);
         }
     }
@@ -1059,22 +1057,23 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
         if (!lf->protocol) {
             return (NULL);
         }
-        if (!OSMatch_Execute(lf->protocol, strlen(lf->protocol), rule->protocol)) {
+        if (OSMatch_Execute(lf->protocol, strlen(lf->protocol), rule->protocol->match) == rule->protocol->negate) {
             return (NULL);
         }
     }
 
     /* Check if any word to match exists */
     if (rule->match) {
-        if (!OSMatch_Execute(lf->log, lf->size, rule->match)) {
+        if (OSMatch_Execute(lf->log, lf->size, rule->match->match) == rule->match->negate) {
             return (NULL);
         }
     }
 
     /* Check if exist any regex for this rule */
     if (rule->regex) {
-        if (!OSRegex_Execute_ex(lf->log, rule->regex, rule_match)) {
-            return (NULL);
+        const char *result = OSRegex_Execute_ex(lf->log, rule->regex->regex, rule_match);
+        if ((result && rule->regex->negate) || (!result && !rule->regex->negate)) {
+            return NULL;
         }
     }
 
@@ -1084,7 +1083,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             return (NULL);
         }
 
-        if (strcmp(rule->action, lf->action) != 0) {
+        if (strcmp(rule->action->string, lf->action) != 0) {
             return (NULL);
         }
     }
@@ -1095,7 +1094,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             return (NULL);
         }
 
-        if (!OSMatch_Execute(lf->url, strlen(lf->url), rule->url)) {
+        if (OSMatch_Execute(lf->url, strlen(lf->url), rule->url->match) == rule->url->negate) {
             return (NULL);
         }
     }
@@ -1106,17 +1105,20 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             return (NULL);
         }
 
-        if (!OSMatch_Execute(lf->location, strlen(lf->location), rule->location)) {
+        if (OSMatch_Execute(lf->location, strlen(lf->location), rule->location->match) == rule->location->negate) {
             return (NULL);
         }
     }
 
     /* Check for dynamic fields */
-
     for (i = 0; i < Config.decoder_order_size && rule->fields[i]; i++) {
-        field = FindField(lf, rule->fields[i]->name);
 
-        if (!(field && OSRegex_Execute_ex(field, rule->fields[i]->regex, rule_match))) {
+        if (field = FindField(lf, rule->fields[i]->name), !field) {
+            return NULL;
+        }
+
+        const char * result = OSRegex_Execute_ex(field, rule->fields[i]->regex, rule_match);
+        if ((result && rule->fields[i]->negate) || (!result && !rule->fields[i]->negate)) {
             return NULL;
         }
     }
@@ -1129,7 +1131,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                 return (NULL);
             }
 
-            if (!OS_IPFoundList(lf->srcip, rule->srcip)) {
+            if (OS_IPFoundList(lf->srcip, rule->srcip->ips) == rule->srcip->negate) {
                 return (NULL);
             }
         }
@@ -1140,7 +1142,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                 return (NULL);
             }
 
-            if (!OS_IPFoundList(lf->dstip, rule->dstip)) {
+            if (OS_IPFoundList(lf->dstip, rule->dstip->ips) == rule->dstip->negate) {
                 return (NULL);
             }
         }
@@ -1150,9 +1152,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                 return (NULL);
             }
 
-            if (!OSMatch_Execute(lf->srcport,
-                                 strlen(lf->srcport),
-                                 rule->srcport)) {
+            if (OSMatch_Execute(lf->srcport, strlen(lf->srcport), rule->srcport->match) == rule->srcport->negate) {
                 return (NULL);
             }
         }
@@ -1161,9 +1161,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                 return (NULL);
             }
 
-            if (!OSMatch_Execute(lf->dstport,
-                                 strlen(lf->dstport),
-                                 rule->dstport)) {
+            if (OSMatch_Execute(lf->dstport, strlen(lf->dstport), rule->dstport->match) == rule->dstport->negate) {
                 return (NULL);
             }
         }
@@ -1181,15 +1179,11 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
         /* Checking if exist any user to match */
         if (rule->user) {
             if (lf->dstuser) {
-                if (!OSMatch_Execute(lf->dstuser,
-                                     strlen(lf->dstuser),
-                                     rule->user)) {
+                if (OSMatch_Execute(lf->dstuser, strlen(lf->dstuser), rule->user->match) == rule->user->negate) {
                     return (NULL);
                 }
             } else if (lf->srcuser) {
-                if (!OSMatch_Execute(lf->srcuser,
-                                     strlen(lf->srcuser),
-                                     rule->user)) {
+                if (OSMatch_Execute(lf->srcuser, strlen(lf->srcuser), rule->user->match) == rule->user->negate) {
                     return (NULL);
                 }
             } else {
@@ -1200,25 +1194,23 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
 
         /* Adding checks for geoip. */
         if(rule->srcgeoip) {
-            if(lf->srcgeoip) {
-                if(!OSMatch_Execute(lf->srcgeoip,
-                            strlen(lf->srcgeoip),
-                            rule->srcgeoip))
-                    return(NULL);
-            } else {
-                return(NULL);
+            if (!lf->srcgeoip) {
+                return NULL;
+            }
+
+            if (OSMatch_Execute(lf->srcgeoip, strlen(lf->srcgeoip), rule->srcgeoip->match) == rule->srcgeoip->negate) {
+                return NULL;
             }
         }
 
 
         if(rule->dstgeoip) {
-            if(lf->dstgeoip) {
-                if(!OSMatch_Execute(lf->dstgeoip,
-                            strlen(lf->dstgeoip),
-                            rule->dstgeoip))
-                    return(NULL);
-            } else {
-                return(NULL);
+            if (!lf->dstgeoip) {
+                return NULL;
+            }
+
+            if (OSMatch_Execute(lf->dstgeoip, strlen(lf->dstgeoip), rule->dstgeoip->match) == rule->dstgeoip->negate) {
+                return NULL;
             }
         }
 
@@ -1249,7 +1241,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
             if (!lf->data) {
                 return (NULL);
             }
-            if (!OSMatch_Execute(lf->data, strlen(lf->data), rule->data)) {
+            if (OSMatch_Execute(lf->data, strlen(lf->data), rule->data->match) == rule->data->negate) {
                 return (NULL);
             }
         }
@@ -1260,9 +1252,8 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                 return(NULL);
             }
 
-            if (!OSMatch_Execute(lf->extra_data,
-                                 strlen(lf->extra_data),
-                                 rule->extra_data)) {
+            if (OSMatch_Execute(lf->extra_data, strlen(lf->extra_data), rule->extra_data->match)
+                == rule->extra_data->negate) {
                 return (NULL);
             }
         }
@@ -1273,9 +1264,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                 return (NULL);
             }
 
-            if (!OSMatch_Execute(lf->hostname,
-                                 strlen(lf->hostname),
-                                 rule->hostname)) {
+            if (OSMatch_Execute(lf->hostname, strlen(lf->hostname), rule->hostname->match) == rule->hostname->negate) {
                 return (NULL);
             }
         }
@@ -1286,9 +1275,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node, regex_matching
                 return (NULL);
             }
 
-            if (!OSMatch_Execute(lf->status,
-                                 strlen(lf->status),
-                                 rule->status)) {
+            if (OSMatch_Execute(lf->status, strlen(lf->status), rule->status->match) == rule->status->negate) {
                 return (NULL);
             }
         }

--- a/src/analysisd/config_json.c
+++ b/src/analysisd/config_json.c
@@ -236,23 +236,132 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
         cJSON_AddNumberToObject(rule,"if_matched_sid",node->ruleinfo->if_matched_sid);
 
         if (node->ruleinfo->group) cJSON_AddStringToObject(rule,"group",node->ruleinfo->group);
-        if (node->ruleinfo->regex) cJSON_AddStringToObject(rule,"regex",node->ruleinfo->regex->regex->raw);
-        if (node->ruleinfo->match) cJSON_AddStringToObject(rule,"match",node->ruleinfo->match->match->raw);
-        if (node->ruleinfo->srcgeoip) cJSON_AddStringToObject(rule,"srcgeoip",node->ruleinfo->srcgeoip->match->raw);
-        if (node->ruleinfo->dstgeoip) cJSON_AddStringToObject(rule,"dstgeoip",node->ruleinfo->dstgeoip->match->raw);
-        if (node->ruleinfo->srcport) cJSON_AddStringToObject(rule,"srcport",node->ruleinfo->srcport->match->raw);
-        if (node->ruleinfo->dstport) cJSON_AddStringToObject(rule,"dstport",node->ruleinfo->dstport->match->raw);
-        if (node->ruleinfo->user) cJSON_AddStringToObject(rule,"user",node->ruleinfo->user->match->raw);
-        if (node->ruleinfo->url) cJSON_AddStringToObject(rule,"url",node->ruleinfo->url->match->raw);
-        if (node->ruleinfo->id) cJSON_AddStringToObject(rule,"id",node->ruleinfo->id->match->raw);
-        if (node->ruleinfo->system_name) cJSON_AddStringToObject(rule,"system_name",node->ruleinfo->system_name->match->raw);
-        if (node->ruleinfo->protocol) cJSON_AddStringToObject(rule,"protocol",node->ruleinfo->protocol->match->raw);
-        if (node->ruleinfo->data) cJSON_AddStringToObject(rule, "data", node->ruleinfo->data->match->raw);
-        if (node->ruleinfo->status) cJSON_AddStringToObject(rule,"status",node->ruleinfo->status->match->raw);
-        if (node->ruleinfo->hostname) cJSON_AddStringToObject(rule,"hostname",node->ruleinfo->hostname->match->raw);
-        if (node->ruleinfo->program_name) cJSON_AddStringToObject(rule,"program_name",node->ruleinfo->program_name->match->raw);
-        if (node->ruleinfo->extra_data) cJSON_AddStringToObject(rule,"extra_data",node->ruleinfo->extra_data->match->raw);
-        if (node->ruleinfo->action) cJSON_AddStringToObject(rule,"action",node->ruleinfo->action->string);
+
+        if (node->ruleinfo->regex) {
+            cJSON * regex = cJSON_CreateObject();
+            cJSON_AddStringToObject(regex, "pattern", node->ruleinfo->regex->regex->raw);
+            cJSON_AddBoolToObject(regex, "negate", node->ruleinfo->regex->negate);
+            cJSON_AddItemToObject(rule, "regex", regex);
+        }
+
+        if (node->ruleinfo->match) {
+            cJSON * match = cJSON_CreateObject();
+            cJSON_AddStringToObject(match, "pattern", node->ruleinfo->match->match->raw);
+            cJSON_AddBoolToObject(match, "negate", node->ruleinfo->match->negate);
+            cJSON_AddItemToObject(rule, "match", match);
+        }
+
+        if (node->ruleinfo->srcgeoip) {
+            cJSON * srcgeoip = cJSON_CreateObject();
+            cJSON_AddStringToObject(srcgeoip, "pattern", node->ruleinfo->srcgeoip->match->raw);
+            cJSON_AddBoolToObject(srcgeoip, "negate", node->ruleinfo->srcgeoip->negate);
+            cJSON_AddItemToObject(rule, "srcgeoip", srcgeoip);
+        }
+
+        if (node->ruleinfo->dstgeoip) {
+            cJSON * dstgeoip = cJSON_CreateObject();
+            cJSON_AddStringToObject(dstgeoip, "pattern", node->ruleinfo->dstgeoip->match->raw);
+            cJSON_AddBoolToObject(dstgeoip, "negate", node->ruleinfo->dstgeoip->negate);
+            cJSON_AddItemToObject(rule, "dstgeoip", dstgeoip);
+        }
+
+        if (node->ruleinfo->srcport) {
+            cJSON * srcport = cJSON_CreateObject();
+            cJSON_AddStringToObject(srcport, "pattern", node->ruleinfo->srcport->match->raw);
+            cJSON_AddBoolToObject(srcport, "negate", node->ruleinfo->srcport->negate);
+            cJSON_AddItemToObject(rule, "srcport", srcport);
+        }
+
+        if (node->ruleinfo->dstport) {
+            cJSON * dstport = cJSON_CreateObject();
+            cJSON_AddStringToObject(dstport, "pattern", node->ruleinfo->dstport->match->raw);
+            cJSON_AddBoolToObject(dstport, "negate", node->ruleinfo->dstport->negate);
+            cJSON_AddItemToObject(rule, "dstport", dstport);
+        }
+
+        if (node->ruleinfo->user) {
+            cJSON * user = cJSON_CreateObject();
+            cJSON_AddStringToObject(user, "pattern", node->ruleinfo->user->match->raw);
+            cJSON_AddBoolToObject(user, "negate", node->ruleinfo->user->negate);
+            cJSON_AddItemToObject(rule, "user", user);
+        }
+
+        if (node->ruleinfo->url) {
+            cJSON * url = cJSON_CreateObject();
+            cJSON_AddStringToObject(url, "pattern", node->ruleinfo->url->match->raw);
+            cJSON_AddBoolToObject(url, "negate", node->ruleinfo->url->negate);
+            cJSON_AddItemToObject(rule, "url", url);
+        }
+
+        if (node->ruleinfo->id) {
+            cJSON * id = cJSON_CreateObject();
+            cJSON_AddStringToObject(id, "pattern", node->ruleinfo->id->match->raw);
+            cJSON_AddBoolToObject(id, "negate", node->ruleinfo->id->negate);
+            cJSON_AddItemToObject(rule, "id", id);
+        }
+
+        if (node->ruleinfo->system_name) {
+            cJSON * system_name = cJSON_CreateObject();
+            cJSON_AddStringToObject(system_name, "pattern", node->ruleinfo->system_name->match->raw);
+            cJSON_AddBoolToObject(system_name, "negate", node->ruleinfo->system_name->negate);
+            cJSON_AddItemToObject(rule, "system_name", system_name);
+        }
+
+        if (node->ruleinfo->protocol) {
+            cJSON * protocol = cJSON_CreateObject();
+            cJSON_AddStringToObject(protocol, "pattern", node->ruleinfo->protocol->match->raw);
+            cJSON_AddBoolToObject(protocol, "negate", node->ruleinfo->protocol->negate);
+            cJSON_AddItemToObject(rule, "protocol", protocol);
+        }
+
+        if (node->ruleinfo->data) {
+            cJSON * data = cJSON_CreateObject();
+            cJSON_AddStringToObject(data, "pattern", node->ruleinfo->data->match->raw);
+            cJSON_AddBoolToObject(data, "negate", node->ruleinfo->data->negate);
+            cJSON_AddItemToObject(rule, "data", data);
+        }
+        if (node->ruleinfo->status) {
+            cJSON * status = cJSON_CreateObject();
+            cJSON_AddStringToObject(status, "pattern", node->ruleinfo->status->match->raw);
+            cJSON_AddBoolToObject(status, "negate", node->ruleinfo->status->negate);
+            cJSON_AddItemToObject(rule, "status", status);
+        }
+
+        if (node->ruleinfo->hostname) {
+            cJSON * hostname = cJSON_CreateObject();
+            cJSON_AddStringToObject(hostname, "pattern", node->ruleinfo->hostname->match->raw);
+            cJSON_AddBoolToObject(hostname, "negate", node->ruleinfo->hostname->negate);
+            cJSON_AddItemToObject(rule, "hostname", hostname);
+        }
+
+        if (node->ruleinfo->program_name) {
+            cJSON * program_name = cJSON_CreateObject();
+            cJSON_AddStringToObject(program_name, "pattern", node->ruleinfo->program_name->match->raw);
+            cJSON_AddBoolToObject(program_name, "negate", node->ruleinfo->program_name->negate);
+            cJSON_AddItemToObject(rule, "program_name", program_name);
+        }
+
+        if (node->ruleinfo->extra_data) {
+            cJSON * extra_data = cJSON_CreateObject();
+            cJSON_AddStringToObject(extra_data, "pattern", node->ruleinfo->extra_data->match->raw);
+            cJSON_AddBoolToObject(extra_data, "negate", node->ruleinfo->extra_data->negate);
+            cJSON_AddItemToObject(rule, "extra_data", extra_data);
+        }
+
+        if (node->ruleinfo->location) {
+            cJSON * location = cJSON_CreateObject();
+            cJSON_AddStringToObject(location, "pattern", node->ruleinfo->location->match->raw);
+            cJSON_AddBoolToObject(location, "negate", node->ruleinfo->location->negate);
+            cJSON_AddItemToObject(rule, "location", location);
+        }
+
+        if (node->ruleinfo->action) {
+            cJSON * action = cJSON_CreateObject();
+            cJSON_AddStringToObject(action, "string", node->ruleinfo->action->string);
+            cJSON_AddBoolToObject(action, "negate", node->ruleinfo->action->negate);
+            cJSON_AddItemToObject(rule, "action", action);
+        }
+
         if (node->ruleinfo->comment) cJSON_AddStringToObject(rule,"comment",node->ruleinfo->comment);
         if (node->ruleinfo->info) cJSON_AddStringToObject(rule,"info",node->ruleinfo->info);
         if (node->ruleinfo->cve) cJSON_AddStringToObject(rule,"cve",node->ruleinfo->cve);
@@ -280,27 +389,48 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
         }
 
         if (node->ruleinfo->fields && node->ruleinfo->fields[0]) {
-            cJSON *_list = cJSON_CreateArray();
-            for (i=0;node->ruleinfo->fields[i];i++) {
-                cJSON_AddItemToArray(_list,cJSON_CreateString(node->ruleinfo->fields[i]->name));
+
+            cJSON * _list = cJSON_CreateArray();
+            for (i = 0; node->ruleinfo->fields[i]; i++) {
+                cJSON * field = cJSON_CreateObject();
+
+                cJSON_AddStringToObject(field, "name", node->ruleinfo->fields[i]->name);
+                cJSON_AddStringToObject(field, "pattern", node->ruleinfo->fields[i]->regex->raw);
+                cJSON_AddBoolToObject(field, "negate", node->ruleinfo->fields[i]->negate);
+
+                cJSON_AddItemToArray(_list, field);
             }
-            cJSON_AddItemToObject(rule,"field",_list);
+
+            cJSON_AddItemToObject(rule, "field", _list);
         }
 
         if (node->ruleinfo->srcip && node->ruleinfo->srcip->ips[0]) {
-            cJSON *_list = cJSON_CreateArray();
-            for (i=0;node->ruleinfo->srcip->ips[i];i++) {
-                cJSON_AddItemToArray(_list,cJSON_CreateString(node->ruleinfo->srcip->ips[i]->ip));
+
+            cJSON * _list = cJSON_CreateArray();
+            for (i = 0; node->ruleinfo->srcip->ips[i]; i++) {
+                cJSON * ip = cJSON_CreateObject();
+
+                cJSON_AddStringToObject(ip, "ip", node->ruleinfo->srcip->ips[i]->ip);
+                cJSON_AddBoolToObject(ip, "negate", node->ruleinfo->srcip->negate);
+
+                cJSON_AddItemToArray(_list, ip);
             }
-            cJSON_AddItemToObject(rule,"srcip",_list);
+
+            cJSON_AddItemToObject(rule, "srcip", _list);
         }
 
         if (node->ruleinfo->dstip && node->ruleinfo->dstip->ips[0]) {
-            cJSON *_list = cJSON_CreateArray();
-            for (i=0;node->ruleinfo->dstip->ips[i];i++) {
-                cJSON_AddItemToArray(_list,cJSON_CreateString(node->ruleinfo->dstip->ips[i]->ip));
+
+            cJSON * _list = cJSON_CreateArray();
+            for (i = 0; node->ruleinfo->dstip->ips[i]; i++) {
+                cJSON * ip = cJSON_CreateObject();
+
+                cJSON_AddStringToObject(ip, "ip", node->ruleinfo->dstip->ips[i]->ip);
+                cJSON_AddBoolToObject(ip, "negate", node->ruleinfo->dstip->negate);
+
+                cJSON_AddItemToArray(_list, ip);
             }
-            cJSON_AddItemToObject(rule,"dstip",_list);
+            cJSON_AddItemToObject(rule, "dstip", _list);
         }
 
         if (same = node->ruleinfo->same_field, same) {

--- a/src/analysisd/config_json.c
+++ b/src/analysisd/config_json.c
@@ -234,24 +234,25 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
         cJSON_AddNumberToObject(rule,"ignore_time",node->ruleinfo->ignore_time);
         cJSON_AddNumberToObject(rule,"decoded_as",node->ruleinfo->decoded_as);
         cJSON_AddNumberToObject(rule,"if_matched_sid",node->ruleinfo->if_matched_sid);
+
         if (node->ruleinfo->group) cJSON_AddStringToObject(rule,"group",node->ruleinfo->group);
-        if (node->ruleinfo->regex) cJSON_AddStringToObject(rule,"regex",node->ruleinfo->regex->raw);
-        if (node->ruleinfo->match) cJSON_AddStringToObject(rule,"match",node->ruleinfo->match->raw);
-        if (node->ruleinfo->srcgeoip) cJSON_AddStringToObject(rule,"srcgeoip",node->ruleinfo->srcgeoip->raw);
-        if (node->ruleinfo->dstgeoip) cJSON_AddStringToObject(rule,"dstgeoip",node->ruleinfo->dstgeoip->raw);
-        if (node->ruleinfo->srcport) cJSON_AddStringToObject(rule,"srcport",node->ruleinfo->srcport->raw);
-        if (node->ruleinfo->dstport) cJSON_AddStringToObject(rule,"dstport",node->ruleinfo->dstport->raw);
-        if (node->ruleinfo->user) cJSON_AddStringToObject(rule,"user",node->ruleinfo->user->raw);
-        if (node->ruleinfo->url) cJSON_AddStringToObject(rule,"url",node->ruleinfo->url->raw);
-        if (node->ruleinfo->id) cJSON_AddStringToObject(rule,"id",node->ruleinfo->id->raw);
-        if (node->ruleinfo->system_name) cJSON_AddStringToObject(rule,"system_name",node->ruleinfo->system_name->raw);
-        if (node->ruleinfo->protocol) cJSON_AddStringToObject(rule,"protocol",node->ruleinfo->protocol->raw);
-        if (node->ruleinfo->data) cJSON_AddStringToObject(rule, "data", node->ruleinfo->data->raw);     
-        if (node->ruleinfo->status) cJSON_AddStringToObject(rule,"status",node->ruleinfo->status->raw);
-        if (node->ruleinfo->hostname) cJSON_AddStringToObject(rule,"hostname",node->ruleinfo->hostname->raw);
-        if (node->ruleinfo->program_name) cJSON_AddStringToObject(rule,"program_name",node->ruleinfo->program_name->raw);
-        if (node->ruleinfo->extra_data) cJSON_AddStringToObject(rule,"extra_data",node->ruleinfo->extra_data->raw);
-        if (node->ruleinfo->action) cJSON_AddStringToObject(rule,"action",node->ruleinfo->action);
+        if (node->ruleinfo->regex) cJSON_AddStringToObject(rule,"regex",node->ruleinfo->regex->regex->raw);
+        if (node->ruleinfo->match) cJSON_AddStringToObject(rule,"match",node->ruleinfo->match->match->raw);
+        if (node->ruleinfo->srcgeoip) cJSON_AddStringToObject(rule,"srcgeoip",node->ruleinfo->srcgeoip->match->raw);
+        if (node->ruleinfo->dstgeoip) cJSON_AddStringToObject(rule,"dstgeoip",node->ruleinfo->dstgeoip->match->raw);
+        if (node->ruleinfo->srcport) cJSON_AddStringToObject(rule,"srcport",node->ruleinfo->srcport->match->raw);
+        if (node->ruleinfo->dstport) cJSON_AddStringToObject(rule,"dstport",node->ruleinfo->dstport->match->raw);
+        if (node->ruleinfo->user) cJSON_AddStringToObject(rule,"user",node->ruleinfo->user->match->raw);
+        if (node->ruleinfo->url) cJSON_AddStringToObject(rule,"url",node->ruleinfo->url->match->raw);
+        if (node->ruleinfo->id) cJSON_AddStringToObject(rule,"id",node->ruleinfo->id->match->raw);
+        if (node->ruleinfo->system_name) cJSON_AddStringToObject(rule,"system_name",node->ruleinfo->system_name->match->raw);
+        if (node->ruleinfo->protocol) cJSON_AddStringToObject(rule,"protocol",node->ruleinfo->protocol->match->raw);
+        if (node->ruleinfo->data) cJSON_AddStringToObject(rule, "data", node->ruleinfo->data->match->raw);
+        if (node->ruleinfo->status) cJSON_AddStringToObject(rule,"status",node->ruleinfo->status->match->raw);
+        if (node->ruleinfo->hostname) cJSON_AddStringToObject(rule,"hostname",node->ruleinfo->hostname->match->raw);
+        if (node->ruleinfo->program_name) cJSON_AddStringToObject(rule,"program_name",node->ruleinfo->program_name->match->raw);
+        if (node->ruleinfo->extra_data) cJSON_AddStringToObject(rule,"extra_data",node->ruleinfo->extra_data->match->raw);
+        if (node->ruleinfo->action) cJSON_AddStringToObject(rule,"action",node->ruleinfo->action->string);
         if (node->ruleinfo->comment) cJSON_AddStringToObject(rule,"comment",node->ruleinfo->comment);
         if (node->ruleinfo->info) cJSON_AddStringToObject(rule,"info",node->ruleinfo->info);
         if (node->ruleinfo->cve) cJSON_AddStringToObject(rule,"cve",node->ruleinfo->cve);
@@ -261,6 +262,7 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
         if (node->ruleinfo->if_matched_regex) cJSON_AddStringToObject(rule,"if_matched_regex",node->ruleinfo->if_matched_regex->raw);
         if (node->ruleinfo->if_matched_group) cJSON_AddStringToObject(rule,"if_matched_group",node->ruleinfo->if_matched_group->raw);
         if (node->ruleinfo->file) cJSON_AddStringToObject(rule,"rule_file",node->ruleinfo->file);
+
         if (node->ruleinfo->category == FIREWALL) {
             cJSON_AddStringToObject(rule,"category","firewall");
         } else if (node->ruleinfo->category == IDS) {
@@ -276,6 +278,7 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
         } else if (node->ruleinfo->category == OSSEC_RL) {
             cJSON_AddStringToObject(rule,"category","ossec");
         }
+
         if (node->ruleinfo->fields && node->ruleinfo->fields[0]) {
             cJSON *_list = cJSON_CreateArray();
             for (i=0;node->ruleinfo->fields[i];i++) {
@@ -283,20 +286,23 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
             }
             cJSON_AddItemToObject(rule,"field",_list);
         }
-        if (node->ruleinfo->srcip && node->ruleinfo->srcip[0]) {
+
+        if (node->ruleinfo->srcip && node->ruleinfo->srcip->ips[0]) {
             cJSON *_list = cJSON_CreateArray();
-            for (i=0;node->ruleinfo->srcip[i];i++) {
-                cJSON_AddItemToArray(_list,cJSON_CreateString(node->ruleinfo->srcip[i]->ip));
+            for (i=0;node->ruleinfo->srcip->ips[i];i++) {
+                cJSON_AddItemToArray(_list,cJSON_CreateString(node->ruleinfo->srcip->ips[i]->ip));
             }
             cJSON_AddItemToObject(rule,"srcip",_list);
         }
-        if (node->ruleinfo->dstip && node->ruleinfo->dstip[0]) {
+
+        if (node->ruleinfo->dstip && node->ruleinfo->dstip->ips[0]) {
             cJSON *_list = cJSON_CreateArray();
-            for (i=0;node->ruleinfo->dstip[i];i++) {
-                cJSON_AddItemToArray(_list,cJSON_CreateString(node->ruleinfo->dstip[i]->ip));
+            for (i=0;node->ruleinfo->dstip->ips[i];i++) {
+                cJSON_AddItemToArray(_list,cJSON_CreateString(node->ruleinfo->dstip->ips[i]->ip));
             }
             cJSON_AddItemToObject(rule,"dstip",_list);
         }
+
         if (same = node->ruleinfo->same_field, same) {
             for (i = 0; same != 0; i++) {
                 if ((same & 1) == 1) {
@@ -305,6 +311,7 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
                 same >>= 1;
             }
         }
+
         if (different = node->ruleinfo->same_field, different) {
             for (i = 0; different != 0; i++) {
                 if ((different & 1) == 1) {

--- a/src/analysisd/expression.c
+++ b/src/analysisd/expression.c
@@ -1,0 +1,64 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "expression.h"
+
+
+void w_calloc_expression_t(w_expression_t ** var, w_exp_type_t type) {
+
+    os_calloc(1, sizeof(w_expression_t), *var);
+    (*var)->exp_type = type;
+
+    switch (type) {
+
+        case EXP_TYPE_OSMATCH:
+            os_calloc(1, sizeof(OSMatch), (*var)->match);
+            break;
+
+        case EXP_TYPE_OSREGEX:
+            os_calloc(1, sizeof(OSRegex), (*var)->regex);
+            break;
+        
+        default:
+            break;
+    }
+}
+
+
+bool w_expression_add_osip(w_expression_t ** var, char * ip) {
+
+    unsigned int ip_s = 0;
+
+    if((*var) == NULL) {
+        w_calloc_expression_t(var, EXP_TYPE_OSIP_ARRAY);
+    }
+
+    while ((*var)->ips && (*var)->ips[ip_s]) {
+        ip_s++;
+    }
+
+    os_realloc((*var)->ips, (ip_s + 2) * sizeof(os_ip *), (*var)->ips);
+    os_calloc(1, sizeof(os_ip), (*var)->ips[ip_s]);
+    (*var)->ips[ip_s + 1] = NULL;
+
+    if (!OS_IsValidIP(ip, (*var)->ips[ip_s])) {
+
+        for(int i = 0; (*var)->ips[i]; i++) {
+            os_free((*var)->ips[i]->ip);
+            os_free((*var)->ips[i]);
+        }
+
+        os_free((*var)->ips);
+        os_free(*var);
+
+        return false;
+    }
+
+    return true;
+}

--- a/src/analysisd/expression.c
+++ b/src/analysisd/expression.c
@@ -35,7 +35,7 @@ bool w_expression_add_osip(w_expression_t ** var, char * ip) {
 
     unsigned int ip_s = 0;
 
-    if((*var) == NULL) {
+    if ((*var) == NULL) {
         w_calloc_expression_t(var, EXP_TYPE_OSIP_ARRAY);
     }
 
@@ -49,7 +49,7 @@ bool w_expression_add_osip(w_expression_t ** var, char * ip) {
 
     if (!OS_IsValidIP(ip, (*var)->ips[ip_s])) {
 
-        for(int i = 0; (*var)->ips[i]; i++) {
+        for (int i = 0; (*var)->ips[i]; i++) {
             os_free((*var)->ips[i]->ip);
             os_free((*var)->ips[i]);
         }

--- a/src/analysisd/expression.h
+++ b/src/analysisd/expression.h
@@ -1,0 +1,64 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef EXPRESSION_H_
+#define EXPRESSION_H_
+
+#include "shared.h"
+
+
+/**
+ * @brief Determine the types of expression allowed
+ */
+typedef enum { 
+    EXP_TYPE_OSREGEX,
+    EXP_TYPE_OSMATCH,
+    EXP_TYPE_STRING,
+    EXP_TYPE_OSIP_ARRAY,
+    EXP_TYPE_PCRE2
+} w_exp_type_t;
+
+
+/**
+ * @brief Represent the expressions used in rules and decoders.
+ *
+ * It can be OSRegex, OSMatch, string or array of os_ip.
+ */
+typedef struct {
+
+    w_exp_type_t exp_type;  ///< Determine the type of expression
+
+    union {                 ///< The expression which analysisd works
+        OSRegex * regex;
+        OSMatch * match;
+        char * string;
+        os_ip ** ips;
+    };
+
+    bool negate;            ///< Determine if the expression is afirmative or negative
+} w_expression_t;
+
+
+/**
+ * @brief Alloc memory for a w_expression_t variable
+ * @param var variable to initialize
+ * @param type type of expression.
+ */
+void w_calloc_expression_t(w_expression_t ** var, w_exp_type_t type);
+
+/**
+ * @brief add ip to os_ip array
+ * @param ips array which save ip
+ * @param ip ip to save
+ * @return true on success, otherwise false
+ */
+bool w_expression_add_osip(w_expression_t ** var, char * ip);
+
+#endif

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -2501,8 +2501,8 @@ bool w_check_attr_negate(xml_node *node, int rule_id) {
                 return false;
             }
             else {
-                mwarn(ANALYSISD_INV_VALUE_RULE, node->values[0],
-                    node->attributes[0], rule_id);
+                mwarn(ANALYSISD_INV_VALUE_RULE, node->values[i],
+                      node->attributes[i], rule_id);
                 return false;
             }
         }

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -583,6 +583,10 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         config_ruleinfo->dstip->negate = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
 
+                        if (!(config_ruleinfo->alert_opts & DO_PACKETINFO)) {
+                            config_ruleinfo->alert_opts |= DO_PACKETINFO;
+                        }
+
                     } else if (strcasecmp(rule_opt[k]->element, xml_user) == 0) {
 
                         user = loadmemory(user, rule_opt[k]->content);

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -14,6 +14,7 @@
 #define MAX_LAST_EVENTS 11
 
 #include "shared.h"
+#include "expression.h"
 #include "active-response.h"
 #include "lists.h"
 
@@ -91,7 +92,9 @@ typedef struct _RuleInfoDetail {
 typedef struct _FieldInfo {
     char *name;
     OSRegex *regex;
+    bool negate;
 } FieldInfo;
+
 
 typedef struct _RuleInfo {
     int sigid;  /* id attribute -- required*/
@@ -145,32 +148,32 @@ typedef struct _RuleInfo {
     void *(*event_search)(void *lf, void *rule, void *rule_match);
 
     char *group;
-    OSMatch *match;
-    OSRegex *regex;
+    w_expression_t * match;
+    w_expression_t * regex;
 
     /* Policy-based rules */
     char *day_time;
     char *week_day;
 
-    os_ip **srcip;
-    os_ip **dstip;
-    OSMatch *srcgeoip;
-    OSMatch *dstgeoip;
-    OSMatch *srcport;
-    OSMatch *dstport;
-    OSMatch *user;
-    OSMatch *url;
-    OSMatch *id;
-    OSMatch *status;
-    OSMatch *hostname;
-    OSMatch *program_name;
-    OSMatch *data;
-    OSMatch *extra_data;
-    OSMatch *location;
-    OSMatch *system_name;
-    OSMatch *protocol;
+    w_expression_t * srcip;
+    w_expression_t * dstip;
+    w_expression_t * srcgeoip;
+    w_expression_t * dstgeoip;
+    w_expression_t * srcport;
+    w_expression_t * dstport;
+    w_expression_t * user;
+    w_expression_t * url;
+    w_expression_t * id;
+    w_expression_t * status;
+    w_expression_t * hostname;
+    w_expression_t * program_name;
+    w_expression_t * data;
+    w_expression_t * extra_data;
+    w_expression_t * location;
+    w_expression_t * system_name;
+    w_expression_t * protocol;
     FieldInfo **fields;
-    char *action;
+    w_expression_t * action;
 
     char *comment; /* description in the xml */
     char *info;

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -55,4 +55,7 @@
 #define COMPRESSED_LOG_LONG_PATH                "(7502): The path of the compressed log is too long."
 #define COMPRESSED_JSON_LONG_PATH               "(7503): The path of the compressed json is too long."
 
+/* Ruleset reading warnings */
+#define ANALYSISD_INV_VALUE_RULE                "(7600): Invalid value '%s' for attribute '%s' in rule %d"
+
 #endif /* WARN_MESSAGES_H */

--- a/src/shared/read-alert.c
+++ b/src/shared/read-alert.c
@@ -272,8 +272,8 @@ alert_data *GetAlertData(int flag, FILE *fp) {
             else if (strncmp(GEOIP_BEGIN_SRC, str, GEOIP_BEGIN_SRC_SZ) == 0) {
                 os_clearnl(str, p);
                 p = str + GEOIP_BEGIN_SRC_SZ;
-                free(alert_data->srcgeoip);
-                os_strdup(p, alert_data->srcgeoip);
+                os_free(al_data->srcgeoip);
+                os_strdup(p, al_data->srcgeoip);
             }
 #endif
             /* srcport */

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -46,6 +46,9 @@ list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,_merror -Wl,--w
 list(APPEND analysisd_names "test_expression")
 list(APPEND analysisd_flags "-Wl,--wrap,OS_IsValidIP")
 
+list(APPEND analysisd_names "test_rules")
+LIST(APPEND analysisd_flags "-Wl,--wrap,_mwarn")
+
 LIST(APPEND analysisd_names "test_same_different_loop")
 LIST(APPEND analysisd_flags "-W")
 

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -43,6 +43,9 @@ list(APPEND analysisd_flags "-Wl,--wrap,wdb_get_agent_labels")
 list(APPEND analysisd_names "test_mitre")
 list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,_merror -Wl,--wrap,wdbc_query_parse_json")
 
+list(APPEND analysisd_names "test_expression")
+list(APPEND analysisd_flags "-Wl,--wrap,OS_IsValidIP")
+
 LIST(APPEND analysisd_names "test_same_different_loop")
 LIST(APPEND analysisd_flags "-W")
 

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -47,7 +47,7 @@ list(APPEND analysisd_names "test_expression")
 list(APPEND analysisd_flags "-Wl,--wrap,OS_IsValidIP")
 
 list(APPEND analysisd_names "test_rules")
-LIST(APPEND analysisd_flags "-Wl,--wrap,_mwarn")
+LIST(APPEND analysisd_flags "-Wl,--wrap,_mwarn -Wl,--wrap,_merror")
 
 LIST(APPEND analysisd_names "test_same_different_loop")
 LIST(APPEND analysisd_flags "-W")

--- a/src/unit_tests/analysisd/test_expression.c
+++ b/src/unit_tests/analysisd/test_expression.c
@@ -24,6 +24,60 @@ bool w_expression_add_osip(w_expression_t ** var, char * ip);
 
 /* tests */
 
+// w_calloc_expression_t
+
+void w_calloc_expression_t_match(void ** state)
+{
+    w_expression_t * var = NULL;
+
+    w_calloc_expression_t(&var, EXP_TYPE_OSMATCH);
+
+    assert_non_null(var);
+    assert_non_null(var->match);
+    assert_int_equal(var->exp_type, EXP_TYPE_OSMATCH);
+
+    os_free(var->match);
+    os_free(var);
+}
+
+void w_calloc_expression_t_regex(void ** state)
+{
+    w_expression_t * var = NULL;
+
+    w_calloc_expression_t(&var, EXP_TYPE_OSREGEX);
+
+    assert_non_null(var);
+    assert_non_null(var->regex);
+    assert_int_equal(var->exp_type, EXP_TYPE_OSREGEX);
+
+    os_free(var->regex);
+    os_free(var);
+}
+
+void w_calloc_expression_t_string(void ** state)
+{
+    w_expression_t * var = NULL;
+
+    w_calloc_expression_t(&var, EXP_TYPE_STRING);
+
+    assert_non_null(var);
+    assert_int_equal(var->exp_type, EXP_TYPE_STRING);
+
+    os_free(var);
+}
+
+void w_calloc_expression_t_osip(void ** state)
+{
+    w_expression_t * var = NULL;
+
+    w_calloc_expression_t(&var, EXP_TYPE_OSIP_ARRAY);
+
+    assert_non_null(var);
+    assert_int_equal(var->exp_type, EXP_TYPE_OSIP_ARRAY);
+
+    os_free(var);
+}
+
 // w_expression_add_osip
 
 void w_expression_add_osip_empty_ok(void ** state)
@@ -114,6 +168,13 @@ void w_expression_add_osip_non_empty_fail(void ** state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {
+
+        // Test w_calloc_expression_t
+        cmocka_unit_test(w_calloc_expression_t_match),
+        cmocka_unit_test(w_calloc_expression_t_regex),
+        cmocka_unit_test(w_calloc_expression_t_string),
+        cmocka_unit_test(w_calloc_expression_t_osip),
+
         // Tests w_add_ip_to_array
         cmocka_unit_test(w_expression_add_osip_empty_ok),
         cmocka_unit_test(w_expression_add_osip_empty_fail),

--- a/src/unit_tests/analysisd/test_expression.c
+++ b/src/unit_tests/analysisd/test_expression.c
@@ -1,0 +1,125 @@
+
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <setjmp.h>
+#include <stdio.h>
+#include <cmocka.h>
+
+#include "../../analysisd/expression.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+bool w_expression_add_osip(w_expression_t ** var, char * ip);
+
+
+/* setup/teardown */
+
+/* wraps */
+
+/* tests */
+
+// w_expression_add_osip
+
+void w_expression_add_osip_empty_ok(void ** state)
+{
+    w_expression_t * list_ips = NULL;
+    bool retval;
+
+    expect_any(__wrap_OS_IsValidIP, ip_address);
+    expect_not_value(__wrap_OS_IsValidIP, final_ip, NULL);
+    will_return(__wrap_OS_IsValidIP, 1);
+
+    retval = w_expression_add_osip(&list_ips, NULL);
+
+    assert_true(retval);
+    assert_int_equal(list_ips->exp_type, EXP_TYPE_OSIP_ARRAY);
+    assert_null(list_ips->ips[1]);
+    assert_non_null(list_ips->ips[0]);
+
+    os_free(list_ips->ips[0]);
+    os_free(list_ips->ips) os_free(list_ips);
+}
+
+void w_expression_add_osip_empty_fail(void ** state)
+{
+    w_expression_t * list_ips = NULL;
+    bool retval;
+
+    expect_any(__wrap_OS_IsValidIP, ip_address);
+    expect_not_value(__wrap_OS_IsValidIP, final_ip, NULL);
+    will_return(__wrap_OS_IsValidIP, 0);
+
+    retval = w_expression_add_osip(&list_ips, NULL);
+
+    assert_false(retval);
+    assert_null(list_ips);
+}
+
+void w_expression_add_osip_non_empty_ok(void ** state)
+{
+    w_expression_t * list_ips = NULL;
+    bool retval;
+
+    os_calloc(1, sizeof(w_expression_t), list_ips);
+    list_ips->exp_type = EXP_TYPE_OSIP_ARRAY;
+
+    os_calloc(2, sizeof(os_ip *), list_ips->ips);
+    os_calloc(1, sizeof(os_ip), list_ips->ips[0]);
+
+    expect_any(__wrap_OS_IsValidIP, ip_address);
+    expect_not_value(__wrap_OS_IsValidIP, final_ip, NULL);
+    will_return(__wrap_OS_IsValidIP, 1);
+
+    retval = w_expression_add_osip(&list_ips, NULL);
+
+    assert_true(retval);
+
+    assert_int_equal(list_ips->exp_type, EXP_TYPE_OSIP_ARRAY);
+    assert_null(list_ips->ips[2]);
+    assert_non_null(list_ips->ips[1]);
+    assert_non_null(list_ips->ips[0]);
+
+    os_free(list_ips->ips[1]);
+    os_free(list_ips->ips[0]);
+    os_free(list_ips->ips) os_free(list_ips);
+}
+
+void w_expression_add_osip_non_empty_fail(void ** state)
+{
+    w_expression_t * list_ips = NULL;
+    bool retval;
+
+    os_calloc(1, sizeof(w_expression_t), list_ips);
+    list_ips->exp_type = EXP_TYPE_OSIP_ARRAY;
+
+    os_calloc(2, sizeof(os_ip *), list_ips->ips);
+    os_calloc(1, sizeof(os_ip), list_ips->ips[0]);
+
+    expect_any(__wrap_OS_IsValidIP, ip_address);
+    expect_not_value(__wrap_OS_IsValidIP, final_ip, NULL);
+    will_return(__wrap_OS_IsValidIP, 0);
+
+    retval = w_expression_add_osip(&list_ips, NULL);
+
+    assert_false(retval);
+    assert_null(list_ips);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        // Tests w_add_ip_to_array
+        cmocka_unit_test(w_expression_add_osip_empty_ok),
+        cmocka_unit_test(w_expression_add_osip_empty_fail),
+        cmocka_unit_test(w_expression_add_osip_non_empty_ok),
+        cmocka_unit_test(w_expression_add_osip_non_empty_fail),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/analysisd/test_expression.c
+++ b/src/unit_tests/analysisd/test_expression.c
@@ -15,8 +15,6 @@
 #include "../../analysisd/expression.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
-bool w_expression_add_osip(w_expression_t ** var, char * ip);
-
 
 /* setup/teardown */
 

--- a/src/unit_tests/analysisd/test_rules.c
+++ b/src/unit_tests/analysisd/test_rules.c
@@ -16,7 +16,8 @@
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
 
-extern int w_check_attr_negate(xml_node *node, int rule_id);
+extern bool w_check_attr_negate(xml_node *node, int rule_id);
+extern bool w_check_attr_field_name(xml_node * node, FieldInfo ** field, int rule_id);
 
 
 /* setup/teardown */
@@ -46,8 +47,9 @@ void w_check_attr_negate_attr_to_yes(void **state)
 
     node.key = 0;
     node.element = NULL;
-    os_calloc(1, sizeof(char*), node.attributes);
+    os_calloc(2, sizeof(char*), node.attributes);
     os_strdup("negate", node.attributes[0]);
+    node.attributes[1] = NULL;
     os_calloc(1, sizeof(char*), node.values);
     os_strdup("yes", node.values[0]);
 
@@ -69,8 +71,9 @@ void w_check_attr_negate_attr_to_no(void **state)
 
     node.key = 0;
     node.element = NULL;
-    os_calloc(1, sizeof(char*), node.attributes);
+    os_calloc(2, sizeof(char*), node.attributes);
     os_strdup("negate", node.attributes[0]);
+    node.attributes[1] = NULL;
     os_calloc(1, sizeof(char*), node.values);
     os_strdup("no", node.values[0]);
 
@@ -86,15 +89,15 @@ void w_check_attr_negate_attr_to_no(void **state)
 
 void w_check_attr_negate_attr_unknow_val(void **state)
 {
-
     xml_node node;
     int rule_id = 1234;
     bool ret_val;
 
     node.key = 0;
     node.element = NULL;
-    os_calloc(1, sizeof(char*), node.attributes);
+    os_calloc(2, sizeof(char*), node.attributes);
     os_strdup("negate", node.attributes[0]);
+    node.attributes[1] = NULL;
     os_calloc(1, sizeof(char*), node.values);
     os_strdup("hello", node.values[0]);
 
@@ -110,6 +113,117 @@ void w_check_attr_negate_attr_unknow_val(void **state)
     assert_false(ret_val);
 }
 
+void w_check_attr_negate_attr_non_negate_attr(void **state)
+{
+    xml_node node;
+    int rule_id = 1234;
+    bool ret_val;
+
+    node.key = 0;
+    node.element = NULL;
+    os_calloc(2, sizeof(char*), node.attributes);
+    os_strdup("hello", node.attributes[0]);
+    node.attributes[1] = NULL;
+
+    ret_val = w_check_attr_negate(&node, rule_id);
+
+    os_free(node.attributes[0]);
+    os_free(node.attributes);
+
+    assert_false(ret_val);
+}
+
+// w_check_attr_field_name
+
+void w_check_attr_field_name_non_attr(void **state)
+{
+    xml_node node = {0, NULL, NULL, NULL, NULL};
+    int rule_id = 1234;
+    FieldInfo *field = NULL;
+    bool ret_val;
+
+    ret_val = w_check_attr_field_name(&node, &field, rule_id);
+
+    assert_false(ret_val);
+}
+
+void w_check_attr_field_name_static_field(void **state)
+{
+    xml_node node;
+    int rule_id = 1234;
+    FieldInfo *field = NULL;
+    bool ret_val;
+
+    node.key = 0;
+    node.element = NULL;
+    os_calloc(2, sizeof(char*), node.attributes);
+    os_strdup("name", node.attributes[0]);
+    node.attributes[1] = NULL;
+    os_calloc(1, sizeof(char*), node.values);
+    os_strdup("action", node.values[0]);
+
+    expect_string(__wrap__merror, formatted_msg, "Failure to read rule 1234. Field 'action' is static.");
+
+    ret_val = w_check_attr_field_name(&node, &field, rule_id);
+
+    assert_false(ret_val);
+
+    os_free(node.attributes[0]);
+    os_free(node.values[0]);
+    os_free(node.attributes);
+    os_free(node.values);
+}
+
+void w_check_attr_field_name_non_name_attr(void **state)
+{
+    xml_node node;
+    int rule_id = 1234;
+    FieldInfo *field = NULL;
+    bool ret_val;
+
+    node.key = 0;
+    node.element = NULL;
+    os_calloc(2, sizeof(char*), node.attributes);
+    os_strdup("hello", node.attributes[0]);
+    node.attributes[1] = NULL;
+
+    expect_string(__wrap__merror, formatted_msg, "Failure to read rule 1234. No such attribute 'name' for field.");
+
+    ret_val = w_check_attr_field_name(&node, &field, rule_id);
+
+    assert_false(ret_val);
+
+    os_free(node.attributes[0]);
+    os_free(node.attributes);
+}
+
+void w_check_attr_field_name_dynamic_field(void **state)
+{
+    xml_node node;
+    int rule_id = 1234;
+    FieldInfo *field = NULL;
+    bool ret_val;
+
+    node.key = 0;
+    node.element = NULL;
+    os_calloc(2, sizeof(char*), node.attributes);
+    os_strdup("name", node.attributes[0]);
+    node.attributes[1] = NULL;
+    os_calloc(1, sizeof(char*), node.values);
+    os_strdup("dynamicField", node.values[0]);
+
+    ret_val = w_check_attr_field_name(&node, &field, rule_id);
+
+    assert_true(ret_val);
+
+    os_free(node.attributes[0]);
+    os_free(node.values[0]);
+    os_free(node.attributes);
+    os_free(node.values);
+    os_free(field->name);
+    os_free(field);
+}
+
 
 int main(void)
 {
@@ -120,6 +234,12 @@ int main(void)
         cmocka_unit_test(w_check_attr_negate_attr_to_yes),
         cmocka_unit_test(w_check_attr_negate_attr_to_no),
         cmocka_unit_test(w_check_attr_negate_attr_unknow_val),
+        cmocka_unit_test(w_check_attr_negate_attr_non_negate_attr),
+        // Test w_check_attr_field_name
+        cmocka_unit_test(w_check_attr_field_name_non_attr),
+        cmocka_unit_test(w_check_attr_field_name_static_field),
+        cmocka_unit_test(w_check_attr_field_name_non_name_attr),
+        cmocka_unit_test(w_check_attr_field_name_dynamic_field),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/analysisd/test_rules.c
+++ b/src/unit_tests/analysisd/test_rules.c
@@ -1,0 +1,126 @@
+
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <setjmp.h>
+#include <stdio.h>
+#include <cmocka.h>
+
+#include "../../analysisd/rules.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+
+extern int w_check_attr_negate(xml_node *node, int rule_id);
+
+
+/* setup/teardown */
+
+/* wraps */
+
+/* tests */
+
+// w_check_attr_negate
+
+void w_check_attr_negate_non_attr(void **state)
+{
+    xml_node node = {0, NULL, NULL, NULL, NULL};
+    int rule_id = 1234;
+    bool ret_val;
+
+    ret_val = w_check_attr_negate(&node, rule_id);
+
+    assert_false(ret_val);
+}
+
+void w_check_attr_negate_attr_to_yes(void **state)
+{
+    xml_node node;
+    int rule_id = 1234;
+    bool ret_val;
+
+    node.key = 0;
+    node.element = NULL;
+    os_calloc(1, sizeof(char*), node.attributes);
+    os_strdup("negate", node.attributes[0]);
+    os_calloc(1, sizeof(char*), node.values);
+    os_strdup("yes", node.values[0]);
+
+    ret_val = w_check_attr_negate(&node, rule_id);
+
+    os_free(node.attributes[0]);
+    os_free(node.values[0]);
+    os_free(node.attributes);
+    os_free(node.values);
+
+    assert_true(ret_val);
+}
+
+void w_check_attr_negate_attr_to_no(void **state)
+{
+    xml_node node;
+    int rule_id = 1234;
+    bool ret_val;
+
+    node.key = 0;
+    node.element = NULL;
+    os_calloc(1, sizeof(char*), node.attributes);
+    os_strdup("negate", node.attributes[0]);
+    os_calloc(1, sizeof(char*), node.values);
+    os_strdup("no", node.values[0]);
+
+    ret_val = w_check_attr_negate(&node, rule_id);
+
+    os_free(node.attributes[0]);
+    os_free(node.values[0]);
+    os_free(node.attributes);
+    os_free(node.values);
+
+    assert_false(ret_val);
+}
+
+void w_check_attr_negate_attr_unknow_val(void **state)
+{
+
+    xml_node node;
+    int rule_id = 1234;
+    bool ret_val;
+
+    node.key = 0;
+    node.element = NULL;
+    os_calloc(1, sizeof(char*), node.attributes);
+    os_strdup("negate", node.attributes[0]);
+    os_calloc(1, sizeof(char*), node.values);
+    os_strdup("hello", node.values[0]);
+
+    expect_string(__wrap__mwarn, formatted_msg, "(7600): Invalid value 'hello' for attribute 'negate' in rule 1234");
+
+    ret_val = w_check_attr_negate(&node, rule_id);
+
+    os_free(node.attributes[0]);
+    os_free(node.values[0]);
+    os_free(node.attributes);
+    os_free(node.values);
+
+    assert_false(ret_val);
+}
+
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+
+        // Test w_check_attr_negate
+        cmocka_unit_test(w_check_attr_negate_non_attr),
+        cmocka_unit_test(w_check_attr_negate_attr_to_yes),
+        cmocka_unit_test(w_check_attr_negate_attr_to_no),
+        cmocka_unit_test(w_check_attr_negate_attr_unknow_val),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
|Related issue|
|---|
|[141](https://github.com/wazuh/wazuh/issues/141)|

Hello team!

This PR allows to create rules as follow to negate the static and dynamic fields extracted in decoding phase.

```xml
<rule id="100000" level="7">
        <decoded_as>dec_user_neg</decoded_as>
        <user negate="yes">eva|root</user>
        <description>Test negation on rules</description>
</rule>
```

For it work the following decoder must be added:
```xml
<decoder name="dec_user_neg">
        <program_name>test_user</program_name>
        <regex>session opened for user (\w+)</regex>
        <order>user</order>
</decoder>
```
To test it you can use following logs:

>Dec 10 01:02:02 host test_user[1234]: session opened for user root
>Dec 10 01:02:02 host test_user[1234]: session opened for user maria
>Dec 10 01:02:02 host test_user[1234]: session opened for user lola


And Logtest output:

```
ossec-testrule: Type one log per line.

Dec 10 01:02:02 host test_user[1234]: session opened for user eva


**Phase 1: Completed pre-decoding.
       full event: 'Dec 10 01:02:02 host test_user[1234]: session opened for user eva'
       timestamp: 'Dec 10 01:02:02'
       hostname: 'host'
       program_name: 'test_user'
       log: 'session opened for user eva'

**Phase 2: Completed decoding.
       decoder: 'dec_user_neg'
       dstuser: 'eva'

```

```
Dec 10 01:02:02 host test_user[1234]: session opened for user maria


**Phase 1: Completed pre-decoding.
       full event: 'Dec 10 01:02:02 host test_user[1234]: session opened for user maria'
       timestamp: 'Dec 10 01:02:02'
       hostname: 'host'
       program_name: 'test_user'
       log: 'session opened for user maria'

**Phase 2: Completed decoding.
       decoder: 'dec_user_neg'
       dstuser: 'maria'

**Phase 3: Completed filtering (rules).
       Rule id: '100000'
       Level: '7'
       Description: 'Test negation on rules'
**Alert to be generated.
```

Best regards,
Eva


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- [x] Compilation without warnings in every supported platform
- [x] Memory test doesn't report memory leaks
- [x] Scan-build doesn't report any bug
- [x] Coverity doesn't report any bug
- [x] Unit test for new functions
- [x] Ruleset UT to test new attribute