### PR TITLE
6352 packages bsd

### DIFF
--- a/src/shared_modules/dbsync/CMakeLists.txt
+++ b/src/shared_modules/dbsync/CMakeLists.txt
@@ -52,7 +52,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         POSITION_INDEPENDENT_CODE 0 # this is to avoid MinGW warning;
         # MinGW generates position-independent-code for DLL by default
   )
-else()
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set_target_properties(dbsync PROPERTIES
         LINK_FLAGS "-static-libgcc -static-libstdc++"
   )

--- a/src/shared_modules/rsync/CMakeLists.txt
+++ b/src/shared_modules/rsync/CMakeLists.txt
@@ -52,7 +52,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         # MinGW generates position-independent-code for DLL by default
   )
   target_link_libraries(rsync crypto ssl ws2_32 crypt32)
-else()
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set_target_properties(rsync PROPERTIES
         LINK_FLAGS "-static-libgcc -static-libstdc++"
   )

--- a/src/shared_modules/utils/filesystemHelper.h
+++ b/src/shared_modules/utils/filesystemHelper.h
@@ -1,0 +1,60 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * October 23, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _FILESYSTEM_HELPER_H
+#define _FILESYSTEM_HELPER_H
+
+#include <string>
+#include <iostream>
+#include <cstdio>
+#include <memory>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+namespace Utils
+{
+    static bool existsDir(const std::string& path)
+    {
+        struct stat info{};
+        return !stat(path.c_str(), &info) && (info.st_mode & S_IFDIR);
+    }
+    struct DirSmartDeleter
+    {
+        void operator()(DIR* dir)
+        {
+            closedir(dir);
+        }
+    };
+
+    std::vector<std::string> enumerateDir(const std::string& path)
+    {
+        std::vector<std::string> ret;
+        std::unique_ptr<DIR, DirSmartDeleter> spDir{opendir(path.c_str())};
+        if (spDir)
+        {
+            auto entry{readdir(spDir.get())};
+            while (entry)
+            {
+                ret.push_back(entry->d_name);
+                entry = readdir(spDir.get());
+            }
+        }
+        return ret;
+    }
+}
+
+#pragma GCC diagnostic pop
+
+#endif // _FILESYSTEM_HELPER_H

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -117,6 +117,17 @@ namespace Utils
         }
         return false;
     }
+
+    static bool endsWith(const std::string& str, const std::string& ending)
+    {
+        if (!str.empty() && str.length() >= ending.length())
+        {
+            const auto endLength{ ending.length()};
+            const auto token{ str.substr(str.length() - endLength, endLength) };
+            return token == ending;
+        }
+        return false;
+    }
 }
 
 #pragma GCC diagnostic pop

--- a/src/shared_modules/utils/tests/filesystemHelper_test.cpp
+++ b/src/shared_modules/utils/tests/filesystemHelper_test.cpp
@@ -1,0 +1,41 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * October 23, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "filesystemHelper_test.h"
+#include "filesystemHelper.h"
+
+void FilesystemUtilsTest::SetUp() {};
+
+void FilesystemUtilsTest::TearDown() {};
+#ifdef WIN32
+TEST_F(FilesystemUtilsTest, FilesystemExistsDir)
+{
+    EXPECT_TRUE(Utils::existsDir(R"(C:\)"));
+}
+
+TEST_F(FilesystemUtilsTest, FilesystemEnumerateDir)
+{
+	const auto items {Utils::enumerateDir(R"(C:\)")};
+    EXPECT_FALSE(items.empty());
+}
+
+#else
+TEST_F(FilesystemUtilsTest, FilesystemExistsDir)
+{
+    EXPECT_TRUE(Utils::existsDir(R"(/usr)"));
+}
+
+TEST_F(FilesystemUtilsTest, FilesystemEnumerateDir)
+{
+	const auto items {Utils::enumerateDir(R"(/usr)")};
+    EXPECT_FALSE(items.empty());
+}
+#endif

--- a/src/shared_modules/utils/tests/filesystemHelper_test.cpp
+++ b/src/shared_modules/utils/tests/filesystemHelper_test.cpp
@@ -23,7 +23,7 @@ TEST_F(FilesystemUtilsTest, FilesystemExistsDir)
 
 TEST_F(FilesystemUtilsTest, FilesystemEnumerateDir)
 {
-	const auto items {Utils::enumerateDir(R"(C:\)")};
+    const auto items {Utils::enumerateDir(R"(C:\)")};
     EXPECT_FALSE(items.empty());
 }
 
@@ -35,7 +35,7 @@ TEST_F(FilesystemUtilsTest, FilesystemExistsDir)
 
 TEST_F(FilesystemUtilsTest, FilesystemEnumerateDir)
 {
-	const auto items {Utils::enumerateDir(R"(/usr)")};
+    const auto items {Utils::enumerateDir(R"(/usr)")};
     EXPECT_FALSE(items.empty());
 }
 #endif

--- a/src/shared_modules/utils/tests/filesystemHelper_test.h
+++ b/src/shared_modules/utils/tests/filesystemHelper_test.h
@@ -1,0 +1,26 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * October 23, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef FILESYSTEM_HELPER_TESTS_H
+#define FILESYSTEM_HELPER_TESTS_H
+#include "gtest/gtest.h"
+
+class FilesystemUtilsTest : public ::testing::Test
+{
+protected:
+
+    FilesystemUtilsTest() = default;
+    virtual ~FilesystemUtilsTest() = default;
+
+    void SetUp() override;
+    void TearDown() override;
+};
+#endif //FILESYSTEM_HELPER_TESTS_H

--- a/src/wazuh_modules/syscollector/sysInfoFreeBSD.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoFreeBSD.cpp
@@ -85,3 +85,25 @@ std::string SysInfo::getSerialNumber() const
 {
     return "unknown";
 }
+
+nlohmann::json SysInfo::getPackages() const
+{
+    nlohmann::json ret;
+    const auto query{Utils::exec(R"(pkg query -a "%n|%m|%v|%q|%c")")};
+    if (!query.empty())
+    {
+        const auto lines{Utils::split(query, "\n")};
+        for (const auto& line : lines)
+        {
+            const auto data{Utils::split(line, "|")};
+            nlohmann::json package;
+            package["name"] = data[0];
+            package["vendor"] = data[1];
+            package["version"] = data[2];
+            package["architecture"] = data[3];
+            package["description"] = data[4];
+            ret.push_back(package);
+        }
+    }
+    return ret;
+}

--- a/src/wazuh_modules/syscollector/sysInfoFreeBSD.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoFreeBSD.cpp
@@ -92,10 +92,10 @@ nlohmann::json SysInfo::getPackages() const
     const auto query{Utils::exec(R"(pkg query -a "%n|%m|%v|%q|%c")")};
     if (!query.empty())
     {
-        const auto lines{Utils::split(query, "\n")};
+        const auto lines{Utils::split(query, '\n')};
         for (const auto& line : lines)
         {
-            const auto data{Utils::split(line, "|")};
+            const auto data{Utils::split(line, '|')};
             nlohmann::json package;
             package["name"] = data[0];
             package["vendor"] = data[1];

--- a/src/wazuh_modules/syscollector/sysInfoLinux.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoLinux.cpp
@@ -11,9 +11,8 @@
 #include "sysInfo.hpp"
 #include <fstream>
 #include <iostream>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include "stringHelper.h"
+#include "filesystemHelper.h"
 #include "cmdHelper.h"
 
 constexpr auto WM_SYS_HW_DIR{"/sys/class/dmi/id/board_serial"};
@@ -21,12 +20,6 @@ constexpr auto WM_SYS_CPU_DIR{"/proc/cpuinfo"};
 constexpr auto WM_SYS_MEM_DIR{"/proc/meminfo"};
 constexpr auto DPKG_PATH {"/var/lib/dpkg/"};
 constexpr auto DPKG_STATUS_PATH {"/var/lib/dpkg/status"};
-
-static bool existDir(const std::string& path)
-{
-    struct stat info{};
-    return !stat(path.c_str(), &info) && (info.st_mode & S_IFDIR);
-}
 
 static void parseLineAndFillMap(const std::string& line, const std::string& separator, std::map<std::string, std::string>& systemInfo)
 {
@@ -283,7 +276,7 @@ void SysInfo::getMemory(nlohmann::json& info) const
 nlohmann::json SysInfo::getPackages() const
 {
     nlohmann::json packages;
-    if (existDir(DPKG_PATH))
+    if (Utils::existsDir(DPKG_PATH))
     {
         packages.push_back(getDpkgInfo(DPKG_STATUS_PATH));
     }

--- a/src/wazuh_modules/syscollector/sysInfoMac.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoMac.cpp
@@ -95,16 +95,32 @@ static nlohmann::json parseAppInfo(const std::string& path)
 {
     nlohmann::json ret;
     std::fstream file{path, std::ios_base::in};
+    static const auto getValueFnc{[](const std::string& val){return Utils::rightTrim(Utils::rightTrim(val, "<"), ">");}};
     if (file.is_open())
     {
-        while(file.good())
+        std::string line;
+        while(std::getline(file, line))
         {
-            std::string line;
-            std::vector<std::string> data;
-            while(std::getline(file, line))
+            line = Utils::trim(line);
+            if (line == "<key>CFBundleName</key>" &&
+                std::getline(file, line))
             {
-                data.push_back(line + "\n");
-                std::cout << line << std::endl
+                ret["name"] = getValueFnc(line);
+            }
+            else if (line == "<key>CFBundleShortVersionString</key>" &&
+                std::getline(file, line))
+            {
+                ret["version"] = getValueFnc(line);
+            }
+            else if (line == "<key>LSApplicationCategoryType</key>" &&
+                std::getline(file, line))
+            {
+                ret["group"] = getValueFnc(line);
+            }
+            else if (line == "<key>CFBundleIdentifier</key>" &&
+                std::getline(file, line))
+            {
+                ret["description"] = getValueFnc(line);
             }
         }
     }

--- a/src/wazuh_modules/syscollector/sysInfoMac.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoMac.cpp
@@ -11,7 +11,10 @@
 #include "sysInfo.hpp"
 #include "cmdHelper.h"
 #include "stringHelper.h"
+#include "filesystemHelper.h"
 #include <sys/sysctl.h>
+
+constexpr auto MAC_APPS_PATH{"/Applications"};
 
 void SysInfo::getMemory(nlohmann::json& info) const
 {
@@ -84,4 +87,15 @@ std::string SysInfo::getSerialNumber() const
 {
     const auto rawData{Utils::exec("system_profiler SPHardwareDataType | grep Serial")};
     return Utils::trim(rawData.substr(rawData.find(":")), " :\t\r\n");
+}
+
+nlohmann::json SysInfo::getPackages() const
+{
+    nlohmann::json ret;
+    const auto apps{Utils::enumerateDir(MAC_APPS_PATH)};
+    for(const auto& app : apps)
+    {
+        std::cout << app << std::endl;
+    }
+    return ret;
 }

--- a/src/wazuh_modules/syscollector/sysInfoMac.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoMac.cpp
@@ -13,8 +13,10 @@
 #include "stringHelper.h"
 #include "filesystemHelper.h"
 #include <sys/sysctl.h>
+#include <fstream>
 
 constexpr auto MAC_APPS_PATH{"/Applications"};
+constexpr auto APP_INFO_PATH{"Contents/Info.plist"};
 
 void SysInfo::getMemory(nlohmann::json& info) const
 {
@@ -89,6 +91,26 @@ std::string SysInfo::getSerialNumber() const
     return Utils::trim(rawData.substr(rawData.find(":")), " :\t\r\n");
 }
 
+static nlohmann::json parseAppInfo(const std::string& path)
+{
+    nlohmann::json ret;
+    std::fstream file{path, std::ios_base::in};
+    if (file.is_open())
+    {
+        while(file.good())
+        {
+            std::string line;
+            std::vector<std::string> data;
+            while(std::getline(file, line))
+            {
+                data.push_back(line + "\n");
+                std::cout << line << std::endl
+            }
+        }
+    }
+    return ret;
+}
+
 nlohmann::json SysInfo::getPackages() const
 {
     nlohmann::json ret;
@@ -97,7 +119,9 @@ nlohmann::json SysInfo::getPackages() const
     {
         if (Utils::endsWith(app, ".app"))
         {
-            std::cout << app << std::endl;
+            const auto path{app + "\\" + APP_INFO_PATH};
+            std::cout << path << std::endl;
+            parseAppInfo(path);
         }
     }
     return ret;

--- a/src/wazuh_modules/syscollector/sysInfoMac.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoMac.cpp
@@ -95,7 +95,10 @@ nlohmann::json SysInfo::getPackages() const
     const auto apps{Utils::enumerateDir(MAC_APPS_PATH)};
     for(const auto& app : apps)
     {
-        std::cout << app << std::endl;
+        if (Utils::endsWith(app, ".app"))
+        {
+            std::cout << app << std::endl;
+        }
     }
     return ret;
 }

--- a/src/wazuh_modules/syscollector/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/syscollectorImp.cpp
@@ -32,8 +32,8 @@ void Syscollector::start()
 {
     while(m_running)
     {
-        const auto hw{m_info.hardware()};
-        const auto packages{m_info.packages()};
+        const auto& hw{m_info.hardware()};
+        const auto& packages{m_info.packages()};
         std::cout << packages.dump() << std::endl;
         std::cout << hw.dump() << std::endl;
         std::this_thread::sleep_for(m_timeout);

--- a/src/wazuh_modules/syscollector/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/syscollectorImp.cpp
@@ -34,8 +34,8 @@ void Syscollector::start()
     {
         const auto hw{m_info.hardware()};
         const auto packages{m_info.packages()};
-        std::cout << packages[0].dump() << std::endl;
-        std::cout << hw[0].dump() << std::endl;
+        std::cout << packages.dump() << std::endl;
+        std::cout << hw.dump() << std::endl;
         std::this_thread::sleep_for(m_timeout);
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|#6352|

## **Description**

This issue aims to make use of the generic synchronization libraries, to use the synchronization solution algorithm that both shared modules provide.

These changes have to be made in the various implementations according to the operating system targeted for this feature.

## **DoD**
- [X] Implementation
- [X] **Run testtool on MAC**
![image](https://user-images.githubusercontent.com/54002291/97173617-9bf0f280-176f-11eb-85a9-6ea43cab9cc3.png)
- [X] **Run testtool on FreeBSD**
![image](https://user-images.githubusercontent.com/54002291/97173650-add29580-176f-11eb-840a-d9e183c0f334.png)
- [X] **RTR
![image](https://user-images.githubusercontent.com/54002291/97173791-e5d9d880-176f-11eb-82ce-4ed865d5cbd3.png)
- **SysInfo UTs:**
> **Linux:**
![image](https://user-images.githubusercontent.com/54002291/97174884-74028e80-1771-11eb-9d9b-a3f6c22618a2.png)
> **Windows:**
![image](https://user-images.githubusercontent.com/54002291/97178850-d4e09580-1776-11eb-8e98-d98bdca1de5b.png)




