### PR TITLE
Fix mem leak when reading bplist files

### DIFF
--- a/src/wazuh_modules/syscollector/syscollector_bsd.c
+++ b/src/wazuh_modules/syscollector/syscollector_bsd.c
@@ -87,11 +87,11 @@ const char * discarded_packages [] = {
     NULL
 };
 
-// Valid package version keys. 
+// Valid package version keys.
 // The custom versions take priority over the default one.
 const char * plist_versions [] = {
     "CFBundleShortVersionString", //default
-    "CliVersion" 
+    "CliVersion"
 };
 
 STATIC int sys_read_apps(const char * app_folder, const char * timestamp, int random_id, int queue_fd, const char* LOCATION);
@@ -361,7 +361,7 @@ cJSON* sys_parse_pkg(const char * app_folder) {
                         parts = OS_StrBreak('>', read_buff, 4);
                         _parts =  OS_StrBreak('<', parts[3], 2);
 
-                    } else if ((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) && 
+                    } else if ((fgets(read_buff, OS_MAXSTR - 1, fp) != NULL) &&
                         strstr(read_buff, "<string>")) {
                         parts = OS_StrBreak('>', read_buff, 2);
                         _parts = OS_StrBreak('<', parts[1], 2);
@@ -386,7 +386,7 @@ cJSON* sys_parse_pkg(const char * app_folder) {
                         }
                         os_free(parts);
                     }
-                    
+
                 } else if (strstr(read_buff, "LSApplicationCategoryType")){
                     if (strstr(read_buff, "<string>")){
                         char ** parts = OS_StrBreak('>', read_buff, 4);
@@ -666,6 +666,7 @@ bool sys_convert_bin_plist(FILE **fp, char *magic_bytes, char *filepath) {
 clean:
     if (root_node) plist_free(root_node);
     if (bin != MAP_FAILED) munmap(bin, filestats.st_size);
+    os_free(xml);
     return status;
 }
 


### PR DESCRIPTION
## Description

This issues closes #6492, now the output of `leaks` is:

```
Process:         wazuh-modulesd [48286]
Path:            /Library/Ossec/*/wazuh-modulesd
Load Address:    0x100ba3000
Identifier:      wazuh-modulesd
Version:         ???
Code Type:       X86-64
Parent Process:  launchd [1]

Date/Time:       2020-11-04 10:01:40.628 +0100
Launch Time:     2020-11-04 09:59:58.832 +0100
OS Version:      Mac OS X 10.15.1 (19B88)
Report Version:  7
Analysis Tool:   /Applications/Xcode.app/Contents/Developer/usr/bin/leaks
Analysis Tool Version:  Xcode 11.3.1 (11C504)

Physical footprint:         1284K
Physical footprint (peak):  1284K
----

leaks Report Version: 4.0
Process 48286: 569 nodes malloced for 61 KB
Process 48286: 13 leaks for 1488 total leaked bytes.

    13 (1.45K) << TOTAL >>

      6 (816 bytes) ROOT LEAK: 0x7f9326e00560 [256]
         1 (112 bytes) 0x7f9326d00480 [112]
         1 (112 bytes) 0x7f9326d00530 [112]
         1 (112 bytes) 0x7f9326d005e0 [112]
         1 (112 bytes) 0x7f9326e00180 [112]
         1 (112 bytes) 0x7f9326e004f0 [112]

      6 (576 bytes) ROOT LEAK: 0x7f9326e003f0 [256]
         1 (64 bytes) 0x7f9326d00440 [64]
         1 (64 bytes) 0x7f9326d004f0 [64]
         1 (64 bytes) 0x7f9326d005a0 [64]
         1 (64 bytes) 0x7f9326e00140 [64]
         1 (64 bytes) 0x7f9326e003b0 [64]

      1 (96 bytes) ROOT LEAK: <OS_xpc_pipe 0x7f9326e00660> [96]
```

The mem leaks that appear are already reported at #6483 and comes from versions prior to 4.0.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- Memory tests for macOS
  - [x] Leaks
