### PR TITLE
Expansion for password's regex

### DIFF
--- a/api/test/integration/test_security_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_POST_endpoints.tavern.yaml
@@ -730,6 +730,20 @@ stages:
     response:
       status_code: 200
 
+  - name: Create a new user (secure password 2)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      json:
+        username: "symbols"
+        password: "new_user1A!@#~½¬?¿ñàÀ"
+        allow_run_as: true
+      method: POST
+    response:
+      status_code: 200
+
   - name: Create a new user (user already exists)
     request:
       verify: False

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -19,7 +19,7 @@ from wazuh.rbac.orm import AuthenticationManager, PoliciesManager, RolesManager,
 from wazuh.rbac.orm import SecurityError
 
 # Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character:
-_user_password = re.compile(r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[_@$!%*?&-])[A-Za-z\d@$!%*?&-_]{8,}$')
+_user_password = re.compile(r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$')
 
 
 def get_user_me():


### PR DESCRIPTION
|Related issue|
|---|
|#6380|

Hi team,

This PR closes #6380. In this PR, we have expanded the regular expression in charge of validating user passwords to accept any type of character. We also created an integrated test to check that it works correctly.

Regards

```
adriiiprodri@wazuh pytest -vv test_security_POST_endpoints.tavern.yaml
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.5, pytest-6.1.1, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/adriiiprodri/Desktop/git/wazuh/api/test/integration, configfile: pytest.ini
plugins: tavern-1.7.0
collected 6 items                                                                                                                                                         

test_security_POST_endpoints.tavern.yaml::POST /security/roles PASSED                                                                                               [ 16%]
test_security_POST_endpoints.tavern.yaml::POST /security/rules PASSED                                                                                               [ 33%]
test_security_POST_endpoints.tavern.yaml::POST /security/policies PASSED                                                                                            [ 50%]
test_security_POST_endpoints.tavern.yaml::POST /security/roles/{role_id}/policies/{policy_id} PASSED                                                                [ 66%]
test_security_POST_endpoints.tavern.yaml::POST /security/roles/{role_id}/rules PASSED                                                                               [ 83%]
test_security_POST_endpoints.tavern.yaml::POST /security/user/{username}/roles/{role_id} PASSED                                                                     [100%]

================================================================ 6 passed, 7 warnings in 114.11s (0:01:54) ================================================================

```
