### PR TITLE
Vulnerability Detector: Lowercase vendor only for macos systems

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5407,17 +5407,21 @@ int wm_vuldet_insert_agent_data(sqlite3 *db, agent_software *agent, int *cpe_ind
     sqlite3_bind_text(stmt, 3, os_minor, -1, NULL);
     sqlite3_bind_int(stmt, 4, ag_cpe ? *cpe_index : 0);
 
+    if (agent->dist == FEED_MAC) {
+        normalized_vendor = w_tolower_str(vendor);
+        sqlite3_bind_text(stmt, 5, normalized_vendor, -1, NULL);
+    } else {
+        sqlite3_bind_text(stmt, 5, vendor, -1, NULL);
+    }
+
     if (agent->dist != FEED_WIN) {
         /* In Windows the package name is
         normalized by the CPE helper */
-        normalized_vendor = w_tolower_str(vendor);
-        sqlite3_bind_text(stmt, 5, normalized_vendor, -1, NULL);
         normalized_name = w_tolower_str(product);
         sqlite3_bind_text(stmt, 6, normalized_name, -1, NULL);
         normalized_source = w_tolower_str(source);
         sqlite3_bind_text(stmt, 7, normalized_source, -1, NULL);
     } else {
-        sqlite3_bind_text(stmt, 5, vendor, -1, NULL);
         sqlite3_bind_text(stmt, 6, product, -1, NULL);
         sqlite3_bind_text(stmt, 7, source, -1, NULL);
     }


### PR DESCRIPTION
|Related issue|
|---|
|#5860|


## Description
The vendor value has to be in lowercase to match correctly vulnerabilities from NVD for macOS systems. However, this change has a negative impact on other OS as RHEL so this fix will apply the change for macOS only.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

