### PR TITLE
Fix spec typos and improve endpoint summaries

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1,10 +1,22 @@
 openapi: '3.0.0'
 info:
-  description: "The Wazuh API is an open source RESTful API that allows for interaction with the Wazuh manager from a
-  web browser, command line tool like cURL or any script or program that can make web requests. The Wazuh WUI relies on
-  this heavily and Wazuh’s goal is to accommodate complete remote management of the Wazuh infrastructure via the Wazuh
-  WUI. Use the Wazuh API to easily perform everyday actions like adding an agent, restarting the manager(s) or agent(s)
-  or looking up syscheck details.\n"
+  description: |
+    The Wazuh API is an open source RESTful API that allows for interaction with the Wazuh manager from a
+    web browser, command line tool like cURL or any script or program that can make web requests. The Wazuh WUI relies on
+    this heavily and Wazuh’s goal is to accommodate complete remote management of the Wazuh infrastructure via the Wazuh
+    WUI. Use the Wazuh API to easily perform everyday actions like adding an agent, restarting the manager(s) or agent(s)
+    or looking up syscheck details.\n
+
+    # Authentication
+
+    Petstore offers two forms of authentication:
+      - API Key
+      - OAuth2
+    OAuth2 - an open protocol to allow secure authorization in a simple
+    and standard method from web, mobile and desktop applications.
+
+    <SecurityDefinitions />
+
   version: '4.0.0'
   x-revision: 4000
   title: 'Wazuh API REST'
@@ -1614,10 +1626,6 @@ components:
       type: string
       format: numbers_delete
       description: "User ID|all"
-    Username:
-      type: string
-      description: "Username of the user"
-      format: alphanumeric
     PoliciesRequest:
       type: object
       required:
@@ -3368,19 +3376,13 @@ components:
       description: "Intended method to get a token"
       x-basicInfoFunc: api.authentication.check_user
     jwt:
+      description: "Uses this token to bla bla"
       type: http
       scheme: bearer
       bearerFormat: JWT
       x-bearerInfoFunc: api.authentication.decode_token
 
   parameters:
-    auth_context:
-      in: query
-      name: Authorization context
-      description: "Authorization context"
-      required: False
-      schema:
-        type: object
     attack_id:
       in: query
       name: id

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -11,7 +11,7 @@ info:
 
     Wazuh API endpoints require authentication in order to be used. Therefore, all calls must include a JSON Web Token.
     JWT is an open standard (RFC 7519) that defines a compact and self-contained way for securely transmitting
-    information between parties as a JSON object. Perform a call with `basicAuth to `GET /security/user/authenticate
+    information between parties as a JSON object. Perform a call with `basicAuth` to `GET /security/user/authenticate`
     and obtain a JWT token in order to run any endpoint.
 
     Login with USER and PASSWORD:
@@ -3390,7 +3390,6 @@ components:
       description: "Intended method to get a token"
       x-basicInfoFunc: api.authentication.check_user
     jwt:
-      description: "Uses this token to bla bla"
       type: http
       scheme: bearer
       bearerFormat: JWT

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1,12 +1,10 @@
 openapi: '3.0.0'
 info:
-  description: "The Wazuh API is an open source RESTful API that allows for interaction\
-    \ with the Wazuh manager from a web browser, command line tool like cURL or any\
-    \ script or program that can make web requests. The Wazuh Kibana app relies on\
-    \ this heavily and Wazuh’s goal is to accommodate complete remote management of\
-    \ the Wazuh infrastructure via the Wazuh Kibana app. Use the API to easily perform\
-    \ everyday actions like adding an agent, restarting the manager(s) or agent(s)\
-    \ or looking up syscheck details.\n"
+  description: "The Wazuh API is an open source RESTful API that allows for interaction with the Wazuh manager from a
+  web browser, command line tool like cURL or any script or program that can make web requests. The Wazuh WUI relies on
+  this heavily and Wazuh’s goal is to accommodate complete remote management of the Wazuh infrastructure via the Wazuh
+  WUI. Use the Wazuh API to easily perform everyday actions like adding an agent, restarting the manager(s) or agent(s)
+  or looking up syscheck details.\n"
   version: '4.0.0'
   x-revision: 4000
   title: 'Wazuh API REST'
@@ -30,8 +28,10 @@ servers:
 x-rbac-catalog:
   resources:
     '*:*':
-      description: "Resource applied in functions which take part in the creation of a specific resource.
-      We call these functions, resourceless functions. Example: agent:create"
+      description: "Resource applied in functions acting on resources that do not yet exist in the system. We call these
+      functions, resourceless functions"
+    'agent:group':
+      description: "Reference agents via group name (i.e. agent:group:web)"
     'agent:id':
       description: "Reference agents via agent ID (i.e. agent:id:001)"
     'group:id':
@@ -50,13 +50,13 @@ x-rbac-catalog:
       description: "Reference security policies via its id (i.e. policy:id:1)"
     'role:id':
       description: "Reference security roles via its id (i.e. role:id:1)"
-    'user:id':
-      description: "Reference security users via its id (i.e. user:id:1)"
     'rule:id':
       description: "Reference security rules via its id (i.e. rule:id:1)"
+    'user:id':
+      description: "Reference security users via its id (i.e. user:id:1)"
   actions:
     'active-response:command':
-      description: "Allow to execute active response commands in the agents"
+      description: "Execute active response commands in the agents"
       resources:
         - $ref: '#/x-rbac-catalog/resources/agent:id'
       example:
@@ -72,7 +72,7 @@ x-rbac-catalog:
         resources: ['*:*:*']
         effect: "allow"
     'agent:read':
-      description: "Access to one or more agents basic information (id, name, group, last keep alive, etc)"
+      description: "Access agents information (id, name, group, last keep alive, etc)"
       resources:
         - $ref: '#/x-rbac-catalog/resources/agent:id'
       example:
@@ -80,7 +80,7 @@ x-rbac-catalog:
         resources: ['agent:id:*']
         effect: "allow"
     'agent:delete':
-      description: "Delete system's agents"
+      description: "Delete agents"
       resources:
         - $ref: '#/x-rbac-catalog/resources/agent:id'
       example:
@@ -88,7 +88,7 @@ x-rbac-catalog:
         resources: ['agent:id:010']
         effect: "allow"
     'agent:modify_group':
-      description: "Change the group of specified agent"
+      description: "Change the group of agents"
       resources:
        - $ref: '#/x-rbac-catalog/resources/agent:id'
       example:
@@ -96,7 +96,7 @@ x-rbac-catalog:
         resources: ['agent:id:*']
         effect: "allow"
     'group:modify_assignments':
-      description: "Allow to change the agents assigned to the group"
+      description: "Change the agents assigned to the group"
       resources:
        - $ref: '#/x-rbac-catalog/resources/group:id'
       example:
@@ -104,7 +104,7 @@ x-rbac-catalog:
         resources: ['group:id:*']
         effect: "allow"
     'agent:upgrade':
-      description: "Upgrade the version of an agent"
+      description: "Upgrade the version of the agents"
       resources:
        - $ref: '#/x-rbac-catalog/resources/agent:id'
       example:
@@ -112,7 +112,7 @@ x-rbac-catalog:
         resources: ['agent:id:*']
         effect: "allow"
     'agent:restart':
-      description: "Restart Wazuh for allowed agents"
+      description: "Restart agents"
       resources:
        - $ref: '#/x-rbac-catalog/resources/agent:id'
       example:
@@ -120,7 +120,7 @@ x-rbac-catalog:
         resources: ['agent:id:050', 'agent:id:049']
         effect: "deny"
     'group:create':
-      description: "Create new groups"
+      description: "Create new agent groups"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
@@ -128,7 +128,7 @@ x-rbac-catalog:
         resources: ['*:*:*']
         effect: "allow"
     'group:read':
-      description: "Access to one or more groups basic information (id, name, agents, etc)"
+      description: "Access agent groups information (id, name, agents, etc)"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
@@ -136,7 +136,7 @@ x-rbac-catalog:
         resources: ['*:*:*']
         effect: "allow"
     'group:update_config':
-      description: "Change group's configuration"
+      description: "Change the configuration of agent groups"
       resources:
         - $ref: '#/x-rbac-catalog/resources/group:id'
       example:
@@ -144,7 +144,7 @@ x-rbac-catalog:
         resources: ['group:id:*']
         effect: "deny"
     'group:delete':
-      description: "Delete system's groups"
+      description: "Delete agent groups"
       resources:
         - $ref: '#/x-rbac-catalog/resources/group:id'
       example:
@@ -152,7 +152,7 @@ x-rbac-catalog:
         resources: ['group:id:*']
         effect: "allow"
     'ciscat:read':
-      description: "Get CIS-CAT results for a list of agents"
+      description: "Access CIS-CAT results for agents"
       resources:
         - $ref: '#/x-rbac-catalog/resources/agent:id'
       example:
@@ -160,7 +160,7 @@ x-rbac-catalog:
         resources: ['agent:id:001', 'agent:id:003']
         effect: "deny"
     'cluster:read':
-      description: "Read Wazuh's cluster configuration"
+      description: "Read Wazuh's cluster nodes configuration"
       resources:
         - $ref: '#/x-rbac-catalog/resources/node:id'
       example:
@@ -168,7 +168,7 @@ x-rbac-catalog:
         resources: ['node:id:worker1', 'node:id:worker3']
         effect: "deny"
     'cluster:read_api_config':
-      description: "Check Wazuh's cluster API configuration"
+      description: "Check Wazuh's cluster nodes API configuration"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
@@ -176,7 +176,7 @@ x-rbac-catalog:
         resources: ['node:id:worker1', 'node:id:worker3']
         effect: "allow"
     'cluster:update_api_config':
-      description: "Modify Wazuh's cluster API configuration"
+      description: "Modify Wazuh's cluster nodes API configuration"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
@@ -184,7 +184,7 @@ x-rbac-catalog:
         resources: ['node:id:worker1', 'node:id:worker3']
         effect: "allow"
     'cluster:read_file':
-      description: "Read Wazuh's cluster files"
+      description: "Read Wazuh's cluster nodes files"
       resources:
         - $ref: '#/x-rbac-catalog/resources/node:id'
         - $ref: '#/x-rbac-catalog/resources/file:path'
@@ -193,7 +193,7 @@ x-rbac-catalog:
         resources: ['node:id:worker1', 'file:path:etc/rules/new-rules.xml']
         effect: "allow"
     'cluster:delete_file':
-      description: "Delete Wazuh's cluster files"
+      description: "Delete Wazuh's cluster nodes files"
       resources:
         - $ref: '#/x-rbac-catalog/resources/node:id'
         - $ref: '#/x-rbac-catalog/resources/file:path'
@@ -202,7 +202,7 @@ x-rbac-catalog:
         resources: ['node:id:worker1', 'file:path:etc/rules/new-rules.xml']
         effect: "deny"
     'cluster:upload_file':
-      description: "Upload new file to Wazuh's cluster node"
+      description: "Upload files to Wazuh's cluster nodes"
       resources:
         - $ref: '#/x-rbac-catalog/resources/node:id'
       example:
@@ -218,7 +218,7 @@ x-rbac-catalog:
         resources: ['node:id:worker1']
         effect: "allow"
     'cluster:status':
-      description: "Check Wazuh's cluster status"
+      description: "Check Wazuh's cluster general status"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
@@ -266,7 +266,7 @@ x-rbac-catalog:
         resources: ['file:path:etc/rules/new-rules.xml']
         effect: "allow"
     'manager:upload_file':
-      description: "Upload new file to Wazuh manager node"
+      description: "Upload files to Wazuh manager"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
@@ -274,7 +274,7 @@ x-rbac-catalog:
         resources: ['*:*:*']
         effect: "deny"
     'manager:restart':
-      description: "Restart Wazuh manager nodes"
+      description: "Restart Wazuh managers"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
@@ -282,7 +282,7 @@ x-rbac-catalog:
         resources: ['*:*:*']
         effect: "deny"
     'mitre:read':
-      description: "Get attacks information from MITRE database."
+      description: "Access attacks information from MITRE database"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
@@ -298,7 +298,7 @@ x-rbac-catalog:
         resources: ['decoder:file:*']
         effect: "allow"
     'lists:read':
-      description: "Read lists files"
+      description: "Read cdb lists files"
       resources:
         - $ref: '#/x-rbac-catalog/resources/list:path'
       example:
@@ -314,7 +314,7 @@ x-rbac-catalog:
         resources: ['rule:file:0610-win-ms_logs_rules.xml']
         effect: "allow"
     'sca:read':
-      description: "Get a list of policies analyzed in the configuration assessment for a given agent"
+      description: "Access agents security configuration assessment"
       resources:
         - $ref: '#/x-rbac-catalog/resources/agent:id'
       example:
@@ -330,7 +330,7 @@ x-rbac-catalog:
         resources: ['*:*:*']
         effect: "deny"
     'security:create_user':
-      description: "Create new system user"
+      description: "Create new system users"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
@@ -338,7 +338,7 @@ x-rbac-catalog:
         resources: ['*:*:*']
         effect: "allow"
     'security:read':
-      description: "Allow read information about system's security resources"
+      description: "Access information about system security resources"
       resources:
         - $ref: '#/x-rbac-catalog/resources/policy:id'
         - $ref: '#/x-rbac-catalog/resources/role:id'
@@ -349,7 +349,7 @@ x-rbac-catalog:
         resources: ['policy:id:*', 'role:id:2', 'user:id:5', 'rule:id:3']
         effect: "allow"
     'security:update':
-      description: "Allow update the information of system's security resources"
+      description: "Update the information of system security resources"
       resources:
         - $ref: '#/x-rbac-catalog/resources/policy:id'
         - $ref: '#/x-rbac-catalog/resources/role:id'
@@ -360,7 +360,7 @@ x-rbac-catalog:
         resources: ['policy:id:*', 'role:id:4', 'user:id:3', 'rule:id:4']
         effect: "deny"
     'security:delete':
-      description: "Delete system's security resources"
+      description: "Delete system security resources"
       resources:
         - $ref: '#/x-rbac-catalog/resources/policy:id'
         - $ref: '#/x-rbac-catalog/resources/role:id'
@@ -371,7 +371,7 @@ x-rbac-catalog:
         resources: ['policy:id:*', 'role:id:3', 'user:id:4', 'rule:id:2']
         effect: "deny"
     'security:read_config':
-      description: "Read current security configuration"
+      description: "Read current system security configuration"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
@@ -379,7 +379,7 @@ x-rbac-catalog:
         resources: ['*:*:*']
         effect: "allow"
     'security:update_config':
-      description: "Update current security configuration"
+      description: "Update current system security configuration"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
@@ -387,7 +387,7 @@ x-rbac-catalog:
         resources: ['*:*:*']
         effect: "allow"
     'syscheck:read':
-      description: "Read information from syscheck's database"
+      description: "Access information from agents syscheck database"
       resources:
         - $ref: '#/x-rbac-catalog/resources/agent:id'
       example:
@@ -395,7 +395,7 @@ x-rbac-catalog:
         resources: ['agent:id:011']
         effect: "allow"
     'syscheck:clear':
-      description: "Clear the syscheck database for specified agents"
+      description: "Clear the agents syscheck database"
       resources:
         - $ref: '#/x-rbac-catalog/resources/agent:id'
       example:
@@ -403,7 +403,7 @@ x-rbac-catalog:
         resources: ['agent:id:*']
         effect: "deny"
     'syscheck:run':
-      description: "Run syscheck"
+      description: "Run agents syscheck scan"
       resources:
         - $ref: '#/x-rbac-catalog/resources/agent:id'
       example:
@@ -411,7 +411,7 @@ x-rbac-catalog:
         resources: ['agent:id:*']
         effect: "allow"
     'syscollector:read':
-      description: "Get syscollector information about a specified agents"
+      description: "Access agents syscollector information"
       resources:
         - $ref: '#/x-rbac-catalog/resources/agent:id'
       example:
@@ -422,14 +422,16 @@ x-rbac-catalog:
 components:
   responses:
     ResponseError:
-      description: "Response to report a result error"
+      description: "Response to report a bad request"
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ApiError'
+            $ref: '#/components/schemas/RequestError'
           example:
             title: "Bad Request"
-            detail: "'{invalid_param}' is not a '{expected_type}'. Failed validating 'format' in schema['items']: {'description': '{parameter_name}', 'format': '{expected_format}', 'minLength': {expected_length}, 'type': '{expected_type}', 'x-scope': ['', '#/components/parameters/{parameter_name}']}."
+            detail: "'{invalid_param}' is not a '{expected_type}'. Failed validating 'format' in schema['items']:
+            {'description': '{parameter_name}', 'format': '{expected_format}', 'minLength': {expected_length}, 'type':
+            '{expected_type}', 'x-scope': ['', '#/components/parameters/{parameter_name}']}"
 
     PermissionDeniedResponse:
       description: "Response to report a permission denied request"
@@ -440,8 +442,10 @@ components:
           example:
             title: "Permission Denied"
             detail: "Permission denied: Resource type: *:*"
-            remediation: "Please, make sure you have permissions to execute the current request. For more information on how to set up permissions, please visit https://documentation.wazuh.com/current/user-manual/api/rbac/configuration.html"
-            code: 4000
+            remediation: "Please, make sure you have permissions to execute the current request. For more information
+            on how to set up permissions, please visit
+            https://documentation.wazuh.com/current/user-manual/api/rbac/configuration.html"
+            error: 4000
             dapi_errors:
               unknown-node:
                 error: "Permission denied: Resource type: *:*"
@@ -467,7 +471,7 @@ components:
             detail: "Invalid credentials"
 
     InvalidHTTPMethodResponse:
-      description: "Response to an invalid HTTP method"
+      description: "Response to report an invalid HTTP method"
       content:
         application/json:
           schema:
@@ -477,7 +481,7 @@ components:
             detail: "Specified method is invalid for this resource"
 
     WrongContentTypeResponse:
-      description: "The content-type does not match the body type"
+      description: "Response to report an invalid content-type"
       content:
         application/json:
           schema:
@@ -485,7 +489,7 @@ components:
           example:
             title: "Wazuh Error"
             detail: "The body type is not the one specified in the content-type"
-            code: 6002
+            error: 6002
 
     RequestTooLargeResponse:
       description: "Maximum request body size exceeded"
@@ -506,7 +510,8 @@ components:
           example:
             title: "Wazuh Error"
             detail: "Maximum number of request per minute reached"
-            remediation: "This limit can be changed in security.yaml file. More information here: https://documentation.wazuh.com/current/user-manual/api/security/configuration.html"
+            remediation: "This limit can be changed in security.yaml file. More information here:
+            https://documentation.wazuh.com/current/user-manual/api/security/configuration.html"
             code: 6001
 
     ResourceNotFoundResponse:
@@ -518,7 +523,8 @@ components:
           example:
             title: "Resource Not Found"
             detail: "The group does not exist"
-            remediation: "Please, use `GET /groups` to find all available groups://documentation.wazuh.com/current/user-manual/api/rbac/configuration.html"
+            remediation: "Please, use `GET /groups` to find all available groups:
+            https://documentation.wazuh.com/current/user-manual/api/rbac/configuration.html"
             code: 1710
             dapi_errors:
               unknown-node:
@@ -559,14 +565,10 @@ components:
     ApiError:
       type: object
       required:
-        - type
         - title
         - detail
       nullable: true
       properties:
-        type:
-          type: string
-          format: uri
         title:
           type: string
         detail:
@@ -593,19 +595,15 @@ components:
     RequestError:
       type: object
       required:
-        - type
         - title
         - detail
       nullable: true
       properties:
-        type:
-          type: string
-          format: uri
         title:
           type: string
         detail:
           type: string
-        code:
+        error:
           type: integer
           format: int32
 
@@ -644,16 +642,16 @@ components:
         total_affected_items:
           type: integer
           format: int32
-          description: "Number of items that have successfully done the requested operation"
+          description: "Number of items that have successfully applied the requested operation"
         failed_items:
           type: array
-          description: "List of items that have failed when doing the requested operation"
+          description: "List of items that have failed applying the requested operation"
           items:
             $ref: '#/components/schemas/SimpleApiError'
         total_failed_items:
           type: integer
           format: int32
-          description: "Number of items that have failed during the requested operation"
+          description: "Number of items that have failed applying the requested operation"
 
     AllItemsResponseAgents:
       allOf:
@@ -1151,9 +1149,10 @@ components:
           description: "API title name"
         api_version:
           type: string
-          description: "API version installed in the node"
+          description: "API version in the manager"
         revision:
           type: integer
+          description: "API revision"
           format: int32
         license_name:
           type: string
@@ -1185,7 +1184,7 @@ components:
       properties:
         status:
           type: string
-          description: "Whether the specified rulesetfile is enabled or disabled in Wazuh"
+          description: "Whether the specified ruleset file is enabled or disabled in Wazuh manager configuration"
           enum:
             - enabled
             - disabled
@@ -1200,7 +1199,8 @@ components:
           items:
             type: string
         command:
-          description: "Command running in the agent. If this value starts by `!`, then it refers to a script name instead of a command name"
+          description: "Command running in the agent. If this value starts by `!`, then it refers to a script name
+          instead of a command name"
           type: string
         custom:
           description: "Whether the specified command is a custom command or not"
@@ -1217,18 +1217,19 @@ components:
           $ref: '#/components/schemas/AgentStatus'
         configSum:
           type: string
-          description: "MD5 checksum of agent configuration file"
+          description: "MD5 checksum of the group configuration file (agent.conf)"
         group:
           type: array
-          description: "List of groups that the agent belongs to"
+          description: "List of groups the agent belongs to"
           items:
             type: string
         mergedSum:
           type: string
-          description: "MD5 checksum of all agent shared configuration files merged"
+          description: "MD5 checksum of all group shared files merged in a single one (merged.mg)"
         ip:
           type: string
-          description: "IP where the agent communicates with the manager. If the manager can't get this information, it will be the same as registerIP field"
+          description: "IP where the agent communicates with the manager. If the manager can't get this information, it
+          will be the same as registerIP field"
         registerIP:
           type: string
           description: "IP used at agent registration process"
@@ -1243,8 +1244,7 @@ components:
           description: "Date when the agent was registered"
         lastKeepAlive:
           type: string
-          description: "Date when the last keep alive was received from the agent"
-
+          description: "Date when the last keepalive was received from the agent"
         os:
           type: object
           properties:
@@ -1300,7 +1300,7 @@ components:
       properties:
         affected_agents:
           type: array
-          description: "List of agents which belonged to the group but were moved to the default one"
+          description: "List of agents which belonged to the group and might have been reassigned to group default"
           items:
             $ref: '#/components/schemas/AgentID'
 
@@ -1321,7 +1321,7 @@ components:
       properties:
         version:
           type: string
-          description: "Wazuh version the agent has intalled"
+          description: "Wazuh version the agent has installed"
         id:
           $ref: '#/components/schemas/AgentID'
         name:
@@ -1335,7 +1335,7 @@ components:
       - pending
       - never_connected
       - disconnected
-      description: "Agent status. It is calculated based on the last keep alive and the Wazuh version"
+      description: "Agent status. It is calculated based on the last keepalive and the Wazuh version"
 
     AgentsSummaryStatus:
       type: object
@@ -1365,7 +1365,7 @@ components:
             count:
               type: integer
               format: int32
-              description: "Return the number of agents with the specific unique fields"
+              description: "Number of agents with the specified unique fields"
 
     AgentSynced:
       type: object
@@ -1408,7 +1408,8 @@ components:
 
     AgentConfiguration:
       type: object
-      description: "Configuration the agent is currently using. The output of this API call depends on the component requested and the agent configuration"
+      description: "Current agent's configuration. The output varies with requested component and the agent
+      configuration"
 
     GroupConfiguration:
       type: object
@@ -1442,11 +1443,12 @@ components:
         error:
           type: integer
           format: int32
-          description: "Number of checks that CIS-CAT wasn't able to run"
+          description: "Number of checks that CIS-CAT was not able to run"
         fail:
           type: integer
           format: int32
-          description: "Number of failed checks. If this number is higher than 0 the host will probably have a vulnerability"
+          description: "Number of failed checks. If this number is higher than 0 the host will probably have a
+          vulnerability"
         notchecked:
           type: integer
           format: int32
@@ -1467,7 +1469,7 @@ components:
         unknown:
           type: integer
           format: int32
-          description: "Number of checks which status CIS-CAT wasn't able to determine"
+          description: "Number of checks which status CIS-CAT was not able to determine"
 
     ## Cluster models
     ClusterNodeBasic:
@@ -1592,11 +1594,11 @@ components:
     Security_rule_id:
       type: string
       format: numbers
-      description: "Rule ID"
+      description: "Security rule ID"
     Security_rule_id_DELETE:
       type: string
       format: numbers_delete
-      description: "Rule ID|all"
+      description: "Security rule ID|all"
     Policy_id:
       type: string
       format: numbers
@@ -1627,17 +1629,17 @@ components:
           description: "Policy name"
           type: string
         policy:
-          description: "This is the definition of the new policy"
+          description: "New policy definition"
           type: object
           properties:
             actions:
               type: array
-              description: "These are the actions that the policy performs"
+              description: "Actions to perform"
               items:
                 type: string
             resources:
               type: array
-              description: "Resources accessed by policy"
+              description: "Resources to apply the actions on"
               items:
                 type: string
             effect:
@@ -1654,17 +1656,17 @@ components:
           description: "Policy name"
           type: string
         policy:
-          description: "This is the definition of the new policy"
+          description: "New policy definition"
           type: object
           properties:
             actions:
               type: array
-              description: "These are the actions that the policy performs"
+              description: "Actions to perform"
               items:
                 type: string
             resources:
               type: array
-              description: "Resources accessed by policy"
+              description: "Resources to apply the actions on"
               items:
                 type: string
             effect:
@@ -1684,17 +1686,17 @@ components:
           description: "Policy name"
           type: string
         policy:
-          description: "This is the definition of the new policy"
+          description: "New policy definition"
           type: object
           properties:
             actions:
               type: array
-              description: "These are the actions that the policy performs"
+              description: "Actions to perform"
               items:
                 type: string
             resources:
               type: array
-              description: "Resources accessed by policy"
+              description: "Resources to apply the actions on"
               items:
                 type: string
             effect:
@@ -1766,7 +1768,7 @@ components:
       properties:
         token:
           type: string
-          description: "User's token"
+          description: "User's JWT token"
 
     # Cluster and manager models
     WazuhDaemonsStatus:
@@ -1822,7 +1824,7 @@ components:
           format: date-time
         type:
           type: string
-          description: "Wazuh installation type. "
+          description: "Wazuh installation type"
           enum:
           - server
           - local
@@ -1840,7 +1842,7 @@ components:
         tz_name:
           type: string
 
-    WazuhConfiguration:
+    WazuhMangerConfiguration:
       type: object
       properties:
         active-response:
@@ -1855,10 +1857,6 @@ components:
           type: object
         auth:
           type: object
-        client:
-          type: object
-        client_buffer:
-          type: object
         cluster:
           type: object
         command:
@@ -1868,6 +1866,8 @@ components:
         database_output:
           type: object
         email_alerts:
+          type: object
+        gcp-pubsub:
           type: object
         global:
           type: object
@@ -1920,8 +1920,6 @@ components:
         osquery:
           type: object
         syscollector:
-          type: object
-        vulnerability-detector:
           type: object
 
     WazuhStats:
@@ -2011,7 +2009,8 @@ components:
         alerts_queue_usage:
           type: number
           format: float
-          description: "If an event matches a rule, an alert is raised. The alerts are pushed to a _pending to write in disk alerts_ queue. This variable shows usage of that queue"
+          description: "If an event matches a rule, an alert is raised. The alerts are pushed to a _pending to write in
+          disk alerts_ queue. This variable shows usage of that queue"
         alerts_written:
           type: number
           format: float
@@ -2031,7 +2030,8 @@ components:
         event_queue_usage:
           type: number
           format: float
-          description: "Same as `syscheck_queue_usage` but for events not catalogued in any of the previously mentioned queues"
+          description: "Same as `syscheck_queue_usage` but for events not catalogued in any of the previously mentioned
+          queues"
         events_dropped:
           type: number
           format: float
@@ -2063,7 +2063,9 @@ components:
         fts_written:
           type: number
           format: float
-          description: "Same as `alerts_written` but focusing in [FTS alerts](https://documentation.wazuh.com/current/user-manual/ruleset/ruleset-xml-syntax/decoders.html?highlight=fts#fts)"
+          description: "Same as `alerts_written` but focusing in [FTS alerts]
+          (https://documentation.wazuh.com/current/user-manual/ruleset/ruleset-xml-syntax/decoders.html?highlight=fts
+          #fts)"
         hostinfo_edps:
           type: number
           format: float
@@ -2111,7 +2113,8 @@ components:
         rule_matching_queue_usage:
           type: number
           format: float
-          description: "After decoding, events are pushed to a _pending to process_ queue which will match the events against the Wazuh ruleset to raise alerts. This variable shows usage of that queue"
+          description: "After decoding, events are pushed to a _pending to process_ queue which will match the events
+          against the Wazuh ruleset to raise alerts. This variable shows usage of that queue"
         sca_edps:
           type: number
           format: float
@@ -2151,7 +2154,8 @@ components:
         syscheck_queue_usage:
           type: number
           format: float
-          description: "Percentage of use in the syscheck events queue pending to be decoded. Events are discarded when the queue is full"
+          description: "Percentage of use in the syscheck events queue pending to be decoded. Events are discarded when
+          the queue is full"
         syscollector_edps:
           type: number
           format: float
@@ -2171,7 +2175,8 @@ components:
         total_events_decoded:
           type: number
           format: float
-          description: "Total events decoded in the last 5 seconds. This number is not accumulative, the number in the following 5 seconds can be lower than the previous one"
+          description: "Total events decoded in the last 5 seconds. This number is not accumulative, the number in the
+          following 5 seconds can be lower than the previous one"
         winevt_edps:
           type: number
           format: float
@@ -2203,7 +2208,7 @@ components:
         evt_count:
           type: number
           format: float
-          description: "Number of events sent to Analysisd during the last five seconds"
+          description: "Number of events sent to analysisd during the last five seconds"
         msg_sent:
           type: number
           format: float
@@ -2414,9 +2419,10 @@ components:
               type: integer
               format: int32
               minimum: 1
-              example: 5
+              example: 50
             block_time:
-              description: "Blocking time for IPs that have exceeded {max_login_attempts}. Time counts from the first attempt"
+              description: "Blocking time for IPs that have exceeded {max_login_attempts}. Time counts from the first
+              attempt"
               type: integer
               format: int32
               minimum: 0
@@ -2428,7 +2434,7 @@ components:
               minimum: 1
               example: 300
         behind_proxy_server:
-          description: Set this option to "yes" in case the API is running behind a proxy server.
+          description: "Set this option to 'yes' in case the API is running behind a proxy server"
           type: boolean
           default: false
         logs:
@@ -2436,7 +2442,7 @@ components:
           additionalProperties: false
           properties:
             level:
-              description: Verbosity level of API logs.
+              description: "Verbosity level of API logs"
               default: info
               type: string
               enum: [disabled, info, warning, error, debug, debug2]
@@ -2445,11 +2451,11 @@ components:
           additionalProperties: false
           properties:
             enabled:
-              description: Enable cache.
+              description: "Enable cache"
               type: boolean
               default: true
             time:
-              description: Cache expiration time in seconds.
+              description: "Cache expiration time in seconds"
               type: number
               format: double
               minimum: 0
@@ -2459,31 +2465,31 @@ components:
           additionalProperties: false
           properties:
             enabled:
-              description: Enable CORS
+              description: "Enable CORS"
               type: boolean
               default: false
             source_route:
-              description: Sources for which the resources will be available. For example 'http://client.example.org'
+              description: "Sources for which the resources will be available. For example 'http://client.example.org'"
               type: string
               example: '*'
             expose_headers:
-              description: Which headers can be exposed as part of the response.
+              description: "Which headers can be exposed as part of the response"
               type: string
               example: '*'
             allow_headers:
-              description: Which HTTP headers can be used during the actual request.
+              description: "Which HTTP headers can be used during the actual request"
               type: string
               example: '*'
             allow_credentials:
-              description: Browsers will only expose the response to frontend JavaScript code if this is enabled.
+              description: "Browsers will only expose the response to frontend JavaScript code if this is enabled"
               type: boolean
               default: false
         use_only_authd:
-          description: Force the use of authd when adding and removing agents.
+          description: "Force the use of authd when adding and removing agents"
           type: boolean
           default: false
         experimental_features:
-          description: Enable features under development.
+          description: "Enable features under development"
           type: boolean
           default: false
 
@@ -2494,7 +2500,8 @@ components:
           type: string
           nullable: true
           format: date-time
-          description: "Date when the latest scan finished. If it is in progress, or no scans have been run, null will be returned"
+          description: "Date when the latest scan finished. If it is in progress, or no scans have been run, null will
+          be returned"
         start:
           type: string
           nullable: true
@@ -2602,7 +2609,8 @@ components:
           description: "Scanned policy ID"
         process:
           type: string
-          description: "Check whether a process is running or not. It's only returned when the checked process it's running"
+          description: "Check whether a process is running or not. It's only returned when the checked process is
+          running"
         rationale:
           type: string
           description: "Explain why this check is necessary"
@@ -2743,7 +2751,8 @@ components:
           type: integer
           format: int32
           minimum: 0
-          description: "Position of this decoder in the decoder file. The parent decoder will have position 0, the following defined decoder will have position 1, and so on"
+          description: "Position of this decoder in the decoder file. The parent decoder will have position 0, the
+          following defined decoder will have position 1, and so on"
         details:
           type: object
           description: "Decoder definition fields"
@@ -2971,7 +2980,7 @@ components:
       properties:
         architecture:
           type: string
-          description: "OS arquitecture"
+          description: "OS architecture"
         hostname:
           type: string
           description: "Machine's hostname"
@@ -3029,7 +3038,7 @@ components:
             - pkg
         multiarch:
           type: string
-          description: "Whether the package has multiarchitecture support"
+          description: "Whether the package has multi architecture support"
           enum:
             - allowed
             - same
@@ -3376,7 +3385,7 @@ components:
     attack_id:
       in: query
       name: id
-      description: "MITRE attack ID."
+      description: "MITRE attack ID"
       schema:
         type: string
         format: alphanumeric
@@ -3435,7 +3444,8 @@ components:
       in: path
       name: configuration
       description: |
-        <p>Selected agent's configuration to read. The configuration to read depends on the selected component. The following table shows all available combinations of component and configuration values:</p>
+        <p>Selected agent's configuration to read. The configuration to read depends on the selected component.
+        The following table shows all available combinations of component and configuration values:</p>
         <table class="table table-striped table-bordered">
         <thead>
         <tr>
@@ -3722,7 +3732,7 @@ components:
     file_format:
       in: query
       name: format
-      description: "Filter by file format. For example 'deb' will output deb files."
+      description: "Filter by file format. For example 'deb' will output deb files"
       schema:
         type: string
         format: alphanumeric
@@ -3863,8 +3873,9 @@ components:
     olderThanParam:
       in: query
       name: older_than
-      description: |
-        Filter out agents whose time lapse from last keep alive signal is longer than specified. Time in seconds, ‘[n_days]d’, ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For never_connected agents, uses the register date. For example, `7d`, `10s` and `10` are valid values. When no time unit is specified, seconds are used.
+      description: "Filter out agents whose time lapse from last keep alive signal is longer than specified. Time in
+      seconds, ‘[n_days]d’, ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For never_connected agents, uses the
+      register date. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, seconds are used"
       schema:
         type: string
         format: timeframe
@@ -3879,14 +3890,14 @@ components:
     phase_name:
       in: query
       name: phase_name
-      description: "Show results filtered by phase."
+      description: "Show results filtered by phase"
       schema:
         type: string
         format: alphanumeric
     platform_name:
       in: query
       name: platform_name
-      description: "Show results filtered by platform."
+      description: "Show results filtered by platform"
       schema:
         type: string
         format: alphanumeric
@@ -4127,17 +4138,16 @@ components:
     search:
       in: query
       name: search
-      description: |
-        Look for elements containing the specified string. To obtain a complementary search, use '-' at the
-        beggining
+      description: "Look for elements containing the specified string. To obtain a complementary search, use '-' at the
+      beggining"
       schema:
         type: string
         format: search
     select:
       in: query
       name: select
-      description: |
-        Select which fields to return (separated by comma). Use '.' for nested fields. For example, "{field1: field2}" may be selected with "field1.field2"
+      description: "Select which fields to return (separated by comma). Use '.' for nested fields. For example,
+      '{field1: field2}' may be selected with 'field1.field2'"
       schema:
         type: array
         items:
@@ -4147,9 +4157,9 @@ components:
     sort:
       in: query
       name: sort
-      description: |
-        Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order.
-        Use '.' for nested fields. For example, "{field1: field2}" may be selected with "field1.field2"
+      description: "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in
+      ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with
+      'field1.field2'"
       schema:
         type: string
         format: sort
@@ -4475,14 +4485,14 @@ components:
     tsc:
       in: query
       name: tsc
-      description: "Filters by TSC requirement."
+      description: "Filters by TSC requirement"
       schema:
         type: string
         format: alphanumeric
     mitre:
       in: query
       name: mitre
-      description: Filters by MITRE attack ID.
+      description: "Filters by MITRE attack ID"
       schema:
         type: string
         format: alphanumeric
@@ -4906,8 +4916,9 @@ components:
     older_than:
       in: query
       name: older_than
-      description: |
-        Consider only agents whose last keep alive is older than the specified time frame. For never_connected agents, register date is considered instead of last keep alive. For example, `7d`, `10s` and `10` are valid values. When no time unit is specified, seconds are assumed. Default value: 7d
+      description: "Consider only agents whose last keep alive is older than the specified time frame. For
+      never_connected agents, register date is considered instead of last keep alive. For example, `7d`, `10s` and `10`
+      are valid values. When no time unit is specified, seconds are assumed"
       schema:
         type: string
         format: timeframe
@@ -4915,7 +4926,8 @@ components:
     ip:
       in: query
       name: ip
-      description: "Filter by the IP used by the agent to communicate with the manager. If it's not available, it will have the same value as registerIP"
+      description: "Filter by the IP used by the agent to communicate with the manager. If it's not available, it will
+      have the same value as registerIP"
       schema:
         type: string
         format: alphanumeric
@@ -4962,7 +4974,8 @@ components:
     file_path:
       in: query
       name: file_path
-      description: "Full path to the WPK file. The file must be on a folder on the Wazuh's installation directory (by default, <code>/var/ossec</code>)"
+      description: "Full path to the WPK file. The file must be on a folder on the Wazuh's installation directory
+      (by default, <code>/var/ossec</code>)"
       required: True
       schema:
         type: string
@@ -4970,25 +4983,11 @@ components:
     installer:
       in: query
       name: installer
-      description: "Installation script. Default is <code>upgrade.sh</code> or <code>upgrade.bat</code> for windows agents"
+      description: "Installation script. Default is <code>upgrade.sh</code> or <code>upgrade.bat</code> for windows
+      agents"
       schema:
         type: string
         format: alphanumeric
-    username:
-      in: path
-      name: username
-      description: "Username"
-      required: True
-      schema:
-        $ref: '#/components/schemas/Username'
-    usernames:
-      in: query
-      name: usernames
-      description: "ID of a user"
-      schema:
-        type: array
-        items:
-          $ref: '#/components/schemas/Username'
     resource_list:
       in: query
       name: resource
@@ -4997,6 +4996,7 @@ components:
         type: string
         enum:
           - '*:*'
+          - 'agent:group'
           - 'agent:id'
           - 'group:id'
           - 'node:id'
@@ -5030,7 +5030,7 @@ tags:
   - name: mitre
     description: "Attacks information from MITRE database"
   - name: overview
-    description: "Overwiew of Wazuh"
+    description: "Overview of Wazuh"
   - name: rules
     description: "Rules management"
   - name: sca
@@ -5127,7 +5127,8 @@ paths:
       tags:
       - agents
       summary: "Delete agents"
-      description: "Delete all agents or a list of them with optional criteria based on the status or time of the last connection"
+      description: "Delete all agents or a list of them with optional criteria based on the status or time of the last
+      connection"
       operationId: api.controllers.agents_controller.delete_agents
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/agent:delete'
@@ -5156,7 +5157,8 @@ paths:
                             older_than:
                               type: string
                               format: timeframe
-                              description: "Return older than parameter used. It can be the default value or the parameter sent by the user"
+                              description: "Return older than parameter used. It can be the default value or the
+                              parameter sent by the user"
               example:
                 data:
                   affected_items:
@@ -5331,7 +5333,9 @@ paths:
                     type: string
                     format: names
                   ip:
-                    description: "If this is not included, the API will get the IP automatically. If you are behind a proxy, you must set the option behind_proxy_server to yes at api.yaml and make sure the proxy is setting HTTP header 'X-Forwarded-For' with origin IP address. Allowed values: IP, IP/NET, ANY"
+                    description: "If this is not included, the API will get the IP automatically. If you are behind a
+                    proxy, you must set the option behind_proxy_server to yes at api.yaml and make sure the proxy is
+                    setting HTTP header 'X-Forwarded-For' with origin IP address. Allowed values: IP, IP/NET, ANY"
                     type: string
                     format: alphanumeric
                   force_time:
@@ -5359,7 +5363,8 @@ paths:
               example:
                 data:
                   id: "007"
-                  key: MDA3IE5ld0hvc3QgMTAuMC4wLjkgZTk5MDE2ZTkzMjMyZDBjZDYyMGIyZTZmMTM2ZjMzMDQxMjY3M2E0NGRmOTNmODk1NzFjMGQyYzczY2VlYzRhZQ==
+                  key: "MDA3IE5ld0hvc3QgMTAuMC4wLjkgZTk5MDE2ZTkzMjMyZDBjZDYyMGIyZTZmMTM2ZjMzMDQxMjY3M2E0NGRmOTNmODk1NzFj
+                  MGQyYzczY2VlYzRhZQ=="
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
@@ -5380,7 +5385,8 @@ paths:
       tags:
         - agents
       summary: "Get active configuration"
-      description: "Return the active configuration the agent is currently using. This can be different from the configuration present in the configuration file, if it has been modified and the agent has not been restarted yet"
+      description: "Return the active configuration the agent is currently using. This can be different from the
+      configuration present in the configuration file, if it has been modified and the agent has not been restarted yet"
       operationId: api.controllers.agents_controller.get_agent_config
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/agent:read'
@@ -5431,7 +5437,8 @@ paths:
       tags:
         - agents
       summary: "Remove agent from groups"
-      description: 'Remove the agent from all groups or a list of them. The agent will automatically revert to the "default" group if it is removed from all its assigned groups'
+      description: 'Remove the agent from all groups or a list of them. The agent will automatically revert to the
+      "default" group if it is removed from all its assigned groups'
       operationId: api.controllers.agents_controller.delete_single_agent_multiple_groups
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/agent:modify_group'
@@ -5479,7 +5486,8 @@ paths:
       tags:
         - agents
       summary: "Get agent configuration sync status"
-      description: "Return whether the agent configuration has been synchronized with the agent or not. This can be useful to check after updating a group configuration"
+      description: "Return whether the agent configuration has been synchronized with the agent or not. This can be
+      useful to check after updating a group configuration"
       operationId: api.controllers.agents_controller.get_sync_agent
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/agent:read'
@@ -5525,7 +5533,8 @@ paths:
       tags:
         - agents
       summary: "Remove an agent from a specific group"
-      description: "Remove an agent from an specified group. If the agent has multigroups, it will preserve all previous groups except the last one"
+      description: "Remove an agent from an specified group. If the agent has multigroups, it will preserve all
+      previous groups except the last one"
       operationId: api.controllers.agents_controller.delete_single_agent_single_group
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/agent:modify_group'
@@ -5543,7 +5552,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               example:
-                message: "Agent '004' removed from group 'dmz'."
+                message: "Agent '004' removed from group 'dmz'"
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'
@@ -5631,7 +5640,8 @@ paths:
                 data:
                   affected_items:
                     - id: '002'
-                      key: MDAyIHdhenVoLWFnZW50MiBhbnkgMzAxYzk0Y2I3NDc5MzliMjAyYTg0OGE3NGIwMTNkODQwZWJkNWUyZmIxMjQ3NzhlNDhjYzUxOGE4MWQyNDFkYw==
+                      key: "MDAyIHdhenVoLWFnZW50MiBhbnkgMzAxYzk0Y2I3NDc5MzliMjAyYTg0OGE3NGIwMTNkODQwZWJkNWUyZmIxMjQ3Nzhl
+                      NDhjYzUxOGE4MWQyNDFkYw=="
                   total_affected_items: 1
                   failed_items: []
                   total_failed_items: 0
@@ -6021,7 +6031,9 @@ paths:
       tags:
         - groups
       summary: "Get groups"
-      description: "Get information about all groups or a list of them. Returns a list containing basic information about each group such as number of agents belonging to the group and the checksums of the configuration and shared files"
+      description: "Get information about all groups or a list of them. Returns a list containing basic information
+      about each group such as number of agents belonging to the group and the checksums of the configuration and
+      shared files"
       operationId: api.controllers.agents_controller.get_list_group
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/group:read'
@@ -6312,7 +6324,8 @@ paths:
       tags:
         - groups
       summary: "Update group configuration"
-      description: "Update an specified group's configuration. This API call expects a full valid XML file with the shared configuration tags/syntax"
+      description: "Update an specified group's configuration. This API call expects a full valid XML file with the
+      shared configuration tags/syntax"
       operationId: api.controllers.agents_controller.put_group_config
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/group:update_config'
@@ -6453,7 +6466,8 @@ paths:
                     oneOf:
                       - type: array
                       - type: object
-                        description: "The output format depends on the type of file that has been requested: rootkit file, rootkit trojans or rcl"
+                        description: "The output format depends on the type of file that has been requested: rootkit
+                        file, rootkit trojans or rcl"
               example:
                 data:
                   vars: None
@@ -6531,7 +6545,8 @@ paths:
       tags:
         - agents
       summary: "Add an agent specifying all its basic properties"
-      description: "Add an agent specifying its name, ID and IP. If an agent with the same ID already exists, replace it using `force` parameter"
+      description: "Add an agent specifying its name, ID and IP. If an agent with the same ID already exists, replace
+      it using `force` parameter"
       operationId: api.controllers.agents_controller.insert_agent
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/agent:create'
@@ -6550,13 +6565,16 @@ paths:
                     maxLength: 64
                     minLength: 64
                     format: wazuh_key
-                    description: "Key to use when communicating with the manager. The agent must have the same key on its `client.keys` file"
+                    description: "Key to use when communicating with the manager. The agent must have the same key on
+                    its `client.keys` file"
                   name:
                     description: "Agent name"
                     type: string
                     format: names
                   ip:
-                    description: "If this is not included, the API will get the IP automatically. If you are behind a proxy, you must set the option behind_proxy_server to yes at api.yaml and make sure the proxy is setting HTTP header 'X-Forwarded-For' with origin IP address. Allowed values: IP, IP/NET, ANY"
+                    description: "If this is not included, the API will get the IP automatically. If you are behind a
+                    proxy, you must set the option behind_proxy_server to yes at api.yaml and make sure the proxy is
+                    setting HTTP header 'X-Forwarded-For' with origin IP address. Allowed values: IP, IP/NET, ANY"
                     type: string
                     format: alphanumeric
                   force_time:
@@ -6585,8 +6603,9 @@ paths:
                       $ref: '#/components/schemas/AgentIdKey'
               example:
                 data:
-                  id: 001
-                  key: MTIzIE5ld0hvc3RfMiAxMC4wLjEwLjEwIDFhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5emFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpNjQ=
+                  id: "001"
+                  key: "MTIzIE5ld0hvc3RfMiAxMC4wLjEwLjEwIDFhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5emFiY2RlZmdoaWprbG1ub3BxcnN0
+                  dXZ3eHl6YWJjZGVmZ2hpNjQ="
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
@@ -6630,7 +6649,8 @@ paths:
               example:
                 data:
                   id: "008"
-                  key: MDA4IG15TmV3QWdlbnQgYW55IDIyNGVmNmI4NjYyMDk5OTc5NzdiZWJhNDRmZTAyNDI0NjU2ZDM1NjhjNWJiZWI4Njk0M2JkMzdjZjA5YjZlM2M=
+                  key: "MDA4IG15TmV3QWdlbnQgYW55IDIyNGVmNmI4NjYyMDk5OTc5NzdiZWJhNDRmZTAyNDI0NjU2ZDM1NjhjNWJiZWI4Njk0M2Jk
+                  MzdjZjA5YjZlM2M="
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
@@ -6919,7 +6939,8 @@ paths:
       tags:
         - agents
       summary: "Get distinct fields in agents"
-      description: "Return all the different combinations that agents have for the selected fields. It also indicates the total number of agents that have each combination"
+      description: "Return all the different combinations that agents have for the selected fields. It also indicates
+      the total number of agents that have each combination"
       operationId: api.controllers.agents_controller.get_agent_fields
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/agent:read'
@@ -7287,7 +7308,8 @@ paths:
       tags:
       - cluster
       summary: "Get cluster nodes healthcheck"
-      description: "Return cluster healthcheck information for all nodes or a list of them. Such information includes last keep alive, last synchronization time and number of agents reporting on each node"
+      description: "Return cluster healthcheck information for all nodes or a list of them. Such information includes
+      last keep alive, last synchronization time and number of agents reporting on each node"
       operationId: api.controllers.cluster_controller.get_healthcheck
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
@@ -7451,7 +7473,8 @@ paths:
                           description: "Network interface used by the **master** to listen to incoming connections"
                           type: string
                         nodes:
-                          description: "List of cluster master nodes. This list is used by **worker** nodes to connect to the master"
+                          description: "List of cluster master nodes. This list is used by **worker** nodes to connect
+                          to the master"
                           type: array
                           items:
                             type: string
@@ -7616,7 +7639,8 @@ paths:
                   total_affected_items: 2
                   failed_items: []
                   total_failed_items: 0
-                message: "API configuration was successfully updated in all specified nodes. Some settings may require restarting the API to be applied"
+                message: "API configuration was successfully updated in all specified nodes. Some settings may require
+                restarting the API to be applied"
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'
@@ -7660,7 +7684,8 @@ paths:
                   total_affected_items: 2
                   failed_items: []
                   total_failed_items: 0
-                message: "API configuration was successfully updated in all specified nodes. Some settings may require restarting the API to be applied"
+                message: "API configuration was successfully updated in all specified nodes. Some settings may require
+                restarting the API to be applied"
                 error: 0
 
         '400':
@@ -7740,7 +7765,8 @@ paths:
       tags:
       - cluster
       summary: "Get a specified node's information"
-      description: "Return basic information about a specified node such as version, compilation date, installation path"
+      description: "Return basic information about a specified node such as version, compilation date, installation
+      path"
       operationId: api.controllers.cluster_controller.get_info_node
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
@@ -7814,7 +7840,7 @@ paths:
                 - type: object
                   properties:
                     data:
-                      $ref: '#/components/schemas/WazuhConfiguration'
+                      $ref: '#/components/schemas/WazuhMangerConfiguration'
               example:
                 data:
                   affected_items:
@@ -7941,7 +7967,8 @@ paths:
       tags:
       - cluster
       summary: "Get a specified node's stats per hour"
-      description: "Return Wazuh statistical information in node {node_id} per hour. Each number in the averages field represents the average of alerts per hour"
+      description: "Return Wazuh statistical information in node {node_id} per hour. Each number in the averages field
+      represents the average of alerts per hour"
       operationId: api.controllers.cluster_controller.get_stats_hourly_node
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
@@ -8009,7 +8036,8 @@ paths:
       tags:
       - cluster
       summary: "Get a specified node's stats per week"
-      description: "Return Wazuh statistical information in node {node_id} per week. Each number in the averages field represents the average of alerts per hour for that specific day"
+      description: "Return Wazuh statistical information in node {node_id} per week. Each number in the averages field
+      represents the average of alerts per hour for that specific day"
       operationId: api.controllers.cluster_controller.get_stats_weekly_node
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
@@ -8411,15 +8439,15 @@ paths:
                     - timestamp: '2020-04-15T13:43:38+00:00'
                       tag: ossec-analysisd
                       level: error
-                      description: " (1277): Invalid syscheck message received."
+                      description: " (1277): Invalid syscheck message received"
                     - timestamp: '2020-04-15T13:43:38+00:00'
                       tag: ossec-analysisd
                       level: error
-                      description: " (1277): Invalid syscheck message received."
+                      description: " (1277): Invalid syscheck message received"
                     - timestamp: '2020-04-15T13:43:30+00:00'
                       tag: ossec-analysisd
                       level: error
-                      description: " (1277): Invalid syscheck message received."
+                      description: " (1277): Invalid syscheck message received"
                   total_affected_items: 3
                   failed_items: []
                   total_failed_items: 0
@@ -8532,7 +8560,12 @@ paths:
                           type: string
               example:
                 data:
-                  contents: '<!-- Local rules -->\n\n<!-- Modify it at your will. -->\n<!-- Copyright (C) 2015-2019, Wazuh Inc. -->\n\n<!-- Example -->\n<group name=\"local,syslog,sshd,\">\n\n  <!--\n  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n -->\n  <rule id=\"100001\" level=\"5\">\n    <if_sid>5716</if_sid>\n    <srcip>1.1.1.1</srcip>\n    <description>sshd: authentication failed from IP 1.1.1.1.</description>\n    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n  </rule>\n\n</group>\n'
+                  contents: '<!-- Local rules -->\n\n<!-- Modify it at your will. -->\n<!-- Copyright (C) 2015-2019,
+                  Wazuh Inc. -->\n\n<!-- Example -->\n<group name=\"local,syslog,sshd,\">\n\n  <!--\n  Dec 10 01:02:02
+                  host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n -->\n  <rule id=\"100001\"
+                  level=\"5\">\n    <if_sid>5716</if_sid>\n    <srcip>1.1.1.1</srcip>\n    <description>sshd:
+                  authentication failed from IP 1.1.1.1.</description>\n    <group>authentication_failed,pci_dss_10.2.4,
+                  pci_dss_10.2.5,</group>\n  </rule>\n\n</group>\n'
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
@@ -8793,7 +8826,8 @@ paths:
       tags:
       - lists
       summary: "Get all CDB lists"
-      description: "Return the contents of all CDB lists. Optionally, the result can be filtered by several criteria. See available parameters for more details"
+      description: "Return the contents of all CDB lists. Optionally, the result can be filtered by several criteria.
+      See available parameters for more details"
       operationId: api.controllers.lists_controller.get_lists
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/lists:read'
@@ -8881,7 +8915,8 @@ paths:
       tags:
       - lists
       summary: "Get paths from all CDB lists"
-      description: "Return the path from all CDB lists. Use this method to know all the CDB lists and their location in the filesystem relative to Wazuh installation folder"
+      description: "Return the path from all CDB lists. Use this method to know all the CDB lists and their location in
+      the filesystem relative to Wazuh installation folder"
       operationId: api.controllers.lists_controller.get_lists_files
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/lists:read'
@@ -9070,7 +9105,7 @@ paths:
                 - type: object
                   properties:
                     data:
-                      $ref: '#/components/schemas/WazuhConfiguration'
+                      $ref: '#/components/schemas/WazuhMangerConfiguration'
               example:
                 data:
                   affected_items:
@@ -9196,7 +9231,8 @@ paths:
       tags:
       - manager
       summary: "Get stats by hour"
-      description: "Return Wazuh statistical information per hour. Each number in the averages field represents the average of alerts per hour"
+      description: "Return Wazuh statistical information per hour. Each number in the averages field represents the
+      average of alerts per hour"
       operationId: api.controllers.manager_controller.get_stats_hourly
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/manager:read'
@@ -9263,7 +9299,8 @@ paths:
       tags:
       - manager
       summary: "Get stats by week"
-      description: "Return Wazuh statistical information per week. Each number in the averages field represents the average of alerts per hour for that specific day"
+      description: "Return Wazuh statistical information per week. Each number in the averages field represents the
+      average of alerts per hour for that specific day"
       operationId: api.controllers.manager_controller.get_stats_weekly
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/manager:read'
@@ -9665,7 +9702,7 @@ paths:
                     - timestamp: '2020-04-15T14:47:51+00:00'
                       tag: wazuh-modulesd:syscollector
                       level: info
-                      description: "Starting evaluation."
+                      description: "Starting evaluation"
                     - timestamp: '2020-04-15T13:50:24+00:00'
                       tag: ossec-maild
                       level: error
@@ -9782,7 +9819,12 @@ paths:
                             type: string
               example:
                 data:
-                  contents: '<!-- Local rules -->\n\n<!-- Modify it at your will. -->\n<!-- Copyright (C) 2015-2019, Wazuh Inc. -->\n\n<!-- Example -->\n<group name=\"local,syslog,sshd,\">\n\n  <!--\n  Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n -->\n  <rule id=\"100001\" level=\"5\">\n    <if_sid>5716</if_sid>\n    <srcip>1.1.1.1</srcip>\n    <description>sshd: authentication failed from IP 1.1.1.1.</description>\n    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n  </rule>\n\n</group>\n'
+                  contents: '<!-- Local rules -->\n\n<!-- Modify it at your will. -->\n<!-- Copyright (C) 2015-2019,
+                  Wazuh Inc. -->\n\n<!-- Example -->\n<group name=\"local,syslog,sshd,\">\n\n  <!--\n  Dec 10 01:02:02
+                  host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2\n -->\n  <rule id=\"100001\"
+                  level=\"5\">\n    <if_sid>5716</if_sid>\n    <srcip>1.1.1.1</srcip>\n
+                  <description>sshd: authentication failed from IP 1.1.1.1.</description>\n
+                  <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n  </rule>\n\n</group>\n'
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
@@ -9981,7 +10023,8 @@ paths:
                   total_affected_items: 1
                   failed_items: []
                   total_failed_items: 0
-                message: "API configuration was successfully updated. Some settings may require restarting the API to be applied"
+                message: "API configuration was successfully updated. Some settings may require restarting the API to
+                be applied"
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'
@@ -10024,7 +10067,8 @@ paths:
                   total_affected_items: 1
                   failed_items: []
                   total_failed_items: 0
-                message: "API configuration was successfully updated. Some settings may require restarting the API to be applied"
+                message: "API configuration was successfully updated. Some settings may require restarting the API to
+                be applied"
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'
@@ -10200,7 +10244,8 @@ paths:
                         - "Packet capture"
                         - "Process use of network"
                       name: "Data Obfuscation"
-                      description: "Command and control (C2) communications are hidden (but not necessarily encrypted)..."
+                      description: "Command and control (C2) communications are hidden (but not necessarily encrypted)
+                      ..."
                       id: "attack-pattern--ad255bfe-a9e6-4b52-a258-8d3462abe842"
                       x_mitre_platforms:
                         - "Linux"
@@ -10253,7 +10298,8 @@ paths:
       tags:
       - rules
       summary: "Get information about a list of Wazuh rules"
-      description: "Return a list containing information about each rule such as file where it's defined, description, rule group, status, etc"
+      description: "Return a list containing information about each rule such as file where it's defined, description,
+      rule group, status, etc"
       operationId: api.controllers.rules_controller.get_rules
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/rules:read'
@@ -10632,7 +10678,8 @@ paths:
               example:
                 data:
                   affected_items:
-                    - description: "This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9"
+                    - description: "This document provides prescriptive guidance for establishing a secure
+                    configuration posture for Debian Linux 9"
                       end_scan: '2019-11-13T10:57:09Z'
                       fail: 26
                       hash_file: c5ada687e0c2ae9504be13b965074cc262e62be4e68fe550d464018def4af61c
@@ -10644,7 +10691,8 @@ paths:
                       score: 7
                       start_scan: '2019-11-13T10:57:09Z'
                       total_checks: 29
-                    - description: "This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9"
+                    - description: "This document provides prescriptive guidance for establishing a secure
+                    configuration posture for Debian Linux 9"
                       end_scan: '2019-11-13T10:57:06Z'
                       fail: 48
                       hash_file: b44ecda10d854ecad25476ed99b5dfd9481e8a846c8d8a7684a1cc3b29f12993
@@ -10720,12 +10768,16 @@ paths:
               example:
                 data:
                   affected_items:
-                  - remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var. For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
-                    rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
+                  - remediation: "For new installations, during installation create a custom partition setup and specify
+                   a separate partition for /var. For systems that were previously installed, create a new partition and
+                    configure /etc/fstab as appropriate"
+                    rationale: "Since the /var directory may contain world-writable files and directories, there is a
+                    risk of resource exhaustion if it is not bound to a separate partition"
                     title: "Ensure separate partition exists for /var"
                     policy_id: cis_debian
                     file: /etc/fstab
-                    description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable"
+                    description: "The /var directory is used by daemons and other system services to temporarily store
+                    dynamic data. Some directories created by these processes may be world-writable"
                     id: 5003
                     result: failed
                     condition: all
@@ -10735,8 +10787,10 @@ paths:
                       value: "1.1.6"
                     - key: cis_csc
                       value: "5"
-                  - remediation: "Run the following commands to remove exim: # apt-get remove exim4; # apt-get purge exim4"
-                    rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
+                  - remediation: "Run the following commands to remove exim: # apt-get remove exim4; # apt-get purge
+                  exim4"
+                    rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended
+                    that the package be removed to reduce the potential attack surface"
                     title: "Ensure IMAP and POP3 server is not enabled (POP3)"
                     policy_id: cis_debian
                     file: /etc/inetd.conf
@@ -10952,7 +11006,8 @@ paths:
       tags:
       - syscheck
       summary: "Get last syscheck scan dates"
-      description: "Return when the last syscheck scan started and ended. If the scan is still in progress the end date will be unknown"
+      description: "Return when the last syscheck scan started and ended. If the scan is still in progress the end date
+      will be unknown"
       operationId: api.controllers.syscheck_controller.get_last_scan_agent
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscheck:read'
@@ -10998,7 +11053,8 @@ paths:
       tags:
         - decoders
       summary: "Get all decoders"
-      description: "Return information about all decoders included in ossec.conf. This information include decoder's route, decoder's name, decoder's file among others"
+      description: "Return information about all decoders included in ossec.conf. This information include decoder's
+      route, decoder's name, decoder's file among others"
       operationId: api.controllers.decoders_controller.get_decoders
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/decoders:read'
@@ -11069,7 +11125,8 @@ paths:
       tags:
         - decoders
       summary: "Get all decoders files"
-      description: "Return information about all decoders files used in Wazuh. This information include decoder's file, decoder's route and decoder's status among others"
+      description: "Return information about all decoders files used in Wazuh. This information include decoder's file,
+      decoder's route and decoder's status among others"
       operationId: api.controllers.decoders_controller.get_decoders_files
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/decoders:read'
@@ -11174,7 +11231,8 @@ paths:
       tags:
         - decoders
       summary: "Get all parent decoders"
-      description: "Return information about all parent decoders. A parent decoder is a decoder used as base of other decoders"
+      description: "Return information about all parent decoders. A parent decoder is a decoder used as base of other
+      decoders"
       operationId: api.controllers.decoders_controller.get_decoders_parents
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/decoders:read'
@@ -11387,7 +11445,8 @@ paths:
       tags:
         - experimental
       summary: "Get hardware info from agents"
-      description: "Return all agents (or a list of them) hardware info. This information include cpu, ram, scan info among others of all agents"
+      description: "Return all agents (or a list of them) hardware info. This information include cpu, ram, scan info
+      among others of all agents"
       operationId: api.controllers.experimental_controller.get_hardware_info
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscollector:read'
@@ -11481,7 +11540,8 @@ paths:
       tags:
         - experimental
       summary: "Get the IPv4 and IPv6 addresses associated to network interfaces"
-      description: "Return all agents (or a list of them) IPv4 and IPv6 addresses associated to their network interfaces. This information include used IP protocol, interface, and IP address among others"
+      description: "Return all agents (or a list of them) IPv4 and IPv6 addresses associated to their network
+      interfaces. This information include used IP protocol, interface, and IP address among others"
       operationId: api.controllers.experimental_controller.get_network_address_info
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscollector:read'
@@ -11558,7 +11618,8 @@ paths:
       tags:
         - experimental
       summary: "Get all network interfaces from agents"
-      description: "Return all agents (or a list of them) network interfaces. This information includes rx, scan, tx info and some network information among other"
+      description: "Return all agents (or a list of them) network interfaces. This information includes rx, scan, tx
+      info and some network information among other"
       operationId: api.controllers.experimental_controller.get_network_interface_info
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscollector:read'
@@ -11677,7 +11738,8 @@ paths:
       tags:
         - experimental
       summary: "Get network protocol info from agents"
-      description: "Return all agents (or a list of them) routing configuration for each network interface. This information includes interface, type protocol information among other"
+      description: "Return all agents (or a list of them) routing configuration for each network interface. This
+      information includes interface, type protocol information among other"
       operationId: api.controllers.experimental_controller.get_network_protocol_info
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscollector:read'
@@ -11751,7 +11813,8 @@ paths:
       tags:
         - experimental
       summary: "Get OS info from agents"
-      description: "Return all agents (or a list of them) OS info. This information includes os information, architecture information among other"
+      description: "Return all agents (or a list of them) OS info. This information includes os information,
+      architecture information among other"
       operationId: api.controllers.experimental_controller.get_os_info
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscollector:read'
@@ -11853,7 +11916,8 @@ paths:
       tags:
         - experimental
       summary: "Get packages info from agents"
-      description: "Return all agents (or a list of them) packages info. This information includes name, section, size, and priority information of all packages among other"
+      description: "Return all agents (or a list of them) packages info. This information includes name, section, size,
+      and priority information of all packages among other"
       operationId: api.controllers.experimental_controller.get_packages_info
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscollector:read'
@@ -11952,7 +12016,8 @@ paths:
       tags:
         - experimental
       summary: "Get ports info from agents"
-      description: "Return all agents (or a list of them) ports info. This information includes local IP, Remote IP, protocol information among other"
+      description: "Return all agents (or a list of them) ports info. This information includes local IP, Remote IP,
+      protocol information among other"
       operationId: api.controllers.experimental_controller.get_ports_info
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscollector:read'
@@ -12353,7 +12418,8 @@ paths:
       tags:
         - syscollector
       summary: "Get network address info of an agent"
-      description: "Return the agent's network address info. This information include used IP protocol, interface, IP address  among others"
+      description: "Return the agent's network address info. This information include used IP protocol, interface, IP
+      address  among others"
       operationId: api.controllers.syscollector_controller.get_network_address_info
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscollector:read'
@@ -12415,7 +12481,8 @@ paths:
       tags:
         - syscollector
       summary: "Get network interface info of an agent"
-      description: "Return the agent's network interface info. This information include rx, scan, tx info and some network information among others"
+      description: "Return the agent's network interface info. This information include rx, scan, tx info and some
+      network information among others"
       operationId: api.controllers.syscollector_controller.get_network_interface_info
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscollector:read'
@@ -12558,7 +12625,8 @@ paths:
       tags:
         - syscollector
       summary: "Get OS info of an agent"
-      description: "Return the agent's OS info. This information include os information, architecture information among others of all agents"
+      description: "Return the agent's OS info. This information include os information, architecture information among
+      others of all agents"
       operationId: api.controllers.syscollector_controller.get_os_info
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscollector:read'
@@ -12619,7 +12687,8 @@ paths:
       tags:
         - syscollector
       summary: "Get packages info of an agent"
-      description: "Return the agent's packages info. This information include name, section, size, priority information of all packages among others"
+      description: "Return the agent's packages info. This information include name, section, size, priority
+      information of all packages among others"
       operationId: api.controllers.syscollector_controller.get_packages_info
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscollector:read'
@@ -12719,7 +12788,8 @@ paths:
       tags:
         - syscollector
       summary: "Get ports info of an agent"
-      description: "Return the agent's ports info. This information include local IP, Remote IP, protocol information among others"
+      description: "Return the agent's ports info. This information include local IP, Remote IP, protocol information
+      among others"
       operationId: api.controllers.syscollector_controller.get_ports_info
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscollector:read'
@@ -12950,7 +13020,8 @@ paths:
       tags:
         - security
       summary: "User/password authentication to get an access token"
-      description: "This method should be called to get an API token. This token will expire after auth_token_exp_timeout seconds (default: 3600). This value can be changed using PUT /security/config"
+      description: "This method should be called to get an API token. This token will expire after
+      auth_token_exp_timeout seconds (default: 3600). This value can be changed using PUT /security/config"
       operationId: api.controllers.security_controller.login_user
       parameters:
         - $ref: '#/components/parameters/raw'
@@ -12989,7 +13060,7 @@ paths:
       tags:
         - security
       summary: "Logout current user"
-      description: "This method should be called to invalidate all the current user's tokens."
+      description: "This method should be called to invalidate all the current user's tokens"
       operationId: api.controllers.security_controller.logout_user
       responses:
         '200':
@@ -13017,7 +13088,9 @@ paths:
       tags:
       - security
       summary: "Auth_context based authentication to get an access token"
-      description: "This method should be called to get an API token using an authorization context body. This token will expire after auth_token_exp_timeout seconds (default: 3600). This value can be changed using PUT /security/config"
+      description: "This method should be called to get an API token using an authorization context body. This token
+      will expire after auth_token_exp_timeout seconds (default: 3600). This value can be changed using PUT
+      /security/config"
       operationId: api.controllers.security_controller.login_user
       parameters:
         - $ref: '#/components/parameters/raw'
@@ -13129,8 +13202,10 @@ paths:
                   - type: object
               example:
                 "*:*":
-                  description: "Resource applied in functions which take part in the creation of a specific resource.
-                                We call these functions, resourceless functions. Example: agent:create"
+                  description: "Resource applied in functions acting on resources that do not yet exist in the system.
+                                We call these functions, resourceless functions"
+                'agent:group':
+                  description: "Reference agents via group name (i.e. agent:group:web)"
                 agent:id:
                   description: 'Reference agents via agent ID (i.e. agent:id:001)'
                 group:id:
@@ -13384,7 +13459,8 @@ paths:
       tags:
         - security
       summary: "Modify a specified role"
-      description: "Modify a role, cannot modify associated policies in this endpoint, at least one property must be indicated"
+      description: "Modify a role, cannot modify associated policies in this endpoint, at least one property must be
+      indicated"
       operationId: api.controllers.security_controller.update_role
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/security:update'
@@ -13443,7 +13519,9 @@ paths:
       tags:
         - security
       summary: "Get all security rules"
-      description: "Get a list of security rules from the system or all of them. These rules must be mapped with roles to obtain certain access privileges. For a specific list, indicate the ids separated by commas. Example: ?rule_ids=1,2,3"
+      description: "Get a list of security rules from the system or all of them. These rules must be mapped with roles
+      to obtain certain access privileges. For a specific list, indicate the ids separated by commas.
+      Example: ?rule_ids=1,2,3"
       operationId: api.controllers.security_controller.get_rules
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/security:read'
@@ -14695,7 +14773,8 @@ paths:
                       major: "04"
                       name: Ubuntu
                       platform: ubuntu
-                      uname: Linux |ee7d4f51c0ae |4.18.0-16-generic |#17~18.04.1-Ubuntu SMP Tue Feb 12 13:35:51 UTC 2019 |x86_64
+                      uname: "Linux |ee7d4f51c0ae |4.18.0-16-generic |#17~18.04.1-Ubuntu SMP Tue Feb 12 13:35:51 UTC
+                      2019 |x86_64"
                       version: 18.04.2 LTS
                     version: Wazuh v3.9.5
                     dateAdd: "2019-08-20 11:42:14"

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5011,7 +5011,7 @@ components:
 tags:
   - name: active-response
     description: "Agents Active Response"
-  - name: agents
+  - name: Agents
     description: "Agents management related operations"
   - name: ciscat
     description: "Retrieve information from CIS-CAT scans"
@@ -5125,7 +5125,7 @@ paths:
   /agents:
     delete:
       tags:
-      - agents
+      - Agents
       summary: "Delete agents"
       description: "Delete all agents or a list of them with optional criteria based on the status or time of the last
       connection"
@@ -5182,7 +5182,7 @@ paths:
     get:
       tags:
       - agents
-      summary: "Get agents"
+      summary: "List agents"
       description: "Return information about all available agents or a list of them"
       operationId: api.controllers.agents_controller.get_agents
       x-rbac-actions:
@@ -5485,7 +5485,7 @@ paths:
     get:
       tags:
         - agents
-      summary: "Get agent configuration sync status"
+      summary: "Get configuration sync status"
       description: "Return whether the agent configuration has been synchronized with the agent or not. This can be
       useful to check after updating a group configuration"
       operationId: api.controllers.agents_controller.get_sync_agent
@@ -5532,7 +5532,7 @@ paths:
     delete:
       tags:
         - agents
-      summary: "Remove an agent from a specific group"
+      summary: "Remove agent from group"
       description: "Remove an agent from an specified group. If the agent has multigroups, it will preserve all
       previous groups except the last one"
       operationId: api.controllers.agents_controller.delete_single_agent_single_group
@@ -5570,7 +5570,7 @@ paths:
     put:
       tags:
         - agents
-      summary: "Assign an agent to a group"
+      summary: "Assign agent to group"
       description: "Assign an agent to a specified group"
       operationId: api.controllers.agents_controller.put_agent_single_group
       x-rbac-actions:
@@ -5615,7 +5615,7 @@ paths:
     get:
       tags:
         - agents
-      summary: "Get agent key"
+      summary: "Get key"
       description: "Return the key of an agent"
       operationId: api.controllers.agents_controller.get_agent_key
       x-rbac-actions:
@@ -5662,7 +5662,7 @@ paths:
     put:
       tags:
         - agents
-      summary: "Restart an agent"
+      summary: "Restart agent"
       description: "Restart the specified agent"
       operationId: api.controllers.agents_controller.restart_agent
       x-rbac-actions:
@@ -5707,7 +5707,7 @@ paths:
     put:
       tags:
         - agents
-      summary: "Upgrade agent using online repository"
+      summary: "Upgrade agent"
       description: "Upgrade the agent using a WPK file from online repository"
       operationId: api.controllers.agents_controller.put_upgrade_agent
       x-rbac-actions:
@@ -5745,7 +5745,7 @@ paths:
     put:
       tags:
         - agents
-      summary: "Upgrade agent using a custom file"
+      summary: "Upgrade agent custom"
       description: "Upgrade the agent using a local WPK file"
       operationId: api.controllers.agents_controller.put_upgrade_custom_agent
       x-rbac-actions:
@@ -5781,7 +5781,7 @@ paths:
     get:
       tags:
         - agents
-      summary: "Get upgrade result from agent"
+      summary: "Get upgrade result"
       description: "Return the upgrade result after updating an agent"
       operationId: api.controllers.agents_controller.get_agent_upgrade
       x-rbac-actions:
@@ -5821,7 +5821,7 @@ paths:
     delete:
       tags:
         - agents
-      summary: "Remove agents assignment from a single group"
+      summary: "Remove agents from group"
       description: "Remove all agents assignment or a list of them from the specified group"
       operationId: api.controllers.agents_controller.delete_multiple_agent_single_group
       x-rbac-actions:
@@ -5873,7 +5873,7 @@ paths:
     put:
       tags:
         - agents
-      summary: "Assign agents to a single group"
+      summary: "Assign agents to group"
       description: "Assign all agents or a list of them to the specified group"
       operationId: api.controllers.agents_controller.put_multiple_agent_single_group
       x-rbac-actions:
@@ -5937,7 +5937,7 @@ paths:
     put:
       tags:
         - agents
-      summary: 'Restart all agents in a group'
+      summary: 'Restart agents in group'
       description: 'Restart all agents which belong to a given group'
       operationId: api.controllers.agents_controller.restart_agents_by_group
       x-rbac-actions:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5181,7 +5181,7 @@ paths:
           $ref: '#/components/responses/TooManyRequestsResponse'
     get:
       tags:
-      - agents
+      - Agents
       summary: "List agents"
       description: "Return information about all available agents or a list of them"
       operationId: api.controllers.agents_controller.get_agents
@@ -5314,7 +5314,7 @@ paths:
           $ref: '#/components/responses/TooManyRequestsResponse'
     post:
       tags:
-      - agents
+      - Agents
       summary: "Add agent"
       description: "Add a new agent"
       operationId: api.controllers.agents_controller.add_agent
@@ -5383,7 +5383,7 @@ paths:
   /agents/{agent_id}/config/{component}/{configuration}:
     get:
       tags:
-        - agents
+        - Agents
       summary: "Get active configuration"
       description: "Return the active configuration the agent is currently using. This can be different from the
       configuration present in the configuration file, if it has been modified and the agent has not been restarted yet"
@@ -5435,7 +5435,7 @@ paths:
   /agents/{agent_id}/group:
     delete:
       tags:
-        - agents
+        - Agents
       summary: "Remove agent from groups"
       description: 'Remove the agent from all groups or a list of them. The agent will automatically revert to the
       "default" group if it is removed from all its assigned groups'
@@ -5484,7 +5484,7 @@ paths:
   /agents/{agent_id}/group/is_sync:
     get:
       tags:
-        - agents
+        - Agents
       summary: "Get configuration sync status"
       description: "Return whether the agent configuration has been synchronized with the agent or not. This can be
       useful to check after updating a group configuration"
@@ -5531,7 +5531,7 @@ paths:
   /agents/{agent_id}/group/{group_id}:
     delete:
       tags:
-        - agents
+        - Agents
       summary: "Remove agent from group"
       description: "Remove an agent from an specified group. If the agent has multigroups, it will preserve all
       previous groups except the last one"
@@ -5569,7 +5569,7 @@ paths:
 
     put:
       tags:
-        - agents
+        - Agents
       summary: "Assign agent to group"
       description: "Assign an agent to a specified group"
       operationId: api.controllers.agents_controller.put_agent_single_group
@@ -5614,7 +5614,7 @@ paths:
   /agents/{agent_id}/key:
     get:
       tags:
-        - agents
+        - Agents
       summary: "Get key"
       description: "Return the key of an agent"
       operationId: api.controllers.agents_controller.get_agent_key
@@ -5661,7 +5661,7 @@ paths:
   /agents/{agent_id}/restart:
     put:
       tags:
-        - agents
+        - Agents
       summary: "Restart agent"
       description: "Restart the specified agent"
       operationId: api.controllers.agents_controller.restart_agent
@@ -5706,7 +5706,7 @@ paths:
   /agents/{agent_id}/upgrade:
     put:
       tags:
-        - agents
+        - Agents
       summary: "Upgrade agent"
       description: "Upgrade the agent using a WPK file from online repository"
       operationId: api.controllers.agents_controller.put_upgrade_agent
@@ -5744,7 +5744,7 @@ paths:
   /agents/{agent_id}/upgrade_custom:
     put:
       tags:
-        - agents
+        - Agents
       summary: "Upgrade agent custom"
       description: "Upgrade the agent using a local WPK file"
       operationId: api.controllers.agents_controller.put_upgrade_custom_agent
@@ -5780,7 +5780,7 @@ paths:
   /agents/{agent_id}/upgrade_result:
     get:
       tags:
-        - agents
+        - Agents
       summary: "Get upgrade result"
       description: "Return the upgrade result after updating an agent"
       operationId: api.controllers.agents_controller.get_agent_upgrade
@@ -5820,7 +5820,7 @@ paths:
   /agents/group:
     delete:
       tags:
-        - agents
+        - Agents
       summary: "Remove agents from group"
       description: "Remove all agents assignment or a list of them from the specified group"
       operationId: api.controllers.agents_controller.delete_multiple_agent_single_group
@@ -5872,7 +5872,7 @@ paths:
 
     put:
       tags:
-        - agents
+        - Agents
       summary: "Assign agents to group"
       description: "Assign all agents or a list of them to the specified group"
       operationId: api.controllers.agents_controller.put_multiple_agent_single_group
@@ -5936,7 +5936,7 @@ paths:
   /agents/group/{group_id}/restart:
     put:
       tags:
-        - agents
+        - Agents
       summary: 'Restart agents in group'
       description: 'Restart all agents which belong to a given group'
       operationId: api.controllers.agents_controller.restart_agents_by_group
@@ -6543,7 +6543,7 @@ paths:
   /agents/insert:
     post:
       tags:
-        - agents
+        - Agents
       summary: "Add an agent specifying all its basic properties"
       description: "Add an agent specifying its name, ID and IP. If an agent with the same ID already exists, replace
       it using `force` parameter"
@@ -6624,7 +6624,7 @@ paths:
   /agents/insert/quick:
     post:
       tags:
-        - agents
+        - Agents
       summary: "Add agent (quick method)"
       description: "Add a new agent with name `agent_name`. This agent will use `any` as IP"
       operationId: api.controllers.agents_controller.post_new_agent
@@ -6665,7 +6665,7 @@ paths:
   /agents/no_group:
     get:
       tags:
-        - agents
+        - Agents
       summary: "Get all agents without group"
       description: "Return a list with all the available agents without group"
       operationId: api.controllers.agents_controller.get_agent_no_group
@@ -6789,7 +6789,7 @@ paths:
   /agents/node/{node_id}/restart:
       put:
         tags:
-          - agents
+          - Agents
         summary: "Restart all agents which belong to a node"
         description: "Restart all agents which belong to a specific given node"
         operationId: api.controllers.agents_controller.restart_agents_by_node
@@ -6837,7 +6837,7 @@ paths:
   /agents/outdated:
     get:
       tags:
-        - agents
+        - Agents
       summary: "Get outdated agents"
       description: "Return the list of outdated agents"
       operationId: api.controllers.agents_controller.get_agent_outdated
@@ -6891,7 +6891,7 @@ paths:
   /agents/restart:
     put:
       tags:
-      - agents
+      - Agents
       summary: "Restart agents"
       description: "Restart all agents or a list of them"
       operationId: api.controllers.agents_controller.restart_agents
@@ -6937,7 +6937,7 @@ paths:
   /agents/stats/distinct:
     get:
       tags:
-        - agents
+        - Agents
       summary: "Get distinct fields in agents"
       description: "Return all the different combinations that agents have for the selected fields. It also indicates
       the total number of agents that have each combination"
@@ -7036,7 +7036,7 @@ paths:
   /agents/summary/os:
     get:
       tags:
-        - agents
+        - Agents
       summary: "Get agents OS summary"
       description: "Return a summary of the OS of available agents"
       operationId: api.controllers.agents_controller.get_agent_summary_os
@@ -7077,7 +7077,7 @@ paths:
   /agents/summary/status:
     get:
       tags:
-        - agents
+        - Agents
       summary: "Get agents status summary"
       description: "Return a summary of the status of available agents"
       operationId: api.controllers.agents_controller.get_agent_summary_status

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5,7 +5,7 @@ info:
     command line tool like cURL or any script or program that can make web requests. The Wazuh WUI relies on this
     heavily and Wazuh’s goal is to accommodate complete remote management of the Wazuh infrastructure via the Wazuh WUI.
     Use the Wazuh API to easily perform everyday actions like adding an agent, restarting the manager(s) or agent(s)
-    or looking up syscheck details.\n
+    or looking up syscheck details.
 
     # Authentication
 
@@ -17,7 +17,7 @@ info:
     Login with USER and PASSWORD:
 
     `curl -u <USER>:<PASSWORD> -k -X GET "https://<HOST_IP>:55000/security/user/authenticate`
-    ```
+    ```json
     {
         "data": {
             "token": "<YOUR_JWT_TOKEN>"

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1396,7 +1396,6 @@ components:
 
     GroupID:
       type: string
-      minLength: 1
       description: "Group name"
       format: group_names
 
@@ -3399,7 +3398,7 @@ components:
     agent_name:
       in: query
       name: agent_name
-      description: "Agent name used when the agent was registered"
+      description: "Agent name"
       required: true
       schema:
         type: string
@@ -3473,7 +3472,7 @@ components:
         <tr>
         <td>agent</td>
         <td>internal</td>
-        <td>agent, monitord, remoted</td>
+        <td><code>&lt;agent&gt;</code>, <code>&lt;monitord&gt;</code>, <code>&lt;remoted&gt;</code></td>
         </tr>
         <tr>
         <td>agentless</td>
@@ -3513,7 +3512,7 @@ components:
         <tr>
         <td>analysis</td>
         <td>internal</td>
-        <td>analysisd</td>
+        <td><code>&lt;analysisd&gt;</code></td>
         </tr>
         <tr>
         <td>auth</td>
@@ -3533,12 +3532,12 @@ components:
         <tr>
         <td>com</td>
         <td>internal</td>
-        <td>execd</td>
+        <td><code>&lt;execd&gt;</code></td>
         </tr>
         <tr>
         <td>com</td>
         <td>cluster</td>
-        <td>cluster</td>
+        <td><code>&lt;cluster&gt;</code></td>
         </tr>
         <tr>
         <td>csyslog</td>
@@ -3563,7 +3562,7 @@ components:
         <tr>
         <td>logcollector</td>
         <td>internal</td>
-        <td>logcollector</td>
+        <td><code>&lt;logcollector&gt;</code></td>
         </tr>
         <tr>
         <td>mail</td>
@@ -3578,17 +3577,17 @@ components:
         <tr>
         <td>mail</td>
         <td>internal</td>
-        <td>maild</td>
+        <td><code>&lt;maild&gt;</code></td>
         </tr>
         <tr>
         <td>monitor</td>
         <td>internal</td>
-        <td>monitord</td>
+        <td><code>&lt;monitord&gt;</code></td>
         </tr>
         <tr>
         <td>monitor</td>
         <td>internal</td>
-        <td>reports</td>
+        <td><code>&lt;reports&gt;</code></td>
         </tr>
         <tr>
         <td>request</td>
@@ -3598,7 +3597,7 @@ components:
         <tr>
         <td>request</td>
         <td>internal</td>
-        <td>remoted</td>
+        <td><code>&lt;remoted&gt;</code></td>
         </tr>
         <tr>
         <td>syscheck</td>
@@ -3613,7 +3612,7 @@ components:
         <tr>
         <td>syscheck</td>
         <td>internal</td>
-        <td>syscheck, rootcheck</td>
+        <td><code>&lt;syscheck&gt;</code>, <code>&lt;rootcheck&gt;</code></td>
         </tr>
         <tr>
         <td>wmodules</td>
@@ -3794,7 +3793,7 @@ components:
     agents_list:
       in: query
       name: agents_list
-      description: "List of agent IDs (separated by comma)"
+      description: "List of agent IDs (separated by comma), all agents selected by default if not specified"
       schema:
         type: array
         items:
@@ -3802,7 +3801,7 @@ components:
     agents_list_delete:
       in: query
       name: agents_list
-      description: "List of agent IDs (separated by comma), use the keyword 'all' to select all agents"
+      description: "List of agent IDs (separated by comma), use the keyword `all` to select all agents"
       required: true
       schema:
         type: array
@@ -3811,7 +3810,7 @@ components:
     groups_list:
       in: query
       name: groups_list
-      description: "Array of group IDs"
+      description: "List of group IDs (separated by comma), all groups selected by default if not specified"
       schema:
         type: array
         items:
@@ -3828,7 +3827,7 @@ components:
     nodes_list:
       in: query
       name: nodes_list
-      description: "List of node IDs (separated by comma)"
+      description: "List of node IDs (separated by comma), all nodes selected by default if not specified"
       schema:
         type: array
         items:
@@ -3875,7 +3874,8 @@ components:
       name: older_than
       description: "Filter out agents whose time lapse from last keep alive signal is longer than specified. Time in
       seconds, ‘[n_days]d’, ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For never_connected agents, uses the
-      register date. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, seconds are used"
+      register date. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, seconds are used.
+      Use 0s to select all agents"
       schema:
         type: string
         format: timeframe
@@ -4173,7 +4173,7 @@ components:
     statusAgentParam:
       in: query
       name: status
-      description: "Filter by agent status. Use commas to enter multiple statuses"
+      description: "Filter by agent status (use commas to enter multiple statuses)"
       schema:
         type: array
         items:
@@ -5009,37 +5009,39 @@ components:
           - 'user:id'
 
 tags:
-  - name: active-response
+  - name: API Info
+    description: "Wazuh API information"
+  - name: Active-response
     description: "Agents Active Response"
   - name: Agents
     description: "Agents management related operations"
-  - name: ciscat
+  - name: Ciscat
     description: "Retrieve information from CIS-CAT scans"
-  - name: cluster
+  - name: Cluster
     description: "Wazuh cluster and nodes management"
-  - name: decoders
+  - name: Decoders
     description: "Decoders management"
-  - name: experimental
+  - name: Experimental
     description: "Not ready for production endpoints. Use with caution"
-  - name: groups
+  - name: Groups
     description: "Group of agents and centralized configurations"
-  - name: lists
+  - name: Lists
     description: "CDB lists management"
-  - name: manager
+  - name: Manager
     description: "Wazuh manager management"
-  - name: mitre
+  - name: Mitre
     description: "Attacks information from MITRE database"
-  - name: overview
+  - name: Overview
     description: "Overview of Wazuh"
-  - name: rules
+  - name: Rules
     description: "Rules management"
-  - name: sca
+  - name: SCA
     description: "Policy monitoring"
-  - name: security
+  - name: Security
     description: "Roles administration and user authentication management"
-  - name: syscheck
+  - name: Syscheck
     description: "File integrity monitoring"
-  - name: syscollector
+  - name: Syscollector
     description: "Syscollector information"
 
 security:
@@ -5048,7 +5050,9 @@ security:
 paths:
   /:
     get:
-      summary: 'Root-endpoint info'
+      tags:
+        - API Info
+      summary: 'Get API info'
       description: "Return basic information about the API"
       operationId: api.controllers.default_controller.default_info
       parameters:
@@ -5075,9 +5079,9 @@ paths:
   /active-response:
     put:
       tags:
-        - active-response
-      summary: "Run AR command in all agents"
-      description: "Run an Active Response command on all agents"
+        - Active-response
+      summary: "Run AR command"
+      description: "Run an Active Response command on all agents or a list of them"
       operationId: api.controllers.active_response_controller.run_command
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/active-response:command'
@@ -5127,7 +5131,7 @@ paths:
       tags:
       - Agents
       summary: "Delete agents"
-      description: "Delete all agents or a list of them with optional criteria based on the status or time of the last
+      description: "Delete agents with optional criteria based on the status or time of the last
       connection"
       operationId: api.controllers.agents_controller.delete_agents
       x-rbac-actions:
@@ -5438,7 +5442,7 @@ paths:
         - Agents
       summary: "Remove agent from groups"
       description: 'Remove the agent from all groups or a list of them. The agent will automatically revert to the
-      "default" group if it is removed from all its assigned groups'
+      default group if it is removed from all its assigned groups'
       operationId: api.controllers.agents_controller.delete_single_agent_multiple_groups
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/agent:modify_group'
@@ -6544,7 +6548,7 @@ paths:
     post:
       tags:
         - Agents
-      summary: "Add an agent specifying all its basic properties"
+      summary: "Add agent full"
       description: "Add an agent specifying its name, ID and IP. If an agent with the same ID already exists, replace
       it using `force` parameter"
       operationId: api.controllers.agents_controller.insert_agent
@@ -6625,7 +6629,7 @@ paths:
     post:
       tags:
         - Agents
-      summary: "Add agent (quick method)"
+      summary: "Add agent quick"
       description: "Add a new agent with name `agent_name`. This agent will use `any` as IP"
       operationId: api.controllers.agents_controller.post_new_agent
       x-rbac-actions:
@@ -6666,8 +6670,8 @@ paths:
     get:
       tags:
         - Agents
-      summary: "Get all agents without group"
-      description: "Return a list with all the available agents without group"
+      summary: "List agents without group"
+      description: "Return a list with all the available agents without an assigned group"
       operationId: api.controllers.agents_controller.get_agent_no_group
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/agent:read'
@@ -6790,7 +6794,7 @@ paths:
       put:
         tags:
           - Agents
-        summary: "Restart all agents which belong to a node"
+        summary: "Restart agents in node"
         description: "Restart all agents which belong to a specific given node"
         operationId: api.controllers.agents_controller.restart_agents_by_node
         x-rbac-actions:
@@ -6838,7 +6842,7 @@ paths:
     get:
       tags:
         - Agents
-      summary: "Get outdated agents"
+      summary: "List outdated agents"
       description: "Return the list of outdated agents"
       operationId: api.controllers.agents_controller.get_agent_outdated
       x-rbac-actions:
@@ -6938,7 +6942,7 @@ paths:
     get:
       tags:
         - Agents
-      summary: "Get distinct fields in agents"
+      summary: "List agents distinct"
       description: "Return all the different combinations that agents have for the selected fields. It also indicates
       the total number of agents that have each combination"
       operationId: api.controllers.agents_controller.get_agent_fields
@@ -7037,7 +7041,7 @@ paths:
     get:
       tags:
         - Agents
-      summary: "Get agents OS summary"
+      summary: "Summarize agents OS"
       description: "Return a summary of the OS of available agents"
       operationId: api.controllers.agents_controller.get_agent_summary_os
       x-rbac-actions:
@@ -7078,7 +7082,7 @@ paths:
     get:
       tags:
         - Agents
-      summary: "Get agents status summary"
+      summary: "Summarize agents status"
       description: "Return a summary of the status of available agents"
       operationId: api.controllers.agents_controller.get_agent_summary_status
       x-rbac-actions:
@@ -7120,7 +7124,7 @@ paths:
     get:
       tags:
       - ciscat
-      summary: "Get CIS-CAT results from an agent"
+      summary: "Get CIS-CAT results"
       description: "Return the agent's ciscat results info"
       operationId: api.controllers.ciscat_controller.get_agents_ciscat_results
       x-rbac-actions:
@@ -7189,7 +7193,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get information about the local node"
+      summary: "Get local node info"
       description: "Return basic information about the cluster node receiving the request"
       operationId: api.controllers.cluster_controller.get_cluster_node
       x-rbac-actions:
@@ -7244,7 +7248,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get cluster nodes information"
+      summary: "Get nodes info"
       description: "Get information about all nodes in the cluster or a list of them"
       operationId: api.controllers.cluster_controller.get_cluster_nodes
       x-rbac-actions:
@@ -7307,7 +7311,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get cluster nodes healthcheck"
+      summary: "Get nodes healthcheck"
       description: "Return cluster healthcheck information for all nodes or a list of them. Such information includes
       last keep alive, last synchronization time and number of agents reporting on each node"
       operationId: api.controllers.cluster_controller.get_healthcheck
@@ -7431,7 +7435,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get local node cluster configuration"
+      summary: "Get local node config"
       description: "Return the current node cluster configuration"
       operationId: api.controllers.cluster_controller.get_config
       x-rbac-actions:
@@ -7517,8 +7521,8 @@ paths:
     get:
       tags:
         - cluster
-      summary: "Get the API configuration of all nodes (or a list of them)"
-      description: "Return the API configuration of all the selected nodes in JSON format"
+      summary: "Get nodes API config"
+      description: "Return the API configuration of all nodes (or a list of them) in JSON format"
       operationId: api.controllers.cluster_controller.get_api_config
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read_api_config'
@@ -7610,8 +7614,9 @@ paths:
     put:
       tags:
         - cluster
-      summary: "Update the API configuration of all nodes (or a list of them)"
-      description: "Update the API configuration of all the selected nodes with the data contained in the API request"
+      summary: "Update nodes API config"
+      description: "Update the API configuration of all nodes (or a list of them) with the data contained in the API
+      request"
       operationId: api.controllers.cluster_controller.put_api_config
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:update_api_config'
@@ -7660,8 +7665,8 @@ paths:
     delete:
       tags:
         - cluster
-      summary: "Restore the default API configuration of all nodes (or a list of them)"
-      description: "Replace the API configuration of all the selected nodes with the default one"
+      summary: "Restore nodes default API config"
+      description: "Restore the default API configuration of all nodes (or a list of them)"
       operationId: api.controllers.cluster_controller.delete_api_config
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:update_api_config'
@@ -7703,7 +7708,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get a specified node's status"
+      summary: "Get node status"
       description: "Return the status of all Wazuh daemons in node node_id"
       operationId: api.controllers.cluster_controller.get_status_node
       x-rbac-actions:
@@ -7764,7 +7769,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get a specified node's information"
+      summary: "Get node info"
       description: "Return basic information about a specified node such as version, compilation date, installation
       path"
       operationId: api.controllers.cluster_controller.get_info_node
@@ -7818,7 +7823,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get a specified node's configuration"
+      summary: "Get node config"
       description: "Return wazuh configuration used in node {node_id}"
       operationId: api.controllers.cluster_controller.get_configuration_node
       x-rbac-actions:
@@ -7897,7 +7902,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get a specified node's stats"
+      summary: "Get node stats"
       description: "Return Wazuh statistical information in node {node_id} for the current or specified date"
       operationId: api.controllers.cluster_controller.get_stats_node
       x-rbac-actions:
@@ -7966,7 +7971,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get a specified node's stats per hour"
+      summary: "Get node stats hour"
       description: "Return Wazuh statistical information in node {node_id} per hour. Each number in the averages field
       represents the average of alerts per hour"
       operationId: api.controllers.cluster_controller.get_stats_hourly_node
@@ -8035,7 +8040,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get a specified node's stats per week"
+      summary: "Get node stats week"
       description: "Return Wazuh statistical information in node {node_id} per week. Each number in the averages field
       represents the average of alerts per hour for that specific day"
       operationId: api.controllers.cluster_controller.get_stats_weekly_node
@@ -8267,7 +8272,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get a specified node's analysisd stats"
+      summary: "Get node stats analysisd"
       description: "Return Wazuh analysisd statistical information in node {node_id}"
       operationId: api.controllers.cluster_controller.get_stats_analysisd_node
       x-rbac-actions:
@@ -8355,7 +8360,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get a specified node's remoted stats"
+      summary: "Get node stats remoted"
       description: "Return Wazuh remoted statistical information in node {node_id}"
       operationId: api.controllers.cluster_controller.get_stats_remoted_node
       x-rbac-actions:
@@ -8405,8 +8410,8 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get a specified node's wazuh logs"
-      description: "Return the last 2000 wazuh log entries in node {node_id}"
+      summary: "Get node logs"
+      description: "Return the last 2000 wazuh log entries in the specified node"
       operationId: api.controllers.cluster_controller.get_log_node
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
@@ -8468,8 +8473,8 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get a summary of a specified node's wazuh logs"
-      description: "Return a summary of the last 2000 wazuh log entries in node {node_id}"
+      summary: "Get node logs summary"
+      description: "Return a summary of the last 2000 wazuh log entries in the specified node"
       operationId: api.controllers.cluster_controller.get_log_summary_node
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
@@ -8531,8 +8536,8 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Get file contents from a specified node in the cluster"
-      description: "Return file contents from any file in cluster node {node_id}"
+      summary: "Get node file content"
+      description: "Return file contents from any file in the specified node"
       operationId: api.controllers.cluster_controller.get_files_node
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
@@ -8580,8 +8585,8 @@ paths:
     put:
       tags:
       - cluster
-      summary: "Updates file contents in a specified cluster node"
-      description: "Replace file contents with the data contained in the API request in a specified cluster node"
+      summary: "Update node file content"
+      description: "Replace file contents with the data contained in the API request for the specified node"
       operationId: api.controllers.cluster_controller.put_files_node
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
@@ -8633,8 +8638,8 @@ paths:
     delete:
       tags:
       - cluster
-      summary: "Removes a file in a specified cluster node"
-      description: "Remove a specified file in the node {node-id}"
+      summary: "Delete node file"
+      description: "Delete a file in the specified node"
       operationId: api.controllers.cluster_controller.delete_files_node
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
@@ -8675,7 +8680,7 @@ paths:
     put:
       tags:
       - cluster
-      summary: "Restart cluster nodes"
+      summary: "Restart nodes"
       description: "Restart all nodes in the cluster or a list of them"
       operationId: api.controllers.cluster_controller.put_restart
       x-rbac-actions:
@@ -8722,7 +8727,7 @@ paths:
     get:
       tags:
       - cluster
-      summary: "Check cluster nodes Wazuh configuration"
+      summary: "Check nodes config"
       description: "Return whether the Wazuh configuration is correct or not in all cluster nodes or a list of them"
       operationId: api.controllers.cluster_controller.get_conf_validation
       x-rbac-actions:
@@ -8772,8 +8777,8 @@ paths:
     get:
       tags:
         - cluster
-      summary: "Get active configuration in node node_id"
-      description: "Return the requested configuration in JSON format"
+      summary: "Get node active configuration"
+      description: "Return the requested configuration in JSON format for the specified node"
       operationId: api.controllers.cluster_controller.get_node_config
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
@@ -8825,7 +8830,7 @@ paths:
     get:
       tags:
       - lists
-      summary: "Get all CDB lists"
+      summary: "Get CDB lists"
       description: "Return the contents of all CDB lists. Optionally, the result can be filtered by several criteria.
       See available parameters for more details"
       operationId: api.controllers.lists_controller.get_lists
@@ -8914,7 +8919,7 @@ paths:
     get:
       tags:
       - lists
-      summary: "Get paths from all CDB lists"
+      summary: "Get CDB lists files"
       description: "Return the path from all CDB lists. Use this method to know all the CDB lists and their location in
       the filesystem relative to Wazuh installation folder"
       operationId: api.controllers.lists_controller.get_lists_files
@@ -8972,7 +8977,7 @@ paths:
     get:
       tags:
       - manager
-      summary: "Get the Wazuh manager status"
+      summary: "Get manager status"
       description: "Return the status of all Wazuh daemons"
       operationId: api.controllers.manager_controller.get_status
       x-rbac-actions:
@@ -9032,7 +9037,7 @@ paths:
     get:
       tags:
       - manager
-      summary: "Get Wazuh manager information"
+      summary: "Get manager information"
       description: "Return basic information such as version, compilation date, installation path"
       operationId: api.controllers.manager_controller.get_info
       x-rbac-actions:
@@ -9084,7 +9089,7 @@ paths:
     get:
       tags:
       - manager
-      summary: "Get configuration"
+      summary: "Get manager configuration"
       description: "Return wazuh configuration used"
       operationId: api.controllers.manager_controller.get_configuration
       x-rbac-actions:
@@ -9162,7 +9167,7 @@ paths:
     get:
       tags:
       - manager
-      summary: "Get stats"
+      summary: "Get manager stats"
       description: "Return Wazuh statistical information for the current or specified date"
       operationId: api.controllers.manager_controller.get_stats
       x-rbac-actions:
@@ -9230,7 +9235,7 @@ paths:
     get:
       tags:
       - manager
-      summary: "Get stats by hour"
+      summary: "Get manager stats hour"
       description: "Return Wazuh statistical information per hour. Each number in the averages field represents the
       average of alerts per hour"
       operationId: api.controllers.manager_controller.get_stats_hourly
@@ -9298,7 +9303,7 @@ paths:
     get:
       tags:
       - manager
-      summary: "Get stats by week"
+      summary: "Get manager stats week"
       description: "Return Wazuh statistical information per week. Each number in the averages field represents the
       average of alerts per hour for that specific day"
       operationId: api.controllers.manager_controller.get_stats_weekly
@@ -9529,7 +9534,7 @@ paths:
     get:
       tags:
       - manager
-      summary: "Get analysisd stats"
+      summary: "Get manager stats analysisd"
       description: "Return Wazuh analysisd statistical information"
       operationId: api.controllers.manager_controller.get_stats_analysisd
       x-rbac-actions:
@@ -9616,7 +9621,7 @@ paths:
     get:
       tags:
       - manager
-      summary: "Get remoted stats"
+      summary: "Get remoted stats remoted "
       description: "Return Wazuh remoted statistical information"
       operationId: api.controllers.manager_controller.get_stats_remoted
       x-rbac-actions:
@@ -9665,7 +9670,7 @@ paths:
     get:
       tags:
       - manager
-      summary: "Get the wazuh manager logs"
+      summary: "Get manager logs"
       description: "Return the last 2000 wazuh log entries"
       operationId: api.controllers.manager_controller.get_log
       x-rbac-actions:
@@ -9727,7 +9732,7 @@ paths:
     get:
       tags:
       - manager
-      summary: "Get a summary of the wazuh manager logs"
+      summary: "Get manager logs summary"
       description: "Return a summary of the last 2000 wazuh log entries"
       operationId: api.controllers.manager_controller.get_log_summary
       x-rbac-actions:
@@ -9791,7 +9796,7 @@ paths:
     get:
       tags:
       - manager
-      summary: "Get file contents"
+      summary: "Get manager file content"
       description: "Return file contents from any file"
       operationId: api.controllers.manager_controller.get_files
       x-rbac-actions:
@@ -9839,7 +9844,7 @@ paths:
     put:
       tags:
       - manager
-      summary: "Update file contents"
+      summary: "Update manager file content"
       description: "Replace file contents with the data contained in the API request"
       operationId: api.controllers.manager_controller.put_files
       x-rbac-actions:
@@ -9887,8 +9892,8 @@ paths:
     delete:
       tags:
       - manager
-      summary: "Removes a file"
-      description: "Remove a specified file"
+      summary: "Delete manager file"
+      description: "Delete a specified file"
       operationId: api.controllers.manager_controller.delete_files
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/manager:read'
@@ -9930,7 +9935,7 @@ paths:
     get:
       tags:
         - manager
-      summary: "Get local API configuration"
+      summary: "Get manager API config"
       description: "Return the local API configuration in JSON format"
       operationId: api.controllers.manager_controller.get_api_config
       x-rbac-actions:
@@ -9996,7 +10001,7 @@ paths:
     put:
       tags:
         - manager
-      summary: "Update local API configuration"
+      summary: "Update manager API config"
       description: "Update local API configuration with the data contained in the API request"
       operationId: api.controllers.manager_controller.put_api_config
       x-rbac-actions:
@@ -10044,8 +10049,8 @@ paths:
     delete:
       tags:
         - manager
-      summary: "Restore default API configuration"
-      description: "Replace local API configuration with the original one"
+      summary: "Restore manager default API config"
+      description: "Restore default local API configuration"
       operationId: api.controllers.manager_controller.delete_api_config
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/manager:update_api_config'
@@ -10085,7 +10090,7 @@ paths:
     put:
       tags:
       - manager
-      summary: "Restart the wazuh manager"
+      summary: "Restart manager"
       description: "Restart the wazuh manager"
       operationId: api.controllers.manager_controller.put_restart
       x-rbac-actions:
@@ -10125,7 +10130,7 @@ paths:
     get:
       tags:
       - manager
-      summary: "Check Wazuh configuration"
+      summary: "Check manager config"
       description: "Return whether the Wazuh configuration is correct"
       operationId: api.controllers.manager_controller.get_conf_validation
       x-rbac-actions:
@@ -10165,8 +10170,8 @@ paths:
     get:
       tags:
         - manager
-      summary: "Get active configuration in manager for one component [on demand]"
-      description: "Return the requested configuration in JSON format"
+      summary: "Get manager active configuration"
+      description: "Return the requested active configuration in JSON format"
       operationId: api.controllers.manager_controller.get_manager_config_ondemand
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/manager:read'
@@ -10212,7 +10217,7 @@ paths:
     get:
       tags:
         - mitre
-      summary: "Get attacks information from MITRE database"
+      summary: "Get MITRE attacks"
       description: "Return the requested attacks from MITRE database"
       operationId: api.controllers.mitre_controller.get_attack
       x-rbac-actions:
@@ -10297,7 +10302,7 @@ paths:
     get:
       tags:
       - rules
-      summary: "Get information about a list of Wazuh rules"
+      summary: "List rules"
       description: "Return a list containing information about each rule such as file where it's defined, description,
       rule group, status, etc"
       operationId: api.controllers.rules_controller.get_rules
@@ -10394,7 +10399,7 @@ paths:
     get:
       tags:
       - rules
-      summary: "Get all rule groups names"
+      summary: "Get rules groups"
       description: "Return a list containing all rule groups names"
       operationId: api.controllers.rules_controller.get_rules_groups
       x-rbac-actions:
@@ -10447,7 +10452,7 @@ paths:
     get:
       tags:
       - rules
-      summary: "Get all specified requirements"
+      summary: "Get rules requirements"
       description: "Return all specified requirement names defined in the Wazuh ruleset"
       operationId: api.controllers.rules_controller.get_rules_requirement
       x-rbac-actions:
@@ -10502,7 +10507,7 @@ paths:
     get:
       tags:
       - rules
-      summary: "Get all files which defines rules"
+      summary: "Get rules files"
       description: "Return a list containing all files used to define rules and their status"
       operationId: api.controllers.rules_controller.get_rules_files
       x-rbac-actions:
@@ -10564,7 +10569,7 @@ paths:
     get:
       tags:
         - rules
-      summary: "Download an specified rule file"
+      summary: "Download rule"
       description: "Download an specified rule file"
       operationId: api.controllers.rules_controller.get_download_file
       x-rbac-actions:
@@ -10646,7 +10651,7 @@ paths:
     get:
       tags:
       - sca
-      summary: "Get security configuration assessment (SCA) database"
+      summary: "Get SCA results"
       description: "Return the security SCA database of an agent"
       operationId: api.controllers.sca_controller.get_sca_agent
       x-rbac-actions:
@@ -10724,7 +10729,7 @@ paths:
     get:
       tags:
       - sca
-      summary: "Get policy monitoring alerts for a given policy"
+      summary: "Get SCA policy checks"
       description: "Return the policy monitoring alerts for a given policy"
       operationId: api.controllers.sca_controller.get_sca_checks
       x-rbac-actions:
@@ -10825,8 +10830,8 @@ paths:
     put:
       tags:
       - syscheck
-      summary: "Run a syscheck scan in all agents"
-      description: "Run syscheck in all agents"
+      summary: "Run FIM scan"
+      description: "Run FIM scan in all agents"
       operationId: api.controllers.syscheck_controller.put_syscheck
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/syscheck:run'
@@ -10873,7 +10878,7 @@ paths:
     get:
       tags:
       - syscheck
-      summary: "Get File integrity monitoring scan results"
+      summary: "Get FIM results"
       description: "Return FIM findings in the specified agent"
       operationId: api.controllers.syscheck_controller.get_syscheck_agent
       x-rbac-actions:
@@ -10960,7 +10965,7 @@ paths:
     delete:
       tags:
         - syscheck
-      summary: "Clear FIM scan results for a specified agent"
+      summary: "Clear FIM results"
       description: "Clear file integrity monitoring scan results for a specified agent"
       operationId: api.controllers.syscheck_controller.delete_syscheck_agent
       x-rbac-actions:
@@ -11005,7 +11010,7 @@ paths:
     get:
       tags:
       - syscheck
-      summary: "Get last syscheck scan dates"
+      summary: "Get last FIM scan"
       description: "Return when the last syscheck scan started and ended. If the scan is still in progress the end date
       will be unknown"
       operationId: api.controllers.syscheck_controller.get_last_scan_agent
@@ -11052,7 +11057,7 @@ paths:
     get:
       tags:
         - decoders
-      summary: "Get all decoders"
+      summary: "Get decoders"
       description: "Return information about all decoders included in ossec.conf. This information include decoder's
       route, decoder's name, decoder's file among others"
       operationId: api.controllers.decoders_controller.get_decoders
@@ -11124,7 +11129,7 @@ paths:
     get:
       tags:
         - decoders
-      summary: "Get all decoders files"
+      summary: "Get decoders files"
       description: "Return information about all decoders files used in Wazuh. This information include decoder's file,
       decoder's route and decoder's status among others"
       operationId: api.controllers.decoders_controller.get_decoders_files
@@ -11184,7 +11189,7 @@ paths:
     get:
       tags:
       - decoders
-      summary: "Download an specified decoder file"
+      summary: "Download decoder file"
       description: "Download an specified decoder file"
       operationId: api.controllers.decoders_controller.get_download_file
       x-rbac-actions:
@@ -11230,7 +11235,7 @@ paths:
     get:
       tags:
         - decoders
-      summary: "Get all parent decoders"
+      summary: "Get parent decoders"
       description: "Return information about all parent decoders. A parent decoder is a decoder used as base of other
       decoders"
       operationId: api.controllers.decoders_controller.get_decoders_parents
@@ -11294,7 +11299,7 @@ paths:
     delete:
       tags:
         - experimental
-      summary: "Clear agents syscheck database"
+      summary: "Clear agents FIM results"
       description: "Clear the syscheck database for all agents or a list of them"
       operationId: api.controllers.experimental_controller.clear_syscheck_database
       x-rbac-actions:
@@ -11351,7 +11356,7 @@ paths:
     get:
       tags:
         - experimental
-      summary: "Get CIS-CAT results"
+      summary: "Get agents CIS-CAT results"
       description: "Return CIS-CAT results for all agents or a list of them"
       operationId: api.controllers.experimental_controller.get_cis_cat_results
       x-rbac-actions:
@@ -11444,7 +11449,7 @@ paths:
     get:
       tags:
         - experimental
-      summary: "Get hardware info from agents"
+      summary: "Get agents hardware"
       description: "Return all agents (or a list of them) hardware info. This information include cpu, ram, scan info
       among others of all agents"
       operationId: api.controllers.experimental_controller.get_hardware_info
@@ -11539,7 +11544,7 @@ paths:
     get:
       tags:
         - experimental
-      summary: "Get the IPv4 and IPv6 addresses associated to network interfaces"
+      summary: "Get agents netaddr"
       description: "Return all agents (or a list of them) IPv4 and IPv6 addresses associated to their network
       interfaces. This information include used IP protocol, interface, and IP address among others"
       operationId: api.controllers.experimental_controller.get_network_address_info
@@ -11617,7 +11622,7 @@ paths:
     get:
       tags:
         - experimental
-      summary: "Get all network interfaces from agents"
+      summary: "Get agents netiface"
       description: "Return all agents (or a list of them) network interfaces. This information includes rx, scan, tx
       info and some network information among other"
       operationId: api.controllers.experimental_controller.get_network_interface_info
@@ -11737,7 +11742,7 @@ paths:
     get:
       tags:
         - experimental
-      summary: "Get network protocol info from agents"
+      summary: "Get agents netproto"
       description: "Return all agents (or a list of them) routing configuration for each network interface. This
       information includes interface, type protocol information among other"
       operationId: api.controllers.experimental_controller.get_network_protocol_info
@@ -11812,7 +11817,7 @@ paths:
     get:
       tags:
         - experimental
-      summary: "Get OS info from agents"
+      summary: "Get agents OS"
       description: "Return all agents (or a list of them) OS info. This information includes os information,
       architecture information among other"
       operationId: api.controllers.experimental_controller.get_os_info
@@ -11915,7 +11920,7 @@ paths:
     get:
       tags:
         - experimental
-      summary: "Get packages info from agents"
+      summary: "Get agents packages"
       description: "Return all agents (or a list of them) packages info. This information includes name, section, size,
       and priority information of all packages among other"
       operationId: api.controllers.experimental_controller.get_packages_info
@@ -12015,7 +12020,7 @@ paths:
     get:
       tags:
         - experimental
-      summary: "Get ports info from agents"
+      summary: "Get agents ports"
       description: "Return all agents (or a list of them) ports info. This information includes local IP, Remote IP,
       protocol information among other"
       operationId: api.controllers.experimental_controller.get_ports_info
@@ -12118,7 +12123,7 @@ paths:
     get:
       tags:
         - experimental
-      summary: "Get processes info from agents"
+      summary: "Get agents processes"
       description: "Return all agents (or a list of them) processes info"
       operationId: api.controllers.experimental_controller.get_processes_info
       x-rbac-actions:
@@ -12245,7 +12250,7 @@ paths:
     get:
       tags:
         - experimental
-      summary: "Get hotfixes info from agents"
+      summary: "Get agents hotfixes"
       description: "Return all agents (or a list of them) hotfixes info"
       operationId: api.controllers.experimental_controller.get_hotfixes_info
       x-rbac-actions:
@@ -12303,7 +12308,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: "Get hardware info"
+      summary: "Get agent hardware"
       description: "Return the agent's hardware info. This information include cpu, ram, scan info among others"
       operationId: api.controllers.syscollector_controller.get_hardware_info
       x-rbac-actions:
@@ -12362,7 +12367,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: "Get hotfixes"
+      summary: "Get agent hotfixes"
       description: "Return all hotfixes installed by Microsoft(R) in Windows(R) systems (KB... fixes)"
       operationId: api.controllers.syscollector_controller.get_hotfix_info
       x-rbac-actions:
@@ -12417,7 +12422,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: "Get network address info of an agent"
+      summary: "Get agent netaddr"
       description: "Return the agent's network address info. This information include used IP protocol, interface, IP
       address  among others"
       operationId: api.controllers.syscollector_controller.get_network_address_info
@@ -12480,7 +12485,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: "Get network interface info of an agent"
+      summary: "Get agent netiface"
       description: "Return the agent's network interface info. This information include rx, scan, tx info and some
       network information among others"
       operationId: api.controllers.syscollector_controller.get_network_interface_info
@@ -12563,7 +12568,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: "Get network protocol info of an agent"
+      summary: "Get agent netproto"
       description: "Return the agent's routing configuration for each network interface"
       operationId: api.controllers.syscollector_controller.get_network_protocol_info
       x-rbac-actions:
@@ -12624,7 +12629,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: "Get OS info of an agent"
+      summary: "Get agent OS"
       description: "Return the agent's OS info. This information include os information, architecture information among
       others of all agents"
       operationId: api.controllers.syscollector_controller.get_os_info
@@ -12686,7 +12691,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: "Get packages info of an agent"
+      summary: "Get agent packages"
       description: "Return the agent's packages info. This information include name, section, size, priority
       information of all packages among others"
       operationId: api.controllers.syscollector_controller.get_packages_info
@@ -12787,7 +12792,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: "Get ports info of an agent"
+      summary: "Get agent ports"
       description: "Return the agent's ports info. This information include local IP, Remote IP, protocol information
       among others"
       operationId: api.controllers.syscollector_controller.get_ports_info
@@ -12891,7 +12896,7 @@ paths:
     get:
       tags:
         - syscollector
-      summary: "Get processes info an agent"
+      summary: "Get agent processes"
       description: "Return the agent's processes info"
       operationId: api.controllers.syscollector_controller.get_processes_info
       x-rbac-actions:
@@ -13019,7 +13024,7 @@ paths:
     get:
       tags:
         - security
-      summary: "User/password authentication to get an access token"
+      summary: "Login"
       description: "This method should be called to get an API token. This token will expire after
       auth_token_exp_timeout seconds (default: 3600). This value can be changed using PUT /security/config"
       operationId: api.controllers.security_controller.login_user
@@ -13087,7 +13092,7 @@ paths:
     post:
       tags:
       - security
-      summary: "Auth_context based authentication to get an access token"
+      summary: "Login auth_context"
       description: "This method should be called to get an API token using an authorization context body. This token
       will expire after auth_token_exp_timeout seconds (default: 3600). This value can be changed using PUT
       /security/config"
@@ -13128,7 +13133,7 @@ paths:
     get:
       tags:
         - security
-      summary: 'Get all RBAC actions'
+      summary: 'List RBAC actions'
       description: 'Get all RBAC actions, including the potential related resources and endpoints.'
       operationId: api.controllers.security_controller.get_rbac_actions
       parameters:
@@ -13185,7 +13190,7 @@ paths:
     get:
       tags:
         - security
-      summary: 'Get RBAC resources'
+      summary: 'List RBAC resources'
       description: 'This method should be called to get all current defined RBAC resources.'
       operationId: api.controllers.security_controller.get_rbac_resources
       parameters:
@@ -13241,8 +13246,8 @@ paths:
     put:
       tags:
       - security
-      summary: "Revoke all active JWT tokens"
-      description: "This method should be called to revoke all JWT tokens"
+      summary: "Revoke JWT tokens"
+      description: "This method should be called to revoke all active JWT tokens"
       operationId: api.controllers.security_controller.revoke_all_tokens
       responses:
         '200':
@@ -13269,7 +13274,7 @@ paths:
     get:
       tags:
         - security
-      summary: "Gets a list of roles or all roles in the system without specifying anything"
+      summary: "List roles"
       description: "For a specific list, indicate the ids separated by commas. Example: ?role_ids=1,2,3"
       operationId: api.controllers.security_controller.get_roles
       x-rbac-actions:
@@ -13331,7 +13336,7 @@ paths:
     post:
       tags:
         - security
-      summary: "Add a new role to the system"
+      summary: "Add role"
       description: "Add a new role, all fields need to be specified"
       operationId: api.controllers.security_controller.add_role
       x-rbac-actions:
@@ -13388,7 +13393,7 @@ paths:
     delete:
       tags:
         - security
-      summary: "Delete a list of roles or all roles in the system"
+      summary: "Delete roles"
       description: "Policies linked to roles are not going to be removed"
       operationId: api.controllers.security_controller.remove_roles
       x-rbac-actions:
@@ -13458,7 +13463,7 @@ paths:
     put:
       tags:
         - security
-      summary: "Modify a specified role"
+      summary: "Update role"
       description: "Modify a role, cannot modify associated policies in this endpoint, at least one property must be
       indicated"
       operationId: api.controllers.security_controller.update_role
@@ -13518,7 +13523,7 @@ paths:
     get:
       tags:
         - security
-      summary: "Get all security rules"
+      summary: "List security rules"
       description: "Get a list of security rules from the system or all of them. These rules must be mapped with roles
       to obtain certain access privileges. For a specific list, indicate the ids separated by commas.
       Example: ?rule_ids=1,2,3"
@@ -13576,7 +13581,7 @@ paths:
     post:
       tags:
         - security
-      summary: "Add a new security rule to the system"
+      summary: "Add security rule"
       description: "Add a new security rule"
       operationId: api.controllers.security_controller.add_rule
       x-rbac-actions:
@@ -13639,8 +13644,9 @@ paths:
     delete:
       tags:
         - security
-      summary: "Delete a list of security rules or all security rules in the system"
-      description: "Roles linked to rules are not going to be removed"
+      summary: "Delete security rules"
+      description: "Delete a list of security rules or all security rules in the system, roles linked to rules are not
+      going to be deleted"
       operationId: api.controllers.security_controller.remove_rules
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/security:delete'
@@ -13689,7 +13695,7 @@ paths:
     put:
       tags:
         - security
-      summary: "Modify a security rule"
+      summary: "Update security rule"
       description: "Modify a security rule by specifying its ID"
       operationId: api.controllers.security_controller.update_rule
       x-rbac-actions:
@@ -13749,7 +13755,7 @@ paths:
     get:
       tags:
         - security
-      summary: "Get all policies in the system"
+      summary: "List policies"
       description: "Get all policies in the system, including the administrator policy"
       operationId: api.controllers.security_controller.get_policies
       x-rbac-actions:
@@ -13812,7 +13818,7 @@ paths:
     post:
       tags:
         - security
-      summary: "Add a new policy"
+      summary: "Add policy"
       description: "Add a new policy, all fields need to be specified"
       operationId: api.controllers.security_controller.add_policy
       x-rbac-actions:
@@ -13882,8 +13888,9 @@ paths:
     delete:
       tags:
         - security
-      summary: "Delete a list of policies or all policies in the system"
-      description: "Roles linked to policies are not going to be removed"
+      summary: "Delete policies"
+      description: "Delete a list of policies or all policies in the system, roles linked to policies are not going to
+      be removed"
       operationId: api.controllers.security_controller.remove_policies
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/security:delete'
@@ -13945,7 +13952,7 @@ paths:
     put:
       tags:
         - security
-      summary: "Modify a specified policy"
+      summary: "Update policy"
       description: "Modify a policy, at least one property must be indicated"
       operationId: api.controllers.security_controller.update_policy
       x-rbac-actions:
@@ -14018,7 +14025,7 @@ paths:
     post:
       tags:
         - security
-      summary: "Create a relation between one role and one or more policies"
+      summary: "Add policies to role"
       description: "Create a specified relation role-policy, one role may have multiples policies"
       operationId: api.controllers.security_controller.set_role_policy
       x-rbac-actions:
@@ -14087,7 +14094,7 @@ paths:
     delete:
       tags:
         - security
-      summary: "Delete a specified relation role-policy"
+      summary: "Remove policies from role"
       description: "Delete a specified relation role-policy"
       operationId: api.controllers.security_controller.remove_role_policy
       x-rbac-actions:
@@ -14135,7 +14142,7 @@ paths:
     post:
       tags:
         - security
-      summary: "Create a relation between one role and one or more security rules"
+      summary: "Add security rules to role"
       description: "Create a specific role-rule relation. One role may have multiple security rules"
       operationId: api.controllers.security_controller.set_role_rule
       x-rbac-actions:
@@ -14184,7 +14191,7 @@ paths:
     delete:
       tags:
         - security
-      summary: "Delete a specific role-rule relation"
+      summary: "Remove security rules from role"
       description: "Delete a specific role-rule relation"
       operationId: api.controllers.security_controller.remove_role_rule
       x-rbac-actions:
@@ -14230,7 +14237,7 @@ paths:
     post:
       tags:
         - security
-      summary: "Create a specified relation between one user and one role"
+      summary: "Add roles to user"
       description: "Create a specified relation role-policy, one user may have multiples roles"
       operationId: api.controllers.security_controller.set_user_role
       x-rbac-actions:
@@ -14280,7 +14287,7 @@ paths:
     delete:
       tags:
         - security
-      summary: "Delete a specified relation user-roles"
+      summary: "Remove roles from user"
       description: "Delete a specified relation user-roles"
       operationId: api.controllers.security_controller.remove_user_role
       x-rbac-actions:
@@ -14328,7 +14335,7 @@ paths:
     get:
       tags:
         - security
-      summary: "Get current user information"
+      summary: "Get current user info"
       description: "Get the information of the current user"
       operationId: api.controllers.security_controller.get_user_me
       parameters:
@@ -14437,7 +14444,7 @@ paths:
     get:
       tags:
         - security
-      summary: "Get user information"
+      summary: "List users"
       description: "Get the information of a specified user"
       operationId: api.controllers.security_controller.get_users
       x-rbac-actions:
@@ -14525,8 +14532,8 @@ paths:
     post:
       tags:
         - security
-      summary: "Create new user"
-      description: "Add a new user to the system through the API"
+      summary: "Add user"
+      description: "Add a new API user to the system"
       operationId: api.controllers.security_controller.create_user
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/security:create_user'
@@ -14591,7 +14598,7 @@ paths:
     delete:
       tags:
         - security
-      summary: "Delete a list of users"
+      summary: "Delete users"
       description: "Delete a list of users by specifying their IDs"
       operationId: api.controllers.security_controller.delete_users
       x-rbac-actions:
@@ -14644,7 +14651,7 @@ paths:
     put:
       tags:
         - security
-      summary: "Modify a user"
+      summary: "Update users"
       description: "Modify a user's password by specifying their ID"
       operationId: api.controllers.security_controller.update_user
       x-rbac-actions:
@@ -14707,7 +14714,7 @@ paths:
     get:
       tags:
         - overview
-      summary: "Get a full agents overview"
+      summary: "Get agents overview"
       description: "Return a dictionary with a full agents overview"
       operationId: api.controllers.overview_controller.get_overview_agents
       x-rbac-actions:
@@ -14805,7 +14812,7 @@ paths:
     get:
       tags:
         - security
-      summary: "Get current security configuration"
+      summary: "Get security config"
       description: "Return the security configuration in JSON format"
       operationId: api.controllers.security_controller.get_security_config
       x-rbac-actions:
@@ -14837,7 +14844,7 @@ paths:
     put:
       tags:
         - security
-      summary: "Update security configuration"
+      summary: "Update security config"
       description: "Update the security configuration with the data contained in the API request"
       operationId: api.controllers.security_controller.put_security_config
       x-rbac-actions:
@@ -14874,7 +14881,7 @@ paths:
     delete:
       tags:
         - security
-      summary: "Restore default security configuration"
+      summary: "Restore default security config"
       description: "Replaces the security configuration with the original one"
       operationId: api.controllers.security_controller.delete_security_config
       x-rbac-actions:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -11,7 +11,7 @@ info:
 
     Wazuh API endpoints require authentication in order to be used. Therefore, all calls must include a JSON Web Token.
     JWT is an open standard (RFC 7519) that defines a compact and self-contained way for securely transmitting
-    information between parties as a JSON object. Perform a call with basicAuth to GET /security/user/authenticate
+    information between parties as a JSON object. Perform a call with `basicAuth to `GET /security/user/authenticate
     and obtain a JWT token in order to run any endpoint.
 
     Login with USER and PASSWORD:
@@ -470,7 +470,7 @@ components:
             detail: "Permission denied: Resource type: *:*"
             remediation: "Please, make sure you have permissions to execute the current request. For more information
             on how to set up permissions, please visit
-            https://documentation.wazuh.com/current/user-manual/api/rbac/configuration.html"
+            https://documentation.wazuh.com/4.0/user-manual/api/rbac/configuration.html"
             error: 4000
             dapi_errors:
               unknown-node:
@@ -537,7 +537,7 @@ components:
             title: "Wazuh Error"
             detail: "Maximum number of request per minute reached"
             remediation: "This limit can be changed in security.yaml file. More information here:
-            https://documentation.wazuh.com/current/user-manual/api/security/configuration.html"
+            https://documentation.wazuh.com/4.0/user-manual/api/security/configuration.html"
             code: 6001
 
     ResourceNotFoundResponse:
@@ -550,7 +550,7 @@ components:
             title: "Resource Not Found"
             detail: "The group does not exist"
             remediation: "Please, use `GET /groups` to find all available groups:
-            https://documentation.wazuh.com/current/user-manual/api/rbac/configuration.html"
+            https://documentation.wazuh.com/4.0/user-manual/api/rbac/configuration.html"
             code: 1710
             dapi_errors:
               unknown-node:
@@ -2085,7 +2085,7 @@ components:
           type: number
           format: float
           description: "Same as `alerts_written` but focusing in [FTS alerts]
-          (https://documentation.wazuh.com/current/user-manual/ruleset/ruleset-xml-syntax/decoders.html?highlight=fts
+          (https://documentation.wazuh.com/4.0/user-manual/ruleset/ruleset-xml-syntax/decoders.html?highlight=fts
           #fts)"
         hostinfo_edps:
           type: number
@@ -14924,4 +14924,4 @@ paths:
 
 externalDocs:
   description: "Find more about Wazuh API usage"
-  url: 'https://documentation.wazuh.com/current/user-manual/api/index.html'
+  url: 'https://documentation.wazuh.com/4.0/user-manual/api/index.html'

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5981,7 +5981,7 @@ paths:
   /groups:
     delete:
       tags:
-        - groups
+        - Groups
       summary: "Delete groups"
       description: "Delete all groups or a list of them"
       operationId: api.controllers.agents_controller.delete_groups
@@ -6033,7 +6033,7 @@ paths:
 
     get:
       tags:
-        - groups
+        - Groups
       summary: "Get groups"
       description: "Get information about all groups or a list of them. Returns a list containing basic information
       about each group such as number of agents belonging to the group and the checksums of the configuration and
@@ -6095,7 +6095,7 @@ paths:
 
     post:
       tags:
-        - groups
+        - Groups
       summary: "Create a group"
       description: "Create a new group"
       operationId: api.controllers.agents_controller.post_group
@@ -6129,7 +6129,7 @@ paths:
   /groups/{group_id}/agents:
     get:
       tags:
-        - groups
+        - Groups
       summary: "Get agents in a group"
       description: "Return the list of agents that belong to the specified group"
       operationId: api.controllers.agents_controller.get_agents_in_group
@@ -6258,7 +6258,7 @@ paths:
   /groups/{group_id}/configuration:
     get:
       tags:
-        - groups
+        - Groups
       summary: "Get group configuration"
       description: "Return the group configuration defined in the `agent.conf` file"
       operationId: api.controllers.agents_controller.get_group_config
@@ -6326,7 +6326,7 @@ paths:
           $ref: '#/components/responses/TooManyRequestsResponse'
     put:
       tags:
-        - groups
+        - Groups
       summary: "Update group configuration"
       description: "Update an specified group's configuration. This API call expects a full valid XML file with the
       shared configuration tags/syntax"
@@ -6376,7 +6376,7 @@ paths:
   /groups/{group_id}/files:
     get:
       tags:
-        - groups
+        - Groups
       summary: "Get group files"
       description: "Return the files placed under the group directory"
       operationId: api.controllers.agents_controller.get_group_files
@@ -6447,7 +6447,7 @@ paths:
   /groups/{group_id}/files/{file_name}/json:
     get:
       tags:
-        - groups
+        - Groups
       summary: "Get a file in group"
       description: "Return the contents of the specified group file parsed to JSON"
       operationId: api.controllers.agents_controller.get_group_file_json
@@ -6502,7 +6502,7 @@ paths:
   /groups/{group_id}/files/{file_name}/xml:
     get:
       tags:
-        - groups
+        - Groups
       summary: "Get a file in group"
       description: "Return the contents of the specified group file parsed to XML"
       operationId: api.controllers.agents_controller.get_group_file_xml
@@ -7123,7 +7123,7 @@ paths:
   /ciscat/{agent_id}/results:
     get:
       tags:
-      - ciscat
+      - Ciscat
       summary: "Get CIS-CAT results"
       description: "Return the agent's ciscat results info"
       operationId: api.controllers.ciscat_controller.get_agents_ciscat_results
@@ -7192,7 +7192,7 @@ paths:
   /cluster/local/info:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get local node info"
       description: "Return basic information about the cluster node receiving the request"
       operationId: api.controllers.cluster_controller.get_cluster_node
@@ -7247,7 +7247,7 @@ paths:
   /cluster/nodes:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get nodes info"
       description: "Get information about all nodes in the cluster or a list of them"
       operationId: api.controllers.cluster_controller.get_cluster_nodes
@@ -7310,7 +7310,7 @@ paths:
   /cluster/healthcheck:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get nodes healthcheck"
       description: "Return cluster healthcheck information for all nodes or a list of them. Such information includes
       last keep alive, last synchronization time and number of agents reporting on each node"
@@ -7383,7 +7383,7 @@ paths:
   /cluster/status:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get cluster status"
       description: "Return information about the cluster status"
       operationId: api.controllers.cluster_controller.get_status
@@ -7434,7 +7434,7 @@ paths:
   /cluster/local/config:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get local node config"
       description: "Return the current node cluster configuration"
       operationId: api.controllers.cluster_controller.get_config
@@ -7520,7 +7520,7 @@ paths:
   /cluster/api/config:
     get:
       tags:
-        - cluster
+        - Cluster
       summary: "Get nodes API config"
       description: "Return the API configuration of all nodes (or a list of them) in JSON format"
       operationId: api.controllers.cluster_controller.get_api_config
@@ -7613,7 +7613,7 @@ paths:
 
     put:
       tags:
-        - cluster
+        - Cluster
       summary: "Update nodes API config"
       description: "Update the API configuration of all nodes (or a list of them) with the data contained in the API
       request"
@@ -7664,7 +7664,7 @@ paths:
 
     delete:
       tags:
-        - cluster
+        - Cluster
       summary: "Restore nodes default API config"
       description: "Restore the default API configuration of all nodes (or a list of them)"
       operationId: api.controllers.cluster_controller.delete_api_config
@@ -7707,7 +7707,7 @@ paths:
   /cluster/{node_id}/status:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get node status"
       description: "Return the status of all Wazuh daemons in node node_id"
       operationId: api.controllers.cluster_controller.get_status_node
@@ -7768,7 +7768,7 @@ paths:
   /cluster/{node_id}/info:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get node info"
       description: "Return basic information about a specified node such as version, compilation date, installation
       path"
@@ -7822,7 +7822,7 @@ paths:
   /cluster/{node_id}/configuration:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get node config"
       description: "Return wazuh configuration used in node {node_id}"
       operationId: api.controllers.cluster_controller.get_configuration_node
@@ -7901,7 +7901,7 @@ paths:
   /cluster/{node_id}/stats:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get node stats"
       description: "Return Wazuh statistical information in node {node_id} for the current or specified date"
       operationId: api.controllers.cluster_controller.get_stats_node
@@ -7970,7 +7970,7 @@ paths:
   /cluster/{node_id}/stats/hourly:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get node stats hour"
       description: "Return Wazuh statistical information in node {node_id} per hour. Each number in the averages field
       represents the average of alerts per hour"
@@ -8039,7 +8039,7 @@ paths:
   /cluster/{node_id}/stats/weekly:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get node stats week"
       description: "Return Wazuh statistical information in node {node_id} per week. Each number in the averages field
       represents the average of alerts per hour for that specific day"
@@ -8271,7 +8271,7 @@ paths:
   /cluster/{node_id}/stats/analysisd:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get node stats analysisd"
       description: "Return Wazuh analysisd statistical information in node {node_id}"
       operationId: api.controllers.cluster_controller.get_stats_analysisd_node
@@ -8359,7 +8359,7 @@ paths:
   /cluster/{node_id}/stats/remoted:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get node stats remoted"
       description: "Return Wazuh remoted statistical information in node {node_id}"
       operationId: api.controllers.cluster_controller.get_stats_remoted_node
@@ -8409,7 +8409,7 @@ paths:
   /cluster/{node_id}/logs:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get node logs"
       description: "Return the last 2000 wazuh log entries in the specified node"
       operationId: api.controllers.cluster_controller.get_log_node
@@ -8472,7 +8472,7 @@ paths:
   /cluster/{node_id}/logs/summary:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get node logs summary"
       description: "Return a summary of the last 2000 wazuh log entries in the specified node"
       operationId: api.controllers.cluster_controller.get_log_summary_node
@@ -8535,7 +8535,7 @@ paths:
   /cluster/{node_id}/files:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Get node file content"
       description: "Return file contents from any file in the specified node"
       operationId: api.controllers.cluster_controller.get_files_node
@@ -8584,7 +8584,7 @@ paths:
 
     put:
       tags:
-      - cluster
+      - Cluster
       summary: "Update node file content"
       description: "Replace file contents with the data contained in the API request for the specified node"
       operationId: api.controllers.cluster_controller.put_files_node
@@ -8637,7 +8637,7 @@ paths:
 
     delete:
       tags:
-      - cluster
+      - Cluster
       summary: "Delete node file"
       description: "Delete a file in the specified node"
       operationId: api.controllers.cluster_controller.delete_files_node
@@ -8679,7 +8679,7 @@ paths:
   /cluster/restart:
     put:
       tags:
-      - cluster
+      - Cluster
       summary: "Restart nodes"
       description: "Restart all nodes in the cluster or a list of them"
       operationId: api.controllers.cluster_controller.put_restart
@@ -8726,7 +8726,7 @@ paths:
   /cluster/configuration/validation:
     get:
       tags:
-      - cluster
+      - Cluster
       summary: "Check nodes config"
       description: "Return whether the Wazuh configuration is correct or not in all cluster nodes or a list of them"
       operationId: api.controllers.cluster_controller.get_conf_validation
@@ -8776,7 +8776,7 @@ paths:
   /cluster/{node_id}/configuration/{component}/{configuration}:
     get:
       tags:
-        - cluster
+        - Cluster
       summary: "Get node active configuration"
       description: "Return the requested configuration in JSON format for the specified node"
       operationId: api.controllers.cluster_controller.get_node_config
@@ -8829,7 +8829,7 @@ paths:
   /lists:
     get:
       tags:
-      - lists
+      - Lists
       summary: "Get CDB lists"
       description: "Return the contents of all CDB lists. Optionally, the result can be filtered by several criteria.
       See available parameters for more details"
@@ -8918,7 +8918,7 @@ paths:
   /lists/files:
     get:
       tags:
-      - lists
+      - Lists
       summary: "Get CDB lists files"
       description: "Return the path from all CDB lists. Use this method to know all the CDB lists and their location in
       the filesystem relative to Wazuh installation folder"
@@ -8976,7 +8976,7 @@ paths:
   /manager/status:
     get:
       tags:
-      - manager
+      - Manager
       summary: "Get manager status"
       description: "Return the status of all Wazuh daemons"
       operationId: api.controllers.manager_controller.get_status
@@ -9036,7 +9036,7 @@ paths:
   /manager/info:
     get:
       tags:
-      - manager
+      - Manager
       summary: "Get manager information"
       description: "Return basic information such as version, compilation date, installation path"
       operationId: api.controllers.manager_controller.get_info
@@ -9088,7 +9088,7 @@ paths:
   /manager/configuration:
     get:
       tags:
-      - manager
+      - Manager
       summary: "Get manager configuration"
       description: "Return wazuh configuration used"
       operationId: api.controllers.manager_controller.get_configuration
@@ -9166,7 +9166,7 @@ paths:
   /manager/stats:
     get:
       tags:
-      - manager
+      - Manager
       summary: "Get manager stats"
       description: "Return Wazuh statistical information for the current or specified date"
       operationId: api.controllers.manager_controller.get_stats
@@ -9234,7 +9234,7 @@ paths:
   /manager/stats/hourly:
     get:
       tags:
-      - manager
+      - Manager
       summary: "Get manager stats hour"
       description: "Return Wazuh statistical information per hour. Each number in the averages field represents the
       average of alerts per hour"
@@ -9302,7 +9302,7 @@ paths:
   /manager/stats/weekly:
     get:
       tags:
-      - manager
+      - Manager
       summary: "Get manager stats week"
       description: "Return Wazuh statistical information per week. Each number in the averages field represents the
       average of alerts per hour for that specific day"
@@ -9533,7 +9533,7 @@ paths:
   /manager/stats/analysisd:
     get:
       tags:
-      - manager
+      - Manager
       summary: "Get manager stats analysisd"
       description: "Return Wazuh analysisd statistical information"
       operationId: api.controllers.manager_controller.get_stats_analysisd
@@ -9620,7 +9620,7 @@ paths:
   /manager/stats/remoted:
     get:
       tags:
-      - manager
+      - Manager
       summary: "Get remoted stats remoted "
       description: "Return Wazuh remoted statistical information"
       operationId: api.controllers.manager_controller.get_stats_remoted
@@ -9669,7 +9669,7 @@ paths:
   /manager/logs:
     get:
       tags:
-      - manager
+      - Manager
       summary: "Get manager logs"
       description: "Return the last 2000 wazuh log entries"
       operationId: api.controllers.manager_controller.get_log
@@ -9731,7 +9731,7 @@ paths:
   /manager/logs/summary:
     get:
       tags:
-      - manager
+      - Manager
       summary: "Get manager logs summary"
       description: "Return a summary of the last 2000 wazuh log entries"
       operationId: api.controllers.manager_controller.get_log_summary
@@ -9795,7 +9795,7 @@ paths:
   /manager/files:
     get:
       tags:
-      - manager
+      - Manager
       summary: "Get manager file content"
       description: "Return file contents from any file"
       operationId: api.controllers.manager_controller.get_files
@@ -9843,7 +9843,7 @@ paths:
 
     put:
       tags:
-      - manager
+      - Manager
       summary: "Update manager file content"
       description: "Replace file contents with the data contained in the API request"
       operationId: api.controllers.manager_controller.put_files
@@ -9891,7 +9891,7 @@ paths:
 
     delete:
       tags:
-      - manager
+      - Manager
       summary: "Delete manager file"
       description: "Delete a specified file"
       operationId: api.controllers.manager_controller.delete_files
@@ -9934,7 +9934,7 @@ paths:
   /manager/api/config:
     get:
       tags:
-        - manager
+        - Manager
       summary: "Get manager API config"
       description: "Return the local API configuration in JSON format"
       operationId: api.controllers.manager_controller.get_api_config
@@ -10000,7 +10000,7 @@ paths:
 
     put:
       tags:
-        - manager
+        - Manager
       summary: "Update manager API config"
       description: "Update local API configuration with the data contained in the API request"
       operationId: api.controllers.manager_controller.put_api_config
@@ -10024,7 +10024,7 @@ paths:
               example:
                 data:
                   affected_items:
-                    - manager
+                    - Manager
                   total_affected_items: 1
                   failed_items: []
                   total_failed_items: 0
@@ -10048,7 +10048,7 @@ paths:
 
     delete:
       tags:
-        - manager
+        - Manager
       summary: "Restore manager default API config"
       description: "Restore default local API configuration"
       operationId: api.controllers.manager_controller.delete_api_config
@@ -10068,7 +10068,7 @@ paths:
               example:
                 data:
                   affected_items:
-                    - manager
+                    - Manager
                   total_affected_items: 1
                   failed_items: []
                   total_failed_items: 0
@@ -10089,7 +10089,7 @@ paths:
   /manager/restart:
     put:
       tags:
-      - manager
+      - Manager
       summary: "Restart manager"
       description: "Restart the wazuh manager"
       operationId: api.controllers.manager_controller.put_restart
@@ -10129,7 +10129,7 @@ paths:
   /manager/configuration/validation:
     get:
       tags:
-      - manager
+      - Manager
       summary: "Check manager config"
       description: "Return whether the Wazuh configuration is correct"
       operationId: api.controllers.manager_controller.get_conf_validation
@@ -10169,7 +10169,7 @@ paths:
   /manager/configuration/{component}/{configuration}:
     get:
       tags:
-        - manager
+        - Manager
       summary: "Get manager active configuration"
       description: "Return the requested active configuration in JSON format"
       operationId: api.controllers.manager_controller.get_manager_config_ondemand
@@ -10216,7 +10216,7 @@ paths:
   /mitre:
     get:
       tags:
-        - mitre
+        - Mitre
       summary: "Get MITRE attacks"
       description: "Return the requested attacks from MITRE database"
       operationId: api.controllers.mitre_controller.get_attack
@@ -10301,7 +10301,7 @@ paths:
   /rules:
     get:
       tags:
-      - rules
+      - Rules
       summary: "List rules"
       description: "Return a list containing information about each rule such as file where it's defined, description,
       rule group, status, etc"
@@ -10398,7 +10398,7 @@ paths:
   /rules/groups:
     get:
       tags:
-      - rules
+      - Rules
       summary: "Get rules groups"
       description: "Return a list containing all rule groups names"
       operationId: api.controllers.rules_controller.get_rules_groups
@@ -10451,7 +10451,7 @@ paths:
   /rules/requirement/{requirement}:
     get:
       tags:
-      - rules
+      - Rules
       summary: "Get rules requirements"
       description: "Return all specified requirement names defined in the Wazuh ruleset"
       operationId: api.controllers.rules_controller.get_rules_requirement
@@ -10506,7 +10506,7 @@ paths:
   /rules/files:
     get:
       tags:
-      - rules
+      - Rules
       summary: "Get rules files"
       description: "Return a list containing all files used to define rules and their status"
       operationId: api.controllers.rules_controller.get_rules_files
@@ -10568,7 +10568,7 @@ paths:
   /rules/files/{filename}/download:
     get:
       tags:
-        - rules
+        - Rules
       summary: "Download rule"
       description: "Download an specified rule file"
       operationId: api.controllers.rules_controller.get_download_file
@@ -10650,7 +10650,7 @@ paths:
   /sca/{agent_id}:
     get:
       tags:
-      - sca
+      - SCA
       summary: "Get SCA results"
       description: "Return the security SCA database of an agent"
       operationId: api.controllers.sca_controller.get_sca_agent
@@ -10728,7 +10728,7 @@ paths:
   /sca/{agent_id}/checks/{policy_id}:
     get:
       tags:
-      - sca
+      - SCA
       summary: "Get SCA policy checks"
       description: "Return the policy monitoring alerts for a given policy"
       operationId: api.controllers.sca_controller.get_sca_checks
@@ -10829,7 +10829,7 @@ paths:
   /syscheck:
     put:
       tags:
-      - syscheck
+      - Syscheck
       summary: "Run FIM scan"
       description: "Run FIM scan in all agents"
       operationId: api.controllers.syscheck_controller.put_syscheck
@@ -10877,7 +10877,7 @@ paths:
   /syscheck/{agent_id}:
     get:
       tags:
-      - syscheck
+      - Syscheck
       summary: "Get FIM results"
       description: "Return FIM findings in the specified agent"
       operationId: api.controllers.syscheck_controller.get_syscheck_agent
@@ -10964,7 +10964,7 @@ paths:
 
     delete:
       tags:
-        - syscheck
+        - Syscheck
       summary: "Clear FIM results"
       description: "Clear file integrity monitoring scan results for a specified agent"
       operationId: api.controllers.syscheck_controller.delete_syscheck_agent
@@ -11009,7 +11009,7 @@ paths:
   /syscheck/{agent_id}/last_scan:
     get:
       tags:
-      - syscheck
+      - Syscheck
       summary: "Get last FIM scan"
       description: "Return when the last syscheck scan started and ended. If the scan is still in progress the end date
       will be unknown"
@@ -11056,7 +11056,7 @@ paths:
   /decoders:
     get:
       tags:
-        - decoders
+        - Decoders
       summary: "Get decoders"
       description: "Return information about all decoders included in ossec.conf. This information include decoder's
       route, decoder's name, decoder's file among others"
@@ -11128,7 +11128,7 @@ paths:
   /decoders/files:
     get:
       tags:
-        - decoders
+        - Decoders
       summary: "Get decoders files"
       description: "Return information about all decoders files used in Wazuh. This information include decoder's file,
       decoder's route and decoder's status among others"
@@ -11188,7 +11188,7 @@ paths:
   /decoders/files/{filename}/download:
     get:
       tags:
-      - decoders
+      - Decoders
       summary: "Download decoder file"
       description: "Download an specified decoder file"
       operationId: api.controllers.decoders_controller.get_download_file
@@ -11234,7 +11234,7 @@ paths:
   /decoders/parents:
     get:
       tags:
-        - decoders
+        - Decoders
       summary: "Get parent decoders"
       description: "Return information about all parent decoders. A parent decoder is a decoder used as base of other
       decoders"
@@ -11298,7 +11298,7 @@ paths:
   /experimental/syscheck:
     delete:
       tags:
-        - experimental
+        - Experimental
       summary: "Clear agents FIM results"
       description: "Clear the syscheck database for all agents or a list of them"
       operationId: api.controllers.experimental_controller.clear_syscheck_database
@@ -11355,7 +11355,7 @@ paths:
   /experimental/ciscat/results:
     get:
       tags:
-        - experimental
+        - Experimental
       summary: "Get agents CIS-CAT results"
       description: "Return CIS-CAT results for all agents or a list of them"
       operationId: api.controllers.experimental_controller.get_cis_cat_results
@@ -11448,7 +11448,7 @@ paths:
   /experimental/syscollector/hardware:
     get:
       tags:
-        - experimental
+        - Experimental
       summary: "Get agents hardware"
       description: "Return all agents (or a list of them) hardware info. This information include cpu, ram, scan info
       among others of all agents"
@@ -11543,7 +11543,7 @@ paths:
   /experimental/syscollector/netaddr:
     get:
       tags:
-        - experimental
+        - Experimental
       summary: "Get agents netaddr"
       description: "Return all agents (or a list of them) IPv4 and IPv6 addresses associated to their network
       interfaces. This information include used IP protocol, interface, and IP address among others"
@@ -11621,7 +11621,7 @@ paths:
   /experimental/syscollector/netiface:
     get:
       tags:
-        - experimental
+        - Experimental
       summary: "Get agents netiface"
       description: "Return all agents (or a list of them) network interfaces. This information includes rx, scan, tx
       info and some network information among other"
@@ -11741,7 +11741,7 @@ paths:
   /experimental/syscollector/netproto:
     get:
       tags:
-        - experimental
+        - Experimental
       summary: "Get agents netproto"
       description: "Return all agents (or a list of them) routing configuration for each network interface. This
       information includes interface, type protocol information among other"
@@ -11816,7 +11816,7 @@ paths:
   /experimental/syscollector/os:
     get:
       tags:
-        - experimental
+        - Experimental
       summary: "Get agents OS"
       description: "Return all agents (or a list of them) OS info. This information includes os information,
       architecture information among other"
@@ -11919,7 +11919,7 @@ paths:
   /experimental/syscollector/packages:
     get:
       tags:
-        - experimental
+        - Experimental
       summary: "Get agents packages"
       description: "Return all agents (or a list of them) packages info. This information includes name, section, size,
       and priority information of all packages among other"
@@ -12019,7 +12019,7 @@ paths:
   /experimental/syscollector/ports:
     get:
       tags:
-        - experimental
+        - Experimental
       summary: "Get agents ports"
       description: "Return all agents (or a list of them) ports info. This information includes local IP, Remote IP,
       protocol information among other"
@@ -12122,7 +12122,7 @@ paths:
   /experimental/syscollector/processes:
     get:
       tags:
-        - experimental
+        - Experimental
       summary: "Get agents processes"
       description: "Return all agents (or a list of them) processes info"
       operationId: api.controllers.experimental_controller.get_processes_info
@@ -12249,7 +12249,7 @@ paths:
   /experimental/syscollector/hotfixes:
     get:
       tags:
-        - experimental
+        - Experimental
       summary: "Get agents hotfixes"
       description: "Return all agents (or a list of them) hotfixes info"
       operationId: api.controllers.experimental_controller.get_hotfixes_info
@@ -12307,7 +12307,7 @@ paths:
   /syscollector/{agent_id}/hardware:
     get:
       tags:
-        - syscollector
+        - Syscollector
       summary: "Get agent hardware"
       description: "Return the agent's hardware info. This information include cpu, ram, scan info among others"
       operationId: api.controllers.syscollector_controller.get_hardware_info
@@ -12366,7 +12366,7 @@ paths:
   /syscollector/{agent_id}/hotfixes:
     get:
       tags:
-        - syscollector
+        - Syscollector
       summary: "Get agent hotfixes"
       description: "Return all hotfixes installed by Microsoft(R) in Windows(R) systems (KB... fixes)"
       operationId: api.controllers.syscollector_controller.get_hotfix_info
@@ -12421,7 +12421,7 @@ paths:
   /syscollector/{agent_id}/netaddr:
     get:
       tags:
-        - syscollector
+        - Syscollector
       summary: "Get agent netaddr"
       description: "Return the agent's network address info. This information include used IP protocol, interface, IP
       address  among others"
@@ -12484,7 +12484,7 @@ paths:
   /syscollector/{agent_id}/netiface:
     get:
       tags:
-        - syscollector
+        - Syscollector
       summary: "Get agent netiface"
       description: "Return the agent's network interface info. This information include rx, scan, tx info and some
       network information among others"
@@ -12567,7 +12567,7 @@ paths:
   /syscollector/{agent_id}/netproto:
     get:
       tags:
-        - syscollector
+        - Syscollector
       summary: "Get agent netproto"
       description: "Return the agent's routing configuration for each network interface"
       operationId: api.controllers.syscollector_controller.get_network_protocol_info
@@ -12628,7 +12628,7 @@ paths:
   /syscollector/{agent_id}/os:
     get:
       tags:
-        - syscollector
+        - Syscollector
       summary: "Get agent OS"
       description: "Return the agent's OS info. This information include os information, architecture information among
       others of all agents"
@@ -12690,7 +12690,7 @@ paths:
   /syscollector/{agent_id}/packages:
     get:
       tags:
-        - syscollector
+        - Syscollector
       summary: "Get agent packages"
       description: "Return the agent's packages info. This information include name, section, size, priority
       information of all packages among others"
@@ -12791,7 +12791,7 @@ paths:
   /syscollector/{agent_id}/ports:
     get:
       tags:
-        - syscollector
+        - Syscollector
       summary: "Get agent ports"
       description: "Return the agent's ports info. This information include local IP, Remote IP, protocol information
       among others"
@@ -12895,7 +12895,7 @@ paths:
   /syscollector/{agent_id}/processes:
     get:
       tags:
-        - syscollector
+        - Syscollector
       summary: "Get agent processes"
       description: "Return the agent's processes info"
       operationId: api.controllers.syscollector_controller.get_processes_info
@@ -13023,7 +13023,7 @@ paths:
   /security/user/authenticate:
     get:
       tags:
-        - security
+        - Security
       summary: "Login"
       description: "This method should be called to get an API token. This token will expire after
       auth_token_exp_timeout seconds (default: 3600). This value can be changed using PUT /security/config"
@@ -13063,7 +13063,7 @@ paths:
 
     delete:
       tags:
-        - security
+        - Security
       summary: "Logout current user"
       description: "This method should be called to invalidate all the current user's tokens"
       operationId: api.controllers.security_controller.logout_user
@@ -13091,7 +13091,7 @@ paths:
   /security/user/authenticate/run_as:
     post:
       tags:
-      - security
+      - Security
       summary: "Login auth_context"
       description: "This method should be called to get an API token using an authorization context body. This token
       will expire after auth_token_exp_timeout seconds (default: 3600). This value can be changed using PUT
@@ -13132,7 +13132,7 @@ paths:
   /security/actions:
     get:
       tags:
-        - security
+        - Security
       summary: 'List RBAC actions'
       description: 'Get all RBAC actions, including the potential related resources and endpoints.'
       operationId: api.controllers.security_controller.get_rbac_actions
@@ -13189,7 +13189,7 @@ paths:
   /security/resources:
     get:
       tags:
-        - security
+        - Security
       summary: 'List RBAC resources'
       description: 'This method should be called to get all current defined RBAC resources.'
       operationId: api.controllers.security_controller.get_rbac_resources
@@ -13245,7 +13245,7 @@ paths:
   /security/user/revoke:
     put:
       tags:
-      - security
+      - Security
       summary: "Revoke JWT tokens"
       description: "This method should be called to revoke all active JWT tokens"
       operationId: api.controllers.security_controller.revoke_all_tokens
@@ -13273,7 +13273,7 @@ paths:
   /security/roles:
     get:
       tags:
-        - security
+        - Security
       summary: "List roles"
       description: "For a specific list, indicate the ids separated by commas. Example: ?role_ids=1,2,3"
       operationId: api.controllers.security_controller.get_roles
@@ -13335,7 +13335,7 @@ paths:
 
     post:
       tags:
-        - security
+        - Security
       summary: "Add role"
       description: "Add a new role, all fields need to be specified"
       operationId: api.controllers.security_controller.add_role
@@ -13392,7 +13392,7 @@ paths:
 
     delete:
       tags:
-        - security
+        - Security
       summary: "Delete roles"
       description: "Policies linked to roles are not going to be removed"
       operationId: api.controllers.security_controller.remove_roles
@@ -13462,7 +13462,7 @@ paths:
   /security/roles/{role_id}:
     put:
       tags:
-        - security
+        - Security
       summary: "Update role"
       description: "Modify a role, cannot modify associated policies in this endpoint, at least one property must be
       indicated"
@@ -13522,7 +13522,7 @@ paths:
   /security/rules:
     get:
       tags:
-        - security
+        - Security
       summary: "List security rules"
       description: "Get a list of security rules from the system or all of them. These rules must be mapped with roles
       to obtain certain access privileges. For a specific list, indicate the ids separated by commas.
@@ -13580,7 +13580,7 @@ paths:
 
     post:
       tags:
-        - security
+        - Security
       summary: "Add security rule"
       description: "Add a new security rule"
       operationId: api.controllers.security_controller.add_rule
@@ -13643,7 +13643,7 @@ paths:
 
     delete:
       tags:
-        - security
+        - Security
       summary: "Delete security rules"
       description: "Delete a list of security rules or all security rules in the system, roles linked to rules are not
       going to be deleted"
@@ -13694,7 +13694,7 @@ paths:
   /security/rules/{rule_id}:
     put:
       tags:
-        - security
+        - Security
       summary: "Update security rule"
       description: "Modify a security rule by specifying its ID"
       operationId: api.controllers.security_controller.update_rule
@@ -13754,7 +13754,7 @@ paths:
   /security/policies:
     get:
       tags:
-        - security
+        - Security
       summary: "List policies"
       description: "Get all policies in the system, including the administrator policy"
       operationId: api.controllers.security_controller.get_policies
@@ -13817,7 +13817,7 @@ paths:
 
     post:
       tags:
-        - security
+        - Security
       summary: "Add policy"
       description: "Add a new policy, all fields need to be specified"
       operationId: api.controllers.security_controller.add_policy
@@ -13887,7 +13887,7 @@ paths:
 
     delete:
       tags:
-        - security
+        - Security
       summary: "Delete policies"
       description: "Delete a list of policies or all policies in the system, roles linked to policies are not going to
       be removed"
@@ -13951,7 +13951,7 @@ paths:
   /security/policies/{policy_id}:
     put:
       tags:
-        - security
+        - Security
       summary: "Update policy"
       description: "Modify a policy, at least one property must be indicated"
       operationId: api.controllers.security_controller.update_policy
@@ -14024,7 +14024,7 @@ paths:
   /security/roles/{role_id}/policies:
     post:
       tags:
-        - security
+        - Security
       summary: "Add policies to role"
       description: "Create a specified relation role-policy, one role may have multiples policies"
       operationId: api.controllers.security_controller.set_role_policy
@@ -14093,7 +14093,7 @@ paths:
 
     delete:
       tags:
-        - security
+        - Security
       summary: "Remove policies from role"
       description: "Delete a specified relation role-policy"
       operationId: api.controllers.security_controller.remove_role_policy
@@ -14141,7 +14141,7 @@ paths:
   /security/roles/{role_id}/rules:
     post:
       tags:
-        - security
+        - Security
       summary: "Add security rules to role"
       description: "Create a specific role-rule relation. One role may have multiple security rules"
       operationId: api.controllers.security_controller.set_role_rule
@@ -14190,7 +14190,7 @@ paths:
 
     delete:
       tags:
-        - security
+        - Security
       summary: "Remove security rules from role"
       description: "Delete a specific role-rule relation"
       operationId: api.controllers.security_controller.remove_role_rule
@@ -14236,7 +14236,7 @@ paths:
   /security/users/{user_id}/roles:
     post:
       tags:
-        - security
+        - Security
       summary: "Add roles to user"
       description: "Create a specified relation role-policy, one user may have multiples roles"
       operationId: api.controllers.security_controller.set_user_role
@@ -14286,7 +14286,7 @@ paths:
 
     delete:
       tags:
-        - security
+        - Security
       summary: "Remove roles from user"
       description: "Delete a specified relation user-roles"
       operationId: api.controllers.security_controller.remove_user_role
@@ -14334,7 +14334,7 @@ paths:
   /security/users/me:
     get:
       tags:
-        - security
+        - Security
       summary: "Get current user info"
       description: "Get the information of the current user"
       operationId: api.controllers.security_controller.get_user_me
@@ -14409,7 +14409,7 @@ paths:
   /security/users/me/policies:
     get:
       tags:
-        - security
+        - Security
       summary: "Get current user processed policies"
       description: "Get the processed policies information for the current user"
       operationId: api.controllers.security_controller.get_user_me_policies
@@ -14443,7 +14443,7 @@ paths:
   /security/users:
     get:
       tags:
-        - security
+        - Security
       summary: "List users"
       description: "Get the information of a specified user"
       operationId: api.controllers.security_controller.get_users
@@ -14531,7 +14531,7 @@ paths:
 
     post:
       tags:
-        - security
+        - Security
       summary: "Add user"
       description: "Add a new API user to the system"
       operationId: api.controllers.security_controller.create_user
@@ -14597,7 +14597,7 @@ paths:
 
     delete:
       tags:
-        - security
+        - Security
       summary: "Delete users"
       description: "Delete a list of users by specifying their IDs"
       operationId: api.controllers.security_controller.delete_users
@@ -14650,7 +14650,7 @@ paths:
   /security/users/{user_id}:
     put:
       tags:
-        - security
+        - Security
       summary: "Update users"
       description: "Modify a user's password by specifying their ID"
       operationId: api.controllers.security_controller.update_user
@@ -14713,7 +14713,7 @@ paths:
   /overview/agents:
     get:
       tags:
-        - overview
+        - Overview
       summary: "Get agents overview"
       description: "Return a dictionary with a full agents overview"
       operationId: api.controllers.overview_controller.get_overview_agents
@@ -14811,7 +14811,7 @@ paths:
   /security/config:
     get:
       tags:
-        - security
+        - Security
       summary: "Get security config"
       description: "Return the security configuration in JSON format"
       operationId: api.controllers.security_controller.get_security_config
@@ -14843,7 +14843,7 @@ paths:
 
     put:
       tags:
-        - security
+        - Security
       summary: "Update security config"
       description: "Update the security configuration with the data contained in the API request"
       operationId: api.controllers.security_controller.put_security_config
@@ -14880,7 +14880,7 @@ paths:
 
     delete:
       tags:
-        - security
+        - Security
       summary: "Restore default security config"
       description: "Replaces the security configuration with the original one"
       operationId: api.controllers.security_controller.delete_security_config

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5079,7 +5079,7 @@ paths:
     put:
       tags:
         - Active-response
-      summary: "Run AR command"
+      summary: "Run command"
       description: "Run an Active Response command on all agents or a list of them"
       operationId: api.controllers.active_response_controller.run_command
       x-rbac-actions:
@@ -7123,7 +7123,7 @@ paths:
     get:
       tags:
       - Ciscat
-      summary: "Get CIS-CAT results"
+      summary: "Get results"
       description: "Return the agent's ciscat results info"
       operationId: api.controllers.ciscat_controller.get_agents_ciscat_results
       x-rbac-actions:
@@ -9620,7 +9620,7 @@ paths:
     get:
       tags:
       - Manager
-      summary: "Get remoted stats remoted "
+      summary: "Get stats remoted"
       description: "Return Wazuh remoted statistical information"
       operationId: api.controllers.manager_controller.get_stats_remoted
       x-rbac-actions:
@@ -11056,7 +11056,7 @@ paths:
     get:
       tags:
         - Decoders
-      summary: "Get decoders"
+      summary: "List decoders"
       description: "Return information about all decoders included in ossec.conf. This information include decoder's
       route, decoder's name, decoder's file among others"
       operationId: api.controllers.decoders_controller.get_decoders
@@ -11128,7 +11128,7 @@ paths:
     get:
       tags:
         - Decoders
-      summary: "Get decoders files"
+      summary: "Get files"
       description: "Return information about all decoders files used in Wazuh. This information include decoder's file,
       decoder's route and decoder's status among others"
       operationId: api.controllers.decoders_controller.get_decoders_files
@@ -11188,7 +11188,7 @@ paths:
     get:
       tags:
       - Decoders
-      summary: "Download decoder file"
+      summary: "Download decoder"
       description: "Download an specified decoder file"
       operationId: api.controllers.decoders_controller.get_download_file
       x-rbac-actions:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1,19 +1,33 @@
 openapi: '3.0.0'
 info:
   description: |
-    The Wazuh API is an open source RESTful API that allows for interaction with the Wazuh manager from a
-    web browser, command line tool like cURL or any script or program that can make web requests. The Wazuh WUI relies on
-    this heavily and Wazuh’s goal is to accommodate complete remote management of the Wazuh infrastructure via the Wazuh
-    WUI. Use the Wazuh API to easily perform everyday actions like adding an agent, restarting the manager(s) or agent(s)
+    The Wazuh API is an open source RESTful API that allows for interaction with the Wazuh manager from a web browser,
+    command line tool like cURL or any script or program that can make web requests. The Wazuh WUI relies on this
+    heavily and Wazuh’s goal is to accommodate complete remote management of the Wazuh infrastructure via the Wazuh WUI.
+    Use the Wazuh API to easily perform everyday actions like adding an agent, restarting the manager(s) or agent(s)
     or looking up syscheck details.\n
 
     # Authentication
 
-    Petstore offers two forms of authentication:
-      - API Key
-      - OAuth2
-    OAuth2 - an open protocol to allow secure authorization in a simple
-    and standard method from web, mobile and desktop applications.
+    Wazuh API endpoints require authentication in order to be used. Therefore, all calls must include a JSON Web Token.
+    JWT is an open standard (RFC 7519) that defines a compact and self-contained way for securely transmitting
+    information between parties as a JSON object. Perform a call with basicAuth to GET /security/user/authenticate
+    and obtain a JWT token in order to run any endpoint.
+
+    Login with USER and PASSWORD:
+
+    `curl -u <USER>:<PASSWORD> -k -X GET "https://<HOST_IP>:55000/security/user/authenticate`
+    ```
+    {
+        "data": {
+            "token": "<YOUR_JWT_TOKEN>"
+        },
+        "error": 0
+    }
+    ```
+    Use the token from previous response to perform any endpoint request:
+
+    `curl -k -X <METHOD> "https://<HOST_IP>:55000/<ENDPOINT>" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"`
 
     <SecurityDefinitions />
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3874,8 +3874,7 @@ components:
       name: older_than
       description: "Filter out agents whose time lapse from last keep alive signal is longer than specified. Time in
       seconds, ‘[n_days]d’, ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For never_connected agents, uses the
-      register date. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, seconds are used.
-      Use 0s to select all agents"
+      register date. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, seconds are used"
       schema:
         type: string
         format: timeframe
@@ -4918,7 +4917,7 @@ components:
       name: older_than
       description: "Consider only agents whose last keep alive is older than the specified time frame. For
       never_connected agents, register date is considered instead of last keep alive. For example, `7d`, `10s` and `10`
-      are valid values. When no time unit is specified, seconds are assumed"
+      are valid values. When no time unit is specified, seconds are assumed. Use 0s to select all agents"
       schema:
         type: string
         format: timeframe
@@ -8977,7 +8976,7 @@ paths:
     get:
       tags:
       - Manager
-      summary: "Get manager status"
+      summary: "Get status"
       description: "Return the status of all Wazuh daemons"
       operationId: api.controllers.manager_controller.get_status
       x-rbac-actions:
@@ -9037,7 +9036,7 @@ paths:
     get:
       tags:
       - Manager
-      summary: "Get manager information"
+      summary: "Get information"
       description: "Return basic information such as version, compilation date, installation path"
       operationId: api.controllers.manager_controller.get_info
       x-rbac-actions:
@@ -9089,7 +9088,7 @@ paths:
     get:
       tags:
       - Manager
-      summary: "Get manager configuration"
+      summary: "Get configuration"
       description: "Return wazuh configuration used"
       operationId: api.controllers.manager_controller.get_configuration
       x-rbac-actions:
@@ -9167,7 +9166,7 @@ paths:
     get:
       tags:
       - Manager
-      summary: "Get manager stats"
+      summary: "Get stats"
       description: "Return Wazuh statistical information for the current or specified date"
       operationId: api.controllers.manager_controller.get_stats
       x-rbac-actions:
@@ -9235,7 +9234,7 @@ paths:
     get:
       tags:
       - Manager
-      summary: "Get manager stats hour"
+      summary: "Get stats hour"
       description: "Return Wazuh statistical information per hour. Each number in the averages field represents the
       average of alerts per hour"
       operationId: api.controllers.manager_controller.get_stats_hourly
@@ -9303,7 +9302,7 @@ paths:
     get:
       tags:
       - Manager
-      summary: "Get manager stats week"
+      summary: "Get stats week"
       description: "Return Wazuh statistical information per week. Each number in the averages field represents the
       average of alerts per hour for that specific day"
       operationId: api.controllers.manager_controller.get_stats_weekly
@@ -9534,7 +9533,7 @@ paths:
     get:
       tags:
       - Manager
-      summary: "Get manager stats analysisd"
+      summary: "Get stats analysisd"
       description: "Return Wazuh analysisd statistical information"
       operationId: api.controllers.manager_controller.get_stats_analysisd
       x-rbac-actions:
@@ -9670,7 +9669,7 @@ paths:
     get:
       tags:
       - Manager
-      summary: "Get manager logs"
+      summary: "Get logs"
       description: "Return the last 2000 wazuh log entries"
       operationId: api.controllers.manager_controller.get_log
       x-rbac-actions:
@@ -9732,7 +9731,7 @@ paths:
     get:
       tags:
       - Manager
-      summary: "Get manager logs summary"
+      summary: "Get logs summary"
       description: "Return a summary of the last 2000 wazuh log entries"
       operationId: api.controllers.manager_controller.get_log_summary
       x-rbac-actions:
@@ -9796,7 +9795,7 @@ paths:
     get:
       tags:
       - Manager
-      summary: "Get manager file content"
+      summary: "Get file content"
       description: "Return file contents from any file"
       operationId: api.controllers.manager_controller.get_files
       x-rbac-actions:
@@ -9844,7 +9843,7 @@ paths:
     put:
       tags:
       - Manager
-      summary: "Update manager file content"
+      summary: "Update file content"
       description: "Replace file contents with the data contained in the API request"
       operationId: api.controllers.manager_controller.put_files
       x-rbac-actions:
@@ -9892,7 +9891,7 @@ paths:
     delete:
       tags:
       - Manager
-      summary: "Delete manager file"
+      summary: "Delete file"
       description: "Delete a specified file"
       operationId: api.controllers.manager_controller.delete_files
       x-rbac-actions:
@@ -9935,7 +9934,7 @@ paths:
     get:
       tags:
         - Manager
-      summary: "Get manager API config"
+      summary: "Get API config"
       description: "Return the local API configuration in JSON format"
       operationId: api.controllers.manager_controller.get_api_config
       x-rbac-actions:
@@ -10001,7 +10000,7 @@ paths:
     put:
       tags:
         - Manager
-      summary: "Update manager API config"
+      summary: "Update API config"
       description: "Update local API configuration with the data contained in the API request"
       operationId: api.controllers.manager_controller.put_api_config
       x-rbac-actions:
@@ -10049,7 +10048,7 @@ paths:
     delete:
       tags:
         - Manager
-      summary: "Restore manager default API config"
+      summary: "Restore default API config"
       description: "Restore default local API configuration"
       operationId: api.controllers.manager_controller.delete_api_config
       x-rbac-actions:
@@ -10130,7 +10129,7 @@ paths:
     get:
       tags:
       - Manager
-      summary: "Check manager config"
+      summary: "Check config"
       description: "Return whether the Wazuh configuration is correct"
       operationId: api.controllers.manager_controller.get_conf_validation
       x-rbac-actions:
@@ -10170,7 +10169,7 @@ paths:
     get:
       tags:
         - Manager
-      summary: "Get manager active configuration"
+      summary: "Get active configuration"
       description: "Return the requested active configuration in JSON format"
       operationId: api.controllers.manager_controller.get_manager_config_ondemand
       x-rbac-actions:
@@ -10399,7 +10398,7 @@ paths:
     get:
       tags:
       - Rules
-      summary: "Get rules groups"
+      summary: "Get groups"
       description: "Return a list containing all rule groups names"
       operationId: api.controllers.rules_controller.get_rules_groups
       x-rbac-actions:
@@ -10452,7 +10451,7 @@ paths:
     get:
       tags:
       - Rules
-      summary: "Get rules requirements"
+      summary: "Get requirements"
       description: "Return all specified requirement names defined in the Wazuh ruleset"
       operationId: api.controllers.rules_controller.get_rules_requirement
       x-rbac-actions:
@@ -10507,7 +10506,7 @@ paths:
     get:
       tags:
       - Rules
-      summary: "Get rules files"
+      summary: "Get files"
       description: "Return a list containing all files used to define rules and their status"
       operationId: api.controllers.rules_controller.get_rules_files
       x-rbac-actions:
@@ -10651,7 +10650,7 @@ paths:
     get:
       tags:
       - SCA
-      summary: "Get SCA results"
+      summary: "Get results"
       description: "Return the security SCA database of an agent"
       operationId: api.controllers.sca_controller.get_sca_agent
       x-rbac-actions:
@@ -10729,7 +10728,7 @@ paths:
     get:
       tags:
       - SCA
-      summary: "Get SCA policy checks"
+      summary: "Get policy checks"
       description: "Return the policy monitoring alerts for a given policy"
       operationId: api.controllers.sca_controller.get_sca_checks
       x-rbac-actions:
@@ -10830,7 +10829,7 @@ paths:
     put:
       tags:
       - Syscheck
-      summary: "Run FIM scan"
+      summary: "Run scan"
       description: "Run FIM scan in all agents"
       operationId: api.controllers.syscheck_controller.put_syscheck
       x-rbac-actions:
@@ -10878,7 +10877,7 @@ paths:
     get:
       tags:
       - Syscheck
-      summary: "Get FIM results"
+      summary: "Get results"
       description: "Return FIM findings in the specified agent"
       operationId: api.controllers.syscheck_controller.get_syscheck_agent
       x-rbac-actions:
@@ -10965,7 +10964,7 @@ paths:
     delete:
       tags:
         - Syscheck
-      summary: "Clear FIM results"
+      summary: "Clear results"
       description: "Clear file integrity monitoring scan results for a specified agent"
       operationId: api.controllers.syscheck_controller.delete_syscheck_agent
       x-rbac-actions:
@@ -11010,7 +11009,7 @@ paths:
     get:
       tags:
       - Syscheck
-      summary: "Get last FIM scan"
+      summary: "Get last scan datetime"
       description: "Return when the last syscheck scan started and ended. If the scan is still in progress the end date
       will be unknown"
       operationId: api.controllers.syscheck_controller.get_last_scan_agent
@@ -13129,6 +13128,142 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
+  /security/users/me:
+    get:
+      tags:
+        - Security
+      summary: "Get current user info"
+      description: "Get the information of the current user"
+      operationId: api.controllers.security_controller.get_user_me
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+      responses:
+        '200':
+          description: "Information about current user"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseUsers'
+                example:
+                  data:
+                    affected_items:
+                      - id: 1
+                        username: wazuh
+                        allow_run_as: true
+                        roles:
+                          - id: 1
+                            name: administrator
+                            rule:
+                              FIND:
+                                r'^auth[a-zA-Z]+$':
+                                  - full_admin
+                            policies:
+                              - id: 1
+                                name: agents_all_resourceless
+                                policy:
+                                  actions:
+                                    - agent:create
+                                    - group:create
+                                  resources:
+                                    - "*:*:*"
+                                  effect: allow
+                              - id: 2
+                                name: agents_all_agents
+                                policy:
+                                  actions:
+                                    - agent:read
+                                    - agent:delete
+                                    - agent:modify_group
+                                    - agent:restart
+                                    - agent:upgrade
+                                  resources:
+                                    - agent:id:*
+                                    - agent:group:*
+                                  effect: allow
+                    total_affected_items: 1
+                    total_failed_items: 0
+                    failed_items: []
+                  message: "Current user information was returned"
+                  error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+  /security/users/me/policies:
+    get:
+      tags:
+        - Security
+      summary: "Get current user processed policies"
+      description: "Get the processed policies information for the current user"
+      operationId: api.controllers.security_controller.get_user_me_policies
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+      responses:
+        '200':
+          description: "Information about current user processed policies"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+              example:
+                data:
+                  syscheck:run:
+                    agent:id:*: allow
+                  syscollector:read:
+                    agent:id:*: allow
+                  rbac_mode: black
+                message: "Current user processed policies information was returned"
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+  /security/user/revoke:
+    put:
+      tags:
+      - Security
+      summary: "Revoke JWT tokens"
+      description: "This method should be called to revoke all active JWT tokens"
+      operationId: api.controllers.security_controller.revoke_all_tokens
+      responses:
+        '200':
+          description: "Tokens were successfully revoked"
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                message: "Tokens were successfully revoked"
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
   /security/actions:
     get:
       tags:
@@ -13242,23 +13377,84 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
-  /security/user/revoke:
-    put:
+  /security/users:
+    get:
       tags:
-      - Security
-      summary: "Revoke JWT tokens"
-      description: "This method should be called to revoke all active JWT tokens"
-      operationId: api.controllers.security_controller.revoke_all_tokens
+        - Security
+      summary: "List users"
+      description: "Get the information of a specified user"
+      operationId: api.controllers.security_controller.get_users
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/security:read'
+      parameters:
+        - $ref: '#/components/parameters/user_ids'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/wait_for_complete'
       responses:
         '200':
-          description: "Tokens were successfully revoked"
+          description: "Information about user"
           content:
             application/json:
               schema:
-                type: object
-              example:
-                message: "Tokens were successfully revoked"
-                error: 0
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseUsers'
+                example:
+                  data:
+                    affected_items:
+                      - id: 3
+                        username: administrator
+                        allow_run_as: true
+                        roles:
+                          - 2
+                      - id: 4
+                        username: guest
+                        allow_run_as: false
+                        roles: []
+                      - id: 5
+                        username: normal
+                        allow_run_as: false
+                        roles:
+                          - 4
+                          - 5
+                          - 6
+                      - id: 6
+                        username: ossec
+                        allow_run_as: true
+                        roles:
+                          - 2
+                          - 5
+                      - username: python
+                        allow_run_as: true
+                        roles: []
+                      - id: 7
+                        username: rbac
+                        allow_run_as: false
+                        roles:
+                          - 3
+                          - 4
+                          - 5
+                      - id: 1
+                        username: wazuh
+                        allow_run_as: true
+                        roles:
+                          - 1
+                      - id: 2
+                        username: wazuh-wui
+                        allow_run_as: true
+                        roles: []
+                    failed_items: []
+                    total_affected_items: 8
+                    total_failed_items: 0
+                  message: "All specified users were returned"
+                  error: 0
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':
@@ -13267,6 +13463,187 @@ paths:
           $ref: '#/components/responses/PermissionDeniedResponse'
         '405':
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+    post:
+      tags:
+        - Security
+      summary: "Add user"
+      description: "Add a new API user to the system"
+      operationId: api.controllers.security_controller.create_user
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/security:create_user'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                  minLength: 4
+                  maxLength: 20
+                  format: names
+                password:
+                  type: string
+                  maxLength: 64
+                  minLength: 8
+                  format: password
+                allow_run_as:
+                  type: boolean
+                  default: False
+              required:
+                - username
+                - password
+      responses:
+        '200':
+          description: "User created successfully"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseUsers'
+                example:
+                  data:
+                    affected_items:
+                      - roles: []
+                        username: wazuh1
+                    failed_items: []
+                    total_affected_items: 1
+                    total_failed_items: 0
+                  message: "User was successfully created"
+                  error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '406':
+          $ref: '#/components/responses/WrongContentTypeResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+    delete:
+      tags:
+        - Security
+      summary: "Delete users"
+      description: "Delete a list of users by specifying their IDs"
+      operationId: api.controllers.security_controller.delete_users
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/security:delete'
+      parameters:
+        - $ref: '#/components/parameters/user_ids_delete'
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+      responses:
+        '200':
+          description: "User deleted successful"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseUsers'
+                example:
+                  data:
+                    affected_items:
+                      - id: 100
+                        username: new_user
+                        allow_run_as: false
+                        roles: []
+                      - id: 102
+                        username: another_user
+                        allow_run_as: true
+                        roles:
+                          - 6
+                    total_affected_items: 2
+                    failed_items: []
+                    total_failed_items: 0
+                  message: "Users were successfully deleted"
+                  error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '406':
+          $ref: '#/components/responses/WrongContentTypeResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+  /security/users/{user_id}:
+    put:
+      tags:
+        - Security
+      summary: "Update users"
+      description: "Modify a user's password by specifying their ID"
+      operationId: api.controllers.security_controller.update_user
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/security:update'
+      parameters:
+        - $ref: '#/components/parameters/user_id_required'
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  type: string
+                  maxLength: 64
+                  minLength: 8
+                  format: password
+                allow_run_as:
+                  type: boolean
+                  default: False
+      responses:
+        '200':
+          description: "User updated successful"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseUsers'
+                example:
+                  data:
+                    affected_items:
+                      - id: 100
+                        username: wazuh-test
+                        allow_run_as: false
+                        roles:
+                          - 2
+                    total_affected_items: 1
+                    failed_items: []
+                    total_failed_items: 0
+                  message: "User was successfully updated"
+                  error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '406':
+          $ref: '#/components/responses/WrongContentTypeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
@@ -14021,6 +14398,104 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
+  /security/users/{user_id}/roles:
+    post:
+      tags:
+        - Security
+      summary: "Add roles to user"
+      description: "Create a specified relation role-policy, one user may have multiples roles"
+      operationId: api.controllers.security_controller.set_user_role
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/security:update'
+      parameters:
+        - $ref: '#/components/parameters/user_id_required'
+        - $ref: '#/components/parameters/role_ids_required'
+        - $ref: '#/components/parameters/security_position'
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+      responses:
+        '200':
+          description: "Role information"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseUsers'
+              example:
+                data:
+                  affected_items:
+                    - id: 3
+                      username: string
+                      roles:
+                        - 9
+                        - 8
+                  total_affected_items: 2
+                  total_failed_items: 0
+                  failed_items: []
+                message: All roles were linked to user 3
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+    delete:
+      tags:
+        - Security
+      summary: "Remove roles from user"
+      description: "Delete a specified relation user-roles"
+      operationId: api.controllers.security_controller.remove_user_role
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/security:delete'
+      parameters:
+        - $ref: '#/components/parameters/user_id_required'
+        - $ref: '#/components/parameters/role_ids_delete'
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+      responses:
+        '200':
+          description: "Role information"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseUsers'
+              example:
+                data:
+                  affected_items:
+                    - id: 3
+                      username: string
+                      roles: []
+                  total_affected_items: 1
+                  total_failed_items: 0
+                  failed_items: []
+                message: All roles were unlinked from user 3
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
   /security/roles/{role_id}/policies:
     post:
       tags:
@@ -14230,483 +14705,6 @@ paths:
           $ref: '#/components/responses/PermissionDeniedResponse'
         '405':
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '429':
-          $ref: '#/components/responses/TooManyRequestsResponse'
-
-  /security/users/{user_id}/roles:
-    post:
-      tags:
-        - Security
-      summary: "Add roles to user"
-      description: "Create a specified relation role-policy, one user may have multiples roles"
-      operationId: api.controllers.security_controller.set_user_role
-      x-rbac-actions:
-        - $ref: '#/x-rbac-catalog/actions/security:update'
-      parameters:
-        - $ref: '#/components/parameters/user_id_required'
-        - $ref: '#/components/parameters/role_ids_required'
-        - $ref: '#/components/parameters/security_position'
-        - $ref: '#/components/parameters/pretty'
-        - $ref: '#/components/parameters/wait_for_complete'
-      responses:
-        '200':
-          description: "Role information"
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/AllItemsResponseUsers'
-              example:
-                data:
-                  affected_items:
-                    - id: 3
-                      username: string
-                      roles:
-                        - 9
-                        - 8
-                  total_affected_items: 2
-                  total_failed_items: 0
-                  failed_items: []
-                message: All roles were linked to user 3
-                error: 0
-        '400':
-          $ref: '#/components/responses/ResponseError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
-        '403':
-          $ref: '#/components/responses/PermissionDeniedResponse'
-        '405':
-          $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '429':
-          $ref: '#/components/responses/TooManyRequestsResponse'
-
-    delete:
-      tags:
-        - Security
-      summary: "Remove roles from user"
-      description: "Delete a specified relation user-roles"
-      operationId: api.controllers.security_controller.remove_user_role
-      x-rbac-actions:
-        - $ref: '#/x-rbac-catalog/actions/security:delete'
-      parameters:
-        - $ref: '#/components/parameters/user_id_required'
-        - $ref: '#/components/parameters/role_ids_delete'
-        - $ref: '#/components/parameters/pretty'
-        - $ref: '#/components/parameters/wait_for_complete'
-      responses:
-        '200':
-          description: "Role information"
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/AllItemsResponseUsers'
-              example:
-                data:
-                  affected_items:
-                    - id: 3
-                      username: string
-                      roles: []
-                  total_affected_items: 1
-                  total_failed_items: 0
-                  failed_items: []
-                message: All roles were unlinked from user 3
-                error: 0
-        '400':
-          $ref: '#/components/responses/ResponseError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
-        '403':
-          $ref: '#/components/responses/PermissionDeniedResponse'
-        '405':
-          $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '429':
-          $ref: '#/components/responses/TooManyRequestsResponse'
-
-  /security/users/me:
-    get:
-      tags:
-        - Security
-      summary: "Get current user info"
-      description: "Get the information of the current user"
-      operationId: api.controllers.security_controller.get_user_me
-      parameters:
-        - $ref: '#/components/parameters/pretty'
-        - $ref: '#/components/parameters/wait_for_complete'
-      responses:
-        '200':
-          description: "Information about current user"
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/AllItemsResponseUsers'
-                example:
-                  data:
-                    affected_items:
-                      - id: 1
-                        username: wazuh
-                        allow_run_as: true
-                        roles:
-                          - id: 1
-                            name: administrator
-                            rule:
-                              FIND:
-                                r'^auth[a-zA-Z]+$':
-                                  - full_admin
-                            policies:
-                              - id: 1
-                                name: agents_all_resourceless
-                                policy:
-                                  actions:
-                                    - agent:create
-                                    - group:create
-                                  resources:
-                                    - "*:*:*"
-                                  effect: allow
-                              - id: 2
-                                name: agents_all_agents
-                                policy:
-                                  actions:
-                                    - agent:read
-                                    - agent:delete
-                                    - agent:modify_group
-                                    - agent:restart
-                                    - agent:upgrade
-                                  resources:
-                                    - agent:id:*
-                                    - agent:group:*
-                                  effect: allow
-                    total_affected_items: 1
-                    total_failed_items: 0
-                    failed_items: []
-                  message: "Current user information was returned"
-                  error: 0
-        '400':
-          $ref: '#/components/responses/ResponseError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
-        '403':
-          $ref: '#/components/responses/PermissionDeniedResponse'
-        '405':
-          $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '429':
-          $ref: '#/components/responses/TooManyRequestsResponse'
-
-
-  /security/users/me/policies:
-    get:
-      tags:
-        - Security
-      summary: "Get current user processed policies"
-      description: "Get the processed policies information for the current user"
-      operationId: api.controllers.security_controller.get_user_me_policies
-      parameters:
-        - $ref: '#/components/parameters/pretty'
-      responses:
-        '200':
-          description: "Information about current user processed policies"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiResponse"
-              example:
-                data:
-                  syscheck:run:
-                    agent:id:*: allow
-                  syscollector:read:
-                    agent:id:*: allow
-                  rbac_mode: black
-                message: "Current user processed policies information was returned"
-                error: 0
-        '400':
-          $ref: '#/components/responses/ResponseError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
-        '405':
-          $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '429':
-          $ref: '#/components/responses/TooManyRequestsResponse'
-
-  /security/users:
-    get:
-      tags:
-        - Security
-      summary: "List users"
-      description: "Get the information of a specified user"
-      operationId: api.controllers.security_controller.get_users
-      x-rbac-actions:
-        - $ref: '#/x-rbac-catalog/actions/security:read'
-      parameters:
-        - $ref: '#/components/parameters/user_ids'
-        - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/offset'
-        - $ref: '#/components/parameters/pretty'
-        - $ref: '#/components/parameters/search'
-        - $ref: '#/components/parameters/sort'
-        - $ref: '#/components/parameters/wait_for_complete'
-      responses:
-        '200':
-          description: "Information about user"
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/AllItemsResponseUsers'
-                example:
-                  data:
-                    affected_items:
-                      - id: 3
-                        username: administrator
-                        allow_run_as: true
-                        roles:
-                          - 2
-                      - id: 4
-                        username: guest
-                        allow_run_as: false
-                        roles: []
-                      - id: 5
-                        username: normal
-                        allow_run_as: false
-                        roles:
-                          - 4
-                          - 5
-                          - 6
-                      - id: 6
-                        username: ossec
-                        allow_run_as: true
-                        roles:
-                          - 2
-                          - 5
-                      - username: python
-                        allow_run_as: true
-                        roles: []
-                      - id: 7
-                        username: rbac
-                        allow_run_as: false
-                        roles:
-                          - 3
-                          - 4
-                          - 5
-                      - id: 1
-                        username: wazuh
-                        allow_run_as: true
-                        roles:
-                          - 1
-                      - id: 2
-                        username: wazuh-wui
-                        allow_run_as: true
-                        roles: []
-                    failed_items: []
-                    total_affected_items: 8
-                    total_failed_items: 0
-                  message: "All specified users were returned"
-                  error: 0
-        '400':
-          $ref: '#/components/responses/ResponseError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
-        '403':
-          $ref: '#/components/responses/PermissionDeniedResponse'
-        '405':
-          $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '429':
-          $ref: '#/components/responses/TooManyRequestsResponse'
-
-    post:
-      tags:
-        - Security
-      summary: "Add user"
-      description: "Add a new API user to the system"
-      operationId: api.controllers.security_controller.create_user
-      x-rbac-actions:
-        - $ref: '#/x-rbac-catalog/actions/security:create_user'
-      parameters:
-        - $ref: '#/components/parameters/pretty'
-        - $ref: '#/components/parameters/wait_for_complete'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                username:
-                  type: string
-                  minLength: 4
-                  maxLength: 20
-                  format: names
-                password:
-                  type: string
-                  maxLength: 64
-                  minLength: 8
-                  format: password
-                allow_run_as:
-                  type: boolean
-                  default: False
-              required:
-                - username
-                - password
-      responses:
-        '200':
-          description: "User created successfully"
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/AllItemsResponseUsers'
-                example:
-                  data:
-                    affected_items:
-                      - roles: []
-                        username: wazuh1
-                    failed_items: []
-                    total_affected_items: 1
-                    total_failed_items: 0
-                  message: "User was successfully created"
-                  error: 0
-        '400':
-          $ref: '#/components/responses/ResponseError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
-        '405':
-          $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '406':
-          $ref: '#/components/responses/WrongContentTypeResponse'
-        '429':
-          $ref: '#/components/responses/TooManyRequestsResponse'
-
-    delete:
-      tags:
-        - Security
-      summary: "Delete users"
-      description: "Delete a list of users by specifying their IDs"
-      operationId: api.controllers.security_controller.delete_users
-      x-rbac-actions:
-        - $ref: '#/x-rbac-catalog/actions/security:delete'
-      parameters:
-        - $ref: '#/components/parameters/user_ids_delete'
-        - $ref: '#/components/parameters/pretty'
-        - $ref: '#/components/parameters/wait_for_complete'
-      responses:
-        '200':
-          description: "User deleted successful"
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/AllItemsResponseUsers'
-                example:
-                  data:
-                    affected_items:
-                      - id: 100
-                        username: new_user
-                        allow_run_as: false
-                        roles: []
-                      - id: 102
-                        username: another_user
-                        allow_run_as: true
-                        roles:
-                          - 6
-                    total_affected_items: 2
-                    failed_items: []
-                    total_failed_items: 0
-                  message: "Users were successfully deleted"
-                  error: 0
-        '400':
-          $ref: '#/components/responses/ResponseError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
-        '405':
-          $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '406':
-          $ref: '#/components/responses/WrongContentTypeResponse'
-        '429':
-          $ref: '#/components/responses/TooManyRequestsResponse'
-
-  /security/users/{user_id}:
-    put:
-      tags:
-        - Security
-      summary: "Update users"
-      description: "Modify a user's password by specifying their ID"
-      operationId: api.controllers.security_controller.update_user
-      x-rbac-actions:
-        - $ref: '#/x-rbac-catalog/actions/security:update'
-      parameters:
-        - $ref: '#/components/parameters/user_id_required'
-        - $ref: '#/components/parameters/pretty'
-        - $ref: '#/components/parameters/wait_for_complete'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                password:
-                  type: string
-                  maxLength: 64
-                  minLength: 8
-                  format: password
-                allow_run_as:
-                  type: boolean
-                  default: False
-      responses:
-        '200':
-          description: "User updated successful"
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/AllItemsResponseUsers'
-                example:
-                  data:
-                    affected_items:
-                      - id: 100
-                        username: wazuh-test
-                        allow_run_as: false
-                        roles:
-                          - 2
-                    total_affected_items: 1
-                    failed_items: []
-                    total_failed_items: 0
-                  message: "User was successfully updated"
-                  error: 0
-        '400':
-          $ref: '#/components/responses/ResponseError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
-        '405':
-          $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '406':
-          $ref: '#/components/responses/WrongContentTypeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 


### PR DESCRIPTION
This issue closes #6272.

It fixes several spec.yaml typos for the new Wazuh API. It also shortens the summary of the endpoints for the redoc documentation and adds an introduction to the authentication tag.

Regards,

David J. Iglesias