### PR TITLE
Remove DISCON_TIME usage from the upgrade module - Implementation

### DIFF
--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_commands.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_commands.c
@@ -16,6 +16,7 @@
 #include "../../wrappers/common.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
+#include "../../wrappers/wazuh/wazuh_db/wdb_agent_wrappers.h"
 #include "../../wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.h"
 
 #include "../../wazuh_modules/wmodules.h"
@@ -139,7 +140,6 @@ void test_wm_agent_upgrade_validate_agent_task_upgrade_ok(void **state)
     (void) state;
 
     int agent = 44;
-    int keep_alive = 2345678;
     wm_upgrade_task *upgrade_task = NULL;
 
     wm_manager_configs *config = state[0];
@@ -148,7 +148,7 @@ void test_wm_agent_upgrade_validate_agent_task_upgrade_ok(void **state)
     config->chunk_size = 5;
 
     agent_task->agent_info->agent_id = agent;
-    agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(AGENT_CS_ACTIVE, agent_task->agent_info->connection_status);
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
     agent_task->task_info->task = upgrade_task;
@@ -179,7 +179,7 @@ void test_wm_agent_upgrade_validate_agent_task_upgrade_ok(void **state)
 
     // wm_agent_upgrade_validate_status
 
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
+    expect_string(__wrap_wm_agent_upgrade_validate_status, connection_status, AGENT_CS_ACTIVE);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_version
@@ -216,7 +216,6 @@ void test_wm_agent_upgrade_validate_agent_task_upgrade_custom_ok(void **state)
     (void) state;
 
     int agent = 44;
-    int keep_alive = 2345678;
     wm_upgrade_custom_task *upgrade_custom_task = NULL;
 
     wm_manager_configs *config = state[0];
@@ -225,7 +224,7 @@ void test_wm_agent_upgrade_validate_agent_task_upgrade_custom_ok(void **state)
     config->chunk_size = 5;
 
     agent_task->agent_info->agent_id = agent;
-    agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(AGENT_CS_ACTIVE, agent_task->agent_info->connection_status);
     upgrade_custom_task = wm_agent_upgrade_init_upgrade_custom_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE_CUSTOM;
     agent_task->task_info->task = upgrade_custom_task;
@@ -256,7 +255,7 @@ void test_wm_agent_upgrade_validate_agent_task_upgrade_custom_ok(void **state)
 
     // wm_agent_upgrade_validate_status
 
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
+    expect_string(__wrap_wm_agent_upgrade_validate_status, connection_status, AGENT_CS_ACTIVE);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_version
@@ -291,7 +290,6 @@ void test_wm_agent_upgrade_validate_agent_task_in_progress_err(void **state)
     (void) state;
 
     int agent = 44;
-    int keep_alive = 2345678;
     wm_upgrade_task *upgrade_task = NULL;
 
     wm_manager_configs *config = state[0];
@@ -300,7 +298,7 @@ void test_wm_agent_upgrade_validate_agent_task_in_progress_err(void **state)
     config->chunk_size = 5;
 
     agent_task->agent_info->agent_id = agent;
-    agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(AGENT_CS_ACTIVE, agent_task->agent_info->connection_status);
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
     agent_task->task_info->task = upgrade_task;
@@ -331,7 +329,7 @@ void test_wm_agent_upgrade_validate_agent_task_in_progress_err(void **state)
 
     // wm_agent_upgrade_validate_status
 
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
+    expect_string(__wrap_wm_agent_upgrade_validate_status, connection_status, AGENT_CS_ACTIVE);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_version
@@ -368,7 +366,6 @@ void test_wm_agent_upgrade_validate_agent_task_task_manager_err(void **state)
     (void) state;
 
     int agent = 44;
-    int keep_alive = 2345678;
     wm_upgrade_task *upgrade_task = NULL;
 
     wm_manager_configs *config = state[0];
@@ -377,7 +374,7 @@ void test_wm_agent_upgrade_validate_agent_task_task_manager_err(void **state)
     config->chunk_size = 5;
 
     agent_task->agent_info->agent_id = agent;
-    agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(AGENT_CS_ACTIVE, agent_task->agent_info->connection_status);
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
     agent_task->task_info->task = upgrade_task;
@@ -408,7 +405,7 @@ void test_wm_agent_upgrade_validate_agent_task_task_manager_err(void **state)
 
     // wm_agent_upgrade_validate_status
 
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
+    expect_string(__wrap_wm_agent_upgrade_validate_status, connection_status, AGENT_CS_ACTIVE);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_version
@@ -445,7 +442,6 @@ void test_wm_agent_upgrade_validate_agent_task_version_err(void **state)
     (void) state;
 
     int agent = 44;
-    int keep_alive = 2345678;
     wm_upgrade_task *upgrade_task = NULL;
 
     wm_manager_configs *config = state[0];
@@ -454,7 +450,7 @@ void test_wm_agent_upgrade_validate_agent_task_version_err(void **state)
     config->chunk_size = 5;
 
     agent_task->agent_info->agent_id = agent;
-    agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(AGENT_CS_ACTIVE, agent_task->agent_info->connection_status);
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
     agent_task->task_info->task = upgrade_task;
@@ -466,7 +462,7 @@ void test_wm_agent_upgrade_validate_agent_task_version_err(void **state)
 
     // wm_agent_upgrade_validate_status
 
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
+    expect_string(__wrap_wm_agent_upgrade_validate_status, connection_status, AGENT_CS_ACTIVE);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_version
@@ -486,7 +482,6 @@ void test_wm_agent_upgrade_validate_agent_task_status_err(void **state)
     (void) state;
 
     int agent = 44;
-    int keep_alive = 2345678;
     wm_upgrade_task *upgrade_task = NULL;
 
     wm_manager_configs *config = state[0];
@@ -495,7 +490,7 @@ void test_wm_agent_upgrade_validate_agent_task_status_err(void **state)
     config->chunk_size = 5;
 
     agent_task->agent_info->agent_id = agent;
-    agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(AGENT_CS_DISCONNECTED, agent_task->agent_info->connection_status);AGENT_CS_DISCONNECTED;
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
     agent_task->task_info->task = upgrade_task;
@@ -507,7 +502,7 @@ void test_wm_agent_upgrade_validate_agent_task_status_err(void **state)
 
     // wm_agent_upgrade_validate_status
 
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
+    expect_string(__wrap_wm_agent_upgrade_validate_status, connection_status, AGENT_CS_DISCONNECTED);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_AGENT_IS_NOT_ACTIVE);
 
     int ret = wm_agent_upgrade_validate_agent_task(agent_task, config);
@@ -520,7 +515,6 @@ void test_wm_agent_upgrade_validate_agent_task_agent_id_err(void **state)
     (void) state;
 
     int agent = 44;
-    int keep_alive = 2345678;
     wm_upgrade_task *upgrade_task = NULL;
 
     wm_manager_configs *config = state[0];
@@ -529,7 +523,7 @@ void test_wm_agent_upgrade_validate_agent_task_agent_id_err(void **state)
     config->chunk_size = 5;
 
     agent_task->agent_info->agent_id = agent;
-    agent_task->agent_info->last_keep_alive = keep_alive;
+    os_strdup(AGENT_CS_NEVER_CONNECTED, agent_task->agent_info->connection_status);
     upgrade_task = wm_agent_upgrade_init_upgrade_task();
     agent_task->task_info->command = WM_UPGRADE_UPGRADE;
     agent_task->task_info->task = upgrade_task;
@@ -550,12 +544,12 @@ void test_wm_agent_upgrade_analyze_agent_ok(void **state)
 
     wm_upgrade_error_code error_code = WM_UPGRADE_SUCCESS;
     int agent = 119;
-    int keep_alive = 123456789;
     char *platform = "ubuntu";
     char *major = "18";
     char *minor = "04";
     char *arch = "x86_64";
     char *version = "v3.13.1";
+    const char *connection_status = AGENT_CS_ACTIVE;
     wm_upgrade_task *upgrade_task = NULL;
 
     wm_manager_configs *config = state[0];
@@ -574,7 +568,7 @@ void test_wm_agent_upgrade_analyze_agent_ok(void **state)
     cJSON_AddStringToObject(agent_info, "os_minor", minor);
     cJSON_AddStringToObject(agent_info, "os_arch", arch);
     cJSON_AddStringToObject(agent_info, "version", version);
-    cJSON_AddNumberToObject(agent_info, "last_keepalive", keep_alive);
+    cJSON_AddStringToObject(agent_info, "connection_status", connection_status);
     cJSON_AddItemToArray(agent_info_array, agent_info);
 
     cJSON *request_status = cJSON_CreateObject();
@@ -608,7 +602,7 @@ void test_wm_agent_upgrade_analyze_agent_ok(void **state)
 
     // wm_agent_upgrade_validate_status
 
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
+    expect_string(__wrap_wm_agent_upgrade_validate_status, connection_status, connection_status);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_version
@@ -648,7 +642,7 @@ void test_wm_agent_upgrade_analyze_agent_ok(void **state)
     assert_string_equal(agent_task->agent_info->minor_version, minor);
     assert_string_equal(agent_task->agent_info->architecture, arch);
     assert_string_equal(agent_task->agent_info->wazuh_version, version);
-    assert_int_equal(agent_task->agent_info->last_keep_alive, keep_alive);
+    assert_string_equal(agent_task->agent_info->connection_status, connection_status);
 }
 
 void test_wm_agent_upgrade_analyze_agent_duplicated_err(void **state)
@@ -657,12 +651,12 @@ void test_wm_agent_upgrade_analyze_agent_duplicated_err(void **state)
 
     wm_upgrade_error_code error_code = WM_UPGRADE_SUCCESS;
     int agent = 120;
-    int keep_alive = 123456789;
     char *platform = "ubuntu";
     char *major = "18";
     char *minor = "04";
     char *arch = "x86_64";
     char *version = "v3.13.1";
+    const char *connection_status = AGENT_CS_ACTIVE;
     wm_upgrade_task *upgrade_task = NULL;
 
     wm_manager_configs *config = state[0];
@@ -681,7 +675,7 @@ void test_wm_agent_upgrade_analyze_agent_duplicated_err(void **state)
     cJSON_AddStringToObject(agent_info, "os_minor", minor);
     cJSON_AddStringToObject(agent_info, "os_arch", arch);
     cJSON_AddStringToObject(agent_info, "version", version);
-    cJSON_AddNumberToObject(agent_info, "last_keepalive", keep_alive);
+    cJSON_AddStringToObject(agent_info, "connection_status", connection_status);
     cJSON_AddItemToArray(agent_info_array, agent_info);
 
     cJSON *request_status = cJSON_CreateObject();
@@ -714,7 +708,7 @@ void test_wm_agent_upgrade_analyze_agent_duplicated_err(void **state)
 
     // wm_agent_upgrade_validate_status
 
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
+    expect_string(__wrap_wm_agent_upgrade_validate_status, connection_status, connection_status);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_version
@@ -754,7 +748,7 @@ void test_wm_agent_upgrade_analyze_agent_duplicated_err(void **state)
     assert_string_equal(agent_task->agent_info->minor_version, minor);
     assert_string_equal(agent_task->agent_info->architecture, arch);
     assert_string_equal(agent_task->agent_info->wazuh_version, version);
-    assert_int_equal(agent_task->agent_info->last_keep_alive, keep_alive);
+    assert_string_equal(agent_task->agent_info->connection_status, connection_status);
 }
 
 void test_wm_agent_upgrade_analyze_agent_unknown_err(void **state)
@@ -763,12 +757,12 @@ void test_wm_agent_upgrade_analyze_agent_unknown_err(void **state)
 
     wm_upgrade_error_code error_code = WM_UPGRADE_SUCCESS;
     int agent = 121;
-    int keep_alive = 123456789;
     char *platform = "ubuntu";
     char *major = "18";
     char *minor = "04";
     char *arch = "x86_64";
     char *version = "v3.13.1";
+    const char *connection_status = AGENT_CS_ACTIVE;
     wm_upgrade_task *upgrade_task = NULL;
 
     wm_manager_configs *config = state[0];
@@ -787,7 +781,7 @@ void test_wm_agent_upgrade_analyze_agent_unknown_err(void **state)
     cJSON_AddStringToObject(agent_info, "os_minor", minor);
     cJSON_AddStringToObject(agent_info, "os_arch", arch);
     cJSON_AddStringToObject(agent_info, "version", version);
-    cJSON_AddNumberToObject(agent_info, "last_keepalive", keep_alive);
+    cJSON_AddStringToObject(agent_info, "connection_status", connection_status);
     cJSON_AddItemToArray(agent_info_array, agent_info);
 
     cJSON *request_status = cJSON_CreateObject();
@@ -820,7 +814,7 @@ void test_wm_agent_upgrade_analyze_agent_unknown_err(void **state)
 
     // wm_agent_upgrade_validate_status
 
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, keep_alive);
+    expect_string(__wrap_wm_agent_upgrade_validate_status, connection_status, connection_status);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_version
@@ -860,7 +854,7 @@ void test_wm_agent_upgrade_analyze_agent_unknown_err(void **state)
     assert_string_equal(agent_task->agent_info->minor_version, minor);
     assert_string_equal(agent_task->agent_info->architecture, arch);
     assert_string_equal(agent_task->agent_info->wazuh_version, version);
-    assert_int_equal(agent_task->agent_info->last_keep_alive, keep_alive);
+    assert_string_equal(agent_task->agent_info->connection_status, connection_status);
 }
 
 void test_wm_agent_upgrade_analyze_agent_validate_err(void **state)
@@ -869,12 +863,12 @@ void test_wm_agent_upgrade_analyze_agent_validate_err(void **state)
 
     wm_upgrade_error_code error_code = WM_UPGRADE_SUCCESS;
     int agent = 119;
-    int keep_alive = 123456789;
     char *platform = "ubuntu";
     char *major = "18";
     char *minor = "04";
     char *arch = "x86_64";
     char *version = "v3.13.1";
+    const char *connection_status = AGENT_CS_NEVER_CONNECTED;
     wm_upgrade_task *upgrade_task = NULL;
 
     wm_manager_configs *config = state[0];
@@ -893,7 +887,7 @@ void test_wm_agent_upgrade_analyze_agent_validate_err(void **state)
     cJSON_AddStringToObject(agent_info, "os_minor", minor);
     cJSON_AddStringToObject(agent_info, "os_arch", arch);
     cJSON_AddStringToObject(agent_info, "version", version);
-    cJSON_AddNumberToObject(agent_info, "last_keepalive", keep_alive);
+    cJSON_AddStringToObject(agent_info, "connection_status", connection_status);
     cJSON_AddItemToArray(agent_info_array, agent_info);
 
     // wdb_agent_info
@@ -915,7 +909,7 @@ void test_wm_agent_upgrade_analyze_agent_validate_err(void **state)
     assert_string_equal(agent_task->agent_info->minor_version, minor);
     assert_string_equal(agent_task->agent_info->architecture, arch);
     assert_string_equal(agent_task->agent_info->wazuh_version, version);
-    assert_int_equal(agent_task->agent_info->last_keep_alive, keep_alive);
+    assert_string_equal(agent_task->agent_info->connection_status, connection_status);
 }
 
 void test_wm_agent_upgrade_analyze_agent_global_db_err(void **state)
@@ -1124,7 +1118,7 @@ void test_wm_agent_upgrade_process_upgrade_custom_command(void **state)
     cJSON_AddStringToObject(agent_info1, "os_minor", "04");
     cJSON_AddStringToObject(agent_info1, "os_arch", "x86_64");
     cJSON_AddStringToObject(agent_info1, "version", "v3.13.1");
-    cJSON_AddNumberToObject(agent_info1, "last_keepalive", 123456789);
+    cJSON_AddStringToObject(agent_info1, "connection_status", AGENT_CS_ACTIVE);
     cJSON_AddItemToArray(agent_info_array1, agent_info1);
 
     cJSON *status_request1 = cJSON_CreateObject();
@@ -1190,7 +1184,7 @@ void test_wm_agent_upgrade_process_upgrade_custom_command(void **state)
 
     // wm_agent_upgrade_validate_status
 
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, 123456789);
+    expect_string(__wrap_wm_agent_upgrade_validate_status, connection_status, AGENT_CS_ACTIVE);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_version
@@ -1391,7 +1385,7 @@ void test_wm_agent_upgrade_process_upgrade_command(void **state)
     cJSON_AddStringToObject(agent_info1, "os_minor", "04");
     cJSON_AddStringToObject(agent_info1, "os_arch", "x86_64");
     cJSON_AddStringToObject(agent_info1, "version", "v3.13.1");
-    cJSON_AddNumberToObject(agent_info1, "last_keepalive", 123456789);
+    cJSON_AddStringToObject(agent_info1, "connection_status", AGENT_CS_ACTIVE);
     cJSON_AddItemToArray(agent_info_array1, agent_info1);
 
     cJSON *status_request1 = cJSON_CreateObject();
@@ -1457,7 +1451,7 @@ void test_wm_agent_upgrade_process_upgrade_command(void **state)
 
     // wm_agent_upgrade_validate_status
 
-    expect_value(__wrap_wm_agent_upgrade_validate_status, last_keep_alive, 123456789);
+    expect_string(__wrap_wm_agent_upgrade_validate_status, connection_status, AGENT_CS_ACTIVE);
     will_return(__wrap_wm_agent_upgrade_validate_status, WM_UPGRADE_SUCCESS);
 
     // wm_agent_upgrade_validate_version

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
@@ -120,19 +120,29 @@ void test_wm_agent_upgrade_validate_id_manager(void **state)
 void test_wm_agent_upgrade_validate_status_ok(void **state)
 {
     (void) state;
-    int last_keep_alive = time(0);
+    const char *connection_status = AGENT_CS_ACTIVE;
 
-    int ret = wm_agent_upgrade_validate_status(last_keep_alive);
+    int ret = wm_agent_upgrade_validate_status(connection_status);
 
     assert_int_equal(ret, WM_UPGRADE_SUCCESS);
+}
+
+void test_wm_agent_upgrade_validate_status_null(void **state)
+{
+    (void) state;
+    const char *connection_status = NULL;
+
+    int ret = wm_agent_upgrade_validate_status(connection_status);
+
+    assert_int_equal(ret, WM_UPGRADE_AGENT_IS_NOT_ACTIVE);
 }
 
 void test_wm_agent_upgrade_validate_status_disconnected(void **state)
 {
     (void) state;
-    int last_keep_alive = time(0) - (DISCON_TIME * 2);
+    const char *connection_status = "disconnected";
 
-    int ret = wm_agent_upgrade_validate_status(last_keep_alive);
+    int ret = wm_agent_upgrade_validate_status(connection_status);
 
     assert_int_equal(ret, WM_UPGRADE_AGENT_IS_NOT_ACTIVE);
 }
@@ -1425,6 +1435,7 @@ int main(void) {
         cmocka_unit_test(test_wm_agent_upgrade_validate_id_manager),
         // wm_agent_upgrade_validate_status
         cmocka_unit_test(test_wm_agent_upgrade_validate_status_ok),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_status_null),
         cmocka_unit_test(test_wm_agent_upgrade_validate_status_disconnected),
         // wm_agent_upgrade_validate_system
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_windows_ok),

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -189,11 +189,6 @@ int __wrap_wdb_sql_exec(__attribute__((unused)) wdb_t *wdb,
     return mock();
 }
 
-cJSON* __wrap_wdb_get_agent_info(int id) {
-    check_expected(id);
-    return mock_ptr_type(cJSON*);
-}
-
 wdb_t* __wrap_wdb_init(__attribute__((unused)) sqlite3* db, const char* id) {
     check_expected(id);
     return mock_ptr_type(wdb_t*);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -61,8 +61,6 @@ void __wrap_wdb_leave(wdb_t *wdb);
 
 int __wrap_wdb_sql_exec(wdb_t *wdb, const char *sql_exec);
 
-cJSON* __wrap_wdb_get_agent_info(int id);
-
 wdb_t* __wrap_wdb_init(sqlite3* db, const char* id);
 
 int __wrap_wdb_close(wdb_t * wdb, bool commit);

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.c
@@ -138,8 +138,8 @@ int __wrap_wm_agent_upgrade_validate_id(int agent_id) {
     return mock();
 }
 
-int __wrap_wm_agent_upgrade_validate_status(int last_keep_alive) {
-    check_expected(last_keep_alive);
+int __wrap_wm_agent_upgrade_validate_status(const char* connection_status) {
+    check_expected(connection_status);
 
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wm_agent_upgrade_wrappers.h
@@ -47,7 +47,7 @@ bool __wrap_wm_agent_upgrade_validate_task_status_message(const cJSON *input_jso
 
 int __wrap_wm_agent_upgrade_validate_id(int agent_id);
 
-int __wrap_wm_agent_upgrade_validate_status(int last_keep_alive);
+int __wrap_wm_agent_upgrade_validate_status(const char* connection_status);
 
 int __wrap_wm_agent_upgrade_validate_version(const wm_agent_info *agent_info, void *task, wm_upgrade_command command, const wm_manager_configs* manager_configs);
 

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_commands.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_commands.c
@@ -264,10 +264,10 @@ STATIC int wm_agent_upgrade_analyze_agent(int agent_id, wm_agent_task *agent_tas
             os_strdup(value->valuestring, agent_task->agent_info->wazuh_version);
         }
 
-        // Last keep alive
-        value = cJSON_GetObjectItem(agent_info->child, "last_keepalive");
-        if(cJSON_IsNumber(value)){
-            agent_task->agent_info->last_keep_alive = value->valueint;
+        // Connection status
+        value = cJSON_GetObjectItem(agent_info->child, "connection_status");
+        if(cJSON_IsString(value) && value->valuestring != NULL){
+            os_strdup(value->valuestring, agent_task->agent_info->connection_status);
         }
 
         // Validate agent and task information
@@ -307,7 +307,7 @@ STATIC int wm_agent_upgrade_validate_agent_task(const wm_agent_task *agent_task,
     }
 
     // Validate agent status
-    validate_result = wm_agent_upgrade_validate_status(agent_task->agent_info->last_keep_alive);
+    validate_result = wm_agent_upgrade_validate_status(agent_task->agent_info->connection_status);
 
     if (validate_result != WM_UPGRADE_SUCCESS) {
         return validate_result;

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.h
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.h
@@ -107,7 +107,7 @@ typedef struct _wm_agent_info {
     char *minor_version;         ///> OS minor version of the agent
     char *architecture;          ///> architecture of the agent
     char *wazuh_version;         ///> wazuh version of the agent
-    int last_keep_alive;         ///> last_keep_alive of the agent
+    char *connection_status;     ///> connection_status of the agent
 } wm_agent_info;
 
 /**
@@ -121,7 +121,7 @@ typedef struct _wm_agent_task {
 extern const char* upgrade_error_codes[];
 
 /**
- * Start listening loop, exits only on error 
+ * Start listening loop, exits only on error
  * @param timeout_sec timeout in seconds
  * @param manager_configs manager configuration parameters
  * @return only on errors, socket will be closed

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
@@ -109,6 +109,7 @@ void wm_agent_upgrade_free_agent_info(wm_agent_info* agent_info) {
         os_free(agent_info->minor_version);
         os_free(agent_info->architecture);
         os_free(agent_info->wazuh_version);
+        os_free(agent_info->connection_status);
         os_free(agent_info);
     }
 }
@@ -246,5 +247,5 @@ STATIC cJSON *wm_agent_send_task_information_worker(const cJSON *message_object)
     os_free(message);
     cJSON_Delete(payload);
 
-    return cJSON_Parse(response);   
+    return cJSON_Parse(response);
 }

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -87,11 +87,11 @@ int wm_agent_upgrade_validate_id(int agent_id) {
     return return_code;
 }
 
-int wm_agent_upgrade_validate_status(int last_keep_alive) {
-    int return_code = WM_UPGRADE_SUCCESS;
+int wm_agent_upgrade_validate_status(const char* connection_status) {
+    int return_code = WM_UPGRADE_AGENT_IS_NOT_ACTIVE;
 
-    if (last_keep_alive < 0 || last_keep_alive < (time(0) - DISCON_TIME)) {
-        return_code = WM_UPGRADE_AGENT_IS_NOT_ACTIVE;
+    if (connection_status && !strcmp(AGENT_CS_ACTIVE, connection_status)) {
+        return_code = WM_UPGRADE_SUCCESS;
     }
 
     return return_code;
@@ -459,14 +459,14 @@ bool wm_agent_upgrade_validate_task_status_message(const cJSON *input_json, char
         cJSON *data_object = cJSON_GetObjectItem(input_json, task_manager_json_keys[WM_TASK_ERROR_MESSAGE]);
         cJSON *status_object = cJSON_GetObjectItem(input_json, task_manager_json_keys[WM_TASK_STATUS]);
         cJSON *agent_json = cJSON_GetObjectItem(input_json, task_manager_json_keys[WM_TASK_AGENT_ID]);
-        
+
         if (error_object && (error_object->type == cJSON_Number) && data_object && (data_object->type == cJSON_String) && agent_json
             && (agent_json->type == cJSON_Number)) {
-            
+
             if (agent_id) {
                 *agent_id = agent_json->valueint;
             }
-            
+
             if (error_object->valueint == WM_UPGRADE_SUCCESS) {
                 if (status && status_object && status_object->type == cJSON_String) {
                     os_strdup(status_object->valuestring, *status);

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.h
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.h
@@ -24,12 +24,12 @@ int wm_agent_upgrade_validate_id(int agent_id);
 
 /**
  * Check if agent status is active
- * @param keep_alive last keep-alive of agent to validate
+ * @param connection_status connection status of the agent to validate
  * @return return_code
  * @retval WM_UPGRADE_SUCCESS
  * @retval WM_UPGRADE_AGENT_IS_NOT_ACTIVE
  * */
-int wm_agent_upgrade_validate_status(int last_keep_alive);
+int wm_agent_upgrade_validate_status(const char* connection_status);
 
 /**
  * Check if agent is valid to upgrade


### PR DESCRIPTION
|Related issue|
|---|
| #6511 |

## Description

This PR includes all the necessary changes and unit test updates to remove the usage of the `DISCON_TIME` definition from the agents' upgrade module. Now, it makes use of the `connection_status` information in `global.db`.

For more details check the **requirements** section in #6511.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind