### PR TITLE
Fix wrong IP when registering a new agent

### DIFF
--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -138,9 +138,8 @@ async def add_agent(request, pretty=False, wait_for_complete=False):
             except KeyError:
                 raise_if_exc(WazuhError(1120))
         else:
-            peername = request.transport.get_extra_info('peername')
-            if peername is not None:
-                f_kwargs['ip'], _ = peername
+            f_kwargs['ip'] = 'any'
+
     f_kwargs['use_only_authd'] = configuration.api_conf['use_only_authd']
 
     dapi = DistributedAPI(f=agent.add_agent,

--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -130,16 +130,6 @@ async def add_agent(request, pretty=False, wait_for_complete=False):
     Body.validate_content_type(request, expected_content_type='application/json')
     f_kwargs = await AgentAddedModel.get_kwargs(request)
 
-    # Get IP if not given
-    if not f_kwargs['ip']:
-        if configuration.api_conf['behind_proxy_server']:
-            try:
-                f_kwargs['ip'] = request.headers['X-Forwarded-For']
-            except KeyError:
-                raise_if_exc(WazuhError(1120))
-        else:
-            f_kwargs['ip'] = 'any'
-
     f_kwargs['use_only_authd'] = configuration.api_conf['use_only_authd']
 
     dapi = DistributedAPI(f=agent.add_agent,

--- a/api/api/models/agent_added.py
+++ b/api/api/models/agent_added.py
@@ -10,7 +10,7 @@ from api.models.base_model_ import Body
 
 class AgentAddedModel(Body):
 
-    def __init__(self, name: str = None, ip: str = None, force_time: int = -1):
+    def __init__(self, name: str = None, ip: str = None, force_time: int = None):
         """AgentAddedModel body model
         :param name: Agent name.
         :type name: str

--- a/api/test/integration/test_agents_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_POST_endpoints.tavern.yaml
@@ -162,6 +162,46 @@ stages:
     delay_after: !float "{global_db_delay}"
 
 ---
+test_name: POST /agents (no IP)
+
+stages:
+  # POST /agents without IP. It must be any
+  - name: Create an agent without IP
+    request:
+      verify: False
+      <<: *agent_request
+      method: POST
+      json:
+        name: "NewAgentWithoutIP"
+    response:
+      status_code: 200
+      json:
+        <<: *agent_create_response
+      save:
+        json:
+          agent_id_no_ip: data.id
+    delay_after: !float "{global_db_delay}"
+
+  - name: Check that this agent has the IP 'any'
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: "{agent_id_no_ip:s}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: "{agent_id_no_ip:s}"
+              registerIP: 'any'
+              ip: 'any'
+
+---
 test_name: POST /groups/{group_id}
 
 stages:
@@ -322,20 +362,6 @@ stages:
       json:
         <<: *agent_create_response
     delay_after: !float "{global_db_delay}"
-
-    # POST /agents/insert
-  - name: Create a new agent using an automatic IP (ip already used by NewAgentPost2)
-    request:
-      verify: False
-      <<: *agent_insert_request
-      json:
-        name: "NewAgentPostInsertNOIP"
-        id: "754"
-        key: "1abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi64"
-    response:
-      status_code: 400
-      json:
-        error: 1706
 
     # POST /agents/insert
   - name: Create a new agent using a manual IP


### PR DESCRIPTION
Hello team, this closes #6358 .

This PR fixes this issue setting the `registerIP` and `ip` values to `any` if no IP is passed through the request body.

In addition, an integration test that was giving a false positive was deleted and a new one was added to test this use case.

## Test results
### Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0
collected 89 items                                                                                                                                                                          

wazuh/tests/test_agent.py .........................................................................................                                                                   [100%]

============================================================================== 89 passed, 11 warnings in 3.09s ==============================================================================

```

```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0
collected 187 items                                                                                                                                                                         

wazuh/core/tests/test_agent.py ...................................................................................................................................................... [ 80%]
.....................................                                                                                                                                                 [100%]

============================================================================= 187 passed, 11 warnings in 1.25s ==============================================================================

```

### Integration tests
```
test_agents_POST_endpoints.tavern.yaml 
	 5 passed, 7 warnings

test_agents_GET_endpoints.tavern.yaml 
	 90 passed, 97 warnings

```

Regards,
Víctor.