### PR TITLE
[FIX] Chown fail when upgrading using API

### DIFF
--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1178,11 +1178,13 @@ class Agent:
         wpk_file_path = path.join(common.ossec_path, 'var', 'upgrade', wpk_file)
 
         # If WPK is already downloaded
+        already_exist_invalid_checksum = False
         if path.isfile(wpk_file_path):
             # Get SHA1 file sum
             sha1hash = hashlib.sha1(open(wpk_file_path, 'rb').read()).hexdigest()
             # Comparing SHA1 hash
             if not sha1hash == agent_new_shasum:
+                already_exist_invalid_checksum = True
                 if debug:
                     print("Downloaded file SHA1 does not match "
                           "(downloaded: {0} / repository: {1})".format(sha1hash, agent_new_shasum))
@@ -1201,6 +1203,14 @@ class Agent:
             raise WazuhInternalError(1714, extra_message=str(e))
 
         if result.ok:
+            # Try to delete the detected invalid file. If there is no permission to do so,
+            # a new file with the current date will be generated in order to do the installation.
+            if already_exist_invalid_checksum:
+                try:
+                    remove(wpk_file_path)
+                except PermissionError:
+                    wpk_file_path = path.join(common.ossec_path, 'var', 'upgrade', f'{wpk_file[:-4]}{int(time())}.wpk')
+
             with open(wpk_file_path, 'wb') as fd:
                 for chunk in result.iter_content(chunk_size=128):
                     fd.write(chunk)

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1204,8 +1204,8 @@ class Agent:
             with open(wpk_file_path, 'wb') as fd:
                 for chunk in result.iter_content(chunk_size=128):
                     fd.write(chunk)
-                chown(wpk_file_path, common.ossec_gid(), common.ossec_gid())
-                chmod(wpk_file_path, 0o660)
+            chown(wpk_file_path, common.ossec_gid(), common.ossec_gid())
+            chmod(wpk_file_path, 0o660)
         else:
             error = "Can't access to the WPK file in {}".format(wpk_url)
             raise WazuhInternalError(1714, extra_message=str(error))


### PR DESCRIPTION
|Related issue|
|---|
|#6357|

Hi team,

This PR closes #6357. In this PR we have fixed an issue detected in the procedure of updating agents through the API. The error is related to permissions and with the new fix it should not arise in any case. More information here: https://github.com/wazuh/wazuh/issues/6357#issuecomment-713476662

### Test results
```
adriiiprodri@wazuh python3 -m pytest -x framework/wazuh/core/tests/test_agent.py
================================ test session starts ================================
platform linux -- Python 3.8.5, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/framework
plugins: tavern-1.7.0
collected 187 items                                                                 

framework/wazuh/core/tests/test_agent.py .................................... [ 19%]
............................................................................. [ 60%]
..........................................................................    [100%]

================================ 187 passed in 1.99s ================================


 adriiiprodri@wazuh python3 -m pytest -x framework/wazuh/tests/test_agent.py     
================================ test session starts ================================
platform linux -- Python 3.8.5, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/framework
plugins: tavern-1.7.0
collected 89 items                                                                  

framework/wazuh/tests/test_agent.py ......................................... [ 46%]
................................................                              [100%]

================================ 89 passed in 3.43s =================================




adriiiprodri@wazuh python3 run_tests.py -rbac both -k agents
Collected tests [6]:
test_agents_DELETE_endpoints.tavern.yaml, test_agents_GET_endpoints.tavern.yaml, test_agents_POST_endpoints.tavern.yaml, test_agents_PUT_endpoints.tavern.yaml, test_rbac_black_agents_endpoints.tavern.yaml, test_rbac_white_agents_endpoints.tavern.yaml


test_agents_DELETE_endpoints.tavern.yaml 
	 7 passed, 8 warnings

test_agents_GET_endpoints.tavern.yaml 
	 90 passed, 91 warnings

test_agents_POST_endpoints.tavern.yaml 
	 4 passed, 5 warnings

test_agents_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings

test_rbac_black_agents_endpoints.tavern.yaml 
	 39 passed, 40 warnings

test_rbac_white_agents_endpoints.tavern.yaml 
	 39 passed, 40 warnings
```

Regards