### PR TITLE
Fix vulnerability in Python's cryptography library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-### Fixed
-
 - **Framework:**
-  - Fix Python's cryptography library ([#6442](https://github.com/wazuh/wazuh/issues/6442))
+  - Update Python's cryptography library to version 3.2.1 ([#6442](https://github.com/wazuh/wazuh/issues/6442))
+
+### Fixed
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v4.0.1] -
+
+### Added
+
+### Changed
+
+### Fixed
+
+- **Framework:**
+  - Fix Python's cryptography library ([#6442](https://github.com/wazuh/wazuh/issues/6442))
+
+### Removed
+
+
 ## [v4.0.0] -
 
 ### Added

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -16,7 +16,7 @@ chardet==3.0.4
 Click==7.0
 clickclick==1.2.2
 connexion==2.6.0
-cryptography==2.9.2
+cryptography==3.2.1
 defusedxml==0.6.0
 docker-pycreds==0.4.0
 docker==4.2.0


### PR DESCRIPTION
|Related issue|
|---|
|#6442|

Hi team,

This PR closes #6442. In this PR we have updated the cryptography library version because a vulnerability has been found in the version we were using.

```
adriiiprodri@wazuh python3 run_tests.py -rbac both -k agents    
Collected tests [6]:
test_agents_DELETE_endpoints.tavern.yaml, test_agents_GET_endpoints.tavern.yaml, test_agents_POST_endpoints.tavern.yaml, test_agents_PUT_endpoints.tavern.yaml, test_rbac_black_agents_endpoints.tavern.yaml, test_rbac_white_agents_endpoints.tavern.yaml


test_agents_DELETE_endpoints.tavern.yaml 
	 7 passed, 8 warnings

test_agents_GET_endpoints.tavern.yaml 
	 90 passed, 91 warnings

test_agents_POST_endpoints.tavern.yaml 
	 5 passed, 6 warnings

test_agents_PUT_endpoints.tavern.yaml 
	 9 passed, 10 warnings

test_rbac_black_agents_endpoints.tavern.yaml 
	 39 passed, 40 warnings

test_rbac_white_agents_endpoints.tavern.yaml 
	 39 passed, 40 warnings
```

Regards