### PR TITLE
Preventing the agents to be added to the disconnection alert hash table in workers

### DIFF
--- a/src/monitord/monitor_actions.c
+++ b/src/monitord/monitor_actions.c
@@ -54,7 +54,7 @@ void monitor_agents_disconnection(){
     if (agents_array) {
         for (int i = 0; agents_array[i] != -1; i++) {
             snprintf(str_agent_id, 12, "%d", agents_array[i]);
-            if (OSHash_Add(agents_to_alert_hash, str_agent_id, (void*)time(0)) == 0) {
+            if (mond.monitor_agents != 0 && OSHash_Add(agents_to_alert_hash, str_agent_id, (void*)time(0)) == 0) {
                 mdebug1("Can't add agent ID '%d' to the alerts hash table",agents_array[i]);
             }
         }

--- a/src/monitord/monitor_actions.c
+++ b/src/monitord/monitor_actions.c
@@ -51,10 +51,10 @@ void monitor_agents_disconnection(){
     char str_agent_id[12];
 
     agents_array = wdb_disconnect_agents(time(0) - mond.global.agents_disconnection_time, &sock);
-    if (agents_array) {
+    if (mond.monitor_agents != 0 && agents_array) {
         for (int i = 0; agents_array[i] != -1; i++) {
             snprintf(str_agent_id, 12, "%d", agents_array[i]);
-            if (mond.monitor_agents != 0 && OSHash_Add(agents_to_alert_hash, str_agent_id, (void*)time(0)) == 0) {
+            if (OSHash_Add(agents_to_alert_hash, str_agent_id, (void*)time(0)) == 0) {
                 mdebug1("Can't add agent ID '%d' to the alerts hash table",agents_array[i]);
             }
         }

--- a/src/monitord/monitor_actions.c
+++ b/src/monitord/monitor_actions.c
@@ -55,11 +55,11 @@ void monitor_agents_disconnection(){
         for (int i = 0; agents_array[i] != -1; i++) {
             snprintf(str_agent_id, 12, "%d", agents_array[i]);
             if (OSHash_Add(agents_to_alert_hash, str_agent_id, (void*)time(0)) == 0) {
-                mdebug1("Can't add agent ID '%d' to the alerts hash table",agents_array[i]);
+                mdebug1("Can't add agent ID '%d' to the alerts hash table", agents_array[i]);
             }
         }
-        os_free(agents_array);
     }
+    os_free(agents_array);
 }
 
 void monitor_agents_alert(){

--- a/src/unit_tests/monitord/test_monitor_actions.c
+++ b/src/unit_tests/monitord/test_monitor_actions.c
@@ -53,6 +53,7 @@ int setup_monitord(void **state) {
     mond.day_wait = 0;
     mond.rotate_log = 1;
     mond.size_rotate = 0;
+    mond.monitor_agents = 0;
 
     mond_time_control.disconnect_counter = 0;
     mond_time_control.alert_counter = 0;
@@ -75,6 +76,7 @@ int teardown_monitord(void **state) {
     mond.day_wait = 0;
     mond.rotate_log = 1;
     mond.size_rotate = 0;
+    mond.monitor_agents = 0;
 
     mond_time_control.disconnect_counter = 0;
     mond_time_control.alert_counter = 0;
@@ -227,6 +229,7 @@ void test_monitor_agents_disconnection(void **state) {
     agents_array_test[2] = -1;
 
     mond.global.agents_disconnection_time = 100;
+    mond.monitor_agents = 1;
 
     expect_value(__wrap_wdb_disconnect_agents, keepalive, last_keepalive - mond.global.agents_disconnection_time);
     will_return(__wrap_wdb_disconnect_agents, agents_array_test);


### PR DESCRIPTION
The variable _monitord_agents_ in **monitord** controls if the disconnection alerts must be generated, among other things.

In a cluster scenario, this daemon runs in all nodes, but it only generates these alerts in the master. So, the workers nodes would unnecessarily add the disconnected agents to the Hash Table, without ever removing them.

In this PR, the variable is evaluated every time the **wdb_disconnect_agents()** method is called and it doesn't iterates the array if _monitor_agents_ is not true.


## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Review logs syntax and correct language

- [x] Unit tests updated 