### PR TITLE
6356 os info linux

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1209,7 +1209,7 @@ syscollector_cpp := $(wildcard wazuh_modules/syscollector/*Win.cpp)
 else ifeq (${uname_S},Linux)
 syscollector_cpp := $(wildcard wazuh_modules/syscollector/*Linux.cpp) wazuh_modules/syscollector/sysOsParsers.cpp
 else ifeq (${uname_S},Darwin)
-syscollector_cpp := $(wildcard wazuh_modules/syscollector/*Mac.cpp) $(wildcard wazuh_modules/syscollector/*CommonBSD.cpp)
+syscollector_cpp := $(wildcard wazuh_modules/syscollector/*Mac.cpp) $(wildcard wazuh_modules/syscollector/*CommonBSD.cpp) wazuh_modules/syscollector/sysOsParsers.cpp
 else ifeq (${uname_S},FreeBSD)
 syscollector_cpp := $(wildcard wazuh_modules/syscollector/*FreeBSD.cpp) $(wildcard wazuh_modules/syscollector/*CommonBSD.cpp) wazuh_modules/syscollector/sysOsParsers.cpp
 else ifeq (${uname_S},OpenBSD)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1207,13 +1207,13 @@ build_syscollector: build_shared_modules
 ifeq (${TARGET},winagent)
 syscollector_cpp := $(wildcard wazuh_modules/syscollector/*Win.cpp)
 else ifeq (${uname_S},Linux)
-syscollector_cpp := $(wildcard wazuh_modules/syscollector/*Linux.cpp) $(wildcard wazuh_modules/syscollector/*sysOsParsers.cpp)
+syscollector_cpp := $(wildcard wazuh_modules/syscollector/*Linux.cpp) wazuh_modules/syscollector/sysOsParsers.cpp
 else ifeq (${uname_S},Darwin)
 syscollector_cpp := $(wildcard wazuh_modules/syscollector/*Mac.cpp) $(wildcard wazuh_modules/syscollector/*CommonBSD.cpp)
 else ifeq (${uname_S},FreeBSD)
-syscollector_cpp := $(wildcard wazuh_modules/syscollector/*FreeBSD.cpp) $(wildcard wazuh_modules/syscollector/*CommonBSD.cpp)
+syscollector_cpp := $(wildcard wazuh_modules/syscollector/*FreeBSD.cpp) $(wildcard wazuh_modules/syscollector/*CommonBSD.cpp) wazuh_modules/syscollector/sysOsParsers.cpp
 else ifeq (${uname_S},OpenBSD)
-syscollector_cpp := $(wildcard wazuh_modules/syscollector/*OpenBSD.cpp) $(wildcard wazuh_modules/syscollector/*CommonBSD.cpp)
+syscollector_cpp := $(wildcard wazuh_modules/syscollector/*OpenBSD.cpp) $(wildcard wazuh_modules/syscollector/*CommonBSD.cpp) wazuh_modules/syscollector/sysOsParsers.cpp
 endif
 
 ifeq (${TARGET},winagent)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1207,7 +1207,7 @@ build_syscollector: build_shared_modules
 ifeq (${TARGET},winagent)
 syscollector_cpp := $(wildcard wazuh_modules/syscollector/*Win.cpp)
 else ifeq (${uname_S},Linux)
-syscollector_cpp := $(wildcard wazuh_modules/syscollector/*Linux.cpp)
+syscollector_cpp := $(wildcard wazuh_modules/syscollector/*Linux.cpp) $(wildcard wazuh_modules/syscollector/*sysOsParsers.cpp)
 else ifeq (${uname_S},Darwin)
 syscollector_cpp := $(wildcard wazuh_modules/syscollector/*Mac.cpp) $(wildcard wazuh_modules/syscollector/*CommonBSD.cpp)
 else ifeq (${uname_S},FreeBSD)

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -52,11 +52,13 @@ else()
   elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     file(GLOB SYSCOLLECTOR_SRC
         "${CMAKE_SOURCE_DIR}/*FreeBSD.cpp"
-        "${CMAKE_SOURCE_DIR}/*CommonBSD.cpp")
+        "${CMAKE_SOURCE_DIR}/*CommonBSD.cpp"
+        "${CMAKE_SOURCE_DIR}/sysOsParsers.cpp")
   elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
     file(GLOB SYSCOLLECTOR_SRC
         "${CMAKE_SOURCE_DIR}/*OpenBSD.cpp"
-        "${CMAKE_SOURCE_DIR}/*CommonBSD.cpp")
+        "${CMAKE_SOURCE_DIR}/*CommonBSD.cpp"
+        "${CMAKE_SOURCE_DIR}/sysOsParsers.cpp")
   endif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -38,7 +38,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_definitions(-DWIN32=1)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   file(GLOB SYSCOLLECTOR_SRC
-      "${CMAKE_SOURCE_DIR}/*Linux.cpp")
+      "${CMAKE_SOURCE_DIR}/*Linux.cpp"
+      "${CMAKE_SOURCE_DIR}/sysOsParsers.cpp")
 else()
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     file(GLOB SYSCOLLECTOR_SRC

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -48,7 +48,8 @@ else()
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     file(GLOB SYSCOLLECTOR_SRC
         "${CMAKE_SOURCE_DIR}/*Mac.cpp"
-        "${CMAKE_SOURCE_DIR}/*CommonBSD.cpp")
+        "${CMAKE_SOURCE_DIR}/*CommonBSD.cpp"
+        "${CMAKE_SOURCE_DIR}/sysOsParsers.cpp")
   elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     file(GLOB SYSCOLLECTOR_SRC
         "${CMAKE_SOURCE_DIR}/*FreeBSD.cpp"

--- a/src/wazuh_modules/syscollector/sysInfo.cpp
+++ b/src/wazuh_modules/syscollector/sysInfo.cpp
@@ -25,3 +25,8 @@ nlohmann::json SysInfo::packages()
 {
     return getPackages();
 }
+
+nlohmann::json SysInfo::os()
+{
+    return getOsInfo();
+}

--- a/src/wazuh_modules/syscollector/sysInfo.hpp
+++ b/src/wazuh_modules/syscollector/sysInfo.hpp
@@ -21,6 +21,7 @@ public:
     virtual ~SysInfo() = default;
     nlohmann::json hardware();
     nlohmann::json packages();
+    nlohmann::json os();
 private:
     virtual std::string getSerialNumber() const;
     virtual std::string getCpuName() const;
@@ -28,6 +29,7 @@ private:
     virtual int getCpuCores() const;
     virtual void getMemory(nlohmann::json& info) const;
     virtual nlohmann::json getPackages() const;
+    virtual nlohmann::json getOsInfo() const;
 };
 
 

--- a/src/wazuh_modules/syscollector/sysInfoCommonBSD.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoCommonBSD.cpp
@@ -66,8 +66,3 @@ std::string SysInfo::getCpuName() const
     spBuff.get()[len] = 0;
     return std::string{reinterpret_cast<const char*>(spBuff.get())};
 }
-
-nlohmann::json SysInfo::getPackages() const
-{
-    return {};
-}

--- a/src/wazuh_modules/syscollector/sysInfoFreeBSD.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoFreeBSD.cpp
@@ -125,5 +125,13 @@ nlohmann::json SysInfo::getOsInfo() const
         ret["os_platform"] = "bsd";
         ret["os_version"] = "unknown";
     }
+    if (uname(&uts) >= 0)
+    {
+        ret["sysname"] = uts.sysname;
+        ret["host_name"] = uts.nodename;
+        ret["version"] = uts.version;
+        ret["architecture"] = uts.machine;
+        ret["release"] = uts.release;
+    }
     return ret;
 }

--- a/src/wazuh_modules/syscollector/sysInfoFreeBSD.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoFreeBSD.cpp
@@ -14,6 +14,7 @@
 #include "sysOsParsers.h"
 #include <sys/sysctl.h>
 #include <sys/vmmeter.h>
+#include <sys/utsname.h>
 
 void SysInfo::getMemory(nlohmann::json& info) const
 {
@@ -118,6 +119,7 @@ nlohmann::json SysInfo::getProcessesInfo() const
 nlohmann::json SysInfo::getOsInfo() const
 {
     nlohmann::json ret;
+    struct utsname uts{};
     const auto spParser{FactorySysOsParser::create("bsd")};
     if(!spParser->parseUname(Utils::exec("uname -r"), ret))
     {

--- a/src/wazuh_modules/syscollector/sysInfoFreeBSD.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoFreeBSD.cpp
@@ -113,3 +113,16 @@ nlohmann::json SysInfo::getProcessesInfo() const
     // Currently not supported for this OS
     return {};
 }
+
+nlohmann::json SysInfo::getOsInfo() const
+{
+    nlohmann::json ret;
+    const auto spParser{FactorySysOsParser::create("bsd")};
+    if(!spParser->parseUname(Utils::exec("uname -r"), ret))
+    {
+        ret["os_name"] = "BSD";
+        ret["os_platform"] = "bsd";
+        ret["os_version"] = "unknown";
+    }
+    return ret;
+}

--- a/src/wazuh_modules/syscollector/sysInfoFreeBSD.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoFreeBSD.cpp
@@ -11,6 +11,7 @@
 #include "sysInfo.hpp"
 #include "cmdHelper.h"
 #include "stringHelper.h"
+#include "sysOsParsers.h"
 #include <sys/sysctl.h>
 #include <sys/vmmeter.h>
 

--- a/src/wazuh_modules/syscollector/sysInfoLinux.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoLinux.cpp
@@ -361,7 +361,7 @@ static bool getOsInfoFromFiles(nlohmann::json& info)
 {
     bool ret{false};
     const std::vector<std::string> UNIX_RELEASE_FILES{"/etc/os-release", "/usr/lib/os-release"};
-    const auto CENTOS_RELEASE_FILE{"/etc/centos-release"};
+    constexpr auto CENTOS_RELEASE_FILE{"/etc/centos-release"};
     static const std::vector<std::pair<std::string, std::string>> PLATFORMS_RELEASE_FILES
     {
         {"centos",      CENTOS_RELEASE_FILE     },
@@ -399,7 +399,6 @@ static bool getOsInfoFromFiles(nlohmann::json& info)
     {
         for (const auto& platform : PLATFORMS_RELEASE_FILES)
         {
-            std::fstream file{platform.second, std::ios_base::in};
             ret |= parseFnc(platform.second, platform.first);
         }
     }

--- a/src/wazuh_modules/syscollector/sysInfoMac.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoMac.cpp
@@ -19,6 +19,7 @@
 #include <sys/proc.h>
 #include <sys/proc_info.h>
 #include <sys/sysctl.h>
+#include <sys/utsname.h>
 #include <fstream>
 
 const std::string MAC_APPS_PATH{"/Applications"};
@@ -257,6 +258,7 @@ nlohmann::json SysInfo::getProcessesInfo() const
 nlohmann::json SysInfo::getOsInfo() const
 {
     nlohmann::json ret;
+    struct utsname uts{};
     MacOsParser parser;
     parser.parseSwVersion(Utils::exec("sw_vers"), ret);
     parser.parseUname(Utils::exec("uname -r"), ret);

--- a/src/wazuh_modules/syscollector/sysInfoMac.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoMac.cpp
@@ -12,6 +12,7 @@
 #include "cmdHelper.h"
 #include "stringHelper.h"
 #include "filesystemHelper.h"
+#include "sysOsParsers.h"
 #include <libproc.h>
 #include <pwd.h>
 #include <grp.h>
@@ -251,4 +252,13 @@ nlohmann::json SysInfo::getProcessesInfo() const
     }
 
     return jsProcessesList;
+}
+
+nlohmann::json SysInfo::getOsInfo() const
+{
+    nlohmann::json ret;
+    MacOsParser parser;
+    parser.parseSwVersion(Utils::exec("sw_vers"), ret);
+    parser.parseUname(Utils::exec("uname -r"), ret);
+    return ret;
 }

--- a/src/wazuh_modules/syscollector/sysInfoMac.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoMac.cpp
@@ -260,5 +260,13 @@ nlohmann::json SysInfo::getOsInfo() const
     MacOsParser parser;
     parser.parseSwVersion(Utils::exec("sw_vers"), ret);
     parser.parseUname(Utils::exec("uname -r"), ret);
+    if (uname(&uts) >= 0)
+    {
+        ret["sysname"] = uts.sysname;
+        ret["host_name"] = uts.nodename;
+        ret["version"] = uts.version;
+        ret["architecture"] = uts.machine;
+        ret["release"] = uts.release;
+    }
     return ret;
 }

--- a/src/wazuh_modules/syscollector/sysInfoOpenBSD.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoOpenBSD.cpp
@@ -93,3 +93,16 @@ nlohmann::json SysInfo::getProcessesInfo() const
     // Currently not supported for this OS
     return {};
 }
+
+nlohmann::json SysInfo::getOsInfo() const
+{
+    nlohmann::json ret;
+    const auto spParser{FactorySysOsParser::create("bsd")};
+    if(!spParser->parseUname(Utils::exec("uname -r"), ret))
+    {
+        ret["os_name"] = "BSD";
+        ret["os_platform"] = "bsd";
+        ret["os_version"] = "unknown";
+    }
+    return ret;
+}

--- a/src/wazuh_modules/syscollector/sysInfoOpenBSD.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoOpenBSD.cpp
@@ -13,6 +13,7 @@
 #include "sysOsParsers.h"
 #include "stringHelper.h"
 #include <sys/sysctl.h>
+#include <sys/utsname.h>
 
 void SysInfo::getMemory(nlohmann::json& info) const
 {
@@ -98,6 +99,7 @@ nlohmann::json SysInfo::getProcessesInfo() const
 nlohmann::json SysInfo::getOsInfo() const
 {
     nlohmann::json ret;
+    struct utsname uts{};
     const auto spParser{FactorySysOsParser::create("bsd")};
     if(!spParser->parseUname(Utils::exec("uname -r"), ret))
     {

--- a/src/wazuh_modules/syscollector/sysInfoOpenBSD.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoOpenBSD.cpp
@@ -96,6 +96,12 @@ nlohmann::json SysInfo::getProcessesInfo() const
     return {};
 }
 
+nlohmann::json SysInfo::getPackages() const
+{
+    // Currently not supported for this OS
+    return {};
+}
+
 nlohmann::json SysInfo::getOsInfo() const
 {
     nlohmann::json ret;

--- a/src/wazuh_modules/syscollector/sysInfoOpenBSD.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoOpenBSD.cpp
@@ -105,5 +105,13 @@ nlohmann::json SysInfo::getOsInfo() const
         ret["os_platform"] = "bsd";
         ret["os_version"] = "unknown";
     }
+    if (uname(&uts) >= 0)
+    {
+        ret["sysname"] = uts.sysname;
+        ret["host_name"] = uts.nodename;
+        ret["version"] = uts.version;
+        ret["architecture"] = uts.machine;
+        ret["release"] = uts.release;
+    }
     return ret;
 }

--- a/src/wazuh_modules/syscollector/sysInfoOpenBSD.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoOpenBSD.cpp
@@ -10,6 +10,7 @@
  */
 #include "sysInfo.hpp"
 #include "cmdHelper.h"
+#include "sysOsParsers.h"
 #include "stringHelper.h"
 #include <sys/sysctl.h>
 

--- a/src/wazuh_modules/syscollector/sysInfoWin.cpp
+++ b/src/wazuh_modules/syscollector/sysInfoWin.cpp
@@ -608,3 +608,9 @@ nlohmann::json SysInfo::getPackages() const
     getHotFixFromRegNT(HKEY_LOCAL_MACHINE, VISTA_REG_HOTFIX, ret);
     return ret;
 }
+
+nlohmann::json SysInfo::getOsInfo() const
+{
+    // Currently not supported for this OS
+    return {};
+}

--- a/src/wazuh_modules/syscollector/sysOsParsers.cpp
+++ b/src/wazuh_modules/syscollector/sysOsParsers.cpp
@@ -246,3 +246,50 @@ bool HpUxOsParser::parseUname(const std::string& in, nlohmann::json& output)
     output["os_platform"] = "hp-ux";
     return ret;
 }
+
+bool MacOsParser::parseSwVersion(const std::string& in, nlohmann::json& output)
+{
+    static const std::map<std::string, std::string> KEY_MAP
+    {
+        {"ProductName",     "os_name"},
+        {"ProductVersion",  "os_version"},
+        {"BuildVersion",    "os_build"},
+    };
+    enum ValueIds
+    {
+        KEY_ID,
+        DATA_ID,
+        MAX_ID
+    };
+    bool ret{false};
+    const auto lines{Utils::split(in, '\n')};
+    for (auto line : lines)
+    {
+        line = Utils::trim(line);
+        const auto data{Utils::split(line, ':')};
+        if (data.size() == MAX_ID)
+        {
+            const auto it{KEY_MAP.find(data[KEY_ID])};
+            if (it != KEY_MAP.end())
+            {
+                output[it->second] = Utils::trim(data[DATA_ID], " \t");
+                ret = true;
+            }
+        }
+    }
+    output["os_platform"] = "darwin";
+    return ret;
+}
+
+bool MacOsParser::parseUname(const std::string& in, nlohmann::json& output)
+{
+    constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
+    std::string match;
+    std::regex pattern{PATTERN_MATCH};
+    const auto ret {findRegexInString(in, match, pattern, 0)};
+    if (ret)
+    {
+        output["os_codename"] = match;
+    }
+    return ret;
+}

--- a/src/wazuh_modules/syscollector/sysOsParsers.cpp
+++ b/src/wazuh_modules/syscollector/sysOsParsers.cpp
@@ -1,0 +1,248 @@
+/*
+ * Wazuh SysInfo
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * October 28, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "sysOsParsers.h"
+#include "stringHelper.h"
+#include <regex>
+
+bool UnixOsParser::parseFile(std::istream& in, nlohmann::json& info)
+{
+    static const std::map<std::string, std::string> KEY_MAP
+    {
+        {"NAME",    "os_name"},
+        {"VERSION", "os_version"},
+        {"ID",      "os_platform"}
+    };
+    enum ValueIds
+    {
+        KEY_ID,
+        DATA_ID,
+        MAX_ID
+    };
+    bool ret{false};
+    std::string line;
+    while(std::getline(in, line))
+    {
+        line = Utils::trim(line);
+        const auto data{Utils::split(line, '=')};
+        if (data.size() == MAX_ID)
+        {
+            const auto it{KEY_MAP.find(data[KEY_ID])};
+            if (it != KEY_MAP.end())
+            {
+                info[it->second] = Utils::trim(data[DATA_ID], " \"");
+                ret = true;
+            }
+        }
+    }
+    return ret;
+}
+
+static bool findRegexInString(const std::string& in,
+                              std::string& match,
+                              const std::regex& pattern,
+                              const size_t matchIndex = 0,
+                              const std::string& start = "")
+{
+    bool ret{false};
+    if (start.empty() || Utils::startsWith(in, start))
+    {
+        std::smatch sm;
+        ret = std::regex_search(in, sm, pattern);
+        if (ret && sm.size() >= matchIndex)
+        {
+            match = sm[matchIndex];
+        }
+    }
+    return ret;
+}
+
+static bool findVersionInStream(std::istream& in,
+                                nlohmann::json& output,
+                                const std::string& regex,
+                                const size_t matchIndex = 0,
+                                const std::string& start = "")
+{
+    bool ret{false};
+    std::string line;
+    std::string match;
+    std::regex pattern{regex};
+    while(!ret && std::getline(in, line))
+    {
+        line = Utils::trim(line);
+        ret = findRegexInString(line, match, pattern, matchIndex, start);
+    }
+    if (ret)
+    {
+        output["os_version"] = match;
+    }
+    return ret;
+}
+
+bool UbuntuOsParser::parseFile(std::istream& in, nlohmann::json& output)
+{
+    constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
+    constexpr auto DISTRIB_FIELD{"DISTRIB_DESCRIPTION"};
+    output["os_name"] = "Ubuntu";
+    output["os_platform"] = "ubuntu";
+    return findVersionInStream(in, output, PATTERN_MATCH, 0, DISTRIB_FIELD);
+}
+
+bool CentosOsParser::parseFile(std::istream& in, nlohmann::json& output)
+{
+    constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
+    output["os_name"] = "Centos Linux";
+    output["os_platform"] = "centos";
+    return findVersionInStream(in, output, PATTERN_MATCH);
+}
+
+bool BSDOsParser::parseUname(const std::string& in, nlohmann::json& output)
+{
+    constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
+    std::string match;
+    std::regex pattern{PATTERN_MATCH};
+    const auto ret {findRegexInString(in, match, pattern)};
+    if (ret)
+    {
+        output["os_version"] = match;
+    }
+    output["os_name"] = "BSD";
+    output["os_platform"] = "bsd";
+    return ret;
+}
+
+bool RedHatOsParser::parseFile(std::istream& in, nlohmann::json& output)
+{
+    constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
+    bool ret{false};
+    std::string line;
+    std::regex pattern{PATTERN_MATCH};
+    while(std::getline(in, line))
+    {
+        std::string match;
+        line = Utils::trim(line);
+        ret = findRegexInString(line, match, pattern);
+        if (ret)
+        {
+            output["os_version"] = match;
+        }
+        if (line.find("CentOS") != std::string::npos)
+        {
+            output["os_name"] = "Centos Linux";
+            output["os_platform"] = "centos";
+        }
+        else if (line.find("Fedora") != std::string::npos)
+        {
+            output["os_name"] = "Fedora";
+            output["os_platform"] = "fedora";
+        }
+        else if (line.find("Server") != std::string::npos)
+        {
+            output["os_name"] = "Red Hat Enterprise Linux Server";
+            output["os_platform"] = "rhel";
+        }
+        else
+        {
+            output["os_name"] = "Red Hat Enterprise Linux";
+            output["os_platform"] = "rhel";
+        }
+    }
+    return ret;
+}
+
+bool DebianOsParser::parseFile(std::istream& in, nlohmann::json& output)
+{
+    constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
+    output["os_name"] = "Debian GNU/Linux";
+    output["os_platform"] = "debian";
+    return findVersionInStream(in, output, PATTERN_MATCH);
+}
+
+bool ArchOsParser::parseFile(std::istream& in, nlohmann::json& output)
+{
+    constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
+    output["os_name"] = "Arch Linux";
+    output["os_platform"] = "arch";
+    return findVersionInStream(in, output, PATTERN_MATCH);
+}
+
+bool SlackwareOsParser::parseFile(std::istream& in, nlohmann::json& output)
+{
+    constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
+    output["os_name"] = "Slackware";
+    output["os_platform"] = "slackware";
+    return findVersionInStream(in, output, PATTERN_MATCH);
+}
+
+bool GentooOsParser::parseFile(std::istream& in, nlohmann::json& output)
+{
+    constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
+    output["os_name"] = "Gentoo";
+    output["os_platform"] = "gentoo";
+    return findVersionInStream(in, output, PATTERN_MATCH);
+}
+
+bool SuSEOsParser::parseFile(std::istream& in, nlohmann::json& output)
+{
+    constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
+    constexpr auto VERSION_FIELD{"VERSION"};
+    output["os_name"] = "SuSE Linux";
+    output["os_platform"] = "suse";
+    return findVersionInStream(in, output, PATTERN_MATCH, 0, VERSION_FIELD);
+}
+
+bool FedoraOsParser::parseFile(std::istream& in, nlohmann::json& output)
+{
+    constexpr auto PATTERN_MATCH{R"([0-9]+\.*)"};
+    output["os_name"] = "Fedora";
+    output["os_platform"] = "fedora";
+    return findVersionInStream(in, output, PATTERN_MATCH);
+}
+
+bool SolarisOsParser::parseFile(std::istream& in, nlohmann::json& output)
+{
+    const std::string HEADER_STRING{"Oracle Solaris "};
+    output["os_name"] = "SunOS";
+    output["os_platform"] = "sunos";
+    std::string line;
+    bool ret{false};
+    while(!ret && std::getline(in, line))
+    {
+        line = Utils::trim(line);
+        ret = Utils::startsWith(line, HEADER_STRING);
+        if (ret)
+        {
+            line = line.substr(HEADER_STRING.size());
+            const auto pos{line.find(" ")};
+            if (pos != std::string::npos)
+            {
+                line = line.substr(0, pos);
+            }
+            output["os_version"] = Utils::trim(line);
+        }
+    }
+    return ret;
+}
+
+bool HpUxOsParser::parseUname(const std::string& in, nlohmann::json& output)
+{
+    constexpr auto PATTERN_MATCH{R"(B\.([0-9].*\.[0-9]*))"};
+    std::string match;
+    std::regex pattern{PATTERN_MATCH};
+    const auto ret {findRegexInString(in, match, pattern, 1)};
+    if (ret)
+    {
+        output["os_version"] = match;
+    }
+    output["os_name"] = "HP-UX";
+    output["os_platform"] = "hp-ux";
+    return ret;
+}

--- a/src/wazuh_modules/syscollector/sysOsParsers.cpp
+++ b/src/wazuh_modules/syscollector/sysOsParsers.cpp
@@ -87,15 +87,14 @@ static bool findCodeNameInString(const std::string& in,
     return ret;
 }
 
-static bool findMajorMinorVersionInString(const std::string& in,
-                                         nlohmann::json& output)
+static void findMajorMinorVersionInString(const std::string& in,
+                                          nlohmann::json& output)
 {
     constexpr auto MINOR_VERSION_PATTERN{"^[0-9]+\\.([0-9]+)\\.*"};
     constexpr auto MAJOR_VERSION_PATTERN{"^([0-9]+)\\.*"};
     std::string version;
     std::regex pattern{MAJOR_VERSION_PATTERN};
-    const auto ret{findRegexInString(in, version, pattern, 1)};
-    if (ret)
+    if (findRegexInString(in, version, pattern, 1))
     {
         output["os_major"] = version;
     }
@@ -104,7 +103,6 @@ static bool findMajorMinorVersionInString(const std::string& in,
     {
         output["os_minor"] = version;
     }
-    return ret;
 }
 
 

--- a/src/wazuh_modules/syscollector/sysOsParsers.h
+++ b/src/wazuh_modules/syscollector/sysOsParsers.h
@@ -126,6 +126,15 @@ public:
     bool parseUname(const std::string& in, nlohmann::json& output) override;
 };
 
+class MacOsParser
+{
+public:
+	MacOsParser() = default;
+	~MacOsParser() = default;
+	bool parseSwVersion(const std::string& in, nlohmann::json& output);
+	bool parseUname(const std::string& in, nlohmann::json& output);
+};
+
 class FactorySysOsParser
 {
 public:

--- a/src/wazuh_modules/syscollector/sysOsParsers.h
+++ b/src/wazuh_modules/syscollector/sysOsParsers.h
@@ -126,6 +126,9 @@ public:
     bool parseUname(const std::string& in, nlohmann::json& output) override;
 };
 
+
+bool parseVersion(const std::string& in, nlohmann::json& output);
+
 class MacOsParser
 {
 public:

--- a/src/wazuh_modules/syscollector/sysOsParsers.h
+++ b/src/wazuh_modules/syscollector/sysOsParsers.h
@@ -1,0 +1,193 @@
+/*
+ * Wazuh SysInfo
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * October 28, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _SYS_OS_PARSERS_H
+#define _SYS_OS_PARSERS_H
+
+#include <istream>
+#include "json.hpp"
+
+struct ISysOsParser
+{
+    virtual ~ISysOsParser() = default;
+    virtual bool parseFile(std::istream& /*in*/, nlohmann::json& /*output*/) {return false;}
+    virtual bool parseUname(const std::string& /*in*/, nlohmann::json& /*output*/) {return false;}
+};
+
+class UnixOsParser : public ISysOsParser
+{
+public:
+    UnixOsParser() = default;
+    ~UnixOsParser() = default;
+    bool parseFile(std::istream& in, nlohmann::json& output) override;
+};
+
+class UbuntuOsParser : public ISysOsParser
+{
+public:
+    UbuntuOsParser() = default;
+    ~UbuntuOsParser() = default;
+    bool parseFile(std::istream& in, nlohmann::json& output) override;
+};
+
+class CentosOsParser : public ISysOsParser
+{
+public:
+    CentosOsParser() = default;
+    ~CentosOsParser() = default;
+    bool parseFile(std::istream& in, nlohmann::json& output) override;
+};
+
+class BSDOsParser : public ISysOsParser
+{
+public:
+    BSDOsParser() = default;
+    ~BSDOsParser() = default;
+    bool parseUname(const std::string& in, nlohmann::json& output) override;
+};
+
+class RedHatOsParser : public ISysOsParser
+{
+public:
+    RedHatOsParser() = default;
+    ~RedHatOsParser() = default;
+    bool parseFile(std::istream& in, nlohmann::json& output) override;
+};
+
+class DebianOsParser : public ISysOsParser
+{
+public:
+    DebianOsParser() = default;
+    ~DebianOsParser() = default;
+    bool parseFile(std::istream& in, nlohmann::json& output) override;
+};
+
+class ArchOsParser : public ISysOsParser
+{
+public:
+    ArchOsParser() = default;
+    ~ArchOsParser() = default;
+    bool parseFile(std::istream& in, nlohmann::json& output) override;
+};
+
+class SlackwareOsParser : public ISysOsParser
+{
+public:
+    SlackwareOsParser() = default;
+    ~SlackwareOsParser() = default;
+    bool parseFile(std::istream& in, nlohmann::json& output) override;
+};
+
+class GentooOsParser : public ISysOsParser
+{
+public:
+    GentooOsParser() = default;
+    ~GentooOsParser() = default;
+    bool parseFile(std::istream& in, nlohmann::json& output) override;
+};
+
+class SuSEOsParser : public ISysOsParser
+{
+public:
+    SuSEOsParser() = default;
+    ~SuSEOsParser() = default;
+    bool parseFile(std::istream& in, nlohmann::json& output) override;
+};
+
+class FedoraOsParser : public ISysOsParser
+{
+public:
+    FedoraOsParser() = default;
+    ~FedoraOsParser() = default;
+    bool parseFile(std::istream& in, nlohmann::json& output) override;
+};
+
+class SolarisOsParser : public ISysOsParser
+{
+public:
+    SolarisOsParser() = default;
+    ~SolarisOsParser() = default;
+    bool parseFile(std::istream& in, nlohmann::json& output) override;
+};
+
+class HpUxOsParser : public ISysOsParser
+{
+public:
+    HpUxOsParser() = default;
+    ~HpUxOsParser() = default;
+    bool parseUname(const std::string& in, nlohmann::json& output) override;
+};
+
+class FactorySysOsParser
+{
+public:
+    static std::unique_ptr<ISysOsParser> create(const std::string& platform)
+    {
+        if (platform == "ubuntu")
+        {
+            return std::make_unique<UbuntuOsParser>();
+        }
+        if (platform == "centos")
+        {
+            return std::make_unique<CentosOsParser>();
+        }
+		if (platform == "unix")
+        {
+            return std::make_unique<UnixOsParser>();
+        }
+        if (platform == "bsd")
+        {
+            return std::make_unique<BSDOsParser>();
+        }
+        if (platform == "fedora")
+        {
+            return std::make_unique<FedoraOsParser>();
+        }
+        if (platform == "solaris")
+        {
+            return std::make_unique<SolarisOsParser>();
+        }
+        if (platform == "debian")
+        {
+            return std::make_unique<DebianOsParser>();
+        }
+        if (platform == "gentoo")
+        {
+            return std::make_unique<GentooOsParser>();
+        }
+        if (platform == "slackware")
+        {
+            return std::make_unique<SlackwareOsParser>();
+        }
+        if (platform == "suse")
+        {
+            return std::make_unique<SuSEOsParser>();
+        }
+        if (platform == "arch")
+        {
+            return std::make_unique<ArchOsParser>();
+        }
+        if (platform == "rhel")
+        {
+            return std::make_unique<RedHatOsParser>();
+        }
+        if (platform == "hp-ux")
+        {
+            return std::make_unique<HpUxOsParser>();
+        }
+        throw std::runtime_error
+        {
+            "Unsupported platform."
+        };
+    }
+};
+
+#endif //_SYS_OS_PARSERS_H

--- a/src/wazuh_modules/syscollector/sysOsParsers.h
+++ b/src/wazuh_modules/syscollector/sysOsParsers.h
@@ -129,10 +129,10 @@ public:
 class MacOsParser
 {
 public:
-	MacOsParser() = default;
-	~MacOsParser() = default;
-	bool parseSwVersion(const std::string& in, nlohmann::json& output);
-	bool parseUname(const std::string& in, nlohmann::json& output);
+    MacOsParser() = default;
+    ~MacOsParser() = default;
+    bool parseSwVersion(const std::string& in, nlohmann::json& output);
+    bool parseUname(const std::string& in, nlohmann::json& output);
 };
 
 class FactorySysOsParser final
@@ -148,7 +148,7 @@ public:
         {
             return std::make_unique<CentosOsParser>();
         }
-		if (platform == "unix")
+        if (platform == "unix")
         {
             return std::make_unique<UnixOsParser>();
         }

--- a/src/wazuh_modules/syscollector/sysOsParsers.h
+++ b/src/wazuh_modules/syscollector/sysOsParsers.h
@@ -126,9 +126,6 @@ public:
     bool parseUname(const std::string& in, nlohmann::json& output) override;
 };
 
-
-bool parseVersion(const std::string& in, nlohmann::json& output);
-
 class MacOsParser
 {
 public:
@@ -138,7 +135,7 @@ public:
 	bool parseUname(const std::string& in, nlohmann::json& output);
 };
 
-class FactorySysOsParser
+class FactorySysOsParser final
 {
 public:
     static std::unique_ptr<ISysOsParser> create(const std::string& platform)

--- a/src/wazuh_modules/syscollector/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/syscollectorImp.cpp
@@ -35,9 +35,11 @@ void Syscollector::start()
         const auto& hw{m_info.hardware()};
         const auto& packages{m_info.packages()};
         const auto& processes{m_info.processes()};        
+        const auto& os{m_info.os()};
         std::cout << packages.dump() << std::endl;
         std::cout << hw.dump() << std::endl;
         std::cout << processes.dump() << std::endl;
+        std::cout << os.dump() << std::endl;
         std::this_thread::sleep_for(m_timeout);
     }
 }

--- a/src/wazuh_modules/syscollector/tests/sysInfo/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/tests/sysInfo/CMakeLists.txt
@@ -8,7 +8,8 @@ file(GLOB sysinfo_UNIT_TEST_SRC
     "*.cpp")
 
 file(GLOB SYSINFO_SRC
-    "${CMAKE_SOURCE_DIR}/sysInfo.cpp")
+    "${CMAKE_SOURCE_DIR}/sysInfo.cpp"
+    "${CMAKE_SOURCE_DIR}/sysOsParsers.cpp")
 
 add_executable(sysinfo_unit_test 
     ${sysinfo_UNIT_TEST_SRC}

--- a/src/wazuh_modules/syscollector/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysInfo/sysInfoParsers_test.cpp
@@ -1,0 +1,306 @@
+/*
+ * Wazuh SysInfoParsers
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * October 19, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+#include "sysInfoParsers_test.h"
+#include "sysOsParsers.h"
+
+void SysInfoParsersTest::SetUp() {};
+
+void SysInfoParsersTest::TearDown()
+{
+};
+
+TEST_F(SysInfoParsersTest, UnixLinux)
+{
+    constexpr auto UNIX_RELEASE_FILE
+    {
+        R"(
+        NAME="Ubuntu"
+        VERSION="20.04.1 LTS (Focal Fossa) "
+        ID=ubuntu
+        ID_LIKE=debian
+        PRETTY_NAME="Ubuntu 20.04.1 LTS"
+        VERSION_ID="20.04"
+        HOME_URL="https://www.ubuntu.com/"
+        SUPPORT_URL="https://help.ubuntu.com/"
+        BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+        PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+        VERSION_CODENAME=focal
+        UBUNTU_CODENAME=focal
+        )"
+    };
+    nlohmann::json output;
+    std::stringstream info{UNIX_RELEASE_FILE};
+    const auto spParser{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("20.04.1 LTS (Focal Fossa)", output["os_version"]);
+    EXPECT_EQ("Ubuntu", output["os_name"]);
+    EXPECT_EQ("ubuntu", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, UnixCentos)
+{
+    constexpr auto UNIX_RELEASE_FILE
+    {
+        R"(
+        NAME="CentOS Linux"
+        VERSION="8 (Core) "
+        ID="centos"
+        ID_LIKE="rhel fedora"
+        VERSION_ID="8"
+        PLATFORM_ID="platform:el8"
+        PRETTY_NAME="CentOS Linux 8 (Core) "
+        ANSI_COLOR="0;31"
+        CPE_NAME="cpe:/o:centos:centos:8"
+        HOME_URL="https://www.centos.org/"
+        BUG_REPORT_URL="https://bugs.centos.org/"
+
+        CENTOS_MANTISBT_PROJECT="CentOS-8"
+        CENTOS_MANTISBT_PROJECT_VERSION="8"
+        REDHAT_SUPPORT_PRODUCT="centos"
+        REDHAT_SUPPORT_PRODUCT_VERSION="8"
+        )"
+    };
+    nlohmann::json output;
+    std::stringstream info{UNIX_RELEASE_FILE};
+    const auto spParser{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("8 (Core)", output["os_version"]);
+    EXPECT_EQ("CentOS Linux", output["os_name"]);
+    EXPECT_EQ("centos", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, Ubuntu)
+{
+    constexpr auto UBUNTU_RELEASE_FILE
+    {
+        R"(DISTRIB_ID=Ubuntu
+          DISTRIB_RELEASE=20.04
+          DISTRIB_CODENAME=focal
+          DISTRIB_DESCRIPTION='Ubuntu 20.04.1 LTS')"
+    };
+    nlohmann::json output;
+    std::stringstream info{UBUNTU_RELEASE_FILE};
+    const auto spParser{FactorySysOsParser::create("ubuntu")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("20.04.1", output["os_version"]);
+    EXPECT_EQ("Ubuntu", output["os_name"]);
+    EXPECT_EQ("ubuntu", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, Centos)
+{
+    constexpr auto CENTOS_RELEASE_FILE
+    {
+        "CentOS Linux release 8.2.2004 (Core)"
+    };
+    nlohmann::json output;
+    std::stringstream info{CENTOS_RELEASE_FILE};
+    const auto spParser{FactorySysOsParser::create("centos")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("8.2.2004", output["os_version"]);
+    EXPECT_EQ("Centos Linux", output["os_name"]);
+    EXPECT_EQ("centos", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, BSDFreeBSD)
+{
+    constexpr auto FREE_BSD_UNAME
+    {
+        "12.1-STABLE"
+    };
+    nlohmann::json output;
+    const auto spParser{FactorySysOsParser::create("bsd")};
+    EXPECT_TRUE(spParser->parseUname(FREE_BSD_UNAME, output));
+    EXPECT_EQ("12.1", output["os_version"]);
+    EXPECT_EQ("BSD", output["os_name"]);
+    EXPECT_EQ("bsd", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, BSDOpenBSD)
+{
+    constexpr auto FREE_BSD_UNAME
+    {
+        "6.6"
+    };
+    nlohmann::json output;
+    const auto spParser{FactorySysOsParser::create("bsd")};
+    EXPECT_TRUE(spParser->parseUname(FREE_BSD_UNAME, output));
+    EXPECT_EQ("6.6", output["os_version"]);
+    EXPECT_EQ("BSD", output["os_name"]);
+    EXPECT_EQ("bsd", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, RedHatCentos)
+{
+    constexpr auto REDHAT_RELEASE_FILE
+    {
+        "CentOS release 5.11 (Final)"
+    };
+    nlohmann::json output;
+    std::stringstream info{REDHAT_RELEASE_FILE};
+    const auto spParser{FactorySysOsParser::create("rhel")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("5.11", output["os_version"]);
+    EXPECT_EQ("Centos Linux", output["os_name"]);
+    EXPECT_EQ("centos", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, Debian)
+{
+    constexpr auto DEBIAN_VERSION_FILE
+    {
+        "10.6"
+    };
+    nlohmann::json output;
+    std::stringstream info{DEBIAN_VERSION_FILE};
+    const auto spParser{FactorySysOsParser::create("debian")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("10.6", output["os_version"]);
+    EXPECT_EQ("Debian GNU/Linux", output["os_name"]);
+    EXPECT_EQ("debian", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, Arch)
+{
+    constexpr auto ARCH_VERSION_FILE
+    {
+        "10.6"
+    };
+    nlohmann::json output;
+    std::stringstream info{ARCH_VERSION_FILE};
+    const auto spParser{FactorySysOsParser::create("arch")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("10.6", output["os_version"]);
+    EXPECT_EQ("Arch Linux", output["os_name"]);
+    EXPECT_EQ("arch", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, Slackware)
+{
+    constexpr auto SLACKWARE_VERSION_FILE
+    {
+        "Slackware 14.1"
+    };
+    nlohmann::json output;
+    std::stringstream info{SLACKWARE_VERSION_FILE};
+    const auto spParser{FactorySysOsParser::create("slackware")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("14.1", output["os_version"]);
+    EXPECT_EQ("Slackware", output["os_name"]);
+    EXPECT_EQ("slackware", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, Gentoo)
+{
+    constexpr auto GENTOO_VERSION_FILE
+    {
+        "Gentoo Base System release 2.6"
+    };
+    nlohmann::json output;
+    std::stringstream info{GENTOO_VERSION_FILE};
+    const auto spParser{FactorySysOsParser::create("gentoo")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("2.6", output["os_version"]);
+    EXPECT_EQ("Gentoo", output["os_name"]);
+    EXPECT_EQ("gentoo", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, SuSE)
+{
+    constexpr auto OPENSUSE_VERSION_FILE
+    {
+        R"(
+        openSUSE 13.1 (x86_64)
+        VERSION = 13.1
+        CODENAME = Bottle
+        )"
+    };
+    nlohmann::json output;
+    std::stringstream info{OPENSUSE_VERSION_FILE};
+    const auto spParser{FactorySysOsParser::create("suse")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("13.1", output["os_version"]);
+    EXPECT_EQ("SuSE Linux", output["os_name"]);
+    EXPECT_EQ("suse", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, Fedora)
+{
+    constexpr auto FEDORA_VERSION_FILE
+    {
+        "Fedora release 22 (Twenty Two)"
+    };
+    nlohmann::json output;
+    std::stringstream info{FEDORA_VERSION_FILE};
+    const auto spParser{FactorySysOsParser::create("fedora")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("22", output["os_version"]);
+    EXPECT_EQ("Fedora", output["os_name"]);
+    EXPECT_EQ("fedora", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, Solaris)
+{
+    constexpr auto SOLARIS_VERSION_FILE
+    {
+        R"(
+                                     Oracle Solaris 11.3 X86
+          Copyright (c) 1983, 2015, Oracle and/or its affiliates.  All rights reserved.
+                                    Assembled 06 October 2015
+        )"
+    };
+    nlohmann::json output;
+    std::stringstream info{SOLARIS_VERSION_FILE};
+    const auto spParser{FactorySysOsParser::create("solaris")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("11.3", output["os_version"]);
+    EXPECT_EQ("SunOS", output["os_name"]);
+    EXPECT_EQ("sunos", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, Solaris1)
+{
+    constexpr auto SOLARIS_VERSION_FILE
+    {
+        R"(
+                            Oracle Solaris 10 1/13 s10x_u11wos_24a X86
+           Copyright (c) 1983, 2013, Oracle and/or its affiliates. All rights reserved.
+                            Assembled 17 January 2013
+        )"
+    };
+    nlohmann::json output;
+    std::stringstream info{SOLARIS_VERSION_FILE};
+    const auto spParser{FactorySysOsParser::create("solaris")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("10", output["os_version"]);
+    EXPECT_EQ("SunOS", output["os_name"]);
+    EXPECT_EQ("sunos", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, HPUX)
+{
+    // https://docstore.mik.ua/manuals/hp-ux/en/5992-4826/pr01s02.html
+    constexpr auto HPUX_UNAME
+    {
+        "B.11.23"
+    };
+    nlohmann::json output;
+    const auto spParser{FactorySysOsParser::create("hp-ux")};
+    EXPECT_TRUE(spParser->parseUname(HPUX_UNAME, output));
+    EXPECT_EQ("11.23", output["os_version"]);
+    EXPECT_EQ("HP-UX", output["os_name"]);
+    EXPECT_EQ("hp-ux", output["os_platform"]);
+}
+
+TEST_F(SysInfoParsersTest, UknownPlatform)
+{
+    EXPECT_THROW(FactorySysOsParser::create("some unknown platform"), std::runtime_error);
+}

--- a/src/wazuh_modules/syscollector/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysInfo/sysInfoParsers_test.cpp
@@ -304,3 +304,28 @@ TEST_F(SysInfoParsersTest, UknownPlatform)
 {
     EXPECT_THROW(FactorySysOsParser::create("some unknown platform"), std::runtime_error);
 }
+
+TEST_F(SysInfoParsersTest, MacOS)
+{
+    constexpr auto MACOS_SW_VERSION
+    {
+        R"(
+        ProductName:    Mac OS X
+        ProductVersion: 10.12.6
+        BuildVersion:   16G29
+        )"
+    };
+    constexpr auto MACOS_UNAME
+    {
+        "16.7.0"
+    };
+    nlohmann::json output;
+    MacOsParser parser;
+    EXPECT_TRUE(parser.parseSwVersion(MACOS_SW_VERSION, output));
+    EXPECT_TRUE(parser.parseUname(MACOS_UNAME, output));
+    EXPECT_EQ("10.12.6", output["os_version"]);
+    EXPECT_EQ("Mac OS X", output["os_name"]);
+    EXPECT_EQ("darwin", output["os_platform"]);
+    EXPECT_EQ("16G29", output["os_build"]);
+    EXPECT_EQ("16.7.0", output["os_codename"]);
+}

--- a/src/wazuh_modules/syscollector/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysInfo/sysInfoParsers_test.cpp
@@ -43,6 +43,9 @@ TEST_F(SysInfoParsersTest, UnixLinux)
     EXPECT_EQ("20.04.1 LTS (Focal Fossa)", output["os_version"]);
     EXPECT_EQ("Ubuntu", output["os_name"]);
     EXPECT_EQ("ubuntu", output["os_platform"]);
+    EXPECT_EQ("focal", output["os_codename"]);
+    EXPECT_EQ("20", output["os_major"]);
+    EXPECT_EQ("04", output["os_minor"]);
 }
 
 TEST_F(SysInfoParsersTest, UnixCentos)
@@ -75,6 +78,7 @@ TEST_F(SysInfoParsersTest, UnixCentos)
     EXPECT_EQ("8 (Core)", output["os_version"]);
     EXPECT_EQ("CentOS Linux", output["os_name"]);
     EXPECT_EQ("centos", output["os_platform"]);
+    EXPECT_EQ("8", output["os_major"]);
 }
 
 TEST_F(SysInfoParsersTest, Ubuntu)
@@ -93,6 +97,9 @@ TEST_F(SysInfoParsersTest, Ubuntu)
     EXPECT_EQ("20.04.1", output["os_version"]);
     EXPECT_EQ("Ubuntu", output["os_name"]);
     EXPECT_EQ("ubuntu", output["os_platform"]);
+    EXPECT_EQ("focal", output["os_codename"]);
+    EXPECT_EQ("20", output["os_major"]);
+    EXPECT_EQ("04", output["os_minor"]);
 }
 
 TEST_F(SysInfoParsersTest, Centos)
@@ -108,6 +115,9 @@ TEST_F(SysInfoParsersTest, Centos)
     EXPECT_EQ("8.2.2004", output["os_version"]);
     EXPECT_EQ("Centos Linux", output["os_name"]);
     EXPECT_EQ("centos", output["os_platform"]);
+    EXPECT_EQ("Core", output["os_codename"]);
+    EXPECT_EQ("8", output["os_major"]);
+    EXPECT_EQ("2", output["os_minor"]);
 }
 
 TEST_F(SysInfoParsersTest, BSDFreeBSD)
@@ -122,6 +132,8 @@ TEST_F(SysInfoParsersTest, BSDFreeBSD)
     EXPECT_EQ("12.1", output["os_version"]);
     EXPECT_EQ("BSD", output["os_name"]);
     EXPECT_EQ("bsd", output["os_platform"]);
+    EXPECT_EQ("12", output["os_major"]);
+    EXPECT_EQ("1", output["os_minor"]);
 }
 
 TEST_F(SysInfoParsersTest, BSDOpenBSD)
@@ -136,6 +148,8 @@ TEST_F(SysInfoParsersTest, BSDOpenBSD)
     EXPECT_EQ("6.6", output["os_version"]);
     EXPECT_EQ("BSD", output["os_name"]);
     EXPECT_EQ("bsd", output["os_platform"]);
+    EXPECT_EQ("6", output["os_major"]);
+    EXPECT_EQ("6", output["os_minor"]);
 }
 
 TEST_F(SysInfoParsersTest, RedHatCentos)
@@ -151,6 +165,9 @@ TEST_F(SysInfoParsersTest, RedHatCentos)
     EXPECT_EQ("5.11", output["os_version"]);
     EXPECT_EQ("Centos Linux", output["os_name"]);
     EXPECT_EQ("centos", output["os_platform"]);
+    EXPECT_EQ("Final", output["os_codename"]);
+    EXPECT_EQ("5", output["os_major"]);
+    EXPECT_EQ("11", output["os_minor"]);
 }
 
 TEST_F(SysInfoParsersTest, Debian)
@@ -166,6 +183,8 @@ TEST_F(SysInfoParsersTest, Debian)
     EXPECT_EQ("10.6", output["os_version"]);
     EXPECT_EQ("Debian GNU/Linux", output["os_name"]);
     EXPECT_EQ("debian", output["os_platform"]);
+    EXPECT_EQ("10", output["os_major"]);
+    EXPECT_EQ("6", output["os_minor"]);
 }
 
 TEST_F(SysInfoParsersTest, Arch)
@@ -181,6 +200,8 @@ TEST_F(SysInfoParsersTest, Arch)
     EXPECT_EQ("10.6", output["os_version"]);
     EXPECT_EQ("Arch Linux", output["os_name"]);
     EXPECT_EQ("arch", output["os_platform"]);
+    EXPECT_EQ("10", output["os_major"]);
+    EXPECT_EQ("6", output["os_minor"]);
 }
 
 TEST_F(SysInfoParsersTest, Slackware)
@@ -196,6 +217,8 @@ TEST_F(SysInfoParsersTest, Slackware)
     EXPECT_EQ("14.1", output["os_version"]);
     EXPECT_EQ("Slackware", output["os_name"]);
     EXPECT_EQ("slackware", output["os_platform"]);
+    EXPECT_EQ("14", output["os_major"]);
+    EXPECT_EQ("1", output["os_minor"]);
 }
 
 TEST_F(SysInfoParsersTest, Gentoo)
@@ -211,6 +234,8 @@ TEST_F(SysInfoParsersTest, Gentoo)
     EXPECT_EQ("2.6", output["os_version"]);
     EXPECT_EQ("Gentoo", output["os_name"]);
     EXPECT_EQ("gentoo", output["os_platform"]);
+    EXPECT_EQ("2", output["os_major"]);
+    EXPECT_EQ("6", output["os_minor"]);
 }
 
 TEST_F(SysInfoParsersTest, SuSE)
@@ -230,6 +255,9 @@ TEST_F(SysInfoParsersTest, SuSE)
     EXPECT_EQ("13.1", output["os_version"]);
     EXPECT_EQ("SuSE Linux", output["os_name"]);
     EXPECT_EQ("suse", output["os_platform"]);
+    EXPECT_EQ("Bottle", output["os_codename"]);
+    EXPECT_EQ("13", output["os_major"]);
+    EXPECT_EQ("1", output["os_minor"]);
 }
 
 TEST_F(SysInfoParsersTest, Fedora)
@@ -245,6 +273,8 @@ TEST_F(SysInfoParsersTest, Fedora)
     EXPECT_EQ("22", output["os_version"]);
     EXPECT_EQ("Fedora", output["os_name"]);
     EXPECT_EQ("fedora", output["os_platform"]);
+    EXPECT_EQ("Twenty Two", output["os_codename"]);
+    EXPECT_EQ("22", output["os_major"]);
 }
 
 TEST_F(SysInfoParsersTest, Solaris)
@@ -264,6 +294,8 @@ TEST_F(SysInfoParsersTest, Solaris)
     EXPECT_EQ("11.3", output["os_version"]);
     EXPECT_EQ("SunOS", output["os_name"]);
     EXPECT_EQ("sunos", output["os_platform"]);
+    EXPECT_EQ("11", output["os_major"]);
+    EXPECT_EQ("3", output["os_minor"]);
 }
 
 TEST_F(SysInfoParsersTest, Solaris1)
@@ -283,6 +315,7 @@ TEST_F(SysInfoParsersTest, Solaris1)
     EXPECT_EQ("10", output["os_version"]);
     EXPECT_EQ("SunOS", output["os_name"]);
     EXPECT_EQ("sunos", output["os_platform"]);
+    EXPECT_EQ("10", output["os_major"]);
 }
 
 TEST_F(SysInfoParsersTest, HPUX)
@@ -298,6 +331,9 @@ TEST_F(SysInfoParsersTest, HPUX)
     EXPECT_EQ("11.23", output["os_version"]);
     EXPECT_EQ("HP-UX", output["os_name"]);
     EXPECT_EQ("hp-ux", output["os_platform"]);
+    EXPECT_EQ("11", output["os_major"]);
+    EXPECT_EQ("23", output["os_minor"]);
+
 }
 
 TEST_F(SysInfoParsersTest, UknownPlatform)
@@ -327,5 +363,7 @@ TEST_F(SysInfoParsersTest, MacOS)
     EXPECT_EQ("Mac OS X", output["os_name"]);
     EXPECT_EQ("darwin", output["os_platform"]);
     EXPECT_EQ("16G29", output["os_build"]);
-    EXPECT_EQ("16.7.0", output["os_codename"]);
+    EXPECT_EQ("Sierra", output["os_codename"]);
+    EXPECT_EQ("10", output["os_major"]);
+    EXPECT_EQ("12", output["os_minor"]);
 }

--- a/src/wazuh_modules/syscollector/tests/sysInfo/sysInfoParsers_test.h
+++ b/src/wazuh_modules/syscollector/tests/sysInfo/sysInfoParsers_test.h
@@ -1,0 +1,27 @@
+/*
+ * Wazuh SysInfo
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * October 28, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */ 
+#ifndef _SYSINFO_PARSERS_TEST_H
+#define _SYSINFO_PARSERS_TEST_H
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+class SysInfoParsersTest : public ::testing::Test {
+
+protected:
+
+    SysInfoParsersTest() = default;
+    virtual ~SysInfoParsersTest() = default;
+
+    void SetUp() override;
+    void TearDown() override;
+};
+
+#endif //_SYSINFO_PARSERS_TEST_H

--- a/src/wazuh_modules/syscollector/tests/sysInfo/sysInfo_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysInfo/sysInfo_test.cpp
@@ -26,6 +26,7 @@ int SysInfo::getCpuMHz() const {return 0;}
 int SysInfo::getCpuCores() const {return 0;}
 void SysInfo::getMemory(nlohmann::json&) const {}
 nlohmann::json SysInfo::getPackages() const {return "";}
+nlohmann::json SysInfo::getOsInfo() const {return "";}
 
 class SysInfoWrapper: public SysInfo
 {
@@ -38,6 +39,7 @@ public:
     MOCK_METHOD(int, getCpuCores, (), (const override));
     MOCK_METHOD(void, getMemory, (nlohmann::json&), (const override));
     MOCK_METHOD(nlohmann::json, getPackages, (), (const override));
+    MOCK_METHOD(nlohmann::json, getOsInfo, (), (const override));
 };
 
 

--- a/src/wazuh_modules/syscollector/testtool/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/testtool/CMakeLists.txt
@@ -24,7 +24,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	add_definitions(-DWIN32=1)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   file(GLOB SYSCOLLECTOR_TESTTOOL_SRC
-      "${CMAKE_SOURCE_DIR}/*Linux.cpp")
+      "${CMAKE_SOURCE_DIR}/*Linux.cpp"
+      "${CMAKE_SOURCE_DIR}/sysOsParsers.cpp")
 else()
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     file(GLOB SYSCOLLECTOR_TESTTOOL_SRC

--- a/src/wazuh_modules/syscollector/testtool/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/testtool/CMakeLists.txt
@@ -34,11 +34,13 @@ else()
   elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     file(GLOB SYSCOLLECTOR_TESTTOOL_SRC
         "${CMAKE_SOURCE_DIR}/*FreeBSD.cpp"
-        "${CMAKE_SOURCE_DIR}/*CommonBSD.cpp")
+        "${CMAKE_SOURCE_DIR}/*CommonBSD.cpp"
+        "${CMAKE_SOURCE_DIR}/sysOsParsers.cpp")
   elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
     file(GLOB SYSCOLLECTOR_TESTTOOL_SRC
         "${CMAKE_SOURCE_DIR}/*OpenBSD.cpp"
-        "${CMAKE_SOURCE_DIR}/*CommonBSD.cpp")
+        "${CMAKE_SOURCE_DIR}/*CommonBSD.cpp"
+        "${CMAKE_SOURCE_DIR}/sysOsParsers.cpp")
   endif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 

--- a/src/wazuh_modules/syscollector/testtool/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/testtool/CMakeLists.txt
@@ -30,7 +30,8 @@ else()
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     file(GLOB SYSCOLLECTOR_TESTTOOL_SRC
         "${CMAKE_SOURCE_DIR}/*Mac.cpp"
-        "${CMAKE_SOURCE_DIR}/*CommonBSD.cpp")
+        "${CMAKE_SOURCE_DIR}/*CommonBSD.cpp"
+        "${CMAKE_SOURCE_DIR}/sysOsParsers.cpp")
   elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     file(GLOB SYSCOLLECTOR_TESTTOOL_SRC
         "${CMAKE_SOURCE_DIR}/*FreeBSD.cpp"


### PR DESCRIPTION
|Related issue|
|---|
|#6356|

## **Description**

This issue aims to make use of the generic synchronization libraries, to use the synchronization solution algorithm that both shared modules provide.

These changes have to be made in the various implementations according to the operating system targeted for this feature.

## **DoD**
- [X] Implementation
- [X] **Run testtool on linux**
![image](https://user-images.githubusercontent.com/54002291/97909988-d33f4080-1d27-11eb-86e1-7edbcd4d86e6.png)
- [X] **Run testtool on MAC**
![image](https://user-images.githubusercontent.com/54002291/97910011-de926c00-1d27-11eb-9dad-8a43f596406b.png)
- [X] **Run testtool on FreeBSD**
![image](https://user-images.githubusercontent.com/54002291/97910093-fcf86780-1d27-11eb-9c53-0482f596ea23.png)
- [X] **Run testtool on OpenBSD**
![image](https://user-images.githubusercontent.com/54002291/97910051-ec47f180-1d27-11eb-9205-77d40aeb5cb6.png)
- **SysInfo UTs:**
> **Linux:**
![image](https://user-images.githubusercontent.com/54002291/97910901-31b8ee80-1d29-11eb-907b-0dd9047a8713.png)
> **Windows:**
![image](https://user-images.githubusercontent.com/54002291/97911758-91fc6000-1d2a-11eb-92c1-8baf9df627e8.png)





