### PR TITLE
Add support OSRegex&PCRE2  for static field

### DIFF
--- a/src/analysisd/config_json.c
+++ b/src/analysisd/config_json.c
@@ -271,111 +271,127 @@ void _getRulesListJSON(RuleNode *list, cJSON *array) {
 
         if (node->ruleinfo->srcgeoip) {
             cJSON * srcgeoip = cJSON_CreateObject();
-            cJSON_AddStringToObject(srcgeoip, "pattern", node->ruleinfo->srcgeoip->match->raw);
+            cJSON_AddStringToObject(srcgeoip, "pattern", w_expression_get_regex_pattern(node->ruleinfo->srcgeoip));
+            cJSON_AddStringToObject(srcgeoip, "type", w_expression_get_regex_type(node->ruleinfo->srcgeoip));
             cJSON_AddBoolToObject(srcgeoip, "negate", node->ruleinfo->srcgeoip->negate);
             cJSON_AddItemToObject(rule, "srcgeoip", srcgeoip);
         }
 
         if (node->ruleinfo->dstgeoip) {
             cJSON * dstgeoip = cJSON_CreateObject();
-            cJSON_AddStringToObject(dstgeoip, "pattern", node->ruleinfo->dstgeoip->match->raw);
+            cJSON_AddStringToObject(dstgeoip, "pattern", w_expression_get_regex_pattern(node->ruleinfo->dstgeoip));
+            cJSON_AddStringToObject(dstgeoip, "type", w_expression_get_regex_type(node->ruleinfo->dstgeoip));
             cJSON_AddBoolToObject(dstgeoip, "negate", node->ruleinfo->dstgeoip->negate);
             cJSON_AddItemToObject(rule, "dstgeoip", dstgeoip);
         }
 
         if (node->ruleinfo->srcport) {
             cJSON * srcport = cJSON_CreateObject();
-            cJSON_AddStringToObject(srcport, "pattern", node->ruleinfo->srcport->match->raw);
+            cJSON_AddStringToObject(srcport, "pattern", w_expression_get_regex_pattern(node->ruleinfo->srcport));
+            cJSON_AddStringToObject(srcport, "type", w_expression_get_regex_type(node->ruleinfo->srcport));
             cJSON_AddBoolToObject(srcport, "negate", node->ruleinfo->srcport->negate);
             cJSON_AddItemToObject(rule, "srcport", srcport);
         }
 
         if (node->ruleinfo->dstport) {
             cJSON * dstport = cJSON_CreateObject();
-            cJSON_AddStringToObject(dstport, "pattern", node->ruleinfo->dstport->match->raw);
+            cJSON_AddStringToObject(dstport, "pattern", w_expression_get_regex_pattern(node->ruleinfo->dstport));
+            cJSON_AddStringToObject(dstport, "type", w_expression_get_regex_type(node->ruleinfo->dstport));
             cJSON_AddBoolToObject(dstport, "negate", node->ruleinfo->dstport->negate);
             cJSON_AddItemToObject(rule, "dstport", dstport);
         }
 
         if (node->ruleinfo->user) {
             cJSON * user = cJSON_CreateObject();
-            cJSON_AddStringToObject(user, "pattern", node->ruleinfo->user->match->raw);
+            cJSON_AddStringToObject(user, "pattern", w_expression_get_regex_pattern(node->ruleinfo->user));
+            cJSON_AddStringToObject(user, "type", w_expression_get_regex_type(node->ruleinfo->user));
             cJSON_AddBoolToObject(user, "negate", node->ruleinfo->user->negate);
             cJSON_AddItemToObject(rule, "user", user);
         }
 
         if (node->ruleinfo->url) {
             cJSON * url = cJSON_CreateObject();
-            cJSON_AddStringToObject(url, "pattern", node->ruleinfo->url->match->raw);
+            cJSON_AddStringToObject(url, "pattern", w_expression_get_regex_pattern(node->ruleinfo->url));
+            cJSON_AddStringToObject(url, "type", w_expression_get_regex_type(node->ruleinfo->url));
             cJSON_AddBoolToObject(url, "negate", node->ruleinfo->url->negate);
             cJSON_AddItemToObject(rule, "url", url);
         }
 
         if (node->ruleinfo->id) {
             cJSON * id = cJSON_CreateObject();
-            cJSON_AddStringToObject(id, "pattern", node->ruleinfo->id->match->raw);
+            cJSON_AddStringToObject(id, "pattern", w_expression_get_regex_pattern(node->ruleinfo->id));
+            cJSON_AddStringToObject(id, "type", w_expression_get_regex_type(node->ruleinfo->id));
             cJSON_AddBoolToObject(id, "negate", node->ruleinfo->id->negate);
             cJSON_AddItemToObject(rule, "id", id);
         }
 
         if (node->ruleinfo->system_name) {
             cJSON * system_name = cJSON_CreateObject();
-            cJSON_AddStringToObject(system_name, "pattern", node->ruleinfo->system_name->match->raw);
+            cJSON_AddStringToObject(system_name, "pattern", w_expression_get_regex_pattern(node->ruleinfo->system_name));
+            cJSON_AddStringToObject(system_name, "type", w_expression_get_regex_type(node->ruleinfo->system_name));
             cJSON_AddBoolToObject(system_name, "negate", node->ruleinfo->system_name->negate);
             cJSON_AddItemToObject(rule, "system_name", system_name);
         }
 
         if (node->ruleinfo->protocol) {
             cJSON * protocol = cJSON_CreateObject();
-            cJSON_AddStringToObject(protocol, "pattern", node->ruleinfo->protocol->match->raw);
+            cJSON_AddStringToObject(protocol, "pattern", w_expression_get_regex_pattern(node->ruleinfo->protocol));
+            cJSON_AddStringToObject(protocol, "type", w_expression_get_regex_type(node->ruleinfo->protocol));
             cJSON_AddBoolToObject(protocol, "negate", node->ruleinfo->protocol->negate);
             cJSON_AddItemToObject(rule, "protocol", protocol);
         }
 
         if (node->ruleinfo->data) {
             cJSON * data = cJSON_CreateObject();
-            cJSON_AddStringToObject(data, "pattern", node->ruleinfo->data->match->raw);
+            cJSON_AddStringToObject(data, "pattern", w_expression_get_regex_pattern(node->ruleinfo->data));
+            cJSON_AddStringToObject(data, "type", w_expression_get_regex_type(node->ruleinfo->data));
             cJSON_AddBoolToObject(data, "negate", node->ruleinfo->data->negate);
             cJSON_AddItemToObject(rule, "data", data);
         }
         if (node->ruleinfo->status) {
             cJSON * status = cJSON_CreateObject();
-            cJSON_AddStringToObject(status, "pattern", node->ruleinfo->status->match->raw);
+            cJSON_AddStringToObject(status, "pattern", w_expression_get_regex_pattern(node->ruleinfo->status));
+            cJSON_AddStringToObject(status, "type", w_expression_get_regex_type(node->ruleinfo->status));
             cJSON_AddBoolToObject(status, "negate", node->ruleinfo->status->negate);
             cJSON_AddItemToObject(rule, "status", status);
         }
 
         if (node->ruleinfo->hostname) {
             cJSON * hostname = cJSON_CreateObject();
-            cJSON_AddStringToObject(hostname, "pattern", node->ruleinfo->hostname->match->raw);
+            cJSON_AddStringToObject(hostname, "pattern", w_expression_get_regex_pattern(node->ruleinfo->hostname));
+            cJSON_AddStringToObject(hostname, "type", w_expression_get_regex_type(node->ruleinfo->hostname));
             cJSON_AddBoolToObject(hostname, "negate", node->ruleinfo->hostname->negate);
             cJSON_AddItemToObject(rule, "hostname", hostname);
         }
 
         if (node->ruleinfo->program_name) {
             cJSON * program_name = cJSON_CreateObject();
-            cJSON_AddStringToObject(program_name, "pattern", node->ruleinfo->program_name->match->raw);
+            cJSON_AddStringToObject(program_name, "pattern", w_expression_get_regex_pattern(node->ruleinfo->program_name));
+            cJSON_AddStringToObject(program_name, "type", w_expression_get_regex_type(node->ruleinfo->program_name));
             cJSON_AddBoolToObject(program_name, "negate", node->ruleinfo->program_name->negate);
             cJSON_AddItemToObject(rule, "program_name", program_name);
         }
 
         if (node->ruleinfo->extra_data) {
             cJSON * extra_data = cJSON_CreateObject();
-            cJSON_AddStringToObject(extra_data, "pattern", node->ruleinfo->extra_data->match->raw);
+            cJSON_AddStringToObject(extra_data, "pattern", w_expression_get_regex_pattern(node->ruleinfo->extra_data));
+            cJSON_AddStringToObject(extra_data, "type", w_expression_get_regex_type(node->ruleinfo->extra_data));
             cJSON_AddBoolToObject(extra_data, "negate", node->ruleinfo->extra_data->negate);
             cJSON_AddItemToObject(rule, "extra_data", extra_data);
         }
 
         if (node->ruleinfo->location) {
             cJSON * location = cJSON_CreateObject();
-            cJSON_AddStringToObject(location, "pattern", node->ruleinfo->location->match->raw);
+            cJSON_AddStringToObject(location, "pattern", w_expression_get_regex_pattern(node->ruleinfo->location));
+            cJSON_AddStringToObject(location, "type", w_expression_get_regex_type(node->ruleinfo->location));
             cJSON_AddBoolToObject(location, "negate", node->ruleinfo->location->negate);
             cJSON_AddItemToObject(rule, "location", location);
         }
 
         if (node->ruleinfo->action) {
             cJSON * action = cJSON_CreateObject();
-            cJSON_AddStringToObject(action, "string", node->ruleinfo->action->string);
+            cJSON_AddStringToObject(action, "pattern", w_expression_get_regex_pattern(node->ruleinfo->action));
+            cJSON_AddStringToObject(action, "type", w_expression_get_regex_type(node->ruleinfo->action));
             cJSON_AddBoolToObject(action, "negate", node->ruleinfo->action->negate);
             cJSON_AddItemToObject(rule, "action", action);
         }

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -51,14 +51,6 @@ STATIC int w_get_attr_offset(xml_node * node);
  */
 STATIC bool w_get_attr_regex_type(xml_node * node, w_exp_type_t * type);
 
-/**
- * @brief Get value of an attribute of a node
- * @param node node to find value of attribute
- * @param name name of the attribute
- * @return value of attribute on success. NULL otherwise
- */
-STATIC const char * w_get_attr_val_by_name(xml_node * node, const char * name);
-
 int getDecoderfromlist(const char *name)
 {
     if (os_decoder_store) {
@@ -962,19 +954,4 @@ STATIC bool w_get_attr_regex_type(xml_node * node, w_exp_type_t * type) {
     }
 
     return retval;
-}
-
-STATIC const char * w_get_attr_val_by_name(xml_node * node, const char * name) {
-
-    if (!node || !node->attributes || !name) {
-        return NULL;
-    }
-
-    for (int i = 0; node->attributes[i]; i++) {
-        if (strcmp(node->attributes[i], name) == 0) {
-            return node->values[i];
-        }
-    }
-
-    return NULL;
 }

--- a/src/analysisd/expression.c
+++ b/src/analysisd/expression.c
@@ -138,6 +138,10 @@ bool w_expression_compile(w_expression_t * expression, char * pattern, int flags
 
             break;
 
+        case EXP_TYPE_STRING:
+            os_strdup(pattern, expression->string);
+            break;
+
         default:
             break;
     }
@@ -270,6 +274,10 @@ const char * w_expression_get_regex_pattern(w_expression_t * expression) {
             retval = expression->pcre2->raw_pattern;
             break;
 
+        case EXP_TYPE_STRING:
+            retval = expression->string;
+            break;
+
         default:
             break;
     }
@@ -297,6 +305,10 @@ const char * w_expression_get_regex_type(w_expression_t * expression) {
 
         case EXP_TYPE_PCRE2:
             retval = PCRE2_STR;
+            break;
+        
+        case EXP_TYPE_STRING:
+            retval = STRING_STR;
             break;
 
         default:

--- a/src/analysisd/expression.h
+++ b/src/analysisd/expression.h
@@ -18,6 +18,7 @@
 #define OSMATCH_STR  "osmatch"
 #define OSREGEX_STR  "osregex"
 #define PCRE2_STR    "pcre2"
+#define STRING_STR   "string"
 
 /**
  * @brief Determine the types of expression allowed

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -24,6 +24,7 @@ int default_timeframe;
 #define RULEPATH "ruleset/rules/"
 #endif
 
+
 /* Prototypes */
 static int getattributes(char **attributes,
                   char **values,
@@ -54,10 +55,13 @@ bool w_check_attr_negate(xml_node *node, int rule_id);
 bool w_check_attr_field_name(xml_node * node, FieldInfo ** field, int rule_id);
 
 /**
- * @brief Check if a option (regex or field) has attribute type
+ * @brief Get regex type attribute of a node
+ * @param node node to find regex type value
+ * @param default_type default type be returned in case of invalid or missing type
+ * @param rule_id rule identifier
+ * @return regex type
  */
-w_exp_type_t w_check_attr_type(xml_node *node, int rule_id);
-
+w_exp_type_t w_check_attr_type(xml_node * node, w_exp_type_t default_type, int rule_id);
 
 /* Will initialize the rules list */
 void Rules_OP_CreateRules()
@@ -213,10 +217,32 @@ int Rules_OP_ReadRules(const char *rulefile)
     char *extra_data = NULL;
     char *program_name = NULL;
     char *location = NULL;
+    char *action = NULL;
     RuleInfo *config_ruleinfo = NULL;
 
     size_t i;
     default_timeframe = 360;
+
+    /* Default regex types */
+    const w_exp_type_t match_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t regex_default_type = EXP_TYPE_OSREGEX;
+    const w_exp_type_t extra_data_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t hostname_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t location_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t program_name_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t protocol_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t user_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t url_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t srcport_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t dstport_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t status_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t system_name_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t data_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t srcgeoip_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t dstgeoip_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t id_default_type = EXP_TYPE_OSMATCH;
+    const w_exp_type_t field_default_type = EXP_TYPE_OSREGEX;
+    const w_exp_type_t action_default_type = EXP_TYPE_STRING;
 
     /* If no directory in the rulefile, add the default */
     if ((strchr(rulefile, '/')) == NULL) {
@@ -417,8 +443,26 @@ int Rules_OP_ReadRules(const char *rulefile)
                 bool negate_system_name = false;
                 bool negate_srcgeoip = false;
                 bool negate_dstgeoip = false;
+                bool negate_action = false;
 
+                w_exp_type_t match_type;
                 w_exp_type_t regex_type;
+                w_exp_type_t extra_data_type;
+                w_exp_type_t hostname_type;
+                w_exp_type_t location_type;
+                w_exp_type_t program_name_type;
+                w_exp_type_t protocol_type;
+                w_exp_type_t user_type;
+                w_exp_type_t url_type;
+                w_exp_type_t srcport_type;
+                w_exp_type_t dstport_type;
+                w_exp_type_t status_type;
+                w_exp_type_t system_name_type;
+                w_exp_type_t data_type;
+                w_exp_type_t srcgeoip_type;
+                w_exp_type_t dstgeoip_type;
+                w_exp_type_t id_type;
+                w_exp_type_t action_type;
 
                 regex = NULL;
                 match = NULL;
@@ -440,6 +484,7 @@ int Rules_OP_ReadRules(const char *rulefile)
                 extra_data = NULL;
                 program_name = NULL;
                 location = NULL;
+                action = NULL;
 
                 XML_NODE rule_opt = NULL;
                 rule_opt =  OS_GetElementsbyNode(&xml, rule[j]);
@@ -460,12 +505,13 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         regex =loadmemory(regex, rule_opt[k]->content);
                         negate_regex = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
-                        regex_type = w_check_attr_type(rule_opt[k], config_ruleinfo->sigid);
+                        regex_type = w_check_attr_type(rule_opt[k], regex_default_type, config_ruleinfo->sigid);
 
                     } else if (strcasecmp(rule_opt[k]->element, xml_match) == 0) {
 
                         match = loadmemory(match, rule_opt[k]->content);
                         negate_match = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        match_type = w_check_attr_type(rule_opt[k], match_default_type, config_ruleinfo->sigid);
 
                     } else if (strcasecmp(rule_opt[k]->element, xml_decoded) == 0) {
                         config_ruleinfo->decoded_as =
@@ -608,6 +654,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         user = loadmemory(user, rule_opt[k]->content);
                         negate_user = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        user_type = w_check_attr_type(rule_opt[k], user_default_type, config_ruleinfo->sigid);
 
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
@@ -617,6 +664,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         srcgeoip = loadmemory(srcgeoip, rule_opt[k]->content);
                         negate_srcgeoip = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        srcgeoip_type = w_check_attr_type(rule_opt[k], srcgeoip_default_type, config_ruleinfo->sigid);
 
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
@@ -626,6 +674,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         dstgeoip = loadmemory(dstgeoip, rule_opt[k]->content);
                         negate_dstgeoip = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        dstgeoip_type = w_check_attr_type(rule_opt[k], dstgeoip_default_type, config_ruleinfo->sigid);
 
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
@@ -635,11 +684,13 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         id = loadmemory(id, rule_opt[k]->content);
                         negate_id = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        id_type = w_check_attr_type(rule_opt[k], id_default_type, config_ruleinfo->sigid);
 
                     } else if (strcasecmp(rule_opt[k]->element, xml_srcport) == 0) {
 
                         srcport = loadmemory(srcport, rule_opt[k]->content);
                         negate_srcport = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        srcport_type = w_check_attr_type(rule_opt[k], srcport_default_type, config_ruleinfo->sigid);
 
                         if (!(config_ruleinfo->alert_opts & DO_PACKETINFO)) {
                             config_ruleinfo->alert_opts |= DO_PACKETINFO;
@@ -649,6 +700,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         dstport = loadmemory(dstport, rule_opt[k]->content);
                         negate_dstport = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        dstport_type = w_check_attr_type(rule_opt[k], dstport_default_type, config_ruleinfo->sigid);
 
                         if (!(config_ruleinfo->alert_opts & DO_PACKETINFO)) {
                             config_ruleinfo->alert_opts |= DO_PACKETINFO;
@@ -658,6 +710,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         status = loadmemory(status, rule_opt[k]->content);
                         negate_status = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        status_type = w_check_attr_type(rule_opt[k], status_default_type, config_ruleinfo->sigid);
 
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
@@ -667,6 +720,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         hostname = loadmemory(hostname, rule_opt[k]->content);
                         negate_hostname = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        hostname_type = w_check_attr_type(rule_opt[k], hostname_default_type, config_ruleinfo->sigid);
 
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
@@ -676,6 +730,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         data = loadmemory(data, rule_opt[k]->content);
                         negate_data = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        data_type = w_check_attr_type(rule_opt[k], data_default_type, config_ruleinfo->sigid);
 
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
@@ -685,6 +740,8 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         extra_data = loadmemory(extra_data, rule_opt[k]->content);
                         negate_extra_data = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        extra_data_type = w_check_attr_type(rule_opt[k], extra_data_default_type,
+                                                            config_ruleinfo->sigid);
 
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
@@ -694,31 +751,33 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         program_name = loadmemory(program_name, rule_opt[k]->content);
                         negate_program_name = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        program_name_type = w_check_attr_type(rule_opt[k], program_name_default_type,
+                                                              config_ruleinfo->sigid);
 
                     } else if (strcasecmp(rule_opt[k]->element, xml_action) == 0) {
 
-                        if (config_ruleinfo->action == NULL) {
-                            w_calloc_expression_t(&config_ruleinfo->action, EXP_TYPE_STRING);
-                        }
-                        config_ruleinfo->action->string = loadmemory(config_ruleinfo->action->string,
-                                                                     rule_opt[k]->content);
-
-                        config_ruleinfo->action->negate = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        action = loadmemory(action, rule_opt[k]->content);
+                        negate_action = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        action_type = w_check_attr_type(rule_opt[k], action_default_type, config_ruleinfo->sigid);
 
                     } else if(strcasecmp(rule_opt[k]->element, xml_system_name) == 0){
 
                         system_name = loadmemory(system_name, rule_opt[k]->content);
                         negate_system_name = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        system_name_type = w_check_attr_type(rule_opt[k], system_name_default_type,
+                                                             config_ruleinfo->sigid);
 
                     } else if(strcasecmp(rule_opt[k]->element, xml_protocol) == 0){
 
                         protocol = loadmemory(protocol, rule_opt[k]->content);
                         negate_protocol = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        protocol_type = w_check_attr_type(rule_opt[k], protocol_default_type, config_ruleinfo->sigid);
 
                     } else if (strcasecmp(rule_opt[k]->element, xml_location) == 0) {
 
                         location = loadmemory(location, rule_opt[k]->content);
                         negate_location = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        location_type = w_check_attr_type(rule_opt[k], location_default_type, config_ruleinfo->sigid);
 
                     } else if (strcasecmp(rule_opt[k]->element, xml_field) == 0) {
 
@@ -728,7 +787,9 @@ int Rules_OP_ReadRules(const char *rulefile)
                             goto cleanup;
                         }
 
-                        w_exp_type_t type = w_check_attr_type(rule_opt[k], config_ruleinfo->sigid);
+                        w_exp_type_t type;
+                        type = w_check_attr_type(rule_opt[k], field_default_type, config_ruleinfo->sigid);
+
                         bool negate = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
 
                         w_calloc_expression_t(&config_ruleinfo->fields[ifield]->regex, type);
@@ -861,6 +922,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         url = loadmemory(url, rule_opt[k]->content);
                         negate_url = w_check_attr_negate(rule_opt[k], config_ruleinfo->sigid);
+                        url_type = w_check_attr_type(rule_opt[k], url_default_type, config_ruleinfo->sigid);
 
                     } else if (strcasecmp(rule_opt[k]->element, xml_compiled) == 0) {
                         int it_id = 0;
@@ -1541,7 +1603,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add in match */
                 if (match) {
-                    w_calloc_expression_t(&config_ruleinfo->match, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->match, match_type);
                     config_ruleinfo->match->negate = negate_match;
 
                     if (!w_expression_compile(config_ruleinfo->match, match, 0)) {
@@ -1554,7 +1616,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add in id */
                 if (id) {
-                    w_calloc_expression_t(&config_ruleinfo->id, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->id, id_type);
                     config_ruleinfo->id->negate = negate_id;
 
                     if (!w_expression_compile(config_ruleinfo->id, id, 0)) {
@@ -1567,7 +1629,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add srcport */
                 if (srcport) {
-                    w_calloc_expression_t(&config_ruleinfo->srcport, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->srcport, srcport_type);
                     config_ruleinfo->srcport->negate = negate_srcport;
 
                     if (!w_expression_compile(config_ruleinfo->srcport, srcport, 0)) {
@@ -1580,7 +1642,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add dstport */
                 if (dstport) {
-                    w_calloc_expression_t(&config_ruleinfo->dstport, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->dstport, dstport_type);
                     config_ruleinfo->dstport->negate = negate_dstport;
 
                     if (!w_expression_compile(config_ruleinfo->dstport, dstport, 0)) {
@@ -1594,7 +1656,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add in status */
                 if (status) {
-                    w_calloc_expression_t(&config_ruleinfo->status, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->status, status_type);
                     config_ruleinfo->status->negate = negate_status;
 
                     if (!w_expression_compile(config_ruleinfo->status, status, 0)) {
@@ -1607,7 +1669,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add in hostname */
                 if (hostname) {
-                    w_calloc_expression_t(&config_ruleinfo->hostname, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->hostname, hostname_type);
                     config_ruleinfo->hostname->negate = negate_hostname;
 
                     if (!w_expression_compile(config_ruleinfo->hostname, hostname, 0)) {
@@ -1620,7 +1682,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add data */
                 if (data) {
-                    w_calloc_expression_t(&config_ruleinfo->data, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->data, data_type);
                     config_ruleinfo->data->negate = negate_data;
 
                     if (!w_expression_compile(config_ruleinfo->data, data, 0)) {
@@ -1633,7 +1695,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add extra data */
                 if (extra_data) {
-                    w_calloc_expression_t(&config_ruleinfo->extra_data, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->extra_data, extra_data_type);
                     config_ruleinfo->extra_data->negate = negate_extra_data;
 
                     if (!w_expression_compile(config_ruleinfo->extra_data, extra_data, 0)) {
@@ -1646,7 +1708,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add in program name */
                 if (program_name) {
-                    w_calloc_expression_t(&config_ruleinfo->program_name, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->program_name, program_name_type);
                     config_ruleinfo->program_name->negate = negate_program_name;
 
                     if (!w_expression_compile(config_ruleinfo->program_name, program_name, 0)) {
@@ -1659,7 +1721,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add in user */
                 if (user) {
-                    w_calloc_expression_t(&config_ruleinfo->user, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->user, user_type);
                     config_ruleinfo->user->negate = negate_user;
 
                     if (!w_expression_compile(config_ruleinfo->user, user, 0)) {
@@ -1672,7 +1734,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Adding in srcgeoip */
                 if(srcgeoip) {
-                    w_calloc_expression_t(&config_ruleinfo->srcgeoip, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->srcgeoip, srcgeoip_type);
                     config_ruleinfo->srcgeoip->negate = negate_srcgeoip;
 
                     if (!w_expression_compile(config_ruleinfo->srcgeoip, srcgeoip, 0)) {
@@ -1685,7 +1747,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Adding in dstgeoip */
                 if(dstgeoip) {
-                    w_calloc_expression_t(&config_ruleinfo->dstgeoip, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->dstgeoip, dstgeoip_type);
                     config_ruleinfo->dstgeoip->negate = negate_dstgeoip;
 
                     if (!w_expression_compile(config_ruleinfo->dstgeoip, dstgeoip, 0)) {
@@ -1699,7 +1761,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add in URL */
                 if (url) {
-                    w_calloc_expression_t(&config_ruleinfo->url, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->url, url_type);
                     config_ruleinfo->url->negate = negate_url;
 
                     if (!w_expression_compile(config_ruleinfo->url, url, 0)) {
@@ -1712,7 +1774,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add location */
                 if (location) {
-                    w_calloc_expression_t(&config_ruleinfo->location, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->location, location_type);
                     config_ruleinfo->location->negate = negate_location;
 
                     if (!w_expression_compile(config_ruleinfo->location, location, 0)) {
@@ -1721,6 +1783,19 @@ int Rules_OP_ReadRules(const char *rulefile)
                     }
 
                     os_free(location);
+                }
+                
+                /* Add location */
+                if (action) {
+                    w_calloc_expression_t(&config_ruleinfo->action, action_type);
+                    config_ruleinfo->action->negate = negate_action;
+
+                    if (!w_expression_compile(config_ruleinfo->action, action, 0)) {
+                        merror(RL_REGEX_SYNTAX, xml_action, config_ruleinfo->sigid);
+                        goto cleanup;
+                    }
+
+                    os_free(action);
                 }
 
                 /* Add matched_group */
@@ -1755,7 +1830,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add protocol */
                 if(protocol){
-                    w_calloc_expression_t(&config_ruleinfo->protocol, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->protocol, protocol_type);
                     config_ruleinfo->protocol->negate = negate_protocol;
 
                     if (!w_expression_compile(config_ruleinfo->protocol, protocol, 0)){
@@ -1768,7 +1843,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Add system_name */
                 if(system_name){
-                    w_calloc_expression_t(&config_ruleinfo->system_name, EXP_TYPE_OSMATCH);
+                    w_calloc_expression_t(&config_ruleinfo->system_name, system_name_type);
                     config_ruleinfo->system_name->negate = negate_system_name;
 
                     if (!w_expression_compile(config_ruleinfo->system_name, system_name, 0)){
@@ -1873,26 +1948,27 @@ int Rules_OP_ReadRules(const char *rulefile)
 
 cleanup:
 
-    free(regex);
-    free(match);
-    free(id);
-    free(srcport);
-    free(dstport);
-    free(status);
-    free(hostname);
-    free(extra_data);
-    free(program_name);
-    free(location);
-    free(user);
-    free(srcgeoip);
-    free(dstgeoip);
-    free(url);
-    free(if_matched_group);
-    free(if_matched_regex);
-    free(system_name);
-    free(protocol);
-    free(data);
-    free(rulepath);
+    os_free(regex);
+    os_free(match);
+    os_free(id);
+    os_free(srcport);
+    os_free(dstport);
+    os_free(status);
+    os_free(hostname);
+    os_free(extra_data);
+    os_free(program_name);
+    os_free(location);
+    os_free(user);
+    os_free(srcgeoip);
+    os_free(dstgeoip);
+    os_free(url);
+    os_free(if_matched_group);
+    os_free(if_matched_regex);
+    os_free(system_name);
+    os_free(protocol);
+    os_free(data);
+    os_free(rulepath);
+    os_free(action)
     OS_ClearNode(rule);
 
     if (retval) {
@@ -2540,30 +2616,37 @@ bool w_check_attr_field_name(xml_node * node, FieldInfo ** field, int rule_id) {
     return false;
 }
 
+w_exp_type_t w_check_attr_type(xml_node * node, w_exp_type_t default_type, int rule_id) {
 
-w_exp_type_t w_check_attr_type(xml_node *node, int rule_id) {
-
-    if (!node->attributes) {
-        return EXP_TYPE_OSREGEX;
-    }
+    const char * xml_osregex_type = OSREGEX_STR;
+    const char * xml_osmatch_type = OSMATCH_STR;
+    const char * xml_pcre2_type = PCRE2_STR;
 
     const char * xml_type = "type";
+    char * str_type = NULL;
+
+    if (!node || !node->attributes) {
+        return default_type;
+    }
 
     for (int i = 0; node->attributes[i]; i++) {
         if (strcasecmp(node->attributes[i], xml_type) == 0) {
-
-            if (strcasecmp(node->values[i], OSREGEX_STR) == 0) {
-                return EXP_TYPE_OSREGEX;
-            }
-            else if (strcasecmp(node->values[i], PCRE2_STR) == 0) {
-                return EXP_TYPE_PCRE2;
-            }
-            else {
-                mwarn(ANALYSISD_INV_VALUE_RULE, node->values[i],
-                      node->attributes[i], rule_id);
-            }
+            str_type = node->values[i];
+            break;
         }
     }
 
-    return EXP_TYPE_OSREGEX;
+    if (!str_type) { 
+        return default_type;
+    } else if (strcasecmp(str_type, xml_osregex_type) == 0) {
+        return EXP_TYPE_OSREGEX;
+    } else if (strcasecmp(str_type, xml_osmatch_type) == 0) {
+        return EXP_TYPE_OSMATCH;
+    } else if (strcasecmp(str_type, xml_pcre2_type) == 0) {
+        return EXP_TYPE_PCRE2;
+    } else {
+        mwarn(ANALYSISD_INV_VALUE_RULE, str_type, "type", rule_id);
+    }
+
+    return default_type;
 }

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -606,3 +606,18 @@ static int _getattributes(unsigned int parent, OS_XML *_lxml)
     xml_error(_lxml, "XMLERR: End of file while reading an attribute.");
     return (-1);
 }
+
+const char * w_get_attr_val_by_name(xml_node * node, const char * name) {
+
+    if (!node || !node->attributes || !name) {
+        return NULL;
+    }
+
+    for (int i = 0; node->attributes[i]; i++) {
+        if (strcmp(node->attributes[i], name) == 0) {
+            return node->values[i];
+        }
+    }
+
+    return NULL;
+}

--- a/src/os_xml/os_xml.h
+++ b/src/os_xml/os_xml.h
@@ -108,4 +108,12 @@ int OS_ApplyVariables(OS_XML *_lxml) __attribute__((nonnull));
 int OS_WriteXML(const char *infile, const char *outfile, const char **nodes,
                 const char *oldval, const char *newval) __attribute__((nonnull(1, 2, 3, 5)));
 
+/**
+ * @brief Get value of an attribute of a node
+ * @param node node to find value of attribute
+ * @param name name of the attribute
+ * @return value of attribute on success. NULL otherwise
+ */
+const char * w_get_attr_val_by_name(xml_node * node, const char * name);
+
 #endif /* OS_XML_H */

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -47,6 +47,7 @@ endif()
 
 add_subdirectory(syscheckd)
 add_subdirectory(shared)
+add_subdirectory(os_xml)
 
 # Config files
 if(${TARGET} STREQUAL "winagent")

--- a/src/unit_tests/analysisd/test_decode-xml.c
+++ b/src/unit_tests/analysisd/test_decode-xml.c
@@ -18,56 +18,12 @@
 #include "../../analysisd/decoders/decode-xml.c"
 #include "../wrappers/common.h"
 
-const char * w_get_attr_val_by_name(xml_node * node, const char * name);
 bool w_get_attr_regex_type(xml_node * node, w_exp_type_t * type);
 int w_get_attr_offset(xml_node * node);
 
 /* setup/teardown */
 
 /* tests */
-
-// w_get_attr_val_by_name
-
-void w_get_attr_val_by_name_null_attr(void ** state) {
-
-    xml_node node = {0};
-    const char * retval;
-
-    retval = w_get_attr_val_by_name(&node, "test_attr_name");
-
-    assert_null(retval);
-}
-
-void w_get_attr_val_by_name_not_found(void ** state) {
-
-    xml_node node = {0};
-    char * attributes[] = {"attr_name_1", "attr_name_2", NULL};
-    char * values[] = {"attr_val_1", "attr_val_2", NULL};
-
-    node.attributes = attributes;
-    node.values = values;
-    const char * retval;
-
-    retval = w_get_attr_val_by_name(&node, "test_attr_name");
-
-    assert_null(retval);
-}
-
-void w_get_attr_val_by_name_found(void ** state) {
-
-    xml_node node = {0};
-    char * attributes[] = {"attr_name_1", "test_attr_name", "attr_name_3", NULL};
-    char * values[] = {"attr_val_1", "test_attr_value", "attr_val_3", NULL};
-
-    node.attributes = attributes;
-    node.values = values;
-    const char * retval;
-
-    retval = w_get_attr_val_by_name(&node, "test_attr_name");
-
-    assert_non_null(retval);
-    assert_string_equal(retval, "test_attr_value");
-}
 
 // w_get_attr_regex_type
 
@@ -239,12 +195,6 @@ void w_get_attr_offset_error(void ** state) {
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-
-        // Test w_get_attr_val_by_name
-        cmocka_unit_test(w_get_attr_val_by_name_null_attr),
-        cmocka_unit_test(w_get_attr_val_by_name_not_found),
-        cmocka_unit_test(w_get_attr_val_by_name_found),
-
         // Test w_get_attr_regex_type
         cmocka_unit_test(w_get_attr_regex_type_not_found),
         cmocka_unit_test(w_get_attr_regex_type_osregex),

--- a/src/unit_tests/analysisd/test_expression.c
+++ b/src/unit_tests/analysisd/test_expression.c
@@ -424,6 +424,7 @@ void w_expression_compile_string(void ** state)
     assert_true(ret);
 
     os_free(pattern);
+    os_free(expression->string);
     os_free(expression);
 }
 
@@ -937,14 +938,12 @@ void w_expression_get_regex_pattern_exp_type_string(void ** state)
     os_calloc(1, sizeof(w_expression_t), expression);
     expression->exp_type = EXP_TYPE_STRING;
 
-    os_calloc(1, sizeof(OSRegex), expression->regex);
-    os_strdup("test", expression->regex->raw);
+    os_strdup("test", expression->string);
 
     const char* ret = w_expression_get_regex_pattern(expression);
-    assert_null(ret);
+    assert_string_equal("test", ret);
 
-    os_free(expression->regex->raw);
-    os_free(expression->regex);
+    os_free(expression->string);
     os_free(expression);
 }
 
@@ -1048,14 +1047,12 @@ void w_expression_get_regex_type_exp_type_string(void ** state)
     os_calloc(1, sizeof(w_expression_t), expression);
     expression->exp_type = EXP_TYPE_STRING;
 
-    os_calloc(1, sizeof(OSRegex), expression->regex);
-    os_strdup("test", expression->regex->raw);
+    os_strdup("test", expression->string);
 
     const char* ret = w_expression_get_regex_type(expression);
-    assert_null(ret);
+    assert_string_equal("string", ret);
 
-    os_free(expression->regex->raw);
-    os_free(expression->regex);
+    os_free(expression->string);
     os_free(expression);
 }
 

--- a/src/unit_tests/os_xml/CMakeLists.txt
+++ b/src/unit_tests/os_xml/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Generate os_xml library
+file(GLOB os_xml_files
+    ${SRC_FOLDER}/os_xml/*.o)
+
+add_library(OS_XML_O STATIC ${os_xml_files})
+
+set_source_files_properties(
+    ${os_xml_files}
+    PROPERTIES
+    EXTERNAL_OBJECT true
+    GENERATED true
+)
+
+set_target_properties(
+    OS_XML_O
+    PROPERTIES
+    LINKER_LANGUAGE C
+)
+
+target_link_libraries(OS_XML_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
+
+add_executable(test_os_xml test_os_xml.c)
+target_compile_options(test_os_xml PRIVATE "-Wall")
+target_link_libraries(test_os_xml OS_XML_O ${TEST_DEPS})
+target_link_libraries(test_os_xml "")
+add_test(NAME test_os_xml COMMAND test_os_xml)

--- a/src/unit_tests/os_xml/test_os_xml.c
+++ b/src/unit_tests/os_xml/test_os_xml.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <setjmp.h>
+#include <stdio.h>
+#include <cmocka.h>
+
+#include "../../os_xml/os_xml.h"
+#include "../wrappers/common.h"
+
+const char * w_get_attr_val_by_name(xml_node * node, const char * name);
+
+
+/* setup/teardown */
+
+/* tests */
+
+// w_get_attr_val_by_name
+
+void w_get_attr_val_by_name_null_attr(void ** state) {
+
+    xml_node node = {0};
+    const char * retval;
+
+    retval = w_get_attr_val_by_name(&node, "test_attr_name");
+
+    assert_null(retval);
+}
+
+void w_get_attr_val_by_name_not_found(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "attr_name_2", NULL};
+    char * values[] = {"attr_val_1", "attr_val_2", NULL};
+
+    node.attributes = attributes;
+    node.values = values;
+    const char * retval;
+
+    retval = w_get_attr_val_by_name(&node, "test_attr_name");
+
+    assert_null(retval);
+}
+
+void w_get_attr_val_by_name_found(void ** state) {
+
+    xml_node node = {0};
+    char * attributes[] = {"attr_name_1", "test_attr_name", "attr_name_3", NULL};
+    char * values[] = {"attr_val_1", "test_attr_value", "attr_val_3", NULL};
+
+    node.attributes = attributes;
+    node.values = values;
+    const char * retval;
+
+    retval = w_get_attr_val_by_name(&node, "test_attr_name");
+
+    assert_non_null(retval);
+    assert_string_equal(retval, "test_attr_value");
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+
+        // Test w_get_attr_val_by_name
+        cmocka_unit_test(w_get_attr_val_by_name_null_attr),
+        cmocka_unit_test(w_get_attr_val_by_name_not_found),
+        cmocka_unit_test(w_get_attr_val_by_name_found)
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/6498|

## Description 
Hi team!,

This PR adds support for PCRE2 & OSRegex in the static fields of the rules:

## List of changes:

Add PCRE2 & OSRegex:
- [X] extra_data
- [X] hostname
- [X] location
- [X] program_name
- [x] protocol
- [X] user
- [X] url
- [X] srcport
- [X] dstport
- [x] status
- [X] system_name
- [x] data
- [x] id
- [x] srcgeoip
- [x] dstgeoip
- [X] match
By default, if the type is not specified, they remain OSMatch.

Add OSMatch & PCRE2 & OSRegex:
- [X] accion
By default, if the type is not specified, they remain string.

Add OSMatch:
- [X] regex
By default, if the type is not specified, they remain OSRegex.

## Test / Task

- [X] Extended the rule parser to accept PCRE2/OSregex and rule matching
- [X] Analysisd shall export the expression type attribute in JSON
- [X] Scan-Build
- [x] Valgrind Report
- [x] Ruleset unit test works
- [X] UT
- [X] UT Coverage
- [X] UT Valgrind