### PR TITLE
Update Vulnerability Detector to get agents by connection status

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2574,7 +2574,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 arch_id++;
             }
 
-            // Replace the state ID by the real values 
+            // Replace the state ID by the real values
             query = vu_queries[VU_UPDATE_CVE_VAL];
             if (wm_vuldet_prepare(db, query, -1, &stmt, NULL) != SQLITE_OK) {
                 return wm_vuldet_sql_error(db, stmt);
@@ -2902,7 +2902,7 @@ char *wm_vuldet_oval_xml_preparser(char *path, vu_feed dist) {
             case V_DEFINITIONS:
                 if (found = strstr(buffer, "</definition"), found) {
                     state = V_END;
-                } 
+                }
                 continue;
             default:
                 /* The XML parser fails to analyse correctly this section.
@@ -2915,7 +2915,7 @@ char *wm_vuldet_oval_xml_preparser(char *path, vu_feed dist) {
                     state = V_CRITERIA;
 
                 // Discard not-affected packages
-                } else if (strstr(buffer, "<definition") && 
+                } else if (strstr(buffer, "<definition") &&
                     strstr(buffer, "unaffected")) {
                     state = V_DEFINITIONS;
                     continue;
@@ -4612,7 +4612,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
         return OS_INVALID;
     }
 
-    id_array = wdb_get_agents_by_keepalive(">", time(0)-DISCON_TIME, TRUE, &sock);
+    id_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, &sock);
 
     if(!id_array) {
         mdebug1("Failed getting agent's ID array.");
@@ -4748,7 +4748,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
         if(cJSON_IsString(json_field) && json_field->valuestring != NULL){
             register_ip = json_field->valuestring;
         }
-        
+
         if (!register_ip) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_NULL_AGENT_IP, id);
             continue;
@@ -4777,7 +4777,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
 
         if (name) {
             os_strdup(name, agents->agent_name);
-        }        
+        }
         if (arch) {
             os_strdup(arch, agents->arch);
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4590,7 +4590,8 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
 int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **updates) {
     agent_software *agents = NULL;
     agent_software *f_agent = NULL;
-    int dist_error;
+    int set_manager = 1;
+    int dist_error = -1;
     char str_id[OS_SIZE_128] = "";
     char *name = NULL;
     char *register_ip = NULL;
@@ -4598,8 +4599,8 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
     char *os_version = NULL;
     char *arch = NULL;
     int build = 0;
+    int id = 0;
     int i = 0;
-    int id = -1;
     vu_feed agent_dist_ver;
     vu_feed agent_dist;
     int *id_array = NULL;
@@ -4614,12 +4615,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
 
     id_array = wdb_get_agents_by_connection_status(AGENT_CS_ACTIVE, &sock);
 
-    if(!id_array) {
-        mdebug1("Failed getting agent's ID array.");
-        return OS_INVALID;
-    }
-
-    for (i = 0; id_array[i] != -1; i++){
+    while (set_manager || (id_array && id_array[i] != -1)) {
         dist_error = -1;
         name = NULL;
         register_ip = NULL;
@@ -4627,11 +4623,17 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
         os_version = NULL;
         arch = NULL;
         build = 0;
-        id = -1;
 
-        json_agt_info = wdb_get_agent_info(id_array[i], &sock);
+        if (set_manager) {
+            id = --set_manager;
+        }
+        else {
+            id = id_array[i++];
+        }
+
+        json_agt_info = wdb_get_agent_info(id, &sock);
         if (!json_agt_info) {
-            mdebug1("Failed to get agent '%d' information from Wazuh DB.", id_array[i]);
+            mdebug1("Failed to get agent '%d' information from Wazuh DB.", id);
             continue;
         }
 
@@ -4650,19 +4652,9 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
             name = json_field->valuestring;
         }
 
-        json_field = cJSON_GetObjectItem(json_agt_info->child, "id");
-        if(cJSON_IsNumber(json_field)){
-            id = json_field->valueint;
-        }
-
         json_field = cJSON_GetObjectItem(json_agt_info->child, "os_build");
         if(cJSON_IsNumber(json_field)){
             build = json_field->valueint;
-        }
-
-        if (id == -1) {
-            mterror(WM_VULNDETECTOR_LOGTAG, VU_NULL_AGENT_ID);
-            continue;
         }
 
         if (!os_name) {


### PR DESCRIPTION
|Related issue|
|---|
| [Issue 6309](https://github.com/wazuh/wazuh/issues/6309) |

## Description

This PR modify the way in which Vulnerability Detector gets the `active` agents to perform the scan. Basically, as part of the [Epic 5887](https://github.com/wazuh/wazuh/issues/5887), a new Wazuh DB command was introduced to get a list of agents filtering by the connection status. So now Vulnerability Detector leverages that command to get the list of agents to be scanned.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind