### PR TITLE
Vulnerability Detector: Fixed agent OS distribution version value for some cases

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4595,7 +4595,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
     char *name = NULL;
     char *register_ip = NULL;
     char *os_name = NULL;
-    char *os_version = NULL;
+    char *os_major = NULL;
     char *arch = NULL;
     int build = 0;
     int i = 0;
@@ -4624,7 +4624,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
         name = NULL;
         register_ip = NULL;
         os_name = NULL;
-        os_version = NULL;
+        os_major = NULL;
         arch = NULL;
         build = 0;
         id = -1;
@@ -4640,9 +4640,9 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
             os_name = json_field->valuestring;
         }
 
-        json_field = cJSON_GetObjectItem(json_agt_info->child, "os_version");
+        json_field = cJSON_GetObjectItem(json_agt_info->child, "os_major");
         if(cJSON_IsString(json_field) && json_field->valuestring != NULL){
-            os_version = json_field->valuestring;
+            os_major = json_field->valuestring;
         }
 
         json_field = cJSON_GetObjectItem(json_agt_info->child, "name");
@@ -4670,54 +4670,54 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AG_NEVER_CON, name);
             }
             continue;
-        } else if (!os_version) {
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_UNSOPPORTED, id, name?name:"");
+        } else if (!os_major) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_UNS_OS_VERSION, id, name?name:"");
             continue;
         }
 
         if (strcasestr(os_name, vu_feed_ext[FEED_UBUNTU])) {
-            if (strstr(os_version, "20")) {
+            if (strstr(os_major, "20")) {
                 agent_dist_ver = FEED_FOCAL;
-            } else if (strstr(os_version, "18")) {
+            } else if (strstr(os_major, "18")) {
                 agent_dist_ver = FEED_BIONIC;
-            } else if (strstr(os_version, "16")) {
+            } else if (strstr(os_major, "16")) {
                 agent_dist_ver = FEED_XENIAL;
-            } else if (strstr(os_version, "14")) {
+            } else if (strstr(os_major, "14")) {
                 agent_dist_ver = FEED_TRUSTY;
             } else {
                 dist_error = FEED_UBUNTU;
             }
             agent_dist = FEED_UBUNTU;
         } else if (strcasestr(os_name, vu_feed_ext[FEED_DEBIAN])) {
-            if (strstr(os_version, "9")) {
+            if (strstr(os_major, "9")) {
                 agent_dist_ver = FEED_STRETCH;
-            } else if (strstr(os_version, "10")) {
+            } else if (strstr(os_major, "10")) {
                 agent_dist_ver = FEED_BUSTER;
             } else {
                 dist_error = FEED_DEBIAN;
             }
             agent_dist = FEED_DEBIAN;
         }  else if (strcasestr(os_name, vu_feed_ext[FEED_REDHAT])) {
-            if (strstr(os_version, "8")) {
+            if (strstr(os_major, "8")) {
                 agent_dist_ver = FEED_RHEL8;
-            } else if (strstr(os_version, "7")) {
+            } else if (strstr(os_major, "7")) {
                 agent_dist_ver = FEED_RHEL7;
-            } else if (strstr(os_version, "6")) {
+            } else if (strstr(os_major, "6")) {
                 agent_dist_ver = FEED_RHEL6;
-            } else if (strstr(os_version, "5")) {
+            } else if (strstr(os_major, "5")) {
                 agent_dist_ver = FEED_RHEL5;
             } else {
                 dist_error = FEED_REDHAT;
             }
             agent_dist = FEED_REDHAT;
         } else if (strcasestr(os_name, vu_feed_ext[FEED_CENTOS])) {
-            if (strstr(os_version, "8")) {
+            if (strstr(os_major, "8")) {
                 agent_dist_ver = FEED_RHEL8;
-            } else if (strstr(os_version, "7")) {
+            } else if (strstr(os_major, "7")) {
                 agent_dist_ver = FEED_RHEL7;
-            } else if (strstr(os_version, "6")) {
+            } else if (strstr(os_major, "6")) {
                 agent_dist_ver = FEED_RHEL6;
-            } else if (strstr(os_version, "5")) {
+            } else if (strstr(os_major, "5")) {
                 agent_dist_ver = FEED_RHEL5;
             } else {
                 dist_error = FEED_CENTOS;
@@ -4733,7 +4733,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
 
         if (dist_error != -1) {
             // Check if the agent OS can be matched with a OVAL
-            if (agent_dist_ver = wm_vuldet_set_allowed_feed(os_name, os_version, updates, &agent_dist), agent_dist_ver == FEED_UNKNOWN) {
+            if (agent_dist_ver = wm_vuldet_set_allowed_feed(os_name, os_major, updates, &agent_dist), agent_dist_ver == FEED_UNKNOWN) {
                 if (dist_error == -2) {
                     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_UNSOPPORTED, id, name?name:"");
                     continue;


### PR DESCRIPTION
|Related issue|
|---|
|#6503|

## Description

I replaced the os_version with the os_major to obtain correctly the `agent_dist_ver` value. 

When the os_version was used and the os_version is 7.8, agent_dist_ver should be equal to FEED_RHEL7 but it was equal to FEED_RHEL8. This can have a negative impact because if we have the VD database empty and we download/update the RHEL 7 database, we will obtain the following messages because the function `wm_vuldet_check_agent_vulnerabilities` will check for any RHEL 8 vulnerabilities instead of RHEL 7. The scan stop if none is found:
```
2020/11/05 10:47:35 wazuh-modulesd:vulnerability-detector[39462] wm_vuln_detector.c:2044 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5450): Analyzing agent '001' vulnerabilities.
2020/11/05 10:47:35 wazuh-modulesd:vulnerability-detector[39462] wm_vuln_detector.c:2055 at wm_vuldet_check_agent_vulnerabilities(): WARNING: (5575): Unavailable vulnerability data for the agent '001' OS. Skipping it.
```

## Configuration options

```xml
<!-- RedHat OS vulnerabilities -->
<provider name="redhat">
  <enabled>yes</enabled>
  <os>7</os>
  <update_interval>1h</update_interval>
</provider>
```

## Logs/Alerts example

```
2020/11/05 12:13:53 wazuh-modulesd:vulnerability-detector[98536] wm_vuln_detector.c:1302 at wm_vuldet_send_agent_report(): DEBUG: (5482): A total of '177' vulnerabilities have been reported for agent '001' thanks to the 'NVD' feed.
2020/11/05 12:13:53 wazuh-modulesd:vulnerability-detector[98536] wm_vuln_detector.c:1303 at wm_vuldet_send_agent_report(): DEBUG: (5482): A total of '761' vulnerabilities have been reported for agent '001' thanks to the 'vendor' feed.
2020/11/05 12:13:53 wazuh-modulesd:vulnerability-detector[98536] wm_vuln_detector.c:1304 at wm_vuldet_send_agent_report(): DEBUG: (5469): A total of '761' vulnerabilities have been reported for agent '001'
2020/11/05 12:13:53 wazuh-modulesd:vulnerability-detector[98536] wm_vuln_detector.c:1305 at wm_vuldet_send_agent_report(): DEBUG: (5470): It took '34' seconds to 'report' vulnerabilities in agent '001'
2020/11/05 12:13:53 wazuh-modulesd:vulnerability-detector[98536] wm_vuln_detector.c:2075 at wm_vuldet_check_agent_vulnerabilities(): INFO: (5471): Finished vulnerability assessment for agent '001'
2020/11/05 12:13:53 wazuh-modulesd:vulnerability-detector[98536] wm_vuln_detector.c:2076 at wm_vuldet_check_agent_vulnerabilities(): DEBUG: (5470): It took '228' seconds to 'scan' vulnerabilities in agent '001'
2020/11/05 12:13:53 wazuh-modulesd:vulnerability-detector[98536] wm_vuln_detector.c:6906 at wm_vuldet_run_scan(): INFO: (5472): Vulnerability scan finished.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind

<!-- Checks for huge PRs that affect the product more generally -->
- [x] The data flow works as expected (agent-manager)
- [x] Checked unit tests (for new features)
