### PR TITLE
Wazuh DB command to set the connection status of an agent in global.db - Implementation

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -23,10 +23,11 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg \
                              -Wl,--wrap,wdb_global_insert_agent -Wl,--wrap,wdb_global_update_agent_name -Wl,--wrap,wdb_global_update_agent_version \
                              -Wl,--wrap,wdb_global_get_agent_labels -Wl,--wrap,wdb_global_del_agent_labels -Wl,--wrap,wdb_global_set_agent_label \
-                             -Wl,--wrap,wdb_global_update_agent_keepalive -Wl,--wrap,wdb_global_delete_agent -Wl,--wrap,wdb_global_select_agent_name \
-                             -Wl,--wrap,wdb_global_select_agent_group -Wl,--wrap,wdb_global_delete_agent_belong -Wl,--wrap,wdb_global_find_agent \
-                             -Wl,--wrap,wdb_global_select_agent_fim_offset -Wl,--wrap,wdb_global_select_agent_reg_offset \
-                             -Wl,--wrap,wdb_global_update_agent_fim_offset -Wl,--wrap,wdb_global_update_agent_reg_offset -Wl,--wrap,wdb_global_select_agent_status \
+                             -Wl,--wrap,wdb_global_update_agent_keepalive -Wl,--wrap,wdb_global_update_agent_connection_status \
+                             -Wl,--wrap,wdb_global_delete_agent -Wl,--wrap,wdb_global_select_agent_name -Wl,--wrap,wdb_global_select_agent_group \
+                             -Wl,--wrap,wdb_global_delete_agent_belong -Wl,--wrap,wdb_global_find_agent -Wl,--wrap,wdb_global_select_agent_fim_offset \
+                             -Wl,--wrap,wdb_global_select_agent_reg_offset -Wl,--wrap,wdb_global_update_agent_fim_offset \
+                             -Wl,--wrap,wdb_global_update_agent_reg_offset -Wl,--wrap,wdb_global_select_agent_status \
                              -Wl,--wrap,wdb_global_update_agent_status -Wl,--wrap,wdb_global_update_agent_group -Wl,--wrap,wdb_global_find_group \
                              -Wl,--wrap,wdb_global_insert_agent_group -Wl,--wrap,wdb_global_insert_agent_belong -Wl,--wrap,wdb_global_delete_group_belong \
                              -Wl,--wrap,wdb_global_delete_group -Wl,--wrap,wdb_global_select_groups -Wl,--wrap,wdb_global_select_agent_keepalive \

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -694,13 +694,13 @@ void test_wdb_insert_agent_success_keep_date(void **state)
 
     // Adding data to JSON
     // Transforming the date 2020-01-01 01:01:01 to a number
-    test_time.tm_year = 2020-1900; 
-    test_time.tm_mon = 1-1; 
-    test_time.tm_mday = 1; 
-    test_time.tm_hour = 1; 
-    test_time.tm_min = 1; 
-    test_time.tm_sec = 1; 
-    test_time.tm_isdst = 0; 
+    test_time.tm_year = 2020-1900;
+    test_time.tm_mon = 1-1;
+    test_time.tm_mday = 1;
+    test_time.tm_hour = 1;
+    test_time.tm_min = 1;
+    test_time.tm_sec = 1;
+    test_time.tm_isdst = 0;
 
     date_returned = mktime(&test_time);
 
@@ -953,10 +953,23 @@ void test_wdb_update_agent_name_success(void **state)
 
 /* Tests wdb_update_agent_data */
 
+void test_wdb_update_agent_data_invalid_data(void **state)
+{
+    int ret = 0;
+    int id = 1;
+    agent_info_data *agent_data = NULL;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid data provided to set in global.db.");
+
+    ret = wdb_update_agent_data(agent_data, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
 void test_wdb_update_agent_data_error_json(void **state)
 {
     int ret = 0;
-    int id = 1;    
+    int id = 1;
     agent_info_data *agent_data = NULL;
 
     os_calloc(1, sizeof(agent_info_data), agent_data);
@@ -1769,6 +1782,184 @@ void test_wdb_update_agent_keepalive_success(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
     ret = wdb_update_agent_keepalive(id, sync_status, NULL);
+
+    assert_int_equal(OS_SUCCESS, ret);
+}
+
+/* Tests wdb_update_agent_connection_status */
+
+void test_wdb_update_agent_connection_status_error_json(void **state)
+{
+    int ret = 0;
+    int id = 1;
+    const char *connection_status = "active";
+
+    will_return(__wrap_cJSON_CreateObject, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
+
+    ret = wdb_update_agent_connection_status(id, connection_status, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_update_agent_connection_status_error_socket(void **state)
+{
+    int ret = 0;
+    int id = 1;
+    const char *connection_status = "active";
+
+    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\"}");
+    const char *query_str = "global update-keepalive {\"id\":1,\"connection_status\":\"active\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddNumberToObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "active");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_INVALID);
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error in the response from socket");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-keepalive {\"id\":1,\"connection_status\":\"active\"}");
+
+    ret = wdb_update_agent_connection_status(id, connection_status, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_update_agent_connection_status_error_sql_execution(void **state)
+{
+    int ret = 0;
+    int id = 1;
+    const char *connection_status = "active";
+
+    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\"}");
+    const char *query_str = "global update-keepalive {\"id\":1,\"connection_status\":\"active\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddNumberToObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "active");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, -100); // Returning any error
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-keepalive {\"id\":1,\"connection_status\":\"active\"}");
+
+    ret = wdb_update_agent_connection_status(id, connection_status, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_update_agent_connection_status_error_result(void **state)
+{
+    int ret = 0;
+    int id = 1;
+    const char *connection_status = "active";
+
+    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\"}");
+    const char *query_str = "global update-keepalive {\"id\":1,\"connection_status\":\"active\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddNumberToObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "active");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error reported in the result of the query");
+
+    ret = wdb_update_agent_connection_status(id, connection_status, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_update_agent_connection_status_success(void **state)
+{
+    int ret = 0;
+    int id = 1;
+    const char *connection_status = "active";
+
+    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\"}");
+    const char *query_str = "global update-keepalive {\"id\":1,\"connection_status\":\"active\"}";
+    const char *response = "ok";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddNumberToObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "active");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    ret = wdb_update_agent_connection_status(id, connection_status, NULL);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
@@ -4906,16 +5097,16 @@ void test_get_agent_date_added_success(void **state) {
     date_add = get_agent_date_added(agent_id);
 
     // The date_returned variable is the date 2020-01-01 01:01:01 transformed to INT
-    test_time.tm_year = 2020-1900; 
-    test_time.tm_mon = 1-1; 
-    test_time.tm_mday = 1; 
-    test_time.tm_hour = 1; 
-    test_time.tm_min = 1; 
-    test_time.tm_sec = 1; 
-    test_time.tm_isdst = 0; 
+    test_time.tm_year = 2020-1900;
+    test_time.tm_mon = 1-1;
+    test_time.tm_mday = 1;
+    test_time.tm_hour = 1;
+    test_time.tm_min = 1;
+    test_time.tm_sec = 1;
+    test_time.tm_isdst = 0;
 
     date_returned = mktime(&test_time);
-    
+
     assert_int_equal(date_returned, date_add);
 }
 
@@ -5012,7 +5203,7 @@ void test_wdb_reset_agents_connection_success(void **state)
 
 int main()
 {
-    const struct CMUnitTest tests[] = 
+    const struct CMUnitTest tests[] =
     {
         /* Tests wdb_create_agent_db */
         cmocka_unit_test_setup_teardown(test_wdb_create_agent_db_error_no_name, setup_wdb_agent, teardown_wdb_agent),
@@ -5038,6 +5229,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_name_error_result, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_name_success, setup_wdb_agent, teardown_wdb_agent),
         /* Tests wdb_update_agent_data */
+        cmocka_unit_test_setup_teardown(test_wdb_update_agent_data_invalid_data, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_data_error_json, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_data_error_socket, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_data_error_sql_execution, setup_wdb_agent, teardown_wdb_agent),
@@ -5060,6 +5252,12 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_keepalive_error_sql_execution, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_keepalive_error_result, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_update_agent_keepalive_success, setup_wdb_agent, teardown_wdb_agent),
+        /* Tests wdb_update_agent_connection_status */
+        cmocka_unit_test_setup_teardown(test_wdb_update_agent_connection_status_error_json, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_update_agent_connection_status_error_socket, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_update_agent_connection_status_error_sql_execution, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_update_agent_connection_status_error_result, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_update_agent_connection_status_success, setup_wdb_agent, teardown_wdb_agent),
         /* Tests wdb_delete_agent_belongs */
         cmocka_unit_test_setup_teardown(test_wdb_delete_agent_belongs_error_socket, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_delete_agent_belongs_error_sql_execution, setup_wdb_agent, teardown_wdb_agent),

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -1810,7 +1810,7 @@ void test_wdb_update_agent_connection_status_error_socket(void **state)
     const char *connection_status = "active";
 
     const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\"}");
-    const char *query_str = "global update-keepalive {\"id\":1,\"connection_status\":\"active\"}";
+    const char *query_str = "global update-connection-status {\"id\":1,\"connection_status\":\"active\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1836,7 +1836,7 @@ void test_wdb_update_agent_connection_status_error_socket(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error in the response from socket");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-keepalive {\"id\":1,\"connection_status\":\"active\"}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-connection-status {\"id\":1,\"connection_status\":\"active\"}");
 
     ret = wdb_update_agent_connection_status(id, connection_status, NULL);
 
@@ -1850,7 +1850,7 @@ void test_wdb_update_agent_connection_status_error_sql_execution(void **state)
     const char *connection_status = "active";
 
     const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\"}");
-    const char *query_str = "global update-keepalive {\"id\":1,\"connection_status\":\"active\"}";
+    const char *query_str = "global update-connection-status {\"id\":1,\"connection_status\":\"active\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1876,7 +1876,7 @@ void test_wdb_update_agent_connection_status_error_sql_execution(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-keepalive {\"id\":1,\"connection_status\":\"active\"}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-connection-status {\"id\":1,\"connection_status\":\"active\"}");
 
     ret = wdb_update_agent_connection_status(id, connection_status, NULL);
 
@@ -1890,7 +1890,7 @@ void test_wdb_update_agent_connection_status_error_result(void **state)
     const char *connection_status = "active";
 
     const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\"}");
-    const char *query_str = "global update-keepalive {\"id\":1,\"connection_status\":\"active\"}";
+    const char *query_str = "global update-connection-status {\"id\":1,\"connection_status\":\"active\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1931,7 +1931,7 @@ void test_wdb_update_agent_connection_status_success(void **state)
     const char *connection_status = "active";
 
     const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\"}");
-    const char *query_str = "global update-keepalive {\"id\":1,\"connection_status\":\"active\"}";
+    const char *query_str = "global update-connection-status {\"id\":1,\"connection_status\":\"active\"}";
     const char *response = "ok";
 
     will_return(__wrap_cJSON_CreateObject, 1);

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -22,7 +22,7 @@ static int test_setup(void **state) {
     test_struct_t *init_data = NULL;
     os_calloc(1,sizeof(test_struct_t),init_data);
     os_calloc(1,sizeof(wdb_t),init_data->wdb);
-    os_strdup("global.db",init_data->wdb->id);
+    os_strdup("global",init_data->wdb->id);
     os_calloc(256,sizeof(char),init_data->output);
     os_calloc(1,sizeof(sqlite3 *),init_data->wdb->db);
     *state = init_data;
@@ -78,7 +78,7 @@ void test_wdb_global_get_agent_labels_bind_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     output = wdb_global_get_agent_labels(data->wdb, atoi(data->wdb->id));
     assert_null(output);
@@ -156,7 +156,7 @@ void test_wdb_global_del_agent_labels_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_del_agent_labels(data->wdb, atoi(data->wdb->id));
     assert_int_equal(result, OS_INVALID);
@@ -240,7 +240,7 @@ void test_wdb_global_set_agent_label_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
     assert_int_equal(result, OS_INVALID);
@@ -262,7 +262,7 @@ void test_wdb_global_set_agent_label_bind2_fail(void **state)
     expect_string(__wrap_sqlite3_bind_text, buffer, "test_key");
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
     assert_int_equal(result, OS_INVALID);
@@ -287,7 +287,7 @@ void test_wdb_global_set_agent_label_bind3_fail(void **state)
     expect_string(__wrap_sqlite3_bind_text, buffer, "test_value");
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
     assert_int_equal(result, OS_INVALID);
@@ -384,7 +384,7 @@ void test_wdb_global_set_sync_status_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_set_sync_status(data->wdb, atoi(data->wdb->id), status);
     assert_int_equal(result, OS_INVALID);
@@ -405,7 +405,7 @@ void test_wdb_global_set_sync_status_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_set_sync_status(data->wdb, atoi(data->wdb->id), status);
     assert_int_equal(result, OS_INVALID);
@@ -503,7 +503,7 @@ void test_wdb_global_sync_agent_info_get_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, last_agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_sync_agent_info_get(data->wdb, &last_agent_id, &output);
 
@@ -768,7 +768,7 @@ void test_wdb_global_sync_agent_info_set_bind1_fail(void **state)
     expect_string(__wrap_sqlite3_bind_text, buffer, "test_name");
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_sync_agent_info_set(data->wdb, json_agent);
 
@@ -801,7 +801,7 @@ void test_wdb_global_sync_agent_info_set_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_sync_agent_info_set(data->wdb, json_agent);
     __real_cJSON_Delete(json_agent);
@@ -836,7 +836,7 @@ void test_wdb_global_sync_agent_info_set_bind3_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_sync_agent_info_set(data->wdb, json_agent);
     __real_cJSON_Delete(json_agent);
@@ -974,7 +974,7 @@ void test_wdb_global_insert_agent_bind1_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
@@ -1003,7 +1003,7 @@ void test_wdb_global_insert_agent_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
@@ -1035,7 +1035,7 @@ void test_wdb_global_insert_agent_bind3_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
@@ -1070,7 +1070,7 @@ void test_wdb_global_insert_agent_bind4_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
@@ -1108,7 +1108,7 @@ void test_wdb_global_insert_agent_bind5_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
@@ -1149,7 +1149,7 @@ void test_wdb_global_insert_agent_bind6_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
@@ -1193,7 +1193,7 @@ void test_wdb_global_insert_agent_bind7_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
@@ -1332,7 +1332,7 @@ void test_wdb_global_update_agent_name_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_name(data->wdb, atoi(data->wdb->id), name);
 
@@ -1358,7 +1358,7 @@ void test_wdb_global_update_agent_name_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_name(data->wdb, agent_id, name);
 
@@ -1510,7 +1510,7 @@ void test_wdb_global_update_agent_version_bind1_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1551,7 +1551,7 @@ void test_wdb_global_update_agent_version_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1596,7 +1596,7 @@ void test_wdb_global_update_agent_version_bind3_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1644,7 +1644,7 @@ void test_wdb_global_update_agent_version_bind4_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1695,7 +1695,7 @@ void test_wdb_global_update_agent_version_bind5_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1749,7 +1749,7 @@ void test_wdb_global_update_agent_version_bind6_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1806,7 +1806,7 @@ void test_wdb_global_update_agent_version_bind7_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1866,7 +1866,7 @@ void test_wdb_global_update_agent_version_bind8_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1929,7 +1929,7 @@ void test_wdb_global_update_agent_version_bind9_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1995,7 +1995,7 @@ void test_wdb_global_update_agent_version_bind10_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2064,7 +2064,7 @@ void test_wdb_global_update_agent_version_bind11_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2136,7 +2136,7 @@ void test_wdb_global_update_agent_version_bind12_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2211,7 +2211,7 @@ void test_wdb_global_update_agent_version_bind13_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2289,7 +2289,7 @@ void test_wdb_global_update_agent_version_bind14_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2370,7 +2370,7 @@ void test_wdb_global_update_agent_version_bind15_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2454,7 +2454,7 @@ void test_wdb_global_update_agent_version_bind16_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2541,7 +2541,7 @@ void test_wdb_global_update_agent_version_bind17_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2769,7 +2769,7 @@ void test_wdb_global_update_agent_keepalive_bind1_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_keepalive(data->wdb, atoi(data->wdb->id), status);
 
@@ -2794,7 +2794,7 @@ void test_wdb_global_update_agent_keepalive_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_keepalive(data->wdb, atoi(data->wdb->id), status);
 
@@ -2897,7 +2897,7 @@ void test_wdb_global_update_agent_connection_status_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
 
@@ -2922,7 +2922,7 @@ void test_wdb_global_update_agent_connection_status_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
     result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
 
     assert_int_equal(result, OS_INVALID);
@@ -3021,7 +3021,7 @@ void test_wdb_global_delete_agent_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_delete_agent(data->wdb, atoi(data->wdb->id));
 
@@ -3112,7 +3112,7 @@ void test_wdb_global_select_agent_name_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_name(data->wdb, atoi(data->wdb->id));
 
@@ -3198,7 +3198,7 @@ void test_wdb_global_select_agent_group_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_group(data->wdb, atoi(data->wdb->id));
 
@@ -3284,7 +3284,7 @@ void test_wdb_global_select_agent_fim_offset_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_fim_offset(data->wdb, atoi(data->wdb->id));
 
@@ -3370,7 +3370,7 @@ void test_wdb_global_select_agent_reg_offset_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_reg_offset(data->wdb, atoi(data->wdb->id));
 
@@ -3456,7 +3456,7 @@ void test_wdb_global_select_agent_status_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_status(data->wdb, atoi(data->wdb->id));
 
@@ -3609,7 +3609,7 @@ void test_wdb_global_select_agent_keepalive_bind1_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_keepalive(data->wdb, name, ip);
 
@@ -3634,7 +3634,7 @@ void test_wdb_global_select_agent_keepalive_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_keepalive(data->wdb, name, ip);
 
@@ -3663,7 +3663,7 @@ void test_wdb_global_select_agent_keepalive_bind3_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_keepalive(data->wdb, name, ip);
 
@@ -3778,7 +3778,7 @@ void test_wdb_global_find_agent_bind1_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_find_agent(data->wdb, name, ip);
 
@@ -3804,7 +3804,7 @@ void test_wdb_global_find_agent_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_find_agent(data->wdb, name, ip);
 
@@ -3833,7 +3833,7 @@ void test_wdb_global_find_agent_bind3_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_find_agent(data->wdb, name, ip);
 
@@ -3944,7 +3944,7 @@ void test_wdb_global_update_agent_fim_offset_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, offset);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_fim_offset(data->wdb, atoi(data->wdb->id), offset);
 
@@ -3968,7 +3968,7 @@ void test_wdb_global_update_agent_fim_offset_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_fim_offset(data->wdb, atoi(data->wdb->id), offset);
 
@@ -4071,7 +4071,7 @@ void test_wdb_global_update_agent_reg_offset_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, offset);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_reg_offset(data->wdb, atoi(data->wdb->id), offset);
 
@@ -4095,7 +4095,7 @@ void test_wdb_global_update_agent_reg_offset_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_reg_offset(data->wdb, atoi(data->wdb->id), offset);
 
@@ -4198,7 +4198,7 @@ void test_wdb_global_update_agent_status_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agt_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_status(data->wdb, atoi(data->wdb->id), agt_status);
 
@@ -4222,7 +4222,7 @@ void test_wdb_global_update_agent_status_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_status(data->wdb, atoi(data->wdb->id), agt_status);
 
@@ -4325,7 +4325,7 @@ void test_wdb_global_update_agent_group_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agt_group);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_group(data->wdb, atoi(data->wdb->id), agt_group);
 
@@ -4349,7 +4349,7 @@ void test_wdb_global_update_agent_group_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_group(data->wdb, atoi(data->wdb->id), agt_group);
 
@@ -4453,7 +4453,7 @@ void test_wdb_global_find_group_bind_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_find_group(data->wdb, group_name);
 
@@ -4547,7 +4547,7 @@ void test_wdb_global_insert_agent_group_bind_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent_group(data->wdb, group_name);
 
@@ -4640,7 +4640,7 @@ void test_wdb_global_insert_agent_belong_bind1_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent_belong(data->wdb, id_group, id_agent);
 
@@ -4665,7 +4665,7 @@ void test_wdb_global_insert_agent_belong_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent_belong(data->wdb, id_group, id_agent);
 
@@ -4765,7 +4765,7 @@ void test_wdb_global_delete_group_belong_bind_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_delete_group_belong(data->wdb, group_name);
 
@@ -4857,7 +4857,7 @@ void test_wdb_global_delete_group_bind_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_delete_group(data->wdb, group_name);
 
@@ -4946,7 +4946,7 @@ void test_wdb_global_delete_agent_belong_bind_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_delete_agent_belong(data->wdb, atoi(data->wdb->id));
 
@@ -5030,7 +5030,7 @@ void test_wdb_global_get_agent_info_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     output = wdb_global_get_agent_info(data->wdb, atoi(data->wdb->id));
     assert_null(output);
@@ -5144,7 +5144,7 @@ void test_wdb_global_get_agents_by_keepalive_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, last_agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_get_agents_by_keepalive(data->wdb, &last_agent_id, comparator, keep_alive, &output);
 
@@ -5172,7 +5172,7 @@ void test_wdb_global_get_agents_by_keepalive_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, keep_alive);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_get_agents_by_keepalive(data->wdb, &last_agent_id, comparator, keep_alive, &output);
 
@@ -5398,7 +5398,7 @@ void test_wdb_global_get_all_agents_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, last_agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_get_all_agents(data->wdb, &last_agent_id, &output);
 
@@ -5513,7 +5513,7 @@ void test_wdb_global_check_manager_keepalive_stmt_error(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_stmt_cache, -1);
-    expect_string(__wrap__merror, formatted_msg, "DB(global.db) Can't cache statement");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) Can't cache statement");
 
     assert_int_equal(wdb_global_check_manager_keepalive(data->wdb), -1);
 }

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -22,7 +22,7 @@ static int test_setup(void **state) {
     test_struct_t *init_data = NULL;
     os_calloc(1,sizeof(test_struct_t),init_data);
     os_calloc(1,sizeof(wdb_t),init_data->wdb);
-    os_strdup("000",init_data->wdb->id);
+    os_strdup("global.db",init_data->wdb->id);
     os_calloc(256,sizeof(char),init_data->output);
     os_calloc(1,sizeof(sqlite3 *),init_data->wdb->db);
     *state = init_data;
@@ -38,6 +38,8 @@ static int test_teardown(void **state){
     os_free(data);
     return 0;
 }
+
+/* Tests wdb_global_get_agent_labels */
 
 void test_wdb_global_get_agent_labels_transaction_fail(void **state)
 {
@@ -76,7 +78,7 @@ void test_wdb_global_get_agent_labels_bind_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     output = wdb_global_get_agent_labels(data->wdb, atoi(data->wdb->id));
     assert_null(output);
@@ -116,6 +118,8 @@ void test_wdb_global_get_agent_labels_success(void **state)
     assert_ptr_equal(output, (cJSON*)1);
 }
 
+/* Tests wdb_global_del_agent_labels */
+
 void test_wdb_global_del_agent_labels_transaction_fail(void **state)
 {
     int result = 0;
@@ -152,7 +156,7 @@ void test_wdb_global_del_agent_labels_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_del_agent_labels(data->wdb, atoi(data->wdb->id));
     assert_int_equal(result, OS_INVALID);
@@ -191,6 +195,8 @@ void test_wdb_global_del_agent_labels_success(void **state)
     result = wdb_global_del_agent_labels(data->wdb, atoi(data->wdb->id));
     assert_int_equal(result, OS_SUCCESS);
 }
+
+/* Tests wdb_global_set_agent_label */
 
 void test_wdb_global_set_agent_label_transaction_fail(void **state)
 {
@@ -234,7 +240,7 @@ void test_wdb_global_set_agent_label_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
     assert_int_equal(result, OS_INVALID);
@@ -256,7 +262,7 @@ void test_wdb_global_set_agent_label_bind2_fail(void **state)
     expect_string(__wrap_sqlite3_bind_text, buffer, "test_key");
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
     assert_int_equal(result, OS_INVALID);
@@ -281,7 +287,7 @@ void test_wdb_global_set_agent_label_bind3_fail(void **state)
     expect_string(__wrap_sqlite3_bind_text, buffer, "test_value");
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
     assert_int_equal(result, OS_INVALID);
@@ -337,6 +343,8 @@ void test_wdb_global_set_agent_label_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_set_sync_status */
+
 void test_wdb_global_set_sync_status_transaction_fail(void **state)
 {
     int result = 0;
@@ -376,7 +384,7 @@ void test_wdb_global_set_sync_status_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_set_sync_status(data->wdb, atoi(data->wdb->id), status);
     assert_int_equal(result, OS_INVALID);
@@ -397,7 +405,7 @@ void test_wdb_global_set_sync_status_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_set_sync_status(data->wdb, atoi(data->wdb->id), status);
     assert_int_equal(result, OS_INVALID);
@@ -444,6 +452,8 @@ void test_wdb_global_set_sync_status_success(void **state)
     result = wdb_global_set_sync_status(data->wdb, atoi(data->wdb->id), status);
     assert_int_equal(result, OS_SUCCESS);
 }
+
+/* Tests wdb_global_sync_agent_info_get */
 
 void test_wdb_global_sync_agent_info_get_transaction_fail(void **state)
 {
@@ -493,7 +503,7 @@ void test_wdb_global_sync_agent_info_get_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, last_agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_sync_agent_info_get(data->wdb, &last_agent_id, &output);
 
@@ -707,6 +717,8 @@ void test_wdb_global_sync_agent_info_get_full(void **state)
     assert_int_equal(result, WDBC_DUE);
 }
 
+/* Tests wdb_global_sync_agent_info_set */
+
 void test_wdb_global_sync_agent_info_set_transaction_fail(void **state)
 {
     int result = 0;
@@ -756,7 +768,7 @@ void test_wdb_global_sync_agent_info_set_bind1_fail(void **state)
     expect_string(__wrap_sqlite3_bind_text, buffer, "test_name");
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_sync_agent_info_set(data->wdb, json_agent);
 
@@ -789,7 +801,7 @@ void test_wdb_global_sync_agent_info_set_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_sync_agent_info_set(data->wdb, json_agent);
     __real_cJSON_Delete(json_agent);
@@ -824,7 +836,7 @@ void test_wdb_global_sync_agent_info_set_bind3_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_sync_agent_info_set(data->wdb, json_agent);
     __real_cJSON_Delete(json_agent);
@@ -900,10 +912,13 @@ void test_wdb_global_sync_agent_info_set_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_insert_agent */
+
 void test_wdb_global_insert_agent_transaction_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 0;
     char *name = NULL;
     char *ip = NULL;
     char *register_ip = NULL;
@@ -914,7 +929,7 @@ void test_wdb_global_insert_agent_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_insert_agent(data->wdb, atoi(data->wdb->id), name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -923,6 +938,7 @@ void test_wdb_global_insert_agent_cache_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 0;
     char *name = NULL;
     char *ip = NULL;
     char *register_ip = NULL;
@@ -934,7 +950,7 @@ void test_wdb_global_insert_agent_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_insert_agent(data->wdb, atoi(data->wdb->id), name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -943,6 +959,7 @@ void test_wdb_global_insert_agent_bind1_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -953,13 +970,13 @@ void test_wdb_global_insert_agent_bind1_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, 000);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, atoi(data->wdb->id), name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -968,6 +985,7 @@ void test_wdb_global_insert_agent_bind2_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -978,16 +996,16 @@ void test_wdb_global_insert_agent_bind2_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, 000);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, atoi(data->wdb->id), name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -996,6 +1014,7 @@ void test_wdb_global_insert_agent_bind3_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1006,7 +1025,7 @@ void test_wdb_global_insert_agent_bind3_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, 000);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1016,9 +1035,9 @@ void test_wdb_global_insert_agent_bind3_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, atoi(data->wdb->id), name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1027,6 +1046,7 @@ void test_wdb_global_insert_agent_bind4_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1037,7 +1057,7 @@ void test_wdb_global_insert_agent_bind4_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, 000);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1050,9 +1070,9 @@ void test_wdb_global_insert_agent_bind4_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, atoi(data->wdb->id), name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1061,6 +1081,7 @@ void test_wdb_global_insert_agent_bind5_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1071,7 +1092,7 @@ void test_wdb_global_insert_agent_bind5_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, 000);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1087,9 +1108,9 @@ void test_wdb_global_insert_agent_bind5_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, atoi(data->wdb->id), name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1098,6 +1119,7 @@ void test_wdb_global_insert_agent_bind6_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1108,7 +1130,7 @@ void test_wdb_global_insert_agent_bind6_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, 000);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1127,9 +1149,9 @@ void test_wdb_global_insert_agent_bind6_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, atoi(data->wdb->id), name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1138,6 +1160,7 @@ void test_wdb_global_insert_agent_bind7_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1148,7 +1171,7 @@ void test_wdb_global_insert_agent_bind7_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, 000);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1170,9 +1193,9 @@ void test_wdb_global_insert_agent_bind7_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, atoi(data->wdb->id), name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1181,6 +1204,7 @@ void test_wdb_global_insert_agent_step_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1191,7 +1215,7 @@ void test_wdb_global_insert_agent_step_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, 000);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1216,7 +1240,7 @@ void test_wdb_global_insert_agent_step_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, atoi(data->wdb->id), name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1225,6 +1249,7 @@ void test_wdb_global_insert_agent_success(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1235,7 +1260,7 @@ void test_wdb_global_insert_agent_success(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, 000);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1258,10 +1283,12 @@ void test_wdb_global_insert_agent_success(void **state)
 
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_insert_agent(data->wdb, atoi(data->wdb->id), name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_SUCCESS);
 }
+
+/* Tests wdb_global_update_agent_name */
 
 void test_wdb_global_update_agent_name_transaction_fail(void **state)
 {
@@ -1305,7 +1332,8 @@ void test_wdb_global_update_agent_name_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+
     result = wdb_global_update_agent_name(data->wdb, atoi(data->wdb->id), name);
 
     assert_int_equal(result, OS_INVALID);
@@ -1316,6 +1344,7 @@ void test_wdb_global_update_agent_name_bind2_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1325,12 +1354,13 @@ void test_wdb_global_update_agent_name_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, 000);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
-    result = wdb_global_update_agent_name(data->wdb, atoi(data->wdb->id), name);
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+
+    result = wdb_global_update_agent_name(data->wdb, agent_id, name);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1339,6 +1369,7 @@ void test_wdb_global_update_agent_name_step_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1348,14 +1379,14 @@ void test_wdb_global_update_agent_name_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, 000);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_update_agent_name(data->wdb, atoi(data->wdb->id), name);
+    result = wdb_global_update_agent_name(data->wdb, agent_id, name);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1364,6 +1395,7 @@ void test_wdb_global_update_agent_name_success(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1373,15 +1405,17 @@ void test_wdb_global_update_agent_name_success(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, 000);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_update_agent_name(data->wdb, atoi(data->wdb->id), name);
+    result = wdb_global_update_agent_name(data->wdb, agent_id, name);
 
     assert_int_equal(result, OS_SUCCESS);
 }
+
+/* Tests wdb_global_update_agent_version */
 
 void test_wdb_global_update_agent_version_transaction_fail(void **state)
 {
@@ -1476,7 +1510,7 @@ void test_wdb_global_update_agent_version_bind1_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1517,7 +1551,7 @@ void test_wdb_global_update_agent_version_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1562,7 +1596,7 @@ void test_wdb_global_update_agent_version_bind3_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1610,7 +1644,7 @@ void test_wdb_global_update_agent_version_bind4_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1661,7 +1695,7 @@ void test_wdb_global_update_agent_version_bind5_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1715,7 +1749,7 @@ void test_wdb_global_update_agent_version_bind6_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1772,7 +1806,7 @@ void test_wdb_global_update_agent_version_bind7_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1832,7 +1866,7 @@ void test_wdb_global_update_agent_version_bind8_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1895,7 +1929,7 @@ void test_wdb_global_update_agent_version_bind9_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -1961,7 +1995,7 @@ void test_wdb_global_update_agent_version_bind10_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2030,7 +2064,7 @@ void test_wdb_global_update_agent_version_bind11_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2102,7 +2136,7 @@ void test_wdb_global_update_agent_version_bind12_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2177,7 +2211,7 @@ void test_wdb_global_update_agent_version_bind13_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2255,7 +2289,7 @@ void test_wdb_global_update_agent_version_bind14_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2336,7 +2370,7 @@ void test_wdb_global_update_agent_version_bind15_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2420,7 +2454,7 @@ void test_wdb_global_update_agent_version_bind16_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2507,7 +2541,7 @@ void test_wdb_global_update_agent_version_bind17_fail(void **state)
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
@@ -2687,6 +2721,8 @@ void test_wdb_global_update_agent_version_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_update_agent_keepalive */
+
 void test_wdb_global_update_agent_keepalive_transaction_fail(void **state)
 {
     int result = 0;
@@ -2732,7 +2768,8 @@ void test_wdb_global_update_agent_keepalive_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_keepalive(data->wdb, atoi(data->wdb->id), status);
 
@@ -2757,7 +2794,8 @@ void test_wdb_global_update_agent_keepalive_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+
     result = wdb_global_update_agent_keepalive(data->wdb, atoi(data->wdb->id), status);
 
     assert_int_equal(result, OS_INVALID);
@@ -2812,6 +2850,135 @@ void test_wdb_global_update_agent_keepalive_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_update_agent_connection_status */
+
+void test_wdb_global_update_agent_connection_status_transaction_fail(void **state)
+{
+    int result = 0;
+    int last_agent_id = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char *connection_status = "active";
+
+    will_return(__wrap_wdb_begin2, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
+
+    result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_update_agent_connection_status_cache_fail(void **state)
+{
+    int result = 0;
+    int last_agent_id = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char *connection_status = "active";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
+
+    result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_update_agent_connection_status_bind1_fail(void **state)
+{
+    int result = 0;
+    int last_agent_id = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char *connection_status = "active";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
+
+    result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_update_agent_connection_status_bind2_fail(void **state)
+{
+    int result = 0;
+    int last_agent_id = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char *connection_status = "active";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
+    result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_update_agent_connection_status_step_fail(void **state)
+{
+    int result = 0;
+    int last_agent_id = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char *connection_status = "active";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+
+    will_return(__wrap_wdb_step, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
+
+    result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_update_agent_connection_status_success(void **state)
+{
+    int result = 0;
+    int last_agent_id = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char *connection_status = "active";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    will_return(__wrap_wdb_step, SQLITE_DONE);
+
+    result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
+
+    assert_int_equal(result, OS_SUCCESS);
+}
+
+/* Tests wdb_global_delete_agent */
+
 void test_wdb_global_delete_agent_transaction_fail(void **state)
 {
     int result = 0;
@@ -2854,7 +3021,7 @@ void test_wdb_global_delete_agent_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_delete_agent(data->wdb, atoi(data->wdb->id));
 
@@ -2902,6 +3069,8 @@ void test_wdb_global_delete_agent_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_select_agent_name */
+
 void test_wdb_global_select_agent_name_transaction_fail(void **state)
 {
     cJSON *result = NULL;
@@ -2943,7 +3112,7 @@ void test_wdb_global_select_agent_name_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_name(data->wdb, atoi(data->wdb->id));
 
@@ -2988,6 +3157,8 @@ void test_wdb_global_select_agent_name_success(void **state)
     assert_ptr_equal(result, (cJSON*) 1);
 }
 
+/* Tests wdb_global_select_agent_group */
+
 void test_wdb_global_select_agent_group_transaction_fail(void **state)
 {
     cJSON *result = NULL;
@@ -3027,7 +3198,7 @@ void test_wdb_global_select_agent_group_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_group(data->wdb, atoi(data->wdb->id));
 
@@ -3072,6 +3243,8 @@ void test_wdb_global_select_agent_group_success(void **state)
     assert_ptr_equal(result, (cJSON*) 1);
 }
 
+/* Tests wdb_global_select_agent_fim_offset */
+
 void test_wdb_global_select_agent_fim_offset_transaction_fail(void **state)
 {
     cJSON *result = NULL;
@@ -3111,7 +3284,7 @@ void test_wdb_global_select_agent_fim_offset_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_fim_offset(data->wdb, atoi(data->wdb->id));
 
@@ -3156,6 +3329,8 @@ void test_wdb_global_select_agent_fim_offset_success(void **state)
     assert_ptr_equal(result, (cJSON*) 1);
 }
 
+/* Tests wdb_global_select_agent_reg_offset */
+
 void test_wdb_global_select_agent_reg_offset_transaction_fail(void **state)
 {
     cJSON *result = NULL;
@@ -3195,7 +3370,7 @@ void test_wdb_global_select_agent_reg_offset_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_reg_offset(data->wdb, atoi(data->wdb->id));
 
@@ -3240,6 +3415,8 @@ void test_wdb_global_select_agent_reg_offset_success(void **state)
     assert_ptr_equal(result, (cJSON*) 1);
 }
 
+/* Tests wdb_global_select_agent_status */
+
 void test_wdb_global_select_agent_status_transaction_fail(void **state)
 {
     cJSON *result = NULL;
@@ -3279,7 +3456,7 @@ void test_wdb_global_select_agent_status_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_status(data->wdb, atoi(data->wdb->id));
 
@@ -3323,6 +3500,8 @@ void test_wdb_global_select_agent_status_success(void **state)
 
     assert_ptr_equal(result, (cJSON*) 1);
 }
+
+/* Tests wdb_global_select_groups */
 
 void test_wdb_global_select_groups_transaction_fail(void **state)
 {
@@ -3382,6 +3561,8 @@ void test_wdb_global_select_groups_success(void **state)
     assert_ptr_equal(result, (cJSON*) 1);
 }
 
+/* Tests wdb_global_select_agent_keepalive */
+
 void test_wdb_global_select_agent_keepalive_transaction_fail(void **state)
 {
     cJSON *result = NULL;
@@ -3428,7 +3609,7 @@ void test_wdb_global_select_agent_keepalive_bind1_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_keepalive(data->wdb, name, ip);
 
@@ -3453,7 +3634,7 @@ void test_wdb_global_select_agent_keepalive_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_keepalive(data->wdb, name, ip);
 
@@ -3482,7 +3663,7 @@ void test_wdb_global_select_agent_keepalive_bind3_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_select_agent_keepalive(data->wdb, name, ip);
 
@@ -3546,6 +3727,8 @@ void test_wdb_global_select_agent_keepalive_success(void **state)
     assert_ptr_equal(result, (cJSON*) 1);
 }
 
+/* Tests wdb_global_find_agent */
+
 void test_wdb_global_find_agent_transaction_fail(void **state)
 {
     cJSON *result = NULL;
@@ -3595,7 +3778,7 @@ void test_wdb_global_find_agent_bind1_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_find_agent(data->wdb, name, ip);
 
@@ -3621,7 +3804,7 @@ void test_wdb_global_find_agent_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_find_agent(data->wdb, name, ip);
 
@@ -3650,7 +3833,7 @@ void test_wdb_global_find_agent_bind3_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_find_agent(data->wdb, name, ip);
 
@@ -3714,6 +3897,8 @@ void test_wdb_global_find_agent_success(void **state)
     assert_ptr_equal(result, (cJSON*) 1);
 }
 
+/* Tests wdb_global_update_agent_fim_offset */
+
 void test_wdb_global_update_agent_fim_offset_transaction_fail(void **state)
 {
     int result = 0;
@@ -3759,7 +3944,7 @@ void test_wdb_global_update_agent_fim_offset_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, offset);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_fim_offset(data->wdb, atoi(data->wdb->id), offset);
 
@@ -3783,8 +3968,8 @@ void test_wdb_global_update_agent_fim_offset_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
     result = wdb_global_update_agent_fim_offset(data->wdb, atoi(data->wdb->id), offset);
 
     assert_int_equal(result, OS_INVALID);
@@ -3839,6 +4024,8 @@ void test_wdb_global_update_agent_fim_offset_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_update_agent_reg_offset */
+
 void test_wdb_global_update_agent_reg_offset_transaction_fail(void **state)
 {
     int result = 0;
@@ -3884,7 +4071,7 @@ void test_wdb_global_update_agent_reg_offset_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, offset);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_reg_offset(data->wdb, atoi(data->wdb->id), offset);
 
@@ -3908,8 +4095,8 @@ void test_wdb_global_update_agent_reg_offset_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
     result = wdb_global_update_agent_reg_offset(data->wdb, atoi(data->wdb->id), offset);
 
     assert_int_equal(result, OS_INVALID);
@@ -3964,6 +4151,8 @@ void test_wdb_global_update_agent_reg_offset_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_update_agent_status */
+
 void test_wdb_global_update_agent_status_transaction_fail(void **state)
 {
     int result = 0;
@@ -4009,7 +4198,7 @@ void test_wdb_global_update_agent_status_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agt_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_status(data->wdb, atoi(data->wdb->id), agt_status);
 
@@ -4033,8 +4222,8 @@ void test_wdb_global_update_agent_status_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
     result = wdb_global_update_agent_status(data->wdb, atoi(data->wdb->id), agt_status);
 
     assert_int_equal(result, OS_INVALID);
@@ -4089,6 +4278,8 @@ void test_wdb_global_update_agent_status_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_update_agent_group */
+
 void test_wdb_global_update_agent_group_transaction_fail(void **state)
 {
     int result = 0;
@@ -4134,7 +4325,7 @@ void test_wdb_global_update_agent_group_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agt_group);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_update_agent_group(data->wdb, atoi(data->wdb->id), agt_group);
 
@@ -4158,8 +4349,8 @@ void test_wdb_global_update_agent_group_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
     result = wdb_global_update_agent_group(data->wdb, atoi(data->wdb->id), agt_group);
 
     assert_int_equal(result, OS_INVALID);
@@ -4214,6 +4405,8 @@ void test_wdb_global_update_agent_group_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_find_group */
+
 void test_wdb_global_find_group_transaction_fail(void **state)
 {
     cJSON *result = NULL;
@@ -4260,7 +4453,7 @@ void test_wdb_global_find_group_bind_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_find_group(data->wdb, group_name);
 
@@ -4310,6 +4503,8 @@ void test_wdb_global_find_group_success(void **state)
     assert_ptr_equal(result, (cJSON*) 1);
 }
 
+/* Tests wdb_global_insert_agent_group */
+
 void test_wdb_global_insert_agent_group_transaction_fail(void **state)
 {
     int result = 0;
@@ -4352,7 +4547,7 @@ void test_wdb_global_insert_agent_group_bind_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent_group(data->wdb, group_name);
 
@@ -4397,6 +4592,8 @@ void test_wdb_global_insert_agent_group_success(void **state)
 
     assert_int_equal(result, OS_SUCCESS);
 }
+
+/* Tests wdb_global_insert_agent_belong */
 
 void test_wdb_global_insert_agent_belong_transaction_fail(void **state)
 {
@@ -4443,7 +4640,7 @@ void test_wdb_global_insert_agent_belong_bind1_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent_belong(data->wdb, id_group, id_agent);
 
@@ -4468,7 +4665,7 @@ void test_wdb_global_insert_agent_belong_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_insert_agent_belong(data->wdb, id_group, id_agent);
 
@@ -4524,6 +4721,8 @@ void test_wdb_global_insert_agent_belong_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_delete_group_belong */
+
 void test_wdb_global_delete_group_belong_transaction_fail(void **state)
 {
     int result = 0;
@@ -4566,7 +4765,7 @@ void test_wdb_global_delete_group_belong_bind_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_delete_group_belong(data->wdb, group_name);
 
@@ -4614,6 +4813,8 @@ void test_wdb_global_delete_group_belong_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_delete_group */
+
 void test_wdb_global_delete_group_transaction_fail(void **state)
 {
     int result = 0;
@@ -4656,7 +4857,7 @@ void test_wdb_global_delete_group_bind_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_text(): ERROR MESSAGE");
 
     result = wdb_global_delete_group(data->wdb, group_name);
 
@@ -4704,6 +4905,8 @@ void test_wdb_global_delete_group_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_delete_agent_belong */
+
 void test_wdb_global_delete_agent_belong_transaction_fail(void **state)
 {
     int result = 0;
@@ -4743,7 +4946,7 @@ void test_wdb_global_delete_agent_belong_bind_fail(void **state)
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_delete_agent_belong(data->wdb, atoi(data->wdb->id));
 
@@ -4789,6 +4992,8 @@ void test_wdb_global_delete_agent_belong_success(void **state)
     assert_int_equal(result, OS_SUCCESS);
 }
 
+/* Tests wdb_global_get_agent_info */
+
 void test_wdb_global_get_agent_info_transaction_fail(void **state)
 {
     cJSON *output = NULL;
@@ -4825,8 +5030,7 @@ void test_wdb_global_get_agent_info_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     output = wdb_global_get_agent_info(data->wdb, atoi(data->wdb->id));
     assert_null(output);
@@ -4865,6 +5069,8 @@ void test_wdb_global_get_agent_info_success(void **state)
     output = wdb_global_get_agent_info(data->wdb, atoi(data->wdb->id));
     assert_ptr_equal(output, (cJSON*)1);
 }
+
+/* Tests wdb_global_get_agents_by_keepalive */
 
 void test_wdb_global_get_agents_by_keepalive_comparator_fail(void **state)
 {
@@ -4938,7 +5144,7 @@ void test_wdb_global_get_agents_by_keepalive_bind1_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, last_agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_get_agents_by_keepalive(data->wdb, &last_agent_id, comparator, keep_alive, &output);
 
@@ -4966,7 +5172,7 @@ void test_wdb_global_get_agents_by_keepalive_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, keep_alive);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_get_agents_by_keepalive(data->wdb, &last_agent_id, comparator, keep_alive, &output);
 
@@ -5003,7 +5209,7 @@ void test_wdb_global_get_agents_by_keepalive_no_agents(void **state)
     assert_int_equal(result, WDBC_OK);
 }
 
-void test_wdb_global_get_agents_by_keepalive_success(void **state)
+void test_wdb_global_get_agents_by_keepalive_success_lt(void **state)
 {
     int result = 0;
     int last_agent_id = 0;
@@ -5014,6 +5220,58 @@ void test_wdb_global_get_agents_by_keepalive_success(void **state)
     int agent_id = 10;
     char str_agt_id[] = "10";
     char comparator = '<';
+    int keep_alive = 100;
+
+    root = cJSON_CreateArray();
+    json_agent = cJSON_CreateObject();
+    cJSON_AddNumberToObject(json_agent, "id", agent_id);
+    cJSON_AddItemToArray(root, json_agent);
+
+    will_return_count(__wrap_wdb_begin2, 1, -1);
+    will_return_count(__wrap_wdb_stmt_cache, 1, -1);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, last_agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_int, value, keep_alive);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+
+    // Mocking one valid agent
+    will_return(__wrap_wdb_exec_stmt, root);
+
+    // No more agents
+    will_return(__wrap_wdb_exec_stmt, NULL);
+    expect_function_call_any(__wrap_cJSON_Delete);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_int, value, keep_alive);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+
+    result = wdb_global_get_agents_by_keepalive(data->wdb, &last_agent_id, comparator, keep_alive, &output);
+
+    assert_string_equal(output, str_agt_id);
+
+    assert_string_equal(output, "10");
+    os_free(output);
+    __real_cJSON_Delete(root);
+    assert_int_equal(result, WDBC_OK);
+}
+
+void test_wdb_global_get_agents_by_keepalive_success_gt(void **state)
+{
+    int result = 0;
+    int last_agent_id = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char *output = NULL;
+    cJSON *root = NULL;
+    cJSON *json_agent = NULL;
+    int agent_id = 10;
+    char str_agt_id[] = "10";
+    char comparator = '>';
     int keep_alive = 100;
 
     root = cJSON_CreateArray();
@@ -5090,6 +5348,8 @@ void test_wdb_global_get_agents_by_keepalive_full(void **state)
     assert_int_equal(result, WDBC_DUE);
 }
 
+/* Tests wdb_global_get_all_agents */
+
 void test_wdb_global_get_all_agents_transaction_fail(void **state)
 {
     int result = 0;
@@ -5138,7 +5398,7 @@ void test_wdb_global_get_all_agents_bind_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, last_agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_int(): ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) sqlite3_bind_int(): ERROR MESSAGE");
 
     result = wdb_global_get_all_agents(data->wdb, &last_agent_id, &output);
 
@@ -5247,11 +5507,13 @@ void test_wdb_global_get_all_agents_full(void **state)
     assert_int_equal(result, WDBC_DUE);
 }
 
+/* Tests wdb_global_check_manager_keepalive */
+
 void test_wdb_global_check_manager_keepalive_stmt_error(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_stmt_cache, -1);
-    expect_string(__wrap__merror, formatted_msg, "DB(000) Can't cache statement");
+    expect_string(__wrap__merror, formatted_msg, "DB(global.db) Can't cache statement");
 
     assert_int_equal(wdb_global_check_manager_keepalive(data->wdb), -1);
 }
@@ -5284,6 +5546,8 @@ void test_wdb_global_check_manager_keepalive_step_ok(void **state) {
 
     assert_int_equal(wdb_global_check_manager_keepalive(data->wdb), 1);
 }
+
+/* Tests wdb_global_reset_agents_connection */
 
 void test_wdb_global_reset_agents_connection_transaction_fail(void **state)
 {
@@ -5343,16 +5607,19 @@ void test_wdb_global_reset_agents_connection_success(void **state)
 int main()
 {
     const struct CMUnitTest tests[] = {
+        /* Tests wdb_global_get_agent_labels */
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_labels_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_labels_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_labels_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_labels_exec_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_labels_success, test_setup, test_teardown),
+        /* Tests wdb_global_del_agent_labels */
         cmocka_unit_test_setup_teardown(test_wdb_global_del_agent_labels_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_del_agent_labels_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_del_agent_labels_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_del_agent_labels_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_del_agent_labels_success, test_setup, test_teardown),
+        /* Tests wdb_global_set_agent_label */
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_label_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_label_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_label_bind1_fail, test_setup, test_teardown),
@@ -5360,12 +5627,14 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_label_bind3_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_label_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_agent_label_success, test_setup, test_teardown),
+        /* Tests wdb_global_set_sync_status */
         cmocka_unit_test_setup_teardown(test_wdb_global_set_sync_status_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_sync_status_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_sync_status_bind1_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_sync_status_bind2_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_sync_status_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_set_sync_status_success, test_setup, test_teardown),
+        /* Tests wdb_global_sync_agent_info_get */
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_get_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_get_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_get_bind_fail, test_setup, test_teardown),
@@ -5373,6 +5642,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_get_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_get_sync_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_get_full, test_setup, test_teardown),
+        /* Tests wdb_global_sync_agent_info_set */
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_set_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_set_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_set_bind1_fail, test_setup, test_teardown),
@@ -5380,6 +5650,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_set_bind3_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_set_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_sync_agent_info_set_success, test_setup, test_teardown),
+        /* Tests wdb_global_insert_agent */
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_bind1_fail, test_setup, test_teardown),
@@ -5391,12 +5662,14 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_bind7_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_success, test_setup, test_teardown),
+        /* Tests wdb_global_update_agent_name */
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_name_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_name_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_name_bind1_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_name_bind2_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_name_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_name_success, test_setup, test_teardown),
+        /* Tests wdb_global_update_agent_version */
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_version_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_version_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_version_bind1_fail, test_setup, test_teardown),
@@ -5418,46 +5691,62 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_version_bind17_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_version_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_version_success, test_setup, test_teardown),
+        /* Tests wdb_global_update_agent_keepalive */
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_keepalive_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_keepalive_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_keepalive_bind1_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_keepalive_bind2_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_keepalive_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_keepalive_success, test_setup, test_teardown),
+        /* Tests wdb_global_update_agent_connection_status */
+        cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_connection_status_transaction_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_connection_status_cache_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_connection_status_bind1_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_connection_status_bind2_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_connection_status_step_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_connection_status_success, test_setup, test_teardown),
+        /* Tests wdb_global_delete_agent */
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_agent_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_agent_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_agent_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_agent_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_agent_success, test_setup, test_teardown),
+        /* Tests wdb_global_select_agent_name */
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_name_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_name_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_name_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_name_exec_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_name_success, test_setup, test_teardown),
+        /* Tests wdb_global_select_agent_group */
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_group_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_group_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_group_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_group_exec_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_group_success, test_setup, test_teardown),
+        /* Tests wdb_global_select_agent_fim_offset */
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_fim_offset_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_fim_offset_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_fim_offset_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_fim_offset_exec_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_fim_offset_success, test_setup, test_teardown),
+        /* Tests wdb_global_select_agent_reg_offset */
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_reg_offset_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_reg_offset_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_reg_offset_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_reg_offset_exec_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_reg_offset_success, test_setup, test_teardown),
+        /* Tests wdb_global_select_agent_status */
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_status_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_status_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_status_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_status_exec_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_status_success, test_setup, test_teardown),
+        /* Tests wdb_global_select_groups */
         cmocka_unit_test_setup_teardown(test_wdb_global_select_groups_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_groups_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_groups_exec_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_groups_success, test_setup, test_teardown),
+        /* Tests wdb_global_select_agent_keepalive */
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_keepalive_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_keepalive_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_keepalive_bind1_fail, test_setup, test_teardown),
@@ -5465,6 +5754,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_keepalive_bind3_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_keepalive_exec_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_select_agent_keepalive_success, test_setup, test_teardown),
+        /* Tests wdb_global_find_agent */
         cmocka_unit_test_setup_teardown(test_wdb_global_find_agent_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_find_agent_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_find_agent_bind1_fail, test_setup, test_teardown),
@@ -5472,84 +5762,100 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_find_agent_bind3_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_find_agent_exec_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_find_agent_success, test_setup, test_teardown),
+        /* Tests wdb_global_update_agent_fim_offset */
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_fim_offset_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_fim_offset_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_fim_offset_bind1_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_fim_offset_bind2_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_fim_offset_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_fim_offset_success, test_setup, test_teardown),
+        /* Tests wdb_global_update_agent_reg_offset */
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_reg_offset_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_reg_offset_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_reg_offset_bind1_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_reg_offset_bind2_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_reg_offset_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_reg_offset_success, test_setup, test_teardown),
+        /* Tests wdb_global_update_agent_status */
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_status_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_status_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_status_bind1_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_status_bind2_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_status_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_status_success, test_setup, test_teardown),
+        /* Tests wdb_global_update_agent_group */
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_group_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_group_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_group_bind1_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_group_bind2_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_group_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_group_success, test_setup, test_teardown),
+        /* Tests wdb_global_find_group */
         cmocka_unit_test_setup_teardown(test_wdb_global_find_group_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_find_group_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_find_group_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_find_group_exec_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_find_group_success, test_setup, test_teardown),
+        /* Tests wdb_global_insert_agent_group */
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_group_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_group_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_group_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_group_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_group_success, test_setup, test_teardown),
+        /* Tests wdb_global_insert_agent_belong */
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_belong_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_belong_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_belong_bind1_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_belong_bind2_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_belong_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_insert_agent_belong_success, test_setup, test_teardown),
+        /* Tests wdb_global_delete_group_belong */
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_group_belong_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_group_belong_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_group_belong_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_group_belong_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_group_belong_success, test_setup, test_teardown),
+        /* Tests wdb_global_delete_group */
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_group_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_group_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_group_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_group_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_group_success, test_setup, test_teardown),
+        /* Tests wdb_global_delete_agent_belong */
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_agent_belong_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_agent_belong_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_agent_belong_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_agent_belong_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_delete_agent_belong_success, test_setup, test_teardown),
+        /* Tests wdb_global_get_agent_info */
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_info_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_info_cache_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_info_bind_fail, test_setup, test_teardown),      
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_info_exec_fail, test_setup, test_teardown),      
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_info_success, test_setup, test_teardown),       
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_comparator_fail, test_setup, test_teardown),              
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_transaction_fail, test_setup, test_teardown),              
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_cache_fail, test_setup, test_teardown),              
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_bind1_fail, test_setup, test_teardown),              
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_bind2_fail, test_setup, test_teardown),              
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_no_agents, test_setup, test_teardown),              
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_success, test_setup, test_teardown),              
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_full, test_setup, test_teardown),              
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_transaction_fail, test_setup, test_teardown),              
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_cache_fail, test_setup, test_teardown),              
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_bind_fail, test_setup, test_teardown),              
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_no_agents, test_setup, test_teardown),              
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_success, test_setup, test_teardown),              
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_info_bind_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_info_exec_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agent_info_success, test_setup, test_teardown),
+        /* Tests wdb_global_get_agents_by_keepalive */
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_comparator_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_transaction_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_cache_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_bind1_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_bind2_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_no_agents, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_success_lt, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_success_gt, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_by_keepalive_full, test_setup, test_teardown),
+        /* Tests wdb_global_get_all_agents */
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_transaction_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_cache_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_bind_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_no_agents, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_full, test_setup, test_teardown),
+        /* Tests wdb_global_check_manager_keepalive */
         cmocka_unit_test_setup_teardown(test_wdb_global_check_manager_keepalive_stmt_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_check_manager_keepalive_step_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_check_manager_keepalive_step_nodata, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_check_manager_keepalive_step_ok, test_setup, test_teardown),
+        /* Tests wdb_global_reset_agents_connection */
         cmocka_unit_test_setup_teardown(test_wdb_global_reset_agents_connection_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_reset_agents_connection_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_reset_agents_step_fail, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -163,6 +163,8 @@ void test_wdb_parse_global_actor_fail(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
+/* Tests wdb_parse_global_insert_agent */
+
 void test_wdb_parse_global_insert_agent_syntax_error(void **state)
 {
     int ret = 0;
@@ -265,6 +267,8 @@ void test_wdb_parse_global_insert_agent_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_update_agent_name */
+
 void test_wdb_parse_global_update_agent_name_syntax_error(void **state)
 {
     int ret = 0;
@@ -352,6 +356,8 @@ void test_wdb_parse_global_update_agent_name_success(void **state)
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
 }
+
+/* Tests wdb_parse_global_update_agent_data */
 
 void test_wdb_parse_global_update_agent_data_syntax_error(void **state)
 {
@@ -506,6 +512,8 @@ void test_wdb_parse_global_update_agent_data_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_get_agent_labels */
+
 void test_wdb_parse_global_get_agent_labels_syntax_error(void **state)
 {
     int ret = 0;
@@ -567,6 +575,8 @@ void test_wdb_parse_global_get_agent_labels_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 
 }
+
+/* Tests wdb_parse_global_set_agent_labels */
 
 void test_wdb_parse_global_set_agent_labels_syntax_error(void **state)
 {
@@ -693,6 +703,8 @@ void test_wdb_parse_global_set_agent_labels_success_only_remove(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_update_agent_keepalive */
+
 void test_wdb_parse_global_update_agent_keepalive_syntax_error(void **state)
 {
     int ret = 0;
@@ -783,6 +795,100 @@ void test_wdb_parse_global_update_agent_keepalive_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_update_connection_status */
+
+void test_wdb_parse_global_update_connection_status_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-connection-status";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-connection-status");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for update-connection-status.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: update-connection-status");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'update-connection-status'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_update_connection_status_invalid_json(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-connection-status {INVALID_JSON}";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-connection-status {INVALID_JSON}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when updating agent connection status.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB JSON error near: NVALID_JSON}");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid JSON syntax, near '{INVALID_JSON}'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_update_connection_status_invalid_data(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-connection-status {\"id\":1,\"connection_status\":null}";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-connection-status {\"id\":1,\"connection_status\":null}");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when updating agent connection status.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid JSON data, near '{\"id\":1,\"connection_status\":null'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_update_connection_status_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-connection-status {\"id\":1,\"connection_status\":\"active\"}";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_value(__wrap_wdb_global_update_agent_connection_status, id, 1);
+    expect_string(__wrap_wdb_global_update_agent_connection_status, connection_status, "active");
+    will_return(__wrap_wdb_global_update_agent_connection_status, OS_INVALID);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-connection-status {\"id\":1,\"connection_status\":\"active\"}");
+    will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Cannot execute Global database query; ERROR MESSAGE");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_update_connection_status_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-connection-status {\"id\":1,\"connection_status\":\"active\"}";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_value(__wrap_wdb_global_update_agent_connection_status, id, 1);
+    expect_string(__wrap_wdb_global_update_agent_connection_status, connection_status, "active");
+    will_return(__wrap_wdb_global_update_agent_connection_status, OS_SUCCESS);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-connection-status {\"id\":1,\"connection_status\":\"active\"}");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+/* Tests wdb_parse_global_delete_agent */
+
 void test_wdb_parse_global_delete_agent_syntax_error(void **state)
 {
     int ret = 0;
@@ -834,6 +940,8 @@ void test_wdb_parse_global_delete_agent_success(void **state)
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
 }
+
+/* Tests wdb_parse_global_select_agent_name */
 
 void test_wdb_parse_global_select_agent_name_syntax_error(void **state)
 {
@@ -891,6 +999,8 @@ void test_wdb_parse_global_select_agent_name_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_select_agent_group */
+
 void test_wdb_parse_global_select_agent_group_syntax_error(void **state)
 {
     int ret = 0;
@@ -947,6 +1057,8 @@ void test_wdb_parse_global_select_agent_group_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_delete_agent_belong */
+
 void test_wdb_parse_global_delete_agent_belong_syntax_error(void **state)
 {
     int ret = 0;
@@ -998,6 +1110,8 @@ void test_wdb_parse_global_delete_agent_belong_success(void **state)
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
 }
+
+/* Tests wdb_parse_global_find_agent */
 
 void test_wdb_parse_global_find_agent_syntax_error(void **state)
 {
@@ -1091,6 +1205,8 @@ void test_wdb_parse_global_find_agent_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_select_fim_offset */
+
 void test_wdb_parse_global_select_fim_offset_syntax_error(void **state)
 {
     int ret = 0;
@@ -1147,6 +1263,8 @@ void test_wdb_parse_global_select_fim_offset_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_select_reg_offset */
+
 void test_wdb_parse_global_select_reg_offset_syntax_error(void **state)
 {
     int ret = 0;
@@ -1202,6 +1320,8 @@ void test_wdb_parse_global_select_reg_offset_success(void **state)
     assert_string_equal(data->output, "ok {\"reg_offset\":123}");
     assert_int_equal(ret, OS_SUCCESS);
 }
+
+/* Tests wdb_parse_global_update_fim_offset */
 
 void test_wdb_parse_global_update_fim_offset_syntax_error(void **state)
 {
@@ -1291,6 +1411,8 @@ void test_wdb_parse_global_update_fim_offset_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_update_reg_offset */
+
 void test_wdb_parse_global_update_reg_offset_syntax_error(void **state)
 {
     int ret = 0;
@@ -1379,6 +1501,8 @@ void test_wdb_parse_global_update_reg_offset_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_select_agent_status */
+
 void test_wdb_parse_global_select_agent_status_syntax_error(void **state)
 {
     int ret = 0;
@@ -1434,6 +1558,8 @@ void test_wdb_parse_global_select_agent_status_success(void **state)
     assert_string_equal(data->output, "ok {\"status\":\"test_status\"}");
     assert_int_equal(ret, OS_SUCCESS);
 }
+
+/* Tests wdb_parse_global_update_agent_status */
 
 void test_wdb_parse_global_update_agent_status_syntax_error(void **state)
 {
@@ -1523,6 +1649,8 @@ void test_wdb_parse_global_update_agent_status_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_update_agent_group */
+
 void test_wdb_parse_global_update_agent_group_syntax_error(void **state)
 {
     int ret = 0;
@@ -1611,6 +1739,8 @@ void test_wdb_parse_global_update_agent_group_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_find_group */
+
 void test_wdb_parse_global_find_group_syntax_error(void **state)
 {
     int ret = 0;
@@ -1667,6 +1797,8 @@ void test_wdb_parse_global_find_group_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_insert_agent_group */
+
 void test_wdb_parse_global_insert_agent_group_syntax_error(void **state)
 {
     int ret = 0;
@@ -1719,6 +1851,8 @@ void test_wdb_parse_global_insert_agent_group_success(void **state)
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
 }
+
+/* Tests wdb_parse_global_insert_agent_belong */
 
 void test_wdb_parse_global_insert_agent_belong_syntax_error(void **state)
 {
@@ -1808,6 +1942,8 @@ void test_wdb_parse_global_insert_agent_belong_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_delete_group_belong */
+
 void test_wdb_parse_global_delete_group_belong_syntax_error(void **state)
 {
     int ret = 0;
@@ -1859,6 +1995,8 @@ void test_wdb_parse_global_delete_group_belong_success(void **state)
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
 }
+
+/* Tests wdb_parse_global_delete_group */
 
 void test_wdb_parse_global_delete_group_syntax_error(void **state)
 {
@@ -1912,6 +2050,8 @@ void test_wdb_parse_global_delete_group_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_select_groups */
+
 void test_wdb_parse_global_select_groups_query_error(void **state)
 {
     int ret = 0;
@@ -1949,6 +2089,8 @@ void test_wdb_parse_global_select_groups_success(void **state)
     assert_string_equal(data->output, "ok {\"id\":1,\"id\":2}");
     assert_int_equal(ret, OS_SUCCESS);
 }
+
+/* Tests wdb_parse_global_select_agent_keepalive */
 
 void test_wdb_parse_global_select_agent_keepalive_syntax_error(void **state)
 {
@@ -2025,6 +2167,8 @@ void test_wdb_parse_global_select_agent_keepalive_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_sync_agent_info_get */
+
 void test_wdb_parse_global_sync_agent_info_get_success(void **state)
 {
     int ret = 0;
@@ -2062,6 +2206,8 @@ void test_wdb_parse_global_sync_agent_info_get_last_id_success(void **state)
     assert_string_equal(data->output, "ok {SYNC INFO}");
     assert_int_equal(ret, OS_SUCCESS);
 }
+
+/* Tests wdb_parse_global_sync_agent_info_set */
 
 void test_wdb_parse_global_sync_agent_info_set_syntax_error(void **state)
 {
@@ -2221,6 +2367,8 @@ void test_wdb_parse_global_sync_agent_info_set_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_get_agents_by_keepalive */
+
 void test_wdb_parse_global_get_agents_by_keepalive_syntax_error(void **state)
 {
     int ret = 0;
@@ -2338,6 +2486,8 @@ void test_wdb_parse_global_get_agents_by_keepalive_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_get_all_agents */
+
 void test_wdb_parse_global_get_all_agents_syntax_error(void **state)
 {
     int ret = 0;
@@ -2405,6 +2555,8 @@ void test_wdb_parse_global_get_all_agents_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_get_agent_info */
+
 void test_wdb_parse_global_get_agent_info_syntax_error(void **state)
 {
     int ret = 0;
@@ -2461,6 +2613,8 @@ void test_wdb_parse_global_get_agent_info_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_reset_agents_connection */
+
 void test_wdb_parse_reset_agents_connection_query_error(void **state)
 {
     int ret = 0;
@@ -2505,106 +2659,139 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sql_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sql_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_actor_fail, test_setup, test_teardown),
+        /* Tests wdb_parse_global_insert_agent */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_compliant_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_update_agent_name */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_name_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_update_agent_data */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_data_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_data_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_data_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_data_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_data_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_get_agent_labels */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_labels_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_labels_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_labels_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_set_agent_labels */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_labels_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_labels_id_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_labels_remove_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_labels_set_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_labels_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_set_agent_labels_success_only_remove, test_setup, test_teardown),
+        /* Tests wdb_parse_global_update_agent_keepalive */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_keepalive_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_keepalive_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_keepalive_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_keepalive_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_keepalive_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_update_connection_status */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_connection_status_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_connection_status_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_connection_status_invalid_data, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_connection_status_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_connection_status_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_delete_agent */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_agent_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_agent_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_agent_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_select_agent_name */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_name_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_name_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_name_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_select_agent_group */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_group_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_group_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_group_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_delete_agent_belong */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_agent_belong_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_agent_belong_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_agent_belong_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_find_agent */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_find_agent_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_find_agent_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_find_agent_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_find_agent_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_find_agent_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_select_fim_offset */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_fim_offset_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_fim_offset_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_fim_offset_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_select_reg_offset */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_reg_offset_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_reg_offset_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_reg_offset_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_update_fim_offset */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_fim_offset_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_fim_offset_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_fim_offset_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_fim_offset_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_fim_offset_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_update_reg_offset */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_reg_offset_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_reg_offset_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_reg_offset_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_reg_offset_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_reg_offset_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_select_agent_status */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_status_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_status_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_status_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_update_agent_status */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_status_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_status_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_status_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_status_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_status_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_update_agent_group */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_group_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_group_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_group_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_group_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_agent_group_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_find_group */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_find_group_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_find_group_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_find_group_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_insert_agent_group */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_group_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_group_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_group_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_insert_agent_belong */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_belong_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_belong_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_belong_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_belong_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_insert_agent_belong_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_delete_group_belong */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_belong_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_belong_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_belong_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_delete_group */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_group_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_select_groups */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_groups_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_groups_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_select_agent_keepalive */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_keepalive_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_keepalive_syntax_error2, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_keepalive_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_select_agent_keepalive_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_sync_agent_info_get */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_get_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_get_last_id_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_sync_agent_info_set */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_invalid_json, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_query_error, test_setup, test_teardown),
@@ -2612,6 +2799,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_del_label_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_set_label_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_get_agents_by_keepalive */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_condition_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_condition2_error, test_setup, test_teardown),
@@ -2619,13 +2807,16 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_last_id_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_last_id2_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_keepalive_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_get_all_agents */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_all_agents_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_all_agents_argument_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_all_agents_argument2_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_all_agents_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_get_agent_info */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_success, test_setup, test_teardown),
+        /* Tests wdb_parse_reset_agents_connection */
         cmocka_unit_test_setup_teardown(test_wdb_parse_reset_agents_connection_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_reset_agents_connection_success, test_setup, test_teardown),
     };

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -110,6 +110,14 @@ int __wrap_wdb_global_update_agent_keepalive(__attribute__((unused)) wdb_t *wdb,
     return mock();
 }
 
+int __wrap_wdb_global_update_agent_connection_status(__attribute__((unused)) wdb_t *wdb,
+                                                     int id,
+                                                     char* connection_status) {
+    check_expected(id);
+    check_expected(connection_status);
+    return mock();
+}
+
 int __wrap_wdb_global_delete_agent( __attribute__((unused)) wdb_t *wdb,
                                     int id) {
     check_expected(id);
@@ -119,19 +127,19 @@ int __wrap_wdb_global_delete_agent( __attribute__((unused)) wdb_t *wdb,
 cJSON* __wrap_wdb_global_select_agent_name( __attribute__((unused)) wdb_t *wdb,
                                             int id) {
     check_expected(id);
-    return mock_ptr_type(cJSON*);   
+    return mock_ptr_type(cJSON*);
 }
 
 cJSON* __wrap_wdb_global_select_agent_group(__attribute__((unused)) wdb_t *wdb,
                                             int id) {
     check_expected(id);
-    return mock_ptr_type(cJSON*);   
+    return mock_ptr_type(cJSON*);
 }
 
 int __wrap_wdb_global_delete_agent_belong(  __attribute__((unused)) wdb_t *wdb,
                                             int id) {
     check_expected(id);
-    return mock();   
+    return mock();
 }
 
 cJSON* __wrap_wdb_global_find_agent(__attribute__((unused)) wdb_t *wdb,

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -44,6 +44,8 @@ int __wrap_wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value
 
 int __wrap_wdb_global_update_agent_keepalive(wdb_t *wdb, int id, char* status);
 
+int __wrap_wdb_global_update_agent_connection_status(wdb_t *wdb, int id, char* connection_status);
+
 int __wrap_wdb_global_delete_agent(wdb_t *wdb, int id);
 
 cJSON* __wrap_wdb_global_select_agent_name(wdb_t *wdb, int id);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1035,6 +1035,16 @@ int wdb_parse_global_set_agent_labels(wdb_t * wdb, char * input, char * output);
 int wdb_parse_global_update_agent_keepalive(wdb_t * wdb, char * input, char * output);
 
 /**
+ * @brief Function to parse the update the agent connection status.
+ *
+ * @param [in] wdb The global struct database.
+ * @param [in] input String with the agent data in JSON format.
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ */
+int wdb_parse_global_update_connection_status(wdb_t * wdb, char * input, char * output);
+
+/**
  * @brief Function to parse the agent delete from agent table request.
  *
  * @param [in] wdb The global struct database.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -980,7 +980,8 @@ int wdb_parse_mitre_get(wdb_t * wdb, char * input, char * output);
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent data in JSON format.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_insert_agent(wdb_t * wdb, char * input, char * output);
 
@@ -990,7 +991,8 @@ int wdb_parse_global_insert_agent(wdb_t * wdb, char * input, char * output);
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent data in JSON format.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_update_agent_name(wdb_t * wdb, char * input, char * output);
 
@@ -1000,7 +1002,8 @@ int wdb_parse_global_update_agent_name(wdb_t * wdb, char * input, char * output)
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent data in JSON format.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_update_agent_data(wdb_t * wdb, char * input, char * output);
 
@@ -1010,7 +1013,8 @@ int wdb_parse_global_update_agent_data(wdb_t * wdb, char * input, char * output)
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query in JSON format.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_get_agent_labels(wdb_t * wdb, char * input, char * output);
 
@@ -1031,7 +1035,8 @@ int wdb_parse_global_get_agent_info(wdb_t * wdb, char * input, char * output);
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id labels_string'.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_set_agent_labels(wdb_t * wdb, char * input, char * output);
 
@@ -1041,17 +1046,19 @@ int wdb_parse_global_set_agent_labels(wdb_t * wdb, char * input, char * output);
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent data in JSON format.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_update_agent_keepalive(wdb_t * wdb, char * input, char * output);
 
 /**
- * @brief Function to parse the update the agent connection status.
+ * @brief Function to parse the update agent connection status.
  *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent data in JSON format.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_update_connection_status(wdb_t * wdb, char * input, char * output);
 
@@ -1061,7 +1068,8 @@ int wdb_parse_global_update_connection_status(wdb_t * wdb, char * input, char * 
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_delete_agent(wdb_t * wdb, char * input, char * output);
 
@@ -1071,7 +1079,8 @@ int wdb_parse_global_delete_agent(wdb_t * wdb, char * input, char * output);
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_select_agent_name(wdb_t * wdb, char * input, char * output);
 
@@ -1081,7 +1090,8 @@ int wdb_parse_global_select_agent_name(wdb_t * wdb, char * input, char * output)
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_select_agent_group(wdb_t * wdb, char * input, char * output);
 
@@ -1091,7 +1101,8 @@ int wdb_parse_global_select_agent_group(wdb_t * wdb, char * input, char * output
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_id'.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_delete_agent_belong(wdb_t * wdb, char * input, char * output);
 
@@ -1101,7 +1112,8 @@ int wdb_parse_global_delete_agent_belong(wdb_t * wdb, char * input, char * outpu
  * @param [in] wdb The global struct database.
  * @param [in] input String JSON with the agent name and ip.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_find_agent(wdb_t * wdb, char * input, char * output);
 
@@ -1131,7 +1143,8 @@ int wdb_parse_global_select_reg_offset(wdb_t * wdb, char * input, char * output)
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent and offset data in JSON format.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_update_fim_offset(wdb_t * wdb, char * input, char * output);
 
@@ -1141,7 +1154,8 @@ int wdb_parse_global_update_fim_offset(wdb_t * wdb, char * input, char * output)
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent and offset data in JSON format.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_update_reg_offset(wdb_t * wdb, char * input, char * output);
 
@@ -1161,7 +1175,8 @@ int wdb_parse_global_select_agent_status(wdb_t * wdb, char * input, char * outpu
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent and update status data in JSON format.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_update_agent_status(wdb_t * wdb, char * input, char * output);
 
@@ -1171,7 +1186,8 @@ int wdb_parse_global_update_agent_status(wdb_t * wdb, char * input, char * outpu
  * @param [in] wdb The global struct database.
  * @param [in] input String with the agent and group data in JSON format.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_update_agent_group(wdb_t * wdb, char * input, char * output);
 
@@ -1181,7 +1197,8 @@ int wdb_parse_global_update_agent_group(wdb_t * wdb, char * input, char * output
  * @param [in] wdb The global struct database.
  * @param [in] input String with the group name.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_find_group(wdb_t * wdb, char * input, char * output);
 
@@ -1191,7 +1208,8 @@ int wdb_parse_global_find_group(wdb_t * wdb, char * input, char * output);
  * @param [in] wdb The global struct database.
  * @param [in] input String with the group name.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_insert_agent_group(wdb_t * wdb, char * input, char * output);
 
@@ -1201,7 +1219,8 @@ int wdb_parse_global_insert_agent_group(wdb_t * wdb, char * input, char * output
  * @param [in] wdb The global struct database.
  * @param [in] input String with the group id and agent id in JSON format.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_insert_agent_belong(wdb_t * wdb, char * input, char * output);
 
@@ -1211,7 +1230,8 @@ int wdb_parse_global_insert_agent_belong(wdb_t * wdb, char * input, char * outpu
  * @param [in] wdb The global struct database.
  * @param [in] input String with the group name.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_delete_group_belong(wdb_t * wdb, char * input, char * output);
 
@@ -1221,7 +1241,8 @@ int wdb_parse_global_delete_group_belong(wdb_t * wdb, char * input, char * outpu
  * @param [in] wdb The global struct database.
  * @param [in] input String with the group name.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_delete_group(wdb_t * wdb, char * input, char * output);
 
@@ -1230,7 +1251,8 @@ int wdb_parse_global_delete_group(wdb_t * wdb, char * input, char * output);
  *
  * @param [in] wdb The global struct database.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_select_groups(wdb_t * wdb, char * output);
 
@@ -1240,7 +1262,8 @@ int wdb_parse_global_select_groups(wdb_t * wdb, char * output);
  * @param [in] wdb The global struct database.
  * @param [in] input String with 'agent_name agent_ip'.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_global_select_agent_keepalive(wdb_t * wdb, char * input, char * output);
 
@@ -1290,7 +1313,8 @@ int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output);
  * 
  * @param [in] wdb The global struct database.
  * @param [out] output Response of the query.
- * @return 0 Success: response contains the value OK. -1 On error: invalid DB query syntax.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_reset_agents_connection(wdb_t * wdb, char * output);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -173,6 +173,7 @@ typedef enum global_db_access {
     WDB_UPDATE_AGENT_NAME,
     WDB_UPDATE_AGENT_DATA,
     WDB_UPDATE_AGENT_KEEPALIVE,
+    WDB_UPDATE_AGENT_CONNECTION_STATUS,
     WDB_UPDATE_AGENT_STATUS,
     WDB_UPDATE_AGENT_GROUP,
     WDB_UPDATE_FIM_OFFSET,
@@ -454,7 +455,7 @@ int wdb_update_agent_name(int id, const char *name, int *sock);
 int wdb_update_agent_data(agent_info_data *agent_data, int *sock);
 
 /**
- * @brief Update agent's last keepalive ond modifies the cluster synchronization status.
+ * @brief Update agent's last keepalive and modifies the cluster synchronization status.
  *
  * @param[in] id Id of the agent for whom the keepalive must be updated.
  * @param[in] sync_status String with the cluster synchronization status to be set.
@@ -462,6 +463,16 @@ int wdb_update_agent_data(agent_info_data *agent_data, int *sock);
  * @return OS_SUCCESS on success or OS_INVALID on failure.
  */
 int wdb_update_agent_keepalive(int id, const char *sync_status, int *sock);
+
+/**
+ * @brief Update agent's connection status.
+ *
+ * @param[in] id Id of the agent for whom the connection status must be updated.
+ * @param[in] connection_status String with the connection status to be set.
+ * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
+ * @return OS_SUCCESS on success or OS_INVALID on failure.
+ */
+int wdb_update_agent_connection_status(int id, const char *connection_status, int *sock);
 
 /**
  * @brief Set agent updating status.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -133,6 +133,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_LABELS_DEL,
     WDB_STMT_GLOBAL_LABELS_SET,
     WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE,
+    WDB_STMT_GLOBAL_UPDATE_AGENT_CONNECTION_STATUS,
     WDB_STMT_GLOBAL_DELETE_AGENT,
     WDB_STMT_GLOBAL_SELECT_AGENT_NAME,
     WDB_STMT_GLOBAL_SELECT_AGENT_GROUP,
@@ -1478,6 +1479,16 @@ int wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value);
  * @return Returns 0 on success or -1 on error.
  */
 int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, const char *sync_status);
+
+/**
+ * @brief Function to update an agent connection status.
+ *
+ * @param [in] wdb The Global struct database.
+ * @param [in] id The agent ID.
+ * @param [in] connection_status The connection status to be set.
+ * @return Returns 0 on success or -1 on error.
+ */
+int wdb_global_update_agent_connection_status(wdb_t *wdb, int id, const char* connection_status);
 
 /**
  * @brief Function to delete an agent from the agent table.

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -400,10 +400,10 @@ int wdb_update_agent_connection_status(int id, const char *connection_status, in
     cJSON_AddStringToObject(data_in, "connection_status", connection_status);
     data_in_str = cJSON_PrintUnformatted(data_in);
 
-    os_calloc(WDBQUERY_SIZE+1, sizeof(char), wdbquery);
-    os_calloc(WDBOUTPUT_SIZE, sizeof(char), wdboutput);
-    snprintf(wdbquery, WDBQUERY_SIZE, global_db_commands[WDB_UPDATE_AGENT_KEEPALIVE], data_in_str);
+    os_malloc(WDBQUERY_SIZE, wdbquery);
+    snprintf(wdbquery, WDBQUERY_SIZE, global_db_commands[WDB_UPDATE_AGENT_CONNECTION_STATUS], data_in_str);
 
+    os_malloc(WDBOUTPUT_SIZE, wdboutput);
     result = wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);
 
     switch (result) {

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -27,6 +27,7 @@ static const char *global_db_commands[] = {
     [WDB_UPDATE_AGENT_NAME] = "global update-agent-name %s",
     [WDB_UPDATE_AGENT_DATA] = "global update-agent-data %s",
     [WDB_UPDATE_AGENT_KEEPALIVE] = "global update-keepalive %s",
+    [WDB_UPDATE_AGENT_CONNECTION_STATUS] = "global update-connection-status %s",
     [WDB_UPDATE_AGENT_STATUS] = "global update-agent-status %s",
     [WDB_UPDATE_AGENT_GROUP] = "global update-agent-group %s",
     [WDB_UPDATE_FIM_OFFSET] = "global update-fim-offset %s",
@@ -375,6 +376,61 @@ int wdb_update_agent_keepalive(int id, const char *sync_status, int *sock) {
             mdebug2("Global DB SQL query: %s", wdbquery);
             result = OS_INVALID;
     }
+
+    return result;
+}
+
+int wdb_update_agent_connection_status(int id, const char *connection_status, int *sock) {
+    int result = 0;
+    cJSON *data_in = NULL;
+    char *data_in_str = NULL;
+    char *wdbquery = NULL;
+    char *wdboutput = NULL;
+    char *payload = NULL;
+    int aux_sock = -1;
+
+    data_in = cJSON_CreateObject();
+
+    if (!data_in) {
+        mdebug1("Error creating data JSON for Wazuh DB.");
+        return OS_INVALID;
+    }
+
+    cJSON_AddNumberToObject(data_in, "id", id);
+    cJSON_AddStringToObject(data_in, "connection_status", connection_status);
+    data_in_str = cJSON_PrintUnformatted(data_in);
+
+    os_calloc(WDBQUERY_SIZE+1, sizeof(char), wdbquery);
+    os_calloc(WDBOUTPUT_SIZE, sizeof(char), wdboutput);
+    snprintf(wdbquery, WDBQUERY_SIZE, global_db_commands[WDB_UPDATE_AGENT_KEEPALIVE], data_in_str);
+
+    result = wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);
+
+    switch (result) {
+        case OS_SUCCESS:
+            if (WDBC_OK != wdbc_parse_result(wdboutput, &payload)) {
+                mdebug1("Global DB Error reported in the result of the query");
+                result = OS_INVALID;
+            }
+            break;
+        case OS_INVALID:
+            mdebug1("Global DB Error in the response from socket");
+            mdebug2("Global DB SQL query: %s", wdbquery);
+            break;
+        default:
+            mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db", WDB2_DIR, WDB_GLOB_NAME);
+            mdebug2("Global DB SQL query: %s", wdbquery);
+            result = OS_INVALID;
+    }
+
+    if (!sock) {
+        wdbc_close(&aux_sock);
+    }
+
+    cJSON_Delete(data_in);
+    os_free(data_in_str);
+    os_free(wdbquery);
+    os_free(wdboutput);
 
     return result;
 }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -479,6 +479,15 @@ int wdb_parse(char * input, char * output) {
             } else {
                 result = wdb_parse_global_update_agent_keepalive(wdb, next, output);
             }
+        } else if (strcmp(query, "update-connection-status") == 0) {
+            if (!next) {
+                mdebug1("Global DB Invalid DB query syntax for update-connection-status.");
+                mdebug2("Global DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                result = OS_INVALID;
+            } else {
+                result = wdb_parse_global_update_connection_status(wdb, next, output);
+            }
         } else if (strcmp(query, "delete-agent") == 0) {
             if (!next) {
                 mdebug1("Global DB Invalid DB query syntax for delete-agent.");
@@ -654,8 +663,8 @@ int wdb_parse(char * input, char * output) {
             } else {
                 result = wdb_parse_global_sync_agent_info_set(wdb, next, output);
             }
-        } 
-        else if (strcmp(query, "get-agents-by-keepalive") == 0) { 
+        }
+        else if (strcmp(query, "get-agents-by-keepalive") == 0) {
             if (!next) {
                 mdebug1("Global DB Invalid DB query syntax for get-agents-by-keepalive.");
                 mdebug2("Global DB query error near: %s", query);
@@ -665,7 +674,7 @@ int wdb_parse(char * input, char * output) {
                 result = wdb_parse_global_get_agents_by_keepalive(wdb, next, output);
             }
         }
-        else if (strcmp(query, "get-all-agents") == 0) { 
+        else if (strcmp(query, "get-all-agents") == 0) {
             if (!next) {
                 mdebug1("Global DB Invalid DB query syntax for get-all-agents.");
                 mdebug2("Global DB query error near: %s", query);
@@ -4429,6 +4438,47 @@ int wdb_parse_global_update_agent_keepalive(wdb_t * wdb, char * input, char * ou
     return OS_SUCCESS;
 }
 
+int wdb_parse_global_update_connection_status(wdb_t * wdb, char * input, char * output) {
+    cJSON *agent_data = NULL;
+    const char *error = NULL;
+    cJSON *j_id = NULL;
+    cJSON *j_connection_status = NULL;
+
+    agent_data = cJSON_ParseWithOpts(input, &error, TRUE);
+    if (!agent_data) {
+        mdebug1("Global DB Invalid JSON syntax when updating agent connection status.");
+        mdebug2("Global DB JSON error near: %s", error);
+        snprintf(output, OS_MAXSTR + 1, "err Invalid JSON syntax, near '%.32s'", input);
+        return OS_INVALID;
+    } else {
+        j_id = cJSON_GetObjectItem(agent_data, "id");
+        j_connection_status = cJSON_GetObjectItem(agent_data, "connection_status");
+
+        if (cJSON_IsNumber(j_id) && cJSON_IsString(j_connection_status)) {
+            // Getting each field
+            int id = j_id->valueint;
+            char *connection_status = j_connection_status->valuestring;
+
+            if (OS_SUCCESS != wdb_global_update_agent_connection_status(wdb, id, connection_status)) {
+                mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB_GLOB_NAME, sqlite3_errmsg(wdb->db));
+                snprintf(output, OS_MAXSTR + 1, "err Cannot execute Global database query; %s", sqlite3_errmsg(wdb->db));
+                cJSON_Delete(agent_data);
+                return OS_INVALID;
+            }
+        } else {
+            mdebug1("Global DB Invalid JSON data when updating agent connection status.");
+            snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, near '%.32s'", input);
+            cJSON_Delete(agent_data);
+            return OS_INVALID;
+        }
+    }
+
+    snprintf(output, OS_MAXSTR + 1, "ok");
+    cJSON_Delete(agent_data);
+
+    return OS_SUCCESS;
+}
+
 int wdb_parse_global_delete_agent(wdb_t * wdb, char * input, char * output) {
     int agent_id = 0;
 
@@ -4907,7 +4957,7 @@ int wdb_parse_global_select_groups(wdb_t * wdb, char * output) {
 int wdb_parse_global_select_agent_keepalive(wdb_t * wdb, char * input, char * output) {
    char *out = NULL;
    char *next = NULL;
-   
+
    if (next = wstr_chr(input, ' '), !next) {
         mdebug1("Invalid DB query syntax.");
         mdebug2("DB query error near: %s", input);
@@ -4971,12 +5021,12 @@ int wdb_parse_global_sync_agent_info_set(wdb_t * wdb, char * input, char * outpu
     cJSON *json_value = NULL;
     cJSON *json_id = NULL;
 
-    /* 
+    /*
     * The cJSON_GetErrorPtr() method is not thread safe, using cJSON_ParseWithOpts() instead,
     * error indicates where the string caused an error.
-    * The third arguments is TRUE and it will give an error if the input string 
+    * The third arguments is TRUE and it will give an error if the input string
     * contains data after the JSON command
-    */ 
+    */
     root = cJSON_ParseWithOpts(input, &error, TRUE);
     if (!root) {
         mdebug1("Global DB Invalid JSON syntax updating unsynced agents.");
@@ -5020,7 +5070,7 @@ int wdb_parse_global_sync_agent_info_set(wdb_t * wdb, char * input, char * outpu
                     json_value = cJSON_GetObjectItem(json_label, "value");
                     json_id = cJSON_GetObjectItem(json_label, "id");
 
-                    if(cJSON_IsString(json_key) && json_key->valuestring != NULL && cJSON_IsString(json_value) && 
+                    if(cJSON_IsString(json_key) && json_key->valuestring != NULL && cJSON_IsString(json_value) &&
                         json_value->valuestring != NULL && cJSON_IsNumber(json_id)){
                         // Inserting labels in the database
                         if (OS_SUCCESS != wdb_global_set_agent_label(wdb, json_id->valueint, json_key->valuestring, json_value->valuestring)) {
@@ -5092,7 +5142,7 @@ int wdb_parse_global_get_agents_by_keepalive(wdb_t* wdb, char* input, char* outp
         return OS_INVALID;
     }
     keep_alive = atoi(next);
-    
+
     /* Get last_id*/
     next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL || strcmp(next, "last_id") != 0) {
@@ -5107,7 +5157,7 @@ int wdb_parse_global_get_agents_by_keepalive(wdb_t* wdb, char* input, char* outp
         return OS_INVALID;
     }
     last_id = atoi(next);
-    
+
     wdbc_result status = wdb_global_get_agents_by_keepalive(wdb, &last_id, comparator, keep_alive, &out);
     snprintf(output, OS_MAXSTR + 1, "%s %s", WDBC_RESULT[status], out);
 
@@ -5122,7 +5172,7 @@ int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output) {
     char *next = NULL;
     const char delim[2] = " ";
     char *savedptr = NULL;
-    
+
     /* Get last_id*/
     next = strtok_r(input, delim, &savedptr);
     if (next == NULL || strcmp(next, "last_id") != 0) {
@@ -5137,10 +5187,10 @@ int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output) {
         return OS_INVALID;
     }
     last_id = atoi(next);
-    
+
     wdbc_result status = wdb_global_get_all_agents(wdb, &last_id, &out);
     snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[status], out);
-    
+
     os_free(out)
 
     return OS_SUCCESS;


### PR DESCRIPTION
|Related issue|
|---|
| [Issue 6304](https://github.com/wazuh/wazuh/issues/6304) |

## Description

This PR includes all the necessary logic to have a new Wazuh DB command called `update-connection-status`. This new command allows a client to update the new `connection_status` column of an agent in `global.db` included as part of the development of the [Epic 5887](https://github.com/wazuh/wazuh/issues/5887).

For more details about the command, see the **Requirements** section of the [Issue 6304](https://github.com/wazuh/wazuh/issues/6304).

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)