### PR TITLE
Modify read-agents methods to work with the agents' connection status - Implementation

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -95,7 +95,6 @@ https://www.gnu.org/licenses/gpl.html\n"
 /* Notify the manager */
 #define NOTIFY_TIME     10      // ... every 10 seconds
 #define RECONNECT_TIME  60      // Time to reconnect
-#define DISCON_TIME     1800    // Take agent as disconnected
 
 /* User Configuration */
 #ifndef MAILUSER

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -1109,7 +1109,7 @@ agent_info *get_agent_info(const char *agent_name, const char *agent_ip, const c
         return NULL;
     }
 
-    /* Allocate memory for the info structure */   
+    /* Allocate memory for the info structure */
     os_calloc(1, sizeof(agent_info), agt_info);
 
     json_field = cJSON_GetObjectItem(json_agt_info->child, "os_uname");
@@ -1149,38 +1149,30 @@ agent_info *get_agent_info(const char *agent_name, const char *agent_ip, const c
 agent_status_t get_agent_status(int agent_id){
     cJSON *json_agt_info = NULL;
     cJSON *json_field = NULL;
-    int last_keepalive = -1;
+    agent_status_t status = GA_STATUS_INV;
 
     json_agt_info = wdb_get_agent_info(agent_id, NULL);
 
     if (!json_agt_info) {
         mdebug1("Failed to get agent '%d' information from Wazuh DB.", agent_id);
-        return GA_STATUS_INV;
-    }
-    
-    json_field = cJSON_GetObjectItem(json_agt_info->child, "last_keepalive");
-    if (cJSON_IsNumber(json_field)) {
-        last_keepalive = json_field->valueint;
-        cJSON_Delete(json_agt_info);
-    
-    } else {
-        cJSON_Delete(json_agt_info);
-        return GA_STATUS_INV;
+        return status;
     }
 
-    if (last_keepalive < 0) {
-        return (GA_STATUS_INV);
+    json_field = cJSON_GetObjectItem(json_agt_info->child, "connection_status");
+    if (cJSON_IsString(json_field)) {
+        if (0 == strcmp(json_field->valuestring, AGENT_CS_PENDING)) {
+            status = GA_STATUS_PENDING;
+        }
+        else if (0 == strcmp(json_field->valuestring, AGENT_CS_ACTIVE)) {
+            status = GA_STATUS_ACTIVE;
+        }
+        else if (0 == strcmp(json_field->valuestring, AGENT_CS_DISCONNECTED)) {
+            status = GA_STATUS_NACTIVE;
+        }
     }
 
-    if (last_keepalive < (time(0) - DISCON_TIME)) {
-        return (GA_STATUS_NACTIVE);
-    }
-
-    if (last_keepalive == 0) {
-        return GA_STATUS_PENDING;
-    }
-
-    return (GA_STATUS_ACTIVE);
+    cJSON_Delete(json_agt_info);
+    return status;
 }
 
 /* List available agents */
@@ -1218,7 +1210,7 @@ char **get_agents(int flag){
         json_ip = cJSON_GetObjectItem(json_agt_info->child, "register_ip");
 
         /* Keeping the same name structure than plain text files in AGENTINFO_DIR */
-        if(cJSON_IsString(json_name) && json_name->valuestring != NULL && 
+        if(cJSON_IsString(json_name) && json_name->valuestring != NULL &&
             cJSON_IsString(json_ip) && json_ip->valuestring != NULL){
             snprintf(agent_name_ip, sizeof(agent_name_ip), "%s-%s", json_name->valuestring, json_ip->valuestring);
         }
@@ -1228,7 +1220,7 @@ char **get_agents(int flag){
             last_keepalive = json_field->valueint;
         }
         cJSON_Delete(json_agt_info);
-    
+
         status = last_keepalive > (time(0) - DISCON_TIME) ? 1 : 0;
 
         switch (flag) {
@@ -1317,7 +1309,7 @@ char **get_agents_by_last_keepalive(int flag, int delta){
         json_ip = cJSON_GetObjectItem(json_agt_info->child, "register_ip");
 
         /* Keeping the same name structure than plain text files in AGENTINFO_DIR */
-        if(cJSON_IsString(json_name) && json_name->valuestring != NULL && 
+        if(cJSON_IsString(json_name) && json_name->valuestring != NULL &&
             cJSON_IsString(json_ip) && json_ip->valuestring != NULL){
             snprintf(agent_name_ip, sizeof(agent_name_ip), "%s-%s", json_name->valuestring, json_ip->valuestring);
             os_realloc(agents_array, (array_size + 2) * sizeof(char *), agents_array);


### PR DESCRIPTION
|Related issue|
|---|
| [Issue 6311](https://github.com/wazuh/wazuh/issues/6311) |

## Description

This PR implements the necessary changes to make the code in `read-agents.c` work with the new `connection_status` column data in Wazuh DB - global.db - agent table.

For more details about this, check the **requirements** section of the [Issue 6311](https://github.com/wazuh/wazuh/issues/6311).

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation

- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind