### PR TITLE
Set follow symbolic link active by default.

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -146,13 +146,12 @@ void dump_syscheck_entry(syscheck_config *syscheck, char *entry, int vals, int r
 
         if (syscheck->dir == NULL) {
             os_calloc(2, sizeof(char *), syscheck->dir);
-            os_calloc(strlen(entry) + 2, sizeof(char), syscheck->dir[0]);
             if (link && !(CHECK_FOLLOW & vals)) {
                 // Taking the link itself if follow_symbolic_link is not enabled
-                snprintf(syscheck->dir[0], strlen(link) + 1, "%s", link);
+                os_strdup(link, syscheck->dir[0]);
             }
             else {
-                snprintf(syscheck->dir[0], strlen(entry) + 1, "%s", entry);
+                os_strdup(entry, syscheck->dir[0]);
             }
             syscheck->dir[1] = NULL;
 
@@ -190,15 +189,14 @@ void dump_syscheck_entry(syscheck_config *syscheck, char *entry, int vals, int r
                 pl++;
             }
             os_realloc(syscheck->dir, (pl + 2) * sizeof(char *), syscheck->dir);
-            syscheck->dir[pl + 1] = NULL;
-            os_calloc(strlen(entry) + 2, sizeof(char), syscheck->dir[pl]);
             if (link && !(CHECK_FOLLOW & vals)) {
                 // Taking the link itself if follow_symbolic_link is not enabled
-                snprintf(syscheck->dir[pl], strlen(link) + 1, "%s", link);
+                os_strdup(link, syscheck->dir[pl]);
             }
             else {
-                snprintf(syscheck->dir[pl], strlen(entry) + 1, "%s", entry);
+                os_strdup(entry, syscheck->dir[pl]);
             }
+            syscheck->dir[pl + 1] = NULL;
 
 #ifdef WIN32
             os_realloc(syscheck->wdata.dirs_status, (pl + 2) * sizeof(whodata_dir_status),
@@ -244,9 +242,20 @@ void dump_syscheck_entry(syscheck_config *syscheck, char *entry, int vals, int r
             syscheck->tag[pl] = NULL;
             syscheck->tag[pl + 1] = NULL;
         } else {
+            os_free(syscheck->dir[pl]);
+            os_free(syscheck->symbolic_links[pl]);
+
             if (link) {
-                os_free(syscheck->symbolic_links[pl]);
+                if (CHECK_FOLLOW & vals) {
+                    os_strdup(entry, syscheck->dir[pl]);
+                } else {
+                    // Taking the link itself if follow_symbolic_link is not enabled
+                    os_strdup(link, syscheck->dir[pl]);
+                }
                 os_strdup(link, syscheck->symbolic_links[pl]);
+            }
+            else {
+                os_strdup(entry, syscheck->dir[pl]);
             }
             syscheck->opts[pl] = vals;
 
@@ -785,7 +794,6 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
     }
 
     /* Extract all directories */
-    char real_path[PATH_MAX + 1] = "";
     char *tmp_str;
     char *tmp_dir;
     char **env_variable;
@@ -823,6 +831,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
 
 #ifdef WIN32
 
+        char full_path_name[PATH_MAX + 1] = "";
         /* If it's an environment variable, expand it */
         if(env_variable = get_paths_from_env_variable(tmp_dir), env_variable){
 
@@ -833,7 +842,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                         strcat(env_variable[i], "\\");
                     }
 
-                    if (retvalF = GetFullPathName(env_variable[i], PATH_MAX, real_path, NULL), retvalF == 0) {
+                    if (retvalF = GetFullPathName(env_variable[i], PATH_MAX, full_path_name, NULL), retvalF == 0) {
                         retvalF = GetLastError();
                         mwarn("Couldn't get full path name '%s' (%d):'%s'\n", env_variable[i], retvalF, win_strerror(retvalF));
                         os_free(env_variable[i]);
@@ -841,16 +850,16 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                     }
 
                     // Remove any trailling path separators
-                    int path_length = strlen(real_path);
+                    int path_length = strlen(full_path_name);
                     if (path_length != 3) { // Drives need :\ attached in order to work properly
-                        tmp_str = real_path + path_length - 1;
+                        tmp_str = full_path_name + path_length - 1;
                         if (*tmp_str == PATH_SEP) {
                             *tmp_str = '\0';
                         }
                     }
 
-                    str_lowercase(real_path);
-                    dump_syscheck_entry(syscheck, real_path, opts, 0, restrictfile, recursion_limit, clean_tag, NULL,
+                    str_lowercase(full_path_name);
+                    dump_syscheck_entry(syscheck, full_path_name, opts, 0, restrictfile, recursion_limit, clean_tag, NULL,
                                         tmp_diff_size);
                 }
                 os_free(env_variable[i]);
@@ -876,7 +885,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         }
 
         /* Get absolute path and monitor it */
-        retvalF = GetFullPathName(tmp_dir, PATH_MAX, real_path, NULL);
+        retvalF = GetFullPathName(tmp_dir, PATH_MAX, full_path_name, NULL);
         if (retvalF == 0) {
             retvalF = GetLastError();
             mwarn("Couldn't get full path name '%s' (%d):'%s'\n", tmp_dir, retvalF, win_strerror(retvalF));
@@ -887,19 +896,20 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         }
 
         // Remove any trailling path separators
-        int path_length = strlen(real_path);
+        int path_length = strlen(full_path_name);
         if (path_length != 3) { // Drives need :\ attached in order to work properly
-            tmp_str = real_path + path_length - 1;
+            tmp_str = full_path_name + path_length - 1;
             if (*tmp_str == PATH_SEP) {
                 *tmp_str = '\0';
             }
         }
 
-        str_lowercase(real_path);
-        dump_syscheck_entry(syscheck, real_path, opts, 0, restrictfile, recursion_limit, clean_tag, NULL,
+        str_lowercase(full_path_name);
+        dump_syscheck_entry(syscheck, full_path_name, opts, 0, restrictfile, recursion_limit, clean_tag, NULL,
                             tmp_diff_size);
 
 #else
+
         /* If it's an environment variable, expand it */
         if (*tmp_dir == '$') {
             if(env_variable = get_paths_from_env_variable(tmp_dir), env_variable) {
@@ -928,12 +938,11 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         }
 
         /* Else, check if it's a wildcard, hard/symbolic link or path of file/directory */
-        strncpy(real_path, tmp_dir, PATH_MAX);
 
         // Remove any trailling path separators
-        int path_length = strlen(real_path);
+        int path_length = strlen(tmp_dir);
         if (path_length != 1) {
-            tmp_str = real_path + path_length - 1;
+            tmp_str = tmp_dir + path_length - 1;
             if (*tmp_str == PATH_SEP) {
                 *tmp_str = '\0';
             }
@@ -943,73 +952,57 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         /* The mingw32 builder used by travis.ci can't find glob.h
          * Yet glob must work on actual win32.
          */
-        if (strchr(real_path, '*') ||
-                strchr(real_path, '?') ||
-                strchr(real_path, '[')) {
+        if (strchr(tmp_dir, '*') ||
+                strchr(tmp_dir, '?') ||
+                strchr(tmp_dir, '[')) {
             int gindex = 0;
             glob_t g;
 
             if (glob(tmp_dir, 0, NULL, &g) != 0) {
-                merror(GLOB_ERROR, real_path);
+                merror(GLOB_ERROR, tmp_dir);
                 dir++;
                 continue;
             }
 
             if (g.gl_pathv[0] == NULL) {
-                merror(GLOB_NFOUND, real_path);
+                merror(GLOB_NFOUND, tmp_dir);
                 dir++;
                 continue;
             }
 
             while (g.gl_pathv[gindex]) {
-                char *resolved_path = NULL;
+                char *resolved_path;
 
-                if (resolved_path = realpath(g.gl_pathv[gindex], NULL), resolved_path) {
-                    if (strcmp(resolved_path, g.gl_pathv[gindex]) == 0) {
-                        dump_syscheck_entry(syscheck, g.gl_pathv[gindex], opts, 0, restrictfile,
-                                            recursion_limit, clean_tag, NULL, tmp_diff_size);
-                    } else {
-                        if (opts & CHECK_FOLLOW) {
-                            dump_syscheck_entry(syscheck, resolved_path, opts, 0, restrictfile,
-                                            recursion_limit, clean_tag, g.gl_pathv[gindex], tmp_diff_size);
-                        } else {
-                            dump_syscheck_entry(syscheck, g.gl_pathv[gindex], opts, 0, restrictfile,
-                                            recursion_limit, clean_tag, NULL, tmp_diff_size);
-                        }
-                    }
-                } else {
+                if (resolved_path = realpath(g.gl_pathv[gindex], NULL), !resolved_path) {
                     mdebug1("Could not check the real path of '%s' due to [(%d)-(%s)].",
                             g.gl_pathv[gindex], errno, strerror(errno));
+                } else if (strcmp(resolved_path, g.gl_pathv[gindex]) == 0) {
+                    dump_syscheck_entry(syscheck, g.gl_pathv[gindex], opts, 0, restrictfile,
+                                        recursion_limit, clean_tag, NULL, tmp_diff_size);
+                } else {
+                    dump_syscheck_entry(syscheck, resolved_path, opts, 0, restrictfile,
+                                        recursion_limit, clean_tag, g.gl_pathv[gindex], tmp_diff_size);
                 }
 
-
+                os_free(resolved_path);
                 gindex++;
             }
 
             globfree(&g);
         }
         else {
-            char *resolved_path = realpath(real_path, NULL);
+            char *resolved_path = realpath(tmp_dir, NULL);
 
             if (!resolved_path) {
-                dump_syscheck_entry(syscheck, real_path, opts, 0, restrictfile,
+                dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile,
+                                    recursion_limit, clean_tag, NULL, tmp_diff_size);
+            } else if (strcmp(resolved_path, tmp_dir) == 0) {
+                dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile,
                                     recursion_limit, clean_tag, NULL, tmp_diff_size);
             } else {
-                if (strcmp(resolved_path, real_path) == 0) {
-                    dump_syscheck_entry(syscheck, real_path, opts, 0, restrictfile,
-                                        recursion_limit, clean_tag, NULL, tmp_diff_size);
-                } else {
-                    if (opts & CHECK_FOLLOW) {
-                        dump_syscheck_entry(syscheck, resolved_path, opts, 0, restrictfile,
-                                        recursion_limit, clean_tag, real_path, tmp_diff_size);
-                    } else {
-                        dump_syscheck_entry(syscheck, real_path, opts, 0, restrictfile,
-                                        recursion_limit, clean_tag, NULL, tmp_diff_size);
-                    }
-                }
+                dump_syscheck_entry(syscheck, resolved_path, opts, 0, restrictfile,
+                                    recursion_limit, clean_tag, tmp_dir, tmp_diff_size);
             }
-
-
 
             os_free(resolved_path);
         }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -989,9 +989,12 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             globfree(&g);
         }
         else {
-            char *resolved_path = NULL;
+            char *resolved_path = realpath(real_path, NULL);
 
-            if (resolved_path = realpath(real_path, NULL), resolved_path) {
+            if (!resolved_path) {
+                dump_syscheck_entry(syscheck, real_path, opts, 0, restrictfile,
+                                    recursion_limit, clean_tag, NULL, tmp_diff_size);
+            } else {
                 if (strcmp(resolved_path, real_path) == 0) {
                     dump_syscheck_entry(syscheck, real_path, opts, 0, restrictfile,
                                         recursion_limit, clean_tag, NULL, tmp_diff_size);
@@ -1004,10 +1007,9 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                                         recursion_limit, clean_tag, NULL, tmp_diff_size);
                     }
                 }
-            } else {
-                mdebug1("Could not check the real path of '%s' due to [(%d)-(%s)].",
-                        real_path, errno, strerror(errno));
             }
+
+
 
             os_free(resolved_path);
         }

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -47,7 +47,7 @@
 #define FIM_WINREGISTRY_START               "(6031): Registry integrity monitoring scan started"
 #define FIM_WINREGISTRY_ENDED               "(6032): Registry integrity monitoring scan ended"
 #define FIM_LINKCHECK_START                 "(6033): Starting symbolic link updater. Interval '%d'."
-#define FIM_LINKCHECK_CHANGED               "(6034): Updating the symbolic link from '%s': '%s' to '%s'."
+#define FIM_LINKCHECK_CHANGED               "(6034): Updating symbolic link '%s': from '%s' to '%s'."
 #define FIM_WHODATA_VOLUMES                 "(6036): Analyzing Windows volumes"
 
 #define FIM_DB_NORMAL_ALERT                 "(6038): Sending DB back to normal alert."

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -74,12 +74,13 @@ void fim_scan() {
         os_calloc(1, sizeof(fim_element), item);
         item->mode = FIM_SCHEDULED;
         item->index = it;
+
+        fim_checker(syscheck.dir[it], item, NULL, 1);
 #ifndef WIN32
         if (syscheck.opts[it] & REALTIME_ACTIVE) {
             realtime_adddir(syscheck.dir[it], 0, (syscheck.opts[it] & CHECK_FOLLOW) ? 1 : 0);
         }
 #endif
-        fim_checker(syscheck.dir[it], item, NULL, 1);
         it++;
         os_free(item);
     }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -523,18 +523,11 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
 
         w_mutex_lock(&syscheck.fim_scan_mutex);
         for (i = 0; syscheck.dir[i]; i++) {
-            if (!syscheck.symbolic_links[i]) {
+            if (!syscheck.symbolic_links[i] || !(CHECK_FOLLOW & syscheck.opts[i])) {
                 continue;
             }
 
-            if (CHECK_FOLLOW & syscheck.opts[i]) {
-                real_path = realpath(syscheck.symbolic_links[i], NULL);
-            }
-            else {
-                // Taking the link itself if follow_symbolic_link is not enabled
-                os_calloc(strlen(syscheck.symbolic_links[i]) + 1, sizeof(char), real_path);
-                snprintf(real_path, strlen(syscheck.symbolic_links[i]) + 1, "%s", syscheck.symbolic_links[i]);
-            }
+            real_path = realpath(syscheck.symbolic_links[i], NULL);
 
             if (*syscheck.dir[i]) {
                 if (real_path) {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -533,7 +533,7 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
                 if (real_path) {
                     // Check if link has changed
                     if (strcmp(real_path, syscheck.dir[i])) {
-                        minfo(FIM_LINKCHECK_CHANGED, syscheck.dir[i], syscheck.symbolic_links[i], real_path);
+                        minfo(FIM_LINKCHECK_CHANGED, syscheck.symbolic_links[i], syscheck.dir[i], real_path);
                         fim_link_update(i, real_path);
                     } else {
                         mdebug1(FIM_LINKCHECK_NOCHANGE, syscheck.dir[i]);

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1663,7 +1663,7 @@ static void test_fim_checker_deleted_file(void **state) {
 
     errno = 0;
 
-    assert_int_equal(fim_data->item->configuration, 33279);
+    assert_int_equal(fim_data->item->configuration, 49663);
     assert_int_equal(fim_data->item->index, 3);
 }
 
@@ -1728,7 +1728,7 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
     errno = 0;
     syscheck.opts[3] &= ~CHECK_SEECHANGES;
 
-    assert_int_equal(fim_data->item->configuration, 41471);
+    assert_int_equal(fim_data->item->configuration, 57855);
     assert_int_equal(fim_data->item->index, 3);
 }
 
@@ -1750,7 +1750,7 @@ static void test_fim_checker_no_file_system(void **state) {
 
     fim_checker(path, fim_data->item, fim_data->w_evt, 1);
 
-    assert_int_equal(fim_data->item->configuration, 33279);
+    assert_int_equal(fim_data->item->configuration, 49663);
     assert_int_equal(fim_data->item->index, 3);
 }
 
@@ -1799,7 +1799,7 @@ static void test_fim_checker_fim_regular(void **state) {
 
     fim_checker(path, fim_data->item, fim_data->w_evt, 1);
 
-    assert_int_equal(fim_data->item->configuration, 33279);
+    assert_int_equal(fim_data->item->configuration, 49663);
     assert_int_equal(fim_data->item->index, 3);
 }
 
@@ -1846,7 +1846,7 @@ static void test_fim_checker_fim_regular_warning(void **state) {
 
     fim_checker(path, fim_data->item, fim_data->w_evt, 1);
 
-    assert_int_equal(fim_data->item->configuration, 33279);
+    assert_int_equal(fim_data->item->configuration, 49663);
     assert_int_equal(fim_data->item->index, 3);
 }
 
@@ -1868,7 +1868,7 @@ static void test_fim_checker_fim_regular_ignore(void **state) {
 
     fim_checker(path, fim_data->item, fim_data->w_evt, 1);
 
-    assert_int_equal(fim_data->item->configuration, 66047);
+    assert_int_equal(fim_data->item->configuration, 82431);
     assert_int_equal(fim_data->item->index, 1);
 }
 
@@ -1889,7 +1889,7 @@ static void test_fim_checker_fim_regular_restrict(void **state) {
 
     fim_checker(path, fim_data->item, fim_data->w_evt, 1);
 
-    assert_int_equal(fim_data->item->configuration, 33279);
+    assert_int_equal(fim_data->item->configuration, 49663);
     assert_int_equal(fim_data->item->index, 3);
 }
 
@@ -2028,7 +2028,7 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
 
     fim_checker(path, fim_data->item, fim_data->w_evt, 1);
 
-    assert_int_equal(fim_data->item->configuration, 33279);
+    assert_int_equal(fim_data->item->configuration, 49663);
     assert_int_equal(fim_data->item->index, 0);
 }
 
@@ -2876,7 +2876,7 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
 
     fim_checker(path, fim_data->item, fim_data->w_evt, 1);
 
-    assert_int_equal(fim_data->item->configuration, 37375);
+    assert_int_equal(fim_data->item->configuration, 49663);
     assert_int_equal(fim_data->item->index, 0);
 }
 

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -2516,8 +2516,7 @@ static void test_fim_checker_deleted_file(void **state) {
     fim_checker(expanded_path, fim_data->item, NULL, 1);
 
     errno = 0;
-
-    assert_int_equal(fim_data->item->configuration, 37375);
+    assert_int_equal(fim_data->item->configuration, 53759);
     assert_int_equal(fim_data->item->index, 7);
 }
 
@@ -2593,7 +2592,7 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
     errno = 0;
     syscheck.opts[7] &= ~CHECK_SEECHANGES;
 
-    assert_int_equal(fim_data->item->configuration, 45567);
+    assert_int_equal(fim_data->item->configuration, 61951);
     assert_int_equal(fim_data->item->index, 7);
 }
 
@@ -2650,7 +2649,7 @@ static void test_fim_checker_fim_regular(void **state) {
 
     fim_checker(expanded_path, fim_data->item, fim_data->w_evt, 1);
 
-    assert_int_equal(fim_data->item->configuration, 37375);
+    assert_int_equal(fim_data->item->configuration, 53759);
     assert_int_equal(fim_data->item->index, 7);
 }
 
@@ -2680,7 +2679,7 @@ static void test_fim_checker_fim_regular_ignore(void **state) {
 
     fim_checker(expanded_path, fim_data->item, fim_data->w_evt, 1);
 
-    assert_int_equal(fim_data->item->configuration, 37375);
+    assert_int_equal(fim_data->item->configuration, 53759);
     assert_int_equal(fim_data->item->index, 7);
 }
 
@@ -2710,7 +2709,7 @@ static void test_fim_checker_fim_regular_restrict(void **state) {
 
     fim_checker(expanded_path, fim_data->item, fim_data->w_evt, 1);
 
-    assert_int_equal(fim_data->item->configuration, 37375);
+    assert_int_equal(fim_data->item->configuration, 53759);
     assert_int_equal(fim_data->item->index, 8);
 }
 
@@ -2766,7 +2765,7 @@ static void test_fim_checker_fim_regular_warning(void **state) {
 
     fim_checker(expanded_path, fim_data->item, fim_data->w_evt, 1);
 
-    assert_int_equal(fim_data->item->configuration, 37375);
+    assert_int_equal(fim_data->item->configuration, 53759);
     assert_int_equal(fim_data->item->index, 7);
 }
 
@@ -2876,7 +2875,7 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
 
     fim_checker(path, fim_data->item, fim_data->w_evt, 1);
 
-    assert_int_equal(fim_data->item->configuration, 49663);
+    assert_int_equal(fim_data->item->configuration, 53759);
     assert_int_equal(fim_data->item->index, 0);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#6320|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR solves the problem of reading directories configured with the following symbolic link option. It also activates this option by default when monitoring a symbolic link.


<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```xml
    <directories>/usr/sbin,/usr/bin</directories>
    <directories>/bin</directories>
    <directories follow_symbolic_link="no">/sbin</directories>
```
<!--
When proceed, this section should include new configuration parameters.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Added unit tests (for new features)
