### PR TITLE
Remove hardcoded server status from agent_control

### DIFF
--- a/src/headers/read-agents.h
+++ b/src/headers/read-agents.h
@@ -13,6 +13,15 @@
 
 #include <external/cJSON/cJSON.h>
 
+/* Status */
+typedef enum agent_status_t {
+    GA_STATUS_ACTIVE = 12,
+    GA_STATUS_NACTIVE,
+    GA_STATUS_NEVER,
+    GA_STATUS_PENDING,
+    GA_STATUS_UNKNOWN
+} agent_status_t;
+
 /* Unique key for each agent */
 typedef struct _agent_info {
     char *last_keepalive;
@@ -24,16 +33,8 @@ typedef struct _agent_info {
     char *version;
     char *config_sum;
     char *merged_sum;
+    agent_status_t connection_status;
 } agent_info;
-
-/* Status */
-
-typedef enum agent_status_t {
-    GA_STATUS_ACTIVE = 12,
-    GA_STATUS_NACTIVE,
-    GA_STATUS_INV,
-    GA_STATUS_PENDING
-} agent_status_t;
 
 /* Print syscheck db (of modified files) */
 int print_syscheck(const char *sk_name, const char *sk_ip, const char *fname, int print_registry,

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -886,10 +886,12 @@ const char *print_agent_status(agent_status_t status)
         return "Active";
     case GA_STATUS_NACTIVE:
         return "Disconnected";
-    case GA_STATUS_INV:
+    case GA_STATUS_NEVER:
         return "Never connected";
     case GA_STATUS_PENDING:
         return "Pending";
+    case GA_STATUS_UNKNOWN:
+        return "Unknown";
     default:
         return "(undefined)";
     }
@@ -1138,6 +1140,25 @@ agent_info *get_agent_info(const char *agent_name, const char *agent_ip, const c
         os_strdup(keepalive_str, agt_info->last_keepalive);
     }
 
+    json_field = cJSON_GetObjectItem(json_agt_info->child, "connection_status");
+    if (cJSON_IsString(json_field)) {
+        if (0 == strcmp(json_field->valuestring, AGENT_CS_PENDING)) {
+            agt_info->connection_status = GA_STATUS_PENDING;
+        }
+        else if (0 == strcmp(json_field->valuestring, AGENT_CS_ACTIVE)) {
+            agt_info->connection_status = GA_STATUS_ACTIVE;
+        }
+        else if (0 == strcmp(json_field->valuestring, AGENT_CS_DISCONNECTED)) {
+            agt_info->connection_status = GA_STATUS_NACTIVE;
+        }
+        else if (0 == strcmp(json_field->valuestring, AGENT_CS_NEVER_CONNECTED)) {
+            agt_info->connection_status = GA_STATUS_NEVER;
+        }
+        else {
+            agt_info->connection_status = GA_STATUS_UNKNOWN;
+        }
+    }
+
     _get_time_rkscan(agent_name, agent_ip, agt_info, agent_id);
 
     cJSON_Delete(json_agt_info);
@@ -1149,7 +1170,7 @@ agent_info *get_agent_info(const char *agent_name, const char *agent_ip, const c
 agent_status_t get_agent_status(int agent_id){
     cJSON *json_agt_info = NULL;
     cJSON *json_field = NULL;
-    agent_status_t status = GA_STATUS_INV;
+    agent_status_t status = GA_STATUS_UNKNOWN;
 
     json_agt_info = wdb_get_agent_info(agent_id, NULL);
 
@@ -1168,6 +1189,9 @@ agent_status_t get_agent_status(int agent_id){
         }
         else if (0 == strcmp(json_field->valuestring, AGENT_CS_DISCONNECTED)) {
             status = GA_STATUS_NACTIVE;
+        }
+        else if (0 == strcmp(json_field->valuestring, AGENT_CS_NEVER_CONNECTED)) {
+            status = GA_STATUS_NEVER;
         }
     }
 
@@ -1196,7 +1220,7 @@ char **get_agents(int flag){
     }
 
     for (i = 0; id_array[i] != -1; i++){
-        agent_status_t status = GA_STATUS_INV;
+        agent_status_t status = GA_STATUS_UNKNOWN;
         char agent_name_ip[OS_SIZE_512] = "";
 
         json_agt_info = wdb_get_agent_info(id_array[i], &sock);
@@ -1222,7 +1246,8 @@ char **get_agents(int flag){
 
         status = !strcmp(json_field->valuestring, AGENT_CS_PENDING) ? GA_STATUS_PENDING :
                  !strcmp(json_field->valuestring, AGENT_CS_ACTIVE) ? GA_STATUS_ACTIVE :
-                 !strcmp(json_field->valuestring, AGENT_CS_DISCONNECTED) ? GA_STATUS_NACTIVE : GA_STATUS_INV;
+                 !strcmp(json_field->valuestring, AGENT_CS_DISCONNECTED) ? GA_STATUS_NACTIVE :
+                 !strcmp(json_field->valuestring, AGENT_CS_NEVER_CONNECTED) ? GA_STATUS_NEVER : GA_STATUS_UNKNOWN;
         cJSON_Delete(json_agt_info);
 
         switch (flag) {

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -272,6 +272,7 @@ int main(int argc, char **argv)
     /* List available agents */
     if (list_agents) {
         cJSON *agents = NULL;
+        const char* server_status = print_agent_status(get_agent_status(0));
 
         if (!csv_output && !json_output) {
             printf("\n%s %s. List of available agents:",
@@ -280,7 +281,7 @@ int main(int argc, char **argv)
             if (inactive_only) {
                 puts("");
             } else {
-                printf("\n   ID: 000, Name: %s (server), IP: 127.0.0.1, Active/Local\n", shost);
+                printf("\n   ID: 000, Name: %s (server), IP: 127.0.0.1, %s/Local\n", shost, server_status);
             }
         } else if(json_output){
                 cJSON *first;
@@ -297,11 +298,11 @@ int main(int argc, char **argv)
                     cJSON_AddStringToObject(first, "id", "000");
                     cJSON_AddStringToObject(first, "name", shost);
                     cJSON_AddStringToObject(first, "ip", "127.0.0.1");
-                    cJSON_AddStringToObject(first, "status", "Active");
+                    cJSON_AddStringToObject(first, "status", server_status);
                     cJSON_AddItemToArray(agents, first);
                 }
         } else if (!inactive_only) {
-            printf("000,%s (server),127.0.0.1,Active/Local,\n", shost);
+            printf("000,%s (server),127.0.0.1,%s/Local,\n", shost, server_status);
         }
 
         print_agents(1, active_only, inactive_only, csv_output, agents);
@@ -412,23 +413,21 @@ int main(int argc, char **argv)
                        print_agent_status(agt_status));
             }
         } else {
-            agt_status = GA_STATUS_ACTIVE;
+            const char* server_status = print_agent_status(get_agent_status(0));
             agt_info = get_agent_info(NULL, "127.0.0.1", "000");
 
             if (!csv_output && !json_output) {
                 printf("\n   Agent ID:   000 (local instance)\n");
                 printf("   Agent Name: %s\n", shost);
                 printf("   IP address: 127.0.0.1\n");
-                printf("   Status:     %s/Local\n\n", print_agent_status(agt_status));
+                printf("   Status:     %s/Local\n\n", server_status);
             } else if (json_output) {
                 cJSON_AddStringToObject(json_data, "id", "000");
                 cJSON_AddStringToObject(json_data, "name", shost);
                 cJSON_AddStringToObject(json_data, "ip", "127.0.0.1");
-                cJSON_AddStringToObject(json_data, "status", print_agent_status(agt_status));
+                cJSON_AddStringToObject(json_data, "status", server_status);
             } else {
-                printf("000,%s,127.0.0.1,%s/Local,",
-                       shost,
-                       print_agent_status(agt_status));
+                printf("000,%s,127.0.0.1,%s/Local,", shost, server_status);
             }
         }
 

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -386,6 +386,10 @@ int main(int argc, char **argv)
             agt_info = get_agent_info(keys.keyentries[agt_id]->name,
                                       keys.keyentries[agt_id]->ip->ip,
                                       agent_id);
+            if (!agt_info) {
+                printf("\n Unable to get agent info\n\n");
+                exit(0);
+            }
 
             /* Get netmask from IP */
             getNetmask(keys.keyentries[agt_id]->ip->netmask, final_mask, 128);
@@ -411,6 +415,10 @@ int main(int argc, char **argv)
             }
         } else {
             agt_info = get_agent_info(NULL, "127.0.0.1", "000");
+            if (!agt_info) {
+                printf("\n Unable to get agent info\n\n");
+                exit(0);
+            }
 
             if (!csv_output && !json_output) {
                 printf("\n   Agent ID:   000 (local instance)\n");

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -371,7 +371,6 @@ int main(int argc, char **argv)
 
     /* Print information from an agent */
     if (info_agent) {
-        agent_status_t agt_status = 0;
         char final_ip[128 + 1];
         char final_mask[128 + 1];
         agent_info *agt_info;
@@ -384,8 +383,6 @@ int main(int argc, char **argv)
         }
 
         if (agt_id != -1) {
-            agt_status = get_agent_status(atoi(keys.keyentries[agt_id]->id));
-
             agt_info = get_agent_info(keys.keyentries[agt_id]->name,
                                       keys.keyentries[agt_id]->ip->ip,
                                       agent_id);
@@ -399,35 +396,34 @@ int main(int argc, char **argv)
                 printf("\n   Agent ID:   %s\n", keys.keyentries[agt_id]->id);
                 printf("   Agent Name: %s\n", keys.keyentries[agt_id]->name);
                 printf("   IP address: %s\n", final_ip);
-                printf("   Status:     %s\n\n", print_agent_status(agt_status));
+                printf("   Status:     %s\n\n", print_agent_status(agt_info->connection_status));
             } else if (json_output) {
                 cJSON_AddStringToObject(json_data, "id", keys.keyentries[agt_id]->id);
                 cJSON_AddStringToObject(json_data, "name", keys.keyentries[agt_id]->name);
                 cJSON_AddStringToObject(json_data, "ip", final_ip);
-                cJSON_AddStringToObject(json_data, "status", print_agent_status(agt_status));
+                cJSON_AddStringToObject(json_data, "status", print_agent_status(agt_info->connection_status));
             } else {
                 printf("%s,%s,%s,%s,",
                        keys.keyentries[agt_id]->id,
                        keys.keyentries[agt_id]->name,
                        final_ip,
-                       print_agent_status(agt_status));
+                       print_agent_status(agt_info->connection_status));
             }
         } else {
-            const char* server_status = print_agent_status(get_agent_status(0));
             agt_info = get_agent_info(NULL, "127.0.0.1", "000");
 
             if (!csv_output && !json_output) {
                 printf("\n   Agent ID:   000 (local instance)\n");
                 printf("   Agent Name: %s\n", shost);
                 printf("   IP address: 127.0.0.1\n");
-                printf("   Status:     %s/Local\n\n", server_status);
+                printf("   Status:     %s/Local\n\n", print_agent_status(agt_info->connection_status));
             } else if (json_output) {
                 cJSON_AddStringToObject(json_data, "id", "000");
                 cJSON_AddStringToObject(json_data, "name", shost);
                 cJSON_AddStringToObject(json_data, "ip", "127.0.0.1");
-                cJSON_AddStringToObject(json_data, "status", server_status);
+                cJSON_AddStringToObject(json_data, "status", print_agent_status(agt_info->connection_status));
             } else {
-                printf("000,%s,127.0.0.1,%s/Local,", shost, server_status);
+                printf("000,%s,127.0.0.1,%s/Local,", shost, print_agent_status(agt_info->connection_status));
             }
         }
 


### PR DESCRIPTION
|Related issue|
|---|
|6484|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR: 
- Removes the hardcoded "Active" status for server information on the agent_control tool.
- Fixes the default value of agent status.
- Fixes segmentation fault in agent_control if WazuhDB is off.

## Tests
The following options where the manager status is processed where tested:
agent_control -l
agent_control -l -c
agent_control -l -j
agent_control -i 000
agent_control -i 000 -c
agent_control -i 000 -j

and the result is successful

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [X] Valgrind (memcheck and descriptor leaks check)
