### PR TITLE
Adapt add_manual and remove_manual to wazuh-db. Update unittests.

### DIFF
--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -26,6 +26,7 @@ from wazuh.core.ossec_queue import OssecQueue
 from wazuh.core.utils import chmod_r, WazuhVersion, plain_dict_to_nested_dict, get_fields_to_nest, WazuhDBQuery, \
     WazuhDBQueryDistinct, WazuhDBQueryGroupBy, WazuhDBBackend, safe_move
 from wazuh.core.wazuh_socket import OssecSocket, OssecSocketJSON
+from wazuh.core.wdb import WazuhDBConnection
 
 
 class WazuhDBQueryAgents(WazuhDBQuery):
@@ -542,18 +543,13 @@ class Agent:
             raise WazuhInternalError(1746, extra_message=str(e))
 
         # Tell wazuhbd to delete agent database
-        wdb_conn = WazuhDBBackend(self.id).connect_to_db()
-        wdb_conn.delete_agents_db([self.id])
+        wdb_backend_conn = WazuhDBBackend(self.id).connect_to_db()
+        wdb_backend_conn.delete_agents_db([self.id])
 
         try:
             # remove agent from groups
-            db_global = glob(common.database_path_global)
-            if not db_global:
-                raise WazuhError(1600)
-
-            conn = Connection(db_global[0])
-            conn.execute('DELETE FROM belongs WHERE id_agent = :id_agent', {'id_agent': int(self.id)})
-            conn.commit()
+            wdb_conn = WazuhDBConnection()
+            wdb_conn.run_wdb_command(f'global sql DELETE FROM belongs WHERE id_agent = {self.id}')
         except Exception as e:
             raise WazuhInternalError(1747, extra_message=str(e))
 
@@ -725,13 +721,8 @@ class Agent:
         force = force if type(force) == int else int(force)
 
         # Check manager name
-        db_global = glob(common.database_path_global)
-        if not db_global:
-            raise WazuhInternalError(1600)
-
-        conn = Connection(db_global[0])
-        conn.execute("SELECT name FROM agent WHERE (id = 0)")
-        manager_name = str(conn.fetch())
+        wdb_conn = WazuhDBConnection()
+        manager_name = wdb_conn.execute("global sql SELECT name FROM agent WHERE (id = 0)")[0]['name']
 
         if name == manager_name:
             raise WazuhError(1705, extra_message=name)

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -689,7 +689,6 @@ def test_agent_remove_authd(mock_ossec_socket):
     (True, False),
     (True, True),
 ])
-@pytest.mark.xfail()
 @patch('wazuh.core.wdb.WazuhDBConnection.delete_agents_db')
 @patch('wazuh.core.agent.remove')
 @patch('wazuh.core.agent.rmtree')
@@ -736,7 +735,7 @@ def test_agent_remove_manual(socket_mock, run_wdb_mock, send_mock, grp_mock, pwd
         stat_mock.assert_called_once_with(common.client_keys)
         chown_mock.assert_called_once_with(common.client_keys + '.tmp', common.ossec_uid(), common.ossec_gid())
         mock_delete_agents.assert_called_once_with(['001'])
-        run_wdb_mock.assert_called_once_with('global sql DELETE FROM belongs WHERE id_agent = 1')
+        run_wdb_mock.assert_called_once_with('global sql DELETE FROM belongs WHERE id_agent = 001')
         remove_mock.assert_any_call(os.path.join(common.ossec_path, 'queue/rids/001'))
 
         # make sure the mock is called with a string according to a non-backup path
@@ -873,9 +872,9 @@ def test_agent_add_authd_ko(mock_ossec_socket, mocked_exception, expected_except
 @patch('wazuh.core.agent.chmod')
 @patch('wazuh.core.agent.stat')
 @patch('wazuh.core.agent.fcntl.lockf')
-@patch('wazuh.core.agent.OssecSocketJSON')
-@patch('wazuh.common.database_path_global', new=os.path.join(test_data_path, 'global.db'))
-def test_agent_add_manual(mock_ossec_socket, mock_lockf, mock_stat, mock_chmod, mock_chown, mock_ossec_gid,
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_add_manual(socket_mock, mock_send, mock_lockf, mock_stat, mock_chmod, mock_chown, mock_ossec_gid,
                           mosck_ossec_uid, mock_copyfile, mock_safe_move, ip, id, key, force):
     """Tests if method _add_manual() works as expected"""
     key = 'MDAyIHdpbmRvd3MtYWdlbnQyIGFueSAzNDA2MjgyMjEwYmUwOWVlMWViNDAyZTYyODZmNWQ2OTE5' \
@@ -883,18 +882,20 @@ def test_agent_add_manual(mock_ossec_socket, mock_lockf, mock_stat, mock_chmod, 
     client_keys_text = f'001 windows-agent any {key}\n \n002 #name '
 
     with patch('wazuh.core.agent.open', mock_open(read_data=client_keys_text)) as m:
-        with patch('sqlite3.connect') as mock_db:
-            mock_db.return_value = test_data.global_db
-            agent = Agent(1)
+        agent = Agent(1)
 
-            agent._add_manual('test_agent', ip=ip, id=id, key=key, force=force)
+        agent._add_manual('test_agent', ip=ip, id=id, key=key, force=force)
 
-            assert agent.id == id, 'ID should has been updated.'
-            mock_chown.assert_called_once_with('{0}.tmp'.format(common.client_keys), ANY, ANY)
-            mock_chmod.assert_called_once_with('{0}.tmp'.format(common.client_keys), ANY)
-            mock_copyfile.assert_called_once_with(common.client_keys, '{0}.tmp'.format(common.client_keys))
-            mock_safe_move.assert_called_once_with('{0}.tmp'.format(common.client_keys), common.client_keys,
-                                                   permissions=ANY)
+        assert agent.id == id, 'ID should has been updated.'
+        calls = [call('global sql select count(*) from agent where (id = 0)'),
+                 call('global sql select name from agent where (id = 0) limit 1 offset 0')]
+
+        mock_send.assert_has_calls(calls)
+        mock_chown.assert_called_once_with('{0}.tmp'.format(common.client_keys), ANY, ANY)
+        mock_chmod.assert_called_once_with('{0}.tmp'.format(common.client_keys), ANY)
+        mock_copyfile.assert_called_once_with(common.client_keys, '{0}.tmp'.format(common.client_keys))
+        mock_safe_move.assert_called_once_with('{0}.tmp'.format(common.client_keys), common.client_keys,
+                                               permissions=ANY)
 
 
 @patch('wazuh.core.agent.copyfile')
@@ -915,54 +916,50 @@ def test_agent_add_manual_ko(mock_lockf, mock_stat, mock_chmod, mock_chown, mock
         agent = Agent(1)
         agent._add_manual('test_agent', '172.19.0.100', key='j3921n19')
 
-    # No database_path_global
-    with pytest.raises(WazuhInternalError, match=".* 1600 .*"):
-        agent = Agent(1)
-        agent._add_manual('test_agent', '172.19.0.100')
-
     # Adding agent with the name of the manager
-    with patch("wazuh.common.database_path_global", new=os.path.join(test_data_path, 'global.db')):
-        with patch('wazuh.core.agent.open', mock_open(read_data=client_keys_text)):
-            with pytest.raises(WazuhError, match=".* 1705 .*"):
-                agent = Agent(1)
-                agent._add_manual('master', '172.19.0.100')
-
-            with patch('wazuh.core.agent.fcntl.lockf'):
-                # ID already exists
-                with pytest.raises(WazuhError, match=".* 1708 .*"):
-                    agent = Agent(1)
-                    agent._add_manual('test_agent', '172.19.0.100', id='001')
-
-                # Name already exists
+    with patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb):
+        with patch('socket.socket.connect'):
+            with patch('wazuh.core.agent.open', mock_open(read_data=client_keys_text)):
                 with pytest.raises(WazuhError, match=".* 1705 .*"):
                     agent = Agent(1)
-                    agent._add_manual('windows-agent', '172.19.0.100')
+                    agent._add_manual('master', '172.19.0.100')
 
-                # IP already assigned
-                with pytest.raises(WazuhError, match=".* 1706 .*"):
-                    agent = Agent(1)
-                    agent._add_manual('test_agent', '192.168.0.1')
-
-                with pytest.raises(WazuhError, match=".* 1725 .*"):
-                    agent._add_manual('test_agent', '172.19.0.100')
-
-                with patch('wazuh.core.agent.Agent.remove') as mock_remove:
-                    # IP already exists and force
-                    with pytest.raises(WazuhError, match=".* 1725 .*"):
+                with patch('wazuh.core.agent.fcntl.lockf'):
+                    # ID already exists
+                    with pytest.raises(WazuhError, match=".* 1708 .*"):
                         agent = Agent(1)
-                        agent._add_manual('test_agent', '192.168.0.1', force=0)
-                    mock_remove.assert_called_once_with(backup=True)
+                        agent._add_manual('test_agent', '172.19.0.100', id='001')
 
-                with patch('wazuh.core.agent.Agent.check_if_delete_agent', return_value=False):
-                    # IP already exists and force
-                    with pytest.raises(WazuhError, match=".* 1706 .*"):
-                        agent = Agent(1)
-                        agent._add_manual('test_agent', '192.168.0.1', force=1)
-
-                    # Name already exists and force
+                    # Name already exists
                     with pytest.raises(WazuhError, match=".* 1705 .*"):
                         agent = Agent(1)
-                        agent._add_manual('windows-agent', '172.19.0.100', force=1)
+                        agent._add_manual('windows-agent', '172.19.0.100')
+
+                    # IP already assigned
+                    with pytest.raises(WazuhError, match=".* 1706 .*"):
+                        agent = Agent(1)
+                        agent._add_manual('test_agent', '192.168.0.1')
+
+                    with pytest.raises(WazuhError, match=".* 1725 .*"):
+                        agent._add_manual('test_agent', '172.19.0.100')
+
+                    with patch('wazuh.core.agent.Agent.remove') as mock_remove:
+                        # IP already exists and force
+                        with pytest.raises(WazuhError, match=".* 1725 .*"):
+                            agent = Agent(1)
+                            agent._add_manual('test_agent', '192.168.0.1', force=0)
+                        mock_remove.assert_called_once_with(backup=True)
+
+                    with patch('wazuh.core.agent.Agent.check_if_delete_agent', return_value=False):
+                        # IP already exists and force
+                        with pytest.raises(WazuhError, match=".* 1706 .*"):
+                            agent = Agent(1)
+                            agent._add_manual('test_agent', '192.168.0.1', force=1)
+
+                        # Name already exists and force
+                        with pytest.raises(WazuhError, match=".* 1705 .*"):
+                            agent = Agent(1)
+                            agent._add_manual('windows-agent', '172.19.0.100', force=1)
 
 
 @patch('wazuh.core.agent.path.exists', return_value=True)
@@ -2172,11 +2169,9 @@ def test_expand_group(socket_mock, send_mock, group, expected_agents):
 @pytest.mark.parametrize('agent_id, expected_exception', [
     ('001', 1746),
     ('006', 1701),
-    ('001', 1600),
+    ('001', 1747),
     ('001', 1748),
-    ('001', 1747)
 ])
-@pytest.mark.xfail()
 @patch('wazuh.core.wdb.WazuhDBConnection.delete_agents_db')
 @patch('wazuh.core.agent.remove')
 @patch('wazuh.core.agent.rmtree')
@@ -2186,16 +2181,14 @@ def test_expand_group(socket_mock, send_mock, group, expected_agents):
 @patch('wazuh.core.agent.glob')
 @patch("wazuh.common.client_keys", new=os.path.join(test_data_path, 'etc', 'client.keys'))
 @patch('wazuh.core.agent.path.isdir', return_value=True)
-@patch('wazuh.core.agent.safe_move')
 @patch('wazuh.core.agent.makedirs')
 @patch('wazuh.core.agent.chmod_r')
 @freeze_time('1975-01-01')
 @patch("wazuh.common.ossec_uid", return_value=getpwnam("root"))
 @patch("wazuh.common.ossec_gid", return_value=getgrnam("root"))
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
-@patch('wazuh.core.wdb.WazuhDBConnection.run_wdb_command')
 @patch('socket.socket.connect')
-def test_agent_remove_manual_ko(socket_mock, run_wdb_mock, send_mock, grp_mock, pwd_mock, chmod_r_mock, makedirs_mock, safe_move_mock,
+def test_agent_remove_manual_ko(socket_mock, send_mock, grp_mock, pwd_mock, chmod_r_mock, makedirs_mock,
                                 isdir_mock, glob_mock, stat_mock, chmod_mock, chown_mock, rmtree_mock, remove_mock, delete_mock,
                                  agent_id, expected_exception):
     """Test the _remove_manual function error cases.
@@ -2207,19 +2200,26 @@ def test_agent_remove_manual_ko(socket_mock, run_wdb_mock, send_mock, grp_mock, 
     expected_exception : int
         Error code that is expected.
     """
+    def check_exception(client_keys):
+        with patch('wazuh.core.agent.open', mock_open(read_data=client_keys)) as m:
+            with pytest.raises(WazuhException, match=f".* {expected_exception} .*"):
+                Agent(agent_id)._remove_manual()
+
     client_keys_text = '\n'.join([f'{str(row["id"]).zfill(3) if expected_exception != 1701 else "100"} '
                                   f'{row["name"]} '
                                   f'{row["register_ip"]} '
-                                  f'{row["internal_key"] + "" if expected_exception != 1746 else " random"}' for row in
+                                  f'{row["internal_key"] + "" if expected_exception != 1746 else " random"}' for row
+                                  in
                                   test_data.global_db.execute(
                                       'select id, name, register_ip, internal_key from agent where id > 0')])
 
-    glob_mock.return_value = ['/var/db/global.db'] if expected_exception != 1600 else []
     rmtree_mock.side_effect = Exception("Boom!")
 
-    with patch('wazuh.core.agent.open', mock_open(read_data=client_keys_text)) as m:
-            with pytest.raises(WazuhException, match=f".* {expected_exception} .*"):
-                Agent(agent_id)._remove_manual()
+    if expected_exception == 1747:
+        check_exception(client_keys_text)
+    else:
+        with patch('wazuh.core.wdb.WazuhDBConnection.run_wdb_command'):
+            check_exception(client_keys_text)
 
     if expected_exception == 1746:
         remove_mock.assert_any_call('{0}/etc/client.keys.tmp'.format(test_data_path))

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -307,7 +307,6 @@ def test_agent_delete_agents_different_status(socket_mock, send_mock):
                in failed_item.message
 
 
-@pytest.mark.xfail()
 @pytest.mark.parametrize('name, agent_id, key', [
     ('agent-1', '001', 'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f'),
     ('a' * 129, '002', 'f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d')
@@ -338,8 +337,8 @@ def test_agent_add_agent(socket_mock, send_mock, open_mock, safe_move_mock, comm
     """
     try:
         add_result = add_agent(name=name, agent_id=agent_id, key=key, use_only_authd=False)
-        assert add_result.dikt['id'] == agent_id
-        assert add_result.dikt['key']
+        assert add_result.dikt['data']['id'] == agent_id
+        assert add_result.dikt['data']['key']
     except WazuhError as e:
         assert e.code == 1738, 'The exception was raised as expected but "error_code" does not match.'
 


### PR DESCRIPTION
|Related issue|
|---|
|#6274|

## Description

Hey team!

The methods `add_manual()` and `remove_manual()` which belong to framework/core/agent.py were not updated after replacing global.db with wazuh-db in the rest of the module. That option will be deprecated in the future so only authd can be used. However, right now, it will be neccessary to offer an option to add and remove agents when said service is not enabled.

This PR performs the changes required in order to use wazuh-db socket inside both methods. I tried to create and delete agents using the framework's agent module while `authd` was not running, and it works fine.

## Tests
The unit tests of framework/core/agent and framework/agent have been updated too. Here are the results: 

### SDK
```
python3 -m pytest wazuh/core/tests/
======================================================= test session starts ========================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: trio-0.6.0, asyncio-0.14.0
collected 652 items                                                                                                                

wazuh/core/tests/test_active_response.py ............                                                                        [  1%]
wazuh/core/tests/test_agent.py ............................................................................................. [ 16%]
..............................................................................................                               [ 30%]
wazuh/core/tests/test_cdb_list.py .................................                                                          [ 35%]
wazuh/core/tests/test_common.py .......                                                                                      [ 36%]
wazuh/core/tests/test_configuration.py ..................................                                                    [ 41%]
wazuh/core/tests/test_decoder.py ...............                                                                             [ 44%]
wazuh/core/tests/test_input_validator.py ...                                                                                 [ 44%]
wazuh/core/tests/test_manager.py ................................                                                            [ 49%]
wazuh/core/tests/test_ossec_queue.py ...................                                                                     [ 52%]
wazuh/core/tests/test_pyDaemonModule.py ......                                                                               [ 53%]
wazuh/core/tests/test_results.py ........................................                                                    [ 59%]
wazuh/core/tests/test_rule.py .....................                                                                          [ 62%]
wazuh/core/tests/test_syscollector.py ...                                                                                    [ 63%]
wazuh/core/tests/test_utils.py ............................................................................................. [ 77%]
...............................................................................................................              [ 94%]
wazuh/core/tests/test_wazuh_socket.py ...............                                                                        [ 96%]
wazuh/core/tests/test_wdb.py .....................                                                                           [100%]

========================================================= warnings summary =========================================================
/home/selu/venv/unittest-env/lib/python3.8/site-packages/jsonschema/compat.py:6
/home/selu/venv/unittest-env/lib/python3.8/site-packages/jsonschema/compat.py:6
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import MutableMapping, Sequence  # noqa

/home/selu/venv/unittest-env/lib/python3.8/site-packages/jinja2/runtime.py:318
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/jinja2/runtime.py:318: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping

/home/selu/venv/unittest-env/lib/python3.8/site-packages/aiohttp/helpers.py:107
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/aiohttp/helpers.py:107: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def noop(*args, **kwargs):  # type: ignore

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:48
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:48: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def problems_middleware(request, handler):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:169
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:169: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_json(self, request):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:177
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:177: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_yaml(self, request):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:236
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:236: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_home(self, req):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:246
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:246: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_config(self, req):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:295
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:295: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_request(cls, req):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:324
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:324: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_response(cls, response, mimetype=None, request=None):

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================= 652 passed, 11 warnings in 2.49s =================================================
```

### Core
```
python3 -m pytest wazuh/tests/test_agent.py -x
======================================================= test session starts ========================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: trio-0.6.0, asyncio-0.14.0
collected 89 items                                                                                                                 

wazuh/tests/test_agent.py .........................................................................................          [100%]

========================================================= warnings summary =========================================================
/home/selu/venv/unittest-env/lib/python3.8/site-packages/jsonschema/compat.py:6
/home/selu/venv/unittest-env/lib/python3.8/site-packages/jsonschema/compat.py:6
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import MutableMapping, Sequence  # noqa

/home/selu/venv/unittest-env/lib/python3.8/site-packages/jinja2/runtime.py:318
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/jinja2/runtime.py:318: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping

/home/selu/venv/unittest-env/lib/python3.8/site-packages/aiohttp/helpers.py:107
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/aiohttp/helpers.py:107: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def noop(*args, **kwargs):  # type: ignore

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:48
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:48: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def problems_middleware(request, handler):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:169
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:169: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_json(self, request):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:177
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:177: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_yaml(self, request):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:236
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:236: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_home(self, req):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:246
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:246: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_config(self, req):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:295
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:295: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_request(cls, req):

/home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:324
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:324: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_response(cls, response, mimetype=None, request=None):

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================= 89 passed, 11 warnings in 2.83s ==================================================
```

Best regards,
Selu.