### PR TITLE
Update information shown in API log debug messages.

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -13517,8 +13517,6 @@ paths:
                   format: names
                 password:
                   type: string
-                  maxLength: 64
-                  minLength: 8
                   format: password
                 allow_run_as:
                   type: boolean
@@ -13632,8 +13630,6 @@ paths:
               properties:
                 password:
                   type: string
-                  maxLength: 64
-                  minLength: 8
                   format: password
                 allow_run_as:
                   type: boolean

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -109,9 +109,12 @@ class DistributedAPI:
             Dictionary with API response or WazuhException in case of error.
         """
         try:
-            self.logger.debug("Receiving parameters {}".format(self.f_kwargs))
-            is_dapi_enabled = self.cluster_items['distributed_api']['enabled']
+            if 'password' in self.f_kwargs:
+                self.logger.debug("Receiving parameters {}".format({**self.f_kwargs, 'password': '****'}))
+            else:
+                self.logger.debug("Receiving parameters {}".format(self.f_kwargs))
 
+            is_dapi_enabled = self.cluster_items['distributed_api']['enabled']
             # First case: execute the request locally.
             # If the distributed api is not enabled
             # If the cluster is disabled or the request type is local_any

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -531,12 +531,13 @@ class WazuhException(Exception):
                'remediation': 'Administrator users cannot be removed or updated'},
         5006: {'message': 'Operation not allowed, the user does not have permissions to perform this action',
                'remediation': 'No user, except administrator users, can change the data of a different user'},
-        5007: {'message': 'Insecure password provided',
-               'remediation': 'The password for users must be at least 8 characters long and must have at least '
-                              'one upper and lower case letter, a number and a symbol'},
+        5007: {'message': 'Insecure user password provided',
+               'remediation': 'The password must contain at least one upper and lower case letter, a number and a symbol.'},
         5008: {'message': 'The current user cannot be deleted',
                'remediation': 'You can delete this user with the administrator user (wazuh) or '
                               'any other user with the necessary permissions'},
+        5009: {'message': 'Insecure user password provided',
+               'remediation': 'The password must contain a length between 8 and 64 characters.'},
 
         # Security issues
         6000: {'message': 'Limit of login attempts reached. '

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -130,7 +130,9 @@ def create_user(username: str = None, password: str = None, allow_run_as: bool =
     result : AffectedItemsWazuhResult
         Status message
     """
-    if not _user_password.match(password):
+    if len(password) > 64 or len(password) < 8:
+        raise WazuhError(5009)
+    elif not _user_password.match(password):
         raise WazuhError(5007)
 
     result = AffectedItemsWazuhResult(none_msg='User could not be created',
@@ -168,8 +170,11 @@ def update_user(user_id: str = None, password: str = None, allow_run_as: bool = 
     """
     if password is None and allow_run_as is None:
         raise WazuhError(4001)
-    if password and not _user_password.match(password):
-        raise WazuhError(5007)
+    if password:
+        if len(password) > 64 or len(password) < 8:
+            raise WazuhError(5009)
+        elif not _user_password.match(password):
+            raise WazuhError(5007)
     result = AffectedItemsWazuhResult(all_msg='User was successfully updated',
                                       none_msg='User could not be updated')
     with AuthenticationManager() as auth:


### PR DESCRIPTION
## Description

Hello team!

This PR changes how some parameters are shown in the API log with debug mode. Now, passwords are obscured before being logged. The place where min and max password length is checked has also changed.

```
2020/11/06 09:39:38 DEBUG: Getting data and status code
2020/11/06 09:39:38 DEBUG: Receiving parameters {'username': 'wazuh-wui', 'roles': [1], 'token_nbf_time': 1604653709, 'run_as': False}
2020/11/06 09:39:38 DEBUG: Starting to execute request locally
2020/11/06 09:39:38 DEBUG: Finished executing request locally
2020/11/06 09:39:38 DEBUG: Time calculating request result: 0.05895853042602539s
2020/11/06 09:39:38 DEBUG: Receiving parameters {}
2020/11/06 09:39:38 DEBUG: Starting to execute request locally
2020/11/06 09:39:38 DEBUG: Finished executing request locally
2020/11/06 09:39:38 DEBUG: Time calculating request result: 0.0021719932556152344s
2020/11/06 09:39:38 DEBUG: Receiving parameters {'password': '****', 'allow_run_as': True, 'user_id': '100'}
2020/11/06 09:39:38 DEBUG: Starting to execute request locally
2020/11/06 09:39:38 DEBUG: Finished executing request locally
2020/11/06 09:39:38 DEBUG: Time calculating request result: 0.12366080284118652s
2020/11/06 09:39:38 INFO: wazuh-wui 192.168.176.1 "PUT /security/users/100" done in 191.00000000617ms: 200
```

Best regards,
Selu.