### PR TITLE
Fix error on getsockopt if socket is disconnected

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -717,7 +717,7 @@ int OS_SetSocketSize(int sock, int mode, int max_msg_size) {
 
         /* Get current maximum size */
         if (getsockopt(sock, SOL_SOCKET, SO_RCVBUF, (void *)&len, &optlen) == -1) {
-            return -1;
+            len = 0;
         }
 
         /* Set maximum message size */
@@ -732,7 +732,7 @@ int OS_SetSocketSize(int sock, int mode, int max_msg_size) {
 
         /* Get current maximum size */
         if (getsockopt(sock, SOL_SOCKET, SO_SNDBUF, (void *)&len, &optlen) == -1) {
-            return -1;
+            len = 0;
         }
 
         /* Set maximum message size */


### PR DESCRIPTION
|Related issue|
|---|
|#6439|

This PR aims to fix an error produced by `getsockopt` at `OS_SetSocketSize` in containers running on gVisor.

The error appears when setting the socket buffer size of newly bound TCP sockets as they are not connected yet. The particular implementation of the gVisor kernel returns an error code while Linux returns the default socket buffer size.

## Log sample

### Previous implementation

```
2020/10/28 12:55:31 wazuh-db: INFO: Started (pid: 15626).
2020/10/28 12:55:31 wazuh-db: CRITICAL: Unable to bind to socket '/queue/db/wdb': 'Transport endpoint is not connected'. Closing local server.
```

### Applying patch

```
2020/10/28 12:59:41 wazuh-db: INFO: Started (pid: 15763).
```

## Tests

- [X] Compile on Ubuntu 20.10.
- [X] Compile and run on Ubuntu 20.04 on gVisor.