### PR TITLE
Adapt SCA framework module to avoid wazuh-db responses greater than 64KB

### DIFF
--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -224,7 +224,7 @@ class WazuhDBConnection:
 
         # if the query has already a parameter limit / offset, divide using it
         offset = 0
-        if 'offset' in query_without_where:
+        if re.search(r'offset \d+', query_without_where):
             offset = int(re.compile(r".* offset (\d+)").match(query_lower).group(1))
             # Replace offset with a wildcard
             query_lower = query_lower.replace(" offset {}".format(offset), " :offset")
@@ -256,6 +256,11 @@ class WazuhDBConnection:
 
             response = []
             step = limit if limit < self.request_slice and limit > 0 else self.request_slice
+            if ':limit' not in query_lower:
+                query_lower += ' :limit'
+            if ':offset' not in query_lower:
+                query_lower += ' :offset'
+
             try:
                 for off in range(offset, limit + offset, step):
                     send_request_to_wdb(query_lower, step, off, response)

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -12,8 +12,8 @@ from wazuh.core.agent import get_agents_info
 from wazuh.core.exception import WazuhInternalError, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.sca import WazuhDBQuerySCA, fields_translation_sca, fields_translation_sca_check, \
-    fields_translation_sca_check_compliance, fields_translation_sca_check_rule, default_query_sca_check, \
-    WazuhDBQuerySCACheck
+    fields_translation_sca_check_compliance, fields_translation_sca_check_rule, default_query_sca_check
+from wazuh.core.utils import process_array
 from wazuh.rbac.decorators import expose_resources
 
 
@@ -100,6 +100,7 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
                                       none_msg='No sca/policy information was returned'
                                       )
     if len(agent_list) != 0:
+        sca_checks = list()
         if agent_list[0] in get_agents_info():
             fields_translation = {**fields_translation_sca_check,
                                   **fields_translation_sca_check_compliance,
@@ -110,12 +111,12 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
                            list(fields_translation_sca_check_rule.keys())
                            )
 
-            db_query = WazuhDBQuerySCACheck(agent_id=agent_list[0], offset=offset, limit=limit, sort=sort,
-                                            search=search, select=full_select, count=True, get_data=True,
-                                            query=f"policy_id={policy_id}" if q == "" else f"policy_id={policy_id};{q}",
-                                            filters=filters, default_query=default_query_sca_check,
-                                            default_sort_field='policy_id', fields=fields_translation, count_field='id')
-
+            # Workaround for too long sca_checks results until the chunk algorithm is implemented (1/2)
+            db_query = WazuhDBQuerySCA(agent_id=agent_list[0], offset=0, limit=None, sort=None, filters=filters,
+                                       search=None, select=full_select, count=True, get_data=True,
+                                       query=f"policy_id={policy_id}" if q == "" else f"policy_id={policy_id};{q}",
+                                       default_query=default_query_sca_check,
+                                       default_sort_field='policy_id', fields=fields_translation, count_field='id')
             result_dict = db_query.run()
 
             if 'items' in result_dict:
@@ -128,6 +129,7 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
             select_fields = set([field if field != 'compliance' else 'compliance'
                                  for field in select_fields if field in fields_translation_sca_check])
             # Rearrange check and compliance fields
+
             for _, group in groups:
                 group_list = list(group)
                 check_dict = {k: v for k, v in group_list[0].items()
@@ -142,10 +144,21 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
                                                    for x in set((map(itemgetter(*field_translations.keys()),
                                                                      group_list)))]
 
-                result.affected_items.append(check_dict)
-            result.total_affected_items = result_dict['totalItems']
+                sca_checks.append(check_dict)
         else:
             result.add_failed_item(id_=agent_list[0], error=WazuhResourceNotFound(1701))
             result.total_affected_items = 0
+
+        # Workaround for too long sca_checks results until the chunk algorithm is implemented (2/2)
+        data = process_array(sca_checks,
+                             search_text=search['value'] if search else None,
+                             complementary_search=search['negation'] if search else False,
+                             sort_by=sort['fields'] if sort else ['policy_id'],
+                             sort_ascending=False if sort and sort['order'] == 'desc' else True,
+                             offset=offset,
+                             limit=limit)
+
+        result.affected_items = data['items']
+        result.total_affected_items = data['totalItems']
 
     return result

--- a/framework/wazuh/tests/test_sca.py
+++ b/framework/wazuh/tests/test_sca.py
@@ -223,6 +223,6 @@ def test_sca_response_without_result(mock_agent, mock_sca_agent):
     """
     with patch('wazuh.core.sca.WazuhDBBackend') as mock_wdb:
         mock_wdb.return_value.connect_to_db.return_value.execute.side_effect = get_fake_sca_data
-        with patch('wazuh.core.sca.WazuhDBQuerySCACheck.run', return_value={}):
+        with patch('wazuh.core.sca.WazuhDBQuerySCA.run', return_value={}):
             with pytest.raises(exception.WazuhException, match=".* 2007 .*"):
                 get_sca_checks('not_exists', agent_list=['000'])


### PR DESCRIPTION
Hello team, this closes #6491 .

As the issue reported, using the `GET /sca/{agent_id}/checks/cis_debian10` endpoint returned an exception caused by the pagination process since it reached the `LIMIT 1` and still was too large to fit in 64KB.

We decided to process data in a less efficient way to avoid this issue until the chunk system is implemented. Once it is implemented, we will need to rework this module again.

# Tests performed
## Unit tests
```
================================================================================= test session starts =================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0, cov-2.10.1
collected 7 items                                                                                                                                                                     

wazuh/tests/test_sca.py .......                                                                                                                                                 [100%]

================================================================================== 7 passed in 0.15s ==================================================================================

================================================================================= test session starts =================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0, cov-2.10.1
collected 21 items                                                                                                                                                                    

framework/wazuh/core/tests/test_wdb.py .....................                                                                                                                    [100%]

================================================================================= 21 passed in 0.06s ==================================================================================

```

## Integration tests
```
Collected tests [3]:
test_rbac_black_sca_endpoints.tavern.yaml, test_rbac_white_sca_endpoints.tavern.yaml, test_sca_endpoints.tavern.yaml


test_rbac_black_sca_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rbac_white_sca_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_sca_endpoints.tavern.yaml 
	 6 passed, 8 warnings

```

Regards,
Víctor.