### PR TITLE
Remove sha256 from upgrade_v4 script

### DIFF
--- a/src/wazuh_db/schema_upgrade_v4.sql
+++ b/src/wazuh_db/schema_upgrade_v4.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS sync_info (
 BEGIN;
 
 INSERT OR REPLACE INTO metadata (key, value) VALUES ('db_version', 4);
-INSERT INTO _fim_entry (file, type, date, changes, size, perm, uid, gid, md5, sha1, uname, gname, mtime, inode, sha256, attributes, symbolic_path) SELECT file, type, date, changes, size, perm, uid, gid, md5, sha1, uname, gname, mtime, inode, sha256, attributes, symbolic_path FROM fim_entry;
+INSERT INTO _fim_entry (file, type, date, changes, size, perm, uid, gid, md5, sha1, uname, gname, mtime, inode, attributes, symbolic_path) SELECT file, type, date, changes, size, perm, uid, gid, md5, sha1, uname, gname, mtime, inode, attributes, symbolic_path FROM fim_entry;
 INSERT INTO sync_info (component) VALUES ('fim');
 
 END;


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims at fixing an error when upgrading agent DBs.

Prior to this change, upgrading the agent DB from version 3 to 4 would fail since `fim_entry` did not have a `sha256` row, so attempting to select this row when inserting into the temporary `_fim_entry` table would fail, triggering wazuh_db to create a backup and recreating the DB from scratch.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
