### PR TITLE
Updating default permissions for global.db to 640

### DIFF
--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -614,7 +614,7 @@ int wdb_create_file(const char *path, const char *source) {
         break;
     }
 
-    if (chmod(path, 0660) < 0) {
+    if (chmod(path, 0640) < 0) {
         merror(CHMOD_ERROR, path, errno, strerror(errno));
         return OS_INVALID;
     }


### PR DESCRIPTION
|Related issue|
|---|
|#6322|

## Description

The **global.db** creation in the **wdb_create_file()** method sets the DB permission to 660 instead of 640 like the rest of databases in _queue/db/_.
This PR updates the default permissions of that function.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
