### PR TITLE
Analysisd decoder accept PCRE2 expressions

### DIFF
--- a/src/analysisd/config_json.c
+++ b/src/analysisd/config_json.c
@@ -91,15 +91,32 @@ void _getDecodersListJSON(OSDecoderNode *list, cJSON *array) {
 
         if (node->osdecoder->accumulate) cJSON_AddStringToObject(decoder,"accumulate","yes"); else cJSON_AddStringToObject(decoder,"accumulate","no");
 
-        if (node->osdecoder->prematch) cJSON_AddStringToObject(decoder,"prematch",node->osdecoder->prematch->raw);
+        if (node->osdecoder->prematch) {
+            cJSON * prematch = cJSON_CreateObject();
+            cJSON_AddStringToObject(prematch, "pattern", w_expression_get_regex_pattern(node->osdecoder->prematch));
+            cJSON_AddStringToObject(prematch, "type", w_expression_get_regex_type(node->osdecoder->prematch));
+            cJSON_AddItemToObject(decoder, "prematch", prematch);
+        }
+
         if (node->osdecoder->prematch_offset & AFTER_PARENT) cJSON_AddStringToObject(decoder,"prematch_offset","after_parent");
 
-        if (node->osdecoder->regex) cJSON_AddStringToObject(decoder,"regex",node->osdecoder->regex->raw);
+        if (node->osdecoder->regex) {
+            cJSON * regex = cJSON_CreateObject();
+            cJSON_AddStringToObject(regex, "pattern", w_expression_get_regex_pattern(node->osdecoder->regex));
+            cJSON_AddStringToObject(regex, "type", w_expression_get_regex_type(node->osdecoder->regex));
+            cJSON_AddItemToObject(decoder, "regex", regex);
+        }
+
         if (node->osdecoder->regex_offset & AFTER_PARENT) cJSON_AddStringToObject(decoder,"regex_offset","after_parent");
         else if (node->osdecoder->regex_offset & AFTER_PREVREGEX) cJSON_AddStringToObject(decoder,"regex_offset","after_regex");
         else if (node->osdecoder->regex_offset & AFTER_PREMATCH) cJSON_AddStringToObject(decoder,"regex_offset","after_prematch");
 
-        if (node->osdecoder->program_name) cJSON_AddStringToObject(decoder,"program_name",node->osdecoder->program_name->raw);
+        if (node->osdecoder->program_name) {
+            cJSON * program_name = cJSON_CreateObject();
+            cJSON_AddStringToObject(program_name, "pattern", w_expression_get_regex_pattern(node->osdecoder->program_name));
+            cJSON_AddStringToObject(program_name, "type", w_expression_get_regex_type(node->osdecoder->program_name));
+            cJSON_AddItemToObject(decoder, "program_name", program_name);
+        }
 
         if (node->osdecoder->fts) {
             cJSON *_list = cJSON_CreateArray();

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -17,14 +17,47 @@
 #include "plugin_decoders.h"
 #include "config.h"
 
+#ifdef WAZUH_UNIT_TESTING
+// Remove STATIC qualifier from tests
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 /* Internal functions */
 static char *_loadmemory(char *at, char *str);
 static int addDecoder2list(const char *name);
 static int os_setdecoderids(const char *p_name);
-static int ReadDecodeAttrs(char *const *names, char *const *values);
 static OSStore *os_decoder_store = NULL;
 
 static void FreeDecoderInfo(OSDecoderInfo *pi);
+
+/**
+ * @brief Get offset attribute value of a node
+ * @param node node to find offset value
+ * @retval AFTER_PARENT if offset is "after_parent"
+ * @retval AFTER_PREMATCH if offset is "after_prematch"
+ * @retval AFTER_PREVREGEX if offset is "after_regex"
+ * @retval AFTER_ERROR if offset is not any previously listed values
+ * @retval 0 if the attribute is not present
+ */
+STATIC int w_get_attr_offset(xml_node * node);
+
+/**
+ * @brief Get regex type attribute of a node
+ * @param node node to find regex type value
+ * @param type if it is defined, return regex type
+ * @return true if it is defined. false otherwise
+ */
+STATIC bool w_get_attr_regex_type(xml_node * node, w_exp_type_t * type);
+
+/**
+ * @brief Get value of an attribute of a node
+ * @param node node to find value of attribute
+ * @param name name of the attribute
+ * @return value of attribute on success. NULL otherwise
+ */
+STATIC const char * w_get_attr_val_by_name(xml_node * node, const char * name);
 
 int getDecoderfromlist(const char *name)
 {
@@ -113,41 +146,6 @@ static int os_setdecoderids(const char *p_name)
     return (1);
 }
 
-static int ReadDecodeAttrs(char *const *names, char *const *values)
-{
-    if (!names || !values) {
-        return (0);
-    }
-
-    if (!names[0] || !values[0]) {
-        return (0);
-    }
-
-    if (strcmp(names[0], "offset") == 0) {
-        int offset = 0;
-
-        /* Offsets can be: after_parent, after_prematch
-         * or after_regex.
-         */
-        if (strcmp(values[0], "after_parent") == 0) {
-            offset |= AFTER_PARENT;
-        } else if (strcmp(values[0], "after_prematch") == 0) {
-            offset |= AFTER_PREMATCH;
-        } else if (strcmp(values[0], "after_regex") == 0) {
-            offset |= AFTER_PREVREGEX;
-        } else {
-            merror(INV_OFFSET, values[0]);
-            offset |= AFTER_ERROR;
-        }
-
-        return (offset);
-    }
-
-    /* Invalid attribute */
-    merror(INV_ATTR, names[0]);
-    return (AFTER_ERROR);
-}
-
 int ReadDecodeXML(const char *file)
 {
     OS_XML xml;
@@ -177,9 +175,14 @@ int ReadDecodeXML(const char *file)
     int i = 0;
     OSDecoderInfo *NULL_Decoder_tmp = NULL;
 
-    char *regex = NULL;
-    char *prematch = NULL;
-    char *p_name = NULL;
+    char * regex_str = NULL;
+    char * prematch_str = NULL;
+    char * p_name_str = NULL;
+
+    w_exp_type_t regex_type;
+    w_exp_type_t prematch_type;
+    w_exp_type_t p_name_type;
+
     XML_NODE elements = NULL;
     OSDecoderInfo *pi = NULL;
 
@@ -238,6 +241,7 @@ int ReadDecodeXML(const char *file)
             goto cleanup;
         }
 
+        /* Only process a decoder node */
         if (strcasecmp(node[i]->element, xml_decoder) != 0) {
             merror(XML_INVELEM, node[i]->element);
             goto cleanup;
@@ -251,7 +255,7 @@ int ReadDecodeXML(const char *file)
             goto cleanup;
         }
 
-        /* Check for additional entries */
+        /* Check for additional attributes */
         if (node[i]->attributes[1] && node[i]->values[1]) {
             if (strcasecmp(node[i]->attributes[1], xml_decoder_status) != 0) {
                 merror(XML_INVELEM, node[i]->element);
@@ -272,11 +276,7 @@ int ReadDecodeXML(const char *file)
         }
 
         /* Create the OSDecoderInfo */
-        pi = (OSDecoderInfo *)calloc(1, sizeof(OSDecoderInfo));
-        if (pi == NULL) {
-            merror(MEM_ERROR, errno, strerror(errno));
-            goto cleanup;
-        }
+        os_calloc(1, sizeof(OSDecoderInfo), pi);
 
         /* Default values to the list */
         pi->parent = NULL;
@@ -296,15 +296,14 @@ int ReadDecodeXML(const char *file)
         pi->prematch_offset = 0;
         pi->flags = SHOW_STRING | JSON_ARRAY;
 
-        regex = NULL;
-        prematch = NULL;
-        p_name = NULL;
+        regex_str = NULL;
+        prematch_str = NULL;
+        p_name_str = NULL;
 
-        /* Check if strdup worked */
-        if (!pi->name) {
-            merror(MEM_ERROR, errno, strerror(errno));
-            goto cleanup;
-        }
+        /* Default regex types */
+        regex_type = EXP_TYPE_OSREGEX;
+        prematch_type = EXP_TYPE_OSREGEX;
+        p_name_type = EXP_TYPE_OSMATCH;
 
         /* Add decoder */
         if (!addDecoder2list(pi->name)) {
@@ -322,70 +321,98 @@ int ReadDecodeXML(const char *file)
                 goto cleanup;
             }
 
-            /* Check if it is a child of a rule */
+            /* Check if it is a child of a decoder */
             else if (strcasecmp(elements[j]->element, xml_parent) == 0) {
                 pi->parent = _loadmemory(pi->parent, elements[j]->content);
             }
 
             /* Get the regex */
             else if (strcasecmp(elements[j]->element, xml_regex) == 0) {
-                int r_offset;
-                r_offset = ReadDecodeAttrs(elements[j]->attributes,
-                                           elements[j]->values);
+
+                int r_offset = w_get_attr_offset(elements[j]);
 
                 if (r_offset & AFTER_ERROR) {
-                    merror(DEC_REGEX_ERROR, pi->name);
-                    goto cleanup;
+                    mwarn(ANALYSISD_INV_VALUE_DEFAULT, "offset", xml_regex, pi->name);
+                    r_offset = 0;
                 }
 
                 /* Only the first regex entry may have an offset */
-                if (regex && r_offset) {
+                if (regex_str && r_offset) {
                     merror(DUP_REGEX, pi->name);
                     merror(DEC_REGEX_ERROR, pi->name);
                     goto cleanup;
                 }
 
-                /* regex offset */
                 if (r_offset) {
                     pi->regex_offset = r_offset;
                 }
 
+                /* get type */
+                if (!w_get_attr_regex_type(elements[j], &regex_type)) {
+                    regex_type = EXP_TYPE_OSREGEX;
+                }
+
+                /* Only OSRegex & pcre2 support for regex label */
+                if (regex_type != EXP_TYPE_OSREGEX && regex_type != EXP_TYPE_PCRE2) {
+                    mwarn(ANALYSISD_INV_VALUE_DEFAULT, "type", xml_regex, pi->name);
+                    regex_type = EXP_TYPE_OSREGEX;
+                }
+
                 /* Assign regex */
-                regex =
-                    _loadmemory(regex,
-                                elements[j]->content);
+                regex_str = _loadmemory(regex_str, elements[j]->content);
             }
 
             /* Get the pre match */
             else if (strcasecmp(elements[j]->element, xml_prematch) == 0) {
-                int r_offset;
 
-                r_offset = ReadDecodeAttrs(
-                               elements[j]->attributes,
-                               elements[j]->values);
+                int pre_offset = w_get_attr_offset(elements[j]);
 
-                if (r_offset & AFTER_ERROR) {
-                    merror_exit(DEC_REGEX_ERROR, pi->name);
+                if (pre_offset & AFTER_ERROR) {
+                    mwarn(ANALYSISD_INV_VALUE_DEFAULT, "offset", xml_prematch,  pi->name);
+                    pre_offset = 0;
                 }
 
                 /* Only the first prematch entry may have an offset */
-                if (prematch && r_offset) {
+                if (prematch_str && pre_offset) {
                     merror(DUP_REGEX, pi->name);
                     merror_exit(DEC_REGEX_ERROR, pi->name);
                 }
 
-                if (r_offset) {
-                    pi->prematch_offset = r_offset;
+                if (pre_offset) {
+                    pi->prematch_offset = pre_offset;
                 }
 
-                prematch =
-                    _loadmemory(prematch,
-                                elements[j]->content);
+                /* Get type */
+                if (!w_get_attr_regex_type(elements[j], &prematch_type)) {
+                    prematch_type = EXP_TYPE_OSREGEX;
+                }
+
+                /* Only OSRegex & pcre2 support for prematch label */
+                if (prematch_type != EXP_TYPE_OSREGEX && prematch_type != EXP_TYPE_PCRE2) {
+                    mwarn(ANALYSISD_INV_VALUE_DEFAULT, "type", xml_prematch, pi->name);
+                    prematch_type = EXP_TYPE_OSREGEX;
+                }
+
+                prematch_str = _loadmemory(prematch_str, elements[j]->content);
             }
 
             /* Get program name */
             else if (strcasecmp(elements[j]->element, xml_program_name) == 0) {
-                p_name = _loadmemory(p_name, elements[j]->content);
+
+                /* Get type */
+                if (!w_get_attr_regex_type(elements[j], &p_name_type)) {
+                    p_name_type = EXP_TYPE_OSMATCH;
+                }
+
+                /* Only OSMatch & EXP_TYPE_OSREGEX & pcre2 support for prematch label */
+                if (p_name_type != EXP_TYPE_OSMATCH && p_name_type != EXP_TYPE_OSREGEX &&
+                    p_name_type != EXP_TYPE_PCRE2) {
+
+                    mwarn(ANALYSISD_INV_VALUE_DEFAULT, "type", xml_program_name, pi->name);
+                    p_name_type = EXP_TYPE_OSMATCH;
+                }
+
+                p_name_str = _loadmemory(p_name_str, elements[j]->content);
             }
 
             /* Get the FTS comment */
@@ -419,7 +446,7 @@ int ReadDecodeXML(const char *file)
                     goto cleanup;
                 }
 
-                pi->plugin_offset = ReadDecodeAttrs(elements[j]->attributes, elements[j]->values);
+                pi->plugin_offset = w_get_attr_offset(elements[j]);
 
                 if (pi->plugin_offset & AFTER_ERROR) {
                     merror_exit(DEC_REGEX_ERROR, pi->name);
@@ -636,14 +663,14 @@ int ReadDecodeXML(const char *file)
         elements = NULL;
 
         /* Prematch must be set */
-        if (!prematch && !pi->parent && !p_name) {
+        if (!prematch_str && !pi->parent && !p_name_str) {
             merror(DECODE_NOPRE, pi->name);
             merror(DEC_REGEX_ERROR, pi->name);
             goto cleanup;
         }
 
         /* If pi->regex is not set, fts must not be set too */
-        if ((!regex && (pi->fts || pi->order)) || (regex && !pi->order)) {
+        if ((!regex_str && (pi->fts || pi->order)) || (regex_str && !pi->order)) {
             merror(DEC_REGEX_ERROR, pi->name);
             goto cleanup;
         }
@@ -663,7 +690,7 @@ int ReadDecodeXML(const char *file)
             if (!pi->parent) {
                 pi->regex_offset = 0;
                 pi->regex_offset |= AFTER_PARENT;
-            } else if (!prematch) {
+            } else if (!prematch_str) {
                 merror(INV_OFFSET, "after_prematch");
                 merror(DEC_REGEX_ERROR, pi->name);
                 goto cleanup;
@@ -672,7 +699,7 @@ int ReadDecodeXML(const char *file)
 
         /* For the after_regex offset */
         if (pi->regex_offset & AFTER_PREVREGEX) {
-            if (!pi->parent || !regex) {
+            if (!pi->parent || !regex_str) {
                 merror(INV_OFFSET, "after_regex");
                 merror(DEC_REGEX_ERROR, pi->name);
                 goto cleanup;
@@ -701,52 +728,54 @@ int ReadDecodeXML(const char *file)
             goto cleanup;
         }
 
-        if (pi->plugin_offset & AFTER_PREMATCH && !prematch) {
+        if (pi->plugin_offset & AFTER_PREMATCH && !prematch_str) {
             merror(INV_OFFSET, "after_prematch");
             merror(DEC_REGEX_ERROR, pi->name);
             goto cleanup;
         }
 
         /* Compile the regex/prematch */
-        if (prematch) {
-            os_calloc(1, sizeof(OSRegex), pi->prematch);
-            if (!OSRegex_Compile(prematch, pi->prematch, 0)) {
-                merror(REGEX_COMPILE, prematch, pi->prematch->error);
+        if (prematch_str) {
+            w_calloc_expression_t(&pi->prematch, prematch_type);
+
+            if (!w_expression_compile(pi->prematch, prematch_str, 0)) {
+                merror(REGEX_SYNTAX, prematch_str);
+                merror(DEC_REGEX_ERROR, pi->name);
                 goto cleanup;
             }
-
-            free(prematch);
-            prematch = NULL;
+            os_free(prematch_str);
         }
 
         /* Compile the p_name */
-        if (p_name) {
-            os_calloc(1, sizeof(OSMatch), pi->program_name);
-            if (!OSMatch_Compile(p_name, pi->program_name, 0)) {
-                merror(REGEX_COMPILE, p_name, pi->program_name->error);
+        if (p_name_str) {
+            w_calloc_expression_t(&pi->program_name, p_name_type);
+
+            if (!w_expression_compile(pi->program_name, p_name_str, 0)) {
+                merror(REGEX_SYNTAX, p_name_str);
+                merror(DEC_REGEX_ERROR, pi->name);
                 goto cleanup;
             }
-
-            free(p_name);
-            p_name = NULL;
+            os_free(p_name_str);
         }
 
         /* We may not have the pi->regex */
-        if (regex) {
-            os_calloc(1, sizeof(OSRegex), pi->regex);
-            if (!OSRegex_Compile(regex, pi->regex, OS_RETURN_SUBSTRING)) {
-                merror(REGEX_COMPILE, regex, pi->regex->error);
+        if (regex_str) {
+
+            w_calloc_expression_t(&pi->regex, regex_type);
+
+            if (!w_expression_compile(pi->regex, regex_str, OS_RETURN_SUBSTRING)) {
+                merror(REGEX_SYNTAX, regex_str);
+                merror(DEC_REGEX_ERROR, pi->name);
                 goto cleanup;
             }
 
             /* We must have the sub_strings to retrieve the nodes */
-            if (!pi->regex->d_sub_strings) {
-                merror(REGEX_SUBS, regex);
+            if (pi->regex->exp_type == EXP_TYPE_OSREGEX && !pi->regex->regex->d_sub_strings) {
+                merror(REGEX_SUBS, regex_str);
                 goto cleanup;
             }
 
-            free(regex);
-            regex = NULL;
+            os_free(regex_str);
         }
 
         /* Validate arguments */
@@ -769,9 +798,9 @@ int ReadDecodeXML(const char *file)
 
 cleanup:
 
-    free(p_name);
-    free(prematch);
-    free(regex);
+    os_free(p_name_str);
+    os_free(prematch_str);
+    os_free(regex_str);
 
     /* Clean node and XML structures */
     OS_ClearNode(elements);
@@ -857,23 +886,95 @@ void FreeDecoderInfo(OSDecoderInfo *pi) {
     int i;
 
     if (pi) {
-        free(pi->parent);
-        free(pi->name);
+        os_free(pi->parent);
+        os_free(pi->name);
 
         if (pi->fields) {
             for (i = 0; i < Config.decoder_order_size; i++) {
-                free(pi->fields[i]);
+                os_free(pi->fields[i]);
             }
 
-            free(pi->fields);
+            os_free(pi->fields);
         }
 
-        free(pi->fts_fields);
-        free(pi->regex);
-        free(pi->prematch);
-        free(pi->program_name);
-        free(pi->order);
+        os_free(pi->fts_fields);
+        w_free_expression_t(&pi->regex);
+        w_free_expression_t(&pi->prematch);
+        w_free_expression_t(&pi->program_name);
+        os_free(pi->order);
 
-        free(pi);
+        os_free(pi);
     }
+}
+
+STATIC int w_get_attr_offset(xml_node * node) {
+
+    int offset = 0;
+    const char * xml_after_parent = "after_parent";
+    const char * xml_after_prematch = "after_prematch";
+    const char * xml_after_regex = "after_regex";
+
+    const char * str_offset = w_get_attr_val_by_name(node, "offset");
+
+    if (!str_offset) {
+        return 0;
+    }
+
+    /*
+     * Offsets can be: after_parent, after_prematch
+     * or after_regex.
+     */
+    if (strcasecmp(str_offset, xml_after_parent) == 0) {
+        offset |= AFTER_PARENT;
+    } else if (strcasecmp(str_offset, xml_after_prematch) == 0) {
+        offset |= AFTER_PREMATCH;
+    } else if (strcasecmp(str_offset, xml_after_regex) == 0) {
+        offset |= AFTER_PREVREGEX;
+    } else {
+        offset |= AFTER_ERROR;
+    }
+
+    return (offset);
+}
+
+STATIC bool w_get_attr_regex_type(xml_node * node, w_exp_type_t * type) {
+
+    const char * xml_osregex_type = OSREGEX_STR;
+    const char * xml_osmatch_type = OSMATCH_STR;
+    const char * xml_pcre2_type = PCRE2_STR;
+    bool retval = false;
+
+    const char * str_type = w_get_attr_val_by_name(node, "type");
+
+    if (!str_type) {
+        return retval;
+    }
+    retval = true;
+
+    if (strcasecmp(str_type, xml_osregex_type) == 0) {
+        *type = EXP_TYPE_OSREGEX;
+    } else if (strcasecmp(str_type, xml_osmatch_type) == 0) {
+        *type = EXP_TYPE_OSMATCH;
+    } else if (strcasecmp(str_type, xml_pcre2_type) == 0) {
+        *type = EXP_TYPE_PCRE2;
+    } else {
+        *type = EXP_TYPE_INVALID;
+    }
+
+    return retval;
+}
+
+STATIC const char * w_get_attr_val_by_name(xml_node * node, const char * name) {
+
+    if (!node || !node->attributes || !name) {
+        return NULL;
+    }
+
+    for (int i = 0; node->attributes[i]; i++) {
+        if (strcmp(node->attributes[i], name) == 0) {
+            return node->values[i];
+        }
+    }
+
+    return NULL;
 }

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -46,8 +46,7 @@ void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match)
 
         /* First check program name */
         if (lf->program_name) {
-            if (!OSMatch_Execute(lf->program_name, lf->p_name_size,
-                                 nnode->program_name)) {
+            if (!w_expression_match(nnode->program_name, lf->program_name, NULL, NULL)) {
                 continue;
             }
             pmatch = lf->log;
@@ -55,7 +54,7 @@ void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match)
 
         /* If prematch fails, go to the next osdecoder in the list */
         if (nnode->prematch) {
-            if (!(pmatch = OSRegex_Execute_ex(lf->log, nnode->prematch, decoder_match))) {
+            if (!w_expression_match(nnode->prematch, lf->log, &pmatch, decoder_match)) {
                 continue;
             }
 
@@ -101,7 +100,8 @@ void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match)
                         llog2 = lf->log;
                     }
 
-                    if ((cmatch = OSRegex_Execute_ex(llog2, nnode->prematch, decoder_match))) {
+                    if (w_expression_match(nnode->prematch, llog2, &cmatch, decoder_match)) {
+
                         if (*cmatch != '\0') {
                             cmatch++;
                         }
@@ -175,7 +175,7 @@ void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match)
                 }
 
                 /* If Regex does not match, return */
-                if (!(result = OSRegex_Execute_ex(llog, nnode->regex, decoder_match))) {
+                if (!w_expression_match(nnode->regex, llog, &result, decoder_match)) {
                     if (nnode->get_next) {
                         child_node = child_node->next;
                         nnode = child_node->osdecoder;

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -13,6 +13,7 @@
 
 #include "shared.h"
 #include "os_regex/os_regex.h"
+#include "../expression.h"
 
 #define AFTER_PARENT    0x001   /* 1   */
 #define AFTER_PREMATCH  0x002   /* 2   */
@@ -50,9 +51,9 @@ typedef struct {
     char **fields;
     char *fts_fields;
 
-    OSRegex *regex;
-    OSRegex *prematch;
-    OSMatch *program_name;
+    w_expression_t * regex;
+    w_expression_t * prematch;
+    w_expression_t * program_name;
 
     void (*plugindecoder)(void *lf, void *decoder_match);
     void* (**order)(struct _Eventinfo *, char *, const char *);

--- a/src/analysisd/expression.h
+++ b/src/analysisd/expression.h
@@ -15,6 +15,9 @@
 #include "external/libpcre2/include/pcre2.h"
 #include "shared.h"
 
+#define OSMATCH_STR  "osmatch"
+#define OSREGEX_STR  "osregex"
+#define PCRE2_STR    "pcre2"
 
 /**
  * @brief Determine the types of expression allowed

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -214,6 +214,7 @@
 /* Regex errors */
 #define REGEX_COMPILE   "(1450): Syntax error on regex: '%s': %d."
 #define REGEX_SUBS      "(1451): Missing sub_strings on regex: '%s'."
+#define REGEX_SYNTAX    "(1452): Syntax error on regex: '%s'"
 
 /* Mail errors */
 #define INVALID_SMTP    "(1501): Invalid SMTP Server: %s"
@@ -234,6 +235,8 @@
 
 #define INV_OFFSET      "(2120): Invalid offset value: '%s'"
 #define INV_ATTR        "(2121): Invalid decoder attribute: '%s'"
+#define INV_VAL         "(2122): Invalid value for attribute: '%s'"
+#define INV_VAL_ATTR    "(2123): Invalid value '%s' for attribute: '%s'"
 
 /* os_zlib */
 #define COMPRESS_ERR    "(2201): Error compressing string: '%s'."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -57,5 +57,7 @@
 
 /* Ruleset reading warnings */
 #define ANALYSISD_INV_VALUE_RULE                "(7600): Invalid value '%s' for attribute '%s' in rule %d"
+#define ANALYSISD_INV_VALUE_DEFAULT             "(7601): Invalid value for attribute '%s' in '%s' option " \
+                                                "(decoder `%s`). Default value will be taken"
 
 #endif /* WARN_MESSAGES_H */

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -47,6 +47,9 @@ list(APPEND analysisd_names "test_expression")
 list(APPEND analysisd_flags "-Wl,--wrap,OS_IsValidIP -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Compile \
                              -Wl,--wrap,OSRegex_Execute -Wl,--wrap,OSRegex_Execute_ex -Wl,--wrap,OSMatch_Compile")
 
+LIST(APPEND analysisd_names "test_decode-xml")
+LIST(APPEND analysisd_flags "")
+
 list(APPEND analysisd_names "test_rules")
 LIST(APPEND analysisd_flags "-Wl,--wrap,_mwarn -Wl,--wrap,_merror")
 

--- a/src/unit_tests/analysisd/test_decode-xml.c
+++ b/src/unit_tests/analysisd/test_decode-xml.c
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <setjmp.h>
+#include <stdio.h>
+#include <cmocka.h>
+
+#ifndef ARGV0
+#define ARGV0 "ossec-analysisd"
+#endif
+
+#include "../../analysisd/decoders/decode-xml.c"
+#include "../wrappers/common.h"
+
+const char * w_get_attr_val_by_name(xml_node * node, const char * name);
+bool w_get_attr_regex_type(xml_node * node, w_exp_type_t * type);
+int w_get_attr_offset(xml_node * node);
+
+/* setup/teardown */
+
+/* tests */
+
+// w_get_attr_val_by_name
+
+void w_get_attr_val_by_name_null_attr(void ** state) {
+
+    xml_node node = {0};
+    const char * retval;
+
+    retval = w_get_attr_val_by_name(&node, "test_attr_name");
+
+    assert_null(retval);
+}
+
+void w_get_attr_val_by_name_not_found(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "attr_name_2", NULL};
+    char * values[] = {"attr_val_1", "attr_val_2", NULL};
+
+    node.attributes = attributes;
+    node.values = values;
+    const char * retval;
+
+    retval = w_get_attr_val_by_name(&node, "test_attr_name");
+
+    assert_null(retval);
+}
+
+void w_get_attr_val_by_name_found(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "test_attr_name", "attr_name_3", NULL};
+    char * values[] = {"attr_val_1", "test_attr_value", "attr_val_3", NULL};
+
+    node.attributes = attributes;
+    node.values = values;
+    const char * retval;
+
+    retval = w_get_attr_val_by_name(&node, "test_attr_name");
+
+    assert_non_null(retval);
+    assert_string_equal(retval, "test_attr_value");
+}
+
+// w_get_attr_regex_type
+
+void w_get_attr_regex_type_not_found(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "attr_name_2", NULL};
+    char * values[] = {"attr_val_1", "attr_val_2", NULL};
+    node.attributes = attributes;
+    node.values = values;
+
+    w_exp_type_t type = -2;
+
+    bool retval;
+
+    retval = w_get_attr_regex_type(&node, &type);
+
+    assert_false(retval);
+    assert_int_equal(type, -2);
+}
+
+void w_get_attr_regex_type_osregex(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "type", "attr_name_3", NULL};
+    char * values[] = {"attr_val_1", "osregex", "attr_val_3", NULL};
+    node.attributes = attributes;
+    node.values = values;
+
+    w_exp_type_t type = -2;
+
+    bool retval;
+
+    retval = w_get_attr_regex_type(&node, &type);
+
+    assert_true(retval);
+    assert_int_equal(type, EXP_TYPE_OSREGEX);
+}
+
+void w_get_attr_regex_type_osmatch(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "type", "attr_name_3", NULL};
+    char * values[] = {"attr_val_1", "osmatch", "attr_val_3", NULL};
+    node.attributes = attributes;
+    node.values = values;
+
+    w_exp_type_t type = -2;
+
+    bool retval;
+
+    retval = w_get_attr_regex_type(&node, &type);
+
+    assert_true(retval);
+    assert_int_equal(type, EXP_TYPE_OSMATCH);
+}
+
+void w_get_attr_regex_type_pcre2(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "type", "attr_name_3", NULL};
+    char * values[] = {"attr_val_1", "PCRE2", "attr_val_3", NULL};
+    node.attributes = attributes;
+    node.values = values;
+
+    w_exp_type_t type = -2;
+
+    bool retval;
+
+    retval = w_get_attr_regex_type(&node, &type);
+
+    assert_true(retval);
+    assert_int_equal(type, EXP_TYPE_PCRE2);
+}
+
+void w_get_attr_regex_type_invalid(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "type", "attr_name_3", NULL};
+    char * values[] = {"attr_val_1", "invalid type", "attr_val_3", NULL};
+    node.attributes = attributes;
+    node.values = values;
+
+    w_exp_type_t type = -2;
+
+    bool retval;
+
+    retval = w_get_attr_regex_type(&node, &type);
+
+    assert_true(retval);
+    assert_int_equal(type, EXP_TYPE_INVALID);
+}
+
+// w_get_attr_offset
+
+void w_get_attr_offset_not_found(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "attr_name_2", "attr_name_3", NULL};
+    char * values[] = {"attr_val_1", "attr_val_2", "attr_val_3", NULL};
+    node.attributes = attributes;
+    node.values = values;
+
+    int retval;
+
+    retval = w_get_attr_offset(&node);
+
+    assert_int_equal(retval, 0);
+}
+
+void w_get_attr_offset_after_parent(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "offset", "attr_name_3", NULL};
+    char * values[] = {"attr_val_1", "after_parent", "attr_val_3", NULL};
+    node.attributes = attributes;
+    node.values = values;
+
+    int retval;
+
+    retval = w_get_attr_offset(&node);
+
+    assert_int_equal(retval, AFTER_PARENT);
+}
+
+void w_get_attr_offset_after_prematch(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "offset", "attr_name_3", NULL};
+    char * values[] = {"attr_val_1", "after_prematch", "attr_val_3", NULL};
+    node.attributes = attributes;
+    node.values = values;
+
+    int retval;
+
+    retval = w_get_attr_offset(&node);
+
+    assert_int_equal(retval, AFTER_PREMATCH);
+}
+void w_get_attr_offset_after_after_regex(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "offset", "attr_name_3", NULL};
+    char * values[] = {"attr_val_1", "after_regex", "attr_val_3", NULL};
+    node.attributes = attributes;
+    node.values = values;
+
+    int retval;
+
+    retval = w_get_attr_offset(&node);
+
+    assert_int_equal(retval, AFTER_PREVREGEX);
+}
+
+void w_get_attr_offset_error(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "offset", "attr_name_3", NULL};
+    char * values[] = {"attr_val_1", "bad_value", "attr_val_3", NULL};
+    node.attributes = attributes;
+    node.values = values;
+
+    int retval;
+
+    retval = w_get_attr_offset(&node);
+
+    assert_int_equal(retval, AFTER_ERROR);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+
+        // Test w_get_attr_val_by_name
+        cmocka_unit_test(w_get_attr_val_by_name_null_attr),
+        cmocka_unit_test(w_get_attr_val_by_name_not_found),
+        cmocka_unit_test(w_get_attr_val_by_name_found),
+
+        // Test w_get_attr_regex_type
+        cmocka_unit_test(w_get_attr_regex_type_not_found),
+        cmocka_unit_test(w_get_attr_regex_type_osregex),
+        cmocka_unit_test(w_get_attr_regex_type_osmatch),
+        cmocka_unit_test(w_get_attr_regex_type_pcre2),
+        cmocka_unit_test(w_get_attr_regex_type_invalid),
+
+        // w_get_attr_offset
+        cmocka_unit_test(w_get_attr_offset_not_found),
+        cmocka_unit_test(w_get_attr_offset_after_parent),
+        cmocka_unit_test(w_get_attr_offset_after_prematch),
+        cmocka_unit_test(w_get_attr_offset_after_after_regex),
+        cmocka_unit_test(w_get_attr_offset_error),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
|Related issue|
|---|
|[5968](https://github.com/wazuh/wazuh/issues/5968)|
|[5972](https://github.com/wazuh/wazuh/issues/5972)|
|[5977](https://github.com/wazuh/wazuh/issues/5977)|

Closes  #5968 #5972 #5977

# Description

Hi team!, 

This PR adds the support for PCRE2 decoders. 

## List of changes:

### program_name

**program_name** supports types:
- [X] osmatch (default)
- [X] pcre2
- [X] osregex


Decoder example:

```
<decoder name="test_pcre2_program_name">
  <program_name type="pcre2">^house(cat(s|)|)$</program_name>
</decoder>
```

this matches the program name 'housecats' 'housecat' and 'house'

### prematch

**prematch** supports types:
- [X] pcre2
- [X] osregex

Decoders example:

```
<decoder name="test_lcre2_program_name">
  <program_name type="pcre2">^house(cat(s|)|)$</program_name>
</decoder>

<decoder name="test_lcre2_json">
   <parent>test_lcre2_program_name</parent>
   <prematch type="pcre2">^json type </prematch>
   <plugin_decoder offset="after_prematch">JSON_Decoder</plugin_decoder>
</decoder>
```

This matches and uses the json decoder plugin to:

```
Apr 27 15:22:23 niban house[001122]: json type { "name": "Stephen", "surname": "Curry", "email": "curry@gmail.com"}'
```

### Regex

**Regex** supports types:
- [X] pcre2
- [X] osregex

sibling decoders example

```
<decoder name="test_lcre2_sibling">
  <program_name type="pcre2">^(?i)pcre2_sibling$</program_name>
</decoder>

<decoder name="test_lcre2_sibling">
  <parent>test_lcre2_sibling</parent>
  <regex type="pcre2">^(\w+):</regex>
  <order>type</order>
</decoder>

<decoder name="test_lcre2_sibling">
  <parent>test_lcre2_sibling</parent>
  <regex type="pcre2">srcuser="(.+?)"</regex>
  <order>srcuser</order>
</decoder>

<decoder name="test_lcre2_sibling">
  <parent>test_lcre2_sibling</parent>
  <regex>action="(\.+)"</regex>
  <order>action</order>
</decoder>

<decoder name="test_lcre2_sibling">
  <parent>test_lcre2_sibling</parent>
  <regex>dstusr="(\.+)"</regex>
  <order>dstuser</order>
</decoder>
```

This matches:

```
Apr 01 19:21:24 hostname2 pcre2_sibling[123412]: INFO: srcuser="Bob" action="called" dstusr="Alice"
Apr 01 19:21:24 hostname2 PCRE2_sibling[123412]: INFO: srcuser="Bob" action="called" dstusr="Alice"
```


### _getDecodersListJSON()

`getconfig decoders` reports `regex`, `prematch` and `program_name as JSON Objects (with the pattern and regex type)



```
[{
	"id": 519,
	"name": "test_pcre2_prematch",
	"children": [{
		"id": 519,
		"name": "test_pcre2_prematch",
		"parent": "test_pcre2_prematch",
		"order": [
			"id",
			"otro"
		],
		"use_own_name": "false",
		"accumulate": "no",
		"prematch": {
			"pattern": "MAGICWORD",
			"type": "osregex"
		},
		"regex": {
			"pattern": " testing after_parent id:(\\S+) (\\w+)",
			"type": "pcre2"
		},
		"type": "syslog"
	}],
	"use_own_name": "false",
	"accumulate": "no",
	"prematch": {
		"pattern": "test_pcre(\\d)_prematch",
		"type": "osregex"
	},
	"type": "syslog"
}, {
	"id": 517,
	"name": "test_lcre2_program_name",
	"children": [],
	"use_own_name": "false",
	"accumulate": "no",
	"program_name": {
		"pattern": "^pcre2_house(cat((?i)s|)|)$",
		"type": "pcre2"
	},
	"type": "syslog"
}]
```


### More specific error messages

In case of regex compilation error, in addition to showing the file name, the wrong pattern of the regex and the name of the decoder are logged:

```
2020/10/25 22:13:10 ossec-testrule: ERROR: (1452): Syntax error on regex: '^(?ipcre2_sibling$'
2020/10/25 22:13:10 ossec-testrule: ERROR: (2107): Decoder configuration error: 'test_lcre2_sibling'.
2020/10/25 22:13:10 ossec-testrule: CRITICAL: (1202): Configuration error at 'etc/decoders/local_decoder.xml'.
```


An offset error log a warning and uses the default offset

Example:

```
<decoder name="test_pcre2_prematch_child2">
  <parent>test_pcre2_prematch</parent>
  <prematch type="osregex">\d\d\d\d\d</prematch> 
  <regex offset="bad_offset" type="pcre2"> (\S+) (\S+) (\S+):(\S+) (\w+)</regex>
  <order>id, otro, otro1, otro2, otro3</order>
</decoder>
```

Log:

```
2020/10/25 22:18:41 ossec-testrule: WARNING: (2120): Invalid offset value: 'bad_offset'
2020/10/25 22:18:41 ossec-testrule: WARNING: (7601): Invalid value for attribute 'offset' in 'regex' option (decoder `test_pcre2_prematch_child2`). Default value will be taken
2020/10/25 22:18:50 ossec-testrule: INFO: Started (pid: 92913).
````


Regards,
Julian Morales