### PR TITLE
Fix limit parameter in GET sca check endpoint and Fix odd offset issue when paginating wdb queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 - **API:**
   - Added missing agent:group resource to RBAC's catalog. ([6427](https://github.com/wazuh/wazuh/issues/6427))
-  - Changed `limit` parameter behaviour in `GET sca/{agent_id}/checks/{policy_id}` endpoint and fixed some loss of information when paginating wdf. ([#6464](https://github.com/wazuh/wazuh/pull/6464))
+  - Changed `limit` parameter behaviour in `GET sca/{agent_id}/checks/{policy_id}` endpoint and fixed some loss of information when paginating `wdb`. ([#6464](https://github.com/wazuh/wazuh/pull/6464))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,9 @@ All notable changes to this project will be documented in this file.
 
 - **API:**
   - Added missing agent:group resource to RBAC's catalog. ([6427](https://github.com/wazuh/wazuh/issues/6427))
+  - Changed `limit` parameter behaviour in `GET sca/{agent_id}/checks/{policy_id}` endpoint and fixed some loss of information when paginating wdf. ([#6464](https://github.com/wazuh/wazuh/pull/6464))
 
 ### Removed
-
-### Fixed
-
-- Fixed an error with `/groups/{group_id}/config` Wazuh API endpoints (GET and PUT) when using complex `localfile` configurations. ([#6276](https://github.com/wazuh/wazuh/pull/6383))
-- Changed `limit` parameter behaviour in `GET sca/{agent_id}/checks/{policy_id}` endpoint. ([#6064](https://github.com/wazuh/wazuh/pull/6064))
 
 ## [v4.0.0] -
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Changed limit parameter behaviour in GET sca checks endpoint. ([#6064](https://github.com/wazuh/wazuh/pull/6064))
+- Fixed an error with `/groups/{group_id}/config` Wazuh API endpoints (GET and PUT) when using complex `localfile` configurations. ([#6276](https://github.com/wazuh/wazuh/pull/6383))
+- Changed `limit` parameter behaviour in `GET sca/{agent_id}/checks/{policy_id}` endpoint. ([#6064](https://github.com/wazuh/wazuh/pull/6064))
 
 ## [v4.0.0] -
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
+### Fixed
+
+- Changed limit parameter behaviour in GET sca checks endpoint. ([#6064](https://github.com/wazuh/wazuh/pull/6064))
+
 ## [v4.0.0] -
 
 ### Added

--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -6,12 +6,12 @@
 import logging
 
 from aiohttp import web
-
-import wazuh.sca as sca
 from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
-from wazuh.core.common import database_limit
+
+import wazuh.sca as sca
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
+from wazuh.core.common import database_limit
 
 logger = logging.getLogger('wazuh')
 
@@ -20,20 +20,34 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
                         references=None, offset=0, limit=database_limit, sort=None, search=None, q=None):
     """Get security configuration assessment (SCA) database of an agent
 
-    :param agent_id: Agent ID. All possible values since 000 onwards.
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
-    :param name: Filters by policy name
-    :param description: Filters by policy description
-    :param references: Filters by references
-    :param offset:First element to return in the collection
-    :param limit: Maximum number of elements to return
-    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
-    ascending or descending order
-    :param search: Looks for elements with the specified string
-    :param q: Query to filter results by. This is specially useful to filter by total checks passed, failed or total
-    score (fields pass, fail, score)
-    :return: AllItemsResponseSCADatabase
+    Parameters
+    ----------
+    agent_id : str
+        Agent ID. All possible values since 000 onwards.
+    pretty : bool
+        Show results in human-readable format
+    wait_for_complete : bool
+        Disable timeout response
+    name : str
+        Filters by policy name
+    description : str
+        Filters by policy description
+    references : str
+        Filters by references
+    offset : int
+        First element to return in the collection
+    limit : int
+        Maximum number of elements to return
+    sort : str
+        Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order
+    search : str
+        Looks for elements with the specified string
+    q : str
+        Query to filter results by. This is specially useful to filter by total checks passed, failed or total score (fields pass, fail, score)
+
+    Returns
+    -------
+    AllItemsResponseSCADatabase
     """
     filters = {'name': name,
                'description': description,
@@ -65,31 +79,58 @@ async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete
                          condition=None, offset=0, limit=database_limit, sort=None, search=None, q=None):
     """Get policy monitoring alerts for a given policy
 
-    :param agent_id: Agent ID. All possible values since 000 onwards
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
-    :param policy_id: Filters by policy id
-    :param title: Filters by title
-    :param description: Filters by policy description
-    :param rationale: Filters by rationale
-    :param remediation: Filters by remediation
-    :param command: Filters by command
-    :param status: Filters by status
-    :param reason: Filters by reason
-    :param file: Filters by file
-    :param process: Filters by process
-    :param directory: Filters by directory
-    :param registry: Filters by registry
-    :param references: Filters by references
-    :param result: Filters by result
-    :param condition: Filters by condition
-    :param offset:First element to return in the collection
-    :param limit: Maximum number of elements to return
-    :param sort: Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in
-    ascending or descending order
-    :param search: Looks for elements with the specified string
-    :param q: Query to filter results by. This is specially useful to filter by total checks passed, failed or total
-    score (fields pass, fail, score)
+    Parameters
+    ----------
+    agent_id : str
+        Agent ID. All possible values since 000 onwards
+    pretty : bool
+        Show results in human-readable format
+    wait_for_complete : bool
+        Disable timeout response
+    policy_id : str
+        Filters by policy id
+    title : str
+        Filters by title
+    description : str
+        Filters by policy description
+    rationale : str
+        Filters by rationale
+    remediation : str
+        Filters by remediation
+    command : str
+        Filters by command
+    status : str
+        Filters by status
+    reason : str
+        Filters by reason
+    file : str
+        Filters by file
+    process : str
+        Filters by process
+    directory : str
+        Filters by directory
+    registry : str
+        Filters by registry
+    references : str
+        Filters by references
+    result : str
+        Filters by result
+    condition : str
+        Filters by condition
+    offset : int
+        First element to return in the collection
+    limit : int
+        Maximum number of elements to return
+    sort : str
+        Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order
+    search : str
+        Looks for elements with the specified string
+    q : str
+        Query to filter results by. This is specially useful to filter by total checks passed, failed or total score (fields pass, fail, score)
+
+    Returns
+    -------
+    AllItemsResponseSCADatabase
     """
     filters = {'title': title,
                'description': description,

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -302,6 +302,8 @@ stages:
           affected_items:
             - <<: *sca_check_result_001
             - <<: *sca_check_result_001
+            - <<: *sca_check_result_001
+            - <<: *sca_check_result_001
           failed_items: []
           total_failed_items: 0
 
@@ -322,6 +324,7 @@ stages:
         data:
           total_affected_items: !anyint
           affected_items:
+            - <<: *sca_check_result_001
             - <<: *sca_check_result_001
           failed_items: []
           total_failed_items: 0

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -998,7 +998,7 @@ stages:
           total_affected_items: !anyint
           affected_items:
             - <<: *sca_check_result_002
-            - <<: *sca_agent_result_002
+            - <<: *sca_check_result_002
           failed_items: []
           total_failed_items: 0
 

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -274,7 +274,6 @@ stages:
               rationale: !anystr
               title: !anystr
               policy_id: !anystr
-              file: !anystr
               description: !anystr
               id: !anyint
               result: !anystr
@@ -947,7 +946,6 @@ stages:
               rationale: !anystr
               title: !anystr
               policy_id: !anystr
-              file: !anystr
               description: !anystr
               id: !anyint
               result: !anystr
@@ -1522,7 +1520,6 @@ stages:
               rationale: !anystr
               title: !anystr
               policy_id: !anystr
-              file: !anystr
               description: !anystr
               id: !anyint
               result: !anystr

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -975,6 +975,8 @@ stages:
           affected_items:
             - <<: *sca_check_result_002
             - <<: *sca_check_result_002
+            - <<: *sca_agent_result_002
+            - <<: *sca_agent_result_002
           failed_items: []
           total_failed_items: 0
 
@@ -996,6 +998,7 @@ stages:
           total_affected_items: !anyint
           affected_items:
             - <<: *sca_check_result_002
+            - <<: *sca_agent_result_002
           failed_items: []
           total_failed_items: 0
 
@@ -1547,6 +1550,8 @@ stages:
           affected_items:
             - <<: *sca_check_result_003
             - <<: *sca_check_result_003
+            - <<: *sca_check_result_003
+            - <<: *sca_check_result_003
           failed_items: []
           total_failed_items: 0
 
@@ -1567,6 +1572,7 @@ stages:
         data:
           total_affected_items: !anyint
           affected_items:
+            - <<: *sca_check_result_003
             - <<: *sca_check_result_003
           failed_items: []
           total_failed_items: 0

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -975,8 +975,8 @@ stages:
           affected_items:
             - <<: *sca_check_result_002
             - <<: *sca_check_result_002
-            - <<: *sca_agent_result_002
-            - <<: *sca_agent_result_002
+            - <<: *sca_check_result_002
+            - <<: *sca_check_result_002
           failed_items: []
           total_failed_items: 0
 

--- a/framework/wazuh/core/tests/test_wdb.py
+++ b/framework/wazuh/core/tests/test_wdb.py
@@ -147,7 +147,7 @@ def test_execute(send_mock, socket_send_mock, connect_mock):
     mywdb = WazuhDBConnection()
     mywdb.execute('agent 000 sql delete from test', delete=True)
     mywdb.execute("agent 000 sql update test set value = 'test' where key = 'test'", update=True)
-    with patch("wazuh.core.wdb.WazuhDBConnection._send", return_value=[{'total':5}]):
+    with patch("wazuh.core.wdb.WazuhDBConnection._send", return_value=[{'total': 5}]):
         mywdb.execute("agent 000 sql select test from test offset 1 limit 1")
         mywdb.execute("agent 000 sql select test from test offset 1 limit 1", count=True)
         mywdb.execute("agent 000 sql select test from test offset 1 count")

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -189,7 +189,7 @@ class WazuhDBConnection:
         """
         def send_request_to_wdb(query_lower, step, off, response):
             try:
-                request = query_lower.replace(':limit', 'limit ' + str(step)).replace(':offset', 'offset ' + str(off))
+                request = query_lower.replace(':limit', 'limit {}'.format(step)).replace(':offset', 'offset {}'.format(off))
                 response.extend(self._send(request))
             except ValueError:
                 # if the step is already 1, it can't be divided

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -1,5 +1,3 @@
-
-
 # Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
@@ -57,10 +55,12 @@ class WazuhDBConnection:
         else:
             input_val_errors = [
                 (query_elements[sql_first_index] == 'sql', "Incorrect WDB request type."),
-                (query_elements[0] == 'agent' or query_elements[0] == 'global', "The {} database is not valid".format(query_elements[0])),
-                (query_elements[1].isdigit() if query_elements[0] == 'agent' else True, "Incorrect agent ID {}".format(query_elements[1])),
-                (query_elements[sql_first_index+1] == 'select' or query_elements[sql_first_index+1] == 'delete' or
-                 query_elements[sql_first_index+1] == 'update', "The API can only send select requests to WDB"),
+                (query_elements[0] == 'agent' or query_elements[0] == 'global',
+                 "The {} database is not valid".format(query_elements[0])),
+                (query_elements[1].isdigit() if query_elements[0] == 'agent' else True,
+                 "Incorrect agent ID {}".format(query_elements[1])),
+                (query_elements[sql_first_index + 1] == 'select' or query_elements[sql_first_index + 1] == 'delete' or
+                 query_elements[sql_first_index + 1] == 'update', "The API can only send select requests to WDB"),
                 (not ';' in query, "Found a not valid symbol in database query: ;")
             ]
 
@@ -189,7 +189,7 @@ class WazuhDBConnection:
         """
         def send_request_to_wdb(query_lower, step, off, response):
             try:
-                request = "{} limit {} offset {}".format(query_lower, step, off)
+                request = query_lower.replace(':limit', 'limit ' + str(step)).replace(':offset', 'offset ' + str(off))
                 response.extend(self._send(request))
             except ValueError:
                 # if the step is already 1, it can't be divided
@@ -219,30 +219,33 @@ class WazuhDBConnection:
             return self._send(query_lower)
 
         # Remove text inside 'where' clause to prevent finding reserved words (offset/count)
-        query_without_where = re.sub(r'where \(.*\)', 'where ()', query_lower)
+        query_without_where = re.sub(r'where \([^()]*\)', 'where ()', query_lower)
 
         # if the query has already a parameter limit / offset, divide using it
         offset = 0
         if 'offset' in query_without_where:
             offset = int(re.compile(r".* offset (\d+)").match(query_lower).group(1))
-            query_lower = query_lower.replace(" offset {}".format(offset), "")
+            # Replace offset with a wildcard
+            query_lower = query_lower.replace(" offset {}".format(offset), " :offset")
 
         if not re.search(r'.?select count\([\w \*]+\)( as [^,]+)? from', query_without_where):
             lim = 0
             if 'limit' in query_lower:
                 lim = int(re.compile(r".* limit (\d+)").match(query_lower).group(1))
-                query_lower = query_lower.replace(" limit {}".format(lim), "")
+                # Replace limit with a wildcard
+                query_lower = query_lower.replace(" limit {}".format(lim), " :limit")
 
             regex = re.compile(r"\w+(?: \d*|)? sql select ([A-Z a-z0-9,*_` \.\-%\(\):\']+) from")
             select = regex.match(query_lower).group(1)
-            countq = query_lower.replace(select, "count(*)", 1)
             gb_regex = re.compile(r"(group by [^\s]+)")
+            countq = query_lower.replace(select, "count(*)", 1).replace(":limit", "").replace(":offset", "")
             try:
                 group_by = gb_regex.search(query_lower)
                 if group_by:
                     countq = countq.replace(group_by.group(1), '')
             except IndexError:
                 pass
+
             try:
                 total = list(self._send(countq)[0].values())[0]
             except IndexError:
@@ -253,7 +256,7 @@ class WazuhDBConnection:
             response = []
             step = limit if limit < self.request_slice and limit > 0 else self.request_slice
             try:
-                for off in range(offset, limit+offset, step):
+                for off in range(offset, limit + offset, step):
                     send_request_to_wdb(query_lower, step, off, response)
             except ValueError as e:
                 raise WazuhError(2006, str(e))

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -196,7 +196,8 @@ class WazuhDBConnection:
                 if step == 1:
                     raise WazuhInternalError(2007)
                 send_request_to_wdb(query_lower, step // 2, off, response)
-                send_request_to_wdb(query_lower, step // 2, step // 2 + off, response)
+                # Add step // 2 remaining when the step is odd to avoid losing information
+                send_request_to_wdb(query_lower, step // 2 + step % 2, step // 2 + off, response)
 
         query_lower = self.__query_lower(query)
 

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -22,15 +22,28 @@ def get_sca_list(agent_list=None, q="", offset=0, limit=common.database_limit, s
                  filters=None):
     """ Get a list of policies analyzed in the configuration assessment for a given agent
 
-    :param agent_list: agent id to get policies from
-    :param q: Defines query to filter in DB.
-    :param offset: First item to return.
-    :param limit: Maximum number of items to return.
-    :param sort: Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
-    :param search: Looks for items with the specified string. Format: {"fields": ["field1","field2"]}
-    :param select: Select fields to return. Format: {"fields":["field1","field2"]}.
-    :param filters: Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
-    :return: AffectedItemsWazuhResult
+    Parameters
+    ----------
+    agent_list : list
+        Agent ids to get policies from.
+    q : str
+        Defines query to filter in DB.
+    offset : int
+        First item to return.
+    limit : int
+        Maximum number of items to return.
+    sort : str
+        Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
+    search : str
+        Looks for items with the specified string. Format: {"fields": ["field1","field2"]}
+    select : str
+        Select fields to return. Format: {"fields":["field1","field2"]}.
+    filters : str
+        Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
+
+    Returns
+    -------
+    AffectedItemsWazuhResult
     """
     result = AffectedItemsWazuhResult(all_msg='All selected sca information was returned',
                                       some_msg='Some sca information was not returned',
@@ -57,16 +70,30 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
                    select=None, filters=None):
     """ Get a list of checks analyzed for a policy
 
-    :param policy_id: policy id to get the checks from
-    :param agent_list: agent id to get the policies from
-    :param q: Defines query to filter in DB.
-    :param offset: First item to return.
-    :param limit: Maximum number of items to return.
-    :param sort: Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
-    :param search: Looks for items with the specified string. Format: {"fields": ["field1","field2"]}
-    :param select: Select fields to return. Format: {"fields":["field1","field2"]}.
-    :param filters: Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
-    :return: AffectedItemsWazuhResult
+    Parameters
+    ----------
+    policy_id : str
+        Policy id to get the checks from.
+    agent_list : list
+        Agent id to get the policies from
+    q : str
+        Defines query to filter in DB.
+    offset : int
+        First item to return.
+    limit : int
+        Maximum number of items to return.
+    sort : str
+        Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
+    search : str
+        Looks for items with the specified string. Format: {"fields": ["field1","field2"]}
+    select : str
+        Select fields to return. Format: {"fields":["field1","field2"]}.
+    filters : str
+        Define field filters required by the user. Format: {"field1":"value1", "field2":["value2","value3"]}
+
+    Returns
+    -------
+    AffectedItemsWazuhResult
     """
     result = AffectedItemsWazuhResult(all_msg='All selected sca/policy information was returned',
                                       some_msg='Some sca/policy information was not returned',

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -12,7 +12,8 @@ from wazuh.core.agent import get_agents_info
 from wazuh.core.exception import WazuhInternalError, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.sca import WazuhDBQuerySCA, fields_translation_sca, fields_translation_sca_check, \
-    fields_translation_sca_check_compliance, fields_translation_sca_check_rule, default_query_sca_check
+    fields_translation_sca_check_compliance, fields_translation_sca_check_rule, default_query_sca_check, \
+    WazuhDBQuerySCACheck
 from wazuh.rbac.decorators import expose_resources
 
 
@@ -82,11 +83,11 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
                            list(fields_translation_sca_check_rule.keys())
                            )
 
-            db_query = WazuhDBQuerySCA(agent_id=agent_list[0], offset=offset, limit=limit, sort=sort, search=search,
-                                       select=full_select, count=True, get_data=True,
-                                       query=f"policy_id={policy_id}" if q == "" else f"policy_id={policy_id};{q}",
-                                       filters=filters, default_query=default_query_sca_check,
-                                       default_sort_field='policy_id', fields=fields_translation, count_field='id')
+            db_query = WazuhDBQuerySCACheck(agent_id=agent_list[0], offset=offset, limit=limit, sort=sort,
+                                            search=search, select=full_select, count=True, get_data=True,
+                                            query=f"policy_id={policy_id}" if q == "" else f"policy_id={policy_id};{q}",
+                                            filters=filters, default_query=default_query_sca_check,
+                                            default_sort_field='policy_id', fields=fields_translation, count_field='id')
 
             result_dict = db_query.run()
 

--- a/framework/wazuh/tests/test_sca.py
+++ b/framework/wazuh/tests/test_sca.py
@@ -223,6 +223,6 @@ def test_sca_response_without_result(mock_agent, mock_sca_agent):
     """
     with patch('wazuh.core.sca.WazuhDBBackend') as mock_wdb:
         mock_wdb.return_value.connect_to_db.return_value.execute.side_effect = get_fake_sca_data
-        with patch('wazuh.core.sca.WazuhDBQuerySCA.run', return_value={}):
+        with patch('wazuh.core.sca.WazuhDBQuerySCACheck.run', return_value={}):
             with pytest.raises(exception.WazuhException, match=".* 2007 .*"):
                 get_sca_checks('not_exists', agent_list=['000'])


### PR DESCRIPTION
|Related issue|
|---|
|#5878|

Hi team,


**The next changes were also posted in the PR #6064, but it needed to be closed due to a change on the base branch. Due to the odd offset issue when paginating, these changes are going to be merged into 4.0.**


This PR is related to the issue #5878 . This PR is solving the limit parameter problem as well as the odd offset issue when paginating wdb queries (last commit).

For the first problem, I have changed the `limit` parameter behavior in `GET /sca/{agent_id}/checks/{policy_id}` endpoint.

**Before the changes**, the `limit` parameter was not working as expected, when you set the `limit` to 3 (as an instance), the `rules` and `compliances` of every check were counted to reach to that limit.

**New behavior**, different than the one proposed in the issue, when you set the `limit` to 3, you will get 3 different checks and all the `rules` and `compliances` corresponding to these 3 checks. 

**CHANGES**: 

- API integration test cases added/updated. `File` field in the json response for `sca check` test had to be removed because it is not always returned. After the changes to the endpoint, for agent `001`, policy_id `cis_debian9_L1` and limit `1`, `File` is not returned, as an instance.

- Function descriptions adapted to `numpydoc` format.

- In `wdb.py`, I have used wildcards in order to know where are the limit and offset parameter. This change will make future queries easier to do as `wdb.py` used to add `limit` and `offset` parameters at the end of the query, which could be wrong sometimes (in this case, for instance).

- `Limit` and `offset` parameters were deleted when removing `where` keyword in query -> updated regex in `wdb.py` in order to make it more appropriate. 

**Test results:**
- API integration tests:
```
test_rbac_black_sca_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rbac_white_sca_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_sca_endpoints.tavern.yaml 
	 6 passed, 8 warnings
```

- Unit tests, all core and SDK tests are passing, showing `test_sca.py`:
```
pytest framework/wazuh/tests/test_sca.py 
============================== 7 passed in 0.31s ===============================
```

**Example of the new behavior:**

- Request:
`curl -X GET "https://localhost:55000/sca/000/checks/cis_debian9_L2?limit=3" -H "accept: application/json" -H "Authorization: Bearer $TOKEN" -k`

- Response:
```
{
   "data": {
      "affected_items": [
         {
            "reason": "",
            "file": "/etc/ssh/sshd_config",
            "result": "failed",
            "description": "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections.",
            "title": "Ensure SSH X11 forwarding is disabled",
            "condition": "all",
            "remediation": "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders.",
            "id": 3528,
            "policy_id": "cis_debian9_L2",
            "status": "",
            "rationale": "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders.",
            "compliance": [
               {
                  "key": "cis_csc",
                  "value": "9.2"
               },
               {
                  "key": "cis",
                  "value": "5.2.6"
               }
            ],
            "rules": [
               {
                  "type": "file",
                  "rule": "f:/etc/ssh/sshd_config -> !r:^# && r:X11Forwarding\\s+no"
               }
            ]
         },
         {
            "reason": "",
            "result": "failed",
            "description": "Set system audit so that audit rules cannot be modified with auditctl. Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot.",
            "title": "Ensure the audit configuration is immutable",
            "directory": "/etc/audit",
            "condition": "all",
            "remediation": "Add the following line to the end of the /etc/audit/audit.rules file: -e 2. Notes: This setting will ensure reloading the auditd config to set active settings requires a system reboot.",
            "id": 3527,
            "policy_id": "cis_debian9_L2",
            "status": "",
            "rationale": "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes.",
            "compliance": [
               {
                  "key": "cis_csc",
                  "value": "6.2,6.3"
               },
               {
                  "key": "cis",
                  "value": "4.1.18"
               }
            ],
            "rules": [
               {
                  "type": "directory",
                  "rule": "d:/etc/audit"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^\\s*\\t*-e 2$"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules"
               }
            ]
         },
         {
            "reason": "",
            "result": "failed",
            "description": "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\".",
            "title": "Ensure kernel module loading and unloading is collected",
            "directory": "/etc/audit",
            "condition": "all",
            "remediation": "For 32 bit systems add the following lines to the /etc/audit/audit.rules file: -w /sbin/insmod -p x -k modules | -w /sbin/rmmod -p x -k modules | -w /sbin/modprobe -p x -k modules | -a always,exit -F arch=b32 -S init_module -S delete_module -k modules. For 64 bit systems add the following lines to the /etc/audit/audit.rules file: -w /sbin/insmod -p x -k modules | -w /sbin/rmmod -p x -k modules | -w /sbin/modprobe -p x -k modules | -a always,exit -F arch=b64 -S init_module -S delete_module -k modules. Notes: Reloading the auditd config to set active settings may require a system reboot.",
            "id": 3526,
            "policy_id": "cis_debian9_L2",
            "status": "",
            "rationale": "Monitoring the use of insmod, rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules.",
            "compliance": [
               {
                  "key": "cis",
                  "value": "4.1.17"
               },
               {
                  "key": "cis_csc",
                  "value": "5.1"
               }
            ],
            "rules": [
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b64 && r:-S init_module && r:-S delete_module && r:-k modules"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-w && r:/sbin/modprobe && r:-p x && r:-k modules"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-w && r:/sbin/insmod && r:-p x && r:-k modules"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules -> r:^-w && r:/sbin/rmmod && r:-p x && r:-k modules"
               },
               {
                  "type": "directory",
                  "rule": "d:/etc/audit"
               },
               {
                  "type": "file",
                  "rule": "f:/etc/audit/audit.rules"
               }
            ]
         }
      ],
      "total_affected_items": 29,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All selected sca/policy information was returned"
}
```

Regards,
Manuel.