### PR TITLE
6122 packages info on for Linux

### DIFF
--- a/src/shared_modules/dbsync/CMakeLists.txt
+++ b/src/shared_modules/dbsync/CMakeLists.txt
@@ -52,6 +52,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         POSITION_INDEPENDENT_CODE 0 # this is to avoid MinGW warning;
         # MinGW generates position-independent-code for DLL by default
   )
+else()
+  set_target_properties(dbsync PROPERTIES
+        LINK_FLAGS "-static-libgcc -static-libstdc++"
+  )
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/shared_modules/rsync/CMakeLists.txt
+++ b/src/shared_modules/rsync/CMakeLists.txt
@@ -52,7 +52,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         # MinGW generates position-independent-code for DLL by default
   )
   target_link_libraries(rsync crypto ssl ws2_32 crypt32)
-
+else()
+  set_target_properties(rsync PROPERTIES
+        LINK_FLAGS "-static-libgcc -static-libstdc++"
+  )
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     
 

--- a/src/wazuh_modules/syscollector/sysInfo.cpp
+++ b/src/wazuh_modules/syscollector/sysInfo.cpp
@@ -20,3 +20,8 @@ nlohmann::json SysInfo::hardware()
     getMemory(ret);
     return ret;
 }
+
+nlohmann::json SysInfo::packages()
+{
+    return getPackages();
+}

--- a/src/wazuh_modules/syscollector/sysInfo.hpp
+++ b/src/wazuh_modules/syscollector/sysInfo.hpp
@@ -27,7 +27,7 @@ private:
     virtual int getCpuMHz() const;
     virtual int getCpuCores() const;
     virtual void getMemory(nlohmann::json& info) const;
-    virtual nlohmann::json getPackages();
+    virtual nlohmann::json getPackages() const;
 };
 
 

--- a/src/wazuh_modules/syscollector/sysInfo.hpp
+++ b/src/wazuh_modules/syscollector/sysInfo.hpp
@@ -18,12 +18,14 @@ public:
 	SysInfo() = default;
 	virtual ~SysInfo() = default;
 	nlohmann::json hardware();
+	nlohmann::json packages();
 private:
     virtual std::string getSerialNumber();
     virtual std::string getCpuName();
     virtual int getCpuMHz();
     virtual int getCpuCores();
     virtual void getMemory(nlohmann::json& info);
+	virtual nlohmann::json getPackages();
 };
 
 

--- a/src/wazuh_modules/syscollector/sysInfoLinux.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoLinux.cpp
@@ -272,7 +272,7 @@ void SysInfo::getMemory(nlohmann::json& info) const
     info["ram_usage"] = 100 - (100*memFree/memTotal);
 }
 
-nlohmann::json SysInfo::getPackages()
+nlohmann::json SysInfo::getPackages() const
 {
     nlohmann::json packages;
     if (existDir(DPKG_PATH))

--- a/src/wazuh_modules/syscollector/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/syscollectorImp.cpp
@@ -33,7 +33,9 @@ void Syscollector::start()
     while(m_running)
     {
         const auto hw{m_info.hardware()};
-        std::cout << hw.dump() << std::endl;
+        const auto packages{m_info.packages()};
+        std::cout << packages[0].dump() << std::endl;
+        std::cout << hw[0].dump() << std::endl;
         std::this_thread::sleep_for(m_timeout);
     }
 }

--- a/src/wazuh_modules/syscollector/tests/sysInfo/sysInfo_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysInfo/sysInfo_test.cpp
@@ -25,6 +25,7 @@ std::string SysInfo::getCpuName(){return "";}
 int SysInfo::getCpuMHz(){return 0;}
 int SysInfo::getCpuCores(){return 0;}
 void SysInfo::getMemory(nlohmann::json&){}
+nlohmann::json SysInfo::getPackages(){return "";}
 
 class SysInfoWrapper: public SysInfo
 {
@@ -36,6 +37,7 @@ public:
     MOCK_METHOD(int, getCpuMHz, (), (override));
     MOCK_METHOD(int, getCpuCores, (), (override));
     MOCK_METHOD(void, getMemory, (nlohmann::json&), (override));
+    MOCK_METHOD(nlohmann::json, getPackages, (), (override));
 };
 
 
@@ -48,5 +50,13 @@ TEST_F(SysInfoTest, hardware)
     EXPECT_CALL(info, getCpuMHz()).WillOnce(Return(2902));
     EXPECT_CALL(info, getMemory(_));
     const auto result {info.hardware()};
+    EXPECT_FALSE(result.empty());
+}
+
+TEST_F(SysInfoTest, packages)
+{
+    SysInfoWrapper info;
+    EXPECT_CALL(info, getPackages()).WillOnce(Return("packages"));
+    const auto result {info.packages()};
     EXPECT_FALSE(result.empty());
 }

--- a/src/wazuh_modules/syscollector/tests/sysInfo/sysInfo_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysInfo/sysInfo_test.cpp
@@ -25,7 +25,7 @@ std::string SysInfo::getCpuName() const {return "";}
 int SysInfo::getCpuMHz() const {return 0;}
 int SysInfo::getCpuCores() const {return 0;}
 void SysInfo::getMemory(nlohmann::json&) const {}
-nlohmann::json SysInfo::getPackages(){return "";}
+nlohmann::json SysInfo::getPackages() const {return "";}
 
 class SysInfoWrapper: public SysInfo
 {
@@ -37,7 +37,7 @@ public:
     MOCK_METHOD(int, getCpuMHz, (), (const override));
     MOCK_METHOD(int, getCpuCores, (), (const override));
     MOCK_METHOD(void, getMemory, (nlohmann::json&), (const override));
-    MOCK_METHOD(nlohmann::json, getPackages, (), (override));
+    MOCK_METHOD(nlohmann::json, getPackages, (), (const override));
 };
 
 


### PR DESCRIPTION
# Packages Info on sysinfo for Linux

## **Related Issue**
[6122](https://github.com/wazuh/wazuh/issues/6122)

## Description
This issue aims to refactor the packages info provider for each os using C++ reducing the scope and responsibilities of the modules..
These changes have to be made in the various implementations according to the operating system targeted for this feature.

## DoD / Tasks
- [X] Implementation
- [X] Run testtool on Ubuntu
![image](https://user-images.githubusercontent.com/54002291/96882761-047d5e00-1456-11eb-8015-deefe6cf31c6.png)
- [X] Run testtool on Centos
Centos 8
![image](https://user-images.githubusercontent.com/54002291/96882832-15c66a80-1456-11eb-9baa-77e33ef86dde.png)
Centos 5
![image](https://user-images.githubusercontent.com/54002291/96883071-5a520600-1456-11eb-83d0-66b8f00da009.png)
- [X] SysInfo UT
![image](https://user-images.githubusercontent.com/54002291/96884252-b36e6980-1457-11eb-8af3-85470ac061dc.png)


