### PR TITLE
Add HTML reports for the API integration tests

### DIFF
--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -4,14 +4,17 @@ import re
 import shutil
 import subprocess
 import time
+import uuid
 from base64 import b64encode
 
 import pytest
 import requests
 import urllib3
 import yaml
+from py.xml import html
 
 current_path = os.path.dirname(os.path.abspath(__file__))
+results = dict()
 
 with open('common.yaml', 'r') as stream:
     common = yaml.safe_load(stream)['variables']
@@ -275,3 +278,112 @@ def api_test(request):
             values['retries'] += 1
     clean_tmp_folder()
     down_env()
+
+
+# HTML report
+class HTMLStyle(html):
+    class body(html.body):
+        style = html.Style(background_color='#F0F0EE')
+
+    class table(html.table):
+        style = html.Style(border='2px solid #005E8C', margin='16px 0px', color='#005E8C',
+                           font_size='15px')
+
+    class colored_td(html.td):
+        style = html.Style(color='#005E8C', padding='5px', border='2px solid #005E8C', text_align='left',
+                           white_space='pre-wrap', font_size='14px')
+
+    class td(html.td):
+        style = html.Style(padding='5px', border='2px solid #005E8C', text_align='left',
+                           white_space='pre-wrap', font_size='14px')
+
+    class th(html.th):
+        style = html.Style(color='#0094ce', padding='5px', border='2px solid #005E8C', text_align='left',
+                           font_weight='bold', font_size='15px')
+
+    class h1(html.h1):
+        style = html.Style(color='#0094ce')
+
+    class h2(html.h2):
+        style = html.Style(color='#0094ce')
+
+    class h3(html.h3):
+        style = html.Style(color='#0094ce')
+
+
+def pytest_html_results_table_header(cells):
+    cells.insert(2, html.th('Stages'))
+    # Remove links
+    cells.pop()
+
+
+def pytest_html_results_table_row(report, cells):
+    try:
+        # Replace the original full name for the test case name
+        cells[1] = HTMLStyle.colored_td(report.test_name)
+        # Insert test stages
+        cells.insert(2, HTMLStyle.colored_td(report.stages))
+        # Replace duration with the colored_td style
+        cells[3] = HTMLStyle.colored_td(cells[3][0])
+        # Remove link rows
+        cells.pop()
+    except AttributeError:
+        pass
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    # Define HTML style
+    pytest_html = item.config.pluginmanager.getplugin('html')
+    pytest_html.html.body = HTMLStyle.body
+    pytest_html.html.table = HTMLStyle.table
+    pytest_html.html.th = HTMLStyle.th
+    pytest_html.html.td = HTMLStyle.td
+    pytest_html.html.h1 = HTMLStyle.h1
+    pytest_html.html.h2 = HTMLStyle.h2
+    pytest_html.html.h3 = HTMLStyle.h3
+
+    outcome = yield
+    report = outcome.get_result()
+
+    # Store the test case name
+    report.test_name = item.spec['test_name']
+
+    # Store the test case stages
+    report.stages = list()
+    for stage in item.spec['stages']:
+        report.stages.extend((stage['name'], html.br()))
+
+    if report.location[0] not in results:
+        results[report.location[0]] = {'passed': 0, 'failed': 0, 'skipped': 0, 'xfailed': 0, 'error': 0}
+
+    if report.when == 'call':
+        if report.longrepr is not None and report.longreprtext.split()[-1] == 'XFailed':
+            results[report.location[0]]['xfailed'] += 1
+        else:
+            results[report.location[0]][report.outcome] += 1
+
+    elif report.outcome == 'failed':
+        results[report.location[0]]['error'] += 1
+
+
+def pytest_html_results_summary(prefix, summary, postfix):
+    postfix.extend([HTMLStyle.table(
+        html.thead(
+            html.tr([
+                HTMLStyle.th("Tests"),
+                HTMLStyle.th("Success"),
+                HTMLStyle.th("Failed"),
+                HTMLStyle.th("XFail"),
+                HTMLStyle.th("Error")]
+            ),
+        ),
+        [html.tbody(
+            html.tr([
+                HTMLStyle.td(k),
+                HTMLStyle.td(v['passed']),
+                HTMLStyle.td(v['failed']),
+                HTMLStyle.td(v['xfailed']),
+                HTMLStyle.td(v['error']),
+            ])
+        ) for k, v in results.items()])])

--- a/api/test/integration/pytest.ini
+++ b/api/test/integration/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
+render_collapsed = True
 tavern-strict=json:off headers:off
 tavern-global-cfg=common.yaml

--- a/api/test/integration/run_tests.py
+++ b/api/test/integration/run_tests.py
@@ -59,7 +59,7 @@ def collect_non_excluded_tests():
     return collected_tests
 
 
-def run_tests(collected_tests, n_iterations=1, html_report=False):
+def run_tests(collected_tests, n_iterations=1):
     os.chdir(TESTS_PATH)
     for test in collected_tests:
         for i in range(1, n_iterations + 1):
@@ -67,8 +67,7 @@ def run_tests(collected_tests, n_iterations=1, html_report=False):
             test_name = f'{test.rsplit(".")[0]}{i if i != 1 else ""}'
             print(f'{test} {iteration_info}')
             f = open(os.path.join(RESULTS_PATH, test_name), 'w')
-            html_params = [f"--html={RESULTS_PATH}/html_reports/{test_name}.html", '--self-contained-html'] \
-                if html_report else []
+            html_params = [f"--html={RESULTS_PATH}/html_reports/{test_name}.html", '--self-contained-html']
             subprocess.call(PYTEST_COMMAND.split(' ') + html_params + [test], stdout=f)
             f.close()
             get_results(filename=os.path.join(RESULTS_PATH, test_name))
@@ -103,8 +102,6 @@ def get_script_arguments():
                              '"both".', action='store')
     parser.add_argument('-i', '--iterations', dest='iterations', default=1, type=int,
                         help='Specify how many times will every test be run. Default 1.', action='store')
-    parser.add_argument('-html', '--html_report', dest='html', default=False,
-                        help='Specify if an HTML report should be generated. Default None.', action='store_true')
 
     return parser.parse_args()
 
@@ -119,10 +116,9 @@ if __name__ == '__main__':
     results = options.results
     rbac_arg = options.rbac
     iterations = options.iterations
-    html = options.html
 
     if results:
         get_results()
     else:
         tests = collect_non_excluded_tests() if exclude else collect_tests(test_list=tl, keyword=key, rbac=rbac_arg)
-        run_tests(collected_tests=tests, n_iterations=iterations, html_report=html)
+        run_tests(collected_tests=tests, n_iterations=iterations)


### PR DESCRIPTION
Hello team, this closes #6400 .

This PR adds a new feature to the API integration tests in order to see the results/logs in an HTML report. This is an example of a report for the `active-response` base integration tests:

![image](https://user-images.githubusercontent.com/37274979/97193475-551fee80-17a9-11eb-841e-0697eaa136b8.png)

A detailed log with the error will show up when clicking the *show details* link in case there are errors/failed tests.

In addition, the `run_tests` script has been updated to generate this report for every run test when adding the `-html` parameter. These reports will be self-contained. The command for the result above was the following:
```shell
python3 run_tests.py -k active-response -rbac no -html
```

Due to the lack of `module` scoped fixtures in tavern, a report will be generated for every run test instead of summing them all up in a single one. Once tavern implements this feature, we will be able to achieve this adapting the automated testing script.

**UPDATE:** The HTML report will always be generated when using the script. The `-html` parameter has been removed.

Regards,
Víctor. 