### PR TITLE
Reduce response time to upgrade request command

### DIFF
--- a/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
@@ -61,7 +61,7 @@ if(${TARGET} STREQUAL "server")
     list(APPEND upgrade_flags "-Wl,--wrap,_mterror -Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,isChroot -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,close \
                             -Wl,--wrap,wm_agent_upgrade_parse_task_module_request -Wl,--wrap,wm_agent_upgrade_task_module_callback -Wl,--wrap,wm_agent_upgrade_parse_agent_response -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fclose \
                             -Wl,--wrap,OS_SHA1_File -Wl,--wrap,wm_agent_upgrade_get_first_node -Wl,--wrap,wm_agent_upgrade_get_next_node -Wl,--wrap,wm_agent_upgrade_compare_versions -Wl,--wrap,wm_agent_upgrade_remove_entry \
-                            -Wl,--wrap,wm_agent_upgrade_validate_task_status_message -Wl,--wrap,wm_agent_upgrade_validate_wpk -Wl,--wrap,wm_agent_upgrade_validate_wpk_custom \
+                            -Wl,--wrap,wm_agent_upgrade_validate_task_status_message -Wl,--wrap,wm_agent_upgrade_validate_wpk -Wl,--wrap,wm_agent_upgrade_validate_wpk_custom -Wl,--wrap,wm_agent_upgrade_validate_wpk_version \
                             -Wl,--wrap,queue_push_ex -Wl,--wrap,queue_pop_ex -Wl,--wrap,queue_pop_ex_timedwait -Wl,--wrap,pthread_cond_signal -Wl,--wrap,pthread_cond_wait -Wl,--wrap,CreateThread \
                             -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,getpid")
 

--- a/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
@@ -54,8 +54,8 @@ if(${TARGET} STREQUAL "server")
     list(APPEND upgrade_names "test_wm_agent_upgrade_commands")
     list(APPEND upgrade_flags "-Wl,--wrap,_mtinfo -Wl,--wrap,_mtwarn \
                             -Wl,--wrap,wm_agent_upgrade_parse_task_module_request -Wl,--wrap,wm_agent_upgrade_task_module_callback -Wl,--wrap,wm_agent_upgrade_validate_task_status_message -Wl,--wrap,wm_agent_upgrade_validate_id \
-                            -Wl,--wrap,wm_agent_upgrade_validate_status -Wl,--wrap,wm_agent_upgrade_validate_version -Wl,--wrap,wdb_get_agent_info -Wl,--wrap,wm_agent_upgrade_create_task_entry -Wl,--wrap,wm_agent_upgrade_parse_data_response \
-                            -Wl,--wrap,wm_agent_upgrade_parse_response -Wl,--wrap,wm_agent_upgrade_prepare_upgrades")
+                            -Wl,--wrap,wm_agent_upgrade_validate_status -Wl,--wrap,wm_agent_upgrade_validate_system -Wl,--wrap,wm_agent_upgrade_validate_version -Wl,--wrap,wdb_get_agent_info -Wl,--wrap,wm_agent_upgrade_create_task_entry \
+                            -Wl,--wrap,wm_agent_upgrade_parse_data_response -Wl,--wrap,wm_agent_upgrade_parse_response -Wl,--wrap,wm_agent_upgrade_prepare_upgrades -Wl,--wrap,wm_agent_upgrade_get_agent_ids")
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_upgrades")
     list(APPEND upgrade_flags "-Wl,--wrap,_mterror -Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,isChroot -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,close \

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_commands.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_commands.c
@@ -23,48 +23,39 @@
 #include "../../wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.h"
 #include "../../headers/shared.h"
 
-int wm_agent_upgrade_analyze_agent(int agent_id, wm_agent_task *agent_task, const wm_manager_configs* manager_configs);
-int wm_agent_upgrade_validate_agent_task(const wm_agent_task *agent_task, const wm_manager_configs* manager_configs);
+int wm_agent_upgrade_analyze_agent(int agent_id, wm_agent_task *agent_task);
+int wm_agent_upgrade_validate_agent_task(const wm_agent_task *agent_task);
+int wm_agent_upgrade_create_upgrade_tasks(cJSON *data_array, wm_upgrade_command command);
 
 // Setup / teardown
 
-static int setup_config_agent_task(void **state) {
-    wm_manager_configs *config = NULL;
+static int setup_agent_task(void **state) {
     wm_agent_task *agent_task = NULL;
-    os_calloc(1, sizeof(wm_manager_configs), config);
     agent_task = wm_agent_upgrade_init_agent_task();
     agent_task->agent_info = wm_agent_upgrade_init_agent_info();
     agent_task->task_info = wm_agent_upgrade_init_task_info();
-    state[0] = (void *)config;
-    state[1] = (void *)agent_task;
+    *state = (void *)agent_task;
     return 0;
 }
 
-static int teardown_config_agent_task(void **state) {
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-    os_free(config);
+static int teardown_agent_task(void **state) {
+    wm_agent_task *agent_task = *state;
     wm_agent_upgrade_free_agent_task(agent_task);
     return 0;
 }
 
 static int setup_analyze_agent_task(void **state) {
     setup_hash_table(NULL);
-    wm_manager_configs *config = NULL;
     wm_agent_task *agent_task = NULL;
-    os_calloc(1, sizeof(wm_manager_configs), config);
     agent_task = wm_agent_upgrade_init_agent_task();
     agent_task->task_info = wm_agent_upgrade_init_task_info();
-    state[0] = (void *)config;
-    state[1] = (void *)agent_task;
+    *state = (void *)agent_task;
     return 0;
 }
 
 static int teardown_analyze_agent_task(void **state) {
     teardown_hash_table();
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-    os_free(config);
+    wm_agent_task *agent_task = *state;
     wm_agent_upgrade_free_agent_task(agent_task);
     return 0;
 }
@@ -140,37 +131,25 @@ void test_wm_agent_upgrade_validate_agent_task_upgrade_ok(void **state)
 
     int agent = 44;
     int keep_alive = 2345678;
+    char *platform = "ubuntu";
+    char *os_major = "18";
+    char *os_minor = "04";
+    char *arch = "x64_86";
+    char *wazuh_version = "v3.13.1";
     wm_upgrade_task *upgrade_task = NULL;
 
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-
-    config->chunk_size = 5;
+    wm_agent_task *agent_task = *state;
 
     agent_task->agent_info->agent_id = agent;
     agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(platform, agent_task->agent_info->platform);
+    os_strdup(os_major, agent_task->agent_info->major_version);
+    os_strdup(os_minor, agent_task->agent_info->minor_version);
+    os_strdup(arch, agent_task->agent_info->architecture);
+    os_strdup(wazuh_version, agent_task->agent_info->wazuh_version);
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
     agent_task->task_info->task = upgrade_task;
-
-    cJSON *request = cJSON_CreateObject();
-    cJSON *origin = cJSON_CreateObject();
-    cJSON *parameters = cJSON_CreateObject();
-    cJSON *agents = cJSON_CreateArray();
-
-    cJSON_AddStringToObject(origin, "module", "upgrade_module");
-    cJSON_AddItemToObject(request, "origin", origin);
-    cJSON_AddStringToObject(request, "command", "upgrade_get_status");
-    cJSON_AddItemToArray(agents, cJSON_CreateNumber(agent));
-    cJSON_AddItemToObject(parameters, "agents", agents);
-    cJSON_AddItemToObject(request, "parameters", parameters);
-
-    cJSON *task_response = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(task_response, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(task_response, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-    cJSON_AddNumberToObject(task_response, "agent", agent);
-    cJSON_AddStringToObject(task_response, "status", "Done");
 
     // wm_agent_upgrade_validate_id
 
@@ -182,31 +161,22 @@ void test_wm_agent_upgrade_validate_agent_task_upgrade_ok(void **state)
     expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
+    // wm_agent_upgrade_validate_system
+
+    expect_string(__wrap_wm_agent_upgrade_validate_system, platform, platform);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_major, os_major);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_minor, os_minor);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, arch, arch);
+    will_return(__wrap_wm_agent_upgrade_validate_system, WM_UPGRADE_SUCCESS);
+
     // wm_agent_upgrade_validate_version
+
+    expect_string(__wrap_wm_agent_upgrade_validate_version, wazuh_version, wazuh_version);
     expect_value(__wrap_wm_agent_upgrade_validate_version, command, agent_task->task_info->command);
-    expect_memory(__wrap_wm_agent_upgrade_validate_version, manager_configs, config, sizeof(config));
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
+    will_return(__wrap_wm_agent_upgrade_validate_version, "v4.1.0");
     will_return(__wrap_wm_agent_upgrade_validate_version, WM_UPGRADE_SUCCESS);
 
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, request);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, request, sizeof(request));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, task_response);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
-
-    // wm_agent_upgrade_validate_task_status_message
-
-    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, task_response, sizeof(task_response));
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, "Done");
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
-
-    int ret = wm_agent_upgrade_validate_agent_task(agent_task, config);
+    int ret = wm_agent_upgrade_validate_agent_task(agent_task);
 
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
 }
@@ -217,38 +187,26 @@ void test_wm_agent_upgrade_validate_agent_task_upgrade_custom_ok(void **state)
 
     int agent = 44;
     int keep_alive = 2345678;
+    char *platform = "ubuntu";
+    char *os_major = "18";
+    char *os_minor = "04";
+    char *arch = "x64_86";
+    char *wazuh_version = "v3.13.1";
     wm_upgrade_custom_task *upgrade_custom_task = NULL;
 
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-
-    config->chunk_size = 5;
+    wm_agent_task *agent_task = *state;
 
     agent_task->agent_info->agent_id = agent;
     agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(platform, agent_task->agent_info->platform);
+    os_strdup(os_major, agent_task->agent_info->major_version);
+    os_strdup(os_minor, agent_task->agent_info->minor_version);
+    os_strdup(arch, agent_task->agent_info->architecture);
+    os_strdup(wazuh_version, agent_task->agent_info->wazuh_version);
     upgrade_custom_task = wm_agent_upgrade_init_upgrade_custom_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE_CUSTOM;
     agent_task->task_info->task = upgrade_custom_task;
 
-    cJSON *request = cJSON_CreateObject();
-    cJSON *origin = cJSON_CreateObject();
-    cJSON *parameters = cJSON_CreateObject();
-    cJSON *agents = cJSON_CreateArray();
-
-    cJSON_AddStringToObject(origin, "module", "upgrade_module");
-    cJSON_AddItemToObject(request, "origin", origin);
-    cJSON_AddStringToObject(request, "command", "upgrade_get_status");
-    cJSON_AddItemToArray(agents, cJSON_CreateNumber(agent));
-    cJSON_AddItemToObject(parameters, "agents", agents);
-    cJSON_AddItemToObject(request, "parameters", parameters);
-
-    cJSON *task_response = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(task_response, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(task_response, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-    cJSON_AddNumberToObject(task_response, "agent", agent);
-    cJSON_AddStringToObject(task_response, "status", "Done");
-
     // wm_agent_upgrade_validate_id
 
     expect_value(__wrap_wm_agent_upgrade_validate_id, agent_id, agent);
@@ -259,185 +217,23 @@ void test_wm_agent_upgrade_validate_agent_task_upgrade_custom_ok(void **state)
     expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
+    // wm_agent_upgrade_validate_system
+
+    expect_string(__wrap_wm_agent_upgrade_validate_system, platform, platform);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_major, os_major);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_minor, os_minor);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, arch, arch);
+    will_return(__wrap_wm_agent_upgrade_validate_system, WM_UPGRADE_SUCCESS);
+
     // wm_agent_upgrade_validate_version
+
+    expect_string(__wrap_wm_agent_upgrade_validate_version, wazuh_version, wazuh_version);
     expect_value(__wrap_wm_agent_upgrade_validate_version, command, agent_task->task_info->command);
-    expect_memory(__wrap_wm_agent_upgrade_validate_version, manager_configs, config, sizeof(config));
     will_return(__wrap_wm_agent_upgrade_validate_version, WM_UPGRADE_SUCCESS);
 
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, request);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, request, sizeof(request));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, task_response);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
-
-    // wm_agent_upgrade_validate_task_status_message
-
-    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, task_response, sizeof(task_response));
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, "Done");
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
-
-    int ret = wm_agent_upgrade_validate_agent_task(agent_task, config);
+    int ret = wm_agent_upgrade_validate_agent_task(agent_task);
 
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
-}
-
-void test_wm_agent_upgrade_validate_agent_task_in_progress_err(void **state)
-{
-    (void) state;
-
-    int agent = 44;
-    int keep_alive = 2345678;
-    wm_upgrade_task *upgrade_task = NULL;
-
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-
-    config->chunk_size = 5;
-
-    agent_task->agent_info->agent_id = agent;
-    agent_task->agent_info->last_keep_alive = keep_alive;
-    upgrade_task = wm_agent_upgrade_init_upgrade_task();
-    agent_task->task_info->command = WM_UPGRADE_UPGRADE;
-    agent_task->task_info->task = upgrade_task;
-
-    cJSON *request = cJSON_CreateObject();
-    cJSON *origin = cJSON_CreateObject();
-    cJSON *parameters = cJSON_CreateObject();
-    cJSON *agents = cJSON_CreateArray();
-
-    cJSON_AddStringToObject(origin, "module", "upgrade_module");
-    cJSON_AddItemToObject(request, "origin", origin);
-    cJSON_AddStringToObject(request, "command", "upgrade_get_status");
-    cJSON_AddItemToArray(agents, cJSON_CreateNumber(agent));
-    cJSON_AddItemToObject(parameters, "agents", agents);
-    cJSON_AddItemToObject(request, "parameters", parameters);
-
-    cJSON *task_response = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(task_response, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(task_response, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-    cJSON_AddNumberToObject(task_response, "agent", agent);
-    cJSON_AddStringToObject(task_response, "status", "Done");
-
-    // wm_agent_upgrade_validate_id
-
-    expect_value(__wrap_wm_agent_upgrade_validate_id, agent_id, agent);
-    will_return(__wrap_wm_agent_upgrade_validate_id, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_validate_status
-
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
-    will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_validate_version
-    expect_value(__wrap_wm_agent_upgrade_validate_version, command, agent_task->task_info->command);
-    expect_memory(__wrap_wm_agent_upgrade_validate_version, manager_configs, config, sizeof(config));
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
-    will_return(__wrap_wm_agent_upgrade_validate_version, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, request);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, request, sizeof(request));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, task_response);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
-
-    // wm_agent_upgrade_validate_task_status_message
-
-    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, task_response, sizeof(task_response));
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, "In progress");
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
-
-    int ret = wm_agent_upgrade_validate_agent_task(agent_task, config);
-
-    assert_int_equal(ret, WM_UPGRADE_UPGRADE_ALREADY_IN_PROGRESS);
-}
-
-void test_wm_agent_upgrade_validate_agent_task_task_manager_err(void **state)
-{
-    (void) state;
-
-    int agent = 44;
-    int keep_alive = 2345678;
-    wm_upgrade_task *upgrade_task = NULL;
-
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-
-    config->chunk_size = 5;
-
-    agent_task->agent_info->agent_id = agent;
-    agent_task->agent_info->last_keep_alive = keep_alive;
-    upgrade_task = wm_agent_upgrade_init_upgrade_task();
-    agent_task->task_info->command = WM_UPGRADE_UPGRADE;
-    agent_task->task_info->task = upgrade_task;
-
-    cJSON *request = cJSON_CreateObject();
-    cJSON *origin = cJSON_CreateObject();
-    cJSON *parameters = cJSON_CreateObject();
-    cJSON *agents = cJSON_CreateArray();
-
-    cJSON_AddStringToObject(origin, "module", "upgrade_module");
-    cJSON_AddItemToObject(request, "origin", origin);
-    cJSON_AddStringToObject(request, "command", "upgrade_get_status");
-    cJSON_AddItemToArray(agents, cJSON_CreateNumber(agent));
-    cJSON_AddItemToObject(parameters, "agents", agents);
-    cJSON_AddItemToObject(request, "parameters", parameters);
-
-    cJSON *task_response = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(task_response, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(task_response, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-    cJSON_AddNumberToObject(task_response, "agent", agent);
-    cJSON_AddStringToObject(task_response, "status", "Done");
-
-    // wm_agent_upgrade_validate_id
-
-    expect_value(__wrap_wm_agent_upgrade_validate_id, agent_id, agent);
-    will_return(__wrap_wm_agent_upgrade_validate_id, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_validate_status
-
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
-    will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_validate_version
-    expect_value(__wrap_wm_agent_upgrade_validate_version, command, agent_task->task_info->command);
-    expect_memory(__wrap_wm_agent_upgrade_validate_version, manager_configs, config, sizeof(config));
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
-    will_return(__wrap_wm_agent_upgrade_validate_version, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, request);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, request, sizeof(request));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, task_response);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
-
-    // wm_agent_upgrade_validate_task_status_message
-
-    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, task_response, sizeof(task_response));
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, "Done");
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 0);
-
-    int ret = wm_agent_upgrade_validate_agent_task(agent_task, config);
-
-    assert_int_equal(ret, WM_UPGRADE_TASK_MANAGER_COMMUNICATION);
 }
 
 void test_wm_agent_upgrade_validate_agent_task_version_err(void **state)
@@ -446,15 +242,22 @@ void test_wm_agent_upgrade_validate_agent_task_version_err(void **state)
 
     int agent = 44;
     int keep_alive = 2345678;
+    char *platform = "ubuntu";
+    char *os_major = "18";
+    char *os_minor = "04";
+    char *arch = "x64_86";
+    char *wazuh_version = "v3.13.1";
     wm_upgrade_task *upgrade_task = NULL;
 
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-
-    config->chunk_size = 5;
+    wm_agent_task *agent_task = *state;
 
     agent_task->agent_info->agent_id = agent;
     agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(platform, agent_task->agent_info->platform);
+    os_strdup(os_major, agent_task->agent_info->major_version);
+    os_strdup(os_minor, agent_task->agent_info->minor_version);
+    os_strdup(arch, agent_task->agent_info->architecture);
+    os_strdup(wazuh_version, agent_task->agent_info->wazuh_version);
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
     agent_task->task_info->task = upgrade_task;
@@ -469,14 +272,71 @@ void test_wm_agent_upgrade_validate_agent_task_version_err(void **state)
     expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
+    // wm_agent_upgrade_validate_system
+
+    expect_string(__wrap_wm_agent_upgrade_validate_system, platform, platform);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_major, os_major);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_minor, os_minor);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, arch, arch);
+    will_return(__wrap_wm_agent_upgrade_validate_system, WM_UPGRADE_SUCCESS);
+
     // wm_agent_upgrade_validate_version
+
+    expect_string(__wrap_wm_agent_upgrade_validate_version, wazuh_version, wazuh_version);
     expect_value(__wrap_wm_agent_upgrade_validate_version, command, agent_task->task_info->command);
-    expect_memory(__wrap_wm_agent_upgrade_validate_version, manager_configs, config, sizeof(config));
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
     will_return(__wrap_wm_agent_upgrade_validate_version, "");
     will_return(__wrap_wm_agent_upgrade_validate_version, WM_UPGRADE_GLOBAL_DB_FAILURE);
 
-    int ret = wm_agent_upgrade_validate_agent_task(agent_task, config);
+    int ret = wm_agent_upgrade_validate_agent_task(agent_task);
+
+    assert_int_equal(ret, WM_UPGRADE_GLOBAL_DB_FAILURE);
+}
+
+void test_wm_agent_upgrade_validate_agent_task_system_err(void **state)
+{
+    (void) state;
+
+    int agent = 44;
+    int keep_alive = 2345678;
+    char *platform = "ubuntu";
+    char *os_major = "18";
+    char *os_minor = "04";
+    char *arch = "x64_86";
+    char *wazuh_version = "v3.13.1";
+    wm_upgrade_task *upgrade_task = NULL;
+
+    wm_agent_task *agent_task = *state;
+
+    agent_task->agent_info->agent_id = agent;
+    agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(platform, agent_task->agent_info->platform);
+    os_strdup(os_major, agent_task->agent_info->major_version);
+    os_strdup(os_minor, agent_task->agent_info->minor_version);
+    os_strdup(arch, agent_task->agent_info->architecture);
+    os_strdup(wazuh_version, agent_task->agent_info->wazuh_version);
+    upgrade_task = wm_agent_upgrade_init_upgrade_task();
+    agent_task->task_info->command = WM_UPGRADE_UPGRADE;
+    agent_task->task_info->task = upgrade_task;
+
+    // wm_agent_upgrade_validate_id
+
+    expect_value(__wrap_wm_agent_upgrade_validate_id, agent_id, agent);
+    will_return(__wrap_wm_agent_upgrade_validate_id, WM_UPGRADE_SUCCESS);
+
+    // wm_agent_upgrade_validate_status
+
+    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
+    will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
+
+    // wm_agent_upgrade_validate_system
+
+    expect_string(__wrap_wm_agent_upgrade_validate_system, platform, platform);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_major, os_major);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_minor, os_minor);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, arch, arch);
+    will_return(__wrap_wm_agent_upgrade_validate_system, WM_UPGRADE_GLOBAL_DB_FAILURE);
+
+    int ret = wm_agent_upgrade_validate_agent_task(agent_task);
 
     assert_int_equal(ret, WM_UPGRADE_GLOBAL_DB_FAILURE);
 }
@@ -487,15 +347,22 @@ void test_wm_agent_upgrade_validate_agent_task_status_err(void **state)
 
     int agent = 44;
     int keep_alive = 2345678;
+    char *platform = "ubuntu";
+    char *os_major = "18";
+    char *os_minor = "04";
+    char *arch = "x64_86";
+    char *wazuh_version = "v3.13.1";
     wm_upgrade_task *upgrade_task = NULL;
 
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-
-    config->chunk_size = 5;
+    wm_agent_task *agent_task = *state;
 
     agent_task->agent_info->agent_id = agent;
     agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(platform, agent_task->agent_info->platform);
+    os_strdup(os_major, agent_task->agent_info->major_version);
+    os_strdup(os_minor, agent_task->agent_info->minor_version);
+    os_strdup(arch, agent_task->agent_info->architecture);
+    os_strdup(wazuh_version, agent_task->agent_info->wazuh_version);
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
     agent_task->task_info->task = upgrade_task;
@@ -510,7 +377,7 @@ void test_wm_agent_upgrade_validate_agent_task_status_err(void **state)
     expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_AGENT_IS_NOT_ACTIVE);
 
-    int ret = wm_agent_upgrade_validate_agent_task(agent_task, config);
+    int ret = wm_agent_upgrade_validate_agent_task(agent_task);
 
     assert_int_equal(ret, WM_UPGRADE_AGENT_IS_NOT_ACTIVE);
 }
@@ -521,15 +388,22 @@ void test_wm_agent_upgrade_validate_agent_task_agent_id_err(void **state)
 
     int agent = 44;
     int keep_alive = 2345678;
+    char *platform = "ubuntu";
+    char *os_major = "18";
+    char *os_minor = "04";
+    char *arch = "x64_86";
+    char *wazuh_version = "v3.13.1";
     wm_upgrade_task *upgrade_task = NULL;
 
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-
-    config->chunk_size = 5;
+    wm_agent_task *agent_task = *state;
 
     agent_task->agent_info->agent_id = agent;
     agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(platform, agent_task->agent_info->platform);
+    os_strdup(os_major, agent_task->agent_info->major_version);
+    os_strdup(os_minor, agent_task->agent_info->minor_version);
+    os_strdup(arch, agent_task->agent_info->architecture);
+    os_strdup(wazuh_version, agent_task->agent_info->wazuh_version);
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
     agent_task->task_info->task = upgrade_task;
@@ -539,7 +413,7 @@ void test_wm_agent_upgrade_validate_agent_task_agent_id_err(void **state)
     expect_value(__wrap_wm_agent_upgrade_validate_id, agent_id, agent);
     will_return(__wrap_wm_agent_upgrade_validate_id, WM_UPGRADE_INVALID_ACTION_FOR_MANAGER);
 
-    int ret = wm_agent_upgrade_validate_agent_task(agent_task, config);
+    int ret = wm_agent_upgrade_validate_agent_task(agent_task);
 
     assert_int_equal(ret, WM_UPGRADE_INVALID_ACTION_FOR_MANAGER);
 }
@@ -558,10 +432,7 @@ void test_wm_agent_upgrade_analyze_agent_ok(void **state)
     char *version = "v3.13.1";
     wm_upgrade_task *upgrade_task = NULL;
 
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-
-    config->chunk_size = 5;
+    wm_agent_task *agent_task = *state;
 
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
@@ -576,25 +447,6 @@ void test_wm_agent_upgrade_analyze_agent_ok(void **state)
     cJSON_AddStringToObject(agent_info, "version", version);
     cJSON_AddNumberToObject(agent_info, "last_keepalive", keep_alive);
     cJSON_AddItemToArray(agent_info_array, agent_info);
-
-    cJSON *request_status = cJSON_CreateObject();
-    cJSON *origin_status = cJSON_CreateObject();
-    cJSON *parameters_status = cJSON_CreateObject();
-    cJSON *agents_status = cJSON_CreateArray();
-
-    cJSON_AddStringToObject(origin_status, "module", "upgrade_module");
-    cJSON_AddItemToObject(request_status, "origin", origin_status);
-    cJSON_AddStringToObject(request_status, "command", "upgrade_get_status");
-    cJSON_AddItemToArray(agents_status, cJSON_CreateNumber(agent));
-    cJSON_AddItemToObject(parameters_status, "agents", agents_status);
-    cJSON_AddItemToObject(request_status, "parameters", parameters_status);
-
-    cJSON *status_response = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(status_response, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(status_response, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-    cJSON_AddNumberToObject(status_response, "agent", agent);
-    cJSON_AddStringToObject(status_response, "status", "Done");
 
     // wdb_agent_info
 
@@ -611,35 +463,26 @@ void test_wm_agent_upgrade_analyze_agent_ok(void **state)
     expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
+    // wm_agent_upgrade_validate_system
+
+    expect_string(__wrap_wm_agent_upgrade_validate_system, platform, platform);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_major, major);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_minor, minor);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, arch, arch);
+    will_return(__wrap_wm_agent_upgrade_validate_system, WM_UPGRADE_SUCCESS);
+
     // wm_agent_upgrade_validate_version
+
+    expect_string(__wrap_wm_agent_upgrade_validate_version, wazuh_version, version);
     expect_value(__wrap_wm_agent_upgrade_validate_version, command, agent_task->task_info->command);
-    expect_memory(__wrap_wm_agent_upgrade_validate_version, manager_configs, config, sizeof(config));
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
+    will_return(__wrap_wm_agent_upgrade_validate_version, "v4.1.0");
     will_return(__wrap_wm_agent_upgrade_validate_version, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, request_status);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, request_status, sizeof(request_status));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, status_response);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
-
-    // wm_agent_upgrade_validate_task_status_message
-
-    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, status_response, sizeof(status_response));
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, "Done");
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
 
     // wm_agent_upgrade_create_task_entry
     expect_value(__wrap_wm_agent_upgrade_create_task_entry, agent_id, agent);
     will_return(__wrap_wm_agent_upgrade_create_task_entry, OSHASH_SUCCESS);
 
-    error_code = wm_agent_upgrade_analyze_agent(agent, agent_task, config);
+    error_code = wm_agent_upgrade_analyze_agent(agent, agent_task);
 
     assert_int_equal(error_code, WM_UPGRADE_SUCCESS);
     assert_non_null(agent_task->agent_info);
@@ -665,10 +508,7 @@ void test_wm_agent_upgrade_analyze_agent_duplicated_err(void **state)
     char *version = "v3.13.1";
     wm_upgrade_task *upgrade_task = NULL;
 
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-
-    config->chunk_size = 5;
+    wm_agent_task *agent_task = *state;
 
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
@@ -683,24 +523,6 @@ void test_wm_agent_upgrade_analyze_agent_duplicated_err(void **state)
     cJSON_AddStringToObject(agent_info, "version", version);
     cJSON_AddNumberToObject(agent_info, "last_keepalive", keep_alive);
     cJSON_AddItemToArray(agent_info_array, agent_info);
-
-    cJSON *request_status = cJSON_CreateObject();
-    cJSON *origin_status = cJSON_CreateObject();
-    cJSON *parameters_status = cJSON_CreateObject();
-    cJSON *agents_status = cJSON_CreateArray();
-
-    cJSON_AddStringToObject(origin_status, "module", "upgrade_module");
-    cJSON_AddItemToObject(request_status, "origin", origin_status);
-    cJSON_AddStringToObject(request_status, "command", "upgrade_get_status");
-    cJSON_AddItemToArray(agents_status, cJSON_CreateNumber(agent));
-    cJSON_AddItemToObject(parameters_status, "agents", agents_status);
-    cJSON_AddItemToObject(request_status, "parameters", parameters_status);
-
-    cJSON *status_response = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(status_response, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(status_response, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-    cJSON_AddNumberToObject(status_response, "agent", agent);
 
     // wdb_agent_info
 
@@ -717,35 +539,26 @@ void test_wm_agent_upgrade_analyze_agent_duplicated_err(void **state)
     expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
+    // wm_agent_upgrade_validate_system
+
+    expect_string(__wrap_wm_agent_upgrade_validate_system, platform, platform);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_major, major);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_minor, minor);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, arch, arch);
+    will_return(__wrap_wm_agent_upgrade_validate_system, WM_UPGRADE_SUCCESS);
+
     // wm_agent_upgrade_validate_version
+
+    expect_string(__wrap_wm_agent_upgrade_validate_version, wazuh_version, version);
     expect_value(__wrap_wm_agent_upgrade_validate_version, command, agent_task->task_info->command);
-    expect_memory(__wrap_wm_agent_upgrade_validate_version, manager_configs, config, sizeof(config));
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
+    will_return(__wrap_wm_agent_upgrade_validate_version, "v4.1.0");
     will_return(__wrap_wm_agent_upgrade_validate_version, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, request_status);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, request_status, sizeof(request_status));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, status_response);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
-
-    // wm_agent_upgrade_validate_task_status_message
-
-    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, status_response, sizeof(status_response));
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, "Done");
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
 
     // wm_agent_upgrade_create_task_entry
     expect_value(__wrap_wm_agent_upgrade_create_task_entry, agent_id, agent);
     will_return(__wrap_wm_agent_upgrade_create_task_entry, OSHASH_DUPLICATE);
 
-    error_code = wm_agent_upgrade_analyze_agent(agent, agent_task, config);
+    error_code = wm_agent_upgrade_analyze_agent(agent, agent_task);
 
     assert_int_equal(error_code, WM_UPGRADE_UPGRADE_ALREADY_IN_PROGRESS);
     assert_non_null(agent_task->agent_info);
@@ -771,10 +584,7 @@ void test_wm_agent_upgrade_analyze_agent_unknown_err(void **state)
     char *version = "v3.13.1";
     wm_upgrade_task *upgrade_task = NULL;
 
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-
-    config->chunk_size = 5;
+    wm_agent_task *agent_task = *state;
 
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
@@ -789,24 +599,6 @@ void test_wm_agent_upgrade_analyze_agent_unknown_err(void **state)
     cJSON_AddStringToObject(agent_info, "version", version);
     cJSON_AddNumberToObject(agent_info, "last_keepalive", keep_alive);
     cJSON_AddItemToArray(agent_info_array, agent_info);
-
-    cJSON *request_status = cJSON_CreateObject();
-    cJSON *origin_status = cJSON_CreateObject();
-    cJSON *parameters_status = cJSON_CreateObject();
-    cJSON *agents_status = cJSON_CreateArray();
-
-    cJSON_AddStringToObject(origin_status, "module", "upgrade_module");
-    cJSON_AddItemToObject(request_status, "origin", origin_status);
-    cJSON_AddStringToObject(request_status, "command", "upgrade_get_status");
-    cJSON_AddItemToArray(agents_status, cJSON_CreateNumber(agent));
-    cJSON_AddItemToObject(parameters_status, "agents", agents_status);
-    cJSON_AddItemToObject(request_status, "parameters", parameters_status);
-
-    cJSON *status_response = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(status_response, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(status_response, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-    cJSON_AddNumberToObject(status_response, "agent", agent);
 
     // wdb_agent_info
 
@@ -823,35 +615,26 @@ void test_wm_agent_upgrade_analyze_agent_unknown_err(void **state)
     expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
+    // wm_agent_upgrade_validate_system
+
+    expect_string(__wrap_wm_agent_upgrade_validate_system, platform, platform);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_major, major);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_minor, minor);
+    expect_string(__wrap_wm_agent_upgrade_validate_system, arch, arch);
+    will_return(__wrap_wm_agent_upgrade_validate_system, WM_UPGRADE_SUCCESS);
+
     // wm_agent_upgrade_validate_version
+
+    expect_string(__wrap_wm_agent_upgrade_validate_version, wazuh_version, version);
     expect_value(__wrap_wm_agent_upgrade_validate_version, command, agent_task->task_info->command);
-    expect_memory(__wrap_wm_agent_upgrade_validate_version, manager_configs, config, sizeof(config));
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
-    will_return(__wrap_wm_agent_upgrade_validate_version, "");
+    will_return(__wrap_wm_agent_upgrade_validate_version, "v4.1.0");
     will_return(__wrap_wm_agent_upgrade_validate_version, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, request_status);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, request_status, sizeof(request_status));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, status_response);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
-
-    // wm_agent_upgrade_validate_task_status_message
-
-    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, status_response, sizeof(status_response));
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, "Done");
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
 
     // wm_agent_upgrade_create_task_entry
     expect_value(__wrap_wm_agent_upgrade_create_task_entry, agent_id, agent);
     will_return(__wrap_wm_agent_upgrade_create_task_entry, OS_INVALID);
 
-    error_code = wm_agent_upgrade_analyze_agent(agent, agent_task, config);
+    error_code = wm_agent_upgrade_analyze_agent(agent, agent_task);
 
     assert_int_equal(error_code, WM_UPGRADE_UNKNOWN_ERROR);
     assert_non_null(agent_task->agent_info);
@@ -877,10 +660,7 @@ void test_wm_agent_upgrade_analyze_agent_validate_err(void **state)
     char *version = "v3.13.1";
     wm_upgrade_task *upgrade_task = NULL;
 
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-
-    config->chunk_size = 5;
+    wm_agent_task *agent_task = *state;
 
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
@@ -906,7 +686,7 @@ void test_wm_agent_upgrade_analyze_agent_validate_err(void **state)
     expect_value(__wrap_wm_agent_upgrade_validate_id, agent_id, agent);
     will_return(__wrap_wm_agent_upgrade_validate_id, WM_UPGRADE_INVALID_ACTION_FOR_MANAGER);
 
-    error_code = wm_agent_upgrade_analyze_agent(agent, agent_task, config);
+    error_code = wm_agent_upgrade_analyze_agent(agent, agent_task);
 
     assert_int_equal(error_code, WM_UPGRADE_INVALID_ACTION_FOR_MANAGER);
     assert_non_null(agent_task->agent_info);
@@ -926,10 +706,7 @@ void test_wm_agent_upgrade_analyze_agent_global_db_err(void **state)
     int agent = 119;
     wm_upgrade_task *upgrade_task = NULL;
 
-    wm_manager_configs *config = state[0];
-    wm_agent_task *agent_task = state[1];
-
-    config->chunk_size = 5;
+    wm_agent_task *agent_task =*state;
 
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
@@ -940,7 +717,7 @@ void test_wm_agent_upgrade_analyze_agent_global_db_err(void **state)
     expect_value(__wrap_wdb_get_agent_info, id, agent);
     will_return(__wrap_wdb_get_agent_info, NULL);
 
-    error_code = wm_agent_upgrade_analyze_agent(agent, agent_task, config);
+    error_code = wm_agent_upgrade_analyze_agent(agent, agent_task);
 
     assert_int_equal(error_code, WM_UPGRADE_GLOBAL_DB_FAILURE);
     assert_non_null(agent_task->agent_info);
@@ -1098,7 +875,6 @@ void test_wm_agent_upgrade_process_upgrade_custom_command(void **state)
     (void) state;
 
     int agents[3];
-    wm_manager_configs *config = NULL;
     wm_upgrade_custom_task *upgrade_custom_task = NULL;
 
     char *custom_file_path = "/tmp/test.wpk";
@@ -1107,9 +883,6 @@ void test_wm_agent_upgrade_process_upgrade_custom_command(void **state)
     agents[0] = 1;
     agents[1] = 2;
     agents[2] = OS_INVALID;
-
-    os_calloc(1, sizeof(wm_manager_configs), config);
-    config->chunk_size = 5;
 
     upgrade_custom_task = wm_agent_upgrade_init_upgrade_custom_task();
     os_strdup(custom_file_path, upgrade_custom_task->custom_file_path);
@@ -1127,24 +900,23 @@ void test_wm_agent_upgrade_process_upgrade_custom_command(void **state)
     cJSON_AddNumberToObject(agent_info1, "last_keepalive", 123456789);
     cJSON_AddItemToArray(agent_info_array1, agent_info1);
 
-    cJSON *status_request1 = cJSON_CreateObject();
-    cJSON *status_origin1 = cJSON_CreateObject();
-    cJSON *status_parameters1 = cJSON_CreateObject();
-    cJSON *status_agents1 = cJSON_CreateArray();
+    cJSON *agents_array1 = cJSON_CreateArray();
+    cJSON_AddItemToArray(agents_array1, cJSON_CreateNumber(agents[0]));
 
-    cJSON_AddStringToObject(status_origin1, "module", "upgrade_module");
-    cJSON_AddItemToObject(status_request1, "origin", status_origin1);
-    cJSON_AddStringToObject(status_request1, "command", "upgrade_get_status");
-    cJSON_AddItemToArray(status_agents1, cJSON_CreateNumber(agents[0]));
-    cJSON_AddItemToObject(status_parameters1, "agents", status_agents1);
-    cJSON_AddItemToObject(status_request1, "parameters", status_parameters1);
+    cJSON *agents_array2 = cJSON_CreateArray();
+    cJSON_AddItemToArray(agents_array2, cJSON_CreateNumber(agents[0]));
 
-    cJSON *status_response1 = cJSON_CreateObject();
+    cJSON *status_request = cJSON_CreateObject();
+    cJSON *status_origin = cJSON_CreateObject();
+    cJSON *status_parameters = cJSON_CreateObject();
+    cJSON *status_agents = cJSON_CreateArray();
 
-    cJSON_AddNumberToObject(status_response1, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(status_response1, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-    cJSON_AddNumberToObject(status_response1, "agent", agents[0]);
-    cJSON_AddStringToObject(status_response1, "status", "Done");
+    cJSON_AddStringToObject(status_origin, "module", "upgrade_module");
+    cJSON_AddItemToObject(status_request, "origin", status_origin);
+    cJSON_AddStringToObject(status_request, "command", "upgrade_get_status");
+    cJSON_AddItemToArray(status_agents, cJSON_CreateNumber(agents[0]));
+    cJSON_AddItemToObject(status_parameters, "agents", status_agents);
+    cJSON_AddItemToObject(status_request, "parameters", status_parameters);
 
     cJSON *task_response1 = cJSON_CreateObject();
 
@@ -1193,27 +965,19 @@ void test_wm_agent_upgrade_process_upgrade_custom_command(void **state)
     expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, 123456789);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
+    // wm_agent_upgrade_validate_system
+
+    expect_string(__wrap_wm_agent_upgrade_validate_system, platform, "ubuntu");
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_major, "18");
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_minor, "04");
+    expect_string(__wrap_wm_agent_upgrade_validate_system, arch, "x86_64");
+    will_return(__wrap_wm_agent_upgrade_validate_system, WM_UPGRADE_SUCCESS);
+
     // wm_agent_upgrade_validate_version
+
+    expect_string(__wrap_wm_agent_upgrade_validate_version, wazuh_version, "v3.13.1");
     expect_value(__wrap_wm_agent_upgrade_validate_version, command, WM_UPGRADE_UPGRADE_CUSTOM);
-    expect_memory(__wrap_wm_agent_upgrade_validate_version, manager_configs, config, sizeof(config));
     will_return(__wrap_wm_agent_upgrade_validate_version, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, status_request1);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, status_request1, sizeof(status_request1));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, status_response1);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
-
-    // wm_agent_upgrade_validate_task_status_message
-
-    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, status_response1, sizeof(status_response1));
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, "Done");
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
 
     // wm_agent_upgrade_create_task_entry
     expect_value(__wrap_wm_agent_upgrade_create_task_entry, agent_id, agents[0]);
@@ -1230,6 +994,25 @@ void test_wm_agent_upgrade_process_upgrade_custom_command(void **state)
     expect_string(__wrap_wm_agent_upgrade_parse_data_response, message, upgrade_error_codes[WM_UPGRADE_GLOBAL_DB_FAILURE]);
     expect_value(__wrap_wm_agent_upgrade_parse_data_response, agent_int, agents[1]);
     will_return(__wrap_wm_agent_upgrade_parse_data_response, task_response2);
+
+    // wm_agent_upgrade_get_agent_ids
+
+    will_return(__wrap_wm_agent_upgrade_get_agent_ids, agents_array1);
+
+    // wm_agent_upgrade_parse_task_module_request
+
+    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
+    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, status_request);
+
+    // wm_agent_upgrade_task_module_callback
+
+    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, status_request, sizeof(status_request));
+    will_return(__wrap_wm_agent_upgrade_task_module_callback, NULL);
+    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
+
+    // wm_agent_upgrade_get_agent_ids
+
+    will_return(__wrap_wm_agent_upgrade_get_agent_ids, agents_array2);
 
     // wm_agent_upgrade_parse_task_module_request
 
@@ -1251,14 +1034,12 @@ void test_wm_agent_upgrade_process_upgrade_custom_command(void **state)
     expect_value(__wrap_wm_agent_upgrade_parse_response, error_id, WM_UPGRADE_SUCCESS);
     will_return(__wrap_wm_agent_upgrade_parse_response, response_json);
 
-    char *result = wm_agent_upgrade_process_upgrade_custom_command(agents, upgrade_custom_task, config);
+    char *result = wm_agent_upgrade_process_upgrade_custom_command(agents, upgrade_custom_task);
 
     state[1] = (void *)result;
 
     assert_non_null(result);
     assert_string_equal(result, "{\"error\":0,\"message\":\"Success\",\"data\":[{\"error\":6,\"message\":\"Agent information not found in database\",\"agent\":2},{\"message\":\"Success\",\"agent\":1,\"task_id\":100}]}");
-
-    os_free(config);
 }
 
 void test_wm_agent_upgrade_process_upgrade_custom_command_no_agents(void **state)
@@ -1266,7 +1047,6 @@ void test_wm_agent_upgrade_process_upgrade_custom_command_no_agents(void **state
     (void) state;
 
     int agents[3];
-    wm_manager_configs *config = NULL;
     wm_upgrade_custom_task *upgrade_custom_task = NULL;
 
     char *custom_file_path = "/tmp/test.wpk";
@@ -1275,9 +1055,6 @@ void test_wm_agent_upgrade_process_upgrade_custom_command_no_agents(void **state
     agents[0] = 1;
     agents[1] = 2;
     agents[2] = OS_INVALID;
-
-    os_calloc(1, sizeof(wm_manager_configs), config);
-    config->chunk_size = 5;
 
     upgrade_custom_task = wm_agent_upgrade_init_upgrade_custom_task();
     os_strdup(custom_file_path, upgrade_custom_task->custom_file_path);
@@ -1326,6 +1103,10 @@ void test_wm_agent_upgrade_process_upgrade_custom_command_no_agents(void **state
     expect_value(__wrap_wm_agent_upgrade_parse_data_response, agent_int, agents[1]);
     will_return(__wrap_wm_agent_upgrade_parse_data_response, task_response2);
 
+    // wm_agent_upgrade_get_agent_ids
+
+    will_return(__wrap_wm_agent_upgrade_get_agent_ids, NULL);
+
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mtwarn, formatted_msg, "(8160): There are no valid agents to upgrade.");
 
@@ -1334,180 +1115,12 @@ void test_wm_agent_upgrade_process_upgrade_custom_command_no_agents(void **state
     expect_value(__wrap_wm_agent_upgrade_parse_response, error_id, WM_UPGRADE_SUCCESS);
     will_return(__wrap_wm_agent_upgrade_parse_response, response_json);
 
-    char *result = wm_agent_upgrade_process_upgrade_custom_command(agents, upgrade_custom_task, config);
+    char *result = wm_agent_upgrade_process_upgrade_custom_command(agents, upgrade_custom_task);
 
     state[1] = (void *)result;
 
     assert_non_null(result);
     assert_string_equal(result, "{\"error\":0,\"message\":\"Success\",\"data\":[{\"error\":6,\"message\":\"Agent information not found in database\",\"agent\":1},{\"error\":6,\"message\":\"Agent information not found in database\",\"agent\":2}]}");
-
-    os_free(config);
-}
-
-void test_wm_agent_upgrade_process_upgrade_custom_command_task_manager_error(void **state)
-{
-    (void) state;
-
-    int agents[3];
-    wm_manager_configs *config = NULL;
-    wm_upgrade_custom_task *upgrade_custom_task = NULL;
-
-    char *custom_file_path = "/tmp/test.wpk";
-    char *custom_installer = "test.sh";
-
-    agents[0] = 1;
-    agents[1] = 2;
-    agents[2] = OS_INVALID;
-
-    os_calloc(1, sizeof(wm_manager_configs), config);
-    config->chunk_size = 5;
-
-    upgrade_custom_task = wm_agent_upgrade_init_upgrade_custom_task();
-    os_strdup(custom_file_path, upgrade_custom_task->custom_file_path);
-    os_strdup(custom_installer, upgrade_custom_task->custom_installer);
-
-    state[0] = (void *)upgrade_custom_task;
-
-    cJSON *agent_info_array1 = cJSON_CreateArray();
-    cJSON *agent_info1 = cJSON_CreateObject();
-    cJSON_AddStringToObject(agent_info1, "os_platform", "ubuntu");
-    cJSON_AddStringToObject(agent_info1, "os_major", "18");
-    cJSON_AddStringToObject(agent_info1, "os_minor", "04");
-    cJSON_AddStringToObject(agent_info1, "os_arch", "x86_64");
-    cJSON_AddStringToObject(agent_info1, "version", "v3.13.1");
-    cJSON_AddNumberToObject(agent_info1, "last_keepalive", 123456789);
-    cJSON_AddItemToArray(agent_info_array1, agent_info1);
-
-    cJSON *status_request1 = cJSON_CreateObject();
-    cJSON *status_origin1 = cJSON_CreateObject();
-    cJSON *status_parameters1 = cJSON_CreateObject();
-    cJSON *status_agents1 = cJSON_CreateArray();
-
-    cJSON_AddStringToObject(status_origin1, "module", "upgrade_module");
-    cJSON_AddItemToObject(status_request1, "origin", status_origin1);
-    cJSON_AddStringToObject(status_request1, "command", "upgrade_get_status");
-    cJSON_AddItemToArray(status_agents1, cJSON_CreateNumber(agents[0]));
-    cJSON_AddItemToObject(status_parameters1, "agents", status_agents1);
-    cJSON_AddItemToObject(status_request1, "parameters", status_parameters1);
-
-    cJSON *status_response1 = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(status_response1, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(status_response1, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-    cJSON_AddNumberToObject(status_response1, "agent", agents[0]);
-    cJSON_AddStringToObject(status_response1, "status", "Done");
-
-    cJSON *task_response1 = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(task_response1, "error", WM_UPGRADE_TASK_MANAGER_COMMUNICATION);
-    cJSON_AddStringToObject(task_response1, "message", upgrade_error_codes[WM_UPGRADE_TASK_MANAGER_COMMUNICATION]);
-    cJSON_AddNumberToObject(task_response1, "agent", agents[0]);
-
-    cJSON *task_response2 = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(task_response2, "error", WM_UPGRADE_GLOBAL_DB_FAILURE);
-    cJSON_AddStringToObject(task_response2, "message", upgrade_error_codes[WM_UPGRADE_GLOBAL_DB_FAILURE]);
-    cJSON_AddNumberToObject(task_response2, "agent", agents[1]);
-
-    cJSON *request_json = cJSON_CreateObject();
-    cJSON *origin_json = cJSON_CreateObject();
-    cJSON *parameters_json= cJSON_CreateObject();
-    cJSON *agents_json = cJSON_CreateArray();
-
-    cJSON_AddStringToObject(origin_json, "module", "upgrade_module");
-    cJSON_AddItemToObject(request_json, "origin", origin_json);
-    cJSON_AddStringToObject(request_json, "command", "upgrade_custom");
-    cJSON_AddItemToArray(agents_json, cJSON_CreateNumber(agents[0]));
-    cJSON_AddItemToObject(parameters_json, "agents", agents_json);
-    cJSON_AddItemToObject(request_json, "parameters", parameters_json);
-
-    cJSON *response_json = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(response_json, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(response_json, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-
-    // Analize agent[0]
-
-    // wdb_agent_info
-
-    expect_value(__wrap_wdb_get_agent_info, id, agents[0]);
-    will_return(__wrap_wdb_get_agent_info, agent_info_array1);
-
-    // wm_agent_upgrade_validate_id
-
-    expect_value(__wrap_wm_agent_upgrade_validate_id, agent_id, agents[0]);
-    will_return(__wrap_wm_agent_upgrade_validate_id, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_validate_status
-
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, 123456789);
-    will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_validate_version
-    expect_value(__wrap_wm_agent_upgrade_validate_version, command, WM_UPGRADE_UPGRADE_CUSTOM);
-    expect_memory(__wrap_wm_agent_upgrade_validate_version, manager_configs, config, sizeof(config));
-    will_return(__wrap_wm_agent_upgrade_validate_version, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, status_request1);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, status_request1, sizeof(status_request1));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, status_response1);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
-
-    // wm_agent_upgrade_validate_task_status_message
-
-    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, status_response1, sizeof(status_response1));
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, "Done");
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
-
-    // wm_agent_upgrade_create_task_entry
-    expect_value(__wrap_wm_agent_upgrade_create_task_entry, agent_id, agents[0]);
-    will_return(__wrap_wm_agent_upgrade_create_task_entry, OSHASH_SUCCESS);
-
-    // Analize agent[1]
-
-    // wdb_agent_info
-
-    expect_value(__wrap_wdb_get_agent_info, id, agents[1]);
-    will_return(__wrap_wdb_get_agent_info, NULL);
-
-    expect_value(__wrap_wm_agent_upgrade_parse_data_response, error_id, WM_UPGRADE_GLOBAL_DB_FAILURE);
-    expect_string(__wrap_wm_agent_upgrade_parse_data_response, message, upgrade_error_codes[WM_UPGRADE_GLOBAL_DB_FAILURE]);
-    expect_value(__wrap_wm_agent_upgrade_parse_data_response, agent_int, agents[1]);
-    will_return(__wrap_wm_agent_upgrade_parse_data_response, task_response2);
-
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_UPGRADE_CUSTOM);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, request_json);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, request_json, sizeof(request_json));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, task_response1);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, OS_INVALID);
-
-    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:agent-upgrade");
-    expect_string(__wrap__mtwarn, formatted_msg, "(8160): There are no valid agents to upgrade.");
-
-    // wm_agent_upgrade_parse_response
-
-    expect_value(__wrap_wm_agent_upgrade_parse_response, error_id, WM_UPGRADE_SUCCESS);
-    will_return(__wrap_wm_agent_upgrade_parse_response, response_json);
-
-    char *result = wm_agent_upgrade_process_upgrade_custom_command(agents, upgrade_custom_task, config);
-
-    state[1] = (void *)result;
-
-    assert_non_null(result);
-    assert_string_equal(result, "{\"error\":0,\"message\":\"Success\",\"data\":[{\"error\":6,\"message\":\"Agent information not found in database\",\"agent\":2},{\"error\":4,\"message\":\"Task manager communication error\",\"agent\":1}]}");
-
-    os_free(config);
 }
 
 void test_wm_agent_upgrade_process_upgrade_command(void **state)
@@ -1515,15 +1128,11 @@ void test_wm_agent_upgrade_process_upgrade_command(void **state)
     (void) state;
 
     int agents[3];
-    wm_manager_configs *config = NULL;
     wm_upgrade_task *upgrade_task = NULL;
 
     agents[0] = 1;
     agents[1] = 2;
     agents[2] = OS_INVALID;
-
-    os_calloc(1, sizeof(wm_manager_configs), config);
-    config->chunk_size = 5;
 
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
 
@@ -1539,24 +1148,23 @@ void test_wm_agent_upgrade_process_upgrade_command(void **state)
     cJSON_AddNumberToObject(agent_info1, "last_keepalive", 123456789);
     cJSON_AddItemToArray(agent_info_array1, agent_info1);
 
-    cJSON *status_request1 = cJSON_CreateObject();
-    cJSON *status_origin1 = cJSON_CreateObject();
-    cJSON *status_parameters1 = cJSON_CreateObject();
-    cJSON *status_agents1 = cJSON_CreateArray();
+    cJSON *agents_array1 = cJSON_CreateArray();
+    cJSON_AddItemToArray(agents_array1, cJSON_CreateNumber(agents[0]));
 
-    cJSON_AddStringToObject(status_origin1, "module", "upgrade_module");
-    cJSON_AddItemToObject(status_request1, "origin", status_origin1);
-    cJSON_AddStringToObject(status_request1, "command", "upgrade_get_status");
-    cJSON_AddItemToArray(status_agents1, cJSON_CreateNumber(agents[0]));
-    cJSON_AddItemToObject(status_parameters1, "agents", status_agents1);
-    cJSON_AddItemToObject(status_request1, "parameters", status_parameters1);
+    cJSON *agents_array2 = cJSON_CreateArray();
+    cJSON_AddItemToArray(agents_array2, cJSON_CreateNumber(agents[0]));
 
-    cJSON *status_response1 = cJSON_CreateObject();
+    cJSON *status_request = cJSON_CreateObject();
+    cJSON *status_origin = cJSON_CreateObject();
+    cJSON *status_parameters = cJSON_CreateObject();
+    cJSON *status_agents = cJSON_CreateArray();
 
-    cJSON_AddNumberToObject(status_response1, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(status_response1, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-    cJSON_AddNumberToObject(status_response1, "agent", agents[0]);
-    cJSON_AddStringToObject(status_response1, "status", "Done");
+    cJSON_AddStringToObject(status_origin, "module", "upgrade_module");
+    cJSON_AddItemToObject(status_request, "origin", status_origin);
+    cJSON_AddStringToObject(status_request, "command", "upgrade_get_status");
+    cJSON_AddItemToArray(status_agents, cJSON_CreateNumber(agents[0]));
+    cJSON_AddItemToObject(status_parameters, "agents", status_agents);
+    cJSON_AddItemToObject(status_request, "parameters", status_parameters);
 
     cJSON *task_response1 = cJSON_CreateObject();
 
@@ -1605,29 +1213,20 @@ void test_wm_agent_upgrade_process_upgrade_command(void **state)
     expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, 123456789);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
+    // wm_agent_upgrade_validate_system
+
+    expect_string(__wrap_wm_agent_upgrade_validate_system, platform, "ubuntu");
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_major, "18");
+    expect_string(__wrap_wm_agent_upgrade_validate_system, os_minor, "04");
+    expect_string(__wrap_wm_agent_upgrade_validate_system, arch, "x86_64");
+    will_return(__wrap_wm_agent_upgrade_validate_system, WM_UPGRADE_SUCCESS);
+
     // wm_agent_upgrade_validate_version
+
+    expect_string(__wrap_wm_agent_upgrade_validate_version, wazuh_version, "v3.13.1");
     expect_value(__wrap_wm_agent_upgrade_validate_version, command, WM_UPGRADE_UPGRADE);
-    expect_memory(__wrap_wm_agent_upgrade_validate_version, manager_configs, config, sizeof(config));
-    will_return(__wrap_wm_agent_upgrade_validate_version, "test.wpk");
-    will_return(__wrap_wm_agent_upgrade_validate_version, "d321af65983fa412e3a12c312ada12ab321a253a");
+    will_return(__wrap_wm_agent_upgrade_validate_version, "v4.1.0");
     will_return(__wrap_wm_agent_upgrade_validate_version, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, status_request1);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, status_request1, sizeof(status_request1));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, status_response1);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
-
-    // wm_agent_upgrade_validate_task_status_message
-
-    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, status_response1, sizeof(status_response1));
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, "Done");
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
 
     // wm_agent_upgrade_create_task_entry
     expect_value(__wrap_wm_agent_upgrade_create_task_entry, agent_id, agents[0]);
@@ -1644,6 +1243,25 @@ void test_wm_agent_upgrade_process_upgrade_command(void **state)
     expect_string(__wrap_wm_agent_upgrade_parse_data_response, message, upgrade_error_codes[WM_UPGRADE_GLOBAL_DB_FAILURE]);
     expect_value(__wrap_wm_agent_upgrade_parse_data_response, agent_int, agents[1]);
     will_return(__wrap_wm_agent_upgrade_parse_data_response, task_response2);
+
+    // wm_agent_upgrade_get_agent_ids
+
+    will_return(__wrap_wm_agent_upgrade_get_agent_ids, agents_array1);
+
+    // wm_agent_upgrade_parse_task_module_request
+
+    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
+    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, status_request);
+
+    // wm_agent_upgrade_task_module_callback
+
+    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, status_request, sizeof(status_request));
+    will_return(__wrap_wm_agent_upgrade_task_module_callback, NULL);
+    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
+
+    // wm_agent_upgrade_get_agent_ids
+
+    will_return(__wrap_wm_agent_upgrade_get_agent_ids, agents_array2);
 
     // wm_agent_upgrade_parse_task_module_request
 
@@ -1665,14 +1283,12 @@ void test_wm_agent_upgrade_process_upgrade_command(void **state)
     expect_value(__wrap_wm_agent_upgrade_parse_response, error_id, WM_UPGRADE_SUCCESS);
     will_return(__wrap_wm_agent_upgrade_parse_response, response_json);
 
-    char *result = wm_agent_upgrade_process_upgrade_command(agents, upgrade_task, config);
+    char *result = wm_agent_upgrade_process_upgrade_command(agents, upgrade_task);
 
     state[1] = (void *)result;
 
     assert_non_null(result);
     assert_string_equal(result, "{\"error\":0,\"message\":\"Success\",\"data\":[{\"error\":6,\"message\":\"Agent information not found in database\",\"agent\":2},{\"message\":\"Success\",\"agent\":1,\"task_id\":110}]}");
-
-    os_free(config);
 }
 
 void test_wm_agent_upgrade_process_upgrade_command_no_agents(void **state)
@@ -1680,15 +1296,11 @@ void test_wm_agent_upgrade_process_upgrade_command_no_agents(void **state)
     (void) state;
 
     int agents[3];
-    wm_manager_configs *config = NULL;
     wm_upgrade_task *upgrade_task = NULL;
 
     agents[0] = 1;
     agents[1] = 2;
     agents[2] = OS_INVALID;
-
-    os_calloc(1, sizeof(wm_manager_configs), config);
-    config->chunk_size = 5;
 
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
 
@@ -1735,6 +1347,10 @@ void test_wm_agent_upgrade_process_upgrade_command_no_agents(void **state)
     expect_value(__wrap_wm_agent_upgrade_parse_data_response, agent_int, agents[1]);
     will_return(__wrap_wm_agent_upgrade_parse_data_response, task_response2);
 
+    // wm_agent_upgrade_get_agent_ids
+
+    will_return(__wrap_wm_agent_upgrade_get_agent_ids, NULL);
+
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mtwarn, formatted_msg, "(8160): There are no valid agents to upgrade.");
 
@@ -1743,177 +1359,12 @@ void test_wm_agent_upgrade_process_upgrade_command_no_agents(void **state)
     expect_value(__wrap_wm_agent_upgrade_parse_response, error_id, WM_UPGRADE_SUCCESS);
     will_return(__wrap_wm_agent_upgrade_parse_response, response_json);
 
-    char *result = wm_agent_upgrade_process_upgrade_command(agents, upgrade_task, config);
+    char *result = wm_agent_upgrade_process_upgrade_command(agents, upgrade_task);
 
     state[1] = (void *)result;
 
     assert_non_null(result);
     assert_string_equal(result, "{\"error\":0,\"message\":\"Success\",\"data\":[{\"error\":6,\"message\":\"Agent information not found in database\",\"agent\":1},{\"error\":6,\"message\":\"Agent information not found in database\",\"agent\":2}]}");
-
-    os_free(config);
-}
-
-void test_wm_agent_upgrade_process_upgrade_command_task_manager_error(void **state)
-{
-    (void) state;
-
-    int agents[3];
-    wm_manager_configs *config = NULL;
-    wm_upgrade_task *upgrade_task = NULL;
-
-    agents[0] = 1;
-    agents[1] = 2;
-    agents[2] = OS_INVALID;
-
-    os_calloc(1, sizeof(wm_manager_configs), config);
-    config->chunk_size = 5;
-
-    upgrade_task = wm_agent_upgrade_init_upgrade_task();
-
-    state[0] = (void *)upgrade_task;
-
-    cJSON *agent_info_array1 = cJSON_CreateArray();
-    cJSON *agent_info1 = cJSON_CreateObject();
-    cJSON_AddStringToObject(agent_info1, "os_platform", "ubuntu");
-    cJSON_AddStringToObject(agent_info1, "os_major", "18");
-    cJSON_AddStringToObject(agent_info1, "os_minor", "04");
-    cJSON_AddStringToObject(agent_info1, "os_arch", "x86_64");
-    cJSON_AddStringToObject(agent_info1, "version", "v3.13.1");
-    cJSON_AddNumberToObject(agent_info1, "last_keepalive", 123456789);
-    cJSON_AddItemToArray(agent_info_array1, agent_info1);
-
-    cJSON *status_request1 = cJSON_CreateObject();
-    cJSON *status_origin1 = cJSON_CreateObject();
-    cJSON *status_parameters1 = cJSON_CreateObject();
-    cJSON *status_agents1 = cJSON_CreateArray();
-
-    cJSON_AddStringToObject(status_origin1, "module", "upgrade_module");
-    cJSON_AddItemToObject(status_request1, "origin", status_origin1);
-    cJSON_AddStringToObject(status_request1, "command", "upgrade_get_status");
-    cJSON_AddItemToArray(status_agents1, cJSON_CreateNumber(agents[0]));
-    cJSON_AddItemToObject(status_parameters1, "agents", status_agents1);
-    cJSON_AddItemToObject(status_request1, "parameters", status_parameters1);
-
-    cJSON *status_response1 = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(status_response1, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(status_response1, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-    cJSON_AddNumberToObject(status_response1, "agent", agents[0]);
-    cJSON_AddStringToObject(status_response1, "status", "Done");
-
-    cJSON *task_response1 = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(task_response1, "error", WM_UPGRADE_TASK_MANAGER_COMMUNICATION);
-    cJSON_AddStringToObject(task_response1, "message", upgrade_error_codes[WM_UPGRADE_TASK_MANAGER_COMMUNICATION]);
-    cJSON_AddNumberToObject(task_response1, "agent", agents[0]);
-
-    cJSON *task_response2 = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(task_response2, "error", WM_UPGRADE_GLOBAL_DB_FAILURE);
-    cJSON_AddStringToObject(task_response2, "message", upgrade_error_codes[WM_UPGRADE_GLOBAL_DB_FAILURE]);
-    cJSON_AddNumberToObject(task_response2, "agent", agents[1]);
-
-    cJSON *request_json = cJSON_CreateObject();
-    cJSON *origin_json = cJSON_CreateObject();
-    cJSON *parameters_json= cJSON_CreateObject();
-    cJSON *agents_json = cJSON_CreateArray();
-
-    cJSON_AddStringToObject(origin_json, "module", "upgrade_module");
-    cJSON_AddItemToObject(request_json, "origin", origin_json);
-    cJSON_AddStringToObject(request_json, "command", "upgrade");
-    cJSON_AddItemToArray(agents_json, cJSON_CreateNumber(agents[0]));
-    cJSON_AddItemToObject(parameters_json, "agents", agents_json);
-    cJSON_AddItemToObject(request_json, "parameters", parameters_json);
-
-    cJSON *response_json = cJSON_CreateObject();
-
-    cJSON_AddNumberToObject(response_json, "error", WM_UPGRADE_SUCCESS);
-    cJSON_AddStringToObject(response_json, "message", upgrade_error_codes[WM_UPGRADE_SUCCESS]);
-
-    // Analize agent[0]
-
-    // wdb_agent_info
-
-    expect_value(__wrap_wdb_get_agent_info, id, agents[0]);
-    will_return(__wrap_wdb_get_agent_info, agent_info_array1);
-
-    // wm_agent_upgrade_validate_id
-
-    expect_value(__wrap_wm_agent_upgrade_validate_id, agent_id, agents[0]);
-    will_return(__wrap_wm_agent_upgrade_validate_id, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_validate_status
-
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, 123456789);
-    will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_validate_version
-    expect_value(__wrap_wm_agent_upgrade_validate_version, command, WM_UPGRADE_UPGRADE);
-    expect_memory(__wrap_wm_agent_upgrade_validate_version, manager_configs, config, sizeof(config));
-    will_return(__wrap_wm_agent_upgrade_validate_version, "test.wpk");
-    will_return(__wrap_wm_agent_upgrade_validate_version, "d321af65983fa412e3a12c312ada12ab321a253a");
-    will_return(__wrap_wm_agent_upgrade_validate_version, WM_UPGRADE_SUCCESS);
-
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_AGENT_GET_STATUS);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, status_request1);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, status_request1, sizeof(status_request1));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, status_response1);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, 0);
-
-    // wm_agent_upgrade_validate_task_status_message
-
-    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, status_response1, sizeof(status_response1));
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, "Done");
-    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
-
-    // wm_agent_upgrade_create_task_entry
-    expect_value(__wrap_wm_agent_upgrade_create_task_entry, agent_id, agents[0]);
-    will_return(__wrap_wm_agent_upgrade_create_task_entry, OSHASH_SUCCESS);
-
-    // Analize agent[1]
-
-    // wdb_agent_info
-
-    expect_value(__wrap_wdb_get_agent_info, id, agents[1]);
-    will_return(__wrap_wdb_get_agent_info, NULL);
-
-    expect_value(__wrap_wm_agent_upgrade_parse_data_response, error_id, WM_UPGRADE_GLOBAL_DB_FAILURE);
-    expect_string(__wrap_wm_agent_upgrade_parse_data_response, message, upgrade_error_codes[WM_UPGRADE_GLOBAL_DB_FAILURE]);
-    expect_value(__wrap_wm_agent_upgrade_parse_data_response, agent_int, agents[1]);
-    will_return(__wrap_wm_agent_upgrade_parse_data_response, task_response2);
-
-    // wm_agent_upgrade_parse_task_module_request
-
-    expect_value(__wrap_wm_agent_upgrade_parse_task_module_request, command, WM_UPGRADE_UPGRADE);
-    will_return(__wrap_wm_agent_upgrade_parse_task_module_request, request_json);
-
-    // wm_agent_upgrade_task_module_callback
-
-    expect_memory(__wrap_wm_agent_upgrade_task_module_callback, task_module_request, request_json, sizeof(request_json));
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, task_response1);
-    will_return(__wrap_wm_agent_upgrade_task_module_callback, OS_INVALID);
-
-    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:agent-upgrade");
-    expect_string(__wrap__mtwarn, formatted_msg, "(8160): There are no valid agents to upgrade.");
-
-    // wm_agent_upgrade_parse_response
-
-    expect_value(__wrap_wm_agent_upgrade_parse_response, error_id, WM_UPGRADE_SUCCESS);
-    will_return(__wrap_wm_agent_upgrade_parse_response, response_json);
-
-    char *result = wm_agent_upgrade_process_upgrade_command(agents, upgrade_task, config);
-
-    state[1] = (void *)result;
-
-    assert_non_null(result);
-    assert_string_equal(result, "{\"error\":0,\"message\":\"Success\",\"data\":[{\"error\":6,\"message\":\"Agent information not found in database\",\"agent\":2},{\"error\":4,\"message\":\"Task manager communication error\",\"agent\":1}]}");
-
-    os_free(config);
 }
 
 int main(void) {
@@ -1921,13 +1372,12 @@ int main(void) {
         // wm_agent_upgrade_cancel_pending_upgrades
         cmocka_unit_test(test_wm_agent_upgrade_cancel_pending_upgrades),
         // wm_agent_upgrade_validate_agent_task
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_upgrade_ok, setup_config_agent_task, teardown_config_agent_task),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_upgrade_custom_ok, setup_config_agent_task, teardown_config_agent_task),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_in_progress_err, setup_config_agent_task, teardown_config_agent_task),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_task_manager_err, setup_config_agent_task, teardown_config_agent_task),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_version_err, setup_config_agent_task, teardown_config_agent_task),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_status_err, setup_config_agent_task, teardown_config_agent_task),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_agent_id_err, setup_config_agent_task, teardown_config_agent_task),
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_upgrade_ok, setup_agent_task, teardown_agent_task),
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_upgrade_custom_ok, setup_agent_task, teardown_agent_task),
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_version_err, setup_agent_task, teardown_agent_task),
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_system_err, setup_agent_task, teardown_agent_task),
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_status_err, setup_agent_task, teardown_agent_task),
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_agent_task_agent_id_err, setup_agent_task, teardown_agent_task),
         // wm_agent_upgrade_analyze_agent
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_analyze_agent_ok, setup_analyze_agent_task, teardown_analyze_agent_task),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_analyze_agent_duplicated_err, setup_analyze_agent_task, teardown_analyze_agent_task),
@@ -1940,11 +1390,9 @@ int main(void) {
         // wm_agent_upgrade_process_upgrade_custom_command
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_process_upgrade_custom_command, setup_process_hash_table, teardown_upgrade_custom_task_string),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_process_upgrade_custom_command_no_agents, setup_process_hash_table, teardown_upgrade_custom_task_string),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_process_upgrade_custom_command_task_manager_error, setup_process_hash_table, teardown_upgrade_custom_task_string),
         // wm_agent_upgrade_process_upgrade_command
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_process_upgrade_command, setup_process_hash_table, teardown_upgrade_task_string),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_process_upgrade_command_no_agents, setup_process_hash_table, teardown_upgrade_task_string),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_process_upgrade_command_task_manager_error, setup_process_hash_table, teardown_upgrade_task_string)
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_tasks.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_tasks.c
@@ -78,6 +78,26 @@ static int teardown_jsons(void **state) {
     return 0;
 }
 
+static int setup_nodes(void **state) {
+    OSHashNode *node = NULL;
+    OSHashNode *node_next = NULL;
+    os_calloc(1, sizeof(OSHashNode), node);
+    os_calloc(1, sizeof(OSHashNode), node_next);
+    node->next = node_next;
+    *state = (void *)node;
+    return 0;
+}
+
+static int teardown_nodes(void **state) {
+    OSHashNode *node = (OSHashNode *)*state;
+    OSHashNode *node_next = node->next;
+    os_free(node_next->key);
+    os_free(node_next);
+    os_free(node->key);
+    os_free(node);
+    return 0;
+}
+
 // Tests
 
 void test_wm_agent_upgrade_create_task_entry_ok(void **state)
@@ -156,6 +176,45 @@ void test_wm_agent_upgrade_get_next_node(void **state)
     OSHashNode* ret = wm_agent_upgrade_get_next_node(&index, node);
 
     assert_int_equal(ret, 1);
+}
+
+void test_wm_agent_upgrade_get_agent_ids_ok(void **state)
+{
+    OSHashNode *node = *state;
+    OSHashNode *node_next = node->next;
+
+    os_strdup("025", node->key);
+    os_strdup("035", node_next->key);
+
+    expect_value(__wrap_OSHash_Begin, self, task_table_by_agent_id);
+    will_return(__wrap_OSHash_Begin, node);
+
+    expect_value(__wrap_OSHash_Next, self, task_table_by_agent_id);
+    will_return(__wrap_OSHash_Next, node_next);
+
+    expect_value(__wrap_OSHash_Next, self, task_table_by_agent_id);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    cJSON *agents_array = wm_agent_upgrade_get_agent_ids();
+
+    assert_non_null(agents_array);
+    assert_int_equal(cJSON_GetArraySize(agents_array), 2);
+    assert_int_equal(cJSON_GetArrayItem(agents_array, 0)->valueint, 25);
+    assert_int_equal(cJSON_GetArrayItem(agents_array, 1)->valueint, 35);
+
+    cJSON_Delete(agents_array);
+}
+
+void test_wm_agent_upgrade_get_agent_ids_empty(void **state)
+{
+    (void) state;
+
+    expect_value(__wrap_OSHash_Begin, self, task_table_by_agent_id);
+    will_return(__wrap_OSHash_Begin, NULL);
+
+    cJSON *agents_array = wm_agent_upgrade_get_agent_ids();
+
+    assert_null(agents_array);
 }
 
 void test_wm_agent_send_task_information_master_ok(void **state)
@@ -719,6 +778,9 @@ int main(void) {
         cmocka_unit_test(test_wm_agent_upgrade_get_first_node),
         // wm_agent_upgrade_get_next_node
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_get_next_node, setup_node, teardown_node),
+        // wm_agent_upgrade_get_agent_ids
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_get_agent_ids_ok, setup_nodes, teardown_nodes),
+        cmocka_unit_test(test_wm_agent_upgrade_get_agent_ids_empty),
         // wm_agent_send_task_information_master
         cmocka_unit_test_teardown(test_wm_agent_send_task_information_master_ok, teardown_jsons),
         cmocka_unit_test_teardown(test_wm_agent_send_task_information_master_json_err, teardown_jsons),

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_tasks_callbacks.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_tasks_callbacks.c
@@ -107,7 +107,7 @@ void test_wm_agent_upgrade_upgrade_success_callback_validate_error(void **state)
     state[1] = (void *)response;
 
     assert_int_equal(error, OS_INVALID);
-    assert_memory_equal(response, input, sizeof(input));
+    assert_null(response);
 }
 
 void test_wm_agent_upgrade_update_status_success_callback_ok(void **state)
@@ -171,7 +171,7 @@ void test_wm_agent_upgrade_update_status_success_callback_delete_error(void **st
     state[0] = (void *)input;
     state[1] = (void *)result;
 
-    assert_int_equal(error, OS_INVALID);
+    assert_int_equal(error, 0);
     assert_memory_equal(result, input, sizeof(input));
 }
 
@@ -191,7 +191,7 @@ void test_wm_agent_upgrade_update_status_success_validate_error(void **state)
     state[1] = (void *)result;
 
     assert_int_equal(error, OS_INVALID);
-    assert_memory_equal(result, input, sizeof(input));
+    assert_null(result);
 }
 
 void test_wm_agent_upgrade_task_module_callback_no_callbacks_ok(void **state)

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_tasks_callbacks.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_tasks_callbacks.c
@@ -85,7 +85,7 @@ void test_wm_agent_upgrade_upgrade_success_callback_no_task_id(void **state)
     state[1] = (void *)response;
 
     assert_int_equal(error, 0);
-    assert_memory_equal(response, input, sizeof(input));
+    assert_memory_equal(response, error_json, sizeof(error_json));
 }
 
 void test_wm_agent_upgrade_upgrade_success_callback_validate_error(void **state)
@@ -102,6 +102,110 @@ void test_wm_agent_upgrade_upgrade_success_callback_validate_error(void **state)
     will_return(__wrap_wm_agent_upgrade_validate_task_ids_message, 0);
 
     cJSON *response = wm_agent_upgrade_upgrade_success_callback(&error, input);
+
+    state[0] = (void *)input;
+    state[1] = (void *)response;
+
+    assert_int_equal(error, OS_INVALID);
+    assert_null(response);
+}
+
+void test_wm_agent_upgrade_get_status_success_callback_ok(void **state)
+{
+    int error = 0;
+    int agent = 9;
+    char *status = "Done";
+    cJSON *input = cJSON_CreateObject();
+
+    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, input, sizeof(input));
+    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, status);
+    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, agent);
+    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
+
+    cJSON *response = wm_agent_upgrade_get_status_success_callback(&error, input);
+
+    state[0] = (void *)input;
+    state[1] = (void *)response;
+
+    assert_int_equal(error, 0);
+    assert_null(response);
+}
+
+void test_wm_agent_upgrade_get_status_success_callback_status_pending(void **state)
+{
+    int error = 0;
+    int agent = 9;
+    char *status = "Pending";
+    cJSON *input = cJSON_CreateObject();
+    cJSON *error_json = cJSON_CreateObject();
+
+    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, input, sizeof(input));
+    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, status);
+    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, agent);
+    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
+
+    expect_value(__wrap_wm_agent_upgrade_remove_entry, agent_id, agent);
+    expect_value(__wrap_wm_agent_upgrade_remove_entry, free, 1);
+    will_return(__wrap_wm_agent_upgrade_remove_entry, 0);
+
+    expect_value(__wrap_wm_agent_upgrade_parse_data_response, error_id, WM_UPGRADE_UPGRADE_ALREADY_IN_PROGRESS);
+    expect_string(__wrap_wm_agent_upgrade_parse_data_response, message, upgrade_error_codes[WM_UPGRADE_UPGRADE_ALREADY_IN_PROGRESS]);
+    expect_value(__wrap_wm_agent_upgrade_parse_data_response, agent_int, agent);
+    will_return(__wrap_wm_agent_upgrade_parse_data_response, error_json);
+
+    cJSON *response = wm_agent_upgrade_get_status_success_callback(&error, input);
+
+    state[0] = (void *)input;
+    state[1] = (void *)response;
+
+    assert_int_equal(error, 0);
+    assert_memory_equal(response, error_json, sizeof(error_json));
+}
+
+void test_wm_agent_upgrade_get_status_success_callback_status_in_progress(void **state)
+{
+    int error = 0;
+    int agent = 9;
+    char *status = "In progress";
+    cJSON *input = cJSON_CreateObject();
+    cJSON *error_json = cJSON_CreateObject();
+
+    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, input, sizeof(input));
+    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, status);
+    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, agent);
+    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 1);
+
+    expect_value(__wrap_wm_agent_upgrade_remove_entry, agent_id, agent);
+    expect_value(__wrap_wm_agent_upgrade_remove_entry, free, 1);
+    will_return(__wrap_wm_agent_upgrade_remove_entry, 0);
+
+    expect_value(__wrap_wm_agent_upgrade_parse_data_response, error_id, WM_UPGRADE_UPGRADE_ALREADY_IN_PROGRESS);
+    expect_string(__wrap_wm_agent_upgrade_parse_data_response, message, upgrade_error_codes[WM_UPGRADE_UPGRADE_ALREADY_IN_PROGRESS]);
+    expect_value(__wrap_wm_agent_upgrade_parse_data_response, agent_int, agent);
+    will_return(__wrap_wm_agent_upgrade_parse_data_response, error_json);
+
+    cJSON *response = wm_agent_upgrade_get_status_success_callback(&error, input);
+
+    state[0] = (void *)input;
+    state[1] = (void *)response;
+
+    assert_int_equal(error, 0);
+    assert_memory_equal(response, error_json, sizeof(error_json));
+}
+
+void test_wm_agent_upgrade_get_status_success_callback_validate_error(void **state)
+{
+    int error = 0;
+    int agent = 9;
+    char *status = "Done";
+    cJSON *input = cJSON_CreateObject();
+
+    expect_memory(__wrap_wm_agent_upgrade_validate_task_status_message, input_json, input, sizeof(input));
+    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, status);
+    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, agent);
+    will_return(__wrap_wm_agent_upgrade_validate_task_status_message, 0);
+
+    cJSON *response = wm_agent_upgrade_get_status_success_callback(&error, input);
 
     state[0] = (void *)input;
     state[1] = (void *)response;
@@ -620,6 +724,11 @@ int main(void) {
         cmocka_unit_test_teardown(test_wm_agent_upgrade_upgrade_success_callback_ok, teardown_jsons),
         cmocka_unit_test_teardown(test_wm_agent_upgrade_upgrade_success_callback_no_task_id, teardown_jsons),
         cmocka_unit_test_teardown(test_wm_agent_upgrade_upgrade_success_callback_validate_error, teardown_jsons),
+        // wm_agent_upgrade_get_status_success_callback
+        cmocka_unit_test_teardown(test_wm_agent_upgrade_get_status_success_callback_ok, teardown_jsons),
+        cmocka_unit_test_teardown(test_wm_agent_upgrade_get_status_success_callback_status_pending, teardown_jsons),
+        cmocka_unit_test_teardown(test_wm_agent_upgrade_get_status_success_callback_status_in_progress, teardown_jsons),
+        cmocka_unit_test_teardown(test_wm_agent_upgrade_get_status_success_callback_validate_error, teardown_jsons),
         // wm_agent_upgrade_update_status_success_callback
         cmocka_unit_test_teardown(test_wm_agent_upgrade_update_status_success_callback_ok, teardown_jsons),
         cmocka_unit_test_teardown(test_wm_agent_upgrade_update_status_success_callback_delete_error, teardown_jsons),

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
@@ -2518,6 +2518,34 @@ void test_wm_agent_upgrade_send_wpk_to_agent_validate_wpk_err(void **state)
     assert_int_equal(res, WM_UPGRADE_WPK_SHA1_DOES_NOT_MATCH);
 }
 
+void test_wm_agent_upgrade_send_wpk_to_agent_validate_wpk_version_err(void **state)
+{
+    (void) state;
+
+    wm_manager_configs *config = state[0];
+    wm_agent_task *agent_task = state[1];
+    wm_upgrade_task *upgrade_task = NULL;
+
+    config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
+
+    agent_task->agent_info->agent_id = 111;
+    os_strdup("ubuntu", agent_task->agent_info->platform);
+    agent_task->task_info->command = WM_UPGRADE_UPGRADE;
+    upgrade_task = wm_agent_upgrade_init_upgrade_task();
+    os_strdup("test.wpk", upgrade_task->wpk_file);
+    os_strdup("d321af65983fa412e3a12c312ada12ab321a253a", upgrade_task->wpk_sha1);
+    agent_task->task_info->task = upgrade_task;
+
+    // wm_agent_upgrade_validate_wpk_version
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST);
+
+    int res = wm_agent_upgrade_send_wpk_to_agent(agent_task, config);
+
+    assert_int_equal(res, WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST);
+}
+
 void test_wm_agent_upgrade_send_wpk_to_agent_validate_wpk_custom_err(void **state)
 {
     (void) state;
@@ -3514,6 +3542,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_send_wpk_to_agent_upgrade_open_file_err, setup_config_agent_task, teardown_config_agent_task),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_send_wpk_to_agent_upgrade_lock_restart_err, setup_config_agent_task, teardown_config_agent_task),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_send_wpk_to_agent_validate_wpk_err, setup_config_agent_task, teardown_config_agent_task),
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_send_wpk_to_agent_validate_wpk_version_err, setup_config_agent_task, teardown_config_agent_task),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_send_wpk_to_agent_validate_wpk_custom_err, setup_config_agent_task, teardown_config_agent_task),
         // wm_agent_upgrade_start_upgrade
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_start_upgrade_upgrade_ok, setup_upgrade_args, teardown_upgrade_args),

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
@@ -1123,6 +1123,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_linux_ok(void **state)
     wm_upgrade_task *upgrade_task = NULL;
 
     config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
 
     agent_task->agent_info->agent_id = 111;
     os_strdup("ubuntu", agent_task->agent_info->platform);
@@ -1131,6 +1132,10 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_linux_ok(void **state)
     os_strdup("test.wpk", upgrade_task->wpk_file);
     os_strdup("d321af65983fa412e3a12c312ada12ab321a253a", upgrade_task->wpk_sha1);
     agent_task->task_info->task = upgrade_task;
+
+    // wm_agent_upgrade_validate_wpk_version
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_wpk
     will_return(__wrap_wm_agent_upgrade_validate_wpk, WM_UPGRADE_SUCCESS);
@@ -1277,6 +1282,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_windows_ok(void **state)
     wm_upgrade_task *upgrade_task = NULL;
 
     config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
 
     agent_task->agent_info->agent_id = 111;
     os_strdup("windows", agent_task->agent_info->platform);
@@ -1285,6 +1291,10 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_windows_ok(void **state)
     os_strdup("test.wpk", upgrade_task->wpk_file);
     os_strdup("d321af65983fa412e3a12c312ada12ab321a253a", upgrade_task->wpk_sha1);
     agent_task->task_info->task = upgrade_task;
+
+    // wm_agent_upgrade_validate_wpk_version
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_wpk
     will_return(__wrap_wm_agent_upgrade_validate_wpk, WM_UPGRADE_SUCCESS);
@@ -1748,6 +1758,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_run_upgrade_err(void **stat
     wm_upgrade_task *upgrade_task = NULL;
 
     config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
 
     agent_task->agent_info->agent_id = 111;
     os_strdup("ubuntu", agent_task->agent_info->platform);
@@ -1756,6 +1767,10 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_run_upgrade_err(void **stat
     os_strdup("test.wpk", upgrade_task->wpk_file);
     os_strdup("d321af65983fa412e3a12c312ada12ab321a253a", upgrade_task->wpk_sha1);
     agent_task->task_info->task = upgrade_task;
+
+    // wm_agent_upgrade_validate_wpk_version
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_wpk
     will_return(__wrap_wm_agent_upgrade_validate_wpk, WM_UPGRADE_SUCCESS);
@@ -1901,6 +1916,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_send_sha1_err(void **state)
     wm_upgrade_task *upgrade_task = NULL;
 
     config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
 
     agent_task->agent_info->agent_id = 111;
     os_strdup("ubuntu", agent_task->agent_info->platform);
@@ -1909,6 +1925,10 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_send_sha1_err(void **state)
     os_strdup("test.wpk", upgrade_task->wpk_file);
     os_strdup("d321af65983fa412e3a12c312ada12ab321a253a", upgrade_task->wpk_sha1);
     agent_task->task_info->task = upgrade_task;
+
+    // wm_agent_upgrade_validate_wpk_version
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_wpk
     will_return(__wrap_wm_agent_upgrade_validate_wpk, WM_UPGRADE_SUCCESS);
@@ -2040,6 +2060,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_close_file_err(void **state
     wm_upgrade_task *upgrade_task = NULL;
 
     config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
 
     agent_task->agent_info->agent_id = 111;
     os_strdup("ubuntu", agent_task->agent_info->platform);
@@ -2048,6 +2069,10 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_close_file_err(void **state
     os_strdup("test.wpk", upgrade_task->wpk_file);
     os_strdup("d321af65983fa412e3a12c312ada12ab321a253a", upgrade_task->wpk_sha1);
     agent_task->task_info->task = upgrade_task;
+
+    // wm_agent_upgrade_validate_wpk_version
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_wpk
     will_return(__wrap_wm_agent_upgrade_validate_wpk, WM_UPGRADE_SUCCESS);
@@ -2161,6 +2186,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_write_file_err(void **state
     wm_upgrade_task *upgrade_task = NULL;
 
     config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
 
     agent_task->agent_info->agent_id = 111;
     os_strdup("ubuntu", agent_task->agent_info->platform);
@@ -2169,6 +2195,10 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_write_file_err(void **state
     os_strdup("test.wpk", upgrade_task->wpk_file);
     os_strdup("d321af65983fa412e3a12c312ada12ab321a253a", upgrade_task->wpk_sha1);
     agent_task->task_info->task = upgrade_task;
+
+    // wm_agent_upgrade_validate_wpk_version
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_wpk
     will_return(__wrap_wm_agent_upgrade_validate_wpk, WM_UPGRADE_SUCCESS);
@@ -2263,6 +2293,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_open_file_err(void **state)
     wm_upgrade_task *upgrade_task = NULL;
 
     config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
 
     agent_task->agent_info->agent_id = 111;
     os_strdup("ubuntu", agent_task->agent_info->platform);
@@ -2271,6 +2302,10 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_open_file_err(void **state)
     os_strdup("test.wpk", upgrade_task->wpk_file);
     os_strdup("d321af65983fa412e3a12c312ada12ab321a253a", upgrade_task->wpk_sha1);
     agent_task->task_info->task = upgrade_task;
+
+    // wm_agent_upgrade_validate_wpk_version
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_wpk
     will_return(__wrap_wm_agent_upgrade_validate_wpk, WM_UPGRADE_SUCCESS);
@@ -2401,6 +2436,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_lock_restart_err(void **sta
     wm_upgrade_task *upgrade_task = NULL;
 
     config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
 
     agent_task->agent_info->agent_id = 111;
     os_strdup("ubuntu", agent_task->agent_info->platform);
@@ -2409,6 +2445,10 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_lock_restart_err(void **sta
     os_strdup("test.wpk", upgrade_task->wpk_file);
     os_strdup("d321af65983fa412e3a12c312ada12ab321a253a", upgrade_task->wpk_sha1);
     agent_task->task_info->task = upgrade_task;
+
+    // wm_agent_upgrade_validate_wpk_version
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_wpk
     will_return(__wrap_wm_agent_upgrade_validate_wpk, WM_UPGRADE_SUCCESS);
@@ -2456,6 +2496,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_validate_wpk_err(void **state)
     wm_upgrade_task *upgrade_task = NULL;
 
     config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
 
     agent_task->agent_info->agent_id = 111;
     os_strdup("ubuntu", agent_task->agent_info->platform);
@@ -2464,6 +2505,10 @@ void test_wm_agent_upgrade_send_wpk_to_agent_validate_wpk_err(void **state)
     os_strdup("test.wpk", upgrade_task->wpk_file);
     os_strdup("d321af65983fa412e3a12c312ada12ab321a253a", upgrade_task->wpk_sha1);
     agent_task->task_info->task = upgrade_task;
+
+    // wm_agent_upgrade_validate_wpk_version
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_wpk
     will_return(__wrap_wm_agent_upgrade_validate_wpk, WM_UPGRADE_WPK_SHA1_DOES_NOT_MATCH);
@@ -2523,6 +2568,7 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_ok(void **state)
     wm_upgrade_task *upgrade_task = NULL;
 
     config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
 
     agent_task->agent_info->agent_id = agent_id;
     os_strdup("ubuntu", agent_task->agent_info->platform);
@@ -2570,6 +2616,9 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_ok(void **state)
     will_return(__wrap_wm_agent_upgrade_validate_task_status_message, agent_id);
 
     // wm_agent_upgrade_send_wpk_to_agent
+
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_SUCCESS);
 
     will_return(__wrap_wm_agent_upgrade_validate_wpk, WM_UPGRADE_SUCCESS);
 
@@ -2723,6 +2772,7 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_legacy_ok(void **state)
     wm_upgrade_task *upgrade_task = NULL;
 
     config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
 
     agent_task->agent_info->agent_id = agent_id;
     os_strdup("ubuntu", agent_task->agent_info->platform);
@@ -2791,6 +2841,9 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_legacy_ok(void **state)
     will_return(__wrap_wm_agent_upgrade_validate_task_status_message, agent_id);
 
     // wm_agent_upgrade_send_wpk_to_agent
+
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_SUCCESS);
 
     will_return(__wrap_wm_agent_upgrade_validate_wpk, WM_UPGRADE_SUCCESS);
 
@@ -3170,6 +3223,7 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_err(void **state)
     wm_upgrade_task *upgrade_task = NULL;
 
     config->chunk_size = 5;
+    config->wpk_repository = WM_UPGRADE_WPK_REPO_URL;
 
     agent_task->agent_info->agent_id = agent_id;
     os_strdup("ubuntu", agent_task->agent_info->platform);
@@ -3237,6 +3291,9 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_err(void **state)
     will_return(__wrap_wm_agent_upgrade_validate_task_status_message, agent_id);
 
     // wm_agent_upgrade_send_wpk_to_agent
+
+    expect_string(__wrap_wm_agent_upgrade_validate_wpk_version, wpk_repository_config, WM_UPGRADE_WPK_REPO_URL);
+    will_return(__wrap_wm_agent_upgrade_validate_wpk_version, WM_UPGRADE_SUCCESS);
 
     will_return(__wrap_wm_agent_upgrade_validate_wpk, WM_UPGRADE_SUCCESS);
 

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
@@ -631,18 +631,31 @@ void test_wm_agent_upgrade_validate_wpk_version_rhel_old_version(void **state)
     assert_string_equal(task->wpk_sha1, "ad87687f6876e876876bb86ad54e57aa");
 }
 
+void test_wm_agent_upgrade_validate_wpk_version_no_version(void **state)
+{
+    wm_agent_info *agent = state[0];
+    wm_upgrade_task *task = state[1];
+    char *repo = "packages.wazuh.com/4.x/wpk";
+
+    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, repo);
+
+    assert_int_equal(ret, WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST);
+    assert_null(task->wpk_repository);
+    assert_null(task->wpk_file);
+    assert_null(task->wpk_sha1);
+}
+
 void test_wm_agent_upgrade_validate_version_upgrade_ok(void **state)
 {
     wm_upgrade_task *task = state[1];
     char *wazuh_version = "v3.9.1";
 
     task->force_upgrade = false;
-    os_strdup("v3.12.0", task->custom_version);
 
     int ret = wm_agent_upgrade_validate_version(wazuh_version, WM_UPGRADE_UPGRADE, task);
 
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
-    assert_string_equal(task->wpk_version, "v3.12.0");
+    assert_string_equal(task->wpk_version, "v3.13.0");
 }
 
 void test_wm_agent_upgrade_validate_version_upgrade_custom_ok(void **state)
@@ -673,6 +686,48 @@ void test_wm_agent_upgrade_validate_version_upgrade_custom_non_minimal(void **st
     int ret = wm_agent_upgrade_validate_version(wazuh_version, WM_UPGRADE_UPGRADE_CUSTOM, task);
 
     assert_int_equal(ret, WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED);
+}
+
+void test_wm_agent_upgrade_validate_version_upgrade_older_version(void **state)
+{
+    wm_upgrade_task *task = state[1];
+    char *wazuh_version = "v3.13.1";
+
+    task->force_upgrade = false;
+    os_strdup("v3.12.0", task->custom_version);
+
+    int ret = wm_agent_upgrade_validate_version(wazuh_version, WM_UPGRADE_UPGRADE, task);
+
+    assert_int_equal(ret, WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT);
+    assert_string_equal(task->wpk_version, "v3.12.0");
+}
+
+void test_wm_agent_upgrade_validate_version_upgrade_greater_version(void **state)
+{
+    wm_upgrade_task *task = state[1];
+    char *wazuh_version = "v3.9.1";
+
+    task->force_upgrade = false;
+    os_strdup("v3.13.1", task->custom_version);
+
+    int ret = wm_agent_upgrade_validate_version(wazuh_version, WM_UPGRADE_UPGRADE, task);
+
+    assert_int_equal(ret, WM_UPGRADE_NEW_VERSION_GREATER_MASTER);
+    assert_string_equal(task->wpk_version, "v3.13.1");
+}
+
+void test_wm_agent_upgrade_validate_version_upgrade_force(void **state)
+{
+    wm_upgrade_task *task = state[1];
+    char *wazuh_version = "v3.9.1";
+
+    task->force_upgrade = true;
+    os_strdup("v3.13.1", task->custom_version);
+
+    int ret = wm_agent_upgrade_validate_version(wazuh_version, WM_UPGRADE_UPGRADE, task);
+
+    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
+    assert_string_equal(task->wpk_version, "v3.13.1");
 }
 
 void test_wm_agent_upgrade_validate_version_version_null(void **state)
@@ -1148,11 +1203,15 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_wpk_version_linux_invalid_repo, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_wpk_version_ubuntu_old_version, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_wpk_version_rhel_old_version, setup_validate_wpk_version, teardown_validate_wpk_version),
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_wpk_version_no_version, setup_validate_wpk_version, teardown_validate_wpk_version),
         // wm_agent_upgrade_validate_version
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_ok, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_custom_ok, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_non_minimal, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_custom_non_minimal, setup_validate_wpk_version, teardown_validate_wpk_version),
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_older_version, setup_validate_wpk_version, teardown_validate_wpk_version),
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_greater_version, setup_validate_wpk_version, teardown_validate_wpk_version),
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_force, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_version_null, setup_validate_wpk_version, teardown_validate_wpk_version),
         // wm_agent_upgrade_validate_wpk
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_wpk_exist, setup_validate_wpk, teardown_validate_wpk),

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
@@ -27,10 +27,6 @@
 #include "../../wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.h"
 #include "../../headers/shared.h"
 
-int wm_agent_upgrade_validate_non_custom_version(const char *agent_version, const wm_agent_info *agent_info, wm_upgrade_task *task, const wm_manager_configs* manager_configs);
-int wm_agent_upgrade_validate_system(const char *platform, const char *os_major, const char *os_minor, const char *arch);
-int wm_agent_upgrade_validate_wpk_version(const wm_agent_info *agent_info, wm_upgrade_task *task, char *wpk_version, const char *wpk_repository_config);
-
 // Setup / teardown
 
 static int setup_validate_wpk_version(void **state) {
@@ -368,7 +364,6 @@ void test_wm_agent_upgrade_validate_wpk_version_windows_https_ok(void **state)
 {
     wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
-    char *version = "v4.0.0";
     char *repo = "packages.wazuh.com/4.x/wpk";
     char *versions = NULL;
 
@@ -377,13 +372,14 @@ void test_wm_agent_upgrade_validate_wpk_version_windows_https_ok(void **state)
     os_strdup("x64", agent->architecture);
 
     task->use_http = false;
+    os_strdup("v4.0.0", task->wpk_version);
 
     os_strdup("v3.13.1 4a313b1312c23a213f2e3209fe0909dd\nv4.0.0 231ef123a32d312b4123c21313ee6780", versions);
 
     expect_string(__wrap_wurl_http_get, url, "https://packages.wazuh.com/4.x/wpk/windows/versions");
     will_return(__wrap_wurl_http_get, versions);
 
-    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, version, repo);
+    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, repo);
 
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
     assert_string_equal(task->wpk_repository, "https://packages.wazuh.com/4.x/wpk/windows/");
@@ -395,7 +391,6 @@ void test_wm_agent_upgrade_validate_wpk_version_windows_http_ok(void **state)
 {
     wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
-    char *version = "v3.13.1";
     char *repo = "packages.wazuh.com/4.x/wpk/";
     char *versions = NULL;
 
@@ -404,13 +399,14 @@ void test_wm_agent_upgrade_validate_wpk_version_windows_http_ok(void **state)
     os_strdup("x64", agent->architecture);
 
     task->use_http = true;
+    os_strdup("v3.13.1", task->wpk_version);
 
     os_strdup("v3.13.1 4a313b1312c23a213f2e3209fe0909dd\nv4.0.0 231ef123a32d312b4123c21313ee6780", versions);
 
     expect_string(__wrap_wurl_http_get, url, "http://packages.wazuh.com/4.x/wpk/windows/versions");
     will_return(__wrap_wurl_http_get, versions);
 
-    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, version, repo);
+    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, repo);
 
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
     assert_string_equal(task->wpk_repository, "http://packages.wazuh.com/4.x/wpk/windows/");
@@ -422,7 +418,6 @@ void test_wm_agent_upgrade_validate_wpk_version_windows_invalid_version(void **s
 {
     wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
-    char *version = "v4.2.0";
     char *repo = "packages.wazuh.com/4.x/wpk/";
     char *versions = NULL;
 
@@ -431,13 +426,14 @@ void test_wm_agent_upgrade_validate_wpk_version_windows_invalid_version(void **s
     os_strdup("x64", agent->architecture);
 
     task->use_http = true;
+    os_strdup("v4.2.0", task->wpk_version);
 
     os_strdup("v3.13.1 4a313b1312c23a213f2e3209fe0909dd\nv4.0.0 231ef123a32d312b4123c21313ee6780", versions);
 
     expect_string(__wrap_wurl_http_get, url, "http://packages.wazuh.com/4.x/wpk/windows/versions");
     will_return(__wrap_wurl_http_get, versions);
 
-    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, version, repo);
+    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, repo);
 
     assert_int_equal(ret, WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST);
     assert_string_equal(task->wpk_repository, repo);
@@ -449,7 +445,6 @@ void test_wm_agent_upgrade_validate_wpk_version_windows_invalid_repo(void **stat
 {
     wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
-    char *version = "v4.2.0";
     char *repo = "error.wazuh.com/wpk/";
     char *versions = NULL;
 
@@ -458,11 +453,12 @@ void test_wm_agent_upgrade_validate_wpk_version_windows_invalid_repo(void **stat
     os_strdup("x64", agent->architecture);
 
     task->use_http = true;
+    os_strdup("v4.2.0", task->wpk_version);
 
     expect_string(__wrap_wurl_http_get, url, "http://error.wazuh.com/wpk/windows/versions");
     will_return(__wrap_wurl_http_get, versions);
 
-    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, version, repo);
+    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, repo);
 
     assert_int_equal(ret, WM_UPGRADE_URL_NOT_FOUND);
     assert_string_equal(task->wpk_repository, repo);
@@ -474,7 +470,6 @@ void test_wm_agent_upgrade_validate_wpk_version_linux_https_ok(void **state)
 {
     wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
-    char *version = "v4.0.0";
     char *repo = "packages.wazuh.com/4.x/wpk";
     char *versions = NULL;
 
@@ -484,13 +479,14 @@ void test_wm_agent_upgrade_validate_wpk_version_linux_https_ok(void **state)
     os_strdup("x64", agent->architecture);
 
     task->use_http = false;
+    os_strdup("v4.0.0", task->wpk_version);
 
     os_strdup("v3.13.1 4a313b1312c23a213f2e3209fe0909dd\nv4.0.0 231ef123a32d312b4123c21313ee6780", versions);
 
     expect_string(__wrap_wurl_http_get, url, "https://packages.wazuh.com/4.x/wpk/linux/x64/versions");
     will_return(__wrap_wurl_http_get, versions);
 
-    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, version, repo);
+    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, repo);
 
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
     assert_string_equal(task->wpk_repository, "https://packages.wazuh.com/4.x/wpk/linux/x64/");
@@ -502,7 +498,6 @@ void test_wm_agent_upgrade_validate_wpk_version_linux_http_ok(void **state)
 {
     wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
-    char *version = "v3.13.1";
     char *repo = "packages.wazuh.com/4.x/wpk/";
     char *versions = NULL;
 
@@ -512,13 +507,14 @@ void test_wm_agent_upgrade_validate_wpk_version_linux_http_ok(void **state)
     os_strdup("x64", agent->architecture);
 
     task->use_http = true;
+    os_strdup("v3.13.1", task->wpk_version);
 
     os_strdup("v3.13.1 4a313b1312c23a213f2e3209fe0909dd\nv4.0.0 231ef123a32d312b4123c21313ee6780", versions);
 
     expect_string(__wrap_wurl_http_get, url, "http://packages.wazuh.com/4.x/wpk/linux/x64/versions");
     will_return(__wrap_wurl_http_get, versions);
 
-    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, version, repo);
+    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, repo);
 
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
     assert_string_equal(task->wpk_repository, "http://packages.wazuh.com/4.x/wpk/linux/x64/");
@@ -530,7 +526,6 @@ void test_wm_agent_upgrade_validate_wpk_version_linux_invalid_version(void **sta
 {
     wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
-    char *version = "v4.2.0";
     char *repo = "packages.wazuh.com/4.x/wpk/";
     char *versions = NULL;
 
@@ -540,13 +535,14 @@ void test_wm_agent_upgrade_validate_wpk_version_linux_invalid_version(void **sta
     os_strdup("x64", agent->architecture);
 
     task->use_http = true;
+    os_strdup("v4.2.0", task->wpk_version);
 
     os_strdup("error\nerror\nerror", versions);
 
     expect_string(__wrap_wurl_http_get, url, "http://packages.wazuh.com/4.x/wpk/linux/x64/versions");
     will_return(__wrap_wurl_http_get, versions);
 
-    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, version, repo);
+    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, repo);
 
     assert_int_equal(ret, WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST);
     assert_string_equal(task->wpk_repository, repo);
@@ -558,7 +554,6 @@ void test_wm_agent_upgrade_validate_wpk_version_linux_invalid_repo(void **state)
 {
     wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
-    char *version = "v4.2.0";
     char *repo = "error.wazuh.com/wpk/";
     char *versions = NULL;
 
@@ -568,11 +563,12 @@ void test_wm_agent_upgrade_validate_wpk_version_linux_invalid_repo(void **state)
     os_strdup("x64", agent->architecture);
 
     task->use_http = true;
+    os_strdup("v4.2.0", task->wpk_version);
 
     expect_string(__wrap_wurl_http_get, url, "http://error.wazuh.com/wpk/linux/x64/versions");
     will_return(__wrap_wurl_http_get, versions);
 
-    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, version, repo);
+    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, repo);
 
     assert_int_equal(ret, WM_UPGRADE_URL_NOT_FOUND);
     assert_string_equal(task->wpk_repository, repo);
@@ -584,7 +580,6 @@ void test_wm_agent_upgrade_validate_wpk_version_ubuntu_old_version(void **state)
 {
     wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
-    char *version = "v3.3.0";
     char *repo = "packages.wazuh.com/4.x/wpk";
     char *versions = NULL;
 
@@ -594,13 +589,14 @@ void test_wm_agent_upgrade_validate_wpk_version_ubuntu_old_version(void **state)
     os_strdup("x64", agent->architecture);
 
     task->use_http = false;
+    os_strdup("v3.3.0", task->wpk_version);
 
     os_strdup("v3.3.0 ad87687f6876e876876bb86ad54e57aa", versions);
 
     expect_string(__wrap_wurl_http_get, url, "https://packages.wazuh.com/4.x/wpk/ubuntu/16.04/x64/versions");
     will_return(__wrap_wurl_http_get, versions);
 
-    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, version, repo);
+    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, repo);
 
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
     assert_string_equal(task->wpk_repository, "https://packages.wazuh.com/4.x/wpk/ubuntu/16.04/x64/");
@@ -612,7 +608,6 @@ void test_wm_agent_upgrade_validate_wpk_version_rhel_old_version(void **state)
 {
     wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
-    char *version = "v3.3.0";
     char *repo = "packages.wazuh.com/4.x/wpk";
     char *versions = NULL;
 
@@ -621,13 +616,14 @@ void test_wm_agent_upgrade_validate_wpk_version_rhel_old_version(void **state)
     os_strdup("x86", agent->architecture);
 
     task->use_http = false;
+    os_strdup("v3.3.0", task->wpk_version);
 
     os_strdup("v3.3.0 ad87687f6876e876876bb86ad54e57aa", versions);
 
     expect_string(__wrap_wurl_http_get, url, "https://packages.wazuh.com/4.x/wpk/rhel/6/x86/versions");
     will_return(__wrap_wurl_http_get, versions);
 
-    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, version, repo);
+    int ret = wm_agent_upgrade_validate_wpk_version(agent, task, repo);
 
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
     assert_string_equal(task->wpk_repository, "https://packages.wazuh.com/4.x/wpk/rhel/6/x86/");
@@ -635,302 +631,55 @@ void test_wm_agent_upgrade_validate_wpk_version_rhel_old_version(void **state)
     assert_string_equal(task->wpk_sha1, "ad87687f6876e876876bb86ad54e57aa");
 }
 
-void test_wm_agent_upgrade_validate_non_custom_version_custom_version_ok(void **state)
-{
-    wm_manager_configs config;
-    wm_agent_info *agent = state[0];
-    wm_upgrade_task *task = state[1];
-    char *agent_version = "v3.9.1";
-    char *versions = NULL;
-
-    config.wpk_repository = WM_UPGRADE_WPK_REPO_URL;
-
-    os_strdup("windows", agent->platform);
-    os_strdup("10", agent->major_version);
-    os_strdup("x64", agent->architecture);
-
-    task->use_http = false;
-    task->force_upgrade = false;
-    os_strdup("v3.12.0", task->custom_version);
-
-    os_strdup("v3.12.0 4a313b1312c23a213f2e3209fe0909dd\nv3.13.0 5387c3443b5c7234ba7232s2aadb4a7e", versions);
-
-    expect_string(__wrap_wurl_http_get, url, "https://packages.wazuh.com/4.x/wpk/windows/versions");
-    will_return(__wrap_wurl_http_get, versions);
-
-    int ret = wm_agent_upgrade_validate_non_custom_version(agent_version, agent, task, &config);
-
-    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
-    assert_string_equal(task->wpk_repository, "https://packages.wazuh.com/4.x/wpk/windows/");
-    assert_string_equal(task->wpk_file, "wazuh_agent_v3.12.0_windows.wpk");
-    assert_string_equal(task->wpk_sha1, "4a313b1312c23a213f2e3209fe0909dd");
-}
-
-void test_wm_agent_upgrade_validate_non_custom_version_manager_version_ok(void **state)
-{
-    wm_manager_configs config;
-    wm_agent_info *agent = state[0];
-    wm_upgrade_task *task = state[1];
-    char *agent_version = "v3.9.1";
-    char *versions = NULL;
-
-    config.wpk_repository = WM_UPGRADE_WPK_REPO_URL;
-
-    os_strdup("windows", agent->platform);
-    os_strdup("10", agent->major_version);
-    os_strdup("x64", agent->architecture);
-
-    task->use_http = false;
-    task->force_upgrade = false;
-
-    os_strdup("v3.12.0 4a313b1312c23a213f2e3209fe0909dd\nv3.13.0 5387c3443b5c7234ba7232s2aadb4a7e", versions);
-
-    expect_string(__wrap_wurl_http_get, url, "https://packages.wazuh.com/4.x/wpk/windows/versions");
-    will_return(__wrap_wurl_http_get, versions);
-
-    int ret = wm_agent_upgrade_validate_non_custom_version(agent_version, agent, task, &config);
-
-    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
-    assert_string_equal(task->wpk_repository, "https://packages.wazuh.com/4.x/wpk/windows/");
-    assert_string_equal(task->wpk_file, "wazuh_agent_v3.13.0_windows.wpk");
-    assert_string_equal(task->wpk_sha1, "5387c3443b5c7234ba7232s2aadb4a7e");
-}
-
-void test_wm_agent_upgrade_validate_non_custom_version_less_current(void **state)
-{
-    wm_manager_configs config;
-    wm_agent_info *agent = state[0];
-    wm_upgrade_task *task = state[1];
-    char *agent_version = "v3.13.0";
-    char *versions = NULL;
-
-    config.wpk_repository = WM_UPGRADE_WPK_REPO_URL;
-
-    os_strdup("windows", agent->platform);
-    os_strdup("10", agent->major_version);
-    os_strdup("x64", agent->architecture);
-
-    task->use_http = false;
-    task->force_upgrade = false;
-    os_strdup("v3.12.0", task->custom_version);
-
-    os_strdup("v3.12.0 4a313b1312c23a213f2e3209fe0909dd\nv3.13.0 5387c3443b5c7234ba7232s2aadb4a7e", versions);
-
-    expect_string(__wrap_wurl_http_get, url, "https://packages.wazuh.com/4.x/wpk/windows/versions");
-    will_return(__wrap_wurl_http_get, versions);
-
-    int ret = wm_agent_upgrade_validate_non_custom_version(agent_version, agent, task, &config);
-
-    assert_int_equal(ret, WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT);
-    assert_string_equal(task->wpk_repository, "https://packages.wazuh.com/4.x/wpk/windows/");
-    assert_string_equal(task->wpk_file, "wazuh_agent_v3.12.0_windows.wpk");
-    assert_string_equal(task->wpk_sha1, "4a313b1312c23a213f2e3209fe0909dd");
-}
-
-void test_wm_agent_upgrade_validate_non_custom_version_less_current_force(void **state)
-{
-    wm_manager_configs config;
-    wm_agent_info *agent = state[0];
-    wm_upgrade_task *task = state[1];
-    char *agent_version = "v3.13.0";
-    char *versions = NULL;
-
-    config.wpk_repository = WM_UPGRADE_WPK_REPO_URL;
-
-    os_strdup("windows", agent->platform);
-    os_strdup("10", agent->major_version);
-    os_strdup("x64", agent->architecture);
-
-    task->use_http = false;
-    task->force_upgrade = true;
-    os_strdup("v3.12.0", task->custom_version);
-
-    os_strdup("v3.12.0 4a313b1312c23a213f2e3209fe0909dd\nv3.13.0 5387c3443b5c7234ba7232s2aadb4a7e", versions);
-
-    expect_string(__wrap_wurl_http_get, url, "https://packages.wazuh.com/4.x/wpk/windows/versions");
-    will_return(__wrap_wurl_http_get, versions);
-
-    int ret = wm_agent_upgrade_validate_non_custom_version(agent_version, agent, task, &config);
-
-    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
-    assert_string_equal(task->wpk_repository, "https://packages.wazuh.com/4.x/wpk/windows/");
-    assert_string_equal(task->wpk_file, "wazuh_agent_v3.12.0_windows.wpk");
-    assert_string_equal(task->wpk_sha1, "4a313b1312c23a213f2e3209fe0909dd");
-}
-
-void test_wm_agent_upgrade_validate_non_custom_version_greater_master(void **state)
-{
-    wm_manager_configs config;
-    wm_agent_info *agent = state[0];
-    wm_upgrade_task *task = state[1];
-    char *agent_version = "v3.9.1";
-    char *versions = NULL;
-
-    config.wpk_repository = WM_UPGRADE_WPK_REPO_URL;
-
-    os_strdup("windows", agent->platform);
-    os_strdup("10", agent->major_version);
-    os_strdup("x64", agent->architecture);
-
-    task->use_http = false;
-    task->force_upgrade = false;
-    os_strdup("v4.0.0", task->custom_version);
-
-    os_strdup("v3.12.0 4a313b1312c23a213f2e3209fe0909dd\nv3.13.0 5387c3443b5c7234ba7232s2aadb4a7e\nv4.0.0 231ef123a32d312b4123c21313ee6780", versions);
-
-    expect_string(__wrap_wurl_http_get, url, "https://packages.wazuh.com/4.x/wpk/windows/versions");
-    will_return(__wrap_wurl_http_get, versions);
-
-    int ret = wm_agent_upgrade_validate_non_custom_version(agent_version, agent, task, &config);
-
-    assert_int_equal(ret, WM_UPGRADE_NEW_VERSION_GREATER_MASTER);
-    assert_string_equal(task->wpk_repository, "https://packages.wazuh.com/4.x/wpk/windows/");
-    assert_string_equal(task->wpk_file, "wazuh_agent_v4.0.0_windows.wpk");
-    assert_string_equal(task->wpk_sha1, "231ef123a32d312b4123c21313ee6780");
-}
-
-void test_wm_agent_upgrade_validate_non_custom_version_greater_master_force(void **state)
-{
-    wm_manager_configs config;
-    wm_agent_info *agent = state[0];
-    wm_upgrade_task *task = state[1];
-    char *agent_version = "v3.9.1";
-    char *versions = NULL;
-
-    config.wpk_repository = WM_UPGRADE_WPK_REPO_URL;
-
-    os_strdup("windows", agent->platform);
-    os_strdup("10", agent->major_version);
-    os_strdup("x64", agent->architecture);
-
-    task->use_http = false;
-    task->force_upgrade = true;
-    os_strdup("v4.0.0", task->custom_version);
-
-    os_strdup("v3.12.0 4a313b1312c23a213f2e3209fe0909dd\nv3.13.0 5387c3443b5c7234ba7232s2aadb4a7e\nv4.0.0 231ef123a32d312b4123c21313ee6780\n", versions);
-
-    expect_string(__wrap_wurl_http_get, url, "https://packages.wazuh.com/4.x/wpk/windows/versions");
-    will_return(__wrap_wurl_http_get, versions);
-
-    int ret = wm_agent_upgrade_validate_non_custom_version(agent_version, agent, task, &config);
-
-    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
-    assert_string_equal(task->wpk_repository, "https://packages.wazuh.com/4.x/wpk/windows/");
-    assert_string_equal(task->wpk_file, "wazuh_agent_v4.0.0_windows.wpk");
-    assert_string_equal(task->wpk_sha1, "231ef123a32d312b4123c21313ee6780");
-}
-
-void test_wm_agent_upgrade_validate_non_custom_version_system_error(void **state)
-{
-    wm_manager_configs config;
-    wm_agent_info *agent = state[0];
-    wm_upgrade_task *task = state[1];
-    char *agent_version = "v3.9.1";
-
-    os_strdup("darwin", agent->platform);
-    os_strdup("10", agent->major_version);
-    os_strdup("15", agent->minor_version);
-    os_strdup("x64", agent->architecture);
-
-    int ret = wm_agent_upgrade_validate_non_custom_version(agent_version, agent, task, &config);
-
-    assert_int_equal(ret, WM_UPGRADE_SYSTEM_NOT_SUPPORTED);
-    assert_null(task->wpk_repository);
-    assert_null(task->wpk_file);
-    assert_null(task->wpk_sha1);
-}
-
 void test_wm_agent_upgrade_validate_version_upgrade_ok(void **state)
 {
-    wm_manager_configs config;
-    wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
-    char *versions = NULL;
+    char *wazuh_version = "v3.9.1";
 
-    config.wpk_repository = WM_UPGRADE_WPK_REPO_URL;
-
-    os_strdup("v3.9.1", agent->wazuh_version);
-    os_strdup("windows", agent->platform);
-    os_strdup("10", agent->major_version);
-    os_strdup("x64", agent->architecture);
-
-    task->use_http = false;
     task->force_upgrade = false;
     os_strdup("v3.12.0", task->custom_version);
 
-    os_strdup("v3.12.0 4a313b1312c23a213f2e3209fe0909dd\nv3.13.0 5387c3443b5c7234ba7232s2aadb4a7e\n", versions);
-
-    expect_string(__wrap_wurl_http_get, url, "https://packages.wazuh.com/4.x/wpk/windows/versions");
-    will_return(__wrap_wurl_http_get, versions);
-
-    int ret = wm_agent_upgrade_validate_version(agent, task, WM_UPGRADE_UPGRADE, &config);
+    int ret = wm_agent_upgrade_validate_version(wazuh_version, WM_UPGRADE_UPGRADE, task);
 
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
-    assert_string_equal(task->wpk_repository, "https://packages.wazuh.com/4.x/wpk/windows/");
-    assert_string_equal(task->wpk_file, "wazuh_agent_v3.12.0_windows.wpk");
-    assert_string_equal(task->wpk_sha1, "4a313b1312c23a213f2e3209fe0909dd");
+    assert_string_equal(task->wpk_version, "v3.12.0");
 }
 
 void test_wm_agent_upgrade_validate_version_upgrade_custom_ok(void **state)
 {
-    wm_manager_configs config;
-    wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
+    char *wazuh_version = "v3.9.1";
 
-    os_strdup("v3.9.1", agent->wazuh_version);
-    os_strdup("windows", agent->platform);
-    os_strdup("10", agent->major_version);
-    os_strdup("x64", agent->architecture);
-
-    int ret = wm_agent_upgrade_validate_version(agent, task, WM_UPGRADE_UPGRADE_CUSTOM, &config);
+    int ret = wm_agent_upgrade_validate_version(wazuh_version, WM_UPGRADE_UPGRADE_CUSTOM, task);
 
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
 }
 
 void test_wm_agent_upgrade_validate_version_upgrade_non_minimal(void **state)
 {
-    wm_manager_configs config;
-    wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
+    char *wazuh_version = "v2.1.1";
 
-    os_strdup("v2.1.1", agent->wazuh_version);
-    os_strdup("windows", agent->platform);
-    os_strdup("10", agent->major_version);
-    os_strdup("x64", agent->architecture);
-
-    int ret = wm_agent_upgrade_validate_version(agent, task, WM_UPGRADE_UPGRADE, &config);
+    int ret = wm_agent_upgrade_validate_version(wazuh_version, WM_UPGRADE_UPGRADE, task);
 
     assert_int_equal(ret, WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED);
 }
 
 void test_wm_agent_upgrade_validate_version_upgrade_custom_non_minimal(void **state)
 {
-    wm_manager_configs config;
-    wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
+    char *wazuh_version = "v2.1.1";
 
-    os_strdup("v2.1.1", agent->wazuh_version);
-    os_strdup("windows", agent->platform);
-    os_strdup("10", agent->major_version);
-    os_strdup("x64", agent->architecture);
-
-    int ret = wm_agent_upgrade_validate_version(agent, task, WM_UPGRADE_UPGRADE_CUSTOM, &config);
+    int ret = wm_agent_upgrade_validate_version(wazuh_version, WM_UPGRADE_UPGRADE_CUSTOM, task);
 
     assert_int_equal(ret, WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED);
 }
 
 void test_wm_agent_upgrade_validate_version_version_null(void **state)
 {
-    wm_manager_configs config;
-    wm_agent_info *agent = state[0];
     wm_upgrade_task *task = state[1];
 
-    agent->wazuh_version = NULL;
-    os_strdup("windows", agent->platform);
-    os_strdup("10", agent->major_version);
-    os_strdup("x64", agent->architecture);
-
-    int ret = wm_agent_upgrade_validate_version(agent, task, WM_UPGRADE_UPGRADE_CUSTOM, &config);
+    int ret = wm_agent_upgrade_validate_version(NULL, WM_UPGRADE_UPGRADE_CUSTOM, task);
 
     assert_int_equal(ret, WM_UPGRADE_GLOBAL_DB_FAILURE);
 }
@@ -1399,14 +1148,6 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_wpk_version_linux_invalid_repo, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_wpk_version_ubuntu_old_version, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_wpk_version_rhel_old_version, setup_validate_wpk_version, teardown_validate_wpk_version),
-        // wm_agent_upgrade_validate_non_custom_version
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_non_custom_version_custom_version_ok, setup_validate_wpk_version, teardown_validate_wpk_version),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_non_custom_version_manager_version_ok, setup_validate_wpk_version, teardown_validate_wpk_version),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_non_custom_version_less_current, setup_validate_wpk_version, teardown_validate_wpk_version),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_non_custom_version_less_current_force, setup_validate_wpk_version, teardown_validate_wpk_version),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_non_custom_version_greater_master, setup_validate_wpk_version, teardown_validate_wpk_version),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_non_custom_version_greater_master_force, setup_validate_wpk_version, teardown_validate_wpk_version),
-        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_non_custom_version_system_error, setup_validate_wpk_version, teardown_validate_wpk_version),
         // wm_agent_upgrade_validate_version
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_ok, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_custom_ok, setup_validate_wpk_version, teardown_validate_wpk_version),

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.c
@@ -117,6 +117,10 @@ OSHashNode* __wrap_wm_agent_upgrade_get_next_node(unsigned int *index, OSHashNod
     }
 }
 
+cJSON* __wrap_wm_agent_upgrade_get_agent_ids() {
+    return mock_type(cJSON*);
+}
+
 int __wrap_wm_agent_upgrade_compare_versions(const char *version1, const char *version2) {
     check_expected(version1);
     check_expected(version2);
@@ -144,14 +148,22 @@ int __wrap_wm_agent_upgrade_validate_status(int last_keep_alive) {
     return mock();
 }
 
-int __wrap_wm_agent_upgrade_validate_version(__attribute__((unused)) const wm_agent_info *agent_info, void *task, wm_upgrade_command command, const wm_manager_configs* manager_configs) {
+int __wrap_wm_agent_upgrade_validate_system(const char *platform, const char *os_major, const char *os_minor, const char *arch) {
+    check_expected(platform);
+    check_expected(os_major);
+    check_expected(os_minor);
+    check_expected(arch);
+
+    return mock();
+}
+
+int __wrap_wm_agent_upgrade_validate_version(const char *wazuh_version, wm_upgrade_command command, void *task) {
+    check_expected(wazuh_version);
     check_expected(command);
-    check_expected(manager_configs);
 
     if (command == WM_UPGRADE_UPGRADE) {
         wm_upgrade_task *upgrade_task = (wm_upgrade_task *)task;
-        os_strdup(mock_type(char*), upgrade_task->wpk_file);
-        os_strdup(mock_type(char*), upgrade_task->wpk_sha1);
+        os_strdup(mock_type(char*), upgrade_task->wpk_version);
     }
 
     return mock();

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.c
@@ -169,6 +169,12 @@ int __wrap_wm_agent_upgrade_validate_version(const char *wazuh_version, wm_upgra
     return mock();
 }
 
+int __wrap_wm_agent_upgrade_validate_wpk_version(__attribute__((unused)) const wm_agent_info *agent_info, __attribute__((unused)) wm_upgrade_task *task, const char *wpk_repository_config) {
+    check_expected(wpk_repository_config);
+
+    return mock();
+}
+
 int __wrap_wm_agent_upgrade_validate_wpk(__attribute__((unused)) const wm_upgrade_task *task) {
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.h
@@ -55,6 +55,8 @@ int __wrap_wm_agent_upgrade_validate_system(const char *platform, const char *os
 
 int __wrap_wm_agent_upgrade_validate_version(const char *wazuh_version, wm_upgrade_command command, void *task);
 
+int __wrap_wm_agent_upgrade_validate_wpk_version(const wm_agent_info *agent_info, wm_upgrade_task *task, const char *wpk_repository_config);
+
 int __wrap_wm_agent_upgrade_validate_wpk(const wm_upgrade_task *task);
 
 int __wrap_wm_agent_upgrade_validate_wpk_custom(const wm_upgrade_custom_task *task);

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.h
@@ -41,6 +41,8 @@ OSHashNode* __wrap_wm_agent_upgrade_get_first_node(unsigned int *index);
 
 OSHashNode* __wrap_wm_agent_upgrade_get_next_node(unsigned int *index, OSHashNode *current);
 
+cJSON* __wrap_wm_agent_upgrade_get_agent_ids();
+
 int __wrap_wm_agent_upgrade_compare_versions(const char *version1, const char *version2);
 
 bool __wrap_wm_agent_upgrade_validate_task_status_message(const cJSON *input_json, char **status, int *agent_id);
@@ -49,7 +51,9 @@ int __wrap_wm_agent_upgrade_validate_id(int agent_id);
 
 int __wrap_wm_agent_upgrade_validate_status(int last_keep_alive);
 
-int __wrap_wm_agent_upgrade_validate_version(const wm_agent_info *agent_info, void *task, wm_upgrade_command command, const wm_manager_configs* manager_configs);
+int __wrap_wm_agent_upgrade_validate_system(const char *platform, const char *os_major, const char *os_minor, const char *arch);
+
+int __wrap_wm_agent_upgrade_validate_version(const char *wazuh_version, wm_upgrade_command command, void *task);
 
 int __wrap_wm_agent_upgrade_validate_wpk(const wm_upgrade_task *task);
 

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_commands.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_commands.c
@@ -69,7 +69,7 @@ STATIC int wm_agent_upgrade_validate_agent_task(const wm_agent_task *agent_task)
  * @param data_array cJSON array where the task responses will be stored
  * @return 1 if there are new upgrades, 0 otherwise
  */
-STATIC int wm_agent_upgrade_create_upgrade_tasks(cJSON *data_array) __attribute__((nonnull));
+STATIC int wm_agent_upgrade_create_upgrade_tasks(cJSON *data_array, wm_upgrade_command command) __attribute__((nonnull));
 
 void wm_agent_upgrade_cancel_pending_upgrades() {
     cJSON *cancel_request = NULL;
@@ -117,7 +117,7 @@ char* wm_agent_upgrade_process_upgrade_command(const int* agent_ids, wm_upgrade_
     }
 
     // Check and create new upgrade tasks if necessary
-    if (!wm_agent_upgrade_create_upgrade_tasks(data_array)) {
+    if (!wm_agent_upgrade_create_upgrade_tasks(data_array, WM_UPGRADE_UPGRADE)) {
         mtwarn(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_NO_AGENTS_TO_UPGRADE);
     }
 
@@ -160,7 +160,7 @@ char* wm_agent_upgrade_process_upgrade_custom_command(const int* agent_ids, wm_u
     }
 
     // Check and create new upgrade tasks if necessary
-    if (!wm_agent_upgrade_create_upgrade_tasks(data_array)) {
+    if (!wm_agent_upgrade_create_upgrade_tasks(data_array, WM_UPGRADE_UPGRADE_CUSTOM)) {
         mtwarn(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_NO_AGENTS_TO_UPGRADE);
     }
 
@@ -309,7 +309,7 @@ STATIC int wm_agent_upgrade_validate_agent_task(const wm_agent_task *agent_task)
     return validate_result;
 }
 
-STATIC int wm_agent_upgrade_create_upgrade_tasks(cJSON *data_array) {
+STATIC int wm_agent_upgrade_create_upgrade_tasks(cJSON *data_array, wm_upgrade_command command) {
     cJSON *agents_array = NULL;
     int new_upgrades = 0;
 
@@ -321,7 +321,7 @@ STATIC int wm_agent_upgrade_create_upgrade_tasks(cJSON *data_array) {
 
             if (agents_array = wm_agent_upgrade_get_agent_ids(), agents_array) {
                 // Create upgrade tasks
-                cJSON *upgrade_request = wm_agent_upgrade_parse_task_module_request(WM_UPGRADE_UPGRADE, agents_array, NULL, NULL);
+                cJSON *upgrade_request = wm_agent_upgrade_parse_task_module_request(command, agents_array, NULL, NULL);
 
                 if (!wm_agent_upgrade_task_module_callback(data_array, upgrade_request, wm_agent_upgrade_upgrade_success_callback, wm_agent_upgrade_remove_entry)) {
                     // Enqueue upgrades

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.c
@@ -25,13 +25,13 @@ const char* upgrade_error_codes[] = {
     [WM_UPGRADE_GLOBAL_DB_FAILURE] = "Agent information not found in database",
     [WM_UPGRADE_INVALID_ACTION_FOR_MANAGER] = "Action not available for Manager (agent 000)",
     [WM_UPGRADE_AGENT_IS_NOT_ACTIVE] = "Agent is not active",
+    [WM_UPGRADE_SYSTEM_NOT_SUPPORTED] = "The WPK for this platform is not available",
     [WM_UPGRADE_UPGRADE_ALREADY_IN_PROGRESS] = "Upgrade procedure could not start. Agent already upgrading",
     [WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED] = "Remote upgrade is not available for this agent version",
-    [WM_UPGRADE_SYSTEM_NOT_SUPPORTED] = "The WPK for this platform is not available",
-    [WM_UPGRADE_URL_NOT_FOUND] = "The repository is not reachable",
-    [WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST] = "The version of the WPK does not exist in the repository",
     [WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT] = "Current agent version is greater or equal",
     [WM_UPGRADE_NEW_VERSION_GREATER_MASTER] = "Upgrading an agent to a version higher than the manager requires the force flag",
+    [WM_UPGRADE_URL_NOT_FOUND] = "The repository is not reachable",
+    [WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST] = "The version of the WPK does not exist in the repository",
     [WM_UPGRADE_WPK_FILE_DOES_NOT_EXIST] = "The WPK file does not exist",
     [WM_UPGRADE_WPK_SHA1_DOES_NOT_MATCH] = "The WPK sha1 of the file is not valid",
     [WM_UPGRADE_SEND_LOCK_RESTART_ERROR] = "Send lock restart error",
@@ -72,7 +72,7 @@ void wm_agent_upgrade_listen_messages(const wm_manager_configs* manager_configs)
 
     while (1) {
         // listen - wait connection
-        fd_set fdset;    
+        fd_set fdset;
         FD_ZERO(&fdset);
         FD_SET(sock, &fdset);
 
@@ -90,7 +90,7 @@ void wm_agent_upgrade_listen_messages(const wm_manager_configs* manager_configs)
             continue;
         }
 
-        //Accept 
+        //Accept
         int peer;
         if (peer = accept(sock, NULL, NULL), peer < 0) {
             if (errno != EINTR) {
@@ -130,14 +130,14 @@ void wm_agent_upgrade_listen_messages(const wm_manager_configs* manager_configs)
             case WM_UPGRADE_UPGRADE:
                 // Upgrade command
                 if (task && agent_ids) {
-                    message = wm_agent_upgrade_process_upgrade_command(agent_ids, (wm_upgrade_task *)task, manager_configs);
+                    message = wm_agent_upgrade_process_upgrade_command(agent_ids, (wm_upgrade_task *)task);
                 }
                 wm_agent_upgrade_free_upgrade_task(task);
                 break;
             case WM_UPGRADE_UPGRADE_CUSTOM:
                 // Upgrade custom command
                 if (task && agent_ids) {
-                    message = wm_agent_upgrade_process_upgrade_custom_command(agent_ids, (wm_upgrade_custom_task *)task, manager_configs);
+                    message = wm_agent_upgrade_process_upgrade_custom_command(agent_ids, (wm_upgrade_custom_task *)task);
                 }
                 wm_agent_upgrade_free_upgrade_custom_task(task);
                 break;

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.h
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.h
@@ -32,13 +32,13 @@ typedef enum _wm_upgrade_error_code {
     WM_UPGRADE_GLOBAL_DB_FAILURE,
     WM_UPGRADE_INVALID_ACTION_FOR_MANAGER,
     WM_UPGRADE_AGENT_IS_NOT_ACTIVE,
+    WM_UPGRADE_SYSTEM_NOT_SUPPORTED,
     WM_UPGRADE_UPGRADE_ALREADY_IN_PROGRESS,
     WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED,
-    WM_UPGRADE_SYSTEM_NOT_SUPPORTED,
-    WM_UPGRADE_URL_NOT_FOUND,
-    WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST,
     WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT,
     WM_UPGRADE_NEW_VERSION_GREATER_MASTER,
+    WM_UPGRADE_URL_NOT_FOUND,
+    WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST,
     WM_UPGRADE_WPK_FILE_DOES_NOT_EXIST,
     WM_UPGRADE_WPK_SHA1_DOES_NOT_MATCH,
     WM_UPGRADE_SEND_LOCK_RESTART_ERROR,
@@ -67,6 +67,7 @@ typedef struct _wm_upgrade_task {
     char *custom_version;        ///> upgrade to a custom version
     bool use_http;               ///> when enabled uses http instead of https to connect to repository
     bool force_upgrade;          ///> when enabled forces upgrade
+    char *wpk_version;           ///> WPK version to install
     char *wpk_file;              ///> WPK file name
     char *wpk_sha1;              ///> WPK sha1 to validate
 } wm_upgrade_task;
@@ -120,7 +121,7 @@ typedef struct _wm_agent_task {
 extern const char* upgrade_error_codes[];
 
 /**
- * Start listening loop, exits only on error 
+ * Start listening loop, exits only on error
  * @param timeout_sec timeout in seconds
  * @param manager_configs manager configuration parameters
  * @return only on errors, socket will be closed
@@ -137,20 +138,18 @@ void wm_agent_upgrade_cancel_pending_upgrades();
  * then starts upgrading process.
  * @param agent_ids array with the list of agents id
  * @param task pointer to a wm_upgrade_task structure
- * @param manager_configs manager configuration parameters
  * @return string with the response
  * */
-char* wm_agent_upgrade_process_upgrade_command(const int* agent_ids, wm_upgrade_task* task, const wm_manager_configs* manager_configs) __attribute__((nonnull));
+char* wm_agent_upgrade_process_upgrade_command(const int* agent_ids, wm_upgrade_task* task) __attribute__((nonnull));
 
 /**
  * Process an upgrade custom command. Create the task for each agent_id, dispatches to task manager and
  * then starts upgrading process.
  * @param agent_ids array with the list of agents id
  * @param task pointer to a wm_upgrade_custom_task structure
- * @param manager_configs manager configuration parameters
  * @return string with the response
  * */
-char* wm_agent_upgrade_process_upgrade_custom_command(const int* agent_ids, wm_upgrade_custom_task* task, const wm_manager_configs* manager_configs) __attribute__((nonnull));
+char* wm_agent_upgrade_process_upgrade_custom_command(const int* agent_ids, wm_upgrade_custom_task* task) __attribute__((nonnull));
 
 /**
  * Process an agent_upgraded command

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_parsing.h
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_parsing.h
@@ -16,9 +16,9 @@
 /**
  * Parse received upgrade message and returns task and agent ids values and a code
  * representing a command if it is valid or an error code otherwise
- * 
+ *
  * Example:
- * 
+ *
  * {
  *	    "command": "upgrade",
  *	    "parameters": {
@@ -27,7 +27,7 @@
  *          "force_upgrade": 0
  *	    }
  * }
- * 
+ *
  * @param buffer message to be parsed
  * @param task on success command task will be stored in this variable
  * @param agent_ids on success agent ids list will be stored in this variable
@@ -42,23 +42,23 @@ int wm_agent_upgrade_parse_message(const char* buffer, void** task, int** agent_
 
 /**
  * Parse a data message
- * 
- * 
+ *
+ *
  * Example 1:
- * 
+ *
  * {
  *     "error":12,
  *     "message":"The repository is not reachable.",
  *     "agent":4
  * }
- * 
+ *
  * Example 2:
- * 
+ *
  * {
  *     "error":1,
  *     "message":"Could not parse message JSON."
  * }
- * 
+ *
  * @param error_id positive number if error, 0 if successs
  * @param message response message
  * @param agent_id [OPTIONAL] id of the agent
@@ -68,9 +68,9 @@ cJSON* wm_agent_upgrade_parse_data_response(int error_id, const char* message, c
 
 /**
  * Parse a response message
- * 
+ *
  * Example:
- * 
+ *
  * {
  *     "error":0,
  *     "data": [
@@ -88,7 +88,7 @@ cJSON* wm_agent_upgrade_parse_data_response(int error_id, const char* message, c
  *     ],
  *     "message": "Successful"
  * }
- * 
+ *
  * @param error_id positive number if error, 0 if successs
  * @param data [OPTIONAL] array of responses
  * @return response json
@@ -97,9 +97,9 @@ cJSON* wm_agent_upgrade_parse_response(int error_id, cJSON *data);
 
 /**
  * Parse a message to be sent to the task module
- * 
+ *
  * Example:
- * 
+ *
  * {
  *	    "command": "upgrade_update_status",
  *	    "origin": {
@@ -111,7 +111,7 @@ cJSON* wm_agent_upgrade_parse_response(int error_id, cJSON *data);
  *          "error_msg": "Send open file error."
  *	    }
  * }
- * 
+ *
  * @param command task command
  * @param agents_array JSON array of agents id
  * @param status optional status string

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
@@ -75,6 +75,7 @@ void wm_agent_upgrade_free_upgrade_task(wm_upgrade_task* upgrade_task) {
     if (upgrade_task) {
         os_free(upgrade_task->custom_version);
         os_free(upgrade_task->wpk_repository);
+        os_free(upgrade_task->wpk_version);
         os_free(upgrade_task->wpk_file);
         os_free(upgrade_task->wpk_sha1);
         os_free(upgrade_task);
@@ -236,5 +237,5 @@ STATIC cJSON *wm_agent_send_task_information_worker(const cJSON *message_object)
     os_free(message);
     cJSON_Delete(payload);
 
-    return cJSON_Parse(response);   
+    return cJSON_Parse(response);
 }

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
@@ -182,6 +182,7 @@ cJSON* wm_agent_upgrade_get_agent_ids() {
     }
     if (!cJSON_GetArraySize(agents_array)) {
         cJSON_Delete(agents_array);
+        return NULL;
     }
 
     return agents_array;

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
@@ -169,6 +169,24 @@ OSHashNode* wm_agent_upgrade_get_next_node(unsigned int *index, OSHashNode *curr
     return OSHash_Next(task_table_by_agent_id, index, current);
 }
 
+cJSON* wm_agent_upgrade_get_agent_ids() {
+    OSHashNode *hash_node;
+    unsigned int index = 0;
+    cJSON *agents_array = cJSON_CreateArray();
+
+    hash_node = OSHash_Begin(task_table_by_agent_id, &index);
+
+    while(hash_node) {
+        cJSON_AddItemToArray(agents_array, cJSON_CreateNumber(atoi(hash_node->key)));
+        hash_node = OSHash_Next(task_table_by_agent_id, &index, hash_node);
+    }
+    if (!cJSON_GetArraySize(agents_array)) {
+        cJSON_Delete(agents_array);
+    }
+
+    return agents_array;
+}
+
 cJSON* wm_agent_upgrade_send_tasks_information(const cJSON *message_object) {
     if (w_is_worker()) {
         return wm_agent_send_task_information_worker(message_object);

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.h
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.h
@@ -159,7 +159,7 @@ cJSON* wm_agent_upgrade_send_tasks_information(const cJSON *message_object) __at
  * @return error code
  * @retval OS_SUCCESS on success
  * @retval OS_INVALID on errors
- * 
+ *
  * */
 int wm_agent_upgrade_task_module_callback(cJSON *data_array, const cJSON* task_module_request, cJSON* (*success_callback)(int *error, cJSON* input_json), void (*error_callback)(int agent_id, int free)) __attribute__((nonnull(1,2)));
 
@@ -172,7 +172,7 @@ int wm_agent_upgrade_task_module_callback(cJSON *data_array, const cJSON* task_m
 cJSON* wm_agent_upgrade_upgrade_success_callback(int *error, cJSON* input_json);
 
 /**
- * Callback function for task manager mensaje, if task manager was able to update task status 
+ * Callback function for task manager mensaje, if task manager was able to update task status
  * then it will send a message to the agent telling it to erase its upgrade_result file
  * @param error if there is any error processing the information, it will be set to OS_INVALID
  * @param input_json response from the task manager

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.h
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.h
@@ -122,6 +122,12 @@ OSHashNode* wm_agent_upgrade_get_first_node(unsigned int *index);
 OSHashNode* wm_agent_upgrade_get_next_node(unsigned int *index, OSHashNode *current);
 
 /**
+ * Returns a JSON array of the agent ids stored in the hash table
+ * @return JSON array of agent ids
+ * */
+cJSON* wm_agent_upgrade_get_agent_ids();
+
+/**
  * Sends the JSON information to the task module and retrieves the answer
  * @param message_object JSON to be sent. Example:
  *  [{
@@ -167,16 +173,25 @@ int wm_agent_upgrade_task_module_callback(cJSON *data_array, const cJSON* task_m
  * Callback defined for upgrade command to process task manager information reponse
  * @param error if there is any error processing the information, it will be set to OS_INVALID
  * @param input_json response from the task manager
- * @return cJSON containing the message that should be included as part of the ugprade response
+ * @return cJSON containing the message that should be included as part of the upgrade response
  * */
 cJSON* wm_agent_upgrade_upgrade_success_callback(int *error, cJSON* input_json);
 
 /**
- * Callback function for task manager mensaje, if task manager was able to update task status
+ * Callback function for task manager message, if task manager was able to get task status
+ * then it will check the status and abort the upgrade if there is already a task in progress
+ * @param error if there is any error processing the information, it will be set to OS_INVALID
+ * @param input_json response from the task manager
+ * @return cJSON containing the message that should be included as part of the upgrade response
+ * */
+cJSON* wm_agent_upgrade_get_status_success_callback(int *error, cJSON* input_json);
+
+/**
+ * Callback function for task manager message, if task manager was able to update task status
  * then it will send a message to the agent telling it to erase its upgrade_result file
  * @param error if there is any error processing the information, it will be set to OS_INVALID
  * @param input_json response from the task manager
- * @return cJSON containing the message that should be included as part of the ugprade response
+ * @return cJSON containing the message that should be included as part of the upgrade response
  * */
 cJSON* wm_agent_upgrade_update_status_success_callback(int *error, cJSON* input_json);
 

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks_callbacks.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks_callbacks.c
@@ -116,14 +116,14 @@ cJSON* wm_agent_upgrade_update_status_success_callback(int *error, cJSON* input_
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         snprintf(buffer, OS_MAXSTR, "%03d com clear_upgrade_result -1", agent_id);
 
-        char *agent_response = wm_agent_upgrade_send_command_to_agent(buffer, strlen(buffer)); 
+        char *agent_response = wm_agent_upgrade_send_command_to_agent(buffer, strlen(buffer));
 
         if (*error = wm_agent_upgrade_parse_agent_response(agent_response, NULL), (*error == OS_SUCCESS)) {
             mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_UPGRADE_FILE_AGENT);
         }
 
         os_free(buffer);
-        os_free(agent_response);   
+        os_free(agent_response);
     } else {
         *error = OS_INVALID;
     }

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks_callbacks.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks_callbacks.c
@@ -88,13 +88,13 @@ cJSON* wm_agent_upgrade_upgrade_success_callback(int *error, cJSON* input_json) 
     char *data = NULL;
     cJSON *response = NULL;
 
-    response = input_json;
-
     if (wm_agent_upgrade_validate_task_ids_message(input_json, &agent_id, &task_id, &data)) {
         if(!task_id) {
             // Remove from table since upgrade will not be started
             wm_agent_upgrade_remove_entry(agent_id, 1);
             response = wm_agent_upgrade_parse_data_response(WM_UPGRADE_TASK_MANAGER_FAILURE, data, &agent_id);
+        } else {
+            response = input_json;
         }
     } else {
         // We cannot know which agent is the one failing so we have to abort the whole process
@@ -106,8 +106,31 @@ cJSON* wm_agent_upgrade_upgrade_success_callback(int *error, cJSON* input_json) 
     return response;
 }
 
+cJSON* wm_agent_upgrade_get_status_success_callback(int *error, cJSON* input_json) {
+    int agent_id = 0;
+    char *status = NULL;
+    cJSON *response = NULL;
+
+    if (wm_agent_upgrade_validate_task_status_message(input_json, &status, &agent_id)) {
+        // Check agent last upgrade task status
+        if (status && (!strcmp(status, task_statuses[WM_TASK_PENDING]) || !strcmp(status, task_statuses[WM_TASK_IN_PROGRESS]))) {
+            // Remove from table since upgrade will not be started
+            wm_agent_upgrade_remove_entry(agent_id, 1);
+            response = wm_agent_upgrade_parse_data_response(WM_UPGRADE_UPGRADE_ALREADY_IN_PROGRESS, upgrade_error_codes[WM_UPGRADE_UPGRADE_ALREADY_IN_PROGRESS], &agent_id);
+        }
+    } else {
+        // We cannot know which agent is the one failing so we have to abort the whole process
+        *error = OS_INVALID;
+    }
+
+    os_free(status);
+
+    return response;
+}
+
 cJSON* wm_agent_upgrade_update_status_success_callback(int *error, cJSON* input_json) {
     int agent_id = 0;
+    cJSON *response = NULL;
 
     if (wm_agent_upgrade_validate_task_status_message(input_json, NULL, &agent_id), agent_id > 0) {
         // Tell agent to erase results file
@@ -118,9 +141,11 @@ cJSON* wm_agent_upgrade_update_status_success_callback(int *error, cJSON* input_
 
         char *agent_response = wm_agent_upgrade_send_command_to_agent(buffer, strlen(buffer));
 
-        if (*error = wm_agent_upgrade_parse_agent_response(agent_response, NULL), (*error == OS_SUCCESS)) {
+        if (wm_agent_upgrade_parse_agent_response(agent_response, NULL) == OS_SUCCESS) {
             mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_UPGRADE_FILE_AGENT);
         }
+
+        response = input_json;
 
         os_free(buffer);
         os_free(agent_response);
@@ -128,5 +153,5 @@ cJSON* wm_agent_upgrade_update_status_success_callback(int *error, cJSON* input_
         *error = OS_INVALID;
     }
 
-    return input_json;
+    return response;
 }

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.c
@@ -265,7 +265,10 @@ STATIC int wm_agent_upgrade_send_wpk_to_agent(const wm_agent_task *agent_task, c
 
     // Validate WPK file
     if (WM_UPGRADE_UPGRADE == agent_task->task_info->command) {
-        result = wm_agent_upgrade_validate_wpk((wm_upgrade_task *)agent_task->task_info->task);
+        result = wm_agent_upgrade_validate_wpk_version(agent_task->agent_info, (wm_upgrade_task *)agent_task->task_info->task, manager_configs->wpk_repository);
+        if (result == WM_UPGRADE_SUCCESS) {
+            result = wm_agent_upgrade_validate_wpk((wm_upgrade_task *)agent_task->task_info->task);
+        }
     } else {
         result = wm_agent_upgrade_validate_wpk_custom((wm_upgrade_custom_task *)agent_task->task_info->task);
     }

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -120,6 +120,10 @@ int wm_agent_upgrade_validate_wpk_version(const wm_agent_info *agent_info, wm_up
     char *versions = NULL;
     int return_code = WM_UPGRADE_SUCCESS;
 
+    if (!task->wpk_version) {
+        return WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST;
+    }
+
     os_calloc(OS_SIZE_1024, sizeof(char), repository_url);
     os_calloc(OS_SIZE_2048, sizeof(char), path_url);
     os_calloc(OS_SIZE_2048, sizeof(char), file_url);

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -9,13 +9,6 @@
  * Foundation.
  */
 
-#ifdef WAZUH_UNIT_TESTING
-// Remove static qualifier when unit testing
-#define STATIC
-#else
-#define STATIC static
-#endif
-
 #include "wazuh_db/wdb.h"
 #include "wazuh_modules/wmodules.h"
 #include "wm_agent_upgrade_validate.h"
@@ -28,46 +21,6 @@
 
 // Mutex needed to download a WPK file
 pthread_mutex_t download_mutex = PTHREAD_MUTEX_INITIALIZER;
-
-/**
- * Check if agent version is valid to upgrade to a non-customized version
- * @param agent_version Wazuh version of agent to validate
- * @param agent_info pointer to agent_info struture
- * @param task pointer to wm_upgrade_task with the params
- * @param manager_configs manager configuration parameters
- * @return return_code
- * @retval WM_UPGRADE_SUCCESS
- * @retval WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT
- * @retval WM_UPGRADE_NEW_VERSION_GREATER_MASTER
- * @retval WM_UPGRADE_GLOBAL_DB_FAILURE
- * */
-STATIC int wm_agent_upgrade_validate_non_custom_version(const char *agent_version, const wm_agent_info *agent_info, wm_upgrade_task *task, const wm_manager_configs* manager_configs) __attribute__((nonnull));
-
-/**
- * Check if WPK exists for this agent
- * @param platform platform of agent to validate
- * @param os_major OS major version of agent to validate
- * @param os_minor OS minor version of agent to validate
- * @param arch architecture of agent to validate
- * @return return_code
- * @retval WM_UPGRADE_SUCCESS
- * @retval WM_UPGRADE_SYSTEM_NOT_SUPPORTED
- * @retval WM_UPGRADE_GLOBAL_DB_FAILURE
- * */
-STATIC int wm_agent_upgrade_validate_system(const char *platform, const char *os_major, const char *os_minor, const char *arch);
-
-/**
- * Check if a WPK exist for the upgrade version
- * @param agent_info structure with the agent information
- * @param task structure with the task information
- * @param wpk_version version to validate
- * @param wpk_repository_config char pointer with the repository url set in module config
- * @return return_code
- * @retval WM_UPGRADE_SUCCESS
- * @retval WM_UPGRADE_URL_NOT_FOUND
- * @retval WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST
- * */
-STATIC int wm_agent_upgrade_validate_wpk_version(const wm_agent_info *agent_info, wm_upgrade_task *task, char *wpk_version, const char *wpk_repository_config) __attribute__((nonnull));
 
 static const char* invalid_platforms[] = {
     "darwin",
@@ -97,21 +50,178 @@ int wm_agent_upgrade_validate_status(int last_keep_alive) {
     return return_code;
 }
 
-int wm_agent_upgrade_validate_version(const wm_agent_info *agent_info, void *task, wm_upgrade_command command, const wm_manager_configs* manager_configs) {
+int wm_agent_upgrade_validate_system(const char *platform, const char *os_major, const char *os_minor, const char *arch) {
+    int invalid_platforms_len = 0;
+    int invalid_platforms_it = 0;
+    int return_code = WM_UPGRADE_GLOBAL_DB_FAILURE;
+
+    if (platform) {
+        if (!strcmp(platform, "windows") || (os_major && arch && (strcmp(platform, "ubuntu") || os_minor))) {
+            return_code = WM_UPGRADE_SUCCESS;
+            invalid_platforms_len = sizeof(invalid_platforms) / sizeof(invalid_platforms[0]);
+
+            for(invalid_platforms_it = 0; invalid_platforms_it < invalid_platforms_len; ++invalid_platforms_it) {
+                if(!strcmp(invalid_platforms[invalid_platforms_it], platform)) {
+                    return_code = WM_UPGRADE_SYSTEM_NOT_SUPPORTED;
+                    break;
+                }
+            }
+
+            if (WM_UPGRADE_SUCCESS == return_code) {
+                if ((!strcmp(platform, "sles") && !strcmp(os_major, "11")) ||
+                    (!strcmp(platform, "rhel") && !strcmp(os_major, "5")) ||
+                    (!strcmp(platform, "centos") && !strcmp(os_major, "5"))) {
+                    return_code = WM_UPGRADE_SYSTEM_NOT_SUPPORTED;
+                }
+            }
+        }
+    }
+
+    return return_code;
+}
+
+int wm_agent_upgrade_validate_version(const char *wazuh_version, wm_upgrade_command command, void *task) {
     char *tmp_agent_version = NULL;
     int return_code = WM_UPGRADE_GLOBAL_DB_FAILURE;
 
-    if (agent_info->wazuh_version) {
-        if (tmp_agent_version = strchr(agent_info->wazuh_version, 'v'), tmp_agent_version) {
+    if (wazuh_version) {
+        if (tmp_agent_version = strchr(wazuh_version, 'v'), tmp_agent_version) {
             return_code = WM_UPGRADE_SUCCESS;
 
             if (wm_agent_upgrade_compare_versions(tmp_agent_version, WM_UPGRADE_MINIMAL_VERSION_SUPPORT) < 0) {
                 return_code = WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED;
             } else if (WM_UPGRADE_UPGRADE == command) {
-                return_code = wm_agent_upgrade_validate_non_custom_version(tmp_agent_version, agent_info, (wm_upgrade_task *)task, manager_configs);
+                wm_upgrade_task *upgrade_task = (wm_upgrade_task *)task;
+                char *manager_version = strchr(__ossec_version, 'v');
+
+                os_strdup(upgrade_task->custom_version ? upgrade_task->custom_version : manager_version, upgrade_task->wpk_version);
+
+                if (!upgrade_task->force_upgrade) {
+                    if (wm_agent_upgrade_compare_versions(tmp_agent_version, upgrade_task->wpk_version) >= 0) {
+                        return_code = WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT;
+                    } else if (wm_agent_upgrade_compare_versions(upgrade_task->wpk_version, manager_version) > 0) {
+                        return_code = WM_UPGRADE_NEW_VERSION_GREATER_MASTER;
+                    }
+                }
             }
         }
     }
+
+    return return_code;
+}
+
+int wm_agent_upgrade_validate_wpk_version(const wm_agent_info *agent_info, wm_upgrade_task *task, const char *wpk_repository_config) {
+    const char *http_tag = "http://";
+    const char *https_tag = "https://";
+    char *repository_url = NULL;
+    char *path_url = NULL;
+    char *file_url = NULL;
+    char *versions_url = NULL;
+    char *versions = NULL;
+    int return_code = WM_UPGRADE_SUCCESS;
+
+    os_calloc(OS_SIZE_1024, sizeof(char), repository_url);
+    os_calloc(OS_SIZE_2048, sizeof(char), path_url);
+    os_calloc(OS_SIZE_2048, sizeof(char), file_url);
+    os_calloc(OS_SIZE_4096, sizeof(char), versions_url);
+
+    if (!task->wpk_repository) {
+        os_strdup(wpk_repository_config, task->wpk_repository);
+    }
+
+    // Set protocol
+    if (!strstr(task->wpk_repository, http_tag) && !strstr(task->wpk_repository, https_tag)) {
+        if (task->use_http) {
+            strcat(repository_url, http_tag);
+        } else {
+            strcat(repository_url, https_tag);
+        }
+    }
+
+    // Set repository
+    strncat(repository_url, task->wpk_repository, OS_SIZE_512);
+    if (task->wpk_repository[strlen(task->wpk_repository) - 1] != '/') {
+        strcat(repository_url, "/");
+    }
+
+    // Set URL path
+    if (!strcmp(agent_info->platform, "windows")) {
+        snprintf(path_url, OS_SIZE_2048, "%swindows/",
+                 repository_url);
+        snprintf(file_url, OS_SIZE_2048, "wazuh_agent_%s_windows.wpk",
+                 task->wpk_version);
+    } else {
+        if (wm_agent_upgrade_compare_versions(task->wpk_version, WM_UPGRADE_NEW_VERSION_REPOSITORY) >= 0) {
+            snprintf(path_url, OS_SIZE_2048, "%slinux/%s/",
+                     repository_url, agent_info->architecture);
+            snprintf(file_url, OS_SIZE_2048, "wazuh_agent_%s_linux_%s.wpk",
+                     task->wpk_version, agent_info->architecture);
+        } else if (!strcmp(agent_info->platform, "ubuntu")) {
+            snprintf(path_url, OS_SIZE_2048, "%s%s/%s.%s/%s/",
+                     repository_url, agent_info->platform, agent_info->major_version, agent_info->minor_version, agent_info->architecture);
+            snprintf(file_url, OS_SIZE_2048, "wazuh_agent_%s_%s_%s.%s_%s.wpk",
+                     task->wpk_version, agent_info->platform, agent_info->major_version, agent_info->minor_version, agent_info->architecture);
+        } else {
+            snprintf(path_url, OS_SIZE_2048, "%s%s/%s/%s/",
+                     repository_url, agent_info->platform, agent_info->major_version, agent_info->architecture);
+            snprintf(file_url, OS_SIZE_2048, "wazuh_agent_%s_%s_%s_%s.wpk",
+                     task->wpk_version, agent_info->platform, agent_info->major_version, agent_info->architecture);
+        }
+    }
+
+    // Set versions respository
+    snprintf(versions_url, OS_SIZE_4096, "%sversions", path_url);
+
+    versions = wurl_http_get(versions_url);
+
+    if (versions) {
+        char *version = versions;
+        char *sha1 = NULL;
+        char *next_line = NULL;
+
+        while (version) {
+            if (next_line = strchr(version, '\n'), next_line) {
+                *next_line = '\0';
+                if (sha1 = strchr(version, ' '), sha1) {
+                    *sha1 = '\0';
+                    if (wm_agent_upgrade_compare_versions(task->wpk_version, version) == 0) {
+                        // Save WPK url, file name and sha1
+                        os_strdup(sha1 + 1, task->wpk_sha1);
+                        os_strdup(file_url, task->wpk_file);
+                        os_free(task->wpk_repository);
+                        os_strdup(path_url, task->wpk_repository);
+                        break;
+                    }
+                }
+                version = next_line + 1;
+            } else {
+                break;
+            }
+        }
+        if (version) {
+            if (sha1 = strchr(version, ' '), sha1) {
+                *sha1 = '\0';
+                if (wm_agent_upgrade_compare_versions(task->wpk_version, version) == 0) {
+                    // Save WPK url, file name and sha1
+                    os_strdup(sha1 + 1, task->wpk_sha1);
+                    os_strdup(file_url, task->wpk_file);
+                    os_free(task->wpk_repository);
+                    os_strdup(path_url, task->wpk_repository);
+                }
+            }
+        }
+        if (!task->wpk_repository || !task->wpk_file || !task->wpk_sha1) {
+            return_code = WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST;
+        }
+    } else {
+        return_code = WM_UPGRADE_URL_NOT_FOUND;
+    }
+
+    os_free(repository_url);
+    os_free(path_url);
+    os_free(file_url);
+    os_free(versions_url);
+    os_free(versions);
 
     return return_code;
 }
@@ -126,7 +236,7 @@ int wm_agent_upgrade_validate_wpk(const wm_upgrade_task *task) {
     char *file_path = NULL;
     os_sha1 file_sha1;
 
-    if (task && task->wpk_repository && task->wpk_file && task->wpk_sha1) {
+    if (task->wpk_repository && task->wpk_file && task->wpk_sha1) {
 
         // Take mutex to avoid downloading many times the same WPK
         w_mutex_lock(&download_mutex);
@@ -180,7 +290,7 @@ int wm_agent_upgrade_validate_wpk_custom(const wm_upgrade_custom_task *task) {
     int return_code = WM_UPGRADE_SUCCESS;
     FILE *wpk_file = NULL;
 
-    if (task && task->custom_file_path) {
+    if (task->custom_file_path) {
         if (wpk_file = fopen(task->custom_file_path, "rb"), !wpk_file) {
             return_code = WM_UPGRADE_WPK_FILE_DOES_NOT_EXIST;
         } else {
@@ -190,178 +300,6 @@ int wm_agent_upgrade_validate_wpk_custom(const wm_upgrade_custom_task *task) {
     } else {
         return_code = WM_UPGRADE_WPK_FILE_DOES_NOT_EXIST;
     }
-
-    return return_code;
-}
-
-STATIC int wm_agent_upgrade_validate_non_custom_version(const char *agent_version, const wm_agent_info *agent_info, wm_upgrade_task *task, const wm_manager_configs* manager_configs) {
-    char *manager_version = NULL;
-    int return_code = WM_UPGRADE_GLOBAL_DB_FAILURE;
-
-    return_code = wm_agent_upgrade_validate_system(agent_info->platform, agent_info->major_version, agent_info->minor_version, agent_info->architecture);
-
-    if (WM_UPGRADE_SUCCESS == return_code) {
-        if (manager_version = strchr(__ossec_version, 'v'), manager_version) {
-            char *wpk_version = task->custom_version ? task->custom_version : manager_version;
-
-            // Check if a WPK package exist for the upgrade version
-            return_code = wm_agent_upgrade_validate_wpk_version(agent_info, task, wpk_version, manager_configs->wpk_repository);
-
-            if (WM_UPGRADE_SUCCESS == return_code && !task->force_upgrade) {
-                if (wm_agent_upgrade_compare_versions(agent_version, wpk_version) >= 0) {
-                    return_code = WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT;
-                } else if (wm_agent_upgrade_compare_versions(wpk_version, manager_version) > 0) {
-                    return_code = WM_UPGRADE_NEW_VERSION_GREATER_MASTER;
-                }
-            }
-        }
-    }
-
-    return return_code;
-}
-
-STATIC int wm_agent_upgrade_validate_system(const char *platform, const char *os_major, const char *os_minor, const char *arch) {
-    int invalid_platforms_len = 0;
-    int invalid_platforms_it = 0;
-    int return_code = WM_UPGRADE_GLOBAL_DB_FAILURE;
-
-    if (platform) {
-        if (!strcmp(platform, "windows") || (os_major && arch && (strcmp(platform, "ubuntu") || os_minor))) {
-            return_code = WM_UPGRADE_SUCCESS;
-            invalid_platforms_len = sizeof(invalid_platforms) / sizeof(invalid_platforms[0]);
-
-            for(invalid_platforms_it = 0; invalid_platforms_it < invalid_platforms_len; ++invalid_platforms_it) {
-                if(!strcmp(invalid_platforms[invalid_platforms_it], platform)) {
-                    return_code = WM_UPGRADE_SYSTEM_NOT_SUPPORTED;
-                    break;
-                }
-            }
-
-            if (WM_UPGRADE_SUCCESS == return_code) {
-                if ((!strcmp(platform, "sles") && !strcmp(os_major, "11")) ||
-                    (!strcmp(platform, "rhel") && !strcmp(os_major, "5")) ||
-                    (!strcmp(platform, "centos") && !strcmp(os_major, "5"))) {
-                    return_code = WM_UPGRADE_SYSTEM_NOT_SUPPORTED;
-                }
-            }
-        }
-    }
-
-    return return_code;
-}
-
-STATIC int wm_agent_upgrade_validate_wpk_version(const wm_agent_info *agent_info, wm_upgrade_task *task, char *wpk_version, const char *wpk_repository_config) {
-    const char *http_tag = "http://";
-    const char *https_tag = "https://";
-    char *repository_url = NULL;
-    char *path_url = NULL;
-    char *file_url = NULL;
-    char *versions_url = NULL;
-    char *versions = NULL;
-    int return_code = WM_UPGRADE_SUCCESS;
-
-    os_calloc(OS_SIZE_1024, sizeof(char), repository_url);
-    os_calloc(OS_SIZE_2048, sizeof(char), path_url);
-    os_calloc(OS_SIZE_2048, sizeof(char), file_url);
-    os_calloc(OS_SIZE_4096, sizeof(char), versions_url);
-
-    if (!task->wpk_repository) {
-        os_strdup(wpk_repository_config, task->wpk_repository);
-    }
-
-    // Set protocol
-    if (!strstr(task->wpk_repository, http_tag) && !strstr(task->wpk_repository, https_tag)) {
-        if (task->use_http) {
-            strcat(repository_url, http_tag);
-        } else {
-            strcat(repository_url, https_tag);
-        }
-    }
-
-    // Set repository
-    strncat(repository_url, task->wpk_repository, OS_SIZE_512);
-    if (task->wpk_repository[strlen(task->wpk_repository) - 1] != '/') {
-        strcat(repository_url, "/");
-    }
-
-    // Set URL path
-    if (!strcmp(agent_info->platform, "windows")) {
-        snprintf(path_url, OS_SIZE_2048, "%swindows/",
-                 repository_url);
-        snprintf(file_url, OS_SIZE_2048, "wazuh_agent_%s_windows.wpk",
-                 wpk_version);
-    } else {
-        if (wm_agent_upgrade_compare_versions(wpk_version, WM_UPGRADE_NEW_VERSION_REPOSITORY) >= 0) {
-            snprintf(path_url, OS_SIZE_2048, "%slinux/%s/",
-                     repository_url, agent_info->architecture);
-            snprintf(file_url, OS_SIZE_2048, "wazuh_agent_%s_linux_%s.wpk",
-                     wpk_version, agent_info->architecture);
-        } else if (!strcmp(agent_info->platform, "ubuntu")) {
-            snprintf(path_url, OS_SIZE_2048, "%s%s/%s.%s/%s/",
-                     repository_url, agent_info->platform, agent_info->major_version, agent_info->minor_version, agent_info->architecture);
-            snprintf(file_url, OS_SIZE_2048, "wazuh_agent_%s_%s_%s.%s_%s.wpk",
-                     wpk_version, agent_info->platform, agent_info->major_version, agent_info->minor_version, agent_info->architecture);
-        } else {
-            snprintf(path_url, OS_SIZE_2048, "%s%s/%s/%s/",
-                     repository_url, agent_info->platform, agent_info->major_version, agent_info->architecture);
-            snprintf(file_url, OS_SIZE_2048, "wazuh_agent_%s_%s_%s_%s.wpk",
-                     wpk_version, agent_info->platform, agent_info->major_version, agent_info->architecture);
-        }
-    }
-
-    // Set versions respository
-    snprintf(versions_url, OS_SIZE_4096, "%sversions", path_url);
-
-    versions = wurl_http_get(versions_url);
-
-    if (versions) {
-        char *version = versions;
-        char *sha1 = NULL;
-        char *next_line = NULL;
-
-        while (version) {
-            if (next_line = strchr(version, '\n'), next_line) {
-                *next_line = '\0';
-                if (sha1 = strchr(version, ' '), sha1) {
-                    *sha1 = '\0';
-                    if (wm_agent_upgrade_compare_versions(wpk_version, version) == 0) {
-                        // Save WPK url, file name and sha1
-                        os_strdup(sha1 + 1, task->wpk_sha1);
-                        os_strdup(file_url, task->wpk_file);
-                        os_free(task->wpk_repository);
-                        os_strdup(path_url, task->wpk_repository);
-                        break;
-                    }
-                }
-                version = next_line + 1;
-            } else {
-                break;
-            }
-        }
-        if (version) {
-            if (sha1 = strchr(version, ' '), sha1) {
-                *sha1 = '\0';
-                if (wm_agent_upgrade_compare_versions(wpk_version, version) == 0) {
-                    // Save WPK url, file name and sha1
-                    os_strdup(sha1 + 1, task->wpk_sha1);
-                    os_strdup(file_url, task->wpk_file);
-                    os_free(task->wpk_repository);
-                    os_strdup(path_url, task->wpk_repository);
-                }
-            }
-        }
-        if (!task->wpk_repository || !task->wpk_file || !task->wpk_sha1) {
-            return_code = WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST;
-        }
-    } else {
-        return_code = WM_UPGRADE_URL_NOT_FOUND;
-    }
-
-    os_free(repository_url);
-    os_free(path_url);
-    os_free(file_url);
-    os_free(versions_url);
-    os_free(versions);
 
     return return_code;
 }
@@ -453,14 +391,14 @@ bool wm_agent_upgrade_validate_task_status_message(const cJSON *input_json, char
         cJSON *data_object = cJSON_GetObjectItem(input_json, task_manager_json_keys[WM_TASK_ERROR_MESSAGE]);
         cJSON *status_object = cJSON_GetObjectItem(input_json, task_manager_json_keys[WM_TASK_STATUS]);
         cJSON *agent_json = cJSON_GetObjectItem(input_json, task_manager_json_keys[WM_TASK_AGENT_ID]);
-        
+
         if (error_object && (error_object->type == cJSON_Number) && data_object && (data_object->type == cJSON_String) && agent_json
             && (agent_json->type == cJSON_Number)) {
-            
+
             if (agent_id) {
                 *agent_id = agent_json->valueint;
             }
-            
+
             if (error_object->valueint == WM_UPGRADE_SUCCESS) {
                 if (status && status_object && status_object->type == cJSON_String) {
                     os_strdup(status_object->valuestring, *status);

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.h
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.h
@@ -32,22 +32,43 @@ int wm_agent_upgrade_validate_id(int agent_id);
 int wm_agent_upgrade_validate_status(int last_keep_alive);
 
 /**
+ * Check if WPK exists for this agent
+ * @param platform platform of agent to validate
+ * @param os_major OS major version of agent to validate
+ * @param os_minor OS minor version of agent to validate
+ * @param arch architecture of agent to validate
+ * @return return_code
+ * @retval WM_UPGRADE_SUCCESS
+ * @retval WM_UPGRADE_SYSTEM_NOT_SUPPORTED
+ * @retval WM_UPGRADE_GLOBAL_DB_FAILURE
+ * */
+int wm_agent_upgrade_validate_system(const char *platform, const char *os_major, const char *os_minor, const char *arch);
+
+/**
  * Check if agent is valid to upgrade
- * @param agent_info pointer to agent_info struture
- * @param task pointer to task with the params
+ * @param wazuh_version wazuh version of agent
  * @param command wm_upgrade_command with the selected upgrade type
- * @param manager_configs manager configuration parameters
+ * @param task pointer to task with the params
  * @return return_code
  * @retval WM_UPGRADE_SUCCESS
  * @retval WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED
- * @retval WM_UPGRADE_SYSTEM_NOT_SUPPORTED
- * @retval WM_UPGRADE_URL_NOT_FOUND
- * @retval WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST
  * @retval WM_UPGRADE_NEW_VERSION_LEES_OR_EQUAL_THAT_CURRENT
  * @retval WM_UPGRADE_NEW_VERSION_GREATER_MASTER
  * @retval WM_UPGRADE_GLOBAL_DB_FAILURE
  * */
-int wm_agent_upgrade_validate_version(const wm_agent_info *agent_info, void *task, wm_upgrade_command command, const wm_manager_configs* manager_configs) __attribute__((nonnull));
+int wm_agent_upgrade_validate_version(const char *wazuh_version, wm_upgrade_command command, void *task)  __attribute__((nonnull(3)));
+
+/**
+ * Check if a WPK exist for the upgrade version
+ * @param agent_info structure with the agent information
+ * @param task structure with the task information
+ * @param wpk_repository_config char pointer with the repository url set in module config
+ * @return return_code
+ * @retval WM_UPGRADE_SUCCESS
+ * @retval WM_UPGRADE_URL_NOT_FOUND
+ * @retval WM_UPGRADE_WPK_VERSION_DOES_NOT_EXIST
+ * */
+int wm_agent_upgrade_validate_wpk_version(const wm_agent_info *agent_info, wm_upgrade_task *task, const char *wpk_repository_config) __attribute__((nonnull));
 
 /**
  * Check if WPK file exist or download it
@@ -57,7 +78,7 @@ int wm_agent_upgrade_validate_version(const wm_agent_info *agent_info, void *tas
  * @retval WM_UPGRADE_WPK_FILE_DOES_NOT_EXIST
  * @retval WM_UPGRADE_WPK_SHA1_DOES_NOT_MATCH
  * */
-int wm_agent_upgrade_validate_wpk(const wm_upgrade_task *task);
+int wm_agent_upgrade_validate_wpk(const wm_upgrade_task *task) __attribute__((nonnull));
 
 /**
  * Check if WPK custom file exist
@@ -66,7 +87,7 @@ int wm_agent_upgrade_validate_wpk(const wm_upgrade_task *task);
  * @retval WM_UPGRADE_SUCCESS
  * @retval WM_UPGRADE_WPK_FILE_DOES_NOT_EXIST
  * */
-int wm_agent_upgrade_validate_wpk_custom(const wm_upgrade_custom_task *task);
+int wm_agent_upgrade_validate_wpk_custom(const wm_upgrade_custom_task *task) __attribute__((nonnull));
 
 /**
  * Compare two versions with format v4.0.0


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/6384|


## Description

This PR includes some changes to reduce the response time to the API upgrade requests:

- Download versions file when upgrading an agent.

- Make only one request to the task manager to get the status of the last upgrade tasks of the agents involved.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
