### PR TITLE
Fix segmentation fault in localfile configuration parser when location is missing

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -372,6 +372,13 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         os_strdup("agent", logf[pl].target[0]);
     }
 
+    /* Missing file */
+    if (logf[pl].file == NULL) {
+        merror(MISS_FILE);
+        os_strdup("", logf[pl].file);
+        return (OS_INVALID);
+    }
+
     /* Missing log format */
     if (!logf[pl].logformat) {
         merror(MISS_LOG_FORMAT);
@@ -512,12 +519,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 os_strdup(logf[pl].exclude, log_config->globs[gl].exclude_path);
             }
         }
-    }
-
-    /* Missing file */
-    if (!logf[pl].file) {
-        merror(MISS_FILE);
-        return (OS_INVALID);
     }
 
     return (0);


### PR DESCRIPTION
## Rationale

The Logcollector configuration parser reads each `<localfile>` stanza in _ossec.conf_ and _agent.conf_. After that, it performs some extra checks:

1. `<log_format>` and `<location>` must exist.
2. On Windows, `<location>` must be either "Application", "System" or "Security" when `<log_format>` is "eventlog".
3. Expand `<location>` if it is a glob pattern.

The parser checks that `<location>` exists after checking points 2 and 3, so they produce a memory error if `<location>` is missing.

In addition, the `<localfile>` configuration is mapped to an array that ends with a stanza having the member `file` null (coming from `<location>`). In other words, that is prone to produce a memory leak.

## Proposed fix

- Let the configuration parser test that `<location>` exists before checking its value. 
- Otherwise, set it to an empty string so that the invalid configuration can be deleted properly.

## Critical configuration

```xml
<localfile>
  <log_format>syslog</log_format>
</localfile>
```

## Memory report

```
==24781== Process terminating with default action of signal 11 (SIGSEGV)
==24781==  Access not within mapped region at address 0x0
==24781==    at 0x483FBF4: index (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==24781==    by 0x1333AC: Read_Localfile (localfile-config.c:452)
==24781==    by 0x126E08: read_main_elements (config.c:117)
==24781==    by 0x1279B2: ReadConfig (config.c:260)
==24781==    by 0x1183E2: LogCollectorConfig (config.c:81)
==24781==    by 0x120760: main (main.c:122)

Segmentation fault (core dumped)
```

## Log after patch

```
2020/10/30 10:35:11 ossec-logcollector: ERROR: (1902): Missing 'location' element.
2020/10/30 10:35:11 ossec-logcollector: ERROR: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
2020/10/30 10:35:11 ossec-logcollector: CRITICAL: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
```

## Affected artifacts

- ossec-logcollector (UNIX)
- ossec-agentd (UNIX)
- ossec-agent.exe (Windows)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

- [X] Compile manager on Linux.
- [X] Compile agent on Linux.
- [X] Put an invalid `<localfile>` configuration in _agent.conf_. Verify that the agent continues running, refuses to restart, and no memory leaks appear.

### Valgrind report on Agentd

```
2020/10/30 11:07:12 ossec-agentd[6956] localfile-config.c:377 at Read_Localfile(): ERROR: (1902): Missing 'location' element.
2020/10/30 11:07:12 ossec-agentd[6956] config.c:373 at ReadConfig(): ERROR: (1202): Configuration error at '/var/ossec/etc/shared/agent.conf'.
2020/10/30 11:07:12 ossec-agentd[6956] localfile-config.c:532 at Test_Localfile(): ERROR: (1207): Localfile remote configuration in '/var/ossec/etc/shared/agent.conf' is corrupted.
```
```
==6956== LEAK SUMMARY:
==6956==    definitely lost: 0 bytes in 0 blocks
==6956==    indirectly lost: 0 bytes in 0 blocks
==6956==      possibly lost: 1,088 bytes in 4 blocks
==6956==    still reachable: 52,245 bytes in 48 blocks
```