### PR TITLE
Agents' connection status management by remoted - Implementation

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -153,7 +153,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
 
         agent_id = atoi(key->id);
 
-        result = wdb_update_agent_keepalive(agent_id, logr.worker_node?"syncreq":"synced", wdb_sock);
+        result = wdb_update_agent_keepalive(agent_id, AGENT_CS_ACTIVE, logr.worker_node?"syncreq":"synced", wdb_sock);
 
         if (OS_SUCCESS != result)
             mwarn("Unable to save agent last keepalive in global.db");
@@ -178,7 +178,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
             w_mutex_unlock(&lastmsg_mutex);
             agent_id = atoi(key->id);
 
-            if (OS_SUCCESS != wdb_update_agent_keepalive(agent_id, logr.worker_node?"syncreq":"synced", wdb_sock)) {
+            if (OS_SUCCESS != wdb_update_agent_keepalive(agent_id, AGENT_CS_PENDING, logr.worker_node?"syncreq":"synced", wdb_sock)) {
                 mwarn("Unable to set last keepalive as pending");
             }
         } else {
@@ -237,6 +237,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
             }
 
             agent_data->id = atoi(key->id);
+            os_strdup(AGENT_CS_ACTIVE, agent_data->connection_status);
             os_strdup(logr.worker_node ? "syncreq" : "synced", agent_data->sync_status);
 
             // Updating version and keepalive in global.db

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -156,7 +156,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
         result = wdb_update_agent_keepalive(agent_id, AGENT_CS_ACTIVE, logr.worker_node?"syncreq":"synced", wdb_sock);
 
         if (OS_SUCCESS != result)
-            mwarn("Unable to save agent last keepalive in global.db");
+            mwarn("Unable to save last keepalive and set connection status as active for agent: %s", key->id);
     } else {
         if (!data) {
             os_calloc(1, sizeof(pending_data_t), data);
@@ -178,8 +178,10 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
             w_mutex_unlock(&lastmsg_mutex);
             agent_id = atoi(key->id);
 
-            if (OS_SUCCESS != wdb_update_agent_keepalive(agent_id, AGENT_CS_PENDING, logr.worker_node?"syncreq":"synced", wdb_sock)) {
-                mwarn("Unable to set last keepalive as pending");
+            result = wdb_update_agent_keepalive(agent_id, AGENT_CS_PENDING, logr.worker_node?"syncreq":"synced", wdb_sock);
+
+            if (OS_SUCCESS != result) {
+                mwarn("Unable to save last keepalive and set connection status as pending for agent: %s", key->id);
             }
         } else {
             /* Update message */

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -11,6 +11,7 @@
 #include "shared.h"
 #include "os_net/os_net.h"
 #include "remoted.h"
+#include "wazuh_db/wdb.h"
 
 /* Global variables */
 int sender_pool;
@@ -241,6 +242,10 @@ void * rem_handler_main(__attribute__((unused)) void * args) {
     char buffer[OS_MAXSTR + 1] = "";
     int wdb_sock = -1;
     mdebug1("Message handler thread started.");
+
+    // Reset all the agents' connection status in Wazuh DB
+    if (OS_SUCCESS != wdb_reset_agents_connection(&wdb_sock))
+        mwarn("Unable to reset the agents' connection status. Possible incorrect statuses until the agents get connected to the manager.");
 
     while (1) {
         message = rem_msgpop();

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -104,6 +104,10 @@ void HandleSecure()
         }
     }
 
+    // Reset all the agents' connection status in Wazuh DB
+    if (OS_SUCCESS != wdb_reset_agents_connection(NULL))
+        mwarn("Unable to reset the agents' connection status. Possible incorrect statuses until the agents get connected to the manager.");
+
     // Create message handler thread pool
     {
         int worker_pool = getDefine_Int("remoted", "worker_pool", 1, 16);
@@ -242,10 +246,6 @@ void * rem_handler_main(__attribute__((unused)) void * args) {
     char buffer[OS_MAXSTR + 1] = "";
     int wdb_sock = -1;
     mdebug1("Message handler thread started.");
-
-    // Reset all the agents' connection status in Wazuh DB
-    if (OS_SUCCESS != wdb_reset_agents_connection(&wdb_sock))
-        mwarn("Unable to reset the agents' connection status. Possible incorrect statuses until the agents get connected to the manager.");
 
     while (1) {
         message = rem_msgpop();

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -992,6 +992,7 @@ void test_wdb_update_agent_data_error_json(void **state)
     os_strdup("nodename", agent_data->node_name);
     os_strdup("agentip", agent_data->agent_ip);
     os_strdup("\"label1\":value1\n\"label2\":value2", agent_data->labels);
+    os_strdup("active", agent_data->connection_status);
     os_strdup("syncreq", agent_data->sync_status);
 
     will_return(__wrap_cJSON_CreateObject, NULL);
@@ -1031,6 +1032,7 @@ void test_wdb_update_agent_data_error_socket(void **state)
     os_strdup("nodename", agent_data->node_name);
     os_strdup("agentip", agent_data->agent_ip);
     os_strdup("\"label1\":value1\n\"label2\":value2", agent_data->labels);
+    os_strdup("active", agent_data->connection_status);
     os_strdup("syncreq", agent_data->sync_status);
 
     const char *json_str = strdup("{\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
@@ -1038,13 +1040,13 @@ void test_wdb_update_agent_data_error_socket(void **state)
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
 \"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
-\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":\"syncreq\"}");
+\"\"label1\":value1\n\"label2\":value2\",\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
     const char *query_str = "global update-agent-data {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
 \"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
-\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":\"syncreq\"}";
+\"\"label1\":value1\n\"label2\":value2\",\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}";
 
     const char *response = "err";
 
@@ -1069,6 +1071,8 @@ void test_wdb_update_agent_data_error_socket(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
     expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
     expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "active");
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_name");
@@ -1109,7 +1113,7 @@ void test_wdb_update_agent_data_error_socket(void **state)
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
 \"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
-\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":\"syncreq\"}");
+\"\"label1\":value1\n\"label2\":value2\",\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
 
     ret = wdb_update_agent_data(agent_data, NULL);
 
@@ -1144,6 +1148,7 @@ void test_wdb_update_agent_data_error_sql_execution(void **state)
     os_strdup("nodename", agent_data->node_name);
     os_strdup("agentip", agent_data->agent_ip);
     os_strdup("\"label1\":value1\n\"label2\":value2", agent_data->labels);
+    os_strdup("active", agent_data->connection_status);
     os_strdup("syncreq", agent_data->sync_status);
 
     const char *json_str = strdup("{\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
@@ -1151,13 +1156,13 @@ void test_wdb_update_agent_data_error_sql_execution(void **state)
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
 \"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
-\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":\"syncreq\"}");
+\"\"label1\":value1\n\"label2\":value2\",\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
     const char *query_str = "global update-agent-data {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
 \"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
-\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":\"syncreq\"}";
+\"\"label1\":value1\n\"label2\":value2\",\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}";
 
     const char *response = "err";
 
@@ -1182,6 +1187,8 @@ void test_wdb_update_agent_data_error_sql_execution(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
     expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
     expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "active");
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_name");
@@ -1222,7 +1229,7 @@ void test_wdb_update_agent_data_error_sql_execution(void **state)
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
 \"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
-\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":\"syncreq\"}");
+\"\"label1\":value1\n\"label2\":value2\",\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
 
     ret = wdb_update_agent_data(agent_data, NULL);
 
@@ -1257,6 +1264,7 @@ void test_wdb_update_agent_data_error_result(void **state)
     os_strdup("nodename", agent_data->node_name);
     os_strdup("agentip", agent_data->agent_ip);
     os_strdup("\"label1\":value1\n\"label2\":value2", agent_data->labels);
+    os_strdup("active", agent_data->connection_status);
     os_strdup("syncreq", agent_data->sync_status);
 
     const char *json_str = strdup("{\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
@@ -1264,13 +1272,13 @@ void test_wdb_update_agent_data_error_result(void **state)
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
 \"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
-\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":\"syncreq\"}");
+\"\"label1\":value1\n\"label2\":value2\",\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
     const char *query_str = "global update-agent-data {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
 \"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
-\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":\"syncreq\"}";
+\"\"label1\":value1\n\"label2\":value2\",\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}";
 
     const char *response = "err";
 
@@ -1295,6 +1303,8 @@ void test_wdb_update_agent_data_error_result(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
     expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
     expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "active");
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_name");
@@ -1365,6 +1375,7 @@ void test_wdb_update_agent_data_success(void **state)
     os_strdup("nodename", agent_data->node_name);
     os_strdup("agentip", agent_data->agent_ip);
     os_strdup("\"label1\":value1\n\"label2\":value2", agent_data->labels);
+    os_strdup("active", agent_data->connection_status);
     os_strdup("syncreq", agent_data->sync_status);
 
     const char *json_str = strdup("{\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
@@ -1372,13 +1383,13 @@ void test_wdb_update_agent_data_success(void **state)
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
 \"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
-\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":\"syncreq\"}");
+\"\"label1\":value1\n\"label2\":value2\",\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
     const char *query_str = "global update-agent-data {\"id\": 1,\"os_name\":\"osname\",\"os_version\":\"osversion\",\
 \"os_major\":\"osmajor\",\"os_minor\":\"osminor\",\"os_codename\":\"oscodename\",\
 \"os_platform\":\"osplatform\",\"os_build\":\"osbuild\",\"os_uname\":\"osuname\",\
 \"os_arch\":\"osarch\",\"version\":\"version\",\"config_sum\":\"csum\",\"merged_sum\":\"msum\",\
 \"manager_host\":\"managerhost\",\"node_name\":\"nodename\",\"agent_ip\":\"agentip\",\"labels\":\
-\"\"label1\":value1\n\"label2\":value2\",\"sync_status\":\"syncreq\"}";
+\"\"label1\":value1\n\"label2\":value2\",\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}";
     const char *response = "ok";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1402,6 +1413,8 @@ void test_wdb_update_agent_data_success(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "agentip");
     expect_string(__wrap_cJSON_AddStringToObject, name, "labels");
     expect_string(__wrap_cJSON_AddStringToObject, string, "\"label1\":value1\n\"label2\":value2");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "active");
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "syncreq");
     expect_string(__wrap_cJSON_AddStringToObject, name, "os_name");
@@ -1614,13 +1627,14 @@ void test_wdb_update_agent_keepalive_error_json(void **state)
 {
     int ret = 0;
     int id = 1;
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_cJSON_CreateObject, NULL);
 
     expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
 
-    ret = wdb_update_agent_keepalive(id, sync_status, NULL);
+    ret = wdb_update_agent_keepalive(id, connection_status, sync_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -1629,10 +1643,11 @@ void test_wdb_update_agent_keepalive_error_socket(void **state)
 {
     int ret = 0;
     int id = 1;
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
-    const char *json_str = strdup("{\"id\":1,\"sync_status\":\"synced\"}");
-    const char *query_str = "global update-keepalive {\"id\":1,\"sync_status\":\"synced\"}";
+    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}");
+    const char *query_str = "global update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1642,6 +1657,8 @@ void test_wdb_update_agent_keepalive_error_socket(void **state)
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "active");
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "synced");
 
@@ -1658,9 +1675,9 @@ void test_wdb_update_agent_keepalive_error_socket(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error in the response from socket");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-keepalive {\"id\":1,\"sync_status\":\"synced\"}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}");
 
-    ret = wdb_update_agent_keepalive(id, sync_status, NULL);
+    ret = wdb_update_agent_keepalive(id, connection_status, sync_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -1669,10 +1686,11 @@ void test_wdb_update_agent_keepalive_error_sql_execution(void **state)
 {
     int ret = 0;
     int id = 1;
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
-    const char *json_str = strdup("{\"id\":1,\"sync_status\":\"synced\"}");
-    const char *query_str = "global update-keepalive {\"id\":1,\"sync_status\":\"synced\"}";
+    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}");
+    const char *query_str = "global update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1682,6 +1700,8 @@ void test_wdb_update_agent_keepalive_error_sql_execution(void **state)
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "active");
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "synced");
 
@@ -1698,9 +1718,9 @@ void test_wdb_update_agent_keepalive_error_sql_execution(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-keepalive {\"id\":1,\"sync_status\":\"synced\"}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}");
 
-    ret = wdb_update_agent_keepalive(id, sync_status, NULL);
+    ret = wdb_update_agent_keepalive(id, connection_status, sync_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -1709,10 +1729,11 @@ void test_wdb_update_agent_keepalive_error_result(void **state)
 {
     int ret = 0;
     int id = 1;
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
-    const char *json_str = strdup("{\"id\":1,\"sync_status\":\"synced\"}");
-    const char *query_str = "global update-keepalive {\"id\":1,\"sync_status\":\"synced\"}";
+    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}");
+    const char *query_str = "global update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1722,6 +1743,8 @@ void test_wdb_update_agent_keepalive_error_result(void **state)
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "active");
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "synced");
 
@@ -1741,7 +1764,7 @@ void test_wdb_update_agent_keepalive_error_result(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error reported in the result of the query");
 
-    ret = wdb_update_agent_keepalive(id, sync_status, NULL);
+    ret = wdb_update_agent_keepalive(id, connection_status, sync_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -1750,10 +1773,11 @@ void test_wdb_update_agent_keepalive_success(void **state)
 {
     int ret = 0;
     int id = 1;
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
-    const char *json_str = strdup("{\"id\":1,\"sync_status\":\"synced\"}");
-    const char *query_str = "global update-keepalive {\"id\":1,\"sync_status\":\"synced\"}";
+    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}");
+    const char *query_str = "global update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}";
     const char *response = "ok";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1763,6 +1787,8 @@ void test_wdb_update_agent_keepalive_success(void **state)
     // Adding data to JSON
     expect_string(__wrap_cJSON_AddNumberToObject, name, "id");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "active");
     expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "synced");
 
@@ -1781,7 +1807,7 @@ void test_wdb_update_agent_keepalive_success(void **state)
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
-    ret = wdb_update_agent_keepalive(id, sync_status, NULL);
+    ret = wdb_update_agent_keepalive(id, connection_status, sync_status, NULL);
 
     assert_int_equal(OS_SUCCESS, ret);
 }

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -1294,12 +1294,13 @@ void test_wdb_global_update_agent_name_transaction_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = NULL;
 
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_update_agent_name(data->wdb, atoi(data->wdb->id), name);
+    result = wdb_global_update_agent_name(data->wdb, agent_id, name);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1308,13 +1309,14 @@ void test_wdb_global_update_agent_name_cache_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = NULL;
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_update_agent_name(data->wdb, atoi(data->wdb->id), name);
+    result = wdb_global_update_agent_name(data->wdb, agent_id, name);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1323,6 +1325,7 @@ void test_wdb_global_update_agent_name_bind1_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     char *name = "test_name";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1334,11 +1337,10 @@ void test_wdb_global_update_agent_name_bind1_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_name(data->wdb, atoi(data->wdb->id), name);
+    result = wdb_global_update_agent_name(data->wdb, agent_id, name);
 
     assert_int_equal(result, OS_INVALID);
 }
-
 
 void test_wdb_global_update_agent_name_bind2_fail(void **state)
 {
@@ -1421,6 +1423,7 @@ void test_wdb_global_update_agent_version_transaction_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = NULL;
     const char *os_version = NULL;
     const char *os_major = NULL;
@@ -1436,14 +1439,15 @@ void test_wdb_global_update_agent_version_transaction_fail(void **state)
     const char *manager_host = NULL;
     const char *node_name = NULL;
     const char *agent_ip = NULL;
+    const char *connection_status = NULL;
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1452,6 +1456,7 @@ void test_wdb_global_update_agent_version_cache_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = NULL;
     const char *os_version = NULL;
     const char *os_major = NULL;
@@ -1467,6 +1472,7 @@ void test_wdb_global_update_agent_version_cache_fail(void **state)
     const char *manager_host = NULL;
     const char *node_name = NULL;
     const char *agent_ip = NULL;
+    const char *connection_status = NULL;
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1474,9 +1480,9 @@ void test_wdb_global_update_agent_version_cache_fail(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1485,6 +1491,7 @@ void test_wdb_global_update_agent_version_bind1_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -1500,6 +1507,7 @@ void test_wdb_global_update_agent_version_bind1_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1512,9 +1520,9 @@ void test_wdb_global_update_agent_version_bind1_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1523,6 +1531,7 @@ void test_wdb_global_update_agent_version_bind2_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -1538,6 +1547,7 @@ void test_wdb_global_update_agent_version_bind2_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1553,9 +1563,9 @@ void test_wdb_global_update_agent_version_bind2_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1564,6 +1574,7 @@ void test_wdb_global_update_agent_version_bind3_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -1579,6 +1590,7 @@ void test_wdb_global_update_agent_version_bind3_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1598,9 +1610,9 @@ void test_wdb_global_update_agent_version_bind3_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1609,6 +1621,7 @@ void test_wdb_global_update_agent_version_bind4_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -1624,6 +1637,7 @@ void test_wdb_global_update_agent_version_bind4_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1646,9 +1660,9 @@ void test_wdb_global_update_agent_version_bind4_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1657,6 +1671,7 @@ void test_wdb_global_update_agent_version_bind5_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -1672,6 +1687,7 @@ void test_wdb_global_update_agent_version_bind5_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1697,9 +1713,9 @@ void test_wdb_global_update_agent_version_bind5_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1708,6 +1724,7 @@ void test_wdb_global_update_agent_version_bind6_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -1723,6 +1740,7 @@ void test_wdb_global_update_agent_version_bind6_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1751,9 +1769,9 @@ void test_wdb_global_update_agent_version_bind6_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1762,6 +1780,7 @@ void test_wdb_global_update_agent_version_bind7_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -1777,6 +1796,7 @@ void test_wdb_global_update_agent_version_bind7_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1808,9 +1828,9 @@ void test_wdb_global_update_agent_version_bind7_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1819,6 +1839,7 @@ void test_wdb_global_update_agent_version_bind8_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -1834,6 +1855,7 @@ void test_wdb_global_update_agent_version_bind8_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1868,9 +1890,9 @@ void test_wdb_global_update_agent_version_bind8_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1879,6 +1901,7 @@ void test_wdb_global_update_agent_version_bind9_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -1894,6 +1917,7 @@ void test_wdb_global_update_agent_version_bind9_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1931,9 +1955,9 @@ void test_wdb_global_update_agent_version_bind9_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1942,6 +1966,7 @@ void test_wdb_global_update_agent_version_bind10_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -1957,6 +1982,7 @@ void test_wdb_global_update_agent_version_bind10_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1997,9 +2023,9 @@ void test_wdb_global_update_agent_version_bind10_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2008,6 +2034,7 @@ void test_wdb_global_update_agent_version_bind11_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -2023,6 +2050,7 @@ void test_wdb_global_update_agent_version_bind11_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -2066,9 +2094,9 @@ void test_wdb_global_update_agent_version_bind11_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2077,6 +2105,7 @@ void test_wdb_global_update_agent_version_bind12_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -2092,6 +2121,7 @@ void test_wdb_global_update_agent_version_bind12_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -2138,9 +2168,9 @@ void test_wdb_global_update_agent_version_bind12_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2149,6 +2179,7 @@ void test_wdb_global_update_agent_version_bind13_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -2164,6 +2195,7 @@ void test_wdb_global_update_agent_version_bind13_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -2213,9 +2245,9 @@ void test_wdb_global_update_agent_version_bind13_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2224,6 +2256,7 @@ void test_wdb_global_update_agent_version_bind14_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -2239,6 +2272,7 @@ void test_wdb_global_update_agent_version_bind14_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -2291,9 +2325,9 @@ void test_wdb_global_update_agent_version_bind14_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2302,6 +2336,7 @@ void test_wdb_global_update_agent_version_bind15_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -2317,6 +2352,7 @@ void test_wdb_global_update_agent_version_bind15_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -2372,9 +2408,9 @@ void test_wdb_global_update_agent_version_bind15_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2383,6 +2419,7 @@ void test_wdb_global_update_agent_version_bind16_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -2398,6 +2435,7 @@ void test_wdb_global_update_agent_version_bind16_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -2449,16 +2487,16 @@ void test_wdb_global_update_agent_version_bind16_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agent_ip);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 16);
-    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2467,6 +2505,7 @@ void test_wdb_global_update_agent_version_bind17_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -2482,6 +2521,7 @@ void test_wdb_global_update_agent_version_bind17_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -2533,19 +2573,111 @@ void test_wdb_global_update_agent_version_bind17_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agent_ip);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 16);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 17);
+    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
+
+
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
+
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
+                                            os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_update_agent_version_bind18_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    const char *os_name = "test_name";
+    const char *os_version = "test_version";
+    const char *os_major = "test_major";
+    const char *os_minor = "test_minor";
+    const char *os_codename = "test_codename";
+    const char *os_platform = "test_platform";
+    const char *os_build = "test_build";
+    const char *os_uname = "test_uname";
+    const char *os_arch = "test_arch";
+    const char *version = "test_version";
+    const char *config_sum = "test_config";
+    const char *merged_sum = "test_merged";
+    const char *manager_host = "test_manager";
+    const char *node_name = "test_node";
+    const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
+    const char *sync_status = "synced";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, os_name);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, buffer, os_version);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_value(__wrap_sqlite3_bind_text, buffer, os_major);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 4);
+    expect_value(__wrap_sqlite3_bind_text, buffer, os_minor);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_value(__wrap_sqlite3_bind_text, buffer, os_codename);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_value(__wrap_sqlite3_bind_text, buffer, os_platform);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_value(__wrap_sqlite3_bind_text, buffer, os_build);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 8);
+    expect_value(__wrap_sqlite3_bind_text, buffer, os_uname);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 9);
+    expect_value(__wrap_sqlite3_bind_text, buffer, os_arch);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 10);
+    expect_value(__wrap_sqlite3_bind_text, buffer, version);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 11);
+    expect_value(__wrap_sqlite3_bind_text, buffer, config_sum);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 12);
+    expect_value(__wrap_sqlite3_bind_text, buffer, merged_sum);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 13);
+    expect_value(__wrap_sqlite3_bind_text, buffer, manager_host);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 14);
+    expect_value(__wrap_sqlite3_bind_text, buffer, node_name);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 15);
+    expect_value(__wrap_sqlite3_bind_text, buffer, agent_ip);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 16);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 17);
     expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 17);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, index, 18);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2554,6 +2686,7 @@ void test_wdb_global_update_agent_version_step_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -2569,6 +2702,7 @@ void test_wdb_global_update_agent_version_step_fail(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -2620,19 +2754,22 @@ void test_wdb_global_update_agent_version_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agent_ip);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 16);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 17);
     expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 17);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, index, 18);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2641,6 +2778,7 @@ void test_wdb_global_update_agent_version_success(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
     const char *os_name = "test_name";
     const char *os_version = "test_version";
     const char *os_major = "test_major";
@@ -2656,6 +2794,7 @@ void test_wdb_global_update_agent_version_success(void **state)
     const char *manager_host = "test_manager";
     const char *node_name = "test_node";
     const char *agent_ip = "test_ip";
+    const char *connection_status = "active";
     const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -2707,16 +2846,19 @@ void test_wdb_global_update_agent_version_success(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agent_ip);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 16);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 17);
     expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 17);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, index, 18);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_update_agent_version(data->wdb, atoi(data->wdb->id), os_name, os_version, os_major,
+    result = wdb_global_update_agent_version(data->wdb, agent_id, os_name, os_version, os_major,
                                             os_minor, os_codename, os_platform, os_build, os_uname, os_arch, version,
-                                            config_sum, merged_sum, manager_host, node_name, agent_ip, sync_status);
+                                            config_sum, merged_sum, manager_host, node_name, agent_ip, connection_status, sync_status);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -2726,14 +2868,15 @@ void test_wdb_global_update_agent_version_success(void **state)
 void test_wdb_global_update_agent_keepalive_transaction_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    const char *connection_status = "active";
     const char *status = "synced";
 
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_update_agent_keepalive(data->wdb, atoi(data->wdb->id), status);
+    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2741,15 +2884,16 @@ void test_wdb_global_update_agent_keepalive_transaction_fail(void **state)
 void test_wdb_global_update_agent_keepalive_cache_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    const char *connection_status = "active";
     const char *status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_update_agent_keepalive(data->wdb, atoi(data->wdb->id), status);
+    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2757,21 +2901,22 @@ void test_wdb_global_update_agent_keepalive_cache_fail(void **state)
 void test_wdb_global_update_agent_keepalive_bind1_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    const char *connection_status = "active";
     const char *status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
-    expect_value(__wrap_sqlite3_bind_text, buffer, status);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_keepalive(data->wdb, atoi(data->wdb->id), status);
+    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2779,24 +2924,54 @@ void test_wdb_global_update_agent_keepalive_bind1_fail(void **state)
 void test_wdb_global_update_agent_keepalive_bind2_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    const char *connection_status = "active";
     const char *status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, buffer, status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
+
+    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_update_agent_keepalive_bind3_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    const char *connection_status = "active";
+    const char *status = "synced";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, index, 3);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_keepalive(data->wdb, atoi(data->wdb->id), status);
+    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2804,25 +2979,29 @@ void test_wdb_global_update_agent_keepalive_bind2_fail(void **state)
 void test_wdb_global_update_agent_keepalive_step_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    const char *connection_status = "active";
     const char *status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, index, 3);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_update_agent_keepalive(data->wdb, atoi(data->wdb->id), status);
+    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2830,22 +3009,26 @@ void test_wdb_global_update_agent_keepalive_step_fail(void **state)
 void test_wdb_global_update_agent_keepalive_success(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
+    int agent_id = 1;
+    const char *connection_status = "active";
     const char *status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, index, 3);
+    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_update_agent_keepalive(data->wdb, atoi(data->wdb->id), status);
+    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -5689,6 +5872,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_version_bind15_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_version_bind16_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_version_bind17_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_version_bind18_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_version_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_version_success, test_setup, test_teardown),
         /* Tests wdb_global_update_agent_keepalive */
@@ -5696,6 +5880,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_keepalive_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_keepalive_bind1_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_keepalive_bind2_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_keepalive_bind3_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_keepalive_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_keepalive_success, test_setup, test_teardown),
         /* Tests wdb_global_update_agent_connection_status */

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -401,7 +401,7 @@ void test_wdb_parse_global_update_agent_data_query_error(void **state)
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
-    \"sync_status\":\"syncreq\"}";
+    \"connection_status\":\"active\",\"sync_status\":\"syncreq\"}";
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg,
@@ -409,7 +409,7 @@ void test_wdb_parse_global_update_agent_data_query_error(void **state)
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
-    \"sync_status\":\"syncreq\"}");
+    \"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
 
     expect_value(__wrap_wdb_global_update_agent_version, id, 1);
     expect_string(__wrap_wdb_global_update_agent_version, os_name, "test_name");
@@ -427,6 +427,7 @@ void test_wdb_parse_global_update_agent_data_query_error(void **state)
     expect_string(__wrap_wdb_global_update_agent_version, manager_host, "test_manager");
     expect_string(__wrap_wdb_global_update_agent_version, node_name, "test_node");
     expect_string(__wrap_wdb_global_update_agent_version, agent_ip, "test_ip");
+    expect_string(__wrap_wdb_global_update_agent_version, connection_status, "active");
     expect_string(__wrap_wdb_global_update_agent_version, sync_status, "syncreq");
 
     will_return(__wrap_wdb_global_update_agent_version, OS_INVALID);
@@ -448,7 +449,7 @@ void test_wdb_parse_global_update_agent_data_invalid_data(void **state)
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
-    \"sync_status\":\"syncreq\"}";
+    \"connection_status\":\"active\",\"sync_status\":\"syncreq\"}";
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg,
@@ -456,7 +457,7 @@ void test_wdb_parse_global_update_agent_data_invalid_data(void **state)
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
-    \"sync_status\":\"syncreq\"}");
+    \"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
 
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when updating agent version.");
 
@@ -474,7 +475,7 @@ void test_wdb_parse_global_update_agent_data_success(void **state)
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
-    \"sync_status\":\"syncreq\"}";
+    \"connection_status\":\"active\",\"sync_status\":\"syncreq\"}";
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg,
@@ -482,7 +483,7 @@ void test_wdb_parse_global_update_agent_data_success(void **state)
     \"os_major\":\"test_major\",\"os_minor\":\"test_minor\",\"os_codename\":\"test_codename\",\"os_platform\":\"test_platform\",\
     \"os_build\":\"test_build\",\"os_uname\":\"test_uname\",\"os_arch\":\"test_arch\",\"version\":\"test_version\",\"config_sum\":\
     \"test_config\",\"merged_sum\":\"test_merged\",\"manager_host\":\"test_manager\",\"node_name\":\"test_node\",\"agent_ip\":\"test_ip\",\
-    \"sync_status\":\"syncreq\"}");
+    \"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
 
     expect_value(__wrap_wdb_global_update_agent_version, id, 1);
     expect_string(__wrap_wdb_global_update_agent_version, os_name, "test_name");
@@ -500,6 +501,7 @@ void test_wdb_parse_global_update_agent_data_success(void **state)
     expect_string(__wrap_wdb_global_update_agent_version, manager_host, "test_manager");
     expect_string(__wrap_wdb_global_update_agent_version, node_name, "test_node");
     expect_string(__wrap_wdb_global_update_agent_version, agent_ip, "test_ip");
+    expect_string(__wrap_wdb_global_update_agent_version, connection_status, "active");
     expect_string(__wrap_wdb_global_update_agent_version, sync_status, "syncreq");
     will_return(__wrap_wdb_global_update_agent_version, OS_SUCCESS);
 
@@ -743,15 +745,15 @@ void test_wdb_parse_global_update_agent_keepalive_invalid_data(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global update-keepalive {\"id\":1,\"sync_status\":null}";
+    char query[OS_BUFFER_SIZE] = "global update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":null}";
 
     will_return(__wrap_wdb_open_global, data->wdb);
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-keepalive {\"id\":1,\"sync_status\":null}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":null}");
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON data when updating agent keepalive.");
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, "err Invalid JSON data, near '{\"id\":1,\"sync_status\":null}'");
+    assert_string_equal(data->output, "err Invalid JSON data, near '{\"id\":1,\"connection_status\":\"act'");
     assert_int_equal(ret, OS_INVALID);
 }
 
@@ -759,14 +761,15 @@ void test_wdb_parse_global_update_agent_keepalive_query_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global update-keepalive {\"id\":1,\"sync_status\":\"syncreq\"}";
+    char query[OS_BUFFER_SIZE] = "global update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}";
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_value(__wrap_wdb_global_update_agent_keepalive, id, 1);
+    expect_string(__wrap_wdb_global_update_agent_keepalive, connection_status, "active");
     expect_string(__wrap_wdb_global_update_agent_keepalive, status, "syncreq");
     will_return(__wrap_wdb_global_update_agent_keepalive, OS_INVALID);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-keepalive {\"id\":1,\"sync_status\":\"syncreq\"}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
 
@@ -780,14 +783,15 @@ void test_wdb_parse_global_update_agent_keepalive_success(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global update-keepalive {\"id\":1,\"sync_status\":\"syncreq\"}";
+    char query[OS_BUFFER_SIZE] = "global update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}";
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_value(__wrap_wdb_global_update_agent_keepalive, id, 1);
+    expect_string(__wrap_wdb_global_update_agent_keepalive, connection_status, "active");
     expect_string(__wrap_wdb_global_update_agent_keepalive, status, "syncreq");
     will_return(__wrap_wdb_global_update_agent_keepalive, OS_SUCCESS);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-keepalive {\"id\":1,\"sync_status\":\"syncreq\"}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-keepalive {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"syncreq\"}");
 
     ret = wdb_parse(query, data->output);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -58,6 +58,7 @@ int __wrap_wdb_global_update_agent_version( __attribute__((unused)) wdb_t *wdb,
                                             const char *manager_host,
                                             const char *node_name,
                                             const char *agent_ip,
+                                            const char *connection_status,
                                             const char *sync_status) {
     check_expected(id);
     check_expected(os_name);
@@ -75,6 +76,7 @@ int __wrap_wdb_global_update_agent_version( __attribute__((unused)) wdb_t *wdb,
     check_expected(manager_host);
     check_expected(node_name);
     check_expected(agent_ip);
+    check_expected(connection_status);
     check_expected(sync_status);
 
     return mock();
@@ -104,8 +106,10 @@ int __wrap_wdb_global_set_agent_label(  __attribute__((unused)) wdb_t *wdb,
 
 int __wrap_wdb_global_update_agent_keepalive(__attribute__((unused)) wdb_t *wdb,
                                             int id,
+                                            char* connection_status,
                                             char* status) {
     check_expected(id);
+    check_expected(connection_status);
     check_expected(status);
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -34,6 +34,7 @@ int __wrap_wdb_global_update_agent_version(wdb_t *wdb,
                                     const char *manager_host,
                                     const char *node_name,
                                     const char *agent_ip,
+                                    const char *connection_status,
                                     const char *sync_status);
 
 cJSON* __wrap_wdb_global_get_agent_labels(wdb_t *wdb, int id);
@@ -42,7 +43,7 @@ int __wrap_wdb_global_del_agent_labels(wdb_t *wdb, int id);
 
 int __wrap_wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value);
 
-int __wrap_wdb_global_update_agent_keepalive(wdb_t *wdb, int id, char* status);
+int __wrap_wdb_global_update_agent_keepalive(wdb_t *wdb, int id, char* connection_status, char* status);
 
 int __wrap_wdb_global_update_agent_connection_status(wdb_t *wdb, int id, char* connection_status);
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -112,12 +112,12 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_MITRE_NAME_GET] = "SELECT name FROM attack WHERE id = ?;",
     [WDB_STMT_GLOBAL_INSERT_AGENT] = "INSERT INTO agent (id, name, ip, register_ip, internal_key, date_add, `group`) VALUES (?,?,?,?,?,?,?);",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_NAME] = "UPDATE agent SET name = ? WHERE id = ?;",
-    [WDB_STMT_GLOBAL_UPDATE_AGENT_VERSION] = "UPDATE agent SET os_name = ?, os_version = ?, os_major = ?, os_minor = ?, os_codename = ?, os_platform = ?, os_build = ?, os_uname = ?, os_arch = ?, version = ?, config_sum = ?, merged_sum = ?, manager_host = ?, node_name = ?, last_keepalive = (CASE WHEN id = 0 THEN 253402300799 ELSE STRFTIME('%s', 'NOW') END), sync_status = ? WHERE id = ?;",
-    [WDB_STMT_GLOBAL_UPDATE_AGENT_VERSION_IP] = "UPDATE agent SET os_name = ?, os_version = ?, os_major = ?, os_minor = ?, os_codename = ?, os_platform = ?, os_build = ?, os_uname = ?, os_arch = ?, version = ?, config_sum = ?, merged_sum = ?, manager_host = ?, node_name = ?, last_keepalive = (CASE WHEN id = 0 THEN 253402300799 ELSE STRFTIME('%s', 'NOW') END), ip = ?, sync_status = ? WHERE id = ?;",
+    [WDB_STMT_GLOBAL_UPDATE_AGENT_VERSION] = "UPDATE agent SET os_name = ?, os_version = ?, os_major = ?, os_minor = ?, os_codename = ?, os_platform = ?, os_build = ?, os_uname = ?, os_arch = ?, version = ?, config_sum = ?, merged_sum = ?, manager_host = ?, node_name = ?, last_keepalive = (CASE WHEN id = 0 THEN 253402300799 ELSE STRFTIME('%s', 'NOW') END), connection_status = ?, sync_status = ? WHERE id = ?;",
+    [WDB_STMT_GLOBAL_UPDATE_AGENT_VERSION_IP] = "UPDATE agent SET os_name = ?, os_version = ?, os_major = ?, os_minor = ?, os_codename = ?, os_platform = ?, os_build = ?, os_uname = ?, os_arch = ?, version = ?, config_sum = ?, merged_sum = ?, manager_host = ?, node_name = ?, last_keepalive = (CASE WHEN id = 0 THEN 253402300799 ELSE STRFTIME('%s', 'NOW') END), ip = ?, connection_status = ?, sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_LABELS_GET] = "SELECT * FROM labels WHERE id = ?;",
     [WDB_STMT_GLOBAL_LABELS_DEL] = "DELETE FROM labels WHERE id = ?;",
     [WDB_STMT_GLOBAL_LABELS_SET] = "INSERT INTO labels (id, key, value) VALUES (?,?,?);",
-    [WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE] = "UPDATE agent SET last_keepalive = CASE WHEN last_keepalive IS NULL THEN 0 ELSE STRFTIME('%s', 'NOW') END, sync_status = ? WHERE id = ?;",
+    [WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE] = "UPDATE agent SET last_keepalive = CASE WHEN last_keepalive IS NULL THEN 0 ELSE STRFTIME('%s', 'NOW') END, connection_status = ?, sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_CONNECTION_STATUS] = "UPDATE agent SET connection_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_DELETE_AGENT] = "DELETE FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_SELECT_AGENT_NAME] = "SELECT name FROM agent WHERE id = ?;",
@@ -1071,6 +1071,7 @@ void wdb_free_agent_info_data(agent_info_data *agent_data) {
         os_free(agent_data->node_name);
         os_free(agent_data->agent_ip);
         os_free(agent_data->labels);
+        os_free(agent_data->connection_status);
         os_free(agent_data->sync_status);
         if (agent_data->osd) {
             os_free(agent_data->osd->os_name);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -49,6 +49,11 @@
 #define WDB_MAX_COMMAND_SIZE    512
 #define WDB_MAX_RESPONSE_SIZE   OS_MAXSTR-WDB_MAX_COMMAND_SIZE
 
+#define AGENT_CS_NEVER_CONNECTED "never_connected"
+#define AGENT_CS_PENDING         "pending"
+#define AGENT_CS_ACTIVE          "active"
+#define AGENT_CS_DISCONNECTED    "disconnected"
+
 typedef enum wdb_stmt {
     WDB_STMT_FIM_LOAD,
     WDB_STMT_FIM_FIND_ENTRY,
@@ -262,6 +267,7 @@ typedef struct agent_info_data {
     char *node_name;
     char *agent_ip;
     char *labels;
+    char *connection_status;
     char *sync_status;
 } agent_info_data;
 
@@ -458,11 +464,12 @@ int wdb_update_agent_data(agent_info_data *agent_data, int *sock);
  * @brief Update agent's last keepalive and modifies the cluster synchronization status.
  *
  * @param[in] id Id of the agent for whom the keepalive must be updated.
+ * @param[in] connection_status String with the connection status to be set.
  * @param[in] sync_status String with the cluster synchronization status to be set.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return OS_SUCCESS on success or OS_INVALID on failure.
  */
-int wdb_update_agent_keepalive(int id, const char *sync_status, int *sock);
+int wdb_update_agent_keepalive(int id, const char *connection_status, const char *sync_status, int *sock);
 
 /**
  * @brief Update agent's connection status.
@@ -1464,6 +1471,7 @@ int wdb_global_update_agent_name(wdb_t *wdb, int id, char* name);
  * @param [in] manager_host The agent's manager host name.
  * @param [in] node_name The agent's manager node name.
  * @param [in] agent_ip The agent's IP address.
+ * @param [in] connection_status The agent's connection status.
  * @param [in] sync_status The agent's synchronization status in cluster.
  * @return Returns 0 on success or -1 on error.
  */
@@ -1484,6 +1492,7 @@ int wdb_global_update_agent_version(wdb_t *wdb,
                                     const char *manager_host,
                                     const char *node_name,
                                     const char *agent_ip,
+                                    const char *connection_status,
                                     const char *sync_status);
 
 /**
@@ -1520,10 +1529,11 @@ int wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value);
  *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
+ * @param [in] connection_status The agent's connection status.
  * @param [in] status The value of sync_status
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, const char *sync_status);
+int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, const char *connection_status, const char *sync_status);
 
 /**
  * @brief Function to update an agent connection status.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -142,6 +142,7 @@ int wdb_global_update_agent_version(wdb_t *wdb,
                                     const char *manager_host,
                                     const char *node_name,
                                     const char *agent_ip,
+                                    const char *connection_status,
                                     const char *sync_status)
 {
     sqlite3_stmt *stmt = NULL;
@@ -220,6 +221,10 @@ int wdb_global_update_agent_version(wdb_t *wdb,
             merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
             return OS_INVALID;
         }
+    }
+    if (sqlite3_bind_text(stmt, index++, connection_status, -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return OS_INVALID;
     }
     if (sqlite3_bind_text(stmt, index++, sync_status, -1, NULL) != SQLITE_OK) {
         merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
@@ -341,7 +346,7 @@ int wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value) {
     }
 }
 
-int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, const char* sync_status) {
+int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, const char *connection_status, const char* sync_status) {
     sqlite3_stmt *stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
@@ -356,11 +361,15 @@ int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, const char* sync_statu
 
     stmt = wdb->stmt[WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE];
 
-    if (sqlite3_bind_text(stmt, 1, sync_status, -1, NULL) != SQLITE_OK) {
+    if (sqlite3_bind_text(stmt, 1, connection_status, -1, NULL) != SQLITE_OK) {
         merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }
-    if (sqlite3_bind_int(stmt, 2, id) != SQLITE_OK) {
+    if (sqlite3_bind_text(stmt, 2, sync_status, -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return OS_INVALID;
+    }
+    if (sqlite3_bind_int(stmt, 3, id) != SQLITE_OK) {
         merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -243,6 +243,7 @@ void wm_sync_manager() {
         manager_data->id = 0;
         os_strdup(os_uname, manager_data->osd->os_uname);
         os_strdup(__ossec_name " " __ossec_version, manager_data->version);
+        os_strdup(AGENT_CS_ACTIVE, manager_data->connection_status);
         os_strdup("synced", manager_data->sync_status);
 
         wdb_update_agent_data(manager_data, &wdb_wmdb_sock);


### PR DESCRIPTION
|Related issue|
|---|
| [Issue 6305](https://github.com/wazuh/wazuh/issues/6305) |

## Description

This PR implements all the necessary logic to make **remoted** be able to manage the connection status of the agents in Wazuh DB. It will update the agents' connection status when receives different messages from the agents. In addition, it will reset the connection status of all the agents during its initialization.

For more details about the implemented changes, check the **requirements** section in the [Issue 6305](https://github.com/wazuh/wazuh/issues/6305).

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind