### PR TITLE
Update expected error codes for login endpoint

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -13068,8 +13068,6 @@ paths:
           $ref: '#/components/responses/ResponseError'
         '401':
           $ref: '#/components/responses/InvalidCredentialsResponse'
-        '403':
-          $ref: '#/components/responses/PermissionDeniedResponse'
         '405':
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
         '429':


### PR DESCRIPTION
## Description

Hello team!

The API spec contained an incorrect error code for the `GET security/user/authenticate` endpoint. 

This is code 403, which occurs when the token used does not grant the necessary permissions to run an endpoint. This situation cannot happen when logging in, since there is no token available at that time, but the user and password credentials.

![image](https://user-images.githubusercontent.com/23361101/97156824-8a134d80-1777-11eb-9903-36c1abbf01ee.png)

This PR removes that code from the spec.

Best regards,
Selu.
