### PR TITLE
Fix in package version field

### DIFF
--- a/src/unit_tests/wazuh_modules/syscollector/test_syscollector_bsd.c
+++ b/src/unit_tests/wazuh_modules/syscollector/test_syscollector_bsd.c
@@ -513,7 +513,7 @@ void test_sys_parse_pkg_version_same_line(void **state) {
     // now it doesn't go through sys_convert_bin_plist
 
     expect_value(wrap_fgets, __stream, (FILE *)1);
-    will_return(wrap_fgets, "<key>CFBundleShortVersionString</key><string>4.5.1</string>");
+    will_return(wrap_fgets, "<key>CFBundleShortVersionString</key><string>4.5.1 (78615.2064)</string>");
 
     expect_value(wrap_fgets, __stream, (FILE *)1);
     will_return(wrap_fgets, NULL);

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -331,6 +331,10 @@ cJSON* sys_parse_pkg(const char * app_folder) {
                         char ** parts = OS_StrBreak('>', read_buff, 4);
                         char ** _parts = OS_StrBreak('<', parts[3], 2);
 
+                        if (strstr(_parts[0], " (") != NULL) {
+                            strtok(_parts[0], " (");
+                        }
+                        
                         cJSON_AddStringToObject(package, "version", _parts[0]);
 
                         for (i = 0; _parts[i]; i++) {
@@ -346,6 +350,10 @@ cJSON* sys_parse_pkg(const char * app_folder) {
                     else if ((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
                         char ** parts = OS_StrBreak('>', read_buff, 2);
                         char ** _parts = OS_StrBreak('<', parts[1], 2);
+
+                        if (strstr(_parts[0], " (") != NULL) {
+                            strtok(_parts[0], " (");
+                        }
 
                         cJSON_AddStringToObject(package, "version", _parts[0]);
 

--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -330,9 +330,9 @@ cJSON* sys_parse_pkg(const char * app_folder) {
                     if (strstr(read_buff, "<string>")){
                         char ** parts = OS_StrBreak('>', read_buff, 4);
                         char ** _parts = OS_StrBreak('<', parts[3], 2);
-
-                        if (strstr(_parts[0], " (") != NULL) {
-                            strtok(_parts[0], " (");
+                        char * delim = strstr(_parts[0], " (");
+                        if (delim) {
+                            *delim = '\0';
                         }
                         
                         cJSON_AddStringToObject(package, "version", _parts[0]);
@@ -350,9 +350,9 @@ cJSON* sys_parse_pkg(const char * app_folder) {
                     else if ((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && strstr(read_buff, "<string>")){
                         char ** parts = OS_StrBreak('>', read_buff, 2);
                         char ** _parts = OS_StrBreak('<', parts[1], 2);
-
-                        if (strstr(_parts[0], " (") != NULL) {
-                            strtok(_parts[0], " (");
+                        char * delim = strstr(_parts[0], " (");
+                        if (delim) {
+                            *delim = '\0';
                         }
 
                         cJSON_AddStringToObject(package, "version", _parts[0]);


### PR DESCRIPTION
|Related issue|
|---|
|#6417|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Now, the packages that contain the build in parentheses inside the version field are removed, showing only the version of the package.

<!--
Add a clear description of how the problem has been solved.
-->


## Logs/Alerts example

The 'zoom' package with this new functionality correctly shows the version:

     pkg|zoom.us||public.app-category.video||||5.3.2|||applications|us.zoom.xos|/Applications/zoom.us.app|0||

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] MAC OS X
- [x] Source installation
- [x] Review logs syntax and correct language

