### PR TITLE
Fix and improve framework unit tests when running them by module

### DIFF
--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -9,8 +9,8 @@ from unittest.mock import patch, MagicMock, call
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         from api import alogging
 
 

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -8,14 +8,14 @@ from unittest.mock import patch, MagicMock, ANY, call
 from copy import deepcopy
 from werkzeug.exceptions import Unauthorized
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         from wazuh.core.results import WazuhResult
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         from api import authentication
 

--- a/framework/wazuh/core/tests/test_active_response.py
+++ b/framework/wazuh/core/tests/test_active_response.py
@@ -8,8 +8,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         from wazuh.core.exception import WazuhError
         from wazuh.core import active_response
 
@@ -46,7 +46,7 @@ def agent_config(expected_exception):
     (None, 'restart-ossec0', [], True),
     (None, 'restart-ossec0', ["arg1", "arg2"], False)
 ])
-@patch('wazuh.common.ossec_path', new=test_data_path)
+@patch('wazuh.core.common.ossec_path', new=test_data_path)
 def test_create_message(expected_exception, command, arguments, custom):
     """Checks message returned is correct
 
@@ -76,7 +76,7 @@ def test_create_message(expected_exception, command, arguments, custom):
             assert '!' in ret, f'! symbol not being added when custom command'
 
 
-@patch('wazuh.common.ossec_path', new=test_data_path)
+@patch('wazuh.core.common.ossec_path', new=test_data_path)
 def test_get_commands():
     """
     Checks if get_commands method returns a list

--- a/framework/wazuh/core/tests/test_active_response.py
+++ b/framework/wazuh/core/tests/test_active_response.py
@@ -4,17 +4,14 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-import sys
 from unittest.mock import patch, MagicMock
 
 import pytest
 
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
-        sys.modules['api'] = MagicMock()
         from wazuh.core.exception import WazuhError
         from wazuh.core import active_response
-        del sys.modules['api']
 
 
 # Variables

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -12,12 +12,11 @@ from unittest.mock import ANY, patch, mock_open, call, Mock
 import pytest
 from freezegun import freeze_time
 
-from api.util import remove_nones_to_dict
-
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         from wazuh.core.agent import *
         from wazuh.core.exception import WazuhException
+        from api.util import remove_nones_to_dict
 
 from pwd import getpwnam
 from grp import getgrnam

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -12,8 +12,8 @@ from unittest.mock import ANY, patch, mock_open, call, Mock
 import pytest
 from freezegun import freeze_time
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         from wazuh.core.agent import *
         from wazuh.core.exception import WazuhException
         from api.util import remove_nones_to_dict
@@ -681,7 +681,7 @@ def test_agent_remove_authd(mock_ossec_socket):
 @patch('wazuh.core.agent.chmod')
 @patch('wazuh.core.agent.stat')
 @patch('wazuh.core.agent.glob')
-@patch("wazuh.common.ossec_path", new=test_data_path)
+@patch("wazuh.core.common.ossec_path", new=test_data_path)
 @patch('wazuh.core.agent.path.exists')
 @patch('wazuh.core.database.isfile', return_value=True)
 @patch('wazuh.core.agent.path.isdir', return_value=False)
@@ -689,8 +689,8 @@ def test_agent_remove_authd(mock_ossec_socket):
 @patch('wazuh.core.agent.makedirs')
 @patch('wazuh.core.agent.chmod_r')
 @freeze_time('1975-01-01')
-@patch("wazuh.common.ossec_uid", return_value=getpwnam("root"))
-@patch("wazuh.common.ossec_gid", return_value=getgrnam("root"))
+@patch("wazuh.core.common.ossec_uid", return_value=getpwnam("root"))
+@patch("wazuh.core.common.ossec_gid", return_value=getgrnam("root"))
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('wazuh.core.wdb.WazuhDBConnection.run_wdb_command')
 @patch('socket.socket.connect')
@@ -851,8 +851,8 @@ def test_agent_add_authd_ko(mock_ossec_socket, mocked_exception, expected_except
 ])
 @patch('wazuh.core.agent.safe_move')
 @patch('wazuh.core.agent.copyfile')
-@patch('wazuh.common.ossec_uid')
-@patch('wazuh.common.ossec_gid')
+@patch('wazuh.core.common.ossec_uid')
+@patch('wazuh.core.common.ossec_gid')
 @patch('wazuh.core.agent.chown')
 @patch('wazuh.core.agent.chmod')
 @patch('wazuh.core.agent.stat')
@@ -884,8 +884,8 @@ def test_agent_add_manual(socket_mock, mock_send, mock_lockf, mock_stat, mock_ch
 
 
 @patch('wazuh.core.agent.copyfile')
-@patch('wazuh.common.ossec_uid')
-@patch('wazuh.common.ossec_gid')
+@patch('wazuh.core.common.ossec_uid')
+@patch('wazuh.core.common.ossec_gid')
 @patch('wazuh.core.agent.chown')
 @patch('wazuh.core.agent.chmod')
 @patch('wazuh.core.agent.stat')
@@ -948,8 +948,8 @@ def test_agent_add_manual_ko(mock_lockf, mock_stat, mock_chmod, mock_chown, mock
 
 
 @patch('wazuh.core.agent.path.exists', return_value=True)
-@patch('wazuh.common.shared_path', new=os.path.join(test_data_path, 'etc', 'shared'))
-@patch('wazuh.common.backup_path', new=os.path.join(test_data_path, 'backup'))
+@patch('wazuh.core.common.shared_path', new=os.path.join(test_data_path, 'etc', 'shared'))
+@patch('wazuh.core.common.backup_path', new=os.path.join(test_data_path, 'backup'))
 @patch('wazuh.core.agent.safe_move')
 @patch('wazuh.core.agent.time', return_value=0)
 @patch('wazuh.core.agent.Agent._remove_manual', return_value='Agent was successfully deleted')
@@ -1149,8 +1149,8 @@ def test_agent_get_agents_overview_sort(socket_mock, send_mock, sort, first_id):
     ('002', 'test_group', True, False, None),
     ('002', 'test_group', False, True, ['default']),
 ])
-@patch('wazuh.common.groups_path', new=test_data_path)
-@patch('wazuh.common.shared_path', new=test_data_path)
+@patch('wazuh.core.common.groups_path', new=test_data_path)
+@patch('wazuh.core.common.shared_path', new=test_data_path)
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_add_group_to_agent(socket_mock, send_mock, agent_id, group_id, force, replace, replace_list):
@@ -1198,8 +1198,8 @@ def test_agent_add_group_to_agent(socket_mock, send_mock, agent_id, group_id, fo
         os.remove(os.path.join(test_data_path, agent_id))
 
 
-@patch('wazuh.common.groups_path', new=os.path.join(test_data_path, 'etc', 'shared'))
-@patch('wazuh.common.shared_path', new=os.path.join(test_data_path, 'etc', 'shared'))
+@patch('wazuh.core.common.groups_path', new=os.path.join(test_data_path, 'etc', 'shared'))
+@patch('wazuh.core.common.shared_path', new=os.path.join(test_data_path, 'etc', 'shared'))
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_add_group_to_agent_ko(socket_mock, send_mock):
@@ -1230,7 +1230,7 @@ def test_agent_add_group_to_agent_ko(socket_mock, send_mock):
             with pytest.raises(WazuhError, match='.* 1751 .*'):
                 Agent.add_group_to_agent('default', '002')
 
-            with patch('wazuh.common.max_groups_per_multigroup', new=0):
+            with patch('wazuh.core.common.max_groups_per_multigroup', new=0):
                 # Multigroup limit exceeded.
                 with pytest.raises(WazuhError, match='.* 1737 .*'):
                     Agent.add_group_to_agent('test_group', '002')
@@ -1315,8 +1315,8 @@ def test_agent_get_agents_group_file(group_exists):
 
 
 @patch('builtins.open')
-@patch('wazuh.common.ossec_uid')
-@patch('wazuh.common.ossec_gid')
+@patch('wazuh.core.common.ossec_uid')
+@patch('wazuh.core.common.ossec_gid')
 @patch('wazuh.core.agent.chown')
 @patch('wazuh.core.agent.chmod')
 def test_agent_set_agent_group_file(mock_chmod, mock_chown, mock_gid, mock_uid, mock_open):
@@ -1340,7 +1340,7 @@ def test_agent_set_agent_group_file_ko():
     ('default0,default1', False),
     ('', False)
 ])
-@patch('wazuh.common.max_groups_per_multigroup', new=3)
+@patch('wazuh.core.common.max_groups_per_multigroup', new=3)
 def test_agent_check_multigroup_limit(groups, expected_result):
     """Test if check_multigroup_limit() returns True when limit of groups is reached
 
@@ -1362,8 +1362,8 @@ def test_agent_check_multigroup_limit(groups, expected_result):
     ('002', 'test_group', False, 'test_group', True),
     ('002', 'test_group', False, 'test_group,another_test', False)
 ])
-@patch('wazuh.common.groups_path', new=test_data_path)
-@patch('wazuh.common.shared_path', new=test_data_path)
+@patch('wazuh.core.common.groups_path', new=test_data_path)
+@patch('wazuh.core.common.shared_path', new=test_data_path)
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_unset_single_group_agent(socket_mock, send_mock, agent_id, group_id, force, previous_groups, set_default):
@@ -1412,8 +1412,8 @@ def test_agent_unset_single_group_agent(socket_mock, send_mock, agent_id, group_
         os.remove(os.path.join(test_data_path, agent_id))
 
 
-@patch('wazuh.common.groups_path', new=os.path.join(test_data_path, 'etc', 'shared'))
-@patch('wazuh.common.shared_path', new=os.path.join(test_data_path, 'etc', 'shared'))
+@patch('wazuh.core.common.groups_path', new=os.path.join(test_data_path, 'etc', 'shared'))
+@patch('wazuh.core.common.shared_path', new=os.path.join(test_data_path, 'etc', 'shared'))
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_unset_single_group_agent_ko(socket_mock, send_mock):
@@ -1528,8 +1528,8 @@ def test_agent_get_versions_ko(socket_mock, send_mock):
 ])
 @patch('wazuh.core.agent.chmod')
 @patch('wazuh.core.agent.chown')
-@patch('wazuh.common.ossec_uid')
-@patch('wazuh.common.ossec_gid')
+@patch('wazuh.core.common.ossec_uid')
+@patch('wazuh.core.common.ossec_gid')
 @patch('wazuh.core.agent.hashlib.sha1')
 @patch('wazuh.core.agent.open')
 @patch('wazuh.core.agent.requests.get')
@@ -1591,8 +1591,8 @@ def test_agent_get_wpk_file(socket_mock, send_mock, versions_mock, get_req_mock,
 
 @patch('wazuh.core.agent.chmod')
 @patch('wazuh.core.agent.chown')
-@patch('wazuh.common.ossec_uid')
-@patch('wazuh.common.ossec_gid')
+@patch('wazuh.core.common.ossec_uid')
+@patch('wazuh.core.common.ossec_gid')
 @patch('wazuh.core.agent.hashlib.sha1')
 @patch('wazuh.core.agent.open')
 @patch('wazuh.core.agent.Agent._get_versions')
@@ -1651,7 +1651,7 @@ def test_agent_get_wpk_file_ko(socket_mock, send_mock, versions_mock, open_mock,
 @patch('wazuh.core.agent.stat', return_value=Mock(st_size=1))
 @patch('wazuh.core.agent.requests.get')
 @patch('wazuh.core.agent.Agent._get_wpk_file')
-@patch('wazuh.common.open_sleep', new=0)
+@patch('wazuh.core.common.open_sleep', new=0)
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_send_wpk_file(socket_mock, send_mock, _get_wpk_mock, get_req_mock, stat_mock, ossec_socket_mock,
@@ -1692,7 +1692,7 @@ def test_agent_send_wpk_file(socket_mock, send_mock, _get_wpk_mock, get_req_mock
 @patch('wazuh.core.agent.stat')
 @patch('wazuh.core.agent.requests.get')
 @patch('wazuh.core.agent.Agent._get_wpk_file')
-@patch('wazuh.common.open_sleep', new=0)
+@patch('wazuh.core.common.open_sleep', new=0)
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_send_wpk_file_ko(socket_mock, send_mock, _get_wpk_mock, get_req_mock, stat_mock, ossec_socket_mock,
@@ -1888,7 +1888,7 @@ def test_agent_upgrade_result_ko(socket_mock, send_mock, mock_sleep, socket_send
 @patch('wazuh.core.agent.stat', return_value=Mock(st_size=1))
 @patch('wazuh.core.agent.requests.get')
 @patch('wazuh.core.agent.path.isfile', return_value=True)
-@patch('wazuh.common.open_sleep', new=0)
+@patch('wazuh.core.common.open_sleep', new=0)
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_send_custom_wpk_file(socket_mock, send_mock, mock_isfile, mock_requests, mock_stat, ossec_socket_mock,
@@ -2164,13 +2164,13 @@ def test_expand_group(socket_mock, send_mock, group, expected_agents):
 @patch('wazuh.core.agent.chmod')
 @patch('wazuh.core.agent.stat')
 @patch('wazuh.core.agent.glob')
-@patch("wazuh.common.client_keys", new=os.path.join(test_data_path, 'etc', 'client.keys'))
+@patch("wazuh.core.common.client_keys", new=os.path.join(test_data_path, 'etc', 'client.keys'))
 @patch('wazuh.core.agent.path.isdir', return_value=True)
 @patch('wazuh.core.agent.makedirs')
 @patch('wazuh.core.agent.chmod_r')
 @freeze_time('1975-01-01')
-@patch("wazuh.common.ossec_uid", return_value=getpwnam("root"))
-@patch("wazuh.common.ossec_gid", return_value=getgrnam("root"))
+@patch("wazuh.core.common.ossec_uid", return_value=getpwnam("root"))
+@patch("wazuh.core.common.ossec_gid", return_value=getgrnam("root"))
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_remove_manual_ko(socket_mock, send_mock, grp_mock, pwd_mock, chmod_r_mock, makedirs_mock,

--- a/framework/wazuh/core/tests/test_cdb_list.py
+++ b/framework/wazuh/core/tests/test_cdb_list.py
@@ -8,8 +8,8 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         from wazuh.core import common
         from wazuh.core.cdb_list import check_path, get_list_from_file, get_relative_path, iterate_lists, \
             split_key_value_with_quotes

--- a/framework/wazuh/core/tests/test_cdb_list.py
+++ b/framework/wazuh/core/tests/test_cdb_list.py
@@ -4,20 +4,17 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-import sys
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import mock_open, patch
 
 import pytest
 
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
-        sys.modules['api'] = MagicMock()
         from wazuh.core import common
         from wazuh.core.cdb_list import check_path, get_list_from_file, get_relative_path, iterate_lists, \
             split_key_value_with_quotes
         from wazuh.core.exception import WazuhError
 
-        del sys.modules['api']
 
 # Variables
 

--- a/framework/wazuh/core/tests/test_common.py
+++ b/framework/wazuh/core/tests/test_common.py
@@ -11,7 +11,7 @@ from pwd import getpwnam
     ('/my/fake/path', '')
 ])
 def test_find_wazuh_path(fake_path, expected):
-    with patch('wazuh.common.__file__', new=fake_path):
+    with patch('wazuh.core.common.__file__', new=fake_path):
         assert(find_wazuh_path() == expected)
 
 
@@ -21,12 +21,12 @@ def test_find_wazuh_path_relative_path():
 
 
 def test_ossec_uid():
-    with patch('wazuh.common.getpwnam', return_value=getpwnam("root")):
+    with patch('wazuh.core.common.getpwnam', return_value=getpwnam("root")):
         ossec_uid()
 
 
 def test_ossec_gid():
-    with patch('wazuh.common.getgrnam', return_value=getgrnam("root")):
+    with patch('wazuh.core.common.getgrnam', return_value=getgrnam("root")):
         ossec_gid()
 
 

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -12,8 +12,8 @@ from xml.etree.ElementTree import fromstring
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
 
@@ -30,7 +30,7 @@ tmp_path = 'tests/data'
 
 @pytest.fixture(scope='module', autouse=True)
 def mock_ossec_path():
-    with patch('wazuh.common.ossec_path', new=os.path.join(parent_directory, tmp_path)):
+    with patch('wazuh.core.common.ossec_path', new=os.path.join(parent_directory, tmp_path)):
         yield
 
 
@@ -166,16 +166,16 @@ def test_get_agent_conf():
     with pytest.raises(WazuhError, match=".* 1710 .*"):
         configuration.get_agent_conf(group_id='noexists')
 
-    with patch('wazuh.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+    with patch('wazuh.core.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         with pytest.raises(WazuhError, match=".* 1006 .*"):
             configuration.get_agent_conf(group_id='default', filename='noexists.conf')
 
-    with patch('wazuh.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+    with patch('wazuh.core.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         with patch('wazuh.core.configuration.load_wazuh_xml', return_value=Exception):
             with pytest.raises(WazuhError, match=".* 1101 .*"):
                 assert isinstance(configuration.get_agent_conf(group_id='default'), dict)
 
-    with patch('wazuh.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+    with patch('wazuh.core.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         assert configuration.get_agent_conf(group_id='default', filename='agent1.conf')['total_affected_items'] == 1
 
 
@@ -183,32 +183,32 @@ def test_get_agent_conf_multigroup():
     with pytest.raises(WazuhError, match=".* 1710 .*"):
         configuration.get_agent_conf_multigroup()
 
-    with patch('wazuh.common.multi_groups_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+    with patch('wazuh.core.common.multi_groups_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         with pytest.raises(WazuhError, match=".* 1006 .*"):
             configuration.get_agent_conf_multigroup(multigroup_id='multigroup', filename='noexists.conf')
 
-    with patch('wazuh.common.multi_groups_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+    with patch('wazuh.core.common.multi_groups_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         with patch('wazuh.core.configuration.load_wazuh_xml', return_value=Exception):
             with pytest.raises(WazuhError, match=".* 1101 .*"):
                 configuration.get_agent_conf_multigroup(multigroup_id='multigroup')
 
-    with patch('wazuh.common.multi_groups_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+    with patch('wazuh.core.common.multi_groups_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         result = configuration.get_agent_conf_multigroup(multigroup_id='multigroup')
         assert set(result.keys()) == {'totalItems', 'items'}
 
 
 def test_get_file_conf():
-    with patch('wazuh.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'noexists')):
+    with patch('wazuh.core.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'noexists')):
         with pytest.raises(WazuhError, match=".* 1710 .*"):
             configuration.get_file_conf(filename='ossec.conf', group_id='default', type_conf='conf',
                                         return_format='xml')
 
-    with patch('wazuh.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+    with patch('wazuh.core.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         with pytest.raises(WazuhError, match=".* 1006 .*"):
             configuration.get_file_conf(filename='noexists.conf', group_id='default', type_conf='conf',
                                         return_format='xml')
 
-    with patch('wazuh.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+    with patch('wazuh.core.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         assert isinstance(configuration.get_file_conf(filename='agent.conf', group_id='default', type_conf='conf',
                                                       return_format='xml'), str)
         assert isinstance(configuration.get_file_conf(filename='agent.conf', group_id='default', type_conf='rcl',
@@ -232,14 +232,14 @@ def test_get_file_conf():
 
 
 def test_parse_internal_options():
-    with patch('wazuh.common.internal_options',
+    with patch('wazuh.core.common.internal_options',
                new=os.path.join(parent_directory, tmp_path, 'configuration/noexists.conf')):
         with pytest.raises(WazuhInternalError, match=".* 1107 .*"):
             configuration.parse_internal_options('ossec', 'python')
 
-    with patch('wazuh.common.internal_options',
+    with patch('wazuh.core.common.internal_options',
                new=os.path.join(parent_directory, tmp_path, 'configuration/local_internal_options.conf')):
-        with patch('wazuh.common.local_internal_options',
+        with patch('wazuh.core.common.local_internal_options',
                    new=os.path.join(parent_directory, tmp_path, 'configuration/local_internal_options.conf')):
             with pytest.raises(WazuhInternalError, match=".* 1108 .*"):
                 configuration.parse_internal_options('ossec', 'python')
@@ -262,7 +262,7 @@ def test_upload_group_configuration():
     with pytest.raises(WazuhError, match=".* 1710 .*"):
         configuration.upload_group_configuration('noexists', 'noexists')
 
-    with patch('wazuh.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+    with patch('wazuh.core.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         with patch('wazuh.core.configuration.open'):
             with pytest.raises(WazuhInternalError, match=".* 1743 .*"):
                 configuration.upload_group_configuration('default', "<agent_config>new_config</agent_config>")
@@ -304,7 +304,7 @@ def test_upload_group_file(mock_safe_move, mock_open):
         with pytest.raises(WazuhError, match=".* 1112 .*"):
             configuration.upload_group_file('default', [], 'agent.conf')
 
-    with patch('wazuh.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+    with patch('wazuh.core.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         with patch('wazuh.core.configuration.subprocess.check_output', return_value=True):
             with patch('wazuh.core.utils.chown', side_effect=None):
                 with patch('wazuh.core.utils.chmod', side_effect=None):
@@ -312,7 +312,7 @@ def test_upload_group_file(mock_safe_move, mock_open):
                                                            "<agent_config>new_config</agent_config>", 'agent.conf') == \
                                                            'Agent configuration was successfully updated'
 
-    with patch('wazuh.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+    with patch('wazuh.core.common.shared_path', new=os.path.join(parent_directory, tmp_path, 'configuration')):
         with pytest.raises(WazuhError, match=".* 1111 .*"):
             configuration.upload_group_file('default', [], 'a.conf')
 

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -14,12 +14,10 @@ import pytest
 
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
-        sys.modules['api'] = MagicMock()
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
 
         del sys.modules['wazuh.rbac.orm']
-        del sys.modules['api']
         from wazuh.tests.util import RBAC_bypasser
 
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser

--- a/framework/wazuh/core/tests/test_decoder.py
+++ b/framework/wazuh/core/tests/test_decoder.py
@@ -9,8 +9,8 @@ from unittest.mock import patch
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         from wazuh.core.exception import WazuhError, WazuhInternalError, WazuhException
         from wazuh.core import decoder
 
@@ -58,7 +58,7 @@ def test_check_status(status, expected_result):
     ('non_existing.xml', 'decoders', "disabled", 777, WazuhError(1502)),
     ('test1_decoders.xml', 'decoders', "all", 000, WazuhError(1502)),
 ])
-@patch('wazuh.common.ossec_path', new=test_data_path)
+@patch('wazuh.core.common.ossec_path', new=test_data_path)
 def test_load_decoders_from_file(filename, relative_dirname, status, permissions, exception):
     full_file_path = os.path.join(test_data_path, relative_dirname, filename)
     try:

--- a/framework/wazuh/core/tests/test_decoder.py
+++ b/framework/wazuh/core/tests/test_decoder.py
@@ -5,17 +5,14 @@
 
 import os
 import stat
-import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
-        sys.modules['api'] = MagicMock()
         from wazuh.core.exception import WazuhError, WazuhInternalError, WazuhException
         from wazuh.core import decoder
-        del sys.modules['api']
 
 
 # Variables

--- a/framework/wazuh/core/tests/test_input_validator.py
+++ b/framework/wazuh/core/tests/test_input_validator.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 from wazuh.core.InputValidator import InputValidator
 import operator
 
+
 class TestInputValidator(TestCase):
 
     def test_check_name(self):

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -4,17 +4,14 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-import sys
-from unittest.mock import patch, mock_open, MagicMock, ANY
+from unittest.mock import patch, mock_open, ANY
 
 import pytest
 
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
-        sys.modules['api'] = MagicMock()
         from wazuh.core.manager import *
         from wazuh.core.exception import WazuhException
-        del sys.modules['api']
 
 ossec_cdb_list = "172.16.19.:\n172.16.19.:\n192.168.:"
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'manager')

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -8,8 +8,8 @@ from unittest.mock import patch, mock_open, ANY
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         from wazuh.core.manager import *
         from wazuh.core.exception import WazuhException
 
@@ -282,7 +282,7 @@ def test_upload_list_ko(mock_chmod, mock_random, mock_time, test_manager):
     'input_decoders_file',
     'input_lists_file'
 ])
-@patch('wazuh.common.ossec_path', test_data_path)
+@patch('wazuh.core.common.ossec_path', test_data_path)
 def test_validate_xml(input_file, test_manager):
     """Tests validate_xml function works
 

--- a/framework/wazuh/core/tests/test_ossec_queue.py
+++ b/framework/wazuh/core/tests/test_ossec_queue.py
@@ -8,6 +8,7 @@ import pytest
 from wazuh.core.ossec_queue import OssecQueue
 from wazuh.core.exception import WazuhException
 
+
 @patch('wazuh.core.ossec_queue.OssecQueue._connect')
 def test_OssecQueue__init__(mock_conn):
     """Tests OssecQueue.__init__ function works"""

--- a/framework/wazuh/core/tests/test_results.py
+++ b/framework/wazuh/core/tests/test_results.py
@@ -7,11 +7,10 @@ from unittest.mock import patch
 
 import pytest
 
-from wazuh import WazuhException, WazuhError
-
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         from wazuh.core.results import WazuhResult, AffectedItemsWazuhResult, _goes_before_than, nested_itemgetter, merge
+        from wazuh import WazuhException, WazuhError
 
 param_name = ['affected_items', 'total_affected_items', 'sort_fields', 'sort_casting', 'sort_ascending',
               'all_msg', 'some_msg', 'none_msg']

--- a/framework/wazuh/core/tests/test_results.py
+++ b/framework/wazuh/core/tests/test_results.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         from wazuh.core.results import WazuhResult, AffectedItemsWazuhResult, _goes_before_than, nested_itemgetter, merge
         from wazuh import WazuhException, WazuhError
 

--- a/framework/wazuh/core/tests/test_rule.py
+++ b/framework/wazuh/core/tests/test_rule.py
@@ -14,11 +14,9 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
-        sys.modules['api'] = MagicMock()
         import wazuh.rbac.decorators
 
         del sys.modules['wazuh.rbac.orm']
-        del sys.modules['api']
         from wazuh.tests.util import RBAC_bypasser
 
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser

--- a/framework/wazuh/core/tests/test_rule.py
+++ b/framework/wazuh/core/tests/test_rule.py
@@ -11,8 +11,8 @@ import pytest
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', '..', 'api'))
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
 
@@ -70,8 +70,8 @@ def test_check_status(status, expected_result):
     ('0350-amazon_rules.xml', 'tests/data/rules', 'enabled', None),
     ('noexists.xml', 'tests/data/rules', 'enabled', WazuhError(1201))
 ])
-@patch("wazuh.common.ossec_path", new=parent_directory)
-@patch("wazuh.common.ruleset_rules_path", new=data_path)
+@patch("wazuh.core.common.ossec_path", new=parent_directory)
+@patch("wazuh.core.common.ruleset_rules_path", new=data_path)
 def test_load_rules_from_file(rule_file, rule_path, rule_status, exception):
     """Test set_groups rule core function."""
     try:

--- a/framework/wazuh/core/tests/test_syscollector.py
+++ b/framework/wazuh/core/tests/test_syscollector.py
@@ -9,8 +9,8 @@ import pytest
 
 from wazuh.tests.util import InitWDBSocketMock
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         from wazuh.core.syscollector import *
         from wazuh.core import common
 

--- a/framework/wazuh/core/tests/test_syscollector.py
+++ b/framework/wazuh/core/tests/test_syscollector.py
@@ -3,8 +3,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -12,11 +11,8 @@ from wazuh.tests.util import InitWDBSocketMock
 
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
-        sys.modules['api'] = MagicMock()
         from wazuh.core.syscollector import *
         from wazuh.core import common
-
-        del sys.modules['api']
 
 
 # Tests

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -14,8 +14,8 @@ from xml.etree import ElementTree
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         from wazuh.core.utils import *
         from wazuh.core import exception
         from wazuh.core.agent import WazuhDBQueryAgents
@@ -1475,7 +1475,7 @@ def test_select_array(select, required_fields, expected_result):
     except WazuhError as e:
         assert e.code == 1724
 
-@patch('wazuh.common.ossec_path', new='/var/ossec')
+@patch('wazuh.core.common.ossec_path', new='/var/ossec')
 @patch('wazuh.core.utils.glob.glob')
 def test_get_files(mock_glob):
     """Test whether get_files() returns expected paths."""

--- a/framework/wazuh/rbac/tests/test_auth_context.py
+++ b/framework/wazuh/rbac/tests/test_auth_context.py
@@ -17,7 +17,7 @@ test_data_path = os.path.join(test_path, 'data/')
 
 @pytest.fixture(scope='function')
 def db_setup():
-    with patch('wazuh.common.ossec_uid'), patch('wazuh.common.ossec_gid'):
+    with patch('wazuh.core.common.ossec_uid'), patch('wazuh.core.common.ossec_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):

--- a/framework/wazuh/rbac/tests/test_decorators.py
+++ b/framework/wazuh/rbac/tests/test_decorators.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine
+from importlib import reload
 
 from wazuh.core.exception import WazuhError
 from wazuh.rbac.tests.utils import init_db
@@ -24,6 +25,7 @@ def db_setup():
             with patch('shutil.chown'), patch('os.chmod'):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     import wazuh.rbac.decorators as decorator
+                    reload(decorator)
     init_db('schema_security_test.sql', test_data_path)
 
     yield decorator

--- a/framework/wazuh/rbac/tests/test_decorators.py
+++ b/framework/wazuh/rbac/tests/test_decorators.py
@@ -20,7 +20,7 @@ test_data_path = os.path.join(test_path, 'data/')
 
 @pytest.fixture(scope='function')
 def db_setup():
-    with patch('wazuh.common.ossec_uid'), patch('wazuh.common.ossec_gid'):
+    with patch('wazuh.core.common.ossec_uid'), patch('wazuh.core.common.ossec_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):

--- a/framework/wazuh/rbac/tests/test_default_configuration.py
+++ b/framework/wazuh/rbac/tests/test_default_configuration.py
@@ -17,7 +17,7 @@ test_data_path = os.path.join(test_path, 'data')
 
 @pytest.fixture(scope='function')
 def db_setup():
-    with patch('wazuh.common.ossec_uid'), patch('wazuh.common.ossec_gid'):
+    with patch('wazuh.core.common.ossec_uid'), patch('wazuh.core.common.ossec_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):

--- a/framework/wazuh/rbac/tests/test_orm.py
+++ b/framework/wazuh/rbac/tests/test_orm.py
@@ -18,7 +18,7 @@ test_data_path = os.path.join(test_path, 'data')
 
 @pytest.fixture(scope='function')
 def db_setup():
-    with patch('wazuh.common.ossec_uid'), patch('wazuh.common.ossec_gid'):
+    with patch('wazuh.core.common.ossec_uid'), patch('wazuh.core.common.ossec_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):

--- a/framework/wazuh/rbac/tests/test_preprocessor.py
+++ b/framework/wazuh/rbac/tests/test_preprocessor.py
@@ -17,7 +17,7 @@ test_data_path = os.path.join(test_path, 'data/')
 
 @pytest.fixture(scope='function')
 def db_setup():
-    with patch('wazuh.common.ossec_uid'), patch('wazuh.common.ossec_gid'):
+    with patch('wazuh.core.common.ossec_uid'), patch('wazuh.core.common.ossec_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):

--- a/framework/wazuh/rbac/tests/utils.py
+++ b/framework/wazuh/rbac/tests/utils.py
@@ -16,7 +16,7 @@ def create_memory_db(sql_file, session, test_data_path):
 
 
 def init_db(schema, test_data_path):
-    with patch('wazuh.common.ossec_uid'), patch('wazuh.common.ossec_gid'):
+    with patch('wazuh.core.common.ossec_uid'), patch('wazuh.core.common.ossec_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):

--- a/framework/wazuh/tests/test_active_response.py
+++ b/framework/wazuh/tests/test_active_response.py
@@ -9,20 +9,18 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from wazuh.core.tests.test_active_response import agent_config, agent_info
-from wazuh.core.exception import WazuhError
-
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
-        sys.modules['api'] = MagicMock()
         import wazuh.rbac.decorators
-        del sys.modules['wazuh.rbac.orm']
-        del sys.modules['api']
         from wazuh.tests.util import RBAC_bypasser
+
+        del sys.modules['wazuh.rbac.orm']
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
 
         from wazuh.active_response import run_command
+        from wazuh.core.tests.test_active_response import agent_config, agent_info
+        from wazuh.core.exception import WazuhError
 
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')

--- a/framework/wazuh/tests/test_active_response.py
+++ b/framework/wazuh/tests/test_active_response.py
@@ -9,8 +9,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         from wazuh.tests.util import RBAC_bypasser
@@ -42,7 +42,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 @patch("wazuh.core.ossec_queue.OssecQueue._connect")
 @patch("wazuh.syscheck.OssecQueue._send", return_value='1')
 @patch("wazuh.core.ossec_queue.OssecQueue.close")
-@patch('wazuh.common.ossec_path', new=test_data_path)
+@patch('wazuh.core.common.ossec_path', new=test_data_path)
 def test_run_command(mock_close,  mock_send, mock_conn, message_exception, send_exception, agent_id, command,
                      arguments, custom):
     """Verify the proper operation of active_response module.

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -14,8 +14,8 @@ import pytest
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../..'))
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         from wazuh.tests.util import RBAC_bypasser
@@ -308,7 +308,7 @@ def test_agent_delete_agents_different_status(socket_mock, send_mock):
     ('a' * 129, '002', 'f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d')
 ])
 @patch('wazuh.core.agent.fcntl.lockf')
-@patch('wazuh.common.client_keys', new=os.path.join(test_agent_path, 'client.keys'))
+@patch('wazuh.core.common.client_keys', new=os.path.join(test_agent_path, 'client.keys'))
 @patch('wazuh.core.agent.chown')
 @patch('wazuh.core.agent.chmod')
 @patch('wazuh.core.agent.copyfile')
@@ -343,8 +343,8 @@ def test_agent_add_agent(socket_mock, send_mock, open_mock, safe_move_mock, comm
     (['group-1', 'group-2'], ['group-1', 'group-2']),
     (['invalid_group'], [])
 ])
-@patch('wazuh.common.client_keys', new=os.path.join(test_agent_path, 'client.keys'))
-@patch('wazuh.common.shared_path', new=test_shared_path)
+@patch('wazuh.core.common.client_keys', new=os.path.join(test_agent_path, 'client.keys'))
+@patch('wazuh.core.common.shared_path', new=test_shared_path)
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_get_agent_groups(socket_mock, send_mock, group_list, expected_result):
@@ -379,7 +379,7 @@ def test_agent_get_agent_groups_exceptions(socket_mock, send_mock, mock_get_grou
 
     """
     mock_get_groups.return_value = {'valid-group'}
-    with patch('wazuh.common.database_path_global', new=db_global):
+    with patch('wazuh.core.common.database_path_global', new=db_global):
         try:
             group_result = get_agent_groups(group_list=[system_groups])
             assert group_result.failed_items
@@ -392,9 +392,9 @@ def test_agent_get_agent_groups_exceptions(socket_mock, send_mock, mock_get_grou
     ['group-1'],
     ['invalid-group']
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('wazuh.common.client_keys', new=os.path.join(test_agent_path, 'client.keys'))
-@patch('wazuh.common.shared_path', new=test_shared_path)
+@patch('wazuh.core.common.database_path_global', new=test_global_bd_path)
+@patch('wazuh.core.common.client_keys', new=os.path.join(test_agent_path, 'client.keys'))
+@patch('wazuh.core.common.shared_path', new=test_shared_path)
 def test_agent_get_group_files(group_list):
     """Test `get_group_files` from agent module.
 
@@ -439,7 +439,7 @@ def test_agent_get_group_files_exceptions(mock_group_exists, mock_process_array,
     expected_exception : Exception
         Exception expected to be raised by `get_group_files` with the given parameters.
     """
-    with patch('wazuh.common.shared_path', new=shared_path):
+    with patch('wazuh.core.common.shared_path', new=shared_path):
         mock_group_exists.return_value = group_exists
         mock_process_array.side_effect = side_effect
         try:
@@ -453,9 +453,9 @@ def test_agent_get_group_files_exceptions(mock_group_exists, mock_process_array,
     'non-existant-group',
     'invalid-group'
 ])
-@patch('wazuh.common.shared_path', new=test_shared_path)
-@patch('wazuh.common.ossec_gid', return_value=getgrnam('root'))
-@patch('wazuh.common.ossec_uid', return_value=getpwnam('root'))
+@patch('wazuh.core.common.shared_path', new=test_shared_path)
+@patch('wazuh.core.common.ossec_gid', return_value=getgrnam('root'))
+@patch('wazuh.core.common.ossec_uid', return_value=getpwnam('root'))
 @patch('wazuh.agent.chown_r')
 def test_create_group(chown_mock, uid_mock, gid_mock, group_id):
     """Test `create_group` function from agent module.
@@ -491,7 +491,7 @@ def test_create_group(chown_mock, uid_mock, gid_mock, group_id):
     ('invalid!', WazuhError, 1722),
     ('delete-me', WazuhInternalError, 1005)
 ])
-@patch('wazuh.common.shared_path', new=test_shared_path)
+@patch('wazuh.core.common.shared_path', new=test_shared_path)
 def test_create_group_exceptions(group_id, exception, exception_code):
     """Test `create_group` function from agent module raises the expected exceptions if an invalid `group_id` is
     specified.
@@ -584,8 +584,8 @@ def test_agent_delete_groups_permission_exception(socket_mock, send_mock, mock_g
     (['none-1', 'none-2'], [WazuhResourceNotFound(1710)]),
     (['default', 'none-1'], [WazuhError(1712), WazuhResourceNotFound(1710)]),
 ])
-@patch('wazuh.common.shared_path', new=test_shared_path)
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
+@patch('wazuh.core.common.shared_path', new=test_shared_path)
+@patch('wazuh.core.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.agent.get_groups')
 def test_agent_delete_groups_other_exceptions(mock_get_groups, group_list, expected_errors):
     """Test `delete_groups` function from agent module returns the expected exceptions when using invalid group lists.
@@ -613,7 +613,7 @@ def test_agent_delete_groups_other_exceptions(mock_get_groups, group_list, expec
     (['group-1'], ['001', '002', '003'], 0),
     (['group-1'], ['001', '002', '003', '100'], 1),
 ])
-@patch('wazuh.common.shared_path', new=test_shared_path)
+@patch('wazuh.core.common.shared_path', new=test_shared_path)
 @patch('wazuh.agent.Agent.add_group_to_agent')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
@@ -692,7 +692,7 @@ def test_agent_assign_agents_to_group_exceptions(socket_mock, send_mock, mock_ad
     ('default', '001'),
     ('group-1', '005')
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
+@patch('wazuh.core.common.database_path_global', new=test_global_bd_path)
 @patch('wazuh.core.agent.Agent.unset_single_group_agent')
 @patch('wazuh.agent.get_groups')
 @patch('wazuh.agent.get_agents_info')
@@ -1065,8 +1065,8 @@ def test_agent_get_agent_config_exceptions(socket_mock, send_mock, agent_list):
 @pytest.mark.parametrize('agent_list', [
     full_agent_list[1:]
 ])
-@patch('wazuh.common.shared_path', new=test_shared_path)
-@patch('wazuh.common.multi_groups_path', new=test_multigroup_path)
+@patch('wazuh.core.common.shared_path', new=test_shared_path)
+@patch('wazuh.core.common.multi_groups_path', new=test_multigroup_path)
 @patch('wazuh.agent.get_agents_info', return_value=full_agent_list)
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
@@ -1113,8 +1113,8 @@ def test_agent_get_agents_sync_group_exceptions(socket_mock, send_mock, agent_li
 @pytest.mark.parametrize('filename, group_list', [
     ('agent.conf', ['default'])
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('wazuh.common.shared_path', new=test_shared_path)
+@patch('wazuh.core.common.database_path_global', new=test_global_bd_path)
+@patch('wazuh.core.common.shared_path', new=test_shared_path)
 def test_agent_get_file_conf(filename, group_list):
     """Test `get_file_conf` from agent module.
 
@@ -1136,8 +1136,8 @@ def test_agent_get_file_conf(filename, group_list):
 @pytest.mark.parametrize('group_list', [
     ['default']
 ])
-@patch('wazuh.common.database_path_global', new=test_global_bd_path)
-@patch('wazuh.common.shared_path', new=test_shared_path)
+@patch('wazuh.core.common.database_path_global', new=test_global_bd_path)
+@patch('wazuh.core.common.shared_path', new=test_shared_path)
 def test_agent_get_agent_conf(group_list):
     """Test `get_agent_agent_conf` function from agent module.
 
@@ -1155,7 +1155,7 @@ def test_agent_get_agent_conf(group_list):
 @pytest.mark.parametrize('group_list', [
     ['default']
 ])
-@patch('wazuh.common.shared_path', new=test_shared_path)
+@patch('wazuh.core.common.shared_path', new=test_shared_path)
 @patch('wazuh.core.configuration.upload_group_configuration')
 def test_agent_upload_group_file(mock_upload, group_list):
     """Test `upload_group_file` function from agent module.
@@ -1180,7 +1180,7 @@ def test_agent_upload_group_file(mock_upload, group_list):
     (full_agent_list, ['group-1'], False, '004'),
     (full_agent_list, ['group-1'], True, None)
 ])
-@patch('wazuh.common.shared_path', new=test_shared_path)
+@patch('wazuh.core.common.shared_path', new=test_shared_path)
 @patch('wazuh.agent.get_distinct_agents')
 @patch('wazuh.agent.get_agent_groups')
 @patch('wazuh.agent.get_agents_summary_status')

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -12,21 +12,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from api.util import remove_nones_to_dict
-from wazuh.core.exception import WazuhResourceNotFound
-
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../..'))
 
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
-        sys.modules['api'] = MagicMock()
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         from wazuh.tests.util import RBAC_bypasser
 
         del sys.modules['wazuh.rbac.orm']
-        del sys.modules['api']
-
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
 
         from wazuh.agent import add_agent, assign_agents_to_group, create_group, delete_agents, delete_groups, \
@@ -39,6 +33,8 @@ with patch('wazuh.common.ossec_uid'):
         from wazuh import WazuhError, WazuhException, WazuhInternalError
         from wazuh.core.results import WazuhResult, AffectedItemsWazuhResult
         from wazuh.core.tests.test_agent import InitAgent
+        from api.util import remove_nones_to_dict
+        from wazuh.core.exception import WazuhResourceNotFound
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 test_agent_path = os.path.join(test_data_path, 'agent')

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -22,7 +22,7 @@ with patch('wazuh.common.getgrnam'):
             from wazuh.tests.util import RBAC_bypasser
             wazuh.rbac.decorators.expose_resources = RBAC_bypasser
 
-            from wazuh.cdb_list import get_lists, get_path_lists
+            from wazuh.cdb_list import get_lists, get_path_lists, iterate_lists
             from wazuh.core import common
             from wazuh.core.results import AffectedItemsWazuhResult
 
@@ -56,6 +56,13 @@ RESULTS_GET_LIST = RESULT_GET_LIST_FILE_1 + RESULT_GET_LIST_FILE_2
 RESULTS_GET_PATH_LIST = RESULT_GET_PATH_LIST_FILE_1 + RESULT_GET_PATH_LIST_FILE_2
 
 TOTAL_LISTS = len(PATHS_FILES)
+
+
+def lists_path_mock(**kwargs):
+    """Mock iterate_lists to avoid the default parameter."""
+    kwargs['absolute_path'] = DATA_PATH
+    return iterate_lists(**kwargs)
+
 
 # Tests
 
@@ -169,7 +176,8 @@ def test_get_lists_sort():
     assert result_b.affected_items == RESULT_GET_LIST_FILE_2 + RESULT_GET_LIST_FILE_1
 
 
-def test_get_path_lists():
+@patch('wazuh.cdb_list.iterate_lists', side_effect=lists_path_mock)
+def test_get_path_lists(iterate_mock):
     """Test `get_path_lists` functionality without any other parameter aside from `path`.
 
     `get_path_lists` works different than `get_lists` as it will read every CDB file from the default path (mocked to
@@ -184,7 +192,8 @@ def test_get_path_lists():
 
 
 @pytest.mark.parametrize("limit", [1, 2])
-def test_get_path_lists_limit(limit):
+@patch('wazuh.cdb_list.iterate_lists', side_effect=lists_path_mock)
+def test_get_path_lists_limit(iterate_mock, limit):
     """Test `get_path_lists` functionality when using the `limit` parameter.
 
     Parameters
@@ -201,7 +210,8 @@ def test_get_path_lists_limit(limit):
 
 
 @pytest.mark.parametrize("offset", [0, 1])
-def test_get_path_lists_offset(offset):
+@patch('wazuh.cdb_list.iterate_lists', side_effect=lists_path_mock)
+def test_get_path_lists_offset(iterate_mock, offset):
     """Test `get__path_lists` functionality when using the `offset` parameter.
 
     Parameters
@@ -234,7 +244,8 @@ def test_get_path_lists_offset(offset):
     ("lists_2", True, "filename", PATHS_FILES, RESULT_GET_PATH_LIST_FILE_1),
     ("invalid", True, "filename", PATHS_FILES, RESULTS_GET_PATH_LIST)
 ])
-def test_get_path_lists_search(search_text, complementary_search, search_in_fields, paths, expected_result):
+@patch('wazuh.cdb_list.iterate_lists', side_effect=lists_path_mock)
+def test_get_path_lists_search(iterate_mock, search_text, complementary_search, search_in_fields, paths, expected_result):
     """Test `get_path_lists` functionality when using the `search` parameter.
 
     Parameters
@@ -259,7 +270,8 @@ def test_get_path_lists_search(search_text, complementary_search, search_in_fiel
     assert result.affected_items == expected_result
 
 
-def test_get_path_lists_sort():
+@patch('wazuh.cdb_list.iterate_lists', side_effect=lists_path_mock)
+def test_get_path_lists_sort(iterate_mock):
     """Test `get_path_lists` functionality when using the `sort` parameter."""
     result_a = get_path_lists(path=PATHS_FILES, sort_by=['filename'], sort_ascending=True)
     result_b = get_path_lists(path=PATHS_FILES, sort_by=['filename'], sort_ascending=False)

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -11,8 +11,8 @@ import pytest
 
 DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "test_cdb_list")
 
-with patch('wazuh.common.getgrnam'):
-    with patch('wazuh.common.getpwnam'):
+with patch('wazuh.core.common.getgrnam'):
+    with patch('wazuh.core.common.getpwnam'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         from wazuh.tests.util import RBAC_bypasser

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -13,18 +13,16 @@ DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "t
 
 with patch('wazuh.common.getgrnam'):
     with patch('wazuh.common.getpwnam'):
-        with patch('wazuh.common.lists_path', DATA_PATH):
-            sys.modules['wazuh.rbac.orm'] = MagicMock()
-            sys.modules['api'] = MagicMock()
-            import wazuh.rbac.decorators
-            del sys.modules['wazuh.rbac.orm']
-            del sys.modules['api']
-            from wazuh.tests.util import RBAC_bypasser
-            wazuh.rbac.decorators.expose_resources = RBAC_bypasser
+        sys.modules['wazuh.rbac.orm'] = MagicMock()
+        import wazuh.rbac.decorators
+        from wazuh.tests.util import RBAC_bypasser
 
-            from wazuh.cdb_list import get_lists, get_path_lists, iterate_lists
-            from wazuh.core import common
-            from wazuh.core.results import AffectedItemsWazuhResult
+        del sys.modules['wazuh.rbac.orm']
+        wazuh.rbac.decorators.expose_resources = RBAC_bypasser
+
+        from wazuh.cdb_list import get_lists, get_path_lists, iterate_lists
+        from wazuh.core import common
+        from wazuh.core.results import AffectedItemsWazuhResult
 
 RELATIVE_PATH = os.path.join("framework", "wazuh", "tests", "data", "test_cdb_list")
 NAME_FILE_1 = "test_lists_1"

--- a/framework/wazuh/tests/test_ciscat.py
+++ b/framework/wazuh/tests/test_ciscat.py
@@ -9,8 +9,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         del sys.modules['wazuh.rbac.orm']
@@ -29,7 +29,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
     (['001'], False),
     (['003'], True)
 ])
-@patch('wazuh.common.wdb_path', new=test_data_path)
+@patch('wazuh.core.common.wdb_path', new=test_data_path)
 @patch('socket.socket.connect')
 @patch('wazuh.ciscat.get_agents_info', return_value=['001'])
 def test_get_ciscat_results(agents_info_mock, socket_mock, agent_id, exception):

--- a/framework/wazuh/tests/test_ciscat.py
+++ b/framework/wazuh/tests/test_ciscat.py
@@ -9,18 +9,15 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from wazuh.tests.util import InitWDBSocketMock
-
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
-        sys.modules['api'] = MagicMock()
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         del sys.modules['wazuh.rbac.orm']
-        del sys.modules['api']
         from wazuh.tests.util import RBAC_bypasser
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
 
+        from wazuh.tests.util import InitWDBSocketMock
         from wazuh.ciscat import get_ciscat_results
         from wazuh.core.results import AffectedItemsWazuhResult
 

--- a/framework/wazuh/tests/test_cluster.py
+++ b/framework/wazuh/tests/test_cluster.py
@@ -3,8 +3,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
 

--- a/framework/wazuh/tests/test_cluster.py
+++ b/framework/wazuh/tests/test_cluster.py
@@ -3,21 +3,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from wazuh.core import common
-
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
-        sys.modules['api'] = MagicMock()
         import wazuh.rbac.decorators
 
         del sys.modules['wazuh.rbac.orm']
-        del sys.modules['api']
 
         from wazuh.tests.util import RBAC_bypasser
 
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
         from wazuh import cluster
+        from wazuh.core import common
         from wazuh.core.exception import WazuhError, WazuhResourceNotFound
         from wazuh.core.cluster.local_client import LocalClient
         from wazuh.core.results import WazuhResult

--- a/framework/wazuh/tests/test_decoders.py
+++ b/framework/wazuh/tests/test_decoders.py
@@ -13,10 +13,8 @@ import pytest
 with patch('wazuh.common.getgrnam'):
     with patch('wazuh.common.getpwnam'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
-        sys.modules['api'] = MagicMock()
         import wazuh.rbac.decorators
         del sys.modules['wazuh.rbac.orm']
-        del sys.modules['api']
         from wazuh.tests.util import RBAC_bypasser
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
 

--- a/framework/wazuh/tests/test_decoders.py
+++ b/framework/wazuh/tests/test_decoders.py
@@ -10,8 +10,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-with patch('wazuh.common.getgrnam'):
-    with patch('wazuh.common.getpwnam'):
+with patch('wazuh.core.common.getgrnam'):
+    with patch('wazuh.core.common.getpwnam'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         del sys.modules['wazuh.rbac.orm']
@@ -45,7 +45,7 @@ decoder_ossec_conf_2 = {
 
 @pytest.fixture(scope='module', autouse=True)
 def mock_ossec_path():
-    with patch('wazuh.common.ossec_path', new=test_data_path):
+    with patch('wazuh.core.common.ossec_path', new=test_data_path):
         with patch('wazuh.core.configuration.get_ossec_conf', return_value=decoder_ossec_conf):
             yield
 

--- a/framework/wazuh/tests/test_group.py
+++ b/framework/wazuh/tests/test_group.py
@@ -5,8 +5,8 @@
 from unittest.mock import patch
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         from wazuh.core.agent import Agent
         from wazuh.core.exception import WazuhException
 

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -11,8 +11,8 @@ import json
 import pytest
 
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         from wazuh.tests.util import RBAC_bypasser
@@ -28,7 +28,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 
 @pytest.fixture(scope='module', autouse=True)
 def mock_ossec_path():
-    with patch('wazuh.common.ossec_path', new=test_data_path):
+    with patch('wazuh.core.common.ossec_path', new=test_data_path):
         yield
 
 

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -10,20 +10,18 @@ import json
 
 import pytest
 
-from wazuh.core.tests.test_manager import get_logs
 
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
-        sys.modules['api'] = MagicMock()
         import wazuh.rbac.decorators
-        del sys.modules['wazuh.rbac.orm']
-
         from wazuh.tests.util import RBAC_bypasser
-        wazuh.rbac.decorators.expose_resources = RBAC_bypasser
-        from wazuh.manager import *
-        del sys.modules['api']
 
+        del sys.modules['wazuh.rbac.orm']
+        wazuh.rbac.decorators.expose_resources = RBAC_bypasser
+
+        from wazuh.manager import *
+        from wazuh.core.tests.test_manager import get_logs
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 

--- a/framework/wazuh/tests/test_mitre.py
+++ b/framework/wazuh/tests/test_mitre.py
@@ -15,19 +15,16 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from wazuh.tests.util import InitWDBSocketMock
 
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
-        sys.modules['api'] = MagicMock()
         import wazuh.rbac.decorators
         del sys.modules['wazuh.rbac.orm']
 
-        from wazuh.tests.util import RBAC_bypasser
+        from wazuh.tests.util import RBAC_bypasser, InitWDBSocketMock
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
         from wazuh.mitre import get_attack, WazuhDBQueryMitre
-        del sys.modules['api']
 
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),

--- a/framework/wazuh/tests/test_mitre.py
+++ b/framework/wazuh/tests/test_mitre.py
@@ -16,8 +16,8 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         del sys.modules['wazuh.rbac.orm']

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -8,8 +8,8 @@ from unittest.mock import patch, mock_open, MagicMock
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         del sys.modules['wazuh.rbac.orm']
@@ -63,13 +63,13 @@ rule_contents = '''
 
 @pytest.fixture(scope='module', autouse=True)
 def mock_ossec_path():
-    with patch('wazuh.common.ossec_path', new=parent_directory):
+    with patch('wazuh.core.common.ossec_path', new=parent_directory):
         yield
 
 
 @pytest.fixture(scope='module', autouse=True)
 def mock_rules_path():
-    with patch('wazuh.common.ruleset_rules_path', new=data_path):
+    with patch('wazuh.core.common.ruleset_rules_path', new=data_path):
         yield
 
 

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -11,10 +11,8 @@ import pytest
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
-        sys.modules['api'] = MagicMock()
         import wazuh.rbac.decorators
         del sys.modules['wazuh.rbac.orm']
-        del sys.modules['api']
         from wazuh.tests.util import RBAC_bypasser
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
 

--- a/framework/wazuh/tests/test_sca.py
+++ b/framework/wazuh/tests/test_sca.py
@@ -11,8 +11,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         from wazuh.tests.util import RBAC_bypasser

--- a/framework/wazuh/tests/test_sca.py
+++ b/framework/wazuh/tests/test_sca.py
@@ -11,21 +11,19 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from wazuh.core import common, exception
-from wazuh.tests.util import InitWDBSocketMock
-
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
-        sys.modules['api'] = MagicMock()
         import wazuh.rbac.decorators
         from wazuh.tests.util import RBAC_bypasser
 
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
         from wazuh.sca import get_sca_list, fields_translation_sca, \
             get_sca_checks, fields_translation_sca_check, fields_translation_sca_check_compliance
+        from wazuh.core import common, exception
         from wazuh.core.results import AffectedItemsWazuhResult
         from wazuh.core.exception import WazuhResourceNotFound
+        from wazuh.tests.util import InitWDBSocketMock
 
         del sys.modules['wazuh.rbac.orm']
 

--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -48,7 +48,7 @@ def create_memory_db(sql_file, session):
 
 @pytest.fixture(scope='function')
 def db_setup():
-    with patch('wazuh.common.ossec_uid'), patch('wazuh.common.ossec_gid'):
+    with patch('wazuh.core.common.ossec_uid'), patch('wazuh.core.common.ossec_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
                 with patch('api.constants.SECURITY_PATH', new=test_data_path):

--- a/framework/wazuh/tests/test_stats.py
+++ b/framework/wazuh/tests/test_stats.py
@@ -10,8 +10,8 @@ import pytest
 
 from wazuh.core.exception import WazuhException
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         del sys.modules['wazuh.rbac.orm']
@@ -94,7 +94,7 @@ def test_hourly(effect):
         assert isinstance(response, AffectedItemsWazuhResult), f'The result is not WazuhResult type'
 
 
-@patch('wazuh.common.stats_path', new=test_data_path)
+@patch('wazuh.core.common.stats_path', new=test_data_path)
 def test_hourly_data():
     """Makes sure that data returned by hourly() fit with the expected."""
     response = hourly()
@@ -121,7 +121,7 @@ def test_weekly(effect):
         assert isinstance(response, AffectedItemsWazuhResult), f'The result is not WazuhResult type'
 
 
-@patch('wazuh.common.stats_path', new=test_data_path)
+@patch('wazuh.core.common.stats_path', new=test_data_path)
 def test_weekly_data():
     """Makes sure that data returned by weekly() fit with the expected."""
     response = weekly()

--- a/framework/wazuh/tests/test_stats.py
+++ b/framework/wazuh/tests/test_stats.py
@@ -13,10 +13,8 @@ from wazuh.core.exception import WazuhException
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
-        sys.modules['api'] = MagicMock()
         import wazuh.rbac.decorators
         del sys.modules['wazuh.rbac.orm']
-        del sys.modules['api']
 
         from wazuh.tests.util import RBAC_bypasser
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser

--- a/framework/wazuh/tests/test_syscheck.py
+++ b/framework/wazuh/tests/test_syscheck.py
@@ -14,12 +14,10 @@ from wazuh.tests.util import InitWDBSocketMock
 
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
-        sys.modules['api'] = MagicMock()
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
 
         del sys.modules['wazuh.rbac.orm']
-        del sys.modules['api']
 
         from wazuh.tests.util import RBAC_bypasser
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser

--- a/framework/wazuh/tests/test_syscheck.py
+++ b/framework/wazuh/tests/test_syscheck.py
@@ -12,8 +12,8 @@ import pytest
 
 from wazuh.tests.util import InitWDBSocketMock
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
 
@@ -242,7 +242,7 @@ def test_syscheck_last_scan_internal_error(glob_mock, version):
     (['001'], None, {'date': '2019-05-21 12:10:20'}, True)
 ])
 @patch('socket.socket.connect')
-@patch('wazuh.common.wdb_path', new=test_data_path)
+@patch('wazuh.core.common.wdb_path', new=test_data_path)
 def test_syscheck_files(socket_mock, agent_id, select, filters, distinct):
     """Test function `files` from syscheck module.
 

--- a/framework/wazuh/tests/test_syscollector.py
+++ b/framework/wazuh/tests/test_syscollector.py
@@ -10,8 +10,8 @@ import pytest
 
 from wazuh.tests.util import InitWDBSocketMock
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.decorators
         del sys.modules['wazuh.rbac.orm']

--- a/framework/wazuh/tests/test_syscollector.py
+++ b/framework/wazuh/tests/test_syscollector.py
@@ -13,10 +13,8 @@ from wazuh.tests.util import InitWDBSocketMock
 with patch('wazuh.common.ossec_uid'):
     with patch('wazuh.common.ossec_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
-        sys.modules['api'] = MagicMock()
         import wazuh.rbac.decorators
         del sys.modules['wazuh.rbac.orm']
-        del sys.modules['api']
 
         from wazuh.tests.util import RBAC_bypasser
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser


### PR DESCRIPTION
Hello team, this closes #6438 .

As the issue stated, some framework unit tests failed when running them all together. All these fails were caused by a memory/cache issue. They are working after these fixes. In addition, they have been improved in order to make the Jenkins integration possible.

# Tests performed
## Framework unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0
collected 1529 items                                                                                                                                                                        

wazuh/core/cluster/dapi/tests/test_dapi.py ......................                                                                                                                     [  1%]
wazuh/core/cluster/tests/test_cluster.py ..................                                                                                                                           [  2%]
wazuh/core/cluster/tests/test_common.py .......                                                                                                                                       [  3%]
wazuh/core/cluster/tests/test_control.py .....                                                                                                                                        [  3%]
wazuh/core/cluster/tests/test_local_client.py .                                                                                                                                       [  3%]
wazuh/core/cluster/tests/test_utils.py .......                                                                                                                                        [  3%]
wazuh/core/cluster/tests/test_worker.py ................                                                                                                                              [  4%]
wazuh/core/tests/test_active_response.py ............                                                                                                                                 [  5%]
wazuh/core/tests/test_agent.py ...................................................................................................................................................... [ 15%]
.....FFF.FF....FF....................                                                                                                                                                 [ 17%]
wazuh/core/tests/test_cdb_list.py .................................                                                                                                                   [ 20%]
wazuh/core/tests/test_common.py .......                                                                                                                                               [ 20%]
wazuh/core/tests/test_configuration.py ..................................                                                                                                             [ 22%]
wazuh/core/tests/test_decoder.py ...............                                                                                                                                      [ 23%]
wazuh/core/tests/test_input_validator.py ...                                                                                                                                          [ 24%]
wazuh/core/tests/test_manager.py ................................                                                                                                                     [ 26%]
wazuh/core/tests/test_ossec_queue.py ...................                                                                                                                              [ 27%]
wazuh/core/tests/test_pyDaemonModule.py ......                                                                                                                                        [ 27%]
wazuh/core/tests/test_results.py ........................................                                                                                                             [ 30%]
wazuh/core/tests/test_rule.py .....................                                                                                                                                   [ 31%]
wazuh/core/tests/test_syscollector.py ...                                                                                                                                             [ 31%]
wazuh/core/tests/test_utils.py ...................................................................................................................................................... [ 41%]
......................................................                                                                                                                                [ 45%]
wazuh/core/tests/test_wazuh_socket.py ...............                                                                                                                                 [ 46%]
wazuh/core/tests/test_wdb.py .....................                                                                                                                                    [ 47%]
wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                              [ 47%]
wazuh/rbac/tests/test_decorators.py .........................................................................................................                                         [ 54%]
wazuh/rbac/tests/test_default_configuration.py ...............................................                                                                                        [ 57%]
wazuh/rbac/tests/test_orm.py .....................................................                                                                                                    [ 61%]
wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                     [ 61%]
wazuh/tests/test_active_response.py .........                                                                                                                                         [ 62%]
wazuh/tests/test_agent.py .........................................................................................                                                                   [ 68%]
wazuh/tests/test_cdb_list.py ...............................................                                                                                                          [ 71%]
wazuh/tests/test_ciscat.py ..                                                                                                                                                         [ 71%]
wazuh/tests/test_cluster.py .......                                                                                                                                                   [ 71%]
wazuh/tests/test_decoders.py ...............................                                                                                                                          [ 73%]
wazuh/tests/test_group.py ........                                                                                                                                                    [ 74%]
wazuh/tests/test_manager.py ........................................                                                                                                                  [ 77%]
wazuh/tests/test_mitre.py ........................................................................................................................................................... [ 87%]
.........................                                                                                                                                                             [ 88%]
wazuh/tests/test_rule.py ....................................................                                                                                                         [ 92%]
wazuh/tests/test_sca.py .......                                                                                                                                                       [ 92%]
wazuh/tests/test_security.py ....................................................................                                                                                     [ 97%]
wazuh/tests/test_stats.py .............                                                                                                                                               [ 98%]
wazuh/tests/test_syscheck.py ..................                                                                                                                                       [ 99%]
wazuh/tests/test_syscollector.py ............                                                                                                                                         [100%]

================================================================================== short test summary info ==================================================================================
FAILED wazuh/core/tests/test_agent.py::test_agent_upgrade[001-Ubuntu-3.10.1-None-packages.wazuh.com/wpk/] - AssertionError: expected call not found.
FAILED wazuh/core/tests/test_agent.py::test_agent_upgrade[002-Ubuntu-4.0.0-None-packages.wazuh.com/4.x/wpk/] - AssertionError: expected call not found.
FAILED wazuh/core/tests/test_agent.py::test_agent_upgrade[008-Windows-4.0.0-test_repo_path/-test_repo_path/] - AssertionError: expected call not found.
FAILED wazuh/core/tests/test_agent.py::test_agent_upgrade_result[001] - AssertionError: expected call not found.
FAILED wazuh/core/tests/test_agent.py::test_agent_upgrade_result[002] - AssertionError: expected call not found.
FAILED wazuh/core/tests/test_agent.py::test_agent_upgrade_custom[001] - AssertionError: expected call not found.
FAILED wazuh/core/tests/test_agent.py::test_agent_upgrade_custom[002] - AssertionError: expected call not found.
================================================================== 7 failed, 1522 passed, 15 warnings in 206.01s (0:03:26) ==================================================================

```

These errors are expected since we are still working on the upgrade module.

## API unit tests
```
==================================== test session starts ====================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: asyncio-0.12.0
collected 195 items                                                                         

api/test/test_alogging.py ........                                                    [  4%]
api/test/test_authentication.py ..........                                            [  9%]
api/test/test_configuration.py .......                                                [ 12%]
api/test/test_util.py ...................................                             [ 30%]
api/test/test_validator.py .......................................................... [ 60%]
.............................................................................         [100%]

============================= 195 passed, 16 warnings in 0.96s ==============================
```

Regards,
Víctor.