### PR TITLE
Registry UT: fim_sync

### DIFF
--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -29,8 +29,8 @@ set_target_properties(
 target_link_libraries(ANALYSISD_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
 # Generate Analysisd tests
-#list(APPEND analysisd_names "test_analysisd_syscheck")
-#list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,_merror -Wl,--wrap,_mdebug1")
+list(APPEND analysisd_names "test_analysisd_syscheck")
+list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,_merror -Wl,--wrap,_mdebug1")
 
 list(APPEND analysisd_names "test_dbsync")
 list(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP \

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -29,8 +29,8 @@ set_target_properties(
 target_link_libraries(ANALYSISD_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
 # Generate Analysisd tests
-list(APPEND analysisd_names "test_analysisd_syscheck")
-list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,_merror -Wl,--wrap,_mdebug1")
+#list(APPEND analysisd_names "test_analysisd_syscheck")
+#list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,_merror -Wl,--wrap,_mdebug1")
 
 list(APPEND analysisd_names "test_dbsync")
 list(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP \

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -178,16 +178,19 @@ endif()
 set(FIM_SYNC_BASE_FLAGS "-Wl,--wrap,fim_send_sync_msg -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 \
                          -Wl,--wrap,_merror -Wl,--wrap,_mdebug2 -Wl,--wrap,queue_push_ex \
                          -Wl,--wrap,fim_db_get_row_path -Wl,--wrap,fim_db_get_data_checksum \
-                         -Wl,--wrap,dbsync_check_msg -Wl,--wrap,fim_send_sync_msg -Wl,--wrap,fim_db_get_count_range \
-                         -Wl,--wrap,fim_db_get_path -Wl,--wrap,fim_entry_json -Wl,--wrap,fim_db_get_checksum_range \
+                         -Wl,--wrap,dbsync_check_msg -Wl,--wrap,fim_db_get_count_range \
+                         -Wl,--wrap,fim_db_get_path -Wl,--wrap,fim_db_get_checksum_range \
                          -Wl,--wrap,dbsync_state_msg -Wl,--wrap,fim_db_sync_path_range \
-                         -Wl,--wrap,fim_db_get_path_range")
+                         -Wl,--wrap,fim_db_get_path_range -Wl,--wrap,fim_db_get_first_path \
+                         -Wl,--wrap,fim_db_get_last_path -Wl,--wrap,fim_db_get_entry_from_sync_msg \
+                         -Wl,--wrap,fim_db_read_line_from_file -Wl,--wrap,fim_db_clean_file \
+                         -Wl,--wrap,free_entry")
 
 list(APPEND syscheckd_tests_names "test_fim_sync")
 if(${TARGET} STREQUAL "winagent")
   list(APPEND syscheckd_tests_flags "${FIM_SYNC_BASE_FLAGS} -Wl,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock")
 else()
-  list(APPEND syscheckd_tests_flags "${FIM_SYNC_BASE_FLAGS} -Wl,--wrap,time")
+  list(APPEND syscheckd_tests_flags "${FIM_SYNC_BASE_FLAGS} -Wl,--wrap,time -Wl,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock")
 endif()
 
 set(RUN_CHECK_BASE_FLAGS "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 \

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -190,7 +190,8 @@ list(APPEND syscheckd_tests_names "test_fim_sync")
 if(${TARGET} STREQUAL "winagent")
   list(APPEND syscheckd_tests_flags "${FIM_SYNC_BASE_FLAGS} -Wl,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock")
 else()
-  list(APPEND syscheckd_tests_flags "${FIM_SYNC_BASE_FLAGS} -Wl,--wrap,time -Wl,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock")
+  list(APPEND syscheckd_tests_flags "${FIM_SYNC_BASE_FLAGS} -Wl,--wrap,time -Wl,--wrap=pthread_mutex_lock \
+                                     -Wl,--wrap=pthread_mutex_unlock")
 endif()
 
 set(RUN_CHECK_BASE_FLAGS "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 \

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -773,41 +773,6 @@ static void test_fim_attributes_json_without_options(void **state) {
     assert_string_equal(cJSON_GetStringValue(checksum), "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
 }
 
-
-static void test_fim_entry_json(void **state) {
-    fim_data_t *fim_data = *state;
-    const char *f_path = "/dir/test";
-    fim_entry *entry = NULL;
-    os_calloc(1, sizeof(fim_entry), entry);
-    entry->type = FIM_TYPE_FILE;
-    os_calloc(1, sizeof(fim_file_data), entry->file_entry.data);
-
-    entry->file_entry.data = fim_data->old_data;
-    fim_data->json = fim_entry_json(f_path, entry);
-
-    assert_non_null(fim_data->json);
-    cJSON *path = cJSON_GetObjectItem(fim_data->json, "path");
-    assert_non_null(path);
-    assert_string_equal(path->valuestring, f_path);
-    cJSON *timestamp = cJSON_GetObjectItem(fim_data->json, "timestamp");
-    assert_non_null(timestamp);
-    assert_int_equal(timestamp->valueint, 1570184220);
-}
-
-static void test_fim_entry_json_null_path(void **state) {
-    fim_data_t *fim_data = *state;
-    fim_entry *entry = NULL;
-    os_calloc(1, sizeof(fim_entry), entry);
-    entry->type = FIM_TYPE_FILE;
-    os_calloc(1, sizeof(fim_file_data), entry->file_entry.data);
-
-    entry->file_entry.data = fim_data->old_data;
-    expect_assert_failure(fim_entry_json(NULL, entry));
-}
-static void test_fim_entry_json_null_data(void **state) {
-    expect_assert_failure(fim_entry_json("/a/path", NULL));
-}
-
 static void test_fim_json_compare_attrs(void **state) {
     fim_data_t *fim_data = *state;
     int i = 0;
@@ -4275,11 +4240,6 @@ int main(void) {
         /* fim_attributes_json */
         cmocka_unit_test_teardown(test_fim_attributes_json, teardown_delete_json),
         cmocka_unit_test_teardown(test_fim_attributes_json_without_options, teardown_delete_json),
-
-        /* fim_entry_json */
-        cmocka_unit_test_teardown(test_fim_entry_json, teardown_delete_json),
-        cmocka_unit_test(test_fim_entry_json_null_path),
-        cmocka_unit_test(test_fim_entry_json_null_data),
 
         /* fim_json_compare_attrs */
         cmocka_unit_test_teardown(test_fim_json_compare_attrs, teardown_delete_json),

--- a/src/unit_tests/syscheckd/test_fim_sync.c
+++ b/src/unit_tests/syscheckd/test_fim_sync.c
@@ -30,11 +30,46 @@
 extern long fim_sync_cur_id;
 extern w_queue_t * fim_sync_queue;
 
+const fim_file_data DEFAULT_FILE_DATA = {
+    // Checksum attributes
+    .size = 0,
+    .perm = "rw-rw-r--",
+    .attributes = NULL,
+    .uid = "1000",
+    .gid = "1000",
+    .user_name = "root",
+    .group_name = "root",
+    .mtime = 123456789,
+    .inode = 1,
+    .hash_md5 = "0123456789abcdef0123456789abcdef",
+    .hash_sha1 = "0123456789abcdef0123456789abcdef01234567",
+    .hash_sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+
+    // Options
+    .mode = FIM_REALTIME,
+    .last_event = 0,
+    .dev = 100,
+    .scanned = 0,
+    .options = (CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MTIME | CHECK_INODE | CHECK_MD5SUM |
+                CHECK_SHA1SUM | CHECK_SHA256SUM),
+    .checksum = "0123456789abcdef0123456789abcdef01234567",
+};
+
 /* Auxiliar structs */
 typedef struct __json_payload_s {
     cJSON *payload;
     char *printed_payload;
 } json_payload_t;
+
+typedef struct __str_pair_s {
+    char *first;
+    char *last;
+} str_pair_t;
+
+typedef struct __pair_entry_str_s {
+    fim_entry *entry;
+    char *str;
+} pair_entry_str_t;
 
 /* redefinitons/wrapping */
 #ifndef TEST_WINAGENT
@@ -48,7 +83,12 @@ static int setup_group(void **state) {
 #ifdef TEST_WINAGENT
     time_mock_value = 1572521857;
 #endif
+    syscheck.database = fim_db_init(FIM_DB_DISK);
+    return 0;
+}
 
+static int teardown_group(void **state) {
+    fim_db_close(syscheck.database);
     return 0;
 }
 
@@ -119,6 +159,215 @@ static int teardown_json_payload(void **state) {
     return 0;
 }
 
+static int setup_str_pair(void **state) {
+    str_pair_t *new;
+    os_calloc(1, sizeof(str_pair_t), new);
+    os_strdup("first", new->first);
+    os_strdup("last", new->last);
+
+    *state = new;
+    return 0;
+}
+
+
+static int teardown_str_pair(void **state) {
+    str_pair_t *new = *state;
+
+    os_free(new->first);
+    os_free(new->last);
+    os_free(new);
+
+    return 0;
+}
+
+static int setup_fim_entry(void **state) {
+    pair_entry_str_t *data = NULL;
+
+
+    data = malloc(sizeof(pair_entry_str_t));
+    data->entry = malloc(sizeof(fim_entry));
+    data->entry->file_entry.data = malloc(sizeof(fim_file_data));
+
+    data->entry->type = FIM_TYPE_FILE;
+    data->entry->file_entry.path = strdup("start");
+
+    data->entry->file_entry.data->size = 1501;
+    data->entry->file_entry.data->perm = strdup("0666");
+    data->entry->file_entry.data->attributes = strdup("rw-rw-rw-");
+    data->entry->file_entry.data->uid = strdup("101");
+    data->entry->file_entry.data->gid = strdup("1001");
+    data->entry->file_entry.data->user_name = strdup("test1");
+    data->entry->file_entry.data->group_name = strdup("testing1");
+    data->entry->file_entry.data->mtime = 1570184224;
+    data->entry->file_entry.data->inode = 606061;
+    strcpy(data->entry->file_entry.data->hash_md5, "3691689a513ace7e508297b583d7550d");
+    strcpy(data->entry->file_entry.data->hash_sha1, "07f05add1049244e7e75ad0f54f24d8094cd8f8b");
+    strcpy(data->entry->file_entry.data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e9959643c6262667b61fbe57694df224d40");
+    data->entry->file_entry.data->mode = FIM_REALTIME;
+    data->entry->file_entry.data->last_event = 1570184221;
+    data->entry->file_entry.data->dev = 12345678;
+    data->entry->file_entry.data->scanned = 123456;
+    data->entry->file_entry.data->options = 511;
+    strcpy(data->entry->file_entry.data->checksum, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+
+    cJSON *json  = fim_entry_json("start", data->entry);
+    data->str = cJSON_PrintUnformatted(json);
+
+    free(json);
+
+    *state = data;
+
+    return data == NULL;
+}
+
+static int teardown_fim_entry(void **state) {
+    pair_entry_str_t *data = *state;
+    // data->str and data->entry should be freed
+    free(data);
+    return 0;
+}
+
+/* Auxiliar functions */
+
+static void expect_fim_db_get_first_row_error(const fdb_t *db, int type, char *path) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_value(__wrap_fim_db_get_first_path, fim_sql, db);
+    expect_value(__wrap_fim_db_get_first_path, type, type);
+    will_return(__wrap_fim_db_get_first_path, path);
+    will_return(__wrap_fim_db_get_first_path, FIMDB_ERR);
+
+    expect_string(__wrap__merror, formatted_msg, "(6706): Couldn't get FIRST FILE row's path.");
+    expect_function_call(__wrap_pthread_mutex_unlock);
+}
+
+static void expect_fim_db_get_first_row_success(const fdb_t *db, int type, char *path) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_value(__wrap_fim_db_get_first_path, fim_sql, db);
+    expect_value(__wrap_fim_db_get_first_path, type, type);
+    will_return(__wrap_fim_db_get_first_path, path);
+    will_return(__wrap_fim_db_get_first_path, FIMDB_OK);
+}
+
+static void expect_fim_db_get_last_row_success(const fdb_t *db, int type, char *path) {
+    expect_value(__wrap_fim_db_get_last_path, fim_sql, db);
+    expect_value(__wrap_fim_db_get_last_path, type, type);
+    will_return(__wrap_fim_db_get_last_path, path);
+    will_return(__wrap_fim_db_get_last_path, FIMDB_OK);
+}
+
+static void expect_fim_db_last_row_error(const fdb_t *db, int type, char *first_path) {
+    expect_fim_db_get_first_row_success(db, type, first_path);
+
+    expect_value(__wrap_fim_db_get_last_path, fim_sql, db);
+    expect_value(__wrap_fim_db_get_last_path, type, type);
+    will_return(__wrap_fim_db_get_last_path, NULL);
+    will_return(__wrap_fim_db_get_last_path, FIMDB_ERR);
+
+    expect_string(__wrap__merror, formatted_msg, "(6706): Couldn't get LAST FILE row's path.");
+    expect_function_call(__wrap_pthread_mutex_unlock);
+}
+
+static void expect_fim_db_get_data_checksum_error(const fdb_t *db) {
+    expect_fim_db_get_first_row_success(syscheck.database, FIM_TYPE_FILE, NULL);
+    expect_fim_db_get_last_row_success(syscheck.database, FIM_TYPE_FILE, NULL);
+
+    expect_value(__wrap_fim_db_get_data_checksum, fim_sql, db);
+    will_return(__wrap_fim_db_get_data_checksum, FIMDB_ERR);
+
+    expect_string(__wrap__merror, formatted_msg, FIM_DB_ERROR_CALC_CHECKSUM);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+}
+
+static void expect_fim_db_get_count_range_n(char *start, char *stop, int n) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_value(__wrap_fim_db_get_count_range, fim_sql, syscheck.database);
+    expect_value(__wrap_fim_db_get_count_range, type, FIM_TYPE_FILE);
+    expect_string(__wrap_fim_db_get_count_range, start, start);
+    expect_string(__wrap_fim_db_get_count_range, top, stop);
+
+    will_return(__wrap_fim_db_get_count_range, n);
+    will_return(__wrap_fim_db_get_count_range, FIMDB_OK);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+}
+
+static void expect_fim_db_get_data_checksum_success(const fdb_t *db, char *first, char *last) {
+    expect_fim_db_get_first_row_success(syscheck.database, FIM_TYPE_FILE, first);
+    expect_fim_db_get_last_row_success(syscheck.database, FIM_TYPE_FILE, last);
+
+    expect_value(__wrap_fim_db_get_data_checksum, fim_sql, db);
+    will_return(__wrap_fim_db_get_data_checksum, FIMDB_OK);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_string(__wrap_dbsync_check_msg, component, "fim_file");
+    expect_value(__wrap_dbsync_check_msg, msg, INTEGRITY_CHECK_GLOBAL);
+    expect_value(__wrap_dbsync_check_msg, id, 1572521857);
+    expect_string(__wrap_dbsync_check_msg, start, first);
+    expect_string(__wrap_dbsync_check_msg, top, last);
+    expect_value(__wrap_dbsync_check_msg, tail, NULL);
+    will_return(__wrap_dbsync_check_msg, strdup("A mock message"));
+
+    expect_string(__wrap_fim_send_sync_msg, msg, "A mock message");
+}
+
+static void expect_fim_db_get_entry_from_sync_msg(char *path, int type, fim_entry *mock_entry) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_value(__wrap_fim_db_get_entry_from_sync_msg, fim_sql, syscheck.database);
+#ifdef TEST_WINAGENT
+    expect_value(__wrap_fim_db_get_entry_from_sync_msg, type, type);
+#endif
+    expect_value(__wrap_fim_db_get_entry_from_sync_msg, path, path);
+    will_return(__wrap_fim_db_get_entry_from_sync_msg, mock_entry);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+}
+
+static void expect_fim_db_get_path_range(fdb_t *db, fim_type type, char *start, char *top, int storage, fim_tmp_file *file, int ret) {
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_value(__wrap_fim_db_get_path_range, fim_sql, db);
+    expect_value(__wrap_fim_db_get_path_range, type, type);
+    expect_string(__wrap_fim_db_get_path_range, start, start);
+    expect_string(__wrap_fim_db_get_path_range, top, top);
+    expect_value(__wrap_fim_db_get_path_range, storage, storage);
+    will_return(__wrap_fim_db_get_path_range, file);
+    will_return(__wrap_fim_db_get_path_range, ret);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+}
+
+static void expect_fim_db_read_line_from_file(fim_tmp_file *file, int storage, int it, char *buffer, int ret) {
+    expect_value(__wrap_fim_db_read_line_from_file, file, file);
+    expect_value(__wrap_fim_db_read_line_from_file, storage, storage);
+    expect_value(__wrap_fim_db_read_line_from_file, it, it);
+
+    will_return(__wrap_fim_db_read_line_from_file, buffer);
+    will_return(__wrap_fim_db_read_line_from_file, ret);
+}
+
+static void expect_read_line(fim_tmp_file *file, char *line, fim_entry *entry, int storage) {
+
+    expect_fim_db_read_line_from_file (file, FIM_DB_DISK, 0, line, FIMDB_OK);
+    expect_fim_db_get_entry_from_sync_msg(line, FIM_TYPE_FILE, entry);
+
+    expect_any(__wrap_dbsync_state_msg, data);
+    expect_string(__wrap_dbsync_state_msg, component, "fim_file");
+    will_return(__wrap_dbsync_state_msg, strdup("msg"));
+
+    expect_any(__wrap_fim_send_sync_msg, msg);
+    expect_fim_db_read_line_from_file(file, storage, 1, NULL, 1);
+
+    expect_any(__wrap_fim_db_clean_file, file);
+    expect_value(__wrap_fim_db_clean_file, storage, storage);
+}
+
+
+
 /* tests */
 /* fim_sync_push_msg */
 static void test_fim_sync_push_msg_success(void **state) {
@@ -153,83 +402,40 @@ static void test_fim_sync_push_msg_no_response(void **state) {
 /* fim_sync_checksum */
 static void test_fim_sync_checksum_first_row_error(void **state) {
     pthread_mutex_t *mutex = NULL;
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value(__wrap_fim_db_get_row_path, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_row_path, mode, FIM_FIRST_ROW);
-    will_return(__wrap_fim_db_get_row_path, NULL);
-    will_return(__wrap_fim_db_get_row_path, FIMDB_ERR);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
-    expect_string(__wrap__merror, formatted_msg, "(6706): Couldn't get FIRST row's path.");
+
+    expect_fim_db_get_first_row_error(syscheck.database, FIM_TYPE_FILE, NULL);
 
     fim_sync_checksum(FIM_TYPE_FILE, mutex);
 }
 
 static void test_fim_sync_checksum_last_row_error(void **state) {
     pthread_mutex_t *mutex = NULL;
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value_count(__wrap_fim_db_get_row_path, fim_sql, syscheck.database, 2);
-    expect_value(__wrap_fim_db_get_row_path, mode, FIM_FIRST_ROW);
-    expect_value(__wrap_fim_db_get_row_path, mode, FIM_LAST_ROW);
-    will_return(__wrap_fim_db_get_row_path, NULL);
-    will_return(__wrap_fim_db_get_row_path, FIMDB_OK);
-    will_return(__wrap_fim_db_get_row_path, NULL);
-    will_return(__wrap_fim_db_get_row_path, FIMDB_ERR);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
-    expect_string(__wrap__merror, formatted_msg, "(6706): Couldn't get LAST row's path.");
+
+    expect_fim_db_last_row_error(syscheck.database, FIM_TYPE_FILE, NULL);
 
     fim_sync_checksum(FIM_TYPE_FILE, mutex);
 }
 
 static void test_fim_sync_checksum_checksum_error(void **state) {
     pthread_mutex_t *mutex = NULL;
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value_count(__wrap_fim_db_get_row_path, fim_sql, syscheck.database, 2);
-    expect_value(__wrap_fim_db_get_row_path, mode, FIM_FIRST_ROW);
-    expect_value(__wrap_fim_db_get_row_path, mode, FIM_LAST_ROW);
-    will_return(__wrap_fim_db_get_row_path, NULL);
-    will_return(__wrap_fim_db_get_row_path, FIMDB_OK);
-    will_return(__wrap_fim_db_get_row_path, NULL);
-    will_return(__wrap_fim_db_get_row_path, FIMDB_OK);
 
-    expect_value(__wrap_fim_db_get_data_checksum, fim_sql, syscheck.database);
-    will_return(__wrap_fim_db_get_data_checksum, FIMDB_ERR);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
-    expect_string(__wrap__merror, formatted_msg, FIM_DB_ERROR_CALC_CHECKSUM);
+    expect_fim_db_get_data_checksum_error(syscheck.database);
 
     fim_sync_checksum(FIM_TYPE_FILE, mutex);
 }
 
 static void test_fim_sync_checksum_empty_db(void **state) {
     pthread_mutex_t *mutex = NULL;
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value_count(__wrap_fim_db_get_row_path, fim_sql, syscheck.database, 2);
-    expect_value(__wrap_fim_db_get_row_path, mode, FIM_FIRST_ROW);
-    expect_value(__wrap_fim_db_get_row_path, mode, FIM_LAST_ROW);
-    will_return(__wrap_fim_db_get_row_path, NULL);
-    will_return(__wrap_fim_db_get_row_path, FIMDB_OK);
-    will_return(__wrap_fim_db_get_row_path, NULL);
-    will_return(__wrap_fim_db_get_row_path, FIMDB_OK);
+
+    expect_fim_db_get_first_row_success(syscheck.database, FIM_TYPE_FILE, NULL);
+    expect_fim_db_get_last_row_success(syscheck.database, FIM_TYPE_FILE, NULL);
 
     expect_value(__wrap_fim_db_get_data_checksum, fim_sql, syscheck.database);
     will_return(__wrap_fim_db_get_data_checksum, FIMDB_OK);
-#ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
-    expect_string(__wrap_dbsync_check_msg, component, "syscheck");
+
+    expect_string(__wrap_dbsync_check_msg, component, "fim_file");
+
     expect_value(__wrap_dbsync_check_msg, msg, INTEGRITY_CLEAR);
     expect_value(__wrap_dbsync_check_msg, id, 1572521857);
     expect_value(__wrap_dbsync_check_msg, start, NULL);
@@ -238,197 +444,135 @@ static void test_fim_sync_checksum_empty_db(void **state) {
     will_return(__wrap_dbsync_check_msg, strdup("A mock message"));
 
     expect_string(__wrap_fim_send_sync_msg, msg, "A mock message");
-
     fim_sync_checksum(FIM_TYPE_FILE, mutex);
 }
 static void test_fim_sync_checksum_success(void **state) {
     pthread_mutex_t *mutex = NULL;
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value_count(__wrap_fim_db_get_row_path, fim_sql, syscheck.database, 2);
-    expect_value(__wrap_fim_db_get_row_path, mode, FIM_FIRST_ROW);
-    expect_value(__wrap_fim_db_get_row_path, mode, FIM_LAST_ROW);
-    will_return(__wrap_fim_db_get_row_path, strdup("start"));
-    will_return(__wrap_fim_db_get_row_path, FIMDB_OK);
-    will_return(__wrap_fim_db_get_row_path, strdup("stop"));
-    will_return(__wrap_fim_db_get_row_path, FIMDB_OK);
+    str_pair_t *pair = *state;
 
-    expect_value(__wrap_fim_db_get_data_checksum, fim_sql, syscheck.database);
-    will_return(__wrap_fim_db_get_data_checksum, FIMDB_OK);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
-    expect_string(__wrap_dbsync_check_msg, component, "syscheck");
-    expect_value(__wrap_dbsync_check_msg, msg, INTEGRITY_CHECK_GLOBAL);
-    expect_value(__wrap_dbsync_check_msg, id, 1572521857);
-    expect_string(__wrap_dbsync_check_msg, start, "start");
-    expect_string(__wrap_dbsync_check_msg, top, "stop");
-    expect_value(__wrap_dbsync_check_msg, tail, NULL);
-    will_return(__wrap_dbsync_check_msg, strdup("A mock message"));
+    char *first = pair->first;
+    char *last = pair->last;
 
-    expect_string(__wrap_fim_send_sync_msg, msg, "A mock message");
+    expect_fim_db_get_data_checksum_success(syscheck.database, first, last);
 
     fim_sync_checksum(FIM_TYPE_FILE, mutex);
 }
 
 /* fim_sync_checksum_split */
 static void test_fim_sync_checksum_split_get_count_range_error(void **state) {
-#ifdef TEST_WINAGENT
+    pthread_mutex_t *mutex = NULL;
+    str_pair_t *pair = *state;
+
+    char *first = pair->first;
+    char *last = pair->last;
+
     expect_function_call(__wrap_pthread_mutex_lock);
-#endif
     expect_value(__wrap_fim_db_get_count_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_count_range, start, "start");
-    expect_string(__wrap_fim_db_get_count_range, top, "top");
+    expect_value(__wrap_fim_db_get_count_range, type, FIM_TYPE_FILE);
+    expect_string(__wrap_fim_db_get_count_range, start, first);
+    expect_string(__wrap_fim_db_get_count_range, top, last);
     will_return(__wrap_fim_db_get_count_range, 0);
     will_return(__wrap_fim_db_get_count_range, FIMDB_ERR);
-#ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
-    expect_string(__wrap__merror, formatted_msg, "(6703): Couldn't get range size between 'start' and 'top'");
 
-    fim_sync_checksum_split("start", "top", 1234);
+    expect_string(__wrap__merror, formatted_msg, "(6703): Couldn't get range size between 'first' and 'last'");
+
+    fim_sync_checksum_split(first, last, 1234);
 }
 
 static void test_fim_sync_checksum_split_range_size_0(void **state) {
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value(__wrap_fim_db_get_count_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_count_range, start, "start");
-    expect_string(__wrap_fim_db_get_count_range, top, "top");
-    will_return(__wrap_fim_db_get_count_range, 0);
-    will_return(__wrap_fim_db_get_count_range, FIMDB_OK);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
+    expect_fim_db_get_count_range_n("start", "top", 0);
     fim_sync_checksum_split("start", "top", 1234);
 }
 
 static void test_fim_sync_checksum_split_range_size_1(void **state) {
-    fim_entry *mock_entry = calloc(1, sizeof(fim_entry)); // To be freed by fim_sync_checksum_split
+    pair_entry_str_t *data = *state;
 
-    if(mock_entry == NULL)
-        fail();
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value(__wrap_fim_db_get_count_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_count_range, start, "start");
-    expect_string(__wrap_fim_db_get_count_range, top, "top");
-    will_return(__wrap_fim_db_get_count_range, 1);
-    will_return(__wrap_fim_db_get_count_range, FIMDB_OK);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path, file_path, "start");
-    will_return(__wrap_fim_db_get_path, mock_entry);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
-    expect_string(__wrap_fim_entry_json, path, "start");
-    will_return(__wrap_fim_entry_json, (cJSON*)2345);
+    expect_fim_db_get_count_range_n("start", "top", 1);
 
-    expect_string(__wrap_dbsync_state_msg, component, "syscheck");
-    expect_value(__wrap_dbsync_state_msg, data, 2345);
-    will_return(__wrap_dbsync_state_msg, strdup("A mock message"));
+    expect_fim_db_get_entry_from_sync_msg("start", FIM_TYPE_FILE, data->entry);
 
-    expect_string(__wrap_fim_send_sync_msg, msg, "A mock message");
+    expect_any(__wrap_dbsync_state_msg, data);
+    expect_string(__wrap_dbsync_state_msg, component, "fim_file");
+    will_return(__wrap_dbsync_state_msg, data->str);
+
+    expect_any(__wrap_fim_send_sync_msg, msg);
 
     fim_sync_checksum_split("start", "top", 1234);
 }
 
 static void test_fim_sync_checksum_split_range_size_1_get_path_error(void **state) {
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value(__wrap_fim_db_get_count_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_count_range, start, "start");
-    expect_string(__wrap_fim_db_get_count_range, top, "top");
-    will_return(__wrap_fim_db_get_count_range, 1);
-    will_return(__wrap_fim_db_get_count_range, FIMDB_OK);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path, file_path, "start");
-    will_return(__wrap_fim_db_get_path, NULL);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
+    expect_fim_db_get_count_range_n("start", "top", 1);
+    expect_fim_db_get_entry_from_sync_msg("start", FIM_TYPE_FILE, NULL);
+
     expect_string(__wrap__merror, formatted_msg, "(6704): Couldn't get path of 'start'");
 
     fim_sync_checksum_split("start", "top", 1234);
 }
 
 static void test_fim_sync_checksum_split_range_size_default(void **state) {
-#ifdef TEST_WINAGENT
+    expect_fim_db_get_count_range_n("start", "top", 2);
+
     expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value(__wrap_fim_db_get_count_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_count_range, start, "start");
-    expect_string(__wrap_fim_db_get_count_range, top, "top");
-    will_return(__wrap_fim_db_get_count_range, 2);
-    will_return(__wrap_fim_db_get_count_range, FIMDB_OK);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
 
     expect_value(__wrap_fim_db_get_checksum_range, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_checksum_range, start, "start");
     expect_string(__wrap_fim_db_get_checksum_range, top, "top");
-    expect_value(__wrap_fim_db_get_checksum_range, id, 1234);
     expect_value(__wrap_fim_db_get_checksum_range, n, 2);
-    will_return(__wrap_fim_db_get_checksum_range, 0);
+
+    will_return(__wrap_fim_db_get_checksum_range, strdup("path1"));
+    will_return(__wrap_fim_db_get_checksum_range, strdup("path2"));
+    will_return(__wrap_fim_db_get_checksum_range, FIMDB_OK);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_string(__wrap_dbsync_check_msg, component, "fim_file");
+    expect_any(__wrap_dbsync_check_msg, msg);
+    expect_value(__wrap_dbsync_check_msg, id, 1234);
+    expect_string(__wrap_dbsync_check_msg, start, "start");
+    expect_string(__wrap_dbsync_check_msg, top, strdup("path1"));
+    expect_string(__wrap_dbsync_check_msg, tail, strdup("path2"));
+    will_return(__wrap_dbsync_check_msg, strdup("plain_text"));
+    expect_string(__wrap_fim_send_sync_msg, msg, "plain_text");
+
+    expect_string(__wrap_dbsync_check_msg, component, "fim_file");
+    expect_any(__wrap_dbsync_check_msg, msg);
+    expect_value(__wrap_dbsync_check_msg, id, 1234);
+    expect_string(__wrap_dbsync_check_msg, start, "path2");
+    expect_string(__wrap_dbsync_check_msg, top, strdup("top"));
+    expect_string(__wrap_dbsync_check_msg, tail, strdup(""));
+    will_return(__wrap_dbsync_check_msg, strdup("plain_text"));
+    expect_string(__wrap_fim_send_sync_msg, msg, "plain_text");
 
     fim_sync_checksum_split("start", "top", 1234);
 }
 
 /* fim_sync_send_list */
 static void test_fim_sync_send_list_sync_path_range_error(void **state) {
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path_range, start, "start");
-    expect_string(__wrap_fim_db_get_path_range, top, "top");
-    expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
-    will_return(__wrap_fim_db_get_path_range, NULL);
-    will_return(__wrap_fim_db_get_path_range, FIMDB_ERR);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
+    str_pair_t *pair = *state;
+    char *start = pair->first;
+    char *top = pair->last;
+
+    expect_fim_db_get_path_range(syscheck.database, FIM_TYPE_FILE, start, top, FIM_DB_DISK, NULL, FIMDB_ERR);
 
     expect_string(__wrap__merror, formatted_msg, FIM_DB_ERROR_SYNC_DB);
 
-    fim_sync_send_list("start", "top");
+    fim_sync_send_list(start, top);
 }
 
 static void test_fim_sync_send_list_success(void **state) {
-    fim_tmp_file *file = calloc(1, sizeof(fim_tmp_file));
-    file->elements = 1;
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path_range, start, "start");
-    expect_string(__wrap_fim_db_get_path_range, top, "top");
-    expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
-    will_return(__wrap_fim_db_get_path_range, file);
-    will_return(__wrap_fim_db_get_path_range, FIMDB_OK);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
+    fim_tmp_file file;
+    file.elements = 1;
 
-    expect_value(__wrap_fim_db_sync_path_range, fim_sql, syscheck.database);
-    will_return(__wrap_fim_db_sync_path_range, FIMDB_OK);
+    fim_entry entry;
+    entry.file_entry.path = "/some/path";
+    entry.file_entry.data = &DEFAULT_FILE_DATA;
+
+    expect_read_line(&file, strdup("/some/path"), &entry, FIM_DB_DISK);
+
+    expect_fim_db_get_path_range(syscheck.database, FIM_TYPE_FILE, "start", "top", FIM_DB_DISK, &file, FIMDB_OK);
 
     fim_sync_send_list("start", "top");
-
-    free(file);
 }
 
 /* fim_sync_dispatch */
@@ -519,49 +663,33 @@ static void test_fim_sync_dispatch_checksum_fail(void **state) {
     fim_sync_cur_id = 1234;
 
     // Inside fim_sync_checksum_split
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value(__wrap_fim_db_get_count_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_count_range, start, "start");
-    expect_string(__wrap_fim_db_get_count_range, top, "top");
-    will_return(__wrap_fim_db_get_count_range, 0);
-    will_return(__wrap_fim_db_get_count_range, FIMDB_OK);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
+    expect_fim_db_get_count_range_n("start", "top", 0);
+
     fim_sync_dispatch(payload);
 }
 
 static void test_fim_sync_dispatch_no_data(void **state) {
-    json_payload_t *json_payload = *state;
+    int i;
     char payload[OS_MAXSTR];
+    char *line = strdup("entry from file");
+
+
+    fim_entry entry;
+    entry.file_entry.path = "/some/path";
+    entry.file_entry.data = &DEFAULT_FILE_DATA;
+
+    json_payload_t *json_payload = *state;
+    fim_tmp_file file;
 
     snprintf(payload, OS_MAXSTR, "no_data %s", json_payload->printed_payload);
-
     fim_sync_cur_id = 1234;
 
     // Inside fim_sync_send_list
-    fim_tmp_file *file = calloc(1, sizeof(fim_tmp_file));
-    file->elements = 1;
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_lock);
-#endif
-    expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path_range, start, "start");
-    expect_string(__wrap_fim_db_get_path_range, top, "top");
-    expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
-    will_return(__wrap_fim_db_get_path_range, file);
-    will_return(__wrap_fim_db_get_path_range, FIMDB_OK);
-#ifdef TEST_WINAGENT
-    expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
-    expect_value(__wrap_fim_db_sync_path_range, fim_sql, syscheck.database);
-    will_return(__wrap_fim_db_sync_path_range, FIMDB_OK);
+    file.elements = 1;
+    expect_fim_db_get_path_range(syscheck.database, FIM_TYPE_FILE, "start", "top", FIM_DB_DISK, &file, FIMDB_OK);
+    expect_read_line(&file, line, &entry, FIM_DB_DISK);
 
     fim_sync_dispatch(payload);
-
-    free(file);
 }
 
 static void test_fim_sync_dispatch_unwknown_command(void **state) {
@@ -585,23 +713,23 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_fim_sync_push_msg_queue_full, setup_fim_sync_queue, teardown_fim_sync_queue),
         cmocka_unit_test(test_fim_sync_push_msg_no_response),
 
-        /* fim_sync_checksum */
-        // cmocka_unit_test(test_fim_sync_checksum_first_row_error),
-        // cmocka_unit_test(test_fim_sync_checksum_last_row_error),
-        // cmocka_unit_test(test_fim_sync_checksum_checksum_error),
-        // cmocka_unit_test(test_fim_sync_checksum_empty_db),
-        // cmocka_unit_test(test_fim_sync_checksum_success),
+        // /* fim_sync_checksum */
+        cmocka_unit_test(test_fim_sync_checksum_first_row_error),
+        cmocka_unit_test(test_fim_sync_checksum_last_row_error),
+        cmocka_unit_test(test_fim_sync_checksum_checksum_error),
+        cmocka_unit_test(test_fim_sync_checksum_empty_db),
+        cmocka_unit_test_setup_teardown(test_fim_sync_checksum_success, setup_str_pair, teardown_str_pair),
 
-        /* fim_sync_checksum_split */
-        // cmocka_unit_test(test_fim_sync_checksum_split_get_count_range_error),
-        // cmocka_unit_test(test_fim_sync_checksum_split_range_size_0),
-        // cmocka_unit_test(test_fim_sync_checksum_split_range_size_1),
-        // cmocka_unit_test(test_fim_sync_checksum_split_range_size_1_get_path_error),
-        // cmocka_unit_test(test_fim_sync_checksum_split_range_size_default),
+        // /* fim_sync_checksum_split */
+        cmocka_unit_test_setup_teardown(test_fim_sync_checksum_split_get_count_range_error, setup_str_pair, teardown_str_pair),
+        cmocka_unit_test(test_fim_sync_checksum_split_range_size_0),
+        cmocka_unit_test_setup_teardown(test_fim_sync_checksum_split_range_size_1, setup_fim_entry, teardown_fim_entry),
+        cmocka_unit_test(test_fim_sync_checksum_split_range_size_1_get_path_error),
+        cmocka_unit_test(test_fim_sync_checksum_split_range_size_default),
 
         /* fim_sync_send_list */
-        // cmocka_unit_test(test_fim_sync_send_list_sync_path_range_error),
-        // cmocka_unit_test(test_fim_sync_send_list_success),
+        cmocka_unit_test_setup_teardown(test_fim_sync_send_list_sync_path_range_error, setup_str_pair, teardown_str_pair),
+        cmocka_unit_test(test_fim_sync_send_list_success),
 
         /* fim_sync_dispatch */
         cmocka_unit_test(test_fim_sync_dispatch_null_payload),
@@ -610,8 +738,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_fim_sync_dispatch_id_not_number, setup_json_payload, teardown_json_payload),
         cmocka_unit_test_setup_teardown(test_fim_sync_dispatch_drop_message, setup_json_payload, teardown_json_payload),
         cmocka_unit_test_setup_teardown(test_fim_sync_dispatch_no_begin_object, setup_json_payload, teardown_json_payload),
-        // cmocka_unit_test_setup_teardown(test_fim_sync_dispatch_checksum_fail, setup_json_payload, teardown_json_payload),
-        // cmocka_unit_test_setup_teardown(test_fim_sync_dispatch_no_data, setup_json_payload, teardown_json_payload),
+        cmocka_unit_test_setup_teardown(test_fim_sync_dispatch_checksum_fail, setup_json_payload, teardown_json_payload),
+        cmocka_unit_test_setup_teardown(test_fim_sync_dispatch_no_data, setup_json_payload, teardown_json_payload),
         cmocka_unit_test_setup_teardown(test_fim_sync_dispatch_unwknown_command, setup_json_payload, teardown_json_payload),
     };
 

--- a/src/unit_tests/syscheckd/test_fim_sync.c
+++ b/src/unit_tests/syscheckd/test_fim_sync.c
@@ -366,8 +366,6 @@ static void expect_read_line(fim_tmp_file *file, char *line, fim_entry *entry, i
     expect_value(__wrap_fim_db_clean_file, storage, storage);
 }
 
-
-
 /* tests */
 /* fim_sync_push_msg */
 static void test_fim_sync_push_msg_success(void **state) {
@@ -565,6 +563,7 @@ static void test_fim_sync_send_list_success(void **state) {
     file.elements = 1;
 
     fim_entry entry;
+    entry.type = FIM_TYPE_FILE;
     entry.file_entry.path = "/some/path";
     entry.file_entry.data = &DEFAULT_FILE_DATA;
 
@@ -675,6 +674,7 @@ static void test_fim_sync_dispatch_no_data(void **state) {
 
 
     fim_entry entry;
+    entry.type = FIM_TYPE_FILE;
     entry.file_entry.path = "/some/path";
     entry.file_entry.data = &DEFAULT_FILE_DATA;
 

--- a/src/unit_tests/wrappers/wazuh/shared/integrity_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/integrity_op_wrappers.c
@@ -31,3 +31,34 @@ char * __wrap_dbsync_state_msg(const char * component, cJSON * data) {
 
     return mock_type(char*);
 }
+
+void expect_dbsync_check_msg_call(const char *component,
+                                         dbsync_msg msg,
+                                         int id,
+                                         const char *start,
+                                         const char *top,
+                                         const char *tail,
+                                         char *ret) {
+
+    expect_string(__wrap_dbsync_check_msg, component, component);
+    expect_value(__wrap_dbsync_check_msg, msg, msg);
+    expect_value(__wrap_dbsync_check_msg, id, id);
+
+    if (start == NULL) {
+        expect_value(__wrap_dbsync_check_msg, start, 0);
+    } else {
+        expect_string(__wrap_dbsync_check_msg, start, start);
+
+    }
+    if (top == NULL) {
+        expect_value(__wrap_dbsync_check_msg, top, 0);
+    } else {
+        expect_string(__wrap_dbsync_check_msg, top, top);
+    }
+    if (tail == NULL) {
+        expect_value(__wrap_dbsync_check_msg, tail, 0);
+    } else {
+        expect_string(__wrap_dbsync_check_msg, tail, tail);
+    }
+    will_return(__wrap_dbsync_check_msg, ret);
+}

--- a/src/unit_tests/wrappers/wazuh/shared/integrity_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/integrity_op_wrappers.h
@@ -18,4 +18,11 @@ char * __wrap_dbsync_check_msg(const char * component, dbsync_msg msg, long id, 
 
 char * __wrap_dbsync_state_msg(const char * component, cJSON * data);
 
+void expect_dbsync_check_msg_call(const char *component,
+                                         dbsync_msg msg,
+                                         int id,
+                                         const char *start,
+                                         const char *top,
+                                         const char *tail,
+                                         char *ret);
 #endif

--- a/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.c
@@ -64,3 +64,5 @@ int __wrap_fim_whodata_event(whodata_evt * w_evt)
 #endif
     return 1;
 }
+
+void __wrap_free_entry(fim_entry *entry) {}

--- a/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.c
@@ -65,4 +65,6 @@ int __wrap_fim_whodata_event(whodata_evt * w_evt)
     return 1;
 }
 
-void __wrap_free_entry(fim_entry *entry) {}
+void __wrap_free_entry(__attribute__((unused)) fim_entry *entry) {
+    return;
+}

--- a/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/create_db_wrappers.h
@@ -32,4 +32,5 @@ int __wrap_fim_registry_event(char *key, fim_file_data *data, int pos);
 
 int __wrap_fim_whodata_event(whodata_evt * w_evt);
 
+void __wrap_free_entry(fim_entry *entry);
 #endif

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -20,13 +20,14 @@ int __wrap_fim_db_get_checksum_range(fdb_t *fim_sql,
                                      int n,
                                      __attribute__ ((__unused__)) EVP_MD_CTX *ctx_left,
                                      __attribute__ ((__unused__)) EVP_MD_CTX *ctx_right,
-                                     __attribute__ ((__unused__)) char **str_pathlh,
-                                     __attribute__ ((__unused__)) char **str_pathuh){
+                                     char **str_pathlh,
+                                     char **str_pathuh){
     check_expected_ptr(fim_sql);
     check_expected(start);
     check_expected(top);
     check_expected(n);
-
+    *str_pathlh = mock();
+    *str_pathuh = mock();
     return mock();
 }
 
@@ -55,10 +56,12 @@ int __wrap_fim_db_get_count_file_entry(__attribute__((unused)) fdb_t * fim_sql){
 }
 
 int __wrap_fim_db_get_count_range(fdb_t *fim_sql,
+                                  fim_type type,
                                   char *start,
                                   char *top,
                                   int *count) {
     check_expected_ptr(fim_sql);
+    check_expected(type);
     check_expected(start);
     check_expected(top);
 
@@ -91,13 +94,32 @@ fim_entry *__wrap_fim_db_get_path(fdb_t *fim_sql,
 
     return mock_type(fim_entry*);
 }
+int __wrap_fim_db_get_last_path(fdb_t * fim_sql, int type, char **path) {
+    check_expected_ptr(fim_sql);
+    check_expected(type);
+
+    *path = mock();
+
+    return mock_type(int);
+}
+
+int __wrap_fim_db_get_first_path(fdb_t * fim_sql, int type, char **path) {
+    check_expected_ptr(fim_sql);
+    check_expected(type);
+
+    *path = mock();
+
+    return mock_type(int);
+}
 
 int __wrap_fim_db_get_path_range(fdb_t *fim_sql,
+                                 int type,
                                  char *start,
                                  char *top,
                                  fim_tmp_file **file,
                                  int storage) {
     check_expected_ptr(fim_sql);
+    check_expected(type);
     check_expected(start);
     check_expected(top);
     check_expected(storage);
@@ -189,4 +211,40 @@ int __wrap_fim_db_sync_path_range(fdb_t *fim_sql,
     check_expected_ptr(fim_sql);
 
     return mock();
+}
+
+#ifndef WIN32
+fim_entry *__wrap_fim_db_get_entry_from_sync_msg(fdb_t *fim_sql,
+                                          __attribute__((unused)) fim_type type,
+                                          const char *path) {
+    check_expected_ptr(fim_sql);
+    check_expected(path);
+
+    return mock();
+}
+
+#else
+fim_entry *__wrap_fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const char *path) {
+    check_expected_ptr(fim_sql);
+    check_expected(type);
+    check_expected(path);
+
+    return mock_type(fim_entry *);
+}
+#endif
+
+int __wrap_fim_db_read_line_from_file(fim_tmp_file *file, int storage, int it, char **buffer) {
+    check_expected_ptr(file);
+    check_expected(storage);
+    check_expected(it);
+
+    *buffer = mock_type(char *);
+
+    return mock();
+
+}
+
+void __wrap_fim_db_clean_file(fim_tmp_file **file, int storage) {
+    check_expected_ptr(file);
+    check_expected(storage);
 }

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -26,8 +26,8 @@ int __wrap_fim_db_get_checksum_range(fdb_t *fim_sql,
     check_expected(start);
     check_expected(top);
     check_expected(n);
-    *str_pathlh = mock();
-    *str_pathuh = mock();
+    *str_pathlh = mock_type(char *);
+    *str_pathuh = mock_type(char *);
     return mock();
 }
 
@@ -98,7 +98,7 @@ int __wrap_fim_db_get_last_path(fdb_t * fim_sql, int type, char **path) {
     check_expected_ptr(fim_sql);
     check_expected(type);
 
-    *path = mock();
+    *path = mock_type(char *);
 
     return mock_type(int);
 }
@@ -107,7 +107,7 @@ int __wrap_fim_db_get_first_path(fdb_t * fim_sql, int type, char **path) {
     check_expected_ptr(fim_sql);
     check_expected(type);
 
-    *path = mock();
+    *path = mock_type(char *);
 
     return mock_type(int);
 }
@@ -215,12 +215,12 @@ int __wrap_fim_db_sync_path_range(fdb_t *fim_sql,
 
 #ifndef WIN32
 fim_entry *__wrap_fim_db_get_entry_from_sync_msg(fdb_t *fim_sql,
-                                          __attribute__((unused)) fim_type type,
-                                          const char *path) {
+                                                 __attribute__((unused)) fim_type type,
+                                                 const char *path) {
     check_expected_ptr(fim_sql);
     check_expected(path);
 
-    return mock();
+    return mock_type(char *);
 }
 
 #else

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -220,7 +220,7 @@ fim_entry *__wrap_fim_db_get_entry_from_sync_msg(fdb_t *fim_sql,
     check_expected_ptr(fim_sql);
     check_expected(path);
 
-    return mock_type(char *);
+    return mock_type(fim_entry *);
 }
 
 #else

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -36,6 +36,7 @@ int __wrap_fim_db_delete_range(fdb_t * fim_sql,
 int __wrap_fim_db_get_count_file_entry(fdb_t * fim_sql);
 
 int __wrap_fim_db_get_count_range(fdb_t *fim_sql,
+                                  fim_type type,
                                   char *start,
                                   char *top,
                                   int *count);
@@ -51,6 +52,7 @@ fim_entry *__wrap_fim_db_get_path(fdb_t *fim_sql,
                                   const char *file_path);
 
 int __wrap_fim_db_get_path_range(fdb_t *fim_sql,
+                                 int type,
                                  char *start,
                                  char *top,
                                  fim_tmp_file **file,
@@ -92,4 +94,17 @@ int __wrap_fim_db_sync_path_range(fdb_t *fim_sql,
                                   fim_tmp_file *file,
                                   int storage);
 
+#ifndef WIN32
+fim_entry *__wrap_fim_db_get_entry_from_sync_msg(fdb_t *fim_sql,
+                                          __attribute__((unused)) fim_type type,
+                                          const char *path);
+
+#else
+fim_entry *__wrap_fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const char *path);
 #endif
+
+#endif
+
+int __wrap_fim_db_read_line_from_file(fim_tmp_file *file, int storage, int it, char **buffer);
+
+void __wrap_fim_db_clean_file(fim_tmp_file **file, int storage);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -96,8 +96,8 @@ int __wrap_fim_db_sync_path_range(fdb_t *fim_sql,
 
 #ifndef WIN32
 fim_entry *__wrap_fim_db_get_entry_from_sync_msg(fdb_t *fim_sql,
-                                          __attribute__((unused)) fim_type type,
-                                          const char *path);
+                                                 __attribute__((unused)) fim_type type,
+                                                 const char *path);
 
 #else
 fim_entry *__wrap_fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const char *path);


### PR DESCRIPTION
|Related issue|
|---|
|#6337|

## Description

After the development of #5576, the unit tests need to be adapted. This PR aims to adapt the tests in the file `test_fim_sync.c`
Closes #6337
## Linux tests
```
[==========] Running 24 test(s).
[ RUN      ] test_fim_sync_push_msg_success
[       OK ] test_fim_sync_push_msg_success
[ RUN      ] test_fim_sync_push_msg_queue_full
[       OK ] test_fim_sync_push_msg_queue_full
[ RUN      ] test_fim_sync_push_msg_no_response
[       OK ] test_fim_sync_push_msg_no_response
[ RUN      ] test_fim_sync_checksum_first_row_error
[       OK ] test_fim_sync_checksum_first_row_error
[ RUN      ] test_fim_sync_checksum_last_row_error
[       OK ] test_fim_sync_checksum_last_row_error
[ RUN      ] test_fim_sync_checksum_checksum_error
[       OK ] test_fim_sync_checksum_checksum_error
[ RUN      ] test_fim_sync_checksum_empty_db
[       OK ] test_fim_sync_checksum_empty_db
[ RUN      ] test_fim_sync_checksum_success
[       OK ] test_fim_sync_checksum_success
[ RUN      ] test_fim_sync_checksum_split_get_count_range_error
[       OK ] test_fim_sync_checksum_split_get_count_range_error
[ RUN      ] test_fim_sync_checksum_split_range_size_0
[       OK ] test_fim_sync_checksum_split_range_size_0
[ RUN      ] test_fim_sync_checksum_split_range_size_1
[       OK ] test_fim_sync_checksum_split_range_size_1
[ RUN      ] test_fim_sync_checksum_split_range_size_1_get_path_error
[       OK ] test_fim_sync_checksum_split_range_size_1_get_path_error
[ RUN      ] test_fim_sync_checksum_split_range_size_default
[       OK ] test_fim_sync_checksum_split_range_size_default
[ RUN      ] test_fim_sync_send_list_sync_path_range_error
[       OK ] test_fim_sync_send_list_sync_path_range_error
[ RUN      ] test_fim_sync_send_list_success
[       OK ] test_fim_sync_send_list_success
[ RUN      ] test_fim_sync_dispatch_null_payload
Expected assertion payload != NULL occurred
[       OK ] test_fim_sync_dispatch_null_payload
[ RUN      ] test_fim_sync_dispatch_no_argument
[       OK ] test_fim_sync_dispatch_no_argument
[ RUN      ] test_fim_sync_dispatch_invalid_argument
[       OK ] test_fim_sync_dispatch_invalid_argument
[ RUN      ] test_fim_sync_dispatch_id_not_number
[       OK ] test_fim_sync_dispatch_id_not_number
[ RUN      ] test_fim_sync_dispatch_drop_message
[       OK ] test_fim_sync_dispatch_drop_message
[ RUN      ] test_fim_sync_dispatch_no_begin_object
[       OK ] test_fim_sync_dispatch_no_begin_object
[ RUN      ] test_fim_sync_dispatch_checksum_fail
[       OK ] test_fim_sync_dispatch_checksum_fail
[ RUN      ] test_fim_sync_dispatch_no_data
[       OK ] test_fim_sync_dispatch_no_data
[ RUN      ] test_fim_sync_dispatch_unwknown_command
[       OK ] test_fim_sync_dispatch_unwknown_command
[==========] 24 test(s) run.
[  PASSED  ] 24 test(s).
```
<!--
Add a clear description of how the problem has been solved.
-->

