### PR TITLE
Add unit tests for registry functions in syscheck_op

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -936,7 +936,7 @@ char *get_registry_group(char **sid, HANDLE hndl) {
     char *result;
     LPSTR local_sid;
 
-    // Get the owner SID of the file or registry
+    // Get the group SID of the file or registry
     dwRtnCode = GetSecurityInfo(hndl,                       // Object handle
                                 SE_REGISTRY_KEY,            // Object type (file or registry)
                                 GROUP_SECURITY_INFORMATION, // Security information bit flags
@@ -1016,7 +1016,9 @@ DWORD get_registry_permissions(HKEY hndl, char *perm_key) {
     int perm_size = OS_SIZE_6144;
     char *permissions = perm_key;
 
-    if (RegGetKeySecurity(hndl, DACL_SECURITY_INFORMATION, NULL, &lpcbSecurityDescriptor) != ERROR_INSUFFICIENT_BUFFER) {
+    if (RegGetKeySecurity(hndl, DACL_SECURITY_INFORMATION, NULL, &lpcbSecurityDescriptor) !=
+        ERROR_INSUFFICIENT_BUFFER) {
+
         dwErrorCode = GetLastError();
         return dwErrorCode;
     }
@@ -1024,8 +1026,7 @@ DWORD get_registry_permissions(HKEY hndl, char *perm_key) {
     os_calloc(lpcbSecurityDescriptor, 1, pSecurityDescriptor);
 
     // Get the security information.
-    dwRtnCode = RegGetKeySecurity(
-                                  hndl,                         // Handle to an open key
+    dwRtnCode = RegGetKeySecurity(hndl,                         // Handle to an open key
                                   DACL_SECURITY_INFORMATION,    // Requeste DACL security information
                                   pSecurityDescriptor,          // Pointer that receives the DACL information
                                   &lpcbSecurityDescriptor);     // Pointer that specifies the size, in bytes

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -616,9 +616,11 @@ void ag_send_syscheck(char * message) {
 
 #else /* #ifndef WIN32 */
 
+// LCOV_EXCL_START
 char *get_registry_user(const char *path, char **sid, HANDLE hndl) {
     return get_user(path, sid, hndl, SE_REGISTRY_KEY);
 }
+// LCOV_EXCL_STOP
 
 char *get_file_user(const char *path, char **sid) {
     HANDLE hFile;

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -3822,9 +3822,9 @@ int main(int argc, char *argv[]) {
         cmocka_unit_test_setup_teardown(test_unescape_syscheck_empty_string, setup_unescape_syscheck_field, teardown_unescape_syscheck_field),
 
         /* get_user tests */
-        // cmocka_unit_test_teardown(test_get_user_success, teardown_string),
-        // cmocka_unit_test_teardown(test_get_user_uid_not_found, teardown_string),
-        // cmocka_unit_test_teardown(test_get_user_error, teardown_string),
+        cmocka_unit_test_teardown(test_get_user_success, teardown_string),
+        cmocka_unit_test_teardown(test_get_user_uid_not_found, teardown_string),
+        cmocka_unit_test_teardown(test_get_user_error, teardown_string),
 
         /* get_group tests */
         cmocka_unit_test(test_get_group_success),

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -309,21 +309,30 @@ static void test_remove_empty_folders_success(void **state) {
 #ifndef TEST_WINAGENT
     char *input = "/var/ossec/queue/diff/local/test-dir/";
     char *first_subdir = "/var/ossec/queue/diff/local/test-dir";
+    char *second_subdir = "/var/ossec/queue/diff/local";
 #else
     char *input = "queue/diff\\local\\test-dir\\";
     char *first_subdir = "queue/diff\\local\\test-dir";
+    char *second_subdir = "queue/diff\\local";
 #endif
     int ret = -1;
     char message[OS_SIZE_1024];
+    char **not_null;
 
-    expect_string(__wrap_wreaddir, name, first_subdir);
-    will_return(__wrap_wreaddir, NULL);
+    if(not_null = calloc(2, sizeof(char*)), !not_null)
+        fail();
+
+    not_null[0] = strdup("some-file.tmp");
+    not_null[1] = NULL;
+
+    expect_wreaddir_call(first_subdir, NULL);
 
     snprintf(message, OS_SIZE_1024, "Removing empty directory '%s'.", first_subdir);
     expect_string(__wrap__mdebug1, formatted_msg, message);
 
-    expect_string(__wrap_rmdir_ex, name, first_subdir);
-    will_return(__wrap_rmdir_ex, 0);
+    expect_rmdir_ex_call(first_subdir, 0);
+
+    expect_wreaddir_call(second_subdir, not_null);
 
     ret = remove_empty_folders(input);
 
@@ -335,38 +344,45 @@ static void test_remove_empty_folders_recursive_success(void **state) {
     char *input = "/var/ossec/queue/diff/local/dir1/dir2/";
     static const char *parent_dirs[] = {
         "/var/ossec/queue/diff/local/dir1/dir2",
-        "/var/ossec/queue/diff/local/dir1"
+        "/var/ossec/queue/diff/local/dir1",
+        "/var/ossec/queue/diff/local"
     };
 #else
     char *input = "queue/diff\\local\\dir1\\dir2\\";
     static const char *parent_dirs[] = {
         "queue/diff\\local\\dir1\\dir2",
-        "queue/diff\\local\\dir1"
+        "queue/diff\\local\\dir1",
+        "queue/diff\\local"
     };
 #endif
-    char messages[2][OS_SIZE_1024];
+    char messages[3][OS_SIZE_1024];
     int ret = -1;
+    char **not_null;
+
+    if(not_null = calloc(2, sizeof(char*)), !not_null)
+        fail();
+
+    not_null[0] = strdup("some-file.tmp");
+    not_null[1] = NULL;
 
     snprintf(messages[0], OS_SIZE_1024, "Removing empty directory '%s'.", parent_dirs[0]);
     snprintf(messages[1], OS_SIZE_1024, "Removing empty directory '%s'.", parent_dirs[1]);
 
     // Remove dir2
-    expect_string(__wrap_wreaddir, name, parent_dirs[0]);
-    will_return(__wrap_wreaddir, NULL);
+    expect_wreaddir_call(parent_dirs[0], NULL);
 
     expect_string(__wrap__mdebug1, formatted_msg, messages[0]);
 
-    expect_string(__wrap_rmdir_ex, name, parent_dirs[0]);
-    will_return(__wrap_rmdir_ex, 0);
+    expect_rmdir_ex_call(parent_dirs[0], 0);
 
     // Remove dir1
-    expect_string(__wrap_wreaddir, name, parent_dirs[1]);
-    will_return(__wrap_wreaddir, NULL);
+    expect_wreaddir_call(parent_dirs[1], NULL);
 
     expect_string(__wrap__mdebug1, formatted_msg, messages[1]);
 
-    expect_string(__wrap_rmdir_ex, name, parent_dirs[1]);
-    will_return(__wrap_rmdir_ex, 0);
+    expect_rmdir_ex_call(parent_dirs[1], 0);
+
+    expect_wreaddir_call(parent_dirs[2], not_null);
 
     ret = remove_empty_folders(input);
 
@@ -393,19 +409,17 @@ static void test_remove_empty_folders_relative_path(void **state) {
     snprintf(messages[1], OS_SIZE_1024, "Removing empty directory '%s'.", parent_dirs[1]);
     snprintf(messages[2], OS_SIZE_1024, "Removing empty directory '%s'.", parent_dirs[2]);
 
-    expect_string(__wrap_wreaddir, name, parent_dirs[0]);
-    expect_string(__wrap_wreaddir, name, parent_dirs[1]);
-    expect_string(__wrap_wreaddir, name, parent_dirs[2]);
-    will_return_always(__wrap_wreaddir, NULL);
+    expect_wreaddir_call(parent_dirs[0], NULL);
+    expect_wreaddir_call(parent_dirs[1], NULL);
+    expect_wreaddir_call(parent_dirs[2], NULL);
 
     expect_string(__wrap__mdebug1, formatted_msg, messages[0]);
     expect_string(__wrap__mdebug1, formatted_msg, messages[1]);
     expect_string(__wrap__mdebug1, formatted_msg, messages[2]);
 
-    expect_string(__wrap_rmdir_ex, name, parent_dirs[0]);
-    expect_string(__wrap_rmdir_ex, name, parent_dirs[1]);
-    expect_string(__wrap_rmdir_ex, name, parent_dirs[2]);
-    will_return_always(__wrap_rmdir_ex, 0);
+    expect_rmdir_ex_call(parent_dirs[0], 0);
+    expect_rmdir_ex_call(parent_dirs[1], 0);
+    expect_rmdir_ex_call(parent_dirs[2], 0);
 
     ret = remove_empty_folders(input);
 
@@ -436,19 +450,17 @@ static void test_remove_empty_folders_absolute_path(void **state) {
     snprintf(messages[1], OS_SIZE_1024, "Removing empty directory '%s'.", parent_dirs[1]);
     snprintf(messages[2], OS_SIZE_1024, "Removing empty directory '%s'.", parent_dirs[2]);
 
-    expect_string(__wrap_wreaddir, name, parent_dirs[0]);
-    expect_string(__wrap_wreaddir, name, parent_dirs[1]);
-    expect_string(__wrap_wreaddir, name, parent_dirs[2]);
-    will_return_always(__wrap_wreaddir, NULL);
+    expect_wreaddir_call(parent_dirs[0], NULL);
+    expect_wreaddir_call(parent_dirs[1], NULL);
+    expect_wreaddir_call(parent_dirs[2], NULL);
 
     expect_string(__wrap__mdebug1, formatted_msg, messages[0]);
     expect_string(__wrap__mdebug1, formatted_msg, messages[1]);
     expect_string(__wrap__mdebug1, formatted_msg, messages[2]);
 
-    expect_string(__wrap_rmdir_ex, name, parent_dirs[0]);
-    expect_string(__wrap_rmdir_ex, name, parent_dirs[1]);
-    expect_string(__wrap_rmdir_ex, name, parent_dirs[2]);
-    will_return_always(__wrap_rmdir_ex, 0);
+    expect_rmdir_ex_call(parent_dirs[0], 0);
+    expect_rmdir_ex_call(parent_dirs[1], 0);
+    expect_rmdir_ex_call(parent_dirs[2], 0);
 
     ret = remove_empty_folders(input);
 
@@ -472,8 +484,7 @@ static void test_remove_empty_folders_non_empty_dir(void **state) {
     subdir[0] = strdup("some-file.tmp");
     subdir[1] = NULL;
 
-    expect_string(__wrap_wreaddir, name, parent_dir);
-    will_return(__wrap_wreaddir, subdir);
+    expect_wreaddir_call(parent_dir, subdir);
 
     ret = remove_empty_folders(input);
 
@@ -492,14 +503,12 @@ static void test_remove_empty_folders_error_removing_dir(void **state) {
     char remove_dir_message[OS_SIZE_1024];
     char dir_not_deleted_message[OS_SIZE_1024];
 
-    expect_string(__wrap_wreaddir, name, parent_dir);
-    will_return(__wrap_wreaddir, NULL);
+    expect_wreaddir_call(parent_dir, NULL);
 
     snprintf(remove_dir_message, OS_SIZE_1024, "Removing empty directory '%s'.", parent_dir);
     expect_string(__wrap__mdebug1, formatted_msg, remove_dir_message);
 
-    expect_string(__wrap_rmdir_ex, name, parent_dir);
-    will_return(__wrap_rmdir_ex, -1);
+    expect_rmdir_ex_call(parent_dir, -1);
 
     snprintf(dir_not_deleted_message, OS_SIZE_1024,
         "Empty directory '%s' couldn't be deleted. ('Directory not empty')", parent_dir);
@@ -507,7 +516,7 @@ static void test_remove_empty_folders_error_removing_dir(void **state) {
 
     ret = remove_empty_folders(input);
 
-    assert_int_equal(ret, 1);
+    assert_int_equal(ret, -1);
 }
 
 #if defined(TEST_SERVER)
@@ -3727,13 +3736,13 @@ int main(int argc, char *argv[]) {
         cmocka_unit_test(test_normalize_path_null_input),
 
         /* remove_empty_folders tests */
-        // cmocka_unit_test(test_remove_empty_folders_success),
-        // cmocka_unit_test(test_remove_empty_folders_recursive_success),
+        cmocka_unit_test(test_remove_empty_folders_success),
+        cmocka_unit_test(test_remove_empty_folders_recursive_success),
         cmocka_unit_test(test_remove_empty_folders_null_input),
         cmocka_unit_test(test_remove_empty_folders_relative_path),
         cmocka_unit_test(test_remove_empty_folders_absolute_path),
         cmocka_unit_test(test_remove_empty_folders_non_empty_dir),
-        // cmocka_unit_test(test_remove_empty_folders_error_removing_dir),
+        cmocka_unit_test(test_remove_empty_folders_error_removing_dir),
 
 #if defined(TEST_SERVER)
         /* sk_decode_sum tests */

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -320,13 +320,13 @@ static void test_remove_empty_folders_success(void **state) {
 #endif
     int ret = -1;
     char message[OS_SIZE_1024];
-    char **not_null;
+    char **mock_directory_content;
 
-    if(not_null = calloc(2, sizeof(char*)), !not_null)
+    if(mock_directory_content = calloc(2, sizeof(char*)), !mock_directory_content)
         fail();
 
-    not_null[0] = strdup("some-file.tmp");
-    not_null[1] = NULL;
+    mock_directory_content[0] = strdup("some-file.tmp");
+    mock_directory_content[1] = NULL;
 
     expect_wreaddir_call(first_subdir, NULL);
 
@@ -335,7 +335,7 @@ static void test_remove_empty_folders_success(void **state) {
 
     expect_rmdir_ex_call(first_subdir, 0);
 
-    expect_wreaddir_call(second_subdir, not_null);
+    expect_wreaddir_call(second_subdir, mock_directory_content);
 
     ret = remove_empty_folders(input);
 
@@ -360,13 +360,13 @@ static void test_remove_empty_folders_recursive_success(void **state) {
 #endif
     char messages[3][OS_SIZE_1024];
     int ret = -1;
-    char **not_null;
+    char **mock_directory_content;
 
-    if(not_null = calloc(2, sizeof(char*)), !not_null)
+    if(mock_directory_content = calloc(2, sizeof(char*)), !mock_directory_content)
         fail();
 
-    not_null[0] = strdup("some-file.tmp");
-    not_null[1] = NULL;
+    mock_directory_content[0] = strdup("some-file.tmp");
+    mock_directory_content[1] = NULL;
 
     snprintf(messages[0], OS_SIZE_1024, "Removing empty directory '%s'.", parent_dirs[0]);
     snprintf(messages[1], OS_SIZE_1024, "Removing empty directory '%s'.", parent_dirs[1]);
@@ -385,7 +385,7 @@ static void test_remove_empty_folders_recursive_success(void **state) {
 
     expect_rmdir_ex_call(parent_dirs[1], 0);
 
-    expect_wreaddir_call(parent_dirs[2], not_null);
+    expect_wreaddir_call(parent_dirs[2], mock_directory_content);
 
     ret = remove_empty_folders(input);
 
@@ -2874,6 +2874,7 @@ static void test_get_file_user_CreateFile_error_generic(void **state) {
 
 static void test_get_file_user_GetSecurityInfo_error(void **state) {
     char **array = *state;
+    char error_msg[OS_SIZE_1024];
 
     expect_CreateFile_call("C:\\a\\path", (HANDLE)1234);
 
@@ -2886,8 +2887,6 @@ static void test_get_file_user_GetSecurityInfo_error(void **state) {
     expect_ConvertSidToStringSid_call("dummy", FALSE);
 
     expect_string(__wrap__mdebug1, formatted_msg, "The user's SID could not be extracted.");
-
-    char error_msg[OS_SIZE_1024];
 
     snprintf(error_msg,
              OS_SIZE_1024,
@@ -2925,6 +2924,7 @@ static void test_get_file_user_LookupAccountSid_error(void **state) {
 
 static void test_get_file_user_LookupAccountSid_error_none_mapped(void **state) {
     char **array = *state;
+    char error_msg[OS_SIZE_1024];
 
     expect_CreateFile_call("C:\\a\\path", (HANDLE)1234);
 
@@ -2936,8 +2936,6 @@ static void test_get_file_user_LookupAccountSid_error_none_mapped(void **state) 
 
     expect_LookupAccountSid_call("", "domainname", FALSE);
     expect_GetLastError_call(ERROR_NONE_MAPPED);
-
-    char error_msg[OS_SIZE_1024];
 
     snprintf(error_msg,
              OS_SIZE_1024,
@@ -3434,11 +3432,10 @@ void test_get_registry_group_GetSecurityInfo_fails(void **state) {
     registry_group_information_t *group_information = *state;
     char *group = group_information->name;
     char *group_id = group_information->id;
+    char error_msg[OS_SIZE_1024];
 
     expect_GetSecurityInfo_call(NULL, (PSID)"", ERROR_ACCESS_DENIED);
     expect_GetLastError_call(ERROR_ACCESS_DENIED);
-
-    char error_msg[OS_SIZE_1024];
 
     snprintf(error_msg,
              OS_SIZE_1024,
@@ -3586,14 +3583,13 @@ void test_get_registry_permissions_GetSecurityDescriptorDacl_no_DACL(void **stat
     HKEY hndl = (HKEY)123456;
     unsigned int retval = 0;
     char permissions[OS_SIZE_6144 + 1];
+    char error_msg[OS_SIZE_1024];
 
     expect_RegGetKeySecurity_call((LPDWORD)120, ERROR_INSUFFICIENT_BUFFER);
 
     expect_RegGetKeySecurity_call((LPDWORD)120, ERROR_SUCCESS);
 
     expect_GetSecurityDescriptorDacl_call(TRUE, (PACL*)0, TRUE);
-
-    char error_msg[OS_SIZE_1024];
 
     snprintf(error_msg,
              OS_SIZE_1024,
@@ -3695,11 +3691,11 @@ void test_get_registry_permissions_success(void **state) {
 }
 
 void test_get_registry_mtime_RegQueryInfoKeyA_fails(void **state) {
-    PFILETIME last_write_time;
+    FILETIME last_write_time;
     unsigned int retval = 0;
     HKEY hndl = (HKEY)123456;
 
-    expect_RegQueryInfoKeyA_call(last_write_time, ERROR_MORE_DATA);
+    expect_RegQueryInfoKeyA_call(&last_write_time, ERROR_MORE_DATA);
 
     expect_string(__wrap__mwarn, formatted_msg, "Couldn't get modification time for registry key.");
 
@@ -3709,11 +3705,11 @@ void test_get_registry_mtime_RegQueryInfoKeyA_fails(void **state) {
 }
 
 void test_get_registry_mtime_success(void **state) {
-    PFILETIME last_write_time;
+    FILETIME last_write_time;
     unsigned int retval = 0;
     HKEY hndl = (HKEY)123456;
 
-    expect_RegQueryInfoKeyA_call(last_write_time, ERROR_SUCCESS);
+    expect_RegQueryInfoKeyA_call(&last_write_time, ERROR_SUCCESS);
 
     retval = get_registry_mtime(hndl);
 

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -64,7 +64,7 @@ typedef struct __unescape_syscheck_field_data_s {
 typedef struct __registry_group_information {
     char *name;
     char *id;
-} registry_group_information;
+} registry_group_information_t;
 
 /* setup/teardown */
 
@@ -95,7 +95,8 @@ static int teardown_string_array(void **state) {
 }
 
 static int setup_get_registry_group(void **state) {
-    registry_group_information *group_information = (registry_group_information *)calloc(1, sizeof(registry_group_information));
+    registry_group_information_t *group_information = (registry_group_information_t *)
+                                                        calloc(1, sizeof(registry_group_information_t));
 
     if (group_information == NULL) {
         return -1;
@@ -114,7 +115,7 @@ static int setup_get_registry_group(void **state) {
 }
 
 static int teardown_get_registry_group(void **state) {
-    registry_group_information *group_information = *state;
+    registry_group_information_t *group_information = *state;
 
     free(group_information->name);
     free(group_information->id);
@@ -3430,7 +3431,7 @@ void test_w_directory_exists_path_is_dir(void **state) {
 
 void test_get_registry_group_GetSecurityInfo_fails(void **state) {
     HKEY hndl = (HKEY)123456;
-    registry_group_information *group_information = *state;
+    registry_group_information_t *group_information = *state;
     char *group = group_information->name;
     char *group_id = group_information->id;
 
@@ -3454,7 +3455,7 @@ void test_get_registry_group_GetSecurityInfo_fails(void **state) {
 
 void test_get_registry_group_ConvertSidToStringSid_fails(void **state) {
     HKEY hndl = (HKEY)123456;
-    registry_group_information *group_information = *state;
+    registry_group_information_t *group_information = *state;
     char *group = group_information->name;
     char *group_id = group_information->id;
 
@@ -3474,7 +3475,7 @@ void test_get_registry_group_ConvertSidToStringSid_fails(void **state) {
 
 void test_get_registry_group_LookupAccountSid_fails(void **state) {
     HKEY hndl = (HKEY)123456;
-    registry_group_information *group_information = *state;
+    registry_group_information_t *group_information = *state;
     char *group = group_information->name;
     char *group_id = group_information->id;
 
@@ -3495,7 +3496,7 @@ void test_get_registry_group_LookupAccountSid_fails(void **state) {
 
 void test_get_registry_group_LookupAccountSid_not_found(void **state) {
     HKEY hndl = (HKEY)123456;
-    registry_group_information *group_information = *state;
+    registry_group_information_t *group_information = *state;
     char *group = group_information->name;
     char *group_id = group_information->id;
 
@@ -3516,7 +3517,7 @@ void test_get_registry_group_LookupAccountSid_not_found(void **state) {
 
 void test_get_registry_group_success(void **state) {
     HKEY hndl = (HKEY)123456;
-    registry_group_information *group_information = *state;
+    registry_group_information_t *group_information = *state;
     char *group = group_information->name;
     char *group_id = group_information->id;
 

--- a/src/unit_tests/syscheckd/registry/test_registry.c
+++ b/src/unit_tests/syscheckd/registry/test_registry.c
@@ -75,11 +75,6 @@ void expect_RegQueryInfoKey_call(DWORD sub_keys, DWORD values, PFILETIME last_wr
     will_return(wrap_RegQueryInfoKey, return_value);
 }
 
-void expect_RegQueryInfoKeyA_call(PFILETIME last_write_time, LONG return_value) {
-    will_return(wrap_RegQueryInfoKeyA, last_write_time);
-    will_return(wrap_RegQueryInfoKeyA, return_value);
-}
-
 void expect_RegEnumKeyEx_call(LPSTR name, DWORD name_length, LONG return_value) {
     will_return(wrap_RegEnumKeyEx, name);
     will_return(wrap_RegEnumKeyEx, name_length);
@@ -117,27 +112,6 @@ void expect_LookupAccountSid_call(char *name, char *DomainName, int ret_value){
     will_return(wrap_LookupAccountSid, name);
     will_return(wrap_LookupAccountSid, DomainName);
     will_return(wrap_LookupAccountSid, ret_value);
-}
-
-void expect_RegGetKeySecurity_call(LPDWORD lpcbSecurityDescriptor, int ret_value){
-    will_return(wrap_RegGetKeySecurity, lpcbSecurityDescriptor);
-    will_return(wrap_RegGetKeySecurity, ret_value);
-}
-
-void expect_GetSecurityDescriptorDacl_call(int fDaclPresent, PACL *pDacl, int ret_value){
-    will_return(wrap_GetSecurityDescriptorDacl, fDaclPresent);
-    will_return(wrap_GetSecurityDescriptorDacl, pDacl);
-    will_return(wrap_GetSecurityDescriptorDacl, ret_value);
-}
-
-void expect_GetAclInformation_call(LPVOID pAclInformation, int ret_value){
-    will_return(wrap_GetAclInformation, pAclInformation);
-    will_return(wrap_GetAclInformation, ret_value);
-}
-
-void expect_GetAce_call(LPVOID *pAce, int ret_value){
-    will_return(wrap_GetAce, pAce);
-    will_return(wrap_GetAce, ret_value);
 }
 
 void expect_fim_registry_get_key_data_call(LPSTR usid, LPSTR gsid, char *uname, char *gname,

--- a/src/unit_tests/syscheckd/registry/test_registry.c
+++ b/src/unit_tests/syscheckd/registry/test_registry.c
@@ -11,10 +11,17 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
+
 #include "../syscheckd/syscheck.h"
 #include "../syscheckd/registry/registry.h"
 #include "../syscheckd/db/fim_db.h"
+
 #include "../../wrappers/common.h"
+#include "../../wrappers/windows/sddl_wrappers.h"
+#include "../../wrappers/windows/aclapi_wrappers.h"
+#include "../../wrappers/windows/winreg_wrappers.h"
+#include "../../wrappers/windows/winbase_wrappers.h"
+#include "../../wrappers/windows/securitybaseapi_wrappers.h"
 
 #define CHECK_REGISTRY_ALL                                                                             \
     CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MTIME | CHECK_MD5SUM | CHECK_SHA1SUM | \
@@ -95,23 +102,6 @@ void expect_SendMSG_call(const char *message_expected, const char *locmsg_expect
     expect_string(__wrap_SendMSG, locmsg, locmsg_expected);
     expect_value(__wrap_SendMSG, loc, loc_expected);
     will_return(__wrap_SendMSG, ret);
-}
-
-void expect_GetSecurityInfo_call(PSID ppsidOwner, PSID pSidGroup, DWORD ret_value){
-    if (ppsidOwner) will_return(wrap_GetSecurityInfo, ppsidOwner);
-    if (pSidGroup) will_return(wrap_GetSecurityInfo, pSidGroup);
-    will_return(wrap_GetSecurityInfo, ret_value);
-}
-
-void expect_ConvertSidToStringSid_call(LPSTR StringSid, int ret_value){
-    will_return(wrap_ConvertSidToStringSid, StringSid);
-    will_return(wrap_ConvertSidToStringSid, ret_value);
-}
-
-void expect_LookupAccountSid_call(char *name, char *DomainName, int ret_value){
-    will_return(wrap_LookupAccountSid, name);
-    will_return(wrap_LookupAccountSid, DomainName);
-    will_return(wrap_LookupAccountSid, ret_value);
 }
 
 void expect_fim_registry_get_key_data_call(LPSTR usid, LPSTR gsid, char *uname, char *gname,

--- a/src/unit_tests/syscheckd/registry/test_registry.c
+++ b/src/unit_tests/syscheckd/registry/test_registry.c
@@ -65,38 +65,6 @@ void fim_registry_process_value_delete_event(fdb_t *fim_sql, fim_entry *data, pt
 void fim_registry_process_key_delete_event(fdb_t *fim_sql, fim_entry *data, pthread_mutex_t *mutex, void *_alert, void *_ev_mode, void *_w_evt);
 void fim_registry_process_value_event(fim_entry *new, fim_entry *saved, fim_event_mode mode, BYTE *data_buffer);
 
-
-void expect_RegOpenKeyEx_call(HKEY hKey, LPCSTR sub_key, DWORD options, REGSAM sam, PHKEY result, LONG return_value) {
-    expect_value(wrap_RegOpenKeyEx, hKey, hKey);
-    expect_string(wrap_RegOpenKeyEx, lpSubKey, sub_key);
-    expect_value(wrap_RegOpenKeyEx, ulOptions, options);
-    expect_value(wrap_RegOpenKeyEx, samDesired, sam);
-    will_return(wrap_RegOpenKeyEx, result);
-    will_return(wrap_RegOpenKeyEx, return_value);
-}
-
-void expect_RegQueryInfoKey_call(DWORD sub_keys, DWORD values, PFILETIME last_write_time, LONG return_value) {
-    will_return(wrap_RegQueryInfoKey, sub_keys);
-    will_return(wrap_RegQueryInfoKey, values);
-    will_return(wrap_RegQueryInfoKey, last_write_time);
-    will_return(wrap_RegQueryInfoKey, return_value);
-}
-
-void expect_RegEnumKeyEx_call(LPSTR name, DWORD name_length, LONG return_value) {
-    will_return(wrap_RegEnumKeyEx, name);
-    will_return(wrap_RegEnumKeyEx, name_length);
-    will_return(wrap_RegEnumKeyEx, return_value);
-}
-
-void expect_RegEnumValue_call(LPSTR value_name, DWORD type, LPBYTE data, DWORD data_length, LONG return_value) {
-    will_return(wrap_RegEnumValue, value_name);
-    will_return(wrap_RegEnumValue, strlen(value_name));
-    will_return(wrap_RegEnumValue, type);
-    will_return(wrap_RegEnumValue, data_length);
-    will_return(wrap_RegEnumValue, data);
-    will_return(wrap_RegEnumValue, return_value);
-}
-
 void expect_SendMSG_call(const char *message_expected, const char *locmsg_expected, char loc_expected, int ret){
     expect_string(__wrap_SendMSG, message, message_expected);
     expect_string(__wrap_SendMSG, locmsg, locmsg_expected);

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
@@ -69,6 +69,11 @@ int __wrap_rmdir_ex(const char *name) {
     return ret;
 }
 
+void expect_rmdir_ex_call(const char *dir, int ret) {
+    expect_string(__wrap_rmdir_ex, name, dir);
+    will_return(__wrap_rmdir_ex, ret);
+}
+
 int __wrap_w_compress_gzfile(const char *filesrc, const char *filedst) {
     check_expected(filesrc);
     check_expected(filedst);
@@ -90,6 +95,11 @@ FILE *__wrap_wfopen(const char * __filename, const char * __modes) {
 char ** __wrap_wreaddir(const char * name) {
     check_expected(name);
     return mock_type(char**);
+}
+
+void expect_wreaddir_call(const char *dir, char **files) {
+    expect_string(__wrap_wreaddir, name, dir);
+    will_return(__wrap_wreaddir, files);
 }
 
 #ifndef WIN32

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
@@ -34,6 +34,8 @@ int __wrap_IsSocket(const char * sock);
 
 int __wrap_rmdir_ex(const char *name);
 
+void expect_rmdir_ex_call(const char *dir, int ret);
+
 int __wrap_w_compress_gzfile(const char *filesrc, const char *filedst);
 
 int __wrap_w_uncompress_gzfile(const char *gzfilesrc, const char *gzfiledst);
@@ -41,6 +43,8 @@ int __wrap_w_uncompress_gzfile(const char *gzfilesrc, const char *gzfiledst);
 FILE *__wrap_wfopen(const char * __filename, const char * __modes);
 
 char ** __wrap_wreaddir(const char * name);
+
+void expect_wreaddir_call(const char *dir, char **files);
 
 #ifndef WIN32
 off_t __wrap_FileSize(const char * path);

--- a/src/unit_tests/wrappers/windows/aclapi_wrappers.c
+++ b/src/unit_tests/wrappers/windows/aclapi_wrappers.c
@@ -24,10 +24,18 @@ DWORD wrap_GetSecurityInfo(__UNUSED_PARAM(HANDLE handle),
     if (ppsidOwner) {
         *ppsidOwner = mock_type(PSID);
     }
+
     if (ppsidGroup) {
         *ppsidGroup = mock_type(PSID);
     }
+
     return mock();
+}
+
+void expect_GetSecurityInfo_call(PSID ppsidOwner, PSID pSidGroup, DWORD ret_value) {
+    if (ppsidOwner) will_return(wrap_GetSecurityInfo, ppsidOwner);
+    if (pSidGroup) will_return(wrap_GetSecurityInfo, pSidGroup);
+    will_return(wrap_GetSecurityInfo, ret_value);
 }
 
 DWORD wrap_GetNamedSecurityInfo(LPCSTR pObjectName,

--- a/src/unit_tests/wrappers/windows/aclapi_wrappers.h
+++ b/src/unit_tests/wrappers/windows/aclapi_wrappers.h
@@ -29,6 +29,8 @@ DWORD wrap_GetSecurityInfo(HANDLE handle,
                            PACL *ppSacl,
                            PSECURITY_DESCRIPTOR *ppSecurityDescriptor);
 
+void expect_GetSecurityInfo_call(PSID ppsidOwner, PSID pSidGroup, DWORD ret_value);
+
 DWORD wrap_GetNamedSecurityInfo(LPCSTR pObjectName,
                                 SE_OBJECT_TYPE ObjectType,
                                 SECURITY_INFORMATION SecurityInfo,

--- a/src/unit_tests/wrappers/windows/errhandlingapi_wrappers.c
+++ b/src/unit_tests/wrappers/windows/errhandlingapi_wrappers.c
@@ -16,3 +16,7 @@
 DWORD wrap_GetLastError(VOID) {
     return mock();
 }
+
+void expect_GetLastError_call(int error_code) {
+    will_return(wrap_GetLastError, error_code);
+}

--- a/src/unit_tests/wrappers/windows/errhandlingapi_wrappers.h
+++ b/src/unit_tests/wrappers/windows/errhandlingapi_wrappers.h
@@ -18,4 +18,6 @@
 
 DWORD wrap_GetLastError(VOID);
 
+void expect_GetLastError_call(int error_code);
+
 #endif

--- a/src/unit_tests/wrappers/windows/fileapi_wrappers.c
+++ b/src/unit_tests/wrappers/windows/fileapi_wrappers.c
@@ -24,6 +24,11 @@ HANDLE wrap_CreateFile(LPCSTR lpFileName,
     return mock_type(HANDLE);
 }
 
+void expect_CreateFile_call(const char *filename, HANDLE ret) {
+    expect_string(wrap_CreateFile, lpFileName, filename);
+    will_return(wrap_CreateFile, (HANDLE)ret);
+}
+
 DWORD wrap_GetFileAttributesA(LPCSTR lpFileName) {
     check_expected(lpFileName);
     return mock();

--- a/src/unit_tests/wrappers/windows/fileapi_wrappers.h
+++ b/src/unit_tests/wrappers/windows/fileapi_wrappers.h
@@ -30,6 +30,8 @@ HANDLE wrap_CreateFile(LPCSTR lpFileName,
                        DWORD dwFlagsAndAttributes,
                        HANDLE hTemplateFile);
 
+void expect_CreateFile_call(const char *filename, HANDLE ret);
+
 DWORD wrap_GetFileAttributesA(LPCSTR lpFileName);
 
 WINBOOL wrap_GetVolumePathNamesForVolumeNameW(LPCWSTR lpszVolumeName,

--- a/src/unit_tests/wrappers/windows/handleapi_wrappers.c
+++ b/src/unit_tests/wrappers/windows/handleapi_wrappers.c
@@ -17,3 +17,8 @@ WINBOOL wrap_CloseHandle(HANDLE hObject) {
     check_expected(hObject);
     return mock();
 }
+
+void expect_CloseHandle_call(HANDLE object, int ret) {
+    expect_value(wrap_CloseHandle, hObject, object);
+    will_return(wrap_CloseHandle, ret);
+}

--- a/src/unit_tests/wrappers/windows/handleapi_wrappers.h
+++ b/src/unit_tests/wrappers/windows/handleapi_wrappers.h
@@ -18,4 +18,6 @@
 
 WINBOOL wrap_CloseHandle (HANDLE hObject);
 
+void expect_CloseHandle_call(HANDLE object, int ret);
+
 #endif

--- a/src/unit_tests/wrappers/windows/sddl_wrappers.c
+++ b/src/unit_tests/wrappers/windows/sddl_wrappers.c
@@ -18,3 +18,8 @@ WINBOOL wrap_ConvertSidToStringSid(__UNUSED_PARAM(PSID Sid),
     *StringSid = mock_type(LPSTR);
     return mock();
 }
+
+void expect_ConvertSidToStringSid_call(LPSTR StringSid, int ret_value) {
+    will_return(wrap_ConvertSidToStringSid, StringSid);
+    will_return(wrap_ConvertSidToStringSid, ret_value);
+}

--- a/src/unit_tests/wrappers/windows/sddl_wrappers.h
+++ b/src/unit_tests/wrappers/windows/sddl_wrappers.h
@@ -18,4 +18,6 @@
 
 WINBOOL wrap_ConvertSidToStringSid(PSID Sid, LPSTR *StringSid);
 
+void expect_ConvertSidToStringSid_call(LPSTR StringSid, int ret_value);
+
 #endif

--- a/src/unit_tests/wrappers/windows/securitybaseapi_wrappers.c
+++ b/src/unit_tests/wrappers/windows/securitybaseapi_wrappers.c
@@ -29,6 +29,12 @@ WINBOOL wrap_GetSecurityDescriptorDacl(__UNUSED_PARAM(PSECURITY_DESCRIPTOR pSecu
     return mock();
 }
 
+void expect_GetSecurityDescriptorDacl_call(int fDaclPresent, PACL *pDacl, int ret_value) {
+    will_return(wrap_GetSecurityDescriptorDacl, fDaclPresent);
+    will_return(wrap_GetSecurityDescriptorDacl, pDacl);
+    will_return(wrap_GetSecurityDescriptorDacl, ret_value);
+}
+
 WINBOOL wrap_GetAclInformation(__UNUSED_PARAM(PACL pAcl),
                                LPVOID pAclInformation,
                                DWORD nAclInformationLength,
@@ -41,11 +47,21 @@ WINBOOL wrap_GetAclInformation(__UNUSED_PARAM(PACL pAcl),
     return mock();
 }
 
+void expect_GetAclInformation_call(LPVOID pAclInformation, int ret_value) {
+    will_return(wrap_GetAclInformation, pAclInformation);
+    will_return(wrap_GetAclInformation, ret_value);
+}
+
 WINBOOL wrap_GetAce(__UNUSED_PARAM(PACL pAcl),
                     __UNUSED_PARAM(DWORD dwAceIndex),
                     LPVOID *pAce) {
     *pAce = mock_type(LPVOID);
     return mock();
+}
+
+void expect_GetAce_call(LPVOID *pAce, int ret_value) {
+    will_return(wrap_GetAce, pAce);
+    will_return(wrap_GetAce, ret_value);
 }
 
 WINBOOL wrap_AdjustTokenPrivileges(HANDLE TokenHandle,

--- a/src/unit_tests/wrappers/windows/securitybaseapi_wrappers.h
+++ b/src/unit_tests/wrappers/windows/securitybaseapi_wrappers.h
@@ -32,14 +32,20 @@ WINBOOL wrap_GetSecurityDescriptorDacl(PSECURITY_DESCRIPTOR pSecurityDescriptor,
                                        PACL *pDacl,
                                        LPBOOL lpbDaclDefaulted);
 
+void expect_GetSecurityDescriptorDacl_call(int fDaclPresent, PACL *pDacl, int ret_value);
+
 WINBOOL wrap_GetAclInformation(PACL pAcl,
                                LPVOID pAclInformation,
                                DWORD nAclInformationLength,
                                ACL_INFORMATION_CLASS dwAclInformationClass);
 
+void expect_GetAclInformation_call(LPVOID pAclInformation, int ret_value);
+
 WINBOOL wrap_GetAce(PACL pAcl,
                     DWORD dwAceIndex,
                     LPVOID *pAce);
+
+void expect_GetAce_call(LPVOID *pAce, int ret_value);
 
 WINBOOL wrap_AdjustTokenPrivileges(HANDLE TokenHandle,
                                    WINBOOL DisableAllPrivileges,

--- a/src/unit_tests/wrappers/windows/winbase_wrappers.c
+++ b/src/unit_tests/wrappers/windows/winbase_wrappers.c
@@ -50,6 +50,12 @@ WINBOOL wrap_LookupAccountSid(__UNUSED_PARAM(LPCSTR lpSystemName),
     return mock();
 }
 
+void expect_LookupAccountSid_call(char *name, char *DomainName, int ret_value) {
+    will_return(wrap_LookupAccountSid, name);
+    will_return(wrap_LookupAccountSid, DomainName);
+    will_return(wrap_LookupAccountSid, ret_value);
+}
+
 WINBOOL wrap_GetFileSecurity(LPCSTR lpFileName,
                              __UNUSED_PARAM(SECURITY_INFORMATION RequestedInformation),
                              PSECURITY_DESCRIPTOR pSecurityDescriptor,

--- a/src/unit_tests/wrappers/windows/winbase_wrappers.c
+++ b/src/unit_tests/wrappers/windows/winbase_wrappers.c
@@ -24,6 +24,10 @@ DWORD wrap_FormatMessage(__UNUSED_PARAM(DWORD dwFlags),
     return 0;
 }
 
+void expect_FormatMessage_call(char *buffer) {
+    will_return(wrap_FormatMessage, buffer);
+}
+
 HLOCAL wrap_LocalFree(__UNUSED_PARAM(HLOCAL hMem)) {
     return NULL;
 }

--- a/src/unit_tests/wrappers/windows/winbase_wrappers.h
+++ b/src/unit_tests/wrappers/windows/winbase_wrappers.h
@@ -47,6 +47,8 @@ WINBOOL wrap_LookupAccountSid(LPCSTR lpSystemName,
                               LPDWORD cchReferencedDomainName,
                               PSID_NAME_USE peUse);
 
+void expect_LookupAccountSid_call(char *name, char *DomainName, int ret_value);
+
 WINBOOL wrap_ReadDirectoryChangesW(HANDLE hDirectory,
                                    LPVOID lpBuffer,
                                    DWORD nBufferLength,

--- a/src/unit_tests/wrappers/windows/winbase_wrappers.h
+++ b/src/unit_tests/wrappers/windows/winbase_wrappers.h
@@ -32,6 +32,8 @@ DWORD wrap_FormatMessage(DWORD dwFlags,
                          DWORD nSize,
                          va_list *Arguments);
 
+void expect_FormatMessage_call(char *buffer);
+
 HLOCAL wrap_LocalFree(HLOCAL hMem);
 
 WINBOOL wrap_GetFileSecurity(LPCSTR lpFileName,

--- a/src/unit_tests/wrappers/windows/winreg_wrappers.c
+++ b/src/unit_tests/wrappers/windows/winreg_wrappers.c
@@ -52,6 +52,11 @@ LONG wrap_RegQueryInfoKeyA(__UNUSED_PARAM(HKEY hKey),
     return mock();
 }
 
+void expect_RegQueryInfoKeyA_call(PFILETIME last_write_time, LONG return_value) {
+    will_return(wrap_RegQueryInfoKeyA, last_write_time);
+    will_return(wrap_RegQueryInfoKeyA, return_value);
+}
+
 LONG wrap_RegEnumKeyEx(__UNUSED_PARAM(HKEY hKey),
                        __UNUSED_PARAM(DWORD dwIndex),
                        LPSTR lpName,
@@ -124,4 +129,9 @@ WINBOOL wrap_RegGetKeySecurity(__UNUSED_PARAM(HKEY hKey),
                                LPDWORD lpcbSecurityDescriptor) {
     *lpcbSecurityDescriptor = mock();
     return mock();
+}
+
+void expect_RegGetKeySecurity_call(LPDWORD lpcbSecurityDescriptor, int ret_value) {
+    will_return(wrap_RegGetKeySecurity, lpcbSecurityDescriptor);
+    will_return(wrap_RegGetKeySecurity, ret_value);
 }

--- a/src/unit_tests/wrappers/windows/winreg_wrappers.c
+++ b/src/unit_tests/wrappers/windows/winreg_wrappers.c
@@ -33,6 +33,13 @@ LONG wrap_RegQueryInfoKey(__UNUSED_PARAM(HKEY hKey),
     return mock();
 }
 
+void expect_RegQueryInfoKey_call(DWORD sub_keys, DWORD values, PFILETIME last_write_time, LONG return_value) {
+    will_return(wrap_RegQueryInfoKey, sub_keys);
+    will_return(wrap_RegQueryInfoKey, values);
+    will_return(wrap_RegQueryInfoKey, last_write_time);
+    will_return(wrap_RegQueryInfoKey, return_value);
+}
+
 LONG wrap_RegQueryInfoKeyA(__UNUSED_PARAM(HKEY hKey),
                           __UNUSED_PARAM(LPSTR lpClass),
                           __UNUSED_PARAM(LPDWORD lpcchClass),
@@ -70,6 +77,12 @@ LONG wrap_RegEnumKeyEx(__UNUSED_PARAM(HKEY hKey),
     return mock();
 }
 
+void expect_RegEnumKeyEx_call(LPSTR name, DWORD name_length, LONG return_value) {
+    will_return(wrap_RegEnumKeyEx, name);
+    will_return(wrap_RegEnumKeyEx, name_length);
+    will_return(wrap_RegEnumKeyEx, return_value);
+}
+
 LONG wrap_RegOpenKeyEx(HKEY hKey,
                        LPCSTR lpSubKey,
                        DWORD ulOptions,
@@ -84,6 +97,15 @@ LONG wrap_RegOpenKeyEx(HKEY hKey,
         memcpy(phkResult, key, sizeof(HKEY));
     }
     return mock();
+}
+
+void expect_RegOpenKeyEx_call(HKEY hKey, LPCSTR sub_key, DWORD options, REGSAM sam, PHKEY result, LONG return_value) {
+    expect_value(wrap_RegOpenKeyEx, hKey, hKey);
+    expect_string(wrap_RegOpenKeyEx, lpSubKey, sub_key);
+    expect_value(wrap_RegOpenKeyEx, ulOptions, options);
+    expect_value(wrap_RegOpenKeyEx, samDesired, sam);
+    will_return(wrap_RegOpenKeyEx, result);
+    will_return(wrap_RegOpenKeyEx, return_value);
 }
 
 LONG wrap_RegEnumValue(__UNUSED_PARAM(HKEY hKey),
@@ -101,6 +123,15 @@ LONG wrap_RegEnumValue(__UNUSED_PARAM(HKEY hKey),
     const void *data = mock_ptr_type(void *);
     memcpy(lpData, data, sizeof(char) * (*lpcbData));
     return mock();
+}
+
+void expect_RegEnumValue_call(LPSTR value_name, DWORD type, LPBYTE data, DWORD data_length, LONG return_value) {
+    will_return(wrap_RegEnumValue, value_name);
+    will_return(wrap_RegEnumValue, strlen(value_name));
+    will_return(wrap_RegEnumValue, type);
+    will_return(wrap_RegEnumValue, data_length);
+    will_return(wrap_RegEnumValue, data);
+    will_return(wrap_RegEnumValue, return_value);
 }
 
 LONG wrap_RegCloseKey(__UNUSED_PARAM(HKEY hKey)) {

--- a/src/unit_tests/wrappers/windows/winreg_wrappers.h
+++ b/src/unit_tests/wrappers/windows/winreg_wrappers.h
@@ -56,6 +56,8 @@ LONG wrap_RegQueryInfoKeyA(HKEY hKey,
                           LPDWORD lpcbSecurityDescriptor,
                           PFILETIME lpftLastWriteTime);
 
+void expect_RegQueryInfoKeyA_call(PFILETIME last_write_time, LONG return_value);
+
 LONG wrap_RegEnumKeyEx(HKEY hKey,
                        DWORD dwIndex,
                        LPSTR lpName,
@@ -92,5 +94,7 @@ WINBOOL wrap_RegGetKeySecurity(__UNUSED_PARAM(HKEY hKey),
                                __UNUSED_PARAM(SECURITY_INFORMATION SecurityInformation),
                                __UNUSED_PARAM(PSECURITY_DESCRIPTOR pSecurityDescriptor),
                                LPDWORD lpcbSecurityDescriptor);
+
+void expect_RegGetKeySecurity_call(LPDWORD lpcbSecurityDescriptor, int ret_value);
 
 #endif

--- a/src/unit_tests/wrappers/windows/winreg_wrappers.h
+++ b/src/unit_tests/wrappers/windows/winreg_wrappers.h
@@ -43,6 +43,8 @@ LONG wrap_RegQueryInfoKey(HKEY hKey,
                           LPDWORD lpcbSecurityDescriptor,
                           PFILETIME lpftLastWriteTime);
 
+void expect_RegQueryInfoKey_call(DWORD sub_keys, DWORD values, PFILETIME last_write_time, LONG return_value);
+
 LONG wrap_RegQueryInfoKeyA(HKEY hKey,
                           LPSTR lpClass,
                           LPDWORD lpcchClass,
@@ -67,11 +69,15 @@ LONG wrap_RegEnumKeyEx(HKEY hKey,
                        LPDWORD lpcchClass,
                        PFILETIME lpftLastWriteTime);
 
+void expect_RegEnumKeyEx_call(LPSTR name, DWORD name_length, LONG return_value);
+
 LONG wrap_RegOpenKeyEx(HKEY hKey,
                        LPCSTR lpSubKey,
                        DWORD ulOptions,
                        REGSAM samDesired,
                        PHKEY phkResult);
+
+void expect_RegOpenKeyEx_call(HKEY hKey, LPCSTR sub_key, DWORD options, REGSAM sam, PHKEY result, LONG return_value);
 
 LONG wrap_RegQueryValueEx(HKEY hKey,
                           LPCSTR lpValueName,
@@ -87,6 +93,8 @@ LONG wrap_RegEnumValue(HKEY hKey,
                        LPDWORD lpReserved,
                        LPDWORD lpType,
                        LPBYTE lpData,LPDWORD lpcbData);
+
+void expect_RegEnumValue_call(LPSTR value_name, DWORD type, LPBYTE data, DWORD data_length, LONG return_value);
 
 LONG wrap_RegCloseKey(HKEY hKey);
 


### PR DESCRIPTION
| Related issue |
| ------------- |
| #6342         |

## Description

This pull request adds unit tests for the new registry functions in the _syscheck_op_ file. These functions are:
* `get_file_user`
* `remove_empty_folders`
* `get_registry_group`
* `get_registry_permissions`
* `get_registry_mtime`

It also creates some expect_* functions to encapsulate the `expect_value`, `expect_string`, `will_return`... _cmocka_ calls.

This pull request closes #6342.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
