### PR TITLE
Fix framework security unittests.

### DIFF
--- a/framework/wazuh/tests/data/security/users_roles_test_cases.yml
+++ b/framework/wazuh/tests/data/security/users_roles_test_cases.yml
@@ -112,8 +112,16 @@ create_user:
     result:
       affected_items: []
       failed_items:
-        "5007":
+        "5009":
           - new_user1
+  - params:
+      username: new_user2
+      password: WazuhWazuh1
+    result:
+      affected_items: []
+      failed_items:
+        "5007":
+          - new_user2
 update_user:
   - params:
       user_id:
@@ -144,7 +152,7 @@ update_user:
     result:
       affected_items: []
       failed_items:
-        "5007":
+        "5009":
           - 106
 remove_users:
   - params:


### PR DESCRIPTION
# Description

Hello team!

After splitting the exception returned when a password is too short/long or when no capital letters, symbols or numbers are used, some tests were not updated and therefore, they are failing.

The related issue is https://github.com/wazuh/wazuh/pull/6524

## Tests
### Unittests
```
======================================================= test session starts ========================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: trio-0.6.0, asyncio-0.14.0
collected 69 items                                                                                                                 

wazuh/tests/test_security.py .....................................................................                           [100%]

========================================================= warnings summary =========================================================
wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/aiohttp/helpers.py:107: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def noop(*args, **kwargs):  # type: ignore

wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import MutableMapping, Sequence  # noqa

wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/jinja2/runtime.py:318: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping

wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:48: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def problems_middleware(request, handler):

wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:169: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_json(self, request):

wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:177: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_openapi_yaml(self, request):

wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:236: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_home(self, req):

wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:246: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def _get_swagger_ui_config(self, req):

wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:295: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_request(cls, req):

wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/connexion/apis/aiohttp_api.py:324: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def get_response(cls, response, mimetype=None, request=None):

wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
  /home/selu/venv/unittest-env/lib/python3.8/site-packages/jose/jws.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping, Iterable

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================= 69 passed, 12 warnings in 57.79s =================================================
```

Best regards,
Selu.