### PR TITLE
Improve the user check in shared.sh

### DIFF
--- a/src/init/shared.sh
+++ b/src/init/shared.sh
@@ -14,14 +14,13 @@ UNAME=`uname -snr`
 NUNAME=`uname`
 
 # If whoami does not exist, try id
-ls "`command -v whoami`" > /dev/null 2>&1
-if [ ! $? = 0 ]; then
+if command -v whoami > /dev/null 2>&1 ; then
+    ME=`whoami 2>/dev/null`
+else
     ME=`id | cut -d " " -f 1`
     if [ "X${ME}" = "Xuid=0(root)" ]; then
         ME="root"
     fi
-else
-    ME=`whoami 2>/dev/null`
 fi
 
 OSSEC_INIT="/etc/ossec-init.conf"

--- a/src/init/shared.sh
+++ b/src/init/shared.sh
@@ -15,7 +15,7 @@ NUNAME=`uname`
 
 # If whoami does not exist, try id
 if command -v whoami > /dev/null 2>&1 ; then
-    ME=`whoami 2>/dev/null`
+    ME=`whoami`
 else
     ME=`id | cut -d " " -f 1`
     if [ "X${ME}" = "Xuid=0(root)" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|#6406|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

This issue closes #6406 by fixing and improving the check for root users in `shared.sh`. Now, the check is UNIX compatible and improves shell syntax.

## Configuration options

NA

## Logs/Alerts example

NA

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
