### PR TITLE
Addition of the agents' connection status column to the agent table in global.db

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_upgrade.c
+++ b/src/unit_tests/wazuh_db/test_wdb_upgrade.c
@@ -273,6 +273,53 @@ void test_wdb_upgrade_global_get_version_success(void **state)
     assert_int_equal(ret, data->wdb);
 }
 
+void test_wdb_upgrade_global_update_v1_to_v2_fail(void **state)
+{
+    wdb_t *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
+    will_return(__wrap_wdb_metadata_table_check, 1);
+
+    expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
+    will_return(__wrap_wdb_metadata_get_entry, "1");
+    will_return(__wrap_wdb_metadata_get_entry, 1);
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database '000' to version 2");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
+    will_return(__wrap_wdb_sql_exec, -1);
+    expect_string(__wrap__mwarn, formatted_msg, "Failed to update global.db to version 2");
+
+    //Global backup success
+    will_return(__wrap_wdb_close, 0);
+    expect_any_always(__wrap_fopen, path);
+    expect_any_always(__wrap_fopen, mode);
+    will_return(__wrap_fopen, 1);
+    will_return(__wrap_fopen, 1);
+    will_return(__wrap_fread, "");
+    will_return(__wrap_fread, 0);
+    expect_any_always(__wrap_fclose, _File);
+    will_return(__wrap_fclose, 0);
+    will_return(__wrap_fclose, 0);
+    expect_any_always(__wrap_chmod, path);
+    will_return(__wrap_chmod, 0);
+    expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
+    expect_string(__wrap_unlink, file, "queue/db/global.db");
+    will_return(__wrap_unlink, 0);
+    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
+    will_return(__wrap_wdb_create_global, OS_SUCCESS);
+    expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
+    expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
+    will_return(__wrap_sqlite3_open_v2, 1);
+    will_return(__wrap_sqlite3_open_v2, SQLITE_OK);
+    expect_string(__wrap_wdb_init, id, "global");
+    will_return(__wrap_wdb_init, (wdb_t*)1);
+    expect_value(__wrap_wdb_pool_append, wdb, (wdb_t*)1);
+
+    ret = wdb_upgrade_global(data->wdb);
+
+    assert_int_equal(ret, 1);
+}
+
 void test_wdb_upgrade_global_fail_backup_fail(void **state)
 {
     wdb_t *ret = NULL;
@@ -531,6 +578,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_fail, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_get_version_fail, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_get_version_success, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_v1_to_v2_fail, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_fail_backup_fail, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_create_backup_global_success, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_create_backup_global_dst_fopen_fail, setup_wdb, teardown_wdb),

--- a/src/unit_tests/wazuh_db/test_wdb_upgrade.c
+++ b/src/unit_tests/wazuh_db/test_wdb_upgrade.c
@@ -33,7 +33,7 @@ typedef struct test_struct {
 
 /* redefinitons/wrapping */
 
-time_t __wrap_time(time_t *__timer) {    
+time_t __wrap_time(time_t *__timer) {
     return 1;
 }
 
@@ -62,13 +62,13 @@ int teardown_wdb(void **state) {
     return 0;
 }
 
-/* Tests wdb_upgrade_global */ 
+/* Tests wdb_upgrade_global */
 
 void test_wdb_upgrade_global_table_fail(void **state)
-{   
+{
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
-    
+
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
     will_return(__wrap_wdb_metadata_table_check, OS_INVALID);
     expect_string(__wrap__mwarn, formatted_msg, "DB(000) Error trying to find metadata table");
@@ -87,9 +87,9 @@ void test_wdb_upgrade_global_table_fail(void **state)
     expect_any_always(__wrap_chmod, path);
     will_return(__wrap_chmod, 0);
     expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
-    expect_string(__wrap_unlink, file, "queue/db/global.db");    
+    expect_string(__wrap_unlink, file, "queue/db/global.db");
     will_return(__wrap_unlink, 0);
-    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");    
+    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
     will_return(__wrap_wdb_create_global, OS_SUCCESS);
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
@@ -105,14 +105,17 @@ void test_wdb_upgrade_global_table_fail(void **state)
 }
 
 void test_wdb_upgrade_global_update_success(void **state)
-{   
+{
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
-    
+
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
     will_return(__wrap_wdb_metadata_table_check, 0);
     expect_string(__wrap__mdebug2, formatted_msg, "Updating database '000' to version 1");
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v1_sql);
+    will_return(__wrap_wdb_sql_exec, 0);
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database '000' to version 2");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
     will_return(__wrap_wdb_sql_exec, 0);
     will_return(__wrap_wdb_global_check_manager_keepalive, 1);
     ret = wdb_upgrade_global(data->wdb);
@@ -162,10 +165,10 @@ void test_wdb_upgrade_global_update_delete_old_version(void **state)
 }
 
 void test_wdb_upgrade_global_update_fail(void **state)
-{   
+{
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
-    
+
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
     will_return(__wrap_wdb_metadata_table_check, 0);
     expect_string(__wrap__mdebug2, formatted_msg, "Updating database '000' to version 1");
@@ -188,9 +191,9 @@ void test_wdb_upgrade_global_update_fail(void **state)
     expect_any_always(__wrap_chmod, path);
     will_return(__wrap_chmod, 0);
     expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
-    expect_string(__wrap_unlink, file, "queue/db/global.db");    
+    expect_string(__wrap_unlink, file, "queue/db/global.db");
     will_return(__wrap_unlink, 0);
-    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");    
+    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
     will_return(__wrap_wdb_create_global, OS_SUCCESS);
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
@@ -206,10 +209,10 @@ void test_wdb_upgrade_global_update_fail(void **state)
 }
 
 void test_wdb_upgrade_global_get_version_fail(void **state)
-{   
+{
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
-    
+
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
     will_return(__wrap_wdb_metadata_table_check, 1);
 
@@ -217,7 +220,7 @@ void test_wdb_upgrade_global_get_version_fail(void **state)
     will_return(__wrap_wdb_metadata_get_entry, "1");
     will_return(__wrap_wdb_metadata_get_entry, -1);
     expect_string(__wrap__mwarn, formatted_msg, "DB(000): Error trying to get DB version");
-   
+
     //Global backup success
     will_return(__wrap_wdb_close, 0);
     expect_any_always(__wrap_fopen, path);
@@ -232,9 +235,9 @@ void test_wdb_upgrade_global_get_version_fail(void **state)
     expect_any_always(__wrap_chmod, path);
     will_return(__wrap_chmod, 0);
     expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
-    expect_string(__wrap_unlink, file, "queue/db/global.db");    
+    expect_string(__wrap_unlink, file, "queue/db/global.db");
     will_return(__wrap_unlink, 0);
-    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");    
+    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
     will_return(__wrap_wdb_create_global, OS_SUCCESS);
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
@@ -251,16 +254,19 @@ void test_wdb_upgrade_global_get_version_fail(void **state)
 }
 
 void test_wdb_upgrade_global_get_version_success(void **state)
-{   
+{
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
-    
+
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
     will_return(__wrap_wdb_metadata_table_check, 1);
 
     expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
     will_return(__wrap_wdb_metadata_get_entry, "1");
     will_return(__wrap_wdb_metadata_get_entry, 1);
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database '000' to version 2");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
+    will_return(__wrap_wdb_sql_exec, 0);
 
     ret = wdb_upgrade_global(data->wdb);
 
@@ -268,10 +274,10 @@ void test_wdb_upgrade_global_get_version_success(void **state)
 }
 
 void test_wdb_upgrade_global_fail_backup_fail(void **state)
-{   
+{
     wdb_t *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
-    
+
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
     will_return(__wrap_wdb_metadata_table_check, 1);
 
@@ -288,10 +294,10 @@ void test_wdb_upgrade_global_fail_backup_fail(void **state)
 }
 
 void test_wdb_create_backup_global_success(void **state)
-{   
+{
     int ret = 0;
-    test_struct_t *data  = (test_struct_t *)*state;    
-    
+    test_struct_t *data  = (test_struct_t *)*state;
+
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
     will_return(__wrap_fopen, 1);
@@ -310,14 +316,14 @@ void test_wdb_create_backup_global_success(void **state)
 }
 
 void test_wdb_create_backup_global_dst_fopen_fail(void **state)
-{   
+{
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    
+
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
     will_return(__wrap_fopen, 0);
-    expect_string(__wrap__merror, formatted_msg, "Couldn't open source 'queue/db/global.db': Success (0)");    
+    expect_string(__wrap__merror, formatted_msg, "Couldn't open source 'queue/db/global.db': Success (0)");
 
     ret = wdb_create_backup_global(1);
 
@@ -325,10 +331,10 @@ void test_wdb_create_backup_global_dst_fopen_fail(void **state)
 }
 
 void test_wdb_create_backup_global_src_fopen_fail(void **state)
-{   
+{
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    
+
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
     will_return(__wrap_fopen, 1);
@@ -343,10 +349,10 @@ void test_wdb_create_backup_global_src_fopen_fail(void **state)
 }
 
 void test_wdb_create_backup_global_fwrite_fail(void **state)
-{   
+{
     int ret = 0;
-    test_struct_t *data  = (test_struct_t *)*state;    
-    
+    test_struct_t *data  = (test_struct_t *)*state;
+
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
     will_return(__wrap_fopen, 1);
@@ -360,17 +366,17 @@ void test_wdb_create_backup_global_fwrite_fail(void **state)
     expect_any_always(__wrap_fclose, _File);
     will_return(__wrap_fclose, 0);
     will_return(__wrap_fclose, 0);
-   
+
     ret = wdb_create_backup_global(1);
 
     assert_int_equal(ret, OS_INVALID);
 }
 
 void test_wdb_create_backup_global_fclose_fail(void **state)
-{   
+{
     int ret = 0;
-    test_struct_t *data  = (test_struct_t *)*state;    
-    
+    test_struct_t *data  = (test_struct_t *)*state;
+
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
     will_return(__wrap_fopen, 1);
@@ -390,10 +396,10 @@ void test_wdb_create_backup_global_fclose_fail(void **state)
 }
 
 void test_wdb_create_backup_global_chmod_fail(void **state)
-{   
+{
     int ret = 0;
-    test_struct_t *data  = (test_struct_t *)*state;    
-    
+    test_struct_t *data  = (test_struct_t *)*state;
+
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
     will_return(__wrap_fopen, 1);
@@ -415,10 +421,10 @@ void test_wdb_create_backup_global_chmod_fail(void **state)
 }
 
 void test_wdb_backup_global_success(void **state)
-{   
+{
     wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;    
-    
+    test_struct_t *data  = (test_struct_t *)*state;
+
     will_return(__wrap_wdb_close, 0);
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
@@ -432,9 +438,9 @@ void test_wdb_backup_global_success(void **state)
     expect_any_always(__wrap_chmod, path);
     will_return(__wrap_chmod, 0);
     expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
-    expect_string(__wrap_unlink, file, "queue/db/global.db");    
+    expect_string(__wrap_unlink, file, "queue/db/global.db");
     will_return(__wrap_unlink, 0);
-    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");    
+    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
     will_return(__wrap_wdb_create_global, OS_SUCCESS);
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
@@ -443,46 +449,46 @@ void test_wdb_backup_global_success(void **state)
     expect_string(__wrap_wdb_init, id, "global");
     will_return(__wrap_wdb_init, (wdb_t*)1);
     expect_value(__wrap_wdb_pool_append, wdb, (wdb_t*)1);
-    
+
     ret = wdb_backup_global(data->wdb, 1);
 
     assert_int_equal(ret, 1);
 }
 
 void test_wdb_backup_global_close_fail(void **state)
-{   
+{
     wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;    
-    
+    test_struct_t *data  = (test_struct_t *)*state;
+
     will_return(__wrap_wdb_close, -1);
-    expect_string(__wrap__merror, formatted_msg, "Couldn't create SQLite Global backup database.");    
-    
+    expect_string(__wrap__merror, formatted_msg, "Couldn't create SQLite Global backup database.");
+
     ret = wdb_backup_global(data->wdb,1);
 
     assert_int_equal(ret, NULL);
 }
 
 void test_wdb_backup_global_create_fail(void **state)
-{   
+{
     wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;    
-    
+    test_struct_t *data  = (test_struct_t *)*state;
+
     will_return(__wrap_wdb_close, 0);
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
     will_return(__wrap_fopen, 0);
     expect_string(__wrap__merror, formatted_msg, "Couldn't open source 'queue/db/global.db': Success (0)");
-    
+
     ret = wdb_backup_global(data->wdb, 1);
 
     assert_int_equal(ret, NULL);
 }
 
 void test_wdb_backup_global_qlite3_open_v2_fail(void **state)
-{   
+{
     wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;    
-    
+    test_struct_t *data  = (test_struct_t *)*state;
+
     will_return(__wrap_wdb_close, 0);
 
     expect_any_always(__wrap_fopen, path);
@@ -497,9 +503,9 @@ void test_wdb_backup_global_qlite3_open_v2_fail(void **state)
     expect_any_always(__wrap_chmod, path);
     will_return(__wrap_chmod, 0);
     expect_string(__wrap__mwarn, formatted_msg, "Creating Global DB backup and creating empty DB");
-    expect_string(__wrap_unlink, file, "queue/db/global.db");    
+    expect_string(__wrap_unlink, file, "queue/db/global.db");
     will_return(__wrap_unlink, 0);
-    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");    
+    expect_string(__wrap_wdb_create_global, path, "queue/db/global.db");
     will_return(__wrap_wdb_create_global, OS_SUCCESS);
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE);
@@ -507,8 +513,8 @@ void test_wdb_backup_global_qlite3_open_v2_fail(void **state)
     will_return(__wrap_sqlite3_open_v2, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "Can't open SQLite backup database 'queue/db/global.db': ERROR MESSAGE");
-    will_return(__wrap_sqlite3_close_v2,0);   
-    
+    will_return(__wrap_sqlite3_close_v2,0);
+
     ret = wdb_backup_global(data->wdb, 1);
 
     assert_int_equal(ret, NULL);
@@ -517,11 +523,11 @@ void test_wdb_backup_global_qlite3_open_v2_fail(void **state)
 int main()
 {
 
-    const struct CMUnitTest tests[] = 
+    const struct CMUnitTest tests[] =
     {
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_table_fail, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_success, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_delete_old_version, setup_wdb, teardown_wdb),        
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_delete_old_version, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_update_fail, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_get_version_fail, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_upgrade_global_get_version_success, setup_wdb, teardown_wdb),

--- a/src/unit_tests/wazuh_db/test_wdb_upgrade.c
+++ b/src/unit_tests/wazuh_db/test_wdb_upgrade.c
@@ -44,7 +44,7 @@ int setup_wdb(void **state) {
     test_struct_t *init_data = NULL;
     os_calloc(1,sizeof(test_struct_t),init_data);
     os_calloc(1,sizeof(wdb_t),init_data->wdb);
-    os_strdup("000",init_data->wdb->id);
+    os_strdup("global",init_data->wdb->id);
     os_calloc(256,sizeof(char),init_data->output);
     os_calloc(1,sizeof(sqlite3 *),init_data->wdb->db);
     *state = init_data;
@@ -71,7 +71,7 @@ void test_wdb_upgrade_global_table_fail(void **state)
 
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
     will_return(__wrap_wdb_metadata_table_check, OS_INVALID);
-    expect_string(__wrap__mwarn, formatted_msg, "DB(000) Error trying to find metadata table");
+    expect_string(__wrap__mwarn, formatted_msg, "DB(global) Error trying to find metadata table");
 
     //Global backup success
     will_return(__wrap_wdb_close, 0);
@@ -111,10 +111,10 @@ void test_wdb_upgrade_global_update_success(void **state)
 
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
     will_return(__wrap_wdb_metadata_table_check, 0);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database '000' to version 1");
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 1");
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v1_sql);
     will_return(__wrap_wdb_sql_exec, 0);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database '000' to version 2");
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 2");
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
     will_return(__wrap_wdb_sql_exec, 0);
     will_return(__wrap_wdb_global_check_manager_keepalive, 1);
@@ -171,7 +171,7 @@ void test_wdb_upgrade_global_update_fail(void **state)
 
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
     will_return(__wrap_wdb_metadata_table_check, 0);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database '000' to version 1");
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 1");
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v1_sql);
     will_return(__wrap_wdb_sql_exec, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Failed to update global.db to version 1");
@@ -219,7 +219,7 @@ void test_wdb_upgrade_global_get_version_fail(void **state)
     expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
     will_return(__wrap_wdb_metadata_get_entry, "1");
     will_return(__wrap_wdb_metadata_get_entry, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "DB(000): Error trying to get DB version");
+    expect_string(__wrap__mwarn, formatted_msg, "DB(global): Error trying to get DB version");
 
     //Global backup success
     will_return(__wrap_wdb_close, 0);
@@ -262,9 +262,12 @@ void test_wdb_upgrade_global_get_version_success(void **state)
     will_return(__wrap_wdb_metadata_table_check, 1);
 
     expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
-    will_return(__wrap_wdb_metadata_get_entry, "1");
+    will_return(__wrap_wdb_metadata_get_entry, "0");
     will_return(__wrap_wdb_metadata_get_entry, 1);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database '000' to version 2");
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 1");
+    expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v1_sql);
+    will_return(__wrap_wdb_sql_exec, 0);
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 2");
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
     will_return(__wrap_wdb_sql_exec, 0);
 
@@ -284,7 +287,7 @@ void test_wdb_upgrade_global_update_v1_to_v2_fail(void **state)
     expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
     will_return(__wrap_wdb_metadata_get_entry, "1");
     will_return(__wrap_wdb_metadata_get_entry, 1);
-    expect_string(__wrap__mdebug2, formatted_msg, "Updating database '000' to version 2");
+    expect_string(__wrap__mdebug2, formatted_msg, "Updating database 'global' to version 2");
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
     will_return(__wrap_wdb_sql_exec, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Failed to update global.db to version 2");
@@ -331,7 +334,7 @@ void test_wdb_upgrade_global_fail_backup_fail(void **state)
     expect_string(__wrap_wdb_metadata_get_entry, key, "db_version");
     will_return(__wrap_wdb_metadata_get_entry, "1");
     will_return(__wrap_wdb_metadata_get_entry, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "DB(000): Error trying to get DB version");
+    expect_string(__wrap__mwarn, formatted_msg, "DB(global): Error trying to get DB version");
     will_return(__wrap_wdb_close, -1);
     expect_string(__wrap__merror, formatted_msg, "Couldn't create SQLite Global backup database.");
 

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS agent (
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);
 CREATE INDEX IF NOT EXISTS agent_ip ON agent (ip);
 
-INSERT INTO agent (id, ip, register_ip, name, date_add, last_keepalive, `group`) VALUES (0, '127.0.0.1', '127.0.0.1', 'localhost', strftime('%s','now'), 253402300799, NULL);
+INSERT INTO agent (id, ip, register_ip, name, date_add, last_keepalive, `group`, connection_status) VALUES (0, '127.0.0.1', '127.0.0.1', 'localhost', strftime('%s','now'), 253402300799, NULL, 'active');
 
 CREATE TABLE IF NOT EXISTS labels (
     id INTEGER,

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS agent (
     fim_offset INTEGER NOT NULL DEFAULT 0,
     reg_offset INTEGER NOT NULL DEFAULT 0,
     `group` TEXT DEFAULT 'default',
-    sync_status TEXT NOT NULL CHECK (sync_status IN ('synced', 'syncreq')) DEFAULT 'synced'
+    sync_status TEXT NOT NULL CHECK (sync_status IN ('synced', 'syncreq')) DEFAULT 'synced',
     connection_status TEXT NOT NULL CHECK (connection_status IN ('pending', 'never_connected', 'active', 'disconnected')) DEFAULT 'never_connected'
 );
 

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS agent (
     reg_offset INTEGER NOT NULL DEFAULT 0,
     `group` TEXT DEFAULT 'default',
     sync_status TEXT NOT NULL CHECK (sync_status IN ('synced', 'syncreq')) DEFAULT 'synced'
+    connection_status TEXT NOT NULL CHECK (connection_status IN ('pending', 'never_connected', 'active', 'disconnected')) DEFAULT 'never_connected'
 );
 
 CREATE INDEX IF NOT EXISTS agent_name ON agent (name);
@@ -68,4 +69,4 @@ CREATE TABLE IF NOT EXISTS metadata (
     value TEXT
 );
 
-INSERT INTO metadata (key, value) VALUES ('db_version', '1');
+INSERT INTO metadata (key, value) VALUES ('db_version', '2');

--- a/src/wazuh_db/schema_global_upgrade_v2.sql
+++ b/src/wazuh_db/schema_global_upgrade_v2.sql
@@ -8,7 +8,6 @@
  * and/or modify it under the terms of GPLv2.
 */
 
-
 BEGIN;
 
 ALTER TABLE agent ADD COLUMN connection_status TEXT NOT NULL CHECK (connection_status IN ('pending', 'never_connected', 'active', 'disconnected')) DEFAULT 'never_connected';
@@ -16,5 +15,3 @@ UPDATE agent SET connection_status = CASE WHEN id = 0 THEN 'active' WHEN last_ke
 UPDATE metadata SET value = '2' where key = 'db_version';
 
 END;
-
-

--- a/src/wazuh_db/schema_global_upgrade_v2.sql
+++ b/src/wazuh_db/schema_global_upgrade_v2.sql
@@ -1,0 +1,20 @@
+/*
+ * SQL Schema for upgrading databases
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * October, 2020.
+ *
+ * This program is a free software, you can redistribute it
+ * and/or modify it under the terms of GPLv2.
+*/
+
+
+BEGIN;
+
+ALTER TABLE agent ADD COLUMN connection_status TEXT NOT NULL CHECK (connection_status IN ('pending', 'never_connected', 'active', 'disconnected')) DEFAULT 'never_connected';
+UPDATE agent SET connection_status = CASE WHEN id = 0 THEN 'active' WHEN last_keepalive IS NOT NULL THEN 'disconnected' ELSE 'never_connected' END;
+UPDATE metadata SET value = '2' where key = 'db_version';
+
+END;
+
+

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -228,6 +228,7 @@ extern char *schema_upgrade_v3_sql;
 extern char *schema_upgrade_v4_sql;
 extern char *schema_upgrade_v5_sql;
 extern char *schema_global_upgrade_v1_sql;
+extern char *schema_global_upgrade_v2_sql;
 
 extern wdb_config wconfig;
 extern pthread_mutex_t pool_mutex;
@@ -384,14 +385,14 @@ int wdb_sca_policy_sha256(wdb_t * wdb, char *id, char * output);
 
 /**
  * @brief Frees agent_info_data struct memory.
- * 
+ *
  * @param[in] agent_data Pointer to the struct to be freed.
  */
 void wdb_free_agent_info_data(agent_info_data *agent_data);
 
 /**
  * @brief Insert agent to the global.db.
- * 
+ *
  * @param[in] id The agent ID.
  * @param[in] name The agent name.
  * @param[in] ip The agent ip address.
@@ -405,7 +406,7 @@ void wdb_free_agent_info_data(agent_info_data *agent_data);
 int wdb_insert_agent(int id,
                      const char *name,
                      const char *ip,
-                     const char *register_ip, 
+                     const char *register_ip,
                      const char *internal_key,
                      const char *group,
                      int keep_date,
@@ -413,7 +414,7 @@ int wdb_insert_agent(int id,
 
 /**
  * @brief Insert a new group.
- * 
+ *
  * @param[in] name The group name.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns OS_SUCCESS on success or OS_INVALID on failure.
@@ -422,7 +423,7 @@ int wdb_insert_group(const char *name, int *sock);
 
 /**
  * @brief Update agent belongs table.
- * 
+ *
  * @param[in] id_group Id of the group to be updated.
  * @param[in] id_agent Id of the agent to be updated.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
@@ -432,7 +433,7 @@ int wdb_update_agent_belongs(int id_group, int id_agent, int *sock);
 
 /**
  * @brief Update agent name in global.db.
- * 
+ *
  * @param[in] id The agent ID.
  * @param[in] name The agent name.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
@@ -442,7 +443,7 @@ int wdb_update_agent_name(int id, const char *name, int *sock);
 
 /**
  * @brief Update agent data in global.db.
- * 
+ *
  * @param[in] agent_data A pointer to an agent_info_data structure with the agent information.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns 0 on success or -1 on error.
@@ -451,7 +452,7 @@ int wdb_update_agent_data(agent_info_data *agent_data, int *sock);
 
 /**
  * @brief Update agent's last keepalive ond modifies the cluster synchronization status.
- * 
+ *
  * @param[in] id Id of the agent for whom the keepalive must be updated.
  * @param[in] sync_status String with the cluster synchronization status to be set.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
@@ -461,7 +462,7 @@ int wdb_update_agent_keepalive(int id, const char *sync_status, int *sock);
 
 /**
  * @brief Set agent updating status.
- * 
+ *
  * @param[in] id ID of the agent.
  * @param[in] status The status to be set. WDB_AGENT_EMPTY, WDB_AGENT_PENDING or WDB_AGENT_UPDATED.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
@@ -471,7 +472,7 @@ int wdb_set_agent_status(int id_agent, int status, int *sock);
 
 /**
  * @brief Update agent group. If the group is not specified, it is set to NULL.
- * 
+ *
  * @param[in] id ID of the agent.
  * @param[in] group The group to be set.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
@@ -481,7 +482,7 @@ int wdb_update_agent_group(int id,char *group, int *sock);
 
 /**
  * @brief Set the file offset either for syscheck as well as registry.
- * 
+ *
  * @param[in] id ID of the agent.
  * @param[in] type An enumerator indicating the offset type. WDB_SYSCHECK or WDB_SYSCHECK_REGISTRY.
  * @param[in] offset to be set in the database.
@@ -492,7 +493,7 @@ int wdb_set_agent_offset(int id, int type, long offset, int *sock);
 
 /**
  * @brief Update agent's labels.
- * 
+ *
  * @param[in] id Id of the agent for whom the labels must be updated.
  * @param[in] labels String with the key-values separated by EOL.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
@@ -505,7 +506,7 @@ int wdb_set_agent_labels(int id, const char *labels, int *sock);
  * This method creates and sends a command to WazuhDB to receive the ID of every agent.
  * If the response is bigger than the capacity of the socket, multiple commands will be sent until every agent ID is obtained.
  * The array is heap allocated memory that must be freed by the caller.
- * 
+ *
  * @param [in] include_manager flag to include the manager on agents list
  * @param [in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Pointer to the array, on success.
@@ -518,7 +519,7 @@ int* wdb_get_all_agents(bool include_manager, int *sock);
  * This method creates and sends a command to WazuhDB to receive the ID of every agent.
  * If the response is bigger than the capacity of the socket, multiple commands will be sent until every agent ID is obtained.
  * The array is heap allocated memory that must be freed by the caller.
- * 
+ *
  * @param [in] condition The symbol ">" or "<". The condition to match keep alive.
  * @param [in] keepalive The keep_alive to search the agents.
  * @param [in] include_manager flag to include the manager on agents list.
@@ -529,7 +530,7 @@ int* wdb_get_agents_by_keepalive(const char* condition, int keepalive, bool incl
 
 /**
  * @brief Find agent id by name and address.
- * 
+ *
  * @param[in] name Name of the agent.
  * @param[in] ip IP address of the agent.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
@@ -539,7 +540,7 @@ int wdb_find_agent(const char *name, const char *ip, int *sock);
 
 /**
  * @brief Returns a JSON with all the agent's information.
- * 
+ *
  * @param[in] id Id of the agent for whom the information is requested.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return JSON* with the information on success or NULL on failure.
@@ -548,7 +549,7 @@ cJSON* wdb_get_agent_info(int id, int *sock);
 
 /**
  * @brief Returns a JSON with all the agent's labels.
- * 
+ *
  * @param[in] id Id of the agent for whom the labels are requested.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return JSON* with the labels on success or NULL on failure.
@@ -557,7 +558,7 @@ cJSON* wdb_get_agent_labels(int id, int *sock);
 
 /**
  * @brief Get name from agent table in global.db by using its ID.
- * 
+ *
  * @param[in] id Id of the agent that the name must be selected.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return A string with the agent name on success or NULL on failure.
@@ -566,7 +567,7 @@ char* wdb_get_agent_name(int id, int *sock);
 
 /**
  * @brief Get group from agent table in global.db by using its ID.
- * 
+ *
  * @param[in] id Id of the agent that the name must be selected.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return A string with the agent group on success or NULL on failure.
@@ -575,7 +576,7 @@ char* wdb_get_agent_group(int id, int *sock);
 
 /**
  * @brief Get agent updating status.
- * 
+ *
  * @param[in] id_agent ID of the agent.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns the WDB_AGENT_* status if success. OS_INVALID on error.
@@ -584,7 +585,7 @@ int wdb_get_agent_status(int id_agent, int *sock);
 
 /**
  * @brief Function to get the agent last keepalive.
- * 
+ *
  * @param [in] name String with the name of the agent.
  * @param [in] ip String with the ip of the agent.
  * @param [in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
@@ -594,7 +595,7 @@ time_t wdb_get_agent_keepalive(const char *name, const char *ip, int *sock);
 
 /**
  * @brief Get the file offset either for syscheck as well as registry.
- * 
+ *
  * @param[in] id ID of the agent.
  * @param[in] type An enumerator indicating the offset type. WDB_SYSCHECK or WDB_SYSCHECK_REGISTRY.
  * @param [in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
@@ -604,7 +605,7 @@ long wdb_get_agent_offset(int id, int type, int *sock);
 
 /**
  * @brief Find group by name.
- * 
+ *
  * @param[in] name The group name.
  * @param [in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns id if success or OS_INVALID on failure.
@@ -613,7 +614,7 @@ int wdb_find_group(const char *name, int *sock);
 
 /**
  * @brief Update groups table.
- * 
+ *
  * @param[in] name The groups directory.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns OS_SUCCESS if success or OS_INVALID on failure.
@@ -622,7 +623,7 @@ int wdb_update_groups(const char *dirname, int *sock);
 
 /**
  * @brief Delete an agent from agent table in global.db by using its ID.
- * 
+ *
  * @param[in] id Id of the agent to be deleted.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return OS_SUCCESS on success or OS_INVALID on failure.
@@ -631,7 +632,7 @@ int wdb_remove_agent(int id, int *sock);
 
 /**
  * @brief Delete group.
- * 
+ *
  * @param[in] name The group name.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns OS_SUCCESS on success or OS_INVALID on failure.
@@ -640,7 +641,7 @@ int wdb_remove_group_db(const char *name, int *sock);
 
 /**
  * @brief Delete an agent from belongs table in global.db by using its ID.
- * 
+ *
  * @param[in] id Id of the agent to be deleted.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns OS_SUCCESS on success or OS_INVALID on failure.
@@ -649,7 +650,7 @@ int wdb_delete_agent_belongs(int id, int *sock);
 
 /**
  * @brief Delete group from belongs table.
- * 
+ *
  * @param[in] name The group name.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns OS_SUCCESS on success or OS_INVALID on failure.
@@ -658,7 +659,7 @@ int wdb_remove_group_from_belongs_db(const char *name, int *sock);
 
 /**
  * @brief Create database for agent from profile.
- * 
+ *
  * @param[in] id Id of the agent.
  * @param[in] name Name of the agent.
  * @return OS_SUCCESS on success or OS_INVALID on failure.
@@ -667,7 +668,7 @@ int wdb_create_agent_db(int id, const char *name);
 
 /**
  * @brief Create database for agent from profile.
- * 
+ *
  * @param[in] agent_id Id of the agent.
  * @return OS_SUCCESS on success or OS_INVALID on failure.
  */
@@ -675,7 +676,7 @@ int wdb_create_agent_db2(const char * agent_id);
 
 /**
  * @brief Remove an agent's database.
- * 
+ *
  * @param[in] id Id of the agent for whom its database must be deleted.
  * @param[in] name Name of the agent for whom its database must be deleted.
  * @return OS_SUCCESS on success or OS_INVALID on failure.
@@ -684,7 +685,7 @@ int wdb_remove_agent_db(int id, const char * name);
 
 /**
  * @brief Update agent multi group.
- * 
+ *
  * @param[in] id The agent id.
  * @param[in] group The group name.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
@@ -695,14 +696,14 @@ int wdb_update_agent_multi_group(int id, char *group, int *sock);
 /**
  * @brief Fill belongs table on start.
  * @param [in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
- * 
+ *
  * @return Returns OS_SUCCESS.
  */
 int wdb_agent_belongs_first_time(int *sock);
 
 /**
  * @brief Get the agent first registration date.
- * 
+ *
  * @param[in] agent_id The agent ID.
  * @return Returns the agent first registration date.
  */
@@ -731,7 +732,7 @@ int wdb_metadata_get_entry (wdb_t * wdb, const char *key, char *output);
 
 /**
  * @brief Checks if the table exists in the database.
- * 
+ *
  * @param[in] wdb Database to query for the table existence.
  * @param[in] key Name of the table to find.
  * @return 1 if the table exists, 0 if the table doesn't exist or OS_INVALID on failure.
@@ -887,7 +888,7 @@ int wdb_remove_database(const char * agent_id);
 
 /**
  * @brief Function to execute a SQL statement and save the result in a JSON array.
- * 
+ *
  * @param [in] stmt The SQL statement to be executed.
  * @return JSON array with the statement execution results. NULL On error.
  */
@@ -895,7 +896,7 @@ cJSON * wdb_exec_stmt(sqlite3_stmt * stmt);
 
 /**
  * @brief Function to execute a SQL query and save the result in a JSON array.
- * 
+ *
  * @param [in] db The SQL database to be queried.
  * @param [in] sql The SQL query.
  * @return JSON array with the query results. NULL On error.
@@ -941,7 +942,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output);
 
 /**
  * @brief Function to get values from MITRE database.
- * 
+ *
  * @param [in] wdb The MITRE struct database.
  * @param [in] input The query to get a value.
  * @param [out] output The response of the query.
@@ -951,7 +952,7 @@ int wdb_parse_mitre_get(wdb_t * wdb, char * input, char * output);
 
 /**
  * @brief Function to parse the agent insert request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent data in JSON format.
  * @param [out] output Response of the query.
@@ -961,7 +962,7 @@ int wdb_parse_global_insert_agent(wdb_t * wdb, char * input, char * output);
 
 /**
  * @brief Function to parse the update agent name request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent data in JSON format.
  * @param [out] output Response of the query.
@@ -971,7 +972,7 @@ int wdb_parse_global_update_agent_name(wdb_t * wdb, char * input, char * output)
 
 /**
  * @brief Function to parse the update agent data request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent data in JSON format.
  * @param [out] output Response of the query.
@@ -981,7 +982,7 @@ int wdb_parse_global_update_agent_data(wdb_t * wdb, char * input, char * output)
 
 /**
  * @brief Function to parse the labels request for a particular agent.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query in JSON format.
@@ -991,7 +992,7 @@ int wdb_parse_global_get_agent_labels(wdb_t * wdb, char * input, char * output);
 
 /**
  * @brief Function to get all the agent information in global.db.
- * 
+ *
  * @param wdb The global struct database.
  * @param input String with 'agent_id'.
  * @param output Response of the query in JSON format.
@@ -1002,7 +1003,7 @@ int wdb_parse_global_get_agent_info(wdb_t * wdb, char * input, char * output);
 
 /**
  * @brief Function to parse string with agent's labels and set them in labels table in global database.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id labels_string'.
  * @param [out] output Response of the query.
@@ -1012,7 +1013,7 @@ int wdb_parse_global_set_agent_labels(wdb_t * wdb, char * input, char * output);
 
 /**
  * @brief Function to parse the update agent keepalive request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent data in JSON format.
  * @param [out] output Response of the query.
@@ -1022,7 +1023,7 @@ int wdb_parse_global_update_agent_keepalive(wdb_t * wdb, char * input, char * ou
 
 /**
  * @brief Function to parse the agent delete from agent table request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query.
@@ -1032,7 +1033,7 @@ int wdb_parse_global_delete_agent(wdb_t * wdb, char * input, char * output);
 
 /**
  * @brief Function to parse the select agent name request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query.
@@ -1042,7 +1043,7 @@ int wdb_parse_global_select_agent_name(wdb_t * wdb, char * input, char * output)
 
 /**
  * @brief Function to parse the select agent group request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query.
@@ -1052,7 +1053,7 @@ int wdb_parse_global_select_agent_group(wdb_t * wdb, char * input, char * output
 
 /**
  * @brief Function to parse the agent delete from belongs table request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query.
@@ -1062,7 +1063,7 @@ int wdb_parse_global_delete_agent_belong(wdb_t * wdb, char * input, char * outpu
 
 /**
  * @brief Function to parse the find agent request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String JSON with the agent name and ip.
  * @param [out] output Response of the query.
@@ -1072,7 +1073,7 @@ int wdb_parse_global_find_agent(wdb_t * wdb, char * input, char * output);
 
 /**
  * @brief Function to parse the select agent fim offset request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query.
@@ -1082,7 +1083,7 @@ int wdb_parse_global_select_fim_offset(wdb_t * wdb, char * input, char * output)
 
 /**
  * @brief Function to parse the select agent reg offset request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query.
@@ -1092,7 +1093,7 @@ int wdb_parse_global_select_reg_offset(wdb_t * wdb, char * input, char * output)
 
 /**
  * @brief Function to parse the update agent fim offset request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent and offset data in JSON format.
  * @param [out] output Response of the query.
@@ -1102,7 +1103,7 @@ int wdb_parse_global_update_fim_offset(wdb_t * wdb, char * input, char * output)
 
 /**
  * @brief Function to parse the update agent reg offset request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent and offset data in JSON format.
  * @param [out] output Response of the query.
@@ -1112,7 +1113,7 @@ int wdb_parse_global_update_reg_offset(wdb_t * wdb, char * input, char * output)
 
 /**
  * @brief Function to parse the select agent update status request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query.
@@ -1122,7 +1123,7 @@ int wdb_parse_global_select_agent_status(wdb_t * wdb, char * input, char * outpu
 
 /**
  * @brief Function to parse the update agent update status request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent and update status data in JSON format.
  * @param [out] output Response of the query.
@@ -1132,7 +1133,7 @@ int wdb_parse_global_update_agent_status(wdb_t * wdb, char * input, char * outpu
 
 /**
  * @brief Function to parse the update agent group request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent and group data in JSON format.
  * @param [out] output Response of the query.
@@ -1142,7 +1143,7 @@ int wdb_parse_global_update_agent_group(wdb_t * wdb, char * input, char * output
 
 /**
  * @brief Function to parse the find group request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the group name.
  * @param [out] output Response of the query.
@@ -1152,7 +1153,7 @@ int wdb_parse_global_find_group(wdb_t * wdb, char * input, char * output);
 
 /**
  * @brief Function to parse the insert group request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the group name.
  * @param [out] output Response of the query.
@@ -1162,7 +1163,7 @@ int wdb_parse_global_insert_agent_group(wdb_t * wdb, char * input, char * output
 
 /**
  * @brief Function to parse the insert agent to belongs table request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the group id and agent id in JSON format.
  * @param [out] output Response of the query.
@@ -1172,7 +1173,7 @@ int wdb_parse_global_insert_agent_belong(wdb_t * wdb, char * input, char * outpu
 
 /**
  * @brief Function to parse the delete group from belongs table request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the group name.
  * @param [out] output Response of the query.
@@ -1182,7 +1183,7 @@ int wdb_parse_global_delete_group_belong(wdb_t * wdb, char * input, char * outpu
 
 /**
  * @brief Function to parse the delete group request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the group name.
  * @param [out] output Response of the query.
@@ -1192,7 +1193,7 @@ int wdb_parse_global_delete_group(wdb_t * wdb, char * input, char * output);
 
 /**
  * @brief Function to parse the select groups request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [out] output Response of the query.
  * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
@@ -1201,7 +1202,7 @@ int wdb_parse_global_select_groups(wdb_t * wdb, char * output);
 
 /**
  * @brief Function to parse the select keepalive request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_name agent_ip'.
  * @param [out] output Response of the query.
@@ -1212,7 +1213,7 @@ int wdb_parse_global_select_agent_keepalive(wdb_t * wdb, char * input, char * ou
 /**
  * @brief Function to parse sync-agent-info-get params and set next ID to iterate on further calls.
  *        If no last_id is provided. Last obtained ID is used.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with starting ID [optional].
  * @param [out] output Response of the query.
@@ -1222,7 +1223,7 @@ int wdb_parse_global_sync_agent_info_get(wdb_t * wdb, char * input, char * outpu
 
 /**
  * @brief Function to parse agent_info and update the agents info from workers.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agents information in JSON format.
  * @param [out] output Response of the query in JSON format.
@@ -1232,7 +1233,7 @@ int wdb_parse_global_sync_agent_info_set(wdb_t * wdb, char * input, char * outpu
 
 /**
  * @brief Function to parse last_id, condition and keepalive for get-agents-by-keepalive.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with last_id, condition, and keepalive.
  * @param [out] output Response of the query.
@@ -1242,7 +1243,7 @@ int wdb_parse_global_get_agents_by_keepalive(wdb_t* wdb, char* input, char* outp
 
 /**
  * @brief Function to parse last_id get-all-agents.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [in] input String with last_id, condition, and keepalive.
  * @param [out] output Response of the query.
@@ -1267,7 +1268,7 @@ wdb_t * wdb_upgrade(wdb_t *wdb);
 
 /**
  * @brief Function to upgrade Global DB to the latest version.
- * 
+ *
  * @param [in] wdb The global.db database to upgrade.
  * @return wdb The global.db database updated on success.
  */
@@ -1281,7 +1282,7 @@ int wdb_create_backup(const char * agent_id, int version);
 
 /**
  * @brief Function to backup Global DB in case of an upgrade failure.
- * 
+ *
  * @param [in] wdb The global.db database to backup.
  * @param [in] version The global.db database version to backup.
  * @return wdb The new empty global.db database on success or NULL on error
@@ -1290,7 +1291,7 @@ wdb_t * wdb_backup_global(wdb_t *wdb, int version);
 
 /**
  * @brief Function to create the Global DB backup file.
- * 
+ *
  * @param [in] wdb The global.db database to backup.
  * @param [in] version The global.db database version to backup.
  * @return wdb OS_SUCESS on success or OS_INVALID on error.
@@ -1341,7 +1342,7 @@ int wdb_journal_wal(sqlite3 *db);
 
 /**
  * @brief Function to get a MITRE technique's name.
- * 
+ *
  * @param [in] wdb The MITRE struct database.
  * @param [in] id MITRE technique's ID.
  * @param [out] output MITRE technique's name.
@@ -1353,7 +1354,7 @@ int wdb_mitre_name_get(wdb_t *wdb, char *id, char *output);
 
 /**
  * @brief Function to insert an agent.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
  * @param [in] name The agent name
@@ -1368,7 +1369,7 @@ int wdb_global_insert_agent(wdb_t *wdb, int id, char* name, char* ip, char* regi
 
 /**
  * @brief Function to update an agent name.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
  * @param [in] name The agent name
@@ -1378,7 +1379,7 @@ int wdb_global_update_agent_name(wdb_t *wdb, int id, char* name);
 
 /**
  * @brief Function to update an agent version data.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID.
  * @param [in] os_name The agent's operating system name.
@@ -1400,7 +1401,7 @@ int wdb_global_update_agent_name(wdb_t *wdb, int id, char* name);
  * @return Returns 0 on success or -1 on error.
  */
 int wdb_global_update_agent_version(wdb_t *wdb,
-                                    int id, 
+                                    int id,
                                     const char *os_name,
                                     const char *os_version,
                                     const char *os_major,
@@ -1420,7 +1421,7 @@ int wdb_global_update_agent_version(wdb_t *wdb,
 
 /**
  * @brief Function to get the labels of a particular agent.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id Agent id.
  * @return JSON with labels on success. NULL on error.
@@ -1429,7 +1430,7 @@ cJSON* wdb_global_get_agent_labels(wdb_t *wdb, int id);
 
 /**
  * @brief Function to delete the labels of a particular agent.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id Agent id.
  * @return 0 On success. -1 On error.
@@ -1438,7 +1439,7 @@ int wdb_global_del_agent_labels(wdb_t *wdb, int id);
 
 /**
  * @brief Function to insert a label of a particular agent.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
  * @param [in] key A string with the label key.
@@ -1449,7 +1450,7 @@ int wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value);
 
 /**
  * @brief Function to update an agent keepalive and the synchronization status.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
  * @param [in] status The value of sync_status
@@ -1459,7 +1460,7 @@ int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, const char *sync_statu
 
 /**
  * @brief Function to delete an agent from the agent table.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
  * @return Returns 0 on success or -1 on error.
@@ -1468,7 +1469,7 @@ int wdb_global_delete_agent(wdb_t *wdb, int id);
 
 /**
  * @brief Function to get the name of a particular agent.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id Agent id.
  * @return JSON with the agent name on success. NULL on error.
@@ -1477,7 +1478,7 @@ cJSON* wdb_global_select_agent_name(wdb_t *wdb, int id);
 
 /**
  * @brief Function to get the group of a particular agent.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id Agent id.
  * @return JSON with the agent group on success. NULL on error.
@@ -1486,7 +1487,7 @@ cJSON* wdb_global_select_agent_group(wdb_t *wdb, int id);
 
 /**
  * @brief Function to delete an agent from the belongs table.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
  * @return Returns 0 on success or -1 on error.
@@ -1495,7 +1496,7 @@ int wdb_global_delete_agent_belong(wdb_t *wdb, int id);
 
 /**
  * @brief Function to get an agent id using the agent name and register ip.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] name The agent name
  * @param [in] ip The agent ip
@@ -1505,7 +1506,7 @@ cJSON* wdb_global_find_agent(wdb_t *wdb, const char *name, const char *ip);
 
 /**
  * @brief Function to get the fim offset of a particular agent.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id Agent id.
  * @return JSON with the agent fim offset on success. NULL on error.
@@ -1514,7 +1515,7 @@ cJSON* wdb_global_select_agent_fim_offset(wdb_t *wdb, int id);
 
 /**
  * @brief Function to get the reg offset of a particular agent.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id Agent id.
  * @return JSON with the agent reg offset on success. NULL on error.
@@ -1523,7 +1524,7 @@ cJSON* wdb_global_select_agent_reg_offset(wdb_t *wdb, int id);
 
 /**
  * @brief Function to update an agent fim offset.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
  * @param [in] offset The value of the offset
@@ -1533,7 +1534,7 @@ int wdb_global_update_agent_fim_offset(wdb_t *wdb, int id, long offset);
 
 /**
  * @brief Function to update an agent reg offset.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
  * @param [in] offset The value of the offset
@@ -1543,7 +1544,7 @@ int wdb_global_update_agent_reg_offset(wdb_t *wdb, int id, long offset);
 
 /**
  * @brief Function to get the update status of a particular agent.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id Agent id.
  * @return JSON with the agent update status on success. NULL on error.
@@ -1552,7 +1553,7 @@ cJSON* wdb_global_select_agent_status(wdb_t *wdb, int id);
 
 /**
  * @brief Function to update an agent update status.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
  * @param [in] status The value of the status
@@ -1562,7 +1563,7 @@ int wdb_global_update_agent_status(wdb_t *wdb, int id, char *status);
 
 /**
  * @brief Function to update an agent group.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
  * @param [in] group The group to be set
@@ -1572,7 +1573,7 @@ int wdb_global_update_agent_group(wdb_t *wdb, int id, char *group);
 
 /**
  * @brief Function to get a group id using the group name.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] group_name The group name.
  * @return JSON with group id on success. NULL on error.
@@ -1581,7 +1582,7 @@ cJSON* wdb_global_find_group(wdb_t *wdb, char* group_name);
 
 /**
  * @brief Function to insert a group using the group name.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] group_name The group name.
  * @return Returns 0 on success or -1 on error.
@@ -1590,7 +1591,7 @@ int wdb_global_insert_agent_group(wdb_t *wdb, char* group_name);
 
 /**
  * @brief Function to insert an agent to the belongs table.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id_group The group id.
  * @param [in] id_agent The agent id.
@@ -1600,7 +1601,7 @@ int wdb_global_insert_agent_belong(wdb_t *wdb, int id_group, int id_agent);
 
 /**
  * @brief Function to delete a group from belongs table using the group name.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] group_name The group name.
  * @return Returns 0 on success or -1 on error.
@@ -1609,7 +1610,7 @@ int wdb_global_delete_group_belong(wdb_t *wdb, char* group_name);
 
 /**
  * @brief Function to delete a group by using the name.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] group_name The group name.
  * @return Returns 0 on success or -1 on error.
@@ -1618,7 +1619,7 @@ int wdb_global_delete_group(wdb_t *wdb, char* group_name);
 
 /**
  * @brief Function to get a list of groups.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @return JSON with all the groups on success. NULL on error.
  */
@@ -1626,7 +1627,7 @@ cJSON* wdb_global_select_groups(wdb_t *wdb);
 
 /**
  * @brief Function to get an agent keepalive using the agent name and register ip.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] name The agent name
  * @param [in] ip The agent ip
@@ -1636,7 +1637,7 @@ cJSON* wdb_global_select_agent_keepalive(wdb_t *wdb, char* name, char* ip);
 
 /**
  * @brief Function to update sync_status of a particular agent.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
  * @param [in] status The value of sync_status
@@ -1646,10 +1647,10 @@ int wdb_global_set_sync_status(wdb_t *wdb, int id, const char *sync_status);
 
 /**
  * @brief Gets and parses agents with 'syncreq' sync_status and sets them to 'synced'.
- *        Response is prepared in one chunk, 
+ *        Response is prepared in one chunk,
  *        if the size of the chunk exceeds WDB_MAX_RESPONSE_SIZE parsing stops and reports the amount of agents obtained.
  *        Multiple calls to this function can be required to fully obtain all agents.
- *       
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] last_agent_id ID where to start querying.
  * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
@@ -1659,7 +1660,7 @@ wdbc_result wdb_global_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char 
 
 /**
  * @brief Function to update the information of an agent.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] agent_info A JSON array with the agent information.
  * @return 0 On success. -1 On error.
@@ -1668,7 +1669,7 @@ int wdb_global_sync_agent_info_set(wdb_t *wdb, cJSON *agent_info);
 
 /**
  * @brief Function to get the information of a particular agent stored in Wazuh DB.
- * 
+ *
  * @param wdb The Global struct database.
  * @param id Agent id.
  * @retval JSON with agent information on success.
@@ -1678,10 +1679,10 @@ cJSON* wdb_global_get_agent_info(wdb_t *wdb, int id);
 
 /*
  * @brief Gets every agent ID based on the keepalive.
- *        Response is prepared in one chunk, 
+ *        Response is prepared in one chunk,
  *        if the size of the chunk exceeds WDB_MAX_RESPONSE_SIZE parsing stops and reports the amount of agents obtained.
  *        Multiple calls to this function can be required to fully obtain all agents.
- *       
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] last_agent_id ID where to start querying.
  * @param [in] condition The symbol '<' or '>' condition used to compare keepalive.
@@ -1693,10 +1694,10 @@ wdbc_result wdb_global_get_agents_by_keepalive(wdb_t *wdb, int* last_agent_id, c
 
 /**
  * @brief Gets every agent ID.
- *        Response is prepared in one chunk, 
+ *        Response is prepared in one chunk,
  *        if the size of the chunk exceeds WDB_MAX_RESPONSE_SIZE parsing stops and reports the amount of agents obtained.
  *        Multiple calls to this function can be required to fully obtain all agents.
- *       
+ *
  * @param [in] wdb The Global struct database.
  * @param [in] last_agent_id ID where to start querying.
  * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -63,6 +63,7 @@ wdb_t * wdb_upgrade(wdb_t *wdb) {
 wdb_t * wdb_upgrade_global(wdb_t *wdb) {
     const char * UPDATES[] = {
         schema_global_upgrade_v1_sql,
+        schema_global_upgrade_v2_sql
     };
 
     char db_version[OS_SIZE_256 + 2];
@@ -96,7 +97,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
 
         if (wdb_sql_exec(wdb, UPDATES[i]) == -1) {
             mwarn("Failed to update global.db to version %d", i + 1);
-            wdb = wdb_backup_global(wdb, version);
+            wdb = wdb_backup_global(wdb, i);
             break;
         }
     }
@@ -155,7 +156,7 @@ wdb_t * wdb_backup_global(wdb_t *wdb, int version) {
         if (wdb_create_backup_global(version) != -1) {
             mwarn("Creating Global DB backup and creating empty DB");
             unlink(path);
-            
+
             if (OS_SUCCESS != wdb_create_global(path)) {
                 merror("Couldn't create SQLite database '%s'", path);
                 return NULL;
@@ -253,7 +254,7 @@ int wdb_create_backup_global(int version) {
     }
 
     while (nbytes = fread(buffer, 1, 4096, source), nbytes) {
-        if (fwrite(buffer, 1, nbytes, dest) != nbytes) {            
+        if (fwrite(buffer, 1, nbytes, dest) != nbytes) {
             result = OS_INVALID;
             break;
         }

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -97,7 +97,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
 
         if (wdb_sql_exec(wdb, UPDATES[i]) == -1) {
             mwarn("Failed to update global.db to version %d", i + 1);
-            wdb = wdb_backup_global(wdb, i);
+            wdb = wdb_backup_global(wdb, version);
             break;
         }
     }


### PR DESCRIPTION
|Related issue|
|---|
| [Issue 6302](https://github.com/wazuh/wazuh/issues/6302) |

## Description

This PR adds the next changes:
- The _wazuh/src/wazuh_db/schema_global.sql_ file was updated to the v2, and the new **connection_status** column was added
- A new upgrade schema _wazuh/src/wazuh_db/schema_global_upgrade_v2.sql_ was created. It adds the new column and sets the proper state for all the existing agents
- The **wdb_upgrade_global()** function was updated to allow the upgrade from V1 to V2, and to properly set the database version number in case of a backup

## Tests

The corresponding tests performed can be found in the issue.

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] QA templates contemplate the added capabilities

- [x] Added unit tests (for new features)
