### PR TITLE
Fix API integration tests in 4.0-RC3

### DIFF
--- a/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
@@ -1091,13 +1091,12 @@ stages:
         error: !anyint
         data:
           affected_items: # Admin rules cannot be deleted. 105 is denied
-            - id: 99
             - id: 100
             - id: 101
             - id: 102
             - id: 104
           failed_items: []
-          total_affected_items: 5
+          total_affected_items: 4
           total_failed_items: 0
 
 ---
@@ -1213,7 +1212,7 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: 6
+          total_affected_items: 5
           total_failed_items: 0
     delay_after: 20
 

--- a/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agents_endpoints.tavern.yaml
@@ -1368,7 +1368,6 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
         content-type: "application/xml"
-      error: !anyint
       data:
         "{file_xml:s}"
     response:
@@ -1384,7 +1383,6 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
         content-type: "application/xml"
-      error: !anyint
       data:
         "{file_xml:s}"
     response:

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -753,7 +753,6 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/files"
       method: PUT
-      error: !anyint
       data: "{ossec_conf}"
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -769,7 +768,6 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/files"
       method: PUT
-      error: !anyint
       data: "{ossec_conf}"
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
@@ -118,7 +118,6 @@ stages:
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
-      error: !anyint
       data: "<!-- NEW Local Decoders -->\n <decoder name=\"local_decoder_example\">\n <program_name>NEW DECODER</program_name>\n </decoder>\n"
       params:
         path: 'etc/decoders/test_decoders.xml'


### PR DESCRIPTION
Hello team, this closes #6269 .

After these changes, all the API integration tests must pass. All changes were test related. This means we didn't have to change anything from the framework code.

Regards.