### PR TITLE
Wazuh DB command to get a list of agents by connection status from global.db - Implementation

### DIFF
--- a/src/headers/wazuhdb_op.h
+++ b/src/headers/wazuhdb_op.h
@@ -14,7 +14,7 @@
 #include "os_net/os_net.h"
 
 /// Enumeration of communication with Wazuh DB status.
-typedef enum wdbc_result { 
+typedef enum wdbc_result {
         WDBC_OK,        ///< Command processed successfully
         WDBC_DUE,       ///< Command processed successfully with pending data
         WDBC_ERROR,     ///< An error occurred
@@ -28,7 +28,9 @@ int wdbc_connect();
 int wdbc_query(const int sock, const char *query, char *response, const int len);
 int wdbc_query_ex(int *sock, const char *query, char *response, const int len);
 int wdbc_parse_result(char *result, char **payload);
+wdbc_result wdbc_parse_result_s(const char* buffer, char** payload);
 cJSON * wdbc_query_parse_json(int *sock, const char *query, char *response, const int len);
+wdbc_result wdbc_query_parse(int *sock, const char *query, char *response, const int len, char** payload);
 
 /**
  * @brief Closes a socket connection if exists

--- a/src/headers/wazuhdb_op.h
+++ b/src/headers/wazuhdb_op.h
@@ -28,7 +28,6 @@ int wdbc_connect();
 int wdbc_query(const int sock, const char *query, char *response, const int len);
 int wdbc_query_ex(int *sock, const char *query, char *response, const int len);
 int wdbc_parse_result(char *result, char **payload);
-wdbc_result wdbc_parse_result_s(const char* buffer, char** payload);
 cJSON * wdbc_query_parse_json(int *sock, const char *query, char *response, const int len);
 wdbc_result wdbc_query_parse(int *sock, const char *query, char *response, const int len, char** payload);
 

--- a/src/shared/wazuhdb_op.c
+++ b/src/shared/wazuhdb_op.c
@@ -192,10 +192,42 @@ int wdbc_parse_result(char *result, char **payload) {
     return retval;
 }
 
+/**
+ * @brief Safe parse the result of the query to Wazuh-DB
+ *
+ * If payload is not NULL, this function stores the address of the result
+ * argument, this is the substring after the first whitespace.
+ *
+ * This function use strncmp for a safe comparison and doesn't write on result
+ *
+ * @param buffer [in] Result from the query to Wazuh-DB to be parsed.
+ * @param payload[out] Pointer inside the buffer where the payload starts.
+ * @return Enum wdbc_result.
+ */
+wdbc_result wdbc_parse_result_s(const char* buffer, char** payload) {
+    wdbc_result retval = WDBC_UNKNOWN;
+    char* ptr = strchr(buffer, ' ');
+    if (payload) {
+        *payload = ptr ? ptr+1 : NULL;
+    }
+
+    if (!strncmp(buffer, WDBC_RESULT[WDBC_OK], strlen(WDBC_RESULT[WDBC_OK]))) {
+        retval = WDBC_OK;
+    } else if (!strncmp(buffer, WDBC_RESULT[WDBC_ERROR], strlen(WDBC_RESULT[WDBC_ERROR]))) {
+        retval = WDBC_ERROR;
+    } else if (!strncmp(buffer, WDBC_RESULT[WDBC_IGNORE], strlen(WDBC_RESULT[WDBC_IGNORE]))) {
+        retval = WDBC_IGNORE;
+    } else if (!strncmp(buffer, WDBC_RESULT[WDBC_DUE], strlen(WDBC_RESULT[WDBC_DUE]))) {
+        retval = WDBC_DUE;
+    }
+
+    return retval;
+}
+
 
 /**
  * @brief Combine wdbc_query_ex and wdbc_parse_result functions and return a JSON item.
- * 
+ *
  * @param[in] sock Pointer to the client socket descriptor.
  * @param[in] query Query to be sent to Wazuh-DB.
  * @param[out] response Char pointer where the response from Wazuh-DB will be stored.
@@ -229,6 +261,42 @@ cJSON * wdbc_query_parse_json(int *sock, const char *query, char *response, cons
 
     root = cJSON_Parse(arg);
     return root;
+}
+
+/**
+ * @brief Combine wdbc_query_ex and wdbc_parse_result functions.
+ *
+ * @param[in] sock Pointer to the client socket descriptor.
+ * @param[in] query Query to be sent to Wazuh-DB.
+ * @param[out] response Char pointer where the response from Wazuh-DB will be stored.
+ * @param[in] len Lenght of the response param.
+ * @param[out] payload Char pointer where the payload from Wazuh-DB will be stored.
+ * @return Enum wdbc_result.
+ */
+
+wdbc_result wdbc_query_parse(int *sock, const char *query, char *response, const int len, char** payload) {
+    wdbc_result status = WDBC_ERROR;
+    char* _payload = NULL;
+
+    int result = wdbc_query_ex(sock, query, response, len);
+    if (OS_SUCCESS == result) {
+        status = wdbc_parse_result_s(response, &_payload);
+        if (status == WDBC_ERROR){
+            merror("Bad response from wazuh-db: %s", _payload);
+        }
+    }
+    else if (-2 == result) {
+        merror("Unable to connect to socket '%s'", WDB_LOCAL_SOCK);
+    }
+    else if (-1 == result) {
+        merror("No response from wazuh-db.");
+    }
+
+    if (payload) {
+        *payload = _payload;
+    }
+
+    return status;
 }
 
 int wdbc_close(int* sock) {

--- a/src/shared/wazuhdb_op.c
+++ b/src/shared/wazuhdb_op.c
@@ -193,39 +193,6 @@ int wdbc_parse_result(char *result, char **payload) {
 }
 
 /**
- * @brief Safe parse the result of the query to Wazuh-DB
- *
- * If payload is not NULL, this function stores the address of the result
- * argument, this is the substring after the first whitespace.
- *
- * This function use strncmp for a safe comparison and doesn't write on result
- *
- * @param buffer [in] Result from the query to Wazuh-DB to be parsed.
- * @param payload[out] Pointer inside the buffer where the payload starts.
- * @return Enum wdbc_result.
- */
-wdbc_result wdbc_parse_result_s(const char* buffer, char** payload) {
-    wdbc_result retval = WDBC_UNKNOWN;
-    char* ptr = strchr(buffer, ' ');
-    if (payload) {
-        *payload = ptr ? ptr+1 : NULL;
-    }
-
-    if (!strncmp(buffer, WDBC_RESULT[WDBC_OK], strlen(WDBC_RESULT[WDBC_OK]))) {
-        retval = WDBC_OK;
-    } else if (!strncmp(buffer, WDBC_RESULT[WDBC_ERROR], strlen(WDBC_RESULT[WDBC_ERROR]))) {
-        retval = WDBC_ERROR;
-    } else if (!strncmp(buffer, WDBC_RESULT[WDBC_IGNORE], strlen(WDBC_RESULT[WDBC_IGNORE]))) {
-        retval = WDBC_IGNORE;
-    } else if (!strncmp(buffer, WDBC_RESULT[WDBC_DUE], strlen(WDBC_RESULT[WDBC_DUE]))) {
-        retval = WDBC_DUE;
-    }
-
-    return retval;
-}
-
-
-/**
  * @brief Combine wdbc_query_ex and wdbc_parse_result functions and return a JSON item.
  *
  * @param[in] sock Pointer to the client socket descriptor.
@@ -280,7 +247,7 @@ wdbc_result wdbc_query_parse(int *sock, const char *query, char *response, const
 
     int result = wdbc_query_ex(sock, query, response, len);
     if (OS_SUCCESS == result) {
-        status = wdbc_parse_result_s(response, &_payload);
+        status = wdbc_parse_result(response, &_payload);
         if (status == WDBC_ERROR){
             merror("Bad response from wazuh-db: %s", _payload);
         }

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -32,7 +32,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,wdb_global_insert_agent_group -Wl,--wrap,wdb_global_insert_agent_belong -Wl,--wrap,wdb_global_delete_group_belong \
                              -Wl,--wrap,wdb_global_delete_group -Wl,--wrap,wdb_global_select_groups -Wl,--wrap,wdb_global_select_agent_keepalive \
                              -Wl,--wrap,wdb_global_sync_agent_info_get -Wl,--wrap,wdb_global_sync_agent_info_set -Wl,--wrap,wdb_global_get_agents_by_keepalive \
-                             -Wl,--wrap,wdb_global_get_all_agents -Wl,--wrap,wdb_global_get_agent_info -Wl,--wrap,wdb_global_reset_agents_connection")
+                             -Wl,--wrap,wdb_global_get_all_agents -Wl,--wrap,wdb_global_get_agent_info -Wl,--wrap,wdb_global_reset_agents_connection \
+                             -Wl,--wrap,wdb_global_get_agents_by_connection_status")
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
@@ -47,7 +48,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_GetObjectItem \
                              -Wl,--wrap,cJSON_Delete -Wl,--wrap,time -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite \
                              -Wl,--wrap,fclose -Wl,--wrap,remove -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,closedir \
-                             -Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,wdbc_query_parse_json \
+                             -Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,wdbc_query_parse_json -Wl,--wrap,wdbc_query_parse \
                              -Wl,--wrap,wdb_create_profile -Wl,--wrap,Privsep_GetUser -Wl,--wrap,Privsep_GetGroup -Wl,--wrap,chown \
                              -Wl,--wrap,chmod -Wl,--wrap,IsDir -Wl,--wrap,isChroot -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek \
                              -Wl,--wrap,stat")

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2649,6 +2649,64 @@ void test_wdb_parse_reset_agents_connection_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_get_agents_by_connection_status */
+
+void test_wdb_parse_global_get_agents_by_connection_status_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-agents-by-connection-status";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agents-by-connection-status");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for get-agents-by-connection-status.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: get-agents-by-connection-status");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-agents-by-connection-status'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_agents_by_connection_status_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-agents-by-connection-status active";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agents-by-connection-status active");
+    expect_string(__wrap_wdb_global_get_agents_by_connection_status, status, "active");
+    will_return(__wrap_wdb_global_get_agents_by_connection_status, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error getting agent information from global.db.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Error getting agent information from global.db.");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_agents_by_connection_status_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-agents-by-connection-status active";
+    cJSON *j_object = NULL;
+
+    j_object = cJSON_CreateObject();
+    cJSON_AddNumberToObject(j_object, "id", 1);
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agents-by-connection-status active");
+    expect_string(__wrap_wdb_global_get_agents_by_connection_status, status, "active");
+    will_return(__wrap_wdb_global_get_agents_by_connection_status, j_object);
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "ok {\"id\":1}");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] = {
@@ -2819,6 +2877,10 @@ int main()
         /* Tests wdb_parse_reset_agents_connection */
         cmocka_unit_test_setup_teardown(test_wdb_parse_reset_agents_connection_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_reset_agents_connection_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_get_agent_info */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_connection_status_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_connection_status_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agents_by_connection_status_success, test_setup, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -290,6 +290,12 @@ int __wrap_wdb_global_reset_agents_connection( __attribute__((unused)) wdb_t *wd
     return mock();
 }
 
+cJSON* __wrap_wdb_global_get_agents_by_connection_status(__attribute__((unused)) wdb_t* wdb,
+                                                         const char* status) {
+    check_expected(status);
+    return mock_ptr_type(cJSON*);
+}
+
 int __wrap_wdb_global_check_manager_keepalive(wdb_t *wdb) {
     (void)wdb;
     return mock();

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -96,6 +96,8 @@ cJSON* __wrap_wdb_global_get_agent_info(wdb_t *wdb, int id);
 
 int __wrap_wdb_global_reset_agents_connection(wdb_t *wdb);
 
+cJSON* __wrap_wdb_global_get_agents_by_connection_status(wdb_t* wdb, const char* status);
+
 int __wrap_wdb_global_check_manager_keepalive(wdb_t *wdb);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -92,22 +92,19 @@ cJSON * __wrap_wdb_exec_stmt(__attribute__((unused)) sqlite3_stmt *stmt) {
 }
 
 int __wrap_wdbc_parse_result(char *result, char **payload) {
-    int retval = mock();
-
     check_expected(result);
 
-    if(payload){
-        *payload = strchr(result, ' ');
+    char *ptr = strchr(result, ' ');
+    if (ptr) {
+        *ptr++ = '\0';
+    } else {
+        ptr = result;
+    }
+    if (payload) {
+        *payload = ptr;
     }
 
-    if(*payload) {
-        (*payload)++;
-    }
-    else {
-        *payload = result;
-    }
-
-    return retval;
+    return mock();
 }
 
 int __wrap_wdbc_query_ex(int *sock, const char *query, char *response, const int len) {
@@ -158,7 +155,27 @@ cJSON* __wrap_wdbc_query_parse_json(__attribute__((unused)) int *sock,
 
     return mock_ptr_type(cJSON *);
 }
-cJSON* __wrap_wdb_exec(__attribute__((unused)) sqlite3 *db, 
+
+wdbc_result __wrap_wdbc_query_parse(int *sock,
+                                    const char *query,
+                                    char *response,
+                                    const int len,
+                                    char** payload) {
+    check_expected(sock);
+    check_expected(query);
+    check_expected(len);
+
+    snprintf(response, len, "%s", mock_ptr_type(char*));
+
+    char* ptr = strchr(response, ' ');
+    if (payload) {
+        *payload = ptr ? ptr+1 : NULL;
+    }
+
+    return mock();
+}
+
+cJSON* __wrap_wdb_exec(__attribute__((unused)) sqlite3 *db,
                  const char *sql) {
     check_expected(sql);
     return mock_ptr_type(cJSON*);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -53,6 +53,8 @@ int __wrap_wdbi_query_clear(wdb_t *wdb, wdb_component_t component, const char *p
 
 cJSON* __wrap_wdbc_query_parse_json(int *sock, const char *query, char *response, const int len);
 
+wdbc_result __wrap_wdbc_query_parse(int *sock, const char *query, char *response, const int len, char** payload);
+
 cJSON* __wrap_wdb_exec(sqlite3 *db, const char *sql);
 
 void __wrap_wdb_leave(wdb_t *wdb);

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -144,9 +144,10 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_GREATER_KEEPALIVE] = "SELECT id FROM agent WHERE id > ? AND last_keepalive > ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_LESS_KEEPALIVE] = "SELECT id FROM agent WHERE id > ? AND last_keepalive < ? LIMIT 1;",
+    [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > 0 AND connection_status = ?;",
     [WDB_STMT_GLOBAL_GET_AGENT_INFO] = "SELECT * FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected' where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",
-    [WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE] = "SELECT COUNT(*) FROM agent WHERE id=0 AND last_keepalive=253402300799;",    
+    [WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE] = "SELECT COUNT(*) FROM agent WHERE id=0 AND last_keepalive=253402300799;",
     [WDB_STMT_PRAGMA_JOURNAL_WAL] = "PRAGMA journal_mode=WAL;",
 };
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -674,7 +674,7 @@ int wdb_delete_agent_belongs(int id, int *sock);
 int wdb_remove_group_from_belongs_db(const char *name, int *sock);
 
 /**
- * @brief Resets the connection_status column of every agent (excluding the manager).
+ * @brief Reset the connection_status column of every agent (excluding the manager).
  *        If connection_status is pending or connected it will be changed to disconnected.
  *        If connection_status is disconnected or never_connected it will not be changed.
  *
@@ -682,6 +682,15 @@ int wdb_remove_group_from_belongs_db(const char *name, int *sock);
  * @return Returns OS_SUCCESS on success or OS_INVALID on failure.
  */
 int wdb_reset_agents_connection(int *sock);
+
+/**
+ * @brief Get every agent (excluding the manager) that match the specified connection status.
+ *
+ * @param[in] status The connection status.
+ * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
+ * @return Pointer to the array, on success. NULL on errors.
+ */
+int* wdb_get_agents_by_connection_status(const char* status, int *sock);
 
 /**
  * @brief Create database for agent from profile.
@@ -1330,7 +1339,7 @@ int wdb_parse_reset_agents_connection(wdb_t * wdb, char * output);
  * @retval 0 Success: Response contains the value.
  * @retval -1 On error: Response contains details of the error.
  */
-int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, char* output) {
+int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, char* output);
 
 int wdbi_checksum_range(wdb_t * wdb, wdb_component_t component, const char * begin, const char * end, os_sha1 hexdigest);
 
@@ -1814,7 +1823,7 @@ int wdb_global_reset_agents_connection(wdb_t *wdb);
  * @retval JSON with every agent ID on success.
  * @retval NULL on error.
  */
-cJSON* wdb_global_get_agents_by_connection_status(wdb_t *wdb, const char status);
+cJSON* wdb_global_get_agents_by_connection_status(wdb_t *wdb, const char* status);
 
 // Finalize a statement securely
 #define wdb_finalize(x) { if (x) { sqlite3_finalize(x); x = NULL; } }

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -684,7 +684,7 @@ int wdb_remove_group_from_belongs_db(const char *name, int *sock);
 int wdb_reset_agents_connection(int *sock);
 
 /**
- * @brief Get every agent (excluding the manager) that match the specified connection status.
+ * @brief Get every agent (excluding the manager) that matches the specified connection status.
  *
  * @param[in] status The connection status.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -160,6 +160,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_GET_AGENTS,
     WDB_STMT_GLOBAL_GET_AGENTS_BY_GREATER_KEEPALIVE,
     WDB_STMT_GLOBAL_GET_AGENTS_BY_LESS_KEEPALIVE,
+    WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS,
     WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS,
     WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE,
     WDB_STMT_PRAGMA_JOURNAL_WAL,
@@ -196,7 +197,8 @@ typedef enum global_db_access {
     WDB_DELETE_GROUP,
     WDB_DELETE_AGENT_BELONG,
     WDB_DELETE_GROUP_BELONG,
-    WDB_RESET_AGENTS_CONNECTION
+    WDB_RESET_AGENTS_CONNECTION,
+    WDB_GET_AGENTS_BY_CONNECTION_STATUS
 } global_db_access;
 
 typedef struct wdb_t {
@@ -1310,13 +1312,25 @@ int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output);
 
 /**
  * @brief Function to parse the reset agent connection status request.
- * 
+ *
  * @param [in] wdb The global struct database.
  * @param [out] output Response of the query.
  * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.
  */
 int wdb_parse_reset_agents_connection(wdb_t * wdb, char * output);
+
+/**
+ * @brief Function to parse the get agents by connection status request.
+ *
+ * @param wdb The global struct database.
+ * @param [in] wdb The global struct database.
+ * @param [in] input String with 'connection_status'.
+ * @param [out] output Response of the query in JSON format.
+ * @retval 0 Success: Response contains the value.
+ * @retval -1 On error: Response contains details of the error.
+ */
+int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, char* output) {
 
 int wdbi_checksum_range(wdb_t * wdb, wdb_component_t component, const char * begin, const char * end, os_sha1 hexdigest);
 
@@ -1786,11 +1800,21 @@ wdbc_result wdb_global_get_all_agents(wdb_t *wdb, int* last_agent_id, char **out
  * @brief Function to reset connection_status column of every agent (excluding the manager).
  *        If connection_status is pending or connected it will be changed to disconnected.
  *        If connection_status is disconnected or never_connected it will not be changed.
- * 
+ *
  * @param [in] wdb The Global struct database.
  * @return 0 On success. -1 On error.
  */
 int wdb_global_reset_agents_connection(wdb_t *wdb);
+
+/**
+ * @brief Function to get the id of every agent with a specific connection_status.
+ *
+ * @param wdb The Global struct database.
+ * @param status Connection status of the agents requested.
+ * @retval JSON with every agent ID on success.
+ * @retval NULL on error.
+ */
+cJSON* wdb_global_get_agents_by_connection_status(wdb_t *wdb, const char status);
 
 // Finalize a statement securely
 #define wdb_finalize(x) { if (x) { sqlite3_finalize(x); x = NULL; } }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1466,7 +1466,7 @@ int wdb_global_check_manager_keepalive(wdb_t *wdb) {
     }
 }
 
-cJSON* wdb_global_get_agents_by_connection_status(wdb_t *wdb, const char status) {
+cJSON* wdb_global_get_agents_by_connection_status(wdb_t* wdb, const char* status) {
     sqlite3_stmt *stmt = NULL;
     cJSON * result = NULL;
 
@@ -1484,7 +1484,7 @@ cJSON* wdb_global_get_agents_by_connection_status(wdb_t *wdb, const char status)
 
     if (sqlite3_bind_text(stmt, 1, status, -1, NULL) != SQLITE_OK) {
         merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-        return OS_INVALID;
+        return NULL;
     }
 
     result = wdb_exec_stmt(stmt);

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1465,3 +1465,33 @@ int wdb_global_check_manager_keepalive(wdb_t *wdb) {
         return -1;
     }
 }
+
+cJSON* wdb_global_get_agents_by_connection_status(wdb_t *wdb, const char status) {
+    sqlite3_stmt *stmt = NULL;
+    cJSON * result = NULL;
+
+    if (!wdb->transaction && wdb_begin2(wdb) < 0) {
+        mdebug1("Cannot begin transaction");
+        return NULL;
+    }
+
+    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS) < 0) {
+        mdebug1("Cannot cache statement");
+        return NULL;
+    }
+
+    stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS];
+
+    if (sqlite3_bind_text(stmt, 1, status, -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return OS_INVALID;
+    }
+
+    result = wdb_exec_stmt(stmt);
+
+    if (!result) {
+        mdebug1("wdb_exec_stmt(): %s", sqlite3_errmsg(wdb->db));
+    }
+
+    return result;
+}

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -697,6 +697,16 @@ int wdb_parse(char * input, char * output) {
         else if (strcmp(query, "reset-agents-connection") == 0) {
             result = wdb_parse_reset_agents_connection(wdb, output);
         }
+        else if (strcmp(query, "get-agents-by-connection-status") == 0) {
+            if (!next) {
+                mdebug1("Global DB Invalid DB query syntax for get-agent-info.");
+                mdebug2("Global DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                result = OS_INVALID;
+            } else {
+                result = wdb_parse_global_get_agents_by_connection_status(wdb, next, output);
+            }
+        }
         else {
             mdebug1("Invalid DB query syntax.");
             mdebug2("Global DB query error near: %s", query);
@@ -5205,4 +5215,31 @@ int wdb_parse_reset_agents_connection(wdb_t * wdb, char * output) {
 
     snprintf(output, OS_MAXSTR + 1, "ok");
     return OS_SUCCESS;
+}
+
+int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, char* output) {
+    int agent_id = 0;
+    cJSON *agents = NULL;
+    char *out = NULL;
+
+    agent_id = atoi(input);
+
+    if (agents = wdb_global_get_agents_by_connection_status(wdb, agent_id), !agents) {
+        mdebug1("Error getting agent information from global.db.");
+        snprintf(output, OS_MAXSTR + 1, "err Error getting agent information from global.db.");
+        return OS_INVALID;
+    }
+    #if 0
+    *output = cJSON_PrintUnformatted(agents);
+    cJSON_Delete(agents);
+
+    return WDBC_OK;
+    #else
+    out = cJSON_PrintUnformatted(agents);
+    snprintf(output, OS_MAXSTR + 1, "ok %s", out);
+    os_free(out);
+    cJSON_Delete(agents);
+
+    return OS_SUCCESS;
+    #endif
 }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -699,7 +699,7 @@ int wdb_parse(char * input, char * output) {
         }
         else if (strcmp(query, "get-agents-by-connection-status") == 0) {
             if (!next) {
-                mdebug1("Global DB Invalid DB query syntax for get-agent-info.");
+                mdebug1("Global DB Invalid DB query syntax for get-agents-by-connection-status.");
                 mdebug2("Global DB query error near: %s", query);
                 snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
                 result = OS_INVALID;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5218,13 +5218,10 @@ int wdb_parse_reset_agents_connection(wdb_t * wdb, char * output) {
 }
 
 int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, char* output) {
-    int agent_id = 0;
     cJSON *agents = NULL;
     char *out = NULL;
 
-    agent_id = atoi(input);
-
-    if (agents = wdb_global_get_agents_by_connection_status(wdb, agent_id), !agents) {
+    if (agents = wdb_global_get_agents_by_connection_status(wdb, input), !agents) {
         mdebug1("Error getting agent information from global.db.");
         snprintf(output, OS_MAXSTR + 1, "err Error getting agent information from global.db.");
         return OS_INVALID;


### PR DESCRIPTION
|Related issue|
|---|
|6308|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fully adds the wdb_get_agents_by_connection_status commands.
- Adds the client side of the comand in wdb_agent.c
- Adds the parsing and execution of the command in wdb_parser.c and wdb_global.c
- Adds UT for new methods
- Contemplates merging the response from multiple socket calls by "continue" command


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Review logs syntax and correct language
- [x] QA integration tests

<!-- Depending on the affected OS -->
  - [X] Valgrind (on UT)
  - [x] Valgrind (on manual test)
  - [x] Scan-build 