### PR TITLE
Vulnerability-Detector: Discard from RedHat OVALs every not-affected package.

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -10151,7 +10151,7 @@ void test_wm_vuldet_oval_xml_preparser_redhat(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "<?xml version=\"1.0\" encoding=\"utf-8\"?>");
 
-    // Criteria section
+    // // Criteria section
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "<criteria operator=\"AND\">");
 
@@ -10176,6 +10176,20 @@ void test_wm_vuldet_oval_xml_preparser_redhat(void **state)
 
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "<ind-def:pattern operation=\"pattern match\"> <![CDATA[(?<=^saved_entry=).*]]> </ind-def:pattern>");
+
+    // random line
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "test line");
+
+    will_return(__wrap_fwrite, 1);
+
+    // skip undisired block
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "<definition class='vulnerability' id='oval:com.redhat.unaffected:def:20072764' version='631'>");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "<advisory from='secalert@redhat.com'>");
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "</definition>");
 
     // random line
     expect_value(__wrap_fgets, __stream, 1);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2899,6 +2899,11 @@ char *wm_vuldet_oval_xml_preparser(char *path, vu_feed dist) {
                     state = V_STATES;
                 }
             break;
+            case V_DEFINITIONS:
+                if (found = strstr(buffer, "</definition"), found) {
+                    state = V_END;
+                } 
+                continue;
             default:
                 /* The XML parser fails to analyse correctly this section.
                 * This is just a workaround, for more information -> Issues #5300 and #5299. */
@@ -2908,6 +2913,12 @@ char *wm_vuldet_oval_xml_preparser(char *path, vu_feed dist) {
 
                 } else if (strstr(buffer, "<criteria ")) {
                     state = V_CRITERIA;
+
+                // Discard not-affected packages
+                } else if (strstr(buffer, "<definition") && 
+                    strstr(buffer, "unaffected")) {
+                    state = V_DEFINITIONS;
+                    continue;
                 }
             }
 


### PR DESCRIPTION
|Related issue|
|---|
|#6277|

## Description

Simple patch for discarding `not-affected` packages when parsing RedHat OVALs.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
