### PR TITLE
Fix API/framework unit test leftovers

### DIFF
--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -4,6 +4,7 @@
 
 
 import logging
+import os
 from unittest.mock import patch, MagicMock, call
 
 import pytest
@@ -25,14 +26,17 @@ def test_accesslogger_log(mock_logger_info):
 @patch('wazuh.core.wlogging.WazuhLogger.__init__')
 def test_apilogger_init(mock_wazuhlogger):
     """Check parameters are as expected when calling __init__ method"""
-    alogging.APILogger(log_path='test_path', foreground_mode=False, debug_level='info',
+    current_logger_path = os.path.join(os.path.dirname(__file__), 'testing.log')
+    alogging.APILogger(log_path=current_logger_path, foreground_mode=False, debug_level='info',
                        logger_name='wazuh')
 
-    assert mock_wazuhlogger.call_args.kwargs['log_path'] == 'test_path'
+    assert mock_wazuhlogger.call_args.kwargs['log_path'] == current_logger_path
     assert not mock_wazuhlogger.call_args.kwargs['foreground_mode']
     assert mock_wazuhlogger.call_args.kwargs['debug_level'] == 'info'
     assert mock_wazuhlogger.call_args.kwargs['logger_name'] == 'wazuh'
     assert mock_wazuhlogger.call_args.kwargs['tag'] == '{asctime} {levelname}: {message}'
+
+    os.path.exists(current_logger_path) and os.remove(current_logger_path)
 
 
 @pytest.mark.parametrize('debug_level, expected_level', [
@@ -46,7 +50,10 @@ def test_apilogger_init(mock_wazuhlogger):
 @patch('api.alogging.logging.Logger.setLevel')
 def test_apilogger_setup_logger(mock_logger, debug_level, expected_level):
     """Check loggin level is as expected"""
-    logger = alogging.APILogger(log_path='test_path', foreground_mode=False, debug_level=debug_level,
+    current_logger_path = os.path.join(os.path.dirname(__file__), 'testing.log')
+    logger = alogging.APILogger(log_path=current_logger_path, foreground_mode=False, debug_level=debug_level,
                                 logger_name='wazuh')
     logger.setup_logger()
     assert mock_logger.call_args == call(expected_level)
+
+    os.path.exists(current_logger_path) and os.remove(current_logger_path)

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 from unittest.mock import patch, MagicMock
 
@@ -162,7 +163,11 @@ def test_ClusterFilter():
 
 def test_ClusterLogger():
     """Verify that ClusterLogger defines the logger used by wazuh-clusterd."""
-    cluster_logger = utils.ClusterLogger(foreground_mode=False, log_path='remove.log', tag='{asctime} {levelname}: [{tag}] [{subtag}] {message}', debug_level=1)
+    current_logger_path = os.path.join(os.path.dirname(__file__), 'testing.log')
+    cluster_logger = utils.ClusterLogger(foreground_mode=False, log_path=current_logger_path,
+                                         tag='{asctime} {levelname}: [{tag}] [{subtag}] {message}', debug_level=1)
     cluster_logger.setup_logger()
 
     assert cluster_logger.logger.level == logging.DEBUG
+
+    os.path.exists(current_logger_path) and os.remove(current_logger_path)

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -140,11 +140,11 @@ logger = None
 
 @pytest.fixture(scope='module')
 def create_log(request):
-    current_path_logger = os.path.join(os.path.dirname(__file__), 'testing.log')
-    logging.basicConfig(filename=current_path_logger, level=logging.DEBUG)
+    current_logger_path = os.path.join(os.path.dirname(__file__), 'testing.log')
+    logging.basicConfig(filename=current_logger_path, level=logging.DEBUG)
     setattr(request.module, 'logger', logging.getLogger('test'))
     yield
-    os.path.exists(current_path_logger) and os.remove(current_path_logger)
+    os.path.exists(current_logger_path) and os.remove(current_logger_path)
 
 
 def get_worker_handler():

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -74,11 +74,7 @@ class InitAgent:
 
         :return: None
         """
-        db_path = os.path.join(data_path, 'global.db')
-        if os.path.isfile(db_path):
-            os.remove(db_path)
-
-        self.global_db = sqlite3.connect(db_path)
+        self.global_db = sqlite3.connect(':memory:')
         self.global_db.row_factory = sqlite3.Row
         self.cur = self.global_db.cursor()
         with open(os.path.join(data_path, 'schema_global_test.sql')) as f:
@@ -98,16 +94,6 @@ def send_msg_to_wdb(msg, raw=False):
     query = ' '.join(msg.split(' ')[2:])
     result = test_data.cur.execute(query).fetchall()
     return list(map(remove_nones_to_dict, map(dict, result)))
-
-
-@pytest.fixture(scope='module', autouse=True)
-def mock_ossec_path():
-    with patch('wazuh.common.ossec_path', new=test_data_path):
-        yield
-        # Delete db after all tests are run
-        db_path = os.path.join(test_data_path, 'global.db')
-        if os.path.isfile(db_path):
-            os.remove(db_path)
 
 
 def get_manager_version():

--- a/framework/wazuh/core/tests/test_decoder.py
+++ b/framework/wazuh/core/tests/test_decoder.py
@@ -4,6 +4,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import stat
 import sys
 from unittest.mock import patch, MagicMock
 
@@ -64,6 +65,10 @@ def test_check_status(status, expected_result):
 def test_load_decoders_from_file(filename, relative_dirname, status, permissions, exception):
     full_file_path = os.path.join(test_data_path, relative_dirname, filename)
     try:
+        old_permissions = stat.S_IMODE(os.lstat(full_file_path).st_mode)
+    except FileNotFoundError:
+        old_permissions = None
+    try:
         # Set file permissions if the file exists
         os.path.exists(full_file_path) and os.chmod(full_file_path, permissions)
         # UUT call
@@ -79,4 +84,4 @@ def test_load_decoders_from_file(filename, relative_dirname, status, permissions
         assert e.code == exception.code
     finally:
         # Set file permissions back to 777 after test if the file exists
-        os.path.exists(full_file_path) and os.chmod(full_file_path, 777)
+        os.path.exists(full_file_path) and os.chmod(full_file_path, old_permissions)

--- a/framework/wazuh/tests/test_decoders.py
+++ b/framework/wazuh/tests/test_decoders.py
@@ -4,6 +4,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
+import stat
 import sys
 from unittest.mock import patch, MagicMock
 
@@ -151,10 +152,12 @@ def test_get_file_exceptions():
             # UUT 2nd call forcing en error opening decoder file
             decoder.get_file(filename='test1_decoders.xml')
     with pytest.raises(WazuhError, match=r'.* 1502 .*'):
+        filename = 'test2_decoders.xml'
+        old_permissions = stat.S_IMODE(os.lstat(os.path.join(
+            test_data_path, 'core/tests/data/decoders', filename)).st_mode)
         try:
-            filename = 'test2_decoders.xml'
             os.chmod(os.path.join(test_data_path, 'core/tests/data/decoders', filename), 000)
             # UUT 3rd call forcing a permissions error opening decoder file
             decoder.get_file(filename=filename)
         finally:
-            os.chmod(os.path.join(test_data_path, 'core/tests/data/decoders', filename), 777)
+            os.chmod(os.path.join(test_data_path, 'core/tests/data/decoders', filename), old_permissions)


### PR DESCRIPTION
Hello team, this closes #6382 .

This PR adds additional code to clean all the unit test leftovers. Most of the changes are just file removals, but there are some changes in the DBs as well. They are now loaded in memory instead.

# Test results
## Framework unit tests
```
wazuh/core/cluster/dapi/tests/test_dapi.py
	22 passed, 11 warnings
wazuh/core/cluster/tests/test_cluster.py
	18 passed
wazuh/core/cluster/tests/test_common.py
	7 passed
wazuh/core/cluster/tests/test_control.py
	5 passed
wazuh/core/cluster/tests/test_local_client.py
	1 passed
wazuh/core/cluster/tests/test_utils.py
	7 passed
wazuh/core/cluster/tests/test_worker.py
	16 passed, 2 warnings
wazuh/core/tests/test_active_response.py
	12 passed
wazuh/core/tests/test_agent.py
	7 failed, 180 passed, 11 warnings
wazuh/core/tests/test_cdb_list.py
	33 passed
wazuh/core/tests/test_common.py
	7 passed
wazuh/core/tests/test_configuration.py
	34 passed
wazuh/core/tests/test_decoder.py
	15 passed
wazuh/core/tests/test_input_validator.py
	3 passed
wazuh/core/tests/test_manager.py
	32 passed
wazuh/core/tests/test_ossec_queue.py
	19 passed
wazuh/core/tests/test_pyDaemonModule.py
	6 passed
wazuh/core/tests/test_results.py
	40 passed
wazuh/core/tests/test_rule.py
	21 passed
wazuh/core/tests/test_syscollector.py
	3 passed
wazuh/core/tests/test_utils.py
	204 passed
wazuh/core/tests/test_wazuh_socket.py
	15 passed
wazuh/core/tests/test_wdb.py
	21 passed
wazuh/rbac/tests/test_auth_context.py
	2 passed, 1 warning
wazuh/rbac/tests/test_decorators.py
	105 passed
wazuh/rbac/tests/test_default_configuration.py
	47 passed
wazuh/rbac/tests/test_orm.py
	53 passed
wazuh/rbac/tests/test_preprocessor.py
	11 passed
wazuh/tests/test_active_response.py
	9 passed
wazuh/tests/test_agent.py
	89 passed, 11 warnings
wazuh/tests/test_cdb_list.py
	47 passed
wazuh/tests/test_ciscat.py
	2 passed
wazuh/tests/test_cluster.py
	7 passed
wazuh/tests/test_decoders.py
	31 passed
wazuh/tests/test_group.py
	8 passed
wazuh/tests/test_manager.py
	40 passed
wazuh/tests/test_mitre.py
	180 passed
wazuh/tests/test_rule.py
	52 passed
wazuh/tests/test_sca.py
	7 passed
wazuh/tests/test_security.py
	68 passed, 12 warnings
wazuh/tests/test_stats.py
	13 passed
wazuh/tests/test_syscheck.py
	18 passed
wazuh/tests/test_syscollector.py
	12 passed

```
Core agent failed test are because of the upgrade module that is changing in `4.1`.

## API unit tests
```
test/test_alogging.py
	8 passed, 1 warning
test/test_authentication.py
	10 passed, 13 warnings
test/test_configuration.py
	7 passed
test/test_util.py
	35 passed, 12 warnings
test/test_validator.py
	135 passed, 2 warnings

```

Regards,
Víctor.