### PR TITLE
Add specific options for ignore and restrict in Windows registries

### DIFF
--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -221,7 +221,8 @@ typedef struct registry {
     int opts;
     int recursion_level;
     int diff_size_limit;
-    OSMatch *filerestrict;
+    OSMatch *restrict_key;
+    OSMatch *restrict_value;
     char *tag;
 } registry;
 
@@ -464,7 +465,8 @@ void dump_syscheck_file(syscheck_config *syscheck, char *entry, int vals, const 
  * @param syscheck Syscheck configuration structure
  * @param entry Entry to be dumped
  * @param opts Indicates the attributes for registries to be set
- * @param restrictfile The restrict regex to be set
+ * @param restrict_key The restrict regex to be set for keys.
+ * @param restrict_key The restrict regex to be set for values.
  * @param recursion_level The recursion level to be set
  * @param tag The tag to be set
  * @param arch Indicates whether to monitor the 64 or 32 version of the registry
@@ -473,11 +475,12 @@ void dump_syscheck_file(syscheck_config *syscheck, char *entry, int vals, const 
 void dump_syscheck_registry(syscheck_config *syscheck,
                             char *entry,
                             int opts,
-                            const char *restrictfile,
+                            const char *restrict_key,
+                            const char *restrict_value,
                             int recursion_level,
                             const char *tag,
                             int arch,
-                            int diff_size) __attribute__((nonnull(1, 2)));
+                            int diff_size);
 #endif
 
 /**

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -225,10 +225,15 @@ typedef struct registry {
     char *tag;
 } registry;
 
-typedef struct registry_regex {
+typedef struct registry_ignore {
+    char *entry;
+    int arch;
+} registry_ignore;
+
+typedef struct registry_ignore_regex {
     OSMatch *regex;
     int arch;
-} registry_regex;
+} registry_ignore_regex;
 
 #endif
 
@@ -379,14 +384,16 @@ typedef struct _config {
 
     /* Windows only registry checking */
 #ifdef WIN32
-    char realtime_change;                       // Variable to activate the change to realtime from a whodata monitoring
-    registry *registry_ignore;                  /* list of registry entries to ignore */
-    registry_regex *registry_ignore_regex;      /* regex of registry entries to ignore */
-    registry *registry;                         /* array of registry entries to be scanned */
-    int max_fd_win_rt;
+    char realtime_change;                              /* Variable to activate the change to realtime from a whodata monitoring*/
+    registry_ignore *key_ignore;                       /* List of registry keys to ignore */
+    registry_ignore_regex *key_ignore_regex;           /* Regex of registry keys to ignore */
+    registry_ignore *value_ignore;                     /* List of registry values to ignore*/
+    registry_ignore_regex *value_ignore_regex;         /* Regex of registry values to ignore */
+    registry *registry;                                /* array of registry entries to be scanned */
+    int max_fd_win_rt;                                 /* Maximum number of descriptors in realtime */
     whodata wdata;
-    registry *registry_nodiff;                     /* list of values/registries to never output diff */
-    registry_regex *registry_nodiff_regex;            /* regex of values/registries to never output diff */
+    registry *registry_nodiff;                         /* list of values/registries to never output diff */
+    registry_ignore_regex *registry_nodiff_regex;      /* regex of values/registries to never output diff */
 #endif
     int max_audit_entries;          /* Maximum entries for Audit (whodata) */
     char **audit_key;               // Listen audit keys

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -57,8 +57,10 @@ int Read_Syscheck_Config(const char *cfgfile)
 #ifdef WIN32
     syscheck.realtime_change = 0;
     syscheck.registry       = NULL;
-    syscheck.registry_ignore = NULL;
-    syscheck.registry_ignore_regex = NULL;
+    syscheck.key_ignore = NULL;
+    syscheck.key_ignore_regex = NULL;
+    syscheck.value_ignore = NULL;
+    syscheck.value_ignore_regex = NULL;
     syscheck.max_fd_win_rt  = 0;
     syscheck.registry_nodiff = NULL;
     syscheck.registry_nodiff_regex = NULL;
@@ -355,15 +357,15 @@ cJSON *getSyscheckConfig(void) {
         cJSON_AddItemToObject(syscfg, "registry", rg);
     }
 
-    if (syscheck.registry_ignore) {
+    if (syscheck.key_ignore) {
         cJSON *rgi = cJSON_CreateArray();
 
-        for (i=0; syscheck.registry_ignore[i].entry; i++) {
+        for (i=0; syscheck.key_ignore[i].entry; i++) {
             cJSON *pair = cJSON_CreateObject();
 
-            cJSON_AddStringToObject(pair, "entry", syscheck.registry_ignore[i].entry);
+            cJSON_AddStringToObject(pair, "entry", syscheck.key_ignore[i].entry);
 
-            if (syscheck.registry_ignore[i].arch == 0) {
+            if (syscheck.key_ignore[i].arch == 0) {
                 cJSON_AddStringToObject(pair,"arch","32bit");
             } else {
                 cJSON_AddStringToObject(pair,"arch","64bit");
@@ -371,18 +373,18 @@ cJSON *getSyscheckConfig(void) {
 
             cJSON_AddItemToArray(rgi, pair);
         }
-        cJSON_AddItemToObject(syscfg, "registry_ignore", rgi);
+        cJSON_AddItemToObject(syscfg, "key_ignore", rgi);
     }
 
-    if (syscheck.registry_ignore_regex) {
+    if (syscheck.key_ignore_regex) {
         cJSON *rgi = cJSON_CreateArray();
 
-        for (i=0;syscheck.registry_ignore_regex[i].regex;i++) {
+        for (i=0;syscheck.key_ignore_regex[i].regex;i++) {
             cJSON *pair = cJSON_CreateObject();
 
-            cJSON_AddStringToObject(pair,"entry",syscheck.registry_ignore_regex[i].regex->raw);
+            cJSON_AddStringToObject(pair,"entry",syscheck.key_ignore_regex[i].regex->raw);
 
-            if (syscheck.registry_ignore_regex[i].arch == 0) {
+            if (syscheck.key_ignore_regex[i].arch == 0) {
                 cJSON_AddStringToObject(pair,"arch","32bit");
             } else {
                 cJSON_AddStringToObject(pair,"arch","64bit");

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -395,7 +395,45 @@ cJSON *getSyscheckConfig(void) {
 
             cJSON_AddItemToArray(rgi, pair);
         }
-        cJSON_AddItemToObject(syscfg,"registry_ignore_sregex",rgi);
+        cJSON_AddItemToObject(syscfg,"key_ignore_sregex",rgi);
+    }
+
+     if (syscheck.value_ignore) {
+        cJSON *rgi = cJSON_CreateArray();
+
+        for (i=0; syscheck.value_ignore[i].entry; i++) {
+            cJSON *pair = cJSON_CreateObject();
+
+            cJSON_AddStringToObject(pair, "entry", syscheck.value_ignore[i].entry);
+
+            if (syscheck.value_ignore[i].arch == 0) {
+                cJSON_AddStringToObject(pair,"arch","32bit");
+            } else {
+                cJSON_AddStringToObject(pair,"arch","64bit");
+            }
+
+            cJSON_AddItemToArray(rgi, pair);
+        }
+        cJSON_AddItemToObject(syscfg, "value_ignore", rgi);
+    }
+
+    if (syscheck.value_ignore_regex) {
+        cJSON *rgi = cJSON_CreateArray();
+
+        for (i=0;syscheck.value_ignore_regex[i].regex;i++) {
+            cJSON *pair = cJSON_CreateObject();
+
+            cJSON_AddStringToObject(pair,"entry",syscheck.value_ignore_regex[i].regex->raw);
+
+            if (syscheck.value_ignore_regex[i].arch == 0) {
+                cJSON_AddStringToObject(pair,"arch","32bit");
+            } else {
+                cJSON_AddStringToObject(pair,"arch","64bit");
+            }
+
+            cJSON_AddItemToArray(rgi, pair);
+        }
+        cJSON_AddItemToObject(syscfg,"value_ignore_regex",rgi);
     }
 
     if (syscheck.registry_nodiff) {

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -15,7 +15,7 @@
 
 #ifdef WIN32
 static char *SYSCHECK_EMPTY[] = { NULL };
-static registry REGISTRY_EMPTY[] = { { NULL, 0, 0, 512, 0, NULL, NULL } };
+static registry REGISTRY_EMPTY[] = { { NULL, 0, 0, 512, 0, NULL, NULL, NULL} };
 #endif
 
 
@@ -342,8 +342,11 @@ cJSON *getSyscheckConfig(void) {
                 cJSON_AddStringToObject(pair, "tags", syscheck.registry[i].tag);
             }
 
-            if (syscheck.registry[i].filerestrict) {
-                cJSON_AddStringToObject(pair,"restrict", syscheck.registry[i].filerestrict->raw);
+            if (syscheck.registry[i].restrict_key) {
+                cJSON_AddStringToObject(pair,"restrict_key", syscheck.registry[i].restrict_key->raw);
+            }
+            if (syscheck.registry[i].restrict_value) {
+                cJSON_AddStringToObject(pair,"restrict_value", syscheck.registry[i].restrict_value->raw);
             }
 
             if (syscheck.file_size_enabled && syscheck.registry[i].diff_size_limit) {

--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -106,70 +106,92 @@ registry *fim_registry_configuration(const char *key, int arch) {
 }
 
 /**
- * @brief Validates a registry path against recursion level and ignore restrictions.
+ * @brief Validates the recursion level of a registry key.
  *
- * @param entry_path A string holding the full path to be validated.
+ * @param key_path Path of the key
  * @param configuration The configuration associated with the registry entry.
  * @return 0 if the path is valid, -1 if the path is to be excluded.
  */
-int fim_registry_validate_path(const char *entry_path, const registry *configuration) {
-    int ign_it;
+int fim_registry_validate_recursion_level(const char *key_path, const registry *configuration) {
     const char *pos;
     int depth = -1;
     unsigned int parent_path_size;
 
-    if (entry_path == NULL || configuration == NULL) {
+    if (key_path == NULL || configuration == NULL) {
         return -1;
     }
 
     /* Verify recursion level */
     parent_path_size = strlen(configuration->entry);
-
-    if (parent_path_size > strlen(entry_path)) {
+    // Recursion level only for registry keys
+    if (parent_path_size > strlen(key_path)) {
         return -1;
     }
 
-    pos = entry_path + parent_path_size;
+    pos = key_path + parent_path_size;
     while (pos = strchr(pos, PATH_SEP), pos) {
         depth++;
         pos++;
     }
 
     if (depth > configuration->recursion_level) {
-        mdebug2(FIM_MAX_RECURSION_LEVEL, depth, configuration->recursion_level, entry_path);
+        mdebug2(FIM_MAX_RECURSION_LEVEL, depth, configuration->recursion_level, key_path);
         return -1;
-    }
-
-    /* Registry ignore list */
-    if (syscheck.registry_ignore) {
-        for (ign_it = 0; syscheck.registry_ignore[ign_it].entry; ign_it++) {
-            if (syscheck.registry_ignore[ign_it].arch != configuration->arch) {
-                continue;
-            }
-
-            if (strncasecmp(syscheck.registry_ignore[ign_it].entry, entry_path, strlen(syscheck.registry_ignore[ign_it].entry)) == 0) {
-                mdebug2(FIM_IGNORE_ENTRY, "registry", entry_path, syscheck.registry_ignore[ign_it].entry);
-                return -1;
-            }
-        }
-    }
-
-    if (syscheck.registry_ignore_regex) {
-        for (ign_it = 0; syscheck.registry_ignore_regex[ign_it].regex; ign_it++) {
-            if (syscheck.registry_ignore_regex[ign_it].arch != configuration->arch) {
-                continue;
-            }
-
-            if (OSMatch_Execute(entry_path, strlen(entry_path), syscheck.registry_ignore_regex[ign_it].regex)) {
-                mdebug2(FIM_IGNORE_SREGEX, "registry", entry_path, syscheck.registry_ignore_regex[ign_it].regex->raw);
-                return -1;
-            }
-        }
     }
 
     return 0;
 }
 
+/**
+ * @brief Validates ignore restrictions of registry entry.
+ *
+ * @param entry A string holding the full path of the key or the name of the value to be validated.
+ * @param configuration The configuration associated with the registry entry.
+ * @param key 1 if the entry is a key, 0 if the entry is a value.
+ * @return 0 if the path is valid, -1 if the path is to be excluded.
+ */
+int fim_registry_validate_ignore(const char *entry, const registry *configuration, int key) {
+    int ign_it;
+    registry_ignore **ignore_list;
+    registry_ignore_regex **ignore_list_regex;
+
+    if (entry == NULL || configuration == NULL) {
+        return -1;
+    }
+
+    if (key) {
+        ignore_list = &syscheck.key_ignore;
+        ignore_list_regex = &syscheck.key_ignore_regex;
+    } else {
+        ignore_list = &syscheck.value_ignore;
+        ignore_list_regex = &syscheck.value_ignore_regex;
+    }
+
+    if (*ignore_list) {
+        for (ign_it = 0; (*ignore_list)[ign_it].entry; ign_it++) {
+            if ((*ignore_list)[ign_it].arch != configuration->arch) {
+                continue;
+            }
+            if (strncasecmp((*ignore_list)[ign_it].entry, entry, strlen((*ignore_list)[ign_it].entry)) == 0) {
+                mdebug2(FIM_IGNORE_ENTRY, key ? "registry" : "value", entry, (*ignore_list)[ign_it].entry);
+                return -1;
+            }
+        }
+    }
+    if (*ignore_list_regex) {
+        for (ign_it = 0; (*ignore_list_regex)[ign_it].regex; ign_it++) {
+            if ((*ignore_list_regex)[ign_it].arch != configuration->arch) {
+                continue;
+
+            }
+            if (OSMatch_Execute(entry, strlen(entry), (*ignore_list_regex)[ign_it].regex)) {
+                mdebug2(FIM_IGNORE_SREGEX, key ? "registry" : "value", entry, (*ignore_list_regex)[ign_it].regex->raw);
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
 /**
  * @brief Compute checksum of a registry key
  *
@@ -636,15 +658,13 @@ void fim_registry_process_value_event(fim_entry *new,
     registry *configuration;
     cJSON *json_event;
     char *diff = NULL;
-
     snprintf(value_path, MAX_KEY, "%s\\%s", new->registry_entry.key->path, new->registry_entry.value->name);
 
     configuration = fim_registry_configuration(value_path, arch);
     if (configuration == NULL) {
         return;
     }
-
-    if (fim_registry_validate_path(value_path, configuration)) {
+    if (fim_registry_validate_ignore(new->registry_entry.value->name, configuration, 0)) {
         return;
     }
 
@@ -787,8 +807,12 @@ void fim_open_key(HKEY root_key_handle,
         return;
     }
 
-    // Check ignore and recursion level restrictions.
-    if (fim_registry_validate_path(full_key, configuration)) {
+    // Recursion level restrictions.
+    if (fim_registry_validate_recursion_level(full_key, configuration)) {
+        return;
+    }
+    // Ignore restriction
+    if (fim_registry_validate_ignore(full_key, configuration, 1)) {
         return;
     }
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -131,7 +131,7 @@ int Start_win32_Syscheck()
         }
 
         if (!syscheck.registry) {
-            dump_syscheck_registry(&syscheck, "", 0, NULL, 0, NULL, 0, -1);
+            dump_syscheck_registry(&syscheck, "", 0, NULL, NULL,  0, NULL, 0, -1);
         }
         os_free(syscheck.registry[0].entry);
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -217,14 +217,23 @@ int Start_win32_Syscheck()
                 minfo(FIM_PRINT_IGNORE_SREGEX, "file", syscheck.ignore_regex[r]->raw);
 
         /* Print registry ignores. */
-        if(syscheck.registry_ignore)
-            for (r = 0; syscheck.registry_ignore[r].entry != NULL; r++)
-                minfo(FIM_PRINT_IGNORE_ENTRY, "registry", syscheck.registry_ignore[r].entry);
+        if(syscheck.key_ignore)
+            for (r = 0; syscheck.key_ignore[r].entry != NULL; r++)
+                minfo(FIM_PRINT_IGNORE_ENTRY, "registry", syscheck.key_ignore[r].entry);
 
         /* Print sregex registry ignores. */
-        if(syscheck.registry_ignore_regex)
-            for (r = 0; syscheck.registry_ignore_regex[r].regex != NULL; r++)
-                minfo(FIM_PRINT_IGNORE_SREGEX, "registry", syscheck.registry_ignore_regex[r].regex->raw);
+        if(syscheck.key_ignore_regex)
+            for (r = 0; syscheck.key_ignore_regex[r].regex != NULL; r++)
+                minfo(FIM_PRINT_IGNORE_SREGEX, "registry", syscheck.key_ignore_regex[r].regex->raw);
+
+        if(syscheck.value_ignore)
+            for (r = 0; syscheck.value_ignore[r].entry != NULL; r++)
+                minfo(FIM_PRINT_IGNORE_ENTRY, "value", syscheck.value_ignore[r].entry);
+
+        /* Print sregex registry ignores. */
+        if(syscheck.value_ignore_regex)
+            for (r = 0; syscheck.value_ignore_regex[r].regex != NULL; r++)
+                minfo(FIM_PRINT_IGNORE_SREGEX, "value", syscheck.value_ignore_regex[r].regex->raw);
 
         /* Print registry values with nodiff. */
         if(syscheck.registry_nodiff)


### PR DESCRIPTION
|Related issue|
|---|
|#6292|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims to add specific options to ignore and restrict Windows registries.
These options are:
- `<registry_ignore_value type="string">"path\\to\\value"</registry_ignore_value>`
- `<registry_ignore_value type="sregex">sregex</registry_ignore_value>`
- `<registry restrict_value="sregex" restrict_key="sregex">path\\to\\registy</registry>`
<!--
Add a clear description of how the problem has been solved.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Windows
- [X] Source installation
- [X] Source upgrade
- Memory tests for Windows
  - [X] Scan-build report
