### PR TITLE
Fix wdb offset

### DIFF
--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1642,7 +1642,6 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/files"
       method: PUT
-      error: !anyint
       data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n  <rule id=\"111111\" level=\"XXX\">\n      <if_sid>5716</if_sid>\n      <srcip>1.1.1.1</srcip>\n      <description>sshd: authentication failed from IP 1.1.1.1.</description>\n      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n    </rule>\n  </group>\n"
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1651,6 +1650,8 @@ stages:
         path: etc/rules/new-rules_corrupted.xml
     response:
       status_code: 200
+      json:
+        error: !anyint
 
   # GET /manager/configuration/validation
   - name: Request validation

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -227,14 +227,14 @@ class WazuhDBConnection:
         if re.search(r'offset \d+', query_without_where):
             offset = int(re.compile(r".* offset (\d+)").match(query_lower).group(1))
             # Replace offset with a wildcard
-            query_lower = query_lower.replace(" offset {}".format(offset), " :offset")
+            query_lower = ' :offset'.join(query_lower.rsplit((' offset {}'.format(offset)), 1))
 
         if not re.search(r'.?select count\([\w \*]+\)( as [^,]+)? from', query_without_where):
             lim = 0
-            if 'limit' in query_lower:
+            if re.search(r'limit \d+', query_without_where):
                 lim = int(re.compile(r".* limit (\d+)").match(query_lower).group(1))
                 # Replace limit with a wildcard
-                query_lower = query_lower.replace(" limit {}".format(lim), " :limit")
+                query_lower = ' :limit'.join(query_lower.rsplit((' limit {}'.format(lim)), 1))
 
             regex = re.compile(r"\w+(?: \d*|)? sql select ([A-Z a-z0-9,*_` \.\-%\(\):\']+) from")
             select = regex.match(query_lower).group(1)


### PR DESCRIPTION
## Description

This PR fixes an error when inner offsets and inner limits are used inside queries processed by wdb.py module.

## Tests
```
pytest -vv test_mitre_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-52-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 1 item                                                                                                                                                                                             

test_mitre_endpoints.tavern.yaml::GET /mitre PASSED                                                                                                                                                    [100%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.base_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================= 1 passed, 3 warnings in 103.69s (0:01:43) ==================================================================================
```

```
pytest -vv test_sca_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-52-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 6 items                                                                                                                                                                                            

test_sca_endpoints.tavern.yaml::GET /sca/001 PASSED                                                                                                                                                    [ 16%]
test_sca_endpoints.tavern.yaml::GET /sca/001/checks/cis_debian9_L1 PASSED                                                                                                                              [ 33%]
test_sca_endpoints.tavern.yaml::GET /sca/002 PASSED                                                                                                                                                    [ 50%]
test_sca_endpoints.tavern.yaml::GET /sca/002/checks/cis_debian9_L1 PASSED                                                                                                                              [ 66%]
test_sca_endpoints.tavern.yaml::GET /sca/003 PASSED                                                                                                                                                    [ 83%]
test_sca_endpoints.tavern.yaml::GET /sca/003/checks/cis_debian9_L1 PASSED                                                                                                                              [100%]

============================================================================================== warnings summary ==============================================================================================
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/hooks.py:43: PytestDeprecationWarning: direct construction of YamlFile has been deprecated, please use YamlFile.from_parent
    return YamlFile(path, parent)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:233: PytestDeprecationWarning: direct construction of YamlItem has been deprecated, please use YamlItem.from_parent
    item = YamlItem(test_spec["test_name"], self, test_spec, self.fspath)

/home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61
  /home/selu/.local/lib/python3.8/site-packages/tavern/testutils/pytesthook/file.py:61: PytestUnknownMarkWarning: Unknown pytest.mark.base_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    pytest_marks.append(getattr(pytest.mark, m))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================= 6 passed, 8 warnings in 110.72s (0:01:50) ==================================================================================
```

Best regards!
Selu.