### PR TITLE
Fixing global.db upgrade for older versions

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -37,7 +37,7 @@ list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
                             -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 \
                             -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,wdb_step -Wl,--wrap,sqlite3_bind_text \
-                            -Wl,--wrap,sqlite3_bind_parameter_index -Wl,--wrap,cJSON_Delete")
+                            -Wl,--wrap,sqlite3_bind_parameter_index -Wl,--wrap,cJSON_Delete -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int")
 
 list(APPEND wdb_tests_names "test_wdb_agent")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,strerror \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -61,7 +61,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,wdb_sql_exec -Wl,--wrap,wdb_metadata_get_entry -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose \
                              -Wl,--wrap,remove -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,closedir -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,fgets \
                              -Wl,--wrap,wdb_init -Wl,--wrap,wdb_close -Wl,--wrap,wdb_create_global -Wl,--wrap,wdb_pool_append -Wl,--wrap,chmod -Wl,--wrap,stat \
-                             -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,time -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_close_v2")
+                             -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,time -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_close_v2 \
+                             -Wl,--wrap,wdb_global_check_manager_keepalive")
 
 list(APPEND wdb_tests_names "test_wdb_metadata")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_errmsg \

--- a/src/unit_tests/wazuh_db/test_wdb_upgrade.c
+++ b/src/unit_tests/wazuh_db/test_wdb_upgrade.c
@@ -114,7 +114,7 @@ void test_wdb_upgrade_global_update_success(void **state)
     expect_string(__wrap__mdebug2, formatted_msg, "Updating database '000' to version 1");
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v1_sql);
     will_return(__wrap_wdb_sql_exec, 0);
-
+    will_return(__wrap_wdb_global_check_manager_keepalive, 1);
     ret = wdb_upgrade_global(data->wdb);
 
     assert_int_equal(ret, data->wdb);
@@ -131,6 +131,7 @@ void test_wdb_upgrade_global_update_fail(void **state)
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v1_sql);
     will_return(__wrap_wdb_sql_exec, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Failed to update global.db to version 1");
+    will_return(__wrap_wdb_global_check_manager_keepalive, 1);
 
     //Global backup success
     will_return(__wrap_wdb_close, 0);

--- a/src/unit_tests/wazuh_db/test_wdb_upgrade.c
+++ b/src/unit_tests/wazuh_db/test_wdb_upgrade.c
@@ -120,6 +120,47 @@ void test_wdb_upgrade_global_update_success(void **state)
     assert_int_equal(ret, data->wdb);
 }
 
+void test_wdb_upgrade_global_update_delete_old_version(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
+    will_return(__wrap_wdb_metadata_table_check, 0);
+    will_return(__wrap_wdb_global_check_manager_keepalive, 0);
+
+    //Global backup success
+    will_return(__wrap_wdb_close, 0);
+    expect_any_always(__wrap_fopen, path);
+    expect_any_always(__wrap_fopen, mode);
+    will_return(__wrap_fopen, 1);
+    will_return(__wrap_fopen, 1);
+    will_return(__wrap_fread, "");
+    will_return(__wrap_fread, 0);
+    expect_any_always(__wrap_fclose, _File);
+    will_return(__wrap_fclose, 0);
+    will_return(__wrap_fclose, 0);
+    expect_any_always(__wrap_chmod, path);
+    will_return(__wrap_chmod, 0);
+    expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
+    expect_string(__wrap_unlink, file, "queue/db/global.db");
+    will_return(__wrap_unlink, 0);
+    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
+    will_return(__wrap_wdb_create_global, OS_SUCCESS);
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
+    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
+    will_return(__wrap_sqlite3_open_v2, 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+    expect_string(__wrap_wdb_init, id, "global");
+    will_return(__wrap_wdb_init, (wdb_t*)1);
+    expect_value(__wrap_wdb_pool_append, wdb, (wdb_t*)1);
+
+
+    ret = wdb_upgrade_global(data->wdb);
+
+    assert_int_equal(ret, 1);
+}
+
 void test_wdb_upgrade_global_update_fail(void **state)
 {   
     wdb_t *ret = NULL;
@@ -480,6 +521,7 @@ int main()
     {
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_table_fail, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_success, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_delete_old_version, setup_wdb, teardown_wdb),        
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_fail, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_get_version_fail, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_get_version_success, setup_wdb, teardown_wdb),

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -277,3 +277,8 @@ cJSON* __wrap_wdb_global_get_agent_info(__attribute__((unused)) wdb_t *wdb,
     check_expected(id);
     return mock_ptr_type(cJSON*);
 }
+
+int __wrap_wdb_global_check_manager_keepalive(wdb_t *wdb) {
+    (void)wdb;
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -92,4 +92,6 @@ wdbc_result __wrap_wdb_global_get_all_agents(wdb_t *wdb, int* last_agent_id, cha
 
 cJSON* __wrap_wdb_global_get_agent_info(wdb_t *wdb, int id);
 
+int __wrap_wdb_global_check_manager_keepalive(wdb_t *wdb);
+
 #endif

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -144,6 +144,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_GREATER_KEEPALIVE] = "SELECT id FROM agent WHERE id > ? AND last_keepalive > ? LIMIT 1;", 
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_LESS_KEEPALIVE] = "SELECT id FROM agent WHERE id > ? AND last_keepalive < ? LIMIT 1;", 
     [WDB_STMT_GLOBAL_GET_AGENT_INFO] = "SELECT * FROM agent WHERE id = ?;",
+    [WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE] = "SELECT COUNT(*) FROM agent WHERE id=0 AND last_keepalive=253402300799;",
     [WDB_STMT_PRAGMA_JOURNAL_WAL] = "PRAGMA journal_mode=WAL;",
 };
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -159,6 +159,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_GET_AGENTS,
     WDB_STMT_GLOBAL_GET_AGENTS_BY_GREATER_KEEPALIVE,
     WDB_STMT_GLOBAL_GET_AGENTS_BY_LESS_KEEPALIVE,
+    WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE,
     WDB_STMT_SIZE,
     WDB_STMT_PRAGMA_JOURNAL_WAL,
 } wdb_stmt;
@@ -1705,5 +1706,18 @@ wdbc_result wdb_global_get_all_agents(wdb_t *wdb, int* last_agent_id, char **out
 
 // Finalize a statement securely
 #define wdb_finalize(x) { if (x) { sqlite3_finalize(x); x = NULL; } }
+
+/**
+ * @brief Check the agent 0 status in the global database
+ *
+ * The table "agent" must have a tuple with id=0 and last_keepalive=1999/12/31 23:59:59 UTC.
+ * Otherwise, the database is either corrupt or old.
+ *
+ * @return Number of tuples matching that condition.
+ * @retval 1 The agent 0 status is OK.
+ * @retval 0 No tuple matching conditions exists.
+ * @retval -1 The table "agent" is missing or an error occurred.
+ */
+int wdb_global_check_manager_keepalive(wdb_t *wdb);
 
 #endif

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -160,8 +160,8 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_GET_AGENTS_BY_GREATER_KEEPALIVE,
     WDB_STMT_GLOBAL_GET_AGENTS_BY_LESS_KEEPALIVE,
     WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE,
-    WDB_STMT_SIZE,
     WDB_STMT_PRAGMA_JOURNAL_WAL,
+    WDB_STMT_SIZE // This must be the last constant
 } wdb_stmt;
 
 typedef enum global_db_access {

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1383,3 +1383,24 @@ wdbc_result wdb_global_get_all_agents(wdb_t *wdb, int* last_agent_id, char **out
 
     return status;
 }
+
+// Check the agent 0 status in the global database
+int wdb_global_check_manager_keepalive(wdb_t *wdb) {
+    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE) < 0) {
+        merror("DB(%s) Can't cache statement", wdb->id);
+        return -1;
+    }
+
+    sqlite3_stmt *stmt = wdb->stmt[WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE];
+
+    switch (sqlite3_step(stmt)) {
+    case SQLITE_ROW:
+        return sqlite3_column_int(stmt, 0);
+
+    case SQLITE_DONE:
+        return 0;
+
+    default:
+        return -1;
+    }
+}

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -79,7 +79,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
         return wdb;
     case 0:
         // The table doesn't exist. Checking if version is 3.9
-        if( wdb_metadata_table_check(wdb,"agent") == 0){
+        if( wdb_metadata_table_check(wdb,"agent") == 1){
             j_agent_columns = wdb_exec(wdb->db, "PRAGMA table_info(agent)");
             cJSON_ArrayForEach(j_column, j_agent_columns) {
                 j_column_name = cJSON_GetObjectItem(j_column, "name");
@@ -88,7 +88,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
                 }
             }
             cJSON_Delete(j_agent_columns);
-            if(column_found == TRUE) {
+            if(column_found == FALSE) {
                 wdb = wdb_backup_global(wdb, -1);
                 return wdb;
             }

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -67,8 +67,6 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
 
     char db_version[OS_SIZE_256 + 2];
     int version = 0;
-    cJSON *j_keep_alive = NULL;
-    char *str_keep_alive = NULL;
 
     switch (wdb_metadata_table_check(wdb,"metadata")) {
     case OS_INVALID:
@@ -77,19 +75,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
         return wdb;
     case 0:
         // The table doesn't exist. Checking if version is 3.10 to upgrade or recreate
-        if( wdb_metadata_table_check(wdb,"agent") == 1){
-            j_keep_alive = wdb_exec(wdb->db, "SELECT last_keepalive FROM agent where id = 0");
-            str_keep_alive = cJSON_PrintUnformatted(j_keep_alive);
-            if(strcmp(str_keep_alive, "[{\"last_keepalive\":253402300799}]") != 0) {
-                wdb = wdb_backup_global(wdb, -1);
-                cJSON_Delete(j_keep_alive);
-                os_free(str_keep_alive);
-                return wdb;
-            }
-            cJSON_Delete(j_keep_alive);
-            os_free(str_keep_alive);
-        }
-        else {
+        if (wdb_global_check_manager_keepalive(wdb) != 1) {
             wdb = wdb_backup_global(wdb, -1);
             return wdb;
         }

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -80,7 +80,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
         if( wdb_metadata_table_check(wdb,"agent") == 1){
             j_keep_alive = wdb_exec(wdb->db, "SELECT last_keepalive FROM agent where id = 0");
             str_keep_alive = cJSON_PrintUnformatted(j_keep_alive);
-            if(strcmp(str_keep_alive, "253402300799") != 0) {
+            if(strcmp(str_keep_alive, "[{\"last_keepalive\":253402300799}]") != 0) {
                 wdb = wdb_backup_global(wdb, -1);
                 cJSON_Delete(j_keep_alive);
                 os_free(str_keep_alive);


### PR DESCRIPTION
|Related issue|
|---|
|#6216|

## Description

Older versions of **global.db** database didn't have columns like _register_ip_ (introduced in 3.9) or had different data types (**last_keepalive** as TEXT instead of INTEGER before 3.10). The  upgrade mechanism now also checks for manager's last keepalive because it was the last change before adding the metadata table.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
