### PR TITLE
Sanitize inotify watches hashmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.0.0] -
 
+### Fixed
+
+- Clean invalid real-time inotify watches from FIM module. ([#6445](https://github.com/wazuh/wazuh/pull/6445))
+
+
+## [v4.0.0] -
+
 ### Added
 
 - Added **enrollment capability**. Agents are now able to request a key from the manager if current key is missing or wrong. ([#5609](https://github.com/wazuh/wazuh/pull/5609))

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -117,6 +117,7 @@ typedef struct whodata_dir_status whodata_dir_status;
 
 typedef struct _rtfim {
     int fd;
+    unsigned int queue_overflow:1;
     OSHash *dirtb;
 #ifdef WIN32
     HANDLE evt;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -151,7 +151,13 @@ void fim_scan() {
     else {
         // In the first scan, the fim inicialization is different between Linux and Windows.
         // Realtime watches are set after the first scan in Windows.
-        mdebug2(FIM_NUM_WATCHES, count_watches());
+        if (syscheck.realtime != NULL) {
+            if (syscheck.realtime->queue_overflow) {
+                realtime_sanitize_watch_map();
+                syscheck.realtime->queue_overflow = false;
+            }
+            mdebug2(FIM_NUM_WATCHES, syscheck.realtime->dirtb->elements);
+        }
     }
 
     minfo(FIM_FREQUENCY_ENDED);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -336,7 +336,14 @@ static int _base_line = 0;
 
         if (_base_line == 0) {
             _base_line = 1;
-            mdebug2(FIM_NUM_WATCHES, count_watches());
+
+            if (syscheck.realtime != NULL) {
+                if (syscheck.realtime->queue_overflow) {
+                    realtime_sanitize_watch_map();
+                    syscheck.realtime->queue_overflow = false;
+                }
+                mdebug2(FIM_NUM_WATCHES, syscheck.realtime->dirtb->elements);
+            }
         }
 
 #ifdef WIN_WHODATA

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -119,6 +119,7 @@ int realtime_adddir(const char *dir, int whodata, int followsl) {
                     if (retval = OSHash_Update_ex(syscheck.realtime->dirtb, wdchar, data), retval == 0) {
                         merror("Unable to update 'dirtb'. Directory not found: '%s'", data);
                         os_free(data);
+                        w_mutex_unlock(&syscheck.fim_realtime_mutex);
                         return (-1);
                     }
                 }
@@ -195,13 +196,9 @@ void realtime_process() {
                         delete_subdirectories_watches(entry);
                         // fall through
                     case IN_DELETE_SELF:
-                        w_mutex_lock(&syscheck.fim_realtime_mutex);
-
-                        char * data = OSHash_Delete_ex(syscheck.realtime->dirtb, wdchar);
                         mdebug2(FIM_INOTIFY_WATCH_DELETED, entry);
-                        os_free(data);
+                        free(OSHash_Delete_ex(syscheck.realtime->dirtb, wdchar));
 
-                        w_mutex_unlock(&syscheck.fim_realtime_mutex);
                         break;
                     }
                 }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -274,7 +274,7 @@ int realtime_update_watch(const char *wd, const char *dir) {
             merror_exit(FIM_CRITICAL_ERROR_OUT_MEM);
         }
 
-        mdebug1(FIM_REALTIME_NEWDIRECTORY, dir);
+        mdebug1(FIM_REALTIME_NEWDIRECTORY, data);
     } else if (retval = OSHash_Update_ex(syscheck.realtime->dirtb, wdchar, data), retval == 0) {
         merror("Unable to update 'dirtb'. Directory not found: '%s'", data);
         os_free(data);
@@ -651,9 +651,11 @@ int fim_check_realtime_directory(const char *dir) {
     return 0;
 }
 
+// LCOV_EXCL_START
 void realtime_sanitize_watch_map() {
     return;
 }
+// LCOV_EXCL_STOP
 
 #else /* !WIN32 */
 

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -246,12 +246,10 @@ int realtime_update_watch(const char *wd, const char *dir) {
             merror(FIM_ERROR_INOTIFY_ADD_MAX_REACHED, dir, new_wd, errno);
             return -1;
         } else if (errno == ENOENT) {
-            if (strcmp(dir, syscheck.dir[index])) {
-                mdebug1("Removing watch on non existent directory '%s'", dir);
-                inotify_rm_watch(syscheck.realtime->fd, old_wd);
-                free(OSHash_Delete_ex(syscheck.realtime->dirtb, wd));
-                return 0;
-            }
+            mdebug1("Removing watch on non existent directory '%s'", dir);
+            inotify_rm_watch(syscheck.realtime->fd, old_wd);
+            free(OSHash_Delete_ex(syscheck.realtime->dirtb, wd));
+            return 0;
         } else {
             mdebug1(FIM_INOTIFY_ADD_WATCH, dir, new_wd, errno, strerror(errno));
             return -1;

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -360,11 +360,9 @@ void free_syscheck_dirtb_data(char *data);
 void delete_subdirectories_watches(char *dir);
 
 /**
- * @brief Count inotify watches
- *
- * @return Number of inotify watches
+ * @brief Remove stale watches from the realtime hashmap
  */
-unsigned int count_watches();
+void realtime_sanitize_watch_map();
 
 /**
  * @brief Check if a file has changed
@@ -391,7 +389,7 @@ char *seechanges_get_diff_path(char *path);
 
 /**
  * @brief Estimate whether the compressed file will fit in the disk_quota limit
- * 
+ *
  * @param file_size Uncompressed file size
  * @return true for files which compressed version could fit, false otherwise
  */
@@ -399,7 +397,7 @@ int seechanges_estimate_compression(const float file_size);
 
 /**
  * @brief Changed the value of syscheck.comp_estimation_perc based on the actual compression rate
- * 
+ *
  * @param compressed_size Size of the compressed file
  * @param uncompressed_size Size of the file before the compression
  */

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -149,7 +149,8 @@ set(RUN_REALTIME_BASE_FLAGS "-Wl,--wrap,inotify_init -Wl,--wrap,inotify_add_watc
                              -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,_merror_exit -Wl,--wrap,send_log_msg \
                              -Wl,--wrap,rbtree_keys -Wl,--wrap,fim_realtime_event -Wl,--wrap,OSHash_Delete_ex \
                              -Wl,--wrap=OSHash_Begin -Wl,--wrap=OSHash_Next -Wl,--wrap=pthread_mutex_lock \
-                             -Wl,--wrap=pthread_mutex_unlock -Wl,--wrap=getpid -Wl,--wrap=atexit -Wl,--wrap=os_random")
+                             -Wl,--wrap=pthread_mutex_unlock -Wl,--wrap=getpid -Wl,--wrap=atexit -Wl,--wrap=os_random \
+                             -Wl,--wrap,inotify_rm_watch")
 
 list(APPEND syscheckd_tests_names "test_run_realtime")
 if(${TARGET} STREQUAL "agent")

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -305,6 +305,8 @@ static int teardown_fim_scan_realtime(void **state) {
 
     free(dir_opts);
 
+    syscheck.realtime = NULL; // Used with local variables in some tests
+
     return 0;
 }
 #endif
@@ -2021,11 +2023,6 @@ static void test_fim_scan_no_realtime(void **state) {
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
     will_return(__wrap_send_log_msg, 1);
 
-    expect_function_call(__wrap_count_watches);
-    will_return(__wrap_count_watches, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "(6345): Folders monitored with real-time engine: 0");
-
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
 
     fim_scan();
@@ -2080,23 +2077,23 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
 
     will_return(__wrap_fim_db_get_count_entry_path, 50000);
 
-    expect_function_call(__wrap_count_watches);
-    will_return(__wrap_count_watches, 6);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "(6345): Folders monitored with real-time engine: 6");
-
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
 
     fim_scan();
 }
 
 static void test_fim_scan_realtime_enabled(void **state) {
+    OSHashNode empty_table = { .key = NULL }, *table = &empty_table;
+    OSHash dirtb = { .elements = 10, .table = &table, .rows = 0 }; // this hash is not reallistic but works for testing
+    rtfim realtime = { .queue_overflow = true, .dirtb = &dirtb };
     int *dir_opts = calloc(6, sizeof(int));
     int it = 0;
 
     if (!dir_opts) {
         fail();
     }
+
+    syscheck.realtime = &realtime;
 
     while (syscheck.dir[it] != NULL) {
         dir_opts[it] = syscheck.opts[it];
@@ -2158,15 +2155,17 @@ static void test_fim_scan_realtime_enabled(void **state) {
     // fim_check_db_state
     will_return(__wrap_fim_db_get_count_entry_path, 50000);
 
-    // fim_scan
-    expect_function_call(__wrap_count_watches);
-    will_return(__wrap_count_watches, 6);
+    // realtime_sanitize_watch_map
+    expect_any(__wrap__mdebug2, formatted_msg);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6345): Folders monitored with real-time engine: 6");
+    // fim_scan
+    expect_string(__wrap__mdebug2, formatted_msg, "(6345): Folders monitored with real-time engine: 10");
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
 
     fim_scan();
+
+    assert_int_equal(syscheck.realtime->queue_overflow, false);
 }
 
 static void test_fim_scan_db_free(void **state) {
@@ -2241,11 +2240,6 @@ static void test_fim_scan_db_free(void **state) {
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":1000,\"alert_type\":\"normal\"}");
     will_return(__wrap_send_log_msg, 1);
 
-    expect_function_call(__wrap_count_watches);
-    will_return(__wrap_count_watches, 6);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "(6345): Folders monitored with real-time engine: 6");
-
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
 
     fim_scan();
@@ -2297,11 +2291,6 @@ static void test_fim_scan_no_limit(void **state) {
     will_return(__wrap_fim_db_set_all_unscanned, 0);
 
     // In fim_scan
-    expect_function_call(__wrap_count_watches);
-    will_return(__wrap_count_watches, 6);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "(6345): Folders monitored with real-time engine: 6");
-
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
 
     fim_scan();
@@ -2893,8 +2882,6 @@ static void test_fim_scan_db_full_double_scan_winreg_check(void **state) {
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":45000,\"alert_type\":\"80_percentage\"}");
     will_return(__wrap_send_log_msg, 1);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6345): Folders monitored with real-time engine: 0");
-
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
 
     fim_scan();
@@ -2960,8 +2947,6 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6342): Maximum number of files to be monitored: '50000'");
     will_return(__wrap_fim_db_get_count_entry_path, 50000);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "(6345): Folders monitored with real-time engine: 0");
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
 
@@ -3051,8 +3036,6 @@ static void test_fim_scan_db_free(void **state) {
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":1000,\"alert_type\":\"normal\"}");
     will_return(__wrap_send_log_msg, 1);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6345): Folders monitored with real-time engine: 0");
-
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
 
     fim_scan();
@@ -3111,8 +3094,6 @@ static void test_fim_scan_no_limit(void **state) {
     will_return(__wrap_fim_db_set_all_unscanned, 0);
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6343): No limit set to maximum number of files to be monitored");
-
-    expect_string(__wrap__mdebug2, formatted_msg, "(6345): Folders monitored with real-time engine: 0");
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_ENDED);
 

--- a/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.h
@@ -15,8 +15,10 @@
 
 int __wrap_OSHash_Add(OSHash *self, const char *key, void *data);
 
+int __real_OSHash_Add_ex(OSHash *self, const char *key, void *data);
 int __wrap_OSHash_Add_ex(OSHash *self, const char *key, void *data);
 
+void *__real_OSHash_Begin(const OSHash *self, unsigned int *i);
 void *__wrap_OSHash_Begin(const OSHash *self, unsigned int *i);
 
 void *__wrap_OSHash_Clean(OSHash *self, void (*cleaner)(void*));
@@ -27,6 +29,7 @@ void *__wrap_OSHash_Delete_ex(OSHash *self, const char *key);
 
 void *__wrap_OSHash_Get(const OSHash *self, const char *key);
 
+void *__real_OSHash_Get_ex(const OSHash *self, const char *key);
 void *__wrap_OSHash_Get_ex(const OSHash *self, const char *key);
 
 void *__wrap_OSHash_Next(const OSHash *self, unsigned int *i, OSHashNode *current);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.c
@@ -13,12 +13,6 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-int __wrap_count_watches() {
-    function_called();
-
-    return mock();
-}
-
 int __wrap_realtime_adddir(const char *dir, int whodata, __attribute__((unused)) int followsl) {
     check_expected(dir);
     check_expected(whodata);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/run_realtime_wrappers.h
@@ -11,8 +11,6 @@
 #ifndef RUN_REALTIME_WRAPPERS_H
 #define RUN_REALTIME_WRAPPERS_H
 
-int __wrap_count_watches();
-
 int __wrap_realtime_adddir(const char *dir, int whodata, int followsl);
 
 int __wrap_realtime_start();


### PR DESCRIPTION
|Related issue|
|---|
|#6299|

## Description

After investigating an increase in the memory used by FIM, we found that when an overflow occured in the inotify queue the lost events could cause some entries in the hashmap to linger indefinitely. This problem was fixed by creating a function that sweeps the hashmap and verifies every entry is properly configured in inotify, removing the ones that correspond to deleted directories.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
