### PR TITLE
Fix warnings and variables usage in Wazuh DB unitests

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -70,6 +70,8 @@ list(APPEND wdb_tests_names "test_wdb_metadata")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_errmsg \
                              -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_finalize -Wl,--wrap,sqlite3_column_int")
 
+# Add extra compiling flags
+add_compile_options(-Wall)
 
 # Compilig tests
 list(LENGTH wdb_tests_names count)

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -78,7 +78,6 @@ void test_wdb_open_global_pool_success(void **state)
 void test_wdb_open_global_create_fail(void **state)
 {
     wdb_t *ret = NULL;
-    test_struct_t *data  = (test_struct_t *)*state;
 
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_value(__wrap_OSHash_Get, self, (OSHash*) 0);
@@ -92,7 +91,7 @@ void test_wdb_open_global_create_fail(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global database not found, creating.");
     will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
 
-    // wdb_create_global 
+    // wdb_create_global
     //// wdb_create_file
     expect_string(__wrap_sqlite3_open_v2, filename, "queue/db/global.db");
     will_return(__wrap_sqlite3_open_v2, NULL);
@@ -111,7 +110,7 @@ void test_wdb_open_global_create_fail(void **state)
 
 int main()
 {
-    const struct CMUnitTest tests[] = 
+    const struct CMUnitTest tests[] =
     {
         cmocka_unit_test_setup_teardown(test_wdb_open_global_pool_success, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_open_global_create_fail, setup_wdb, teardown_wdb)

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -956,7 +956,6 @@ void test_wdb_update_agent_name_success(void **state)
 void test_wdb_update_agent_data_invalid_data(void **state)
 {
     int ret = 0;
-    int id = 1;
     agent_info_data *agent_data = NULL;
 
     expect_string(__wrap__mdebug1, formatted_msg, "Invalid data provided to set in global.db.");
@@ -969,7 +968,6 @@ void test_wdb_update_agent_data_invalid_data(void **state)
 void test_wdb_update_agent_data_error_json(void **state)
 {
     int ret = 0;
-    int id = 1;
     agent_info_data *agent_data = NULL;
 
     os_calloc(1, sizeof(agent_info_data), agent_data);
@@ -1009,7 +1007,6 @@ void test_wdb_update_agent_data_error_json(void **state)
 void test_wdb_update_agent_data_error_socket(void **state)
 {
     int ret = 0;
-    int id = 1;
     agent_info_data *agent_data = NULL;
 
     os_calloc(1, sizeof(agent_info_data), agent_data);
@@ -1125,7 +1122,6 @@ void test_wdb_update_agent_data_error_socket(void **state)
 void test_wdb_update_agent_data_error_sql_execution(void **state)
 {
     int ret = 0;
-    int id = 1;
     agent_info_data *agent_data = NULL;
 
     os_calloc(1, sizeof(agent_info_data), agent_data);
@@ -1241,7 +1237,6 @@ void test_wdb_update_agent_data_error_sql_execution(void **state)
 void test_wdb_update_agent_data_error_result(void **state)
 {
     int ret = 0;
-    int id = 1;
     agent_info_data *agent_data = NULL;
 
     os_calloc(1, sizeof(agent_info_data), agent_data);
@@ -1352,7 +1347,6 @@ void test_wdb_update_agent_data_error_result(void **state)
 void test_wdb_update_agent_data_success(void **state)
 {
     int ret = 0;
-    int id = 1;
     agent_info_data *agent_data = NULL;
 
     os_calloc(1, sizeof(agent_info_data), agent_data);
@@ -2365,8 +2359,6 @@ void test_wdb_remove_agent_error_delete_belongs_and_name(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error in the response from socket");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global delete-agent-belong 1");
 
-    const char *query_name_str = "global select-agent-name 1";
-
     // Calling Wazuh DB in select-agent-name
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, NULL);
@@ -3025,7 +3017,6 @@ void test_wdb_get_agent_status_error_no_json_response(void **state) {
 void test_wdb_get_agent_status_error_json_data(void **state) {
     cJSON *root = NULL;
     cJSON *row = NULL;
-    cJSON *str = NULL;
     int id = 1;
     int status = 0;
 
@@ -4690,8 +4681,7 @@ void test_wdb_update_groups_error_max_path(void **state) {
 
     // Generating a very long group name
     os_calloc(PATH_MAX+1, sizeof(char), very_long_name);
-    int i = 0;
-    for (i; i < PATH_MAX; ++i) {*(very_long_name + i) = 'A';};
+    for (int i = 0; i < PATH_MAX; ++i) {*(very_long_name + i) = 'A';}
 
     root = __real_cJSON_CreateArray();
     row1 = __real_cJSON_CreateObject();
@@ -4719,8 +4709,6 @@ void test_wdb_update_groups_error_max_path(void **state) {
     will_return(__wrap_opendir, 0);
 
     //// Call to wdb_remove_group_db
-    const char *name = "test_group";
-
     const char *query_str = "global delete-group-belong test_group";
     const char *response = "err";
 
@@ -4771,8 +4759,6 @@ void test_wdb_update_groups_error_removing_group_db(void **state) {
     will_return(__wrap_opendir, 0);
 
     //// Call to wdb_remove_group_db
-    const char *name = "test_group";
-
     const char *query_str = "global delete-group-belong test_group";
     const char *response = "err";
 
@@ -4926,8 +4912,6 @@ void test_wdb_agent_belongs_first_time_success(void **state) {
     cJSON *root = NULL;
     cJSON *row = NULL;
     cJSON *str = NULL;
-    int id = 1;
-    char *name = NULL;
 
     root = __real_cJSON_CreateArray();
     row = __real_cJSON_CreateObject();

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -913,7 +913,6 @@ void test_wdb_global_insert_agent_transaction_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 0;
     char *name = NULL;
     char *ip = NULL;
     char *register_ip = NULL;
@@ -924,7 +923,7 @@ void test_wdb_global_insert_agent_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, 1, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -933,7 +932,6 @@ void test_wdb_global_insert_agent_cache_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 0;
     char *name = NULL;
     char *ip = NULL;
     char *register_ip = NULL;
@@ -945,7 +943,7 @@ void test_wdb_global_insert_agent_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, 1, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -954,7 +952,6 @@ void test_wdb_global_insert_agent_bind1_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -965,13 +962,13 @@ void test_wdb_global_insert_agent_bind1_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, 1, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -980,7 +977,6 @@ void test_wdb_global_insert_agent_bind2_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -991,7 +987,7 @@ void test_wdb_global_insert_agent_bind2_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1000,7 +996,7 @@ void test_wdb_global_insert_agent_bind2_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, 1, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1009,7 +1005,6 @@ void test_wdb_global_insert_agent_bind3_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1020,7 +1015,7 @@ void test_wdb_global_insert_agent_bind3_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1032,7 +1027,7 @@ void test_wdb_global_insert_agent_bind3_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, 1, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1041,7 +1036,6 @@ void test_wdb_global_insert_agent_bind4_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1052,7 +1046,7 @@ void test_wdb_global_insert_agent_bind4_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1067,7 +1061,7 @@ void test_wdb_global_insert_agent_bind4_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, 1, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1076,7 +1070,6 @@ void test_wdb_global_insert_agent_bind5_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1087,7 +1080,7 @@ void test_wdb_global_insert_agent_bind5_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1105,7 +1098,7 @@ void test_wdb_global_insert_agent_bind5_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, 1, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1114,7 +1107,6 @@ void test_wdb_global_insert_agent_bind6_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1125,7 +1117,7 @@ void test_wdb_global_insert_agent_bind6_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1146,7 +1138,7 @@ void test_wdb_global_insert_agent_bind6_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, 1, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1155,7 +1147,6 @@ void test_wdb_global_insert_agent_bind7_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1166,7 +1157,7 @@ void test_wdb_global_insert_agent_bind7_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1190,7 +1181,7 @@ void test_wdb_global_insert_agent_bind7_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, 1, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1199,7 +1190,6 @@ void test_wdb_global_insert_agent_step_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1210,7 +1200,7 @@ void test_wdb_global_insert_agent_step_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1235,7 +1225,7 @@ void test_wdb_global_insert_agent_step_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, 1, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1244,7 +1234,6 @@ void test_wdb_global_insert_agent_success(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
     char *ip = "test_ip";
     char *register_ip = "0.0.0.0";
@@ -1255,7 +1244,7 @@ void test_wdb_global_insert_agent_success(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
@@ -1278,7 +1267,7 @@ void test_wdb_global_insert_agent_success(void **state)
 
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_insert_agent(data->wdb, agent_id, name, ip, register_ip, internal_key, group, date_add);
+    result = wdb_global_insert_agent(data->wdb, 1, name, ip, register_ip, internal_key, group, date_add);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -1289,13 +1278,12 @@ void test_wdb_global_update_agent_name_transaction_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = NULL;
 
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_update_agent_name(data->wdb, agent_id, name);
+    result = wdb_global_update_agent_name(data->wdb, 1, name);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1304,14 +1292,13 @@ void test_wdb_global_update_agent_name_cache_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = NULL;
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_update_agent_name(data->wdb, agent_id, name);
+    result = wdb_global_update_agent_name(data->wdb, 1, name);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1320,7 +1307,6 @@ void test_wdb_global_update_agent_name_bind1_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1332,7 +1318,7 @@ void test_wdb_global_update_agent_name_bind1_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_name(data->wdb, agent_id, name);
+    result = wdb_global_update_agent_name(data->wdb, 1, name);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1341,7 +1327,6 @@ void test_wdb_global_update_agent_name_bind2_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1351,13 +1336,13 @@ void test_wdb_global_update_agent_name_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_name(data->wdb, agent_id, name);
+    result = wdb_global_update_agent_name(data->wdb, 1, name);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1366,7 +1351,6 @@ void test_wdb_global_update_agent_name_step_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1376,14 +1360,14 @@ void test_wdb_global_update_agent_name_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_update_agent_name(data->wdb, agent_id, name);
+    result = wdb_global_update_agent_name(data->wdb, 1, name);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -1392,7 +1376,6 @@ void test_wdb_global_update_agent_name_success(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     char *name = "test_name";
 
     will_return(__wrap_wdb_begin2, 1);
@@ -1402,12 +1385,12 @@ void test_wdb_global_update_agent_name_success(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, name);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_update_agent_name(data->wdb, agent_id, name);
+    result = wdb_global_update_agent_name(data->wdb, 1, name);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -2864,14 +2847,13 @@ void test_wdb_global_update_agent_keepalive_transaction_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     const char *connection_status = "active";
     const char *status = "synced";
 
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
+    result = wdb_global_update_agent_keepalive(data->wdb, 1, connection_status, status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2880,7 +2862,6 @@ void test_wdb_global_update_agent_keepalive_cache_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     const char *connection_status = "active";
     const char *status = "synced";
 
@@ -2888,7 +2869,7 @@ void test_wdb_global_update_agent_keepalive_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
+    result = wdb_global_update_agent_keepalive(data->wdb, 1, connection_status, status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2897,7 +2878,6 @@ void test_wdb_global_update_agent_keepalive_bind1_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     const char *connection_status = "active";
     const char *status = "synced";
 
@@ -2911,7 +2891,7 @@ void test_wdb_global_update_agent_keepalive_bind1_fail(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
+    result = wdb_global_update_agent_keepalive(data->wdb, 1, connection_status, status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2920,7 +2900,6 @@ void test_wdb_global_update_agent_keepalive_bind2_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     const char *connection_status = "active";
     const char *status = "synced";
 
@@ -2937,7 +2916,7 @@ void test_wdb_global_update_agent_keepalive_bind2_fail(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
+    result = wdb_global_update_agent_keepalive(data->wdb, 1, connection_status, status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2946,7 +2925,6 @@ void test_wdb_global_update_agent_keepalive_bind3_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     const char *connection_status = "active";
     const char *status = "synced";
 
@@ -2960,13 +2938,13 @@ void test_wdb_global_update_agent_keepalive_bind3_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 3);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
+    result = wdb_global_update_agent_keepalive(data->wdb, 1, connection_status, status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -2975,7 +2953,6 @@ void test_wdb_global_update_agent_keepalive_step_fail(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     const char *connection_status = "active";
     const char *status = "synced";
 
@@ -2989,14 +2966,14 @@ void test_wdb_global_update_agent_keepalive_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 3);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
+    result = wdb_global_update_agent_keepalive(data->wdb, 1, connection_status, status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3005,7 +2982,6 @@ void test_wdb_global_update_agent_keepalive_success(void **state)
 {
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    int agent_id = 1;
     const char *connection_status = "active";
     const char *status = "synced";
 
@@ -3019,11 +2995,11 @@ void test_wdb_global_update_agent_keepalive_success(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 3);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_update_agent_keepalive(data->wdb, agent_id, connection_status, status);
+    result = wdb_global_update_agent_keepalive(data->wdb, 1, connection_status, status);
 
     assert_int_equal(result, OS_SUCCESS);
 }

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -49,7 +49,7 @@ void test_wdb_global_get_agent_labels_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    output = wdb_global_get_agent_labels(data->wdb, atoi(data->wdb->id));
+    output = wdb_global_get_agent_labels(data->wdb, 1);
     assert_null(output);
 }
 
@@ -62,7 +62,7 @@ void test_wdb_global_get_agent_labels_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    output = wdb_global_get_agent_labels(data->wdb, atoi(data->wdb->id));
+    output = wdb_global_get_agent_labels(data->wdb, 1);
     assert_null(output);
 }
 
@@ -74,13 +74,13 @@ void test_wdb_global_get_agent_labels_bind_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    output = wdb_global_get_agent_labels(data->wdb, atoi(data->wdb->id));
+    output = wdb_global_get_agent_labels(data->wdb, 1);
     assert_null(output);
 }
 
@@ -98,7 +98,7 @@ void test_wdb_global_get_agent_labels_exec_fail(void **state)
     will_return(__wrap_wdb_exec_stmt, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "wdb_exec_stmt(): ERROR MESSAGE");
 
-    output = wdb_global_get_agent_labels(data->wdb, atoi(data->wdb->id));
+    output = wdb_global_get_agent_labels(data->wdb, 1);
     assert_null(output);
 }
 
@@ -114,7 +114,7 @@ void test_wdb_global_get_agent_labels_success(void **state)
     will_return_always(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt, (cJSON*)1);
 
-    output = wdb_global_get_agent_labels(data->wdb, atoi(data->wdb->id));
+    output = wdb_global_get_agent_labels(data->wdb, 1);
     assert_ptr_equal(output, (cJSON*)1);
 }
 
@@ -128,7 +128,7 @@ void test_wdb_global_del_agent_labels_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_del_agent_labels(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_del_agent_labels(data->wdb, 1);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -141,7 +141,7 @@ void test_wdb_global_del_agent_labels_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_del_agent_labels(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_del_agent_labels(data->wdb, 1);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -153,12 +153,12 @@ void test_wdb_global_del_agent_labels_bind_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_del_agent_labels(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_del_agent_labels(data->wdb, 1);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -170,13 +170,13 @@ void test_wdb_global_del_agent_labels_step_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_del_agent_labels(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_del_agent_labels(data->wdb, 1);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -188,11 +188,11 @@ void test_wdb_global_del_agent_labels_success(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_del_agent_labels(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_del_agent_labels(data->wdb, 1);
     assert_int_equal(result, OS_SUCCESS);
 }
 
@@ -208,7 +208,7 @@ void test_wdb_global_set_agent_label_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
+    result = wdb_global_set_agent_label(data->wdb, 1, key, value);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -223,7 +223,7 @@ void test_wdb_global_set_agent_label_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
+    result = wdb_global_set_agent_label(data->wdb, 1, key, value);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -237,12 +237,12 @@ void test_wdb_global_set_agent_label_bind1_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
+    result = wdb_global_set_agent_label(data->wdb, 1, key, value);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -256,7 +256,7 @@ void test_wdb_global_set_agent_label_bind2_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_string(__wrap_sqlite3_bind_text, buffer, "test_key");
@@ -264,7 +264,7 @@ void test_wdb_global_set_agent_label_bind2_fail(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
+    result = wdb_global_set_agent_label(data->wdb, 1, key, value);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -278,7 +278,7 @@ void test_wdb_global_set_agent_label_bind3_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_string(__wrap_sqlite3_bind_text, buffer, "test_key");
@@ -289,7 +289,7 @@ void test_wdb_global_set_agent_label_bind3_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
+    result = wdb_global_set_agent_label(data->wdb, 1, key, value);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -303,7 +303,7 @@ void test_wdb_global_set_agent_label_step_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_string(__wrap_sqlite3_bind_text, buffer, "test_key");
@@ -315,7 +315,7 @@ void test_wdb_global_set_agent_label_step_fail(void **state)
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
+    result = wdb_global_set_agent_label(data->wdb, 1, key, value);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -329,7 +329,7 @@ void test_wdb_global_set_agent_label_success(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
     expect_string(__wrap_sqlite3_bind_text, buffer, "test_key");
@@ -339,7 +339,7 @@ void test_wdb_global_set_agent_label_success(void **state)
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_set_agent_label(data->wdb, atoi(data->wdb->id), key, value);
+    result = wdb_global_set_agent_label(data->wdb, 1, key, value);
     assert_int_equal(result, OS_SUCCESS);
 }
 
@@ -354,7 +354,7 @@ void test_wdb_global_set_sync_status_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_set_sync_status(data->wdb, atoi(data->wdb->id), status);
+    result = wdb_global_set_sync_status(data->wdb, 1, status);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -368,7 +368,7 @@ void test_wdb_global_set_sync_status_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_set_sync_status(data->wdb, atoi(data->wdb->id), status);
+    result = wdb_global_set_sync_status(data->wdb, 1, status);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -386,7 +386,7 @@ void test_wdb_global_set_sync_status_bind1_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_set_sync_status(data->wdb, atoi(data->wdb->id), status);
+    result = wdb_global_set_sync_status(data->wdb, 1, status);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -402,12 +402,12 @@ void test_wdb_global_set_sync_status_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_set_sync_status(data->wdb, atoi(data->wdb->id), status);
+    result = wdb_global_set_sync_status(data->wdb, 1, status);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -423,13 +423,13 @@ void test_wdb_global_set_sync_status_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_set_sync_status(data->wdb, atoi(data->wdb->id), status);
+    result = wdb_global_set_sync_status(data->wdb, 1, status);
     assert_int_equal(result, OS_INVALID);
 }
 
@@ -445,11 +445,11 @@ void test_wdb_global_set_sync_status_success(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_set_sync_status(data->wdb, atoi(data->wdb->id), status);
+    result = wdb_global_set_sync_status(data->wdb, 1, status);
     assert_int_equal(result, OS_SUCCESS);
 }
 
@@ -3039,7 +3039,7 @@ void test_wdb_global_update_agent_connection_status_transaction_fail(void **stat
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3054,7 +3054,7 @@ void test_wdb_global_update_agent_connection_status_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3074,7 +3074,7 @@ void test_wdb_global_update_agent_connection_status_bind1_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3092,12 +3092,12 @@ void test_wdb_global_update_agent_connection_status_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
-    result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3115,14 +3115,14 @@ void test_wdb_global_update_agent_connection_status_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3140,11 +3140,11 @@ void test_wdb_global_update_agent_connection_status_success(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_update_agent_connection_status(data->wdb, atoi(data->wdb->id), connection_status);
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -3159,7 +3159,7 @@ void test_wdb_global_delete_agent_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_delete_agent(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_delete_agent(data->wdb, 1);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3173,7 +3173,7 @@ void test_wdb_global_delete_agent_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_delete_agent(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_delete_agent(data->wdb, 1);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3187,12 +3187,12 @@ void test_wdb_global_delete_agent_bind_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_delete_agent(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_delete_agent(data->wdb, 1);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3206,14 +3206,14 @@ void test_wdb_global_delete_agent_step_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_delete_agent(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_delete_agent(data->wdb, 1);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3227,11 +3227,11 @@ void test_wdb_global_delete_agent_success(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_delete_agent(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_delete_agent(data->wdb, 1);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -3246,7 +3246,7 @@ void test_wdb_global_select_agent_name_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_select_agent_name(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_name(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3260,7 +3260,7 @@ void test_wdb_global_select_agent_name_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_select_agent_name(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_name(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3274,12 +3274,12 @@ void test_wdb_global_select_agent_name_bind_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_select_agent_name(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_name(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3293,13 +3293,13 @@ void test_wdb_global_select_agent_name_exec_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt, NULL);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "wdb_exec_stmt(): ERROR MESSAGE");
 
-    result = wdb_global_select_agent_name(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_name(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3313,11 +3313,11 @@ void test_wdb_global_select_agent_name_success(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt, (cJSON*) 1);
 
-    result = wdb_global_select_agent_name(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_name(data->wdb, 1);
 
     assert_ptr_equal(result, (cJSON*) 1);
 }
@@ -3332,7 +3332,7 @@ void test_wdb_global_select_agent_group_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_select_agent_group(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_group(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3346,7 +3346,7 @@ void test_wdb_global_select_agent_group_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_select_agent_group(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_group(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3360,12 +3360,12 @@ void test_wdb_global_select_agent_group_bind_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_select_agent_group(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_group(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3379,13 +3379,13 @@ void test_wdb_global_select_agent_group_exec_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt, NULL);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "wdb_exec_stmt(): ERROR MESSAGE");
 
-    result = wdb_global_select_agent_group(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_group(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3399,11 +3399,11 @@ void test_wdb_global_select_agent_group_success(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt, (cJSON*) 1);
 
-    result = wdb_global_select_agent_group(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_group(data->wdb, 1);
 
     assert_ptr_equal(result, (cJSON*) 1);
 }
@@ -3418,7 +3418,7 @@ void test_wdb_global_select_agent_fim_offset_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_select_agent_fim_offset(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_fim_offset(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3432,7 +3432,7 @@ void test_wdb_global_select_agent_fim_offset_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_select_agent_fim_offset(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_fim_offset(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3446,12 +3446,12 @@ void test_wdb_global_select_agent_fim_offset_bind_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_select_agent_fim_offset(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_fim_offset(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3465,13 +3465,13 @@ void test_wdb_global_select_agent_fim_offset_exec_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt, NULL);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "wdb_exec_stmt(): ERROR MESSAGE");
 
-    result = wdb_global_select_agent_fim_offset(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_fim_offset(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3485,11 +3485,11 @@ void test_wdb_global_select_agent_fim_offset_success(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt, (cJSON*) 1);
 
-    result = wdb_global_select_agent_fim_offset(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_fim_offset(data->wdb, 1);
 
     assert_ptr_equal(result, (cJSON*) 1);
 }
@@ -3504,7 +3504,7 @@ void test_wdb_global_select_agent_reg_offset_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_select_agent_reg_offset(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_reg_offset(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3518,7 +3518,7 @@ void test_wdb_global_select_agent_reg_offset_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_select_agent_reg_offset(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_reg_offset(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3532,12 +3532,12 @@ void test_wdb_global_select_agent_reg_offset_bind_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_select_agent_reg_offset(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_reg_offset(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3551,13 +3551,13 @@ void test_wdb_global_select_agent_reg_offset_exec_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt, NULL);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "wdb_exec_stmt(): ERROR MESSAGE");
 
-    result = wdb_global_select_agent_reg_offset(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_reg_offset(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3571,11 +3571,11 @@ void test_wdb_global_select_agent_reg_offset_success(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt, (cJSON*) 1);
 
-    result = wdb_global_select_agent_reg_offset(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_reg_offset(data->wdb, 1);
 
     assert_ptr_equal(result, (cJSON*) 1);
 }
@@ -3590,7 +3590,7 @@ void test_wdb_global_select_agent_status_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_select_agent_status(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_status(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3604,7 +3604,7 @@ void test_wdb_global_select_agent_status_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_select_agent_status(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_status(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3618,12 +3618,12 @@ void test_wdb_global_select_agent_status_bind_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_select_agent_status(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_status(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3637,13 +3637,13 @@ void test_wdb_global_select_agent_status_exec_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt, NULL);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "wdb_exec_stmt(): ERROR MESSAGE");
 
-    result = wdb_global_select_agent_status(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_status(data->wdb, 1);
 
     assert_null(result);
 }
@@ -3657,11 +3657,11 @@ void test_wdb_global_select_agent_status_success(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt, (cJSON*) 1);
 
-    result = wdb_global_select_agent_status(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_select_agent_status(data->wdb, 1);
 
     assert_ptr_equal(result, (cJSON*) 1);
 }
@@ -4063,7 +4063,7 @@ void test_wdb_global_update_agent_fim_offset_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_update_agent_fim_offset(data->wdb, atoi(data->wdb->id), offset);
+    result = wdb_global_update_agent_fim_offset(data->wdb, 1, offset);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4078,7 +4078,7 @@ void test_wdb_global_update_agent_fim_offset_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_update_agent_fim_offset(data->wdb, atoi(data->wdb->id), offset);
+    result = wdb_global_update_agent_fim_offset(data->wdb, 1, offset);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4098,7 +4098,7 @@ void test_wdb_global_update_agent_fim_offset_bind1_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_fim_offset(data->wdb, atoi(data->wdb->id), offset);
+    result = wdb_global_update_agent_fim_offset(data->wdb, 1, offset);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4116,12 +4116,12 @@ void test_wdb_global_update_agent_fim_offset_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, offset);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_fim_offset(data->wdb, atoi(data->wdb->id), offset);
+    result = wdb_global_update_agent_fim_offset(data->wdb, 1, offset);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4139,14 +4139,14 @@ void test_wdb_global_update_agent_fim_offset_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, offset);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_update_agent_fim_offset(data->wdb, atoi(data->wdb->id), offset);
+    result = wdb_global_update_agent_fim_offset(data->wdb, 1, offset);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4164,11 +4164,11 @@ void test_wdb_global_update_agent_fim_offset_success(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, offset);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_update_agent_fim_offset(data->wdb, atoi(data->wdb->id), offset);
+    result = wdb_global_update_agent_fim_offset(data->wdb, 1, offset);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -4184,7 +4184,7 @@ void test_wdb_global_update_agent_reg_offset_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_update_agent_reg_offset(data->wdb, atoi(data->wdb->id), offset);
+    result = wdb_global_update_agent_reg_offset(data->wdb, 1, offset);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4199,7 +4199,7 @@ void test_wdb_global_update_agent_reg_offset_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_update_agent_reg_offset(data->wdb, atoi(data->wdb->id), offset);
+    result = wdb_global_update_agent_reg_offset(data->wdb, 1, offset);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4219,7 +4219,7 @@ void test_wdb_global_update_agent_reg_offset_bind1_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_reg_offset(data->wdb, atoi(data->wdb->id), offset);
+    result = wdb_global_update_agent_reg_offset(data->wdb, 1, offset);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4237,12 +4237,12 @@ void test_wdb_global_update_agent_reg_offset_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, offset);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_reg_offset(data->wdb, atoi(data->wdb->id), offset);
+    result = wdb_global_update_agent_reg_offset(data->wdb, 1, offset);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4260,14 +4260,14 @@ void test_wdb_global_update_agent_reg_offset_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, offset);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_update_agent_reg_offset(data->wdb, atoi(data->wdb->id), offset);
+    result = wdb_global_update_agent_reg_offset(data->wdb, 1, offset);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4285,11 +4285,11 @@ void test_wdb_global_update_agent_reg_offset_success(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, offset);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_update_agent_reg_offset(data->wdb, atoi(data->wdb->id), offset);
+    result = wdb_global_update_agent_reg_offset(data->wdb, 1, offset);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -4305,7 +4305,7 @@ void test_wdb_global_update_agent_status_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_update_agent_status(data->wdb, atoi(data->wdb->id), agt_status);
+    result = wdb_global_update_agent_status(data->wdb, 1, agt_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4320,7 +4320,7 @@ void test_wdb_global_update_agent_status_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_update_agent_status(data->wdb, atoi(data->wdb->id), agt_status);
+    result = wdb_global_update_agent_status(data->wdb, 1, agt_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4340,7 +4340,7 @@ void test_wdb_global_update_agent_status_bind1_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_status(data->wdb, atoi(data->wdb->id), agt_status);
+    result = wdb_global_update_agent_status(data->wdb, 1, agt_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4358,12 +4358,12 @@ void test_wdb_global_update_agent_status_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agt_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_status(data->wdb, atoi(data->wdb->id), agt_status);
+    result = wdb_global_update_agent_status(data->wdb, 1, agt_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4381,14 +4381,14 @@ void test_wdb_global_update_agent_status_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agt_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_update_agent_status(data->wdb, atoi(data->wdb->id), agt_status);
+    result = wdb_global_update_agent_status(data->wdb, 1, agt_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4406,11 +4406,11 @@ void test_wdb_global_update_agent_status_success(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agt_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_update_agent_status(data->wdb, atoi(data->wdb->id), agt_status);
+    result = wdb_global_update_agent_status(data->wdb, 1, agt_status);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -4426,7 +4426,7 @@ void test_wdb_global_update_agent_group_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_update_agent_group(data->wdb, atoi(data->wdb->id), agt_group);
+    result = wdb_global_update_agent_group(data->wdb, 1, agt_group);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4441,7 +4441,7 @@ void test_wdb_global_update_agent_group_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_update_agent_group(data->wdb, atoi(data->wdb->id), agt_group);
+    result = wdb_global_update_agent_group(data->wdb, 1, agt_group);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4461,7 +4461,7 @@ void test_wdb_global_update_agent_group_bind1_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_group(data->wdb, atoi(data->wdb->id), agt_group);
+    result = wdb_global_update_agent_group(data->wdb, 1, agt_group);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4479,12 +4479,12 @@ void test_wdb_global_update_agent_group_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agt_group);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_group(data->wdb, atoi(data->wdb->id), agt_group);
+    result = wdb_global_update_agent_group(data->wdb, 1, agt_group);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4502,14 +4502,14 @@ void test_wdb_global_update_agent_group_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agt_group);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_update_agent_group(data->wdb, atoi(data->wdb->id), agt_group);
+    result = wdb_global_update_agent_group(data->wdb, 1, agt_group);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -4527,11 +4527,11 @@ void test_wdb_global_update_agent_group_success(void **state)
     expect_value(__wrap_sqlite3_bind_text, buffer, agt_group);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_update_agent_group(data->wdb, atoi(data->wdb->id), agt_group);
+    result = wdb_global_update_agent_group(data->wdb, 1, agt_group);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -5041,7 +5041,7 @@ void test_wdb_global_delete_agent_belong_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_delete_agent_belong(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_delete_agent_belong(data->wdb, 1);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -5055,7 +5055,7 @@ void test_wdb_global_delete_agent_belong_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_delete_agent_belong(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_delete_agent_belong(data->wdb, 1);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -5068,13 +5068,13 @@ void test_wdb_global_delete_agent_belong_bind_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_delete_agent_belong(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_delete_agent_belong(data->wdb, 1);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -5088,14 +5088,14 @@ void test_wdb_global_delete_agent_belong_step_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_delete_agent_belong(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_delete_agent_belong(data->wdb, 1);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -5109,11 +5109,11 @@ void test_wdb_global_delete_agent_belong_success(void **state)
     will_return(__wrap_wdb_stmt_cache, 1);
 
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_delete_agent_belong(data->wdb, atoi(data->wdb->id));
+    result = wdb_global_delete_agent_belong(data->wdb, 1);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -5128,7 +5128,7 @@ void test_wdb_global_get_agent_info_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    output = wdb_global_get_agent_info(data->wdb, atoi(data->wdb->id));
+    output = wdb_global_get_agent_info(data->wdb, 1);
     assert_null(output);
 }
 
@@ -5141,7 +5141,7 @@ void test_wdb_global_get_agent_info_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    output = wdb_global_get_agent_info(data->wdb, atoi(data->wdb->id));
+    output = wdb_global_get_agent_info(data->wdb, 1);
     assert_null(output);
 }
 
@@ -5153,12 +5153,12 @@ void test_wdb_global_get_agent_info_bind_fail(void **state)
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, atoi(data->wdb->id));
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    output = wdb_global_get_agent_info(data->wdb, atoi(data->wdb->id));
+    output = wdb_global_get_agent_info(data->wdb, 1);
     assert_null(output);
 }
 
@@ -5176,7 +5176,7 @@ void test_wdb_global_get_agent_info_exec_fail(void **state)
     will_return(__wrap_wdb_exec_stmt, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "wdb_exec_stmt(): ERROR MESSAGE");
 
-    output = wdb_global_get_agent_info(data->wdb, atoi(data->wdb->id));
+    output = wdb_global_get_agent_info(data->wdb, 1);
     assert_null(output);
 }
 
@@ -5192,7 +5192,7 @@ void test_wdb_global_get_agent_info_success(void **state)
     will_return_always(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt, (cJSON*)1);
 
-    output = wdb_global_get_agent_info(data->wdb, atoi(data->wdb->id));
+    output = wdb_global_get_agent_info(data->wdb, 1);
     assert_ptr_equal(output, (cJSON*)1);
 }
 

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -751,7 +751,6 @@ void test_wdb_global_sync_agent_info_set_cache_fail(void **state)
 void test_wdb_global_sync_agent_info_set_bind1_fail(void **state)
 {
     int result = 0;
-    int n = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     cJSON *json_agent = NULL;
 
@@ -779,7 +778,6 @@ void test_wdb_global_sync_agent_info_set_bind1_fail(void **state)
 void test_wdb_global_sync_agent_info_set_bind2_fail(void **state)
 {
     int result = 0;
-    int n = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     cJSON *json_agent = NULL;
     int agent_id = 10;
@@ -811,7 +809,6 @@ void test_wdb_global_sync_agent_info_set_bind2_fail(void **state)
 void test_wdb_global_sync_agent_info_set_bind3_fail(void **state)
 {
     int result = 0;
-    int n = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     cJSON *json_agent = NULL;
     int agent_id = 10;
@@ -846,7 +843,6 @@ void test_wdb_global_sync_agent_info_set_bind3_fail(void **state)
 void test_wdb_global_sync_agent_info_set_step_fail(void **state)
 {
     int result = 0;
-    int n = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     cJSON *json_agent = NULL;
     int agent_id = 10;
@@ -882,7 +878,6 @@ void test_wdb_global_sync_agent_info_set_step_fail(void **state)
 void test_wdb_global_sync_agent_info_set_success(void **state)
 {
     int result = 0;
-    int n = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     cJSON *json_agent = NULL;
     int agent_id = 10;
@@ -3038,7 +3033,6 @@ void test_wdb_global_update_agent_keepalive_success(void **state)
 void test_wdb_global_update_agent_connection_status_transaction_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     const char *connection_status = "active";
 
@@ -3053,7 +3047,6 @@ void test_wdb_global_update_agent_connection_status_transaction_fail(void **stat
 void test_wdb_global_update_agent_connection_status_cache_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     const char *connection_status = "active";
 
@@ -3069,7 +3062,6 @@ void test_wdb_global_update_agent_connection_status_cache_fail(void **state)
 void test_wdb_global_update_agent_connection_status_bind1_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     const char *connection_status = "active";
 
@@ -3090,7 +3082,6 @@ void test_wdb_global_update_agent_connection_status_bind1_fail(void **state)
 void test_wdb_global_update_agent_connection_status_bind2_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     const char *connection_status = "active";
 
@@ -3114,7 +3105,6 @@ void test_wdb_global_update_agent_connection_status_bind2_fail(void **state)
 void test_wdb_global_update_agent_connection_status_step_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     const char *connection_status = "active";
 
@@ -3140,7 +3130,6 @@ void test_wdb_global_update_agent_connection_status_step_fail(void **state)
 void test_wdb_global_update_agent_connection_status_success(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     const char *connection_status = "active";
 
@@ -3165,7 +3154,6 @@ void test_wdb_global_update_agent_connection_status_success(void **state)
 void test_wdb_global_delete_agent_transaction_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, -1);
@@ -3179,7 +3167,6 @@ void test_wdb_global_delete_agent_transaction_fail(void **state)
 void test_wdb_global_delete_agent_cache_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, 1);
@@ -3194,7 +3181,6 @@ void test_wdb_global_delete_agent_cache_fail(void **state)
 void test_wdb_global_delete_agent_bind_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, 1);
@@ -3214,7 +3200,6 @@ void test_wdb_global_delete_agent_bind_fail(void **state)
 void test_wdb_global_delete_agent_step_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, 1);
@@ -3236,7 +3221,6 @@ void test_wdb_global_delete_agent_step_fail(void **state)
 void test_wdb_global_delete_agent_success(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, 1);
@@ -3257,7 +3241,6 @@ void test_wdb_global_delete_agent_success(void **state)
 void test_wdb_global_select_agent_name_transaction_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, -1);
@@ -3271,7 +3254,6 @@ void test_wdb_global_select_agent_name_transaction_fail(void **state)
 void test_wdb_global_select_agent_name_cache_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, 1);
@@ -3827,7 +3809,6 @@ void test_wdb_global_select_agent_keepalive_bind2_fail(void **state)
 void test_wdb_global_select_agent_keepalive_bind3_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *name = "test_name";
     char *ip = "0.0.0.0";
@@ -3856,7 +3837,6 @@ void test_wdb_global_select_agent_keepalive_bind3_fail(void **state)
 void test_wdb_global_select_agent_keepalive_exec_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *name = "test_name";
     char *ip = "0.0.0.0";
@@ -3886,7 +3866,6 @@ void test_wdb_global_select_agent_keepalive_exec_fail(void **state)
 void test_wdb_global_select_agent_keepalive_success(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *name = "test_name";
     char *ip = "0.0.0.0";
@@ -3915,7 +3894,6 @@ void test_wdb_global_select_agent_keepalive_success(void **state)
 void test_wdb_global_find_agent_transaction_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *name = "test_name";
     char *ip = "0.0.0.0";
@@ -3931,7 +3909,6 @@ void test_wdb_global_find_agent_transaction_fail(void **state)
 void test_wdb_global_find_agent_cache_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *name = "test_name";
     char *ip = "0.0.0.0";
@@ -3948,7 +3925,6 @@ void test_wdb_global_find_agent_cache_fail(void **state)
 void test_wdb_global_find_agent_bind1_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *name = "test_name";
     char *ip = "0.0.0.0";
@@ -3971,7 +3947,6 @@ void test_wdb_global_find_agent_bind1_fail(void **state)
 void test_wdb_global_find_agent_bind2_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *name = "test_name";
     char *ip = "0.0.0.0";
@@ -3997,7 +3972,6 @@ void test_wdb_global_find_agent_bind2_fail(void **state)
 void test_wdb_global_find_agent_bind3_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *name = "test_name";
     char *ip = "0.0.0.0";
@@ -4026,7 +4000,6 @@ void test_wdb_global_find_agent_bind3_fail(void **state)
 void test_wdb_global_find_agent_exec_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *name = "test_name";
     char *ip = "0.0.0.0";
@@ -4056,7 +4029,6 @@ void test_wdb_global_find_agent_exec_fail(void **state)
 void test_wdb_global_find_agent_success(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *name = "test_name";
     char *ip = "0.0.0.0";
@@ -4085,7 +4057,6 @@ void test_wdb_global_find_agent_success(void **state)
 void test_wdb_global_update_agent_fim_offset_transaction_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     long offset = 100;
 
@@ -4100,7 +4071,6 @@ void test_wdb_global_update_agent_fim_offset_transaction_fail(void **state)
 void test_wdb_global_update_agent_fim_offset_cache_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     long offset = 100;
 
@@ -4116,7 +4086,6 @@ void test_wdb_global_update_agent_fim_offset_cache_fail(void **state)
 void test_wdb_global_update_agent_fim_offset_bind1_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     long offset = 100;
 
@@ -4137,7 +4106,6 @@ void test_wdb_global_update_agent_fim_offset_bind1_fail(void **state)
 void test_wdb_global_update_agent_fim_offset_bind2_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     long offset = 100;
 
@@ -4161,7 +4129,6 @@ void test_wdb_global_update_agent_fim_offset_bind2_fail(void **state)
 void test_wdb_global_update_agent_fim_offset_step_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     long offset = 100;
 
@@ -4187,7 +4154,6 @@ void test_wdb_global_update_agent_fim_offset_step_fail(void **state)
 void test_wdb_global_update_agent_fim_offset_success(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     long offset = 100;
 
@@ -4212,7 +4178,6 @@ void test_wdb_global_update_agent_fim_offset_success(void **state)
 void test_wdb_global_update_agent_reg_offset_transaction_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     long offset = 100;
 
@@ -4227,7 +4192,6 @@ void test_wdb_global_update_agent_reg_offset_transaction_fail(void **state)
 void test_wdb_global_update_agent_reg_offset_cache_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     long offset = 100;
 
@@ -4243,7 +4207,6 @@ void test_wdb_global_update_agent_reg_offset_cache_fail(void **state)
 void test_wdb_global_update_agent_reg_offset_bind1_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     long offset = 100;
 
@@ -4264,7 +4227,6 @@ void test_wdb_global_update_agent_reg_offset_bind1_fail(void **state)
 void test_wdb_global_update_agent_reg_offset_bind2_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     long offset = 100;
 
@@ -4288,7 +4250,6 @@ void test_wdb_global_update_agent_reg_offset_bind2_fail(void **state)
 void test_wdb_global_update_agent_reg_offset_step_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     long offset = 100;
 
@@ -4314,7 +4275,6 @@ void test_wdb_global_update_agent_reg_offset_step_fail(void **state)
 void test_wdb_global_update_agent_reg_offset_success(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     long offset = 100;
 
@@ -4339,7 +4299,6 @@ void test_wdb_global_update_agent_reg_offset_success(void **state)
 void test_wdb_global_update_agent_status_transaction_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *agt_status = "updated";
 
@@ -4354,7 +4313,6 @@ void test_wdb_global_update_agent_status_transaction_fail(void **state)
 void test_wdb_global_update_agent_status_cache_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *agt_status = "updated";
 
@@ -4370,7 +4328,6 @@ void test_wdb_global_update_agent_status_cache_fail(void **state)
 void test_wdb_global_update_agent_status_bind1_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *agt_status = "updated";
 
@@ -4391,7 +4348,6 @@ void test_wdb_global_update_agent_status_bind1_fail(void **state)
 void test_wdb_global_update_agent_status_bind2_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *agt_status = "updated";
 
@@ -4415,7 +4371,6 @@ void test_wdb_global_update_agent_status_bind2_fail(void **state)
 void test_wdb_global_update_agent_status_step_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *agt_status = "updated";
 
@@ -4441,7 +4396,6 @@ void test_wdb_global_update_agent_status_step_fail(void **state)
 void test_wdb_global_update_agent_status_success(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *agt_status = "updated";
 
@@ -4466,7 +4420,6 @@ void test_wdb_global_update_agent_status_success(void **state)
 void test_wdb_global_update_agent_group_transaction_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *agt_group = "test_group";
 
@@ -4481,7 +4434,6 @@ void test_wdb_global_update_agent_group_transaction_fail(void **state)
 void test_wdb_global_update_agent_group_cache_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *agt_group = "test_group";
 
@@ -4497,7 +4449,6 @@ void test_wdb_global_update_agent_group_cache_fail(void **state)
 void test_wdb_global_update_agent_group_bind1_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *agt_group = "test_group";
 
@@ -4518,7 +4469,6 @@ void test_wdb_global_update_agent_group_bind1_fail(void **state)
 void test_wdb_global_update_agent_group_bind2_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *agt_group = "test_group";
 
@@ -4542,7 +4492,6 @@ void test_wdb_global_update_agent_group_bind2_fail(void **state)
 void test_wdb_global_update_agent_group_step_fail(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *agt_group = "test_group";
 
@@ -4568,7 +4517,6 @@ void test_wdb_global_update_agent_group_step_fail(void **state)
 void test_wdb_global_update_agent_group_success(void **state)
 {
     int result = 0;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *agt_group = "test_group";
 
@@ -4593,7 +4541,6 @@ void test_wdb_global_update_agent_group_success(void **state)
 void test_wdb_global_find_group_transaction_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *group_name = "test_name";
 
@@ -4608,7 +4555,6 @@ void test_wdb_global_find_group_transaction_fail(void **state)
 void test_wdb_global_find_group_cache_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *group_name = "test_name";
 
@@ -4624,7 +4570,6 @@ void test_wdb_global_find_group_cache_fail(void **state)
 void test_wdb_global_find_group_bind_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *group_name = "test_name";
 
@@ -4646,7 +4591,6 @@ void test_wdb_global_find_group_bind_fail(void **state)
 void test_wdb_global_find_group_exec_fail(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *group_name = "test_name";
 
@@ -4669,7 +4613,6 @@ void test_wdb_global_find_group_exec_fail(void **state)
 void test_wdb_global_find_group_success(void **state)
 {
     cJSON *result = NULL;
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char *group_name = "test_name";
 
@@ -5842,7 +5785,6 @@ void test_wdb_global_reset_agents_connection_cache_fail(void **state)
 
 void test_wdb_global_reset_agents_step_fail(void **state)
 {
-    int last_agent_id = 0;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_begin2, 1);

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -1843,7 +1843,6 @@ void test_wdb_parse_global_insert_agent_group_success(void **state)
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char query[OS_BUFFER_SIZE] = "global insert-agent-group test_group";
-    cJSON *j_object = NULL;
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: insert-agent-group test_group");

--- a/src/unit_tests/wazuh_db/test_wdb_upgrade.c
+++ b/src/unit_tests/wazuh_db/test_wdb_upgrade.c
@@ -366,7 +366,6 @@ void test_wdb_upgrade_global_fail_backup_fail(void **state)
 void test_wdb_create_backup_global_success(void **state)
 {
     int ret = 0;
-    test_struct_t *data  = (test_struct_t *)*state;
 
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
@@ -388,7 +387,6 @@ void test_wdb_create_backup_global_success(void **state)
 void test_wdb_create_backup_global_dst_fopen_fail(void **state)
 {
     int ret = 0;
-    test_struct_t *data  = (test_struct_t *)*state;
 
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
@@ -403,7 +401,6 @@ void test_wdb_create_backup_global_dst_fopen_fail(void **state)
 void test_wdb_create_backup_global_src_fopen_fail(void **state)
 {
     int ret = 0;
-    test_struct_t *data  = (test_struct_t *)*state;
 
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
@@ -421,7 +418,6 @@ void test_wdb_create_backup_global_src_fopen_fail(void **state)
 void test_wdb_create_backup_global_fwrite_fail(void **state)
 {
     int ret = 0;
-    test_struct_t *data  = (test_struct_t *)*state;
 
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
@@ -445,7 +441,6 @@ void test_wdb_create_backup_global_fwrite_fail(void **state)
 void test_wdb_create_backup_global_fclose_fail(void **state)
 {
     int ret = 0;
-    test_struct_t *data  = (test_struct_t *)*state;
 
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);
@@ -468,7 +463,6 @@ void test_wdb_create_backup_global_fclose_fail(void **state)
 void test_wdb_create_backup_global_chmod_fail(void **state)
 {
     int ret = 0;
-    test_struct_t *data  = (test_struct_t *)*state;
 
     expect_any_always(__wrap_fopen, path);
     expect_any_always(__wrap_fopen, mode);


### PR DESCRIPTION
|Related issue|
|---|
|6485|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR:
- Adds `-Wall` compilation flag in WazuhDB makefile to have visibility of the Warnings of this module.
- Fix all the warnings reported on WazuhDB UT
- Fix the agent ID variable used during the tests of wdb_global
<!--


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux

- UT
  - [X] UT build without warnings
  - [X] UT execution successfully

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Valgrind (memcheck and descriptor leaks check)


