### PR TITLE
Fix client.keys permissions when created by enrollment_op

### DIFF
--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -393,6 +393,7 @@ static int w_enrollment_store_key_entry(const char* keys) {
     if (chmod(file.name, 0640) == -1) {
         merror(CHMOD_ERROR, file.name, errno, strerror(errno));
         fclose(file.fp);
+        unlink(file.name);
         return -1;
     }
 

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -389,6 +389,13 @@ static int w_enrollment_store_key_entry(const char* keys) {
         merror(FOPEN_ERROR, isChroot() ? AUTH_FILE : KEYSFILE_PATH, errno, strerror(errno));
         return -1;
     }
+
+    if (chmod(file.name, 0640) == -1) {
+        merror(CHMOD_ERROR, file.name, errno, strerror(errno));
+        fclose(file.fp);
+        return -1;
+    }
+
     fprintf(file.fp, "%s\n", keys);
     fclose(file.fp);
 

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -44,7 +44,8 @@ set(ENROLLMENT_OP_BASE_FLAGS "-Wl,--wrap=OS_IsValidIP,--wrap=_merror,--wrap=_mwa
 if(${TARGET} STREQUAL "winagent")
     list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS}")
 else()
-    list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS} -Wl,--wrap=fprintf,--wrap=gethostname,--wrap=getpid")
+    list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS} -Wl,--wrap=fprintf,--wrap=gethostname,--wrap=getpid \
+                                -Wl,--wrap=fgets,--wrap=chmod,--wrap=stat")
 endif()
 
 list(APPEND shared_tests_names "test_time_op")

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -10,6 +10,7 @@
 #include "os_auth/auth.h"
 
 #include "../wrappers/common.h"
+#include "../wrappers/posix/stat_wrappers.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/shared/validate_op_wrappers.h"
 #include "../wrappers/externals/openssl/bio_wrappers.h"
@@ -618,6 +619,29 @@ void test_w_enrollment_store_key_entry_cannot_open(void **state) {
     assert_int_equal(ret, -1);
 }
 
+#ifndef WIN32
+void test_w_enrollment_store_key_entry_chmod_fail(void **state) {
+    FILE file;
+    const char* key_string = "KEY EXAMPLE STRING";
+    char key_file[1024];
+
+    expect_string(__wrap_TempFile, source, KEYSFILE_PATH);
+    expect_value(__wrap_TempFile, copy, 0);
+    will_return(__wrap_TempFile, strdup("client.keys.temp"));
+    will_return(__wrap_TempFile, 6);
+    will_return(__wrap_TempFile, 0);
+
+    expect_string(__wrap_chmod, path, "client.keys.temp");
+    will_return(__wrap_chmod, -1);
+
+    snprintf(key_file, 1024, "(1127): Could not chmod object '%s' due to [(2)-(No such file or directory)].", "client.keys.temp");
+    expect_string(__wrap__merror, formatted_msg, key_file);
+
+    int ret = w_enrollment_store_key_entry(key_string);
+    assert_int_equal(ret, -1);
+}
+#endif
+
 void test_w_enrollment_store_key_entry_success(void **state) {
     FILE file;
     const char* key_string = "KEY EXAMPLE STRING";
@@ -635,6 +659,9 @@ void test_w_enrollment_store_key_entry_success(void **state) {
     will_return(__wrap_TempFile, strdup("client.keys.temp"));
     will_return(__wrap_TempFile, 6);
     will_return(__wrap_TempFile, 0);
+
+    expect_string(__wrap_chmod, path, "client.keys.temp");
+    will_return(__wrap_chmod, 0);
 
     expect_value(__wrap_fprintf, stream, 6);
     expect_string(__wrap_fprintf, formatted_msg, "KEY EXAMPLE STRING\n");
@@ -691,6 +718,9 @@ void test_w_enrollment_process_agent_key_valid_key(void **state) {
     will_return(__wrap_TempFile, strdup("client.keys.temp"));
     will_return(__wrap_TempFile, 4);
     will_return(__wrap_TempFile, 0);
+
+    expect_string(__wrap_chmod, path, "client.keys.temp");
+    will_return(__wrap_chmod, 0);
 
     expect_value(__wrap_fprintf, stream, 4);
     expect_string(__wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
@@ -785,6 +815,9 @@ void test_w_enrollment_process_response_success(void **state) {
         will_return(__wrap_TempFile, strdup("client.keys.temp"));
         will_return(__wrap_TempFile, 4);
         will_return(__wrap_TempFile, 0);
+
+        expect_string(__wrap_chmod, path, "client.keys.temp");
+        will_return(__wrap_chmod, 0);
 
         expect_value(__wrap_fprintf, stream, 4);
         expect_string(__wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
@@ -888,6 +921,9 @@ void test_w_enrollment_request_key(void **state) {
             will_return(__wrap_TempFile, strdup("client.keys.temp"));
             will_return(__wrap_TempFile, 4);
             will_return(__wrap_TempFile, 0);
+
+            expect_string(__wrap_chmod, path, "client.keys.temp");
+            will_return(__wrap_chmod, 0);
 
             expect_value(__wrap_fprintf, stream, 4);
             expect_string(__wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
@@ -1028,6 +1064,9 @@ int main()
         // w_enrollment_store_key_entry
         cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_null_key, setup_file_ops, teardown_file_ops),
         cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_cannot_open, setup_file_ops, teardown_file_ops),
+#ifndef WIN32
+        cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_chmod_fail, setup_file_ops, teardown_file_ops),
+#endif
         cmocka_unit_test_setup_teardown(test_w_enrollment_store_key_entry_success, setup_file_ops, teardown_file_ops),
         // w_enrollment_process_agent_key
         cmocka_unit_test(test_w_enrollment_process_agent_key_empty_buff),


### PR DESCRIPTION
|Related issue|
|---|
|6372|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

When client.keys is created by **enrollment_op.c**, **TempFile()** copies the permissions from existent src file (original client.keys). 
If the src file doesn't exist, the new file will only have owner permissions.
If the file is created by **agentd** during autoenrollment, the owner will be ossec, and will be no permission issues.
If the file is created by **agent-auth**, the owner is root, and ossec group will not have read permissions over the file.

In this PR, client.keys is set with permission 640 (read group permission for ossec) right after creating the temporary file that will finally replace old client.keys



## Logs/Alerts example

![image](https://user-images.githubusercontent.com/11434230/96821197-d409d580-13fd-11eb-9664-06e79b7d0296.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] MAC OS X
- [X] Source installation
- [x] Package installation
- [X] Review logs syntax and correct language
- [x] QA Integration Tests

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
