### PR TITLE
Remove temporary files on close and fix limit on read

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -150,7 +150,7 @@
 #define FIM_HEALTHCHECK_THREAD_ACTIVE       "(6255): Whodata health-check: Reading thread active."
 #define FIM_HEALTHCHECK_THREAD_FINISHED     "(6256): Whodata health-check: Reading thread finished."
 #define FIM_HEALTHCHECK_CREATE_ERROR        "(6257): Whodata health-check: Failed to receive creation event."
-
+#define FIM_UNABLE_TO_READ_TEMP_FILE        "(6258): Detected error or EOF before processing all entries."
 
 
 #define FIM_HEALTHCHECK_SUCCESS             "(6261): Whodata health-check: Success."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -47,6 +47,7 @@
 #define FIM_WHODATA_PARAMETER                   "(6932): Invalid parameter type (%ld) for '%s'."
 #define FIM_WHODATA_RENDER_EVENT                "(6933): Error rendering the event. Error %lu."
 #define FIM_WHODATA_RENDER_PARAM                "(6934): Invalid number of rendered parameters."
+#define FIM_DB_TEMPORARY_FILE_POSITION          "(6935): Unable to reposition temporary file to beginning. Error[%d]: '%s'"
 
 
 /* Monitord warning messages */

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2561,7 +2561,7 @@ FILE * wfopen(const char * pathname, const char * mode) {
     for (i = 0; mode[i]; ++i) {
         switch (mode[i]) {
         case '+':
-            dwDesiredAccess |= GENERIC_WRITE;
+            dwDesiredAccess |= GENERIC_WRITE | GENERIC_READ;
             flags &= ~_O_RDONLY;
             break;
         case 'a':

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -238,7 +238,7 @@ set(FIM_DB_BASE_FLAGS "-Wl,--wrap=w_is_file,--wrap=remove,--wrap=sqlite3_open_v2
                        -Wl,--wrap=fclose,--wrap=fopen,--wrap=getpid,--wrap=fflush -Wl,--wrap=wstr_escape_json \
                        -Wl,--wrap=sqlite3_bind_int64,--wrap=sqlite3_column_int64 -Wl,--wrap=fread,--wrap=fwrite \
                        -Wl,--wrap=fprintf,--wrap=fgets,--wrap=stat,--wrap=wstr_split,--wrap=os_random \
-                       -Wl,--wrap=DirSize,--wrap=IsDir")
+                       -Wl,--wrap=DirSize,--wrap=IsDir,--wrap=wfopen,--wrap=_mwarn")
 
 list(APPEND syscheckd_tests_names "test_fim_db")
 if(${TARGET} STREQUAL "agent")

--- a/src/unit_tests/syscheckd/test_fim_db.c
+++ b/src/unit_tests/syscheckd/test_fim_db.c
@@ -351,8 +351,6 @@ static int teardown_fim_tmp_file_disk(void **state) {
     expect_value(__wrap_fclose, _File, file->fd);
     will_return(__wrap_fclose, 1);
 
-    expect_string(__wrap_remove, filename, file->path);
-    will_return(__wrap_remove, 1);
     fim_db_clean_file(&file, FIM_DB_DISK);
     return 0;
 }
@@ -1501,16 +1499,16 @@ void test_fim_db_get_path_range_failed(void **state) {
     test_fim_db_insert_data *test_data = *state;
     fim_tmp_file *file = NULL;
 
-    expect_string(__wrap_fopen, mode, "w+");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, __modes, "w+");
+    will_return(__wrap_wfopen, 0);
 
     will_return(__wrap_os_random, 2345);
 
 #ifndef TEST_WINAGENT
-    expect_string(__wrap_fopen, path, "/var/ossec/tmp/tmp_19283746523452345");
+    expect_string(__wrap_wfopen, __filename, "/var/ossec/tmp/tmp_19283746523452345");
     expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage '/var/ossec/tmp/tmp_19283746523452345': Success (0)");
 #else
-    expect_string(__wrap_fopen, path, "tmp/tmp_19283746523452345");
+    expect_string(__wrap_wfopen, __filename, "tmp/tmp_19283746523452345");
     expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage 'tmp/tmp_19283746523452345': Success (0)");
 #endif
 
@@ -1526,13 +1524,13 @@ void test_fim_db_get_path_range_success(void **state) {
     will_return(__wrap_os_random, 2345);
 
 #ifdef TEST_WINAGENT
-    expect_string(__wrap_fopen, path, "tmp/tmp_19283746523452345");
+    expect_string(__wrap_wfopen, __filename, "tmp/tmp_19283746523452345");
 #else
-    expect_string(__wrap_fopen, path, "/var/ossec/tmp/tmp_19283746523452345");
+    expect_string(__wrap_wfopen, __filename, "/var/ossec/tmp/tmp_19283746523452345");
 #endif
 
-    expect_string(__wrap_fopen, mode, "w+");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, __modes, "w+");
+    will_return(__wrap_wfopen, 1);
 
     will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
     will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
@@ -1568,13 +1566,13 @@ void test_fim_db_get_not_scanned_failed(void **state) {
     will_return(__wrap_os_random, 2345);
 
 #ifdef TEST_WINAGENT
-    expect_string(__wrap_fopen, path, "tmp/tmp_19283746523452345");
+    expect_string(__wrap_wfopen, __filename, "tmp/tmp_19283746523452345");
 #else
-    expect_string(__wrap_fopen, path, "/var/ossec/tmp/tmp_19283746523452345");
+    expect_string(__wrap_wfopen, __filename, "/var/ossec/tmp/tmp_19283746523452345");
 #endif
 
-    expect_string(__wrap_fopen, mode, "w+");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, __modes, "w+");
+    will_return(__wrap_wfopen, 0);
 #ifndef TEST_WINAGENT
     expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage '/var/ossec/tmp/tmp_19283746523452345': Success (0)");
 #else
@@ -1593,13 +1591,13 @@ void test_fim_db_get_not_scanned_success(void **state) {
     will_return(__wrap_os_random, 2345);
 
 #ifdef TEST_WINAGENT
-    expect_string(__wrap_fopen, path, "tmp/tmp_19283746523452345");
+    expect_string(__wrap_wfopen, __filename, "tmp/tmp_19283746523452345");
 #else
-    expect_string(__wrap_fopen, path, "/var/ossec/tmp/tmp_19283746523452345");
+    expect_string(__wrap_wfopen, __filename, "/var/ossec/tmp/tmp_19283746523452345");
 #endif
 
-    expect_string(__wrap_fopen, mode, "w+");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, __modes, "w+");
+    will_return(__wrap_wfopen, 1);
 
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
     wraps_fim_db_check_transaction();
@@ -2163,13 +2161,16 @@ void test_fim_db_process_get_query_error(void **state) {
 void test_fim_db_sync_path_range_disk(void **state) {
     test_fim_db_insert_data *test_data = *state;
     test_data->tmp_file->fd = (FILE*)2345;
+    test_data->tmp_file->elements = 1;
 
     will_return(__wrap_fseek, 0);
 #ifdef WIN32
-    expect_value(wrap_fgets, __stream, (FILE*)2345);
+    expect_value_count(wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(wrap_fgets, "00000000000000000000000000000010");
     will_return(wrap_fgets, "/tmp/file\n");
 #else
-    expect_value(__wrap_fgets, __stream, (FILE*)2345);
+    expect_value_count(__wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(__wrap_fgets, "00000000000000000000000000000010");
     will_return(__wrap_fgets, "/tmp/file\n");
 #endif
     will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
@@ -2196,15 +2197,13 @@ void test_fim_db_sync_path_range_disk(void **state) {
 
     expect_string(__wrap_fim_send_sync_msg, msg, "This is the returned JSON");
 
-    expect_string(__wrap_remove, filename, "/tmp/file");
-    will_return(__wrap_remove, 0);
-
     int ret = fim_db_sync_path_range(test_data->fim_sql, &syscheck.fim_entry_mutex, test_data->tmp_file, syscheck.database_store);
     assert_int_equal(FIMDB_OK, ret);
 }
 
 void test_fim_db_sync_path_range_memory(void **state) {
     test_fim_db_insert_data *test_data = *state;
+    test_data->tmp_file->elements = 1;
 
     will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
     will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
@@ -2238,14 +2237,17 @@ void test_fim_db_sync_path_range_memory(void **state) {
 void test_fim_db_delete_range_success(void **state) {
     test_fim_db_insert_data *test_data = *state;
     test_data->tmp_file->fd = (FILE*)2345;
+    test_data->tmp_file->elements = 1;
     int ret;
 
     will_return(__wrap_fseek, 0);
 #ifdef WIN32
-    expect_value(wrap_fgets, __stream, (FILE*)2345);
+    expect_value_count(wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(wrap_fgets, "00000000000000000000000000000010");
     will_return(wrap_fgets, "/tmp/file\n");
 #else
-    expect_value(__wrap_fgets, __stream, (FILE*)2345);
+    expect_value_count(__wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(__wrap_fgets, "00000000000000000000000000000010");
     will_return(__wrap_fgets, "/tmp/file\n");
 #endif
     will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
@@ -2268,9 +2270,6 @@ void test_fim_db_delete_range_success(void **state) {
     expect_value(__wrap_fclose, _File, (FILE*)2345);
     will_return(__wrap_fclose, 1);
 
-    expect_string(__wrap_remove, filename, "/tmp/file");
-    will_return(__wrap_remove, 0);
-
     ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
 
     assert_int_equal(ret, FIMDB_OK);
@@ -2279,14 +2278,17 @@ void test_fim_db_delete_range_success(void **state) {
 void test_fim_db_delete_range_error(void **state) {
     test_fim_db_insert_data *test_data = *state;
     test_data->tmp_file->fd = (FILE*)2345;
+    test_data->tmp_file->elements = 1;
     int ret;
 
     will_return(__wrap_fseek, 0);
 #ifdef WIN32
-    expect_value(wrap_fgets, __stream, (FILE*)2345);
+    expect_value_count(wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(wrap_fgets, "00000000000000000000000000000010");
     will_return(wrap_fgets, "/tmp/file\n");
 #else
-    expect_value(__wrap_fgets, __stream, (FILE*)2345);
+    expect_value_count(__wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(__wrap_fgets, "00000000000000000000000000000010");
     will_return(__wrap_fgets, "/tmp/file\n");
 #endif
     will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
@@ -2304,9 +2306,6 @@ void test_fim_db_delete_range_error(void **state) {
     expect_value(__wrap_fclose, _File, (FILE*)2345);
     will_return(__wrap_fclose, 1);
 
-    expect_string(__wrap_remove, filename, "/tmp/file");
-    will_return(__wrap_remove, 0);
-
     ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
 
     assert_int_equal(ret, FIMDB_OK);
@@ -2315,14 +2314,17 @@ void test_fim_db_delete_range_error(void **state) {
 void test_fim_db_delete_range_path_error(void **state) {
     test_fim_db_insert_data *test_data = *state;
     test_data->tmp_file->fd = (FILE*)2345;
+    test_data->tmp_file->elements = 1;
     int ret;
 
     will_return(__wrap_fseek, 0);
 #ifdef WIN32
-    expect_value(wrap_fgets, __stream, (FILE*)2345);
+    expect_value_count(wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(wrap_fgets, "00000000000000000000000000000001");
     will_return(wrap_fgets, "\n");
 #else
-    expect_value(__wrap_fgets, __stream, (FILE*)2345);
+    expect_value_count(__wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(__wrap_fgets, "00000000000000000000000000000001");
     will_return(__wrap_fgets, "\n");
 #endif
 
@@ -2331,12 +2333,90 @@ void test_fim_db_delete_range_path_error(void **state) {
     expect_value(__wrap_fclose, _File, (FILE*)2345);
     will_return(__wrap_fclose, 1);
 
-    expect_string(__wrap_remove, filename, "/tmp/file");
-    will_return(__wrap_remove, 0);
+    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
+
+    assert_int_equal(ret, FIMDB_ERR);
+}
+
+void test_fim_db_delete_range_fail_to_reposition_file(void **state) {
+    char warning_message[OS_SIZE_256];
+    test_fim_db_insert_data *test_data = *state;
+    test_data->tmp_file->fd = (FILE*)2345;
+    test_data->tmp_file->elements = 1;
+    int ret;
+
+    will_return(__wrap_fseek, -1);
+
+    snprintf(warning_message, OS_SIZE_256, FIM_DB_TEMPORARY_FILE_POSITION, errno, strerror(errno));
+
+    expect_string(__wrap__mwarn, formatted_msg, warning_message);
+
+    expect_value(__wrap_fclose, _File, (FILE*)2345);
+    will_return(__wrap_fclose, 1);
 
     ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
 
-    assert_int_equal(ret, FIMDB_OK);
+    assert_int_equal(ret, FIMDB_ERR);
+}
+
+void test_fim_db_delete_range_fail_to_read_line_length(void **state) {
+    char debug_message[OS_SIZE_256];
+    test_fim_db_insert_data *test_data = *state;
+    test_data->tmp_file->fd = (FILE*)2345;
+    test_data->tmp_file->elements = 1;
+    int ret;
+
+    will_return(__wrap_fseek, 0);
+
+#ifdef WIN32
+    expect_value(wrap_fgets, __stream, (FILE*)2345);
+    will_return(wrap_fgets, NULL);
+#else
+    expect_value(__wrap_fgets, __stream, (FILE*)2345);
+    will_return(__wrap_fgets, NULL);
+#endif
+
+    snprintf(debug_message, OS_SIZE_256, FIM_UNABLE_TO_READ_TEMP_FILE);
+
+    expect_string(__wrap__mdebug1, formatted_msg, debug_message);
+
+    expect_value(__wrap_fclose, _File, (FILE*)2345);
+    will_return(__wrap_fclose, 1);
+
+    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
+
+    assert_int_equal(ret, FIMDB_ERR);
+}
+
+void test_fim_db_delete_range_fail_to_read_line(void **state) {
+    char debug_message[OS_SIZE_256];
+    test_fim_db_insert_data *test_data = *state;
+    test_data->tmp_file->fd = (FILE*)2345;
+    test_data->tmp_file->elements = 1;
+    int ret;
+
+    will_return(__wrap_fseek, 0);
+
+#ifdef WIN32
+    expect_value_count(wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(wrap_fgets, "00000000000000000000000000000010");
+    will_return(wrap_fgets, NULL);
+#else
+    expect_value_count(__wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(__wrap_fgets, "00000000000000000000000000000001");
+    will_return(__wrap_fgets, NULL);
+#endif
+
+    snprintf(debug_message, OS_SIZE_256, FIM_UNABLE_TO_READ_TEMP_FILE);
+
+    expect_string(__wrap__mdebug1, formatted_msg, debug_message);
+
+    expect_value(__wrap_fclose, _File, (FILE*)2345);
+    will_return(__wrap_fclose, 1);
+
+    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
+
+    assert_int_equal(ret, FIMDB_ERR);
 }
 
 /*----------------------------------------------*/
@@ -2344,14 +2424,17 @@ void test_fim_db_delete_range_path_error(void **state) {
 void test_fim_db_delete_not_scanned(void **state) {
     test_fim_db_insert_data *test_data = *state;
     test_data->tmp_file->fd = (FILE*)2345;
+    test_data->tmp_file->elements = 1;
     int ret;
 
     will_return(__wrap_fseek, 0);
 #ifdef WIN32
-    expect_value(wrap_fgets, __stream, (FILE*)2345);
+    expect_value_count(wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(wrap_fgets, "00000000000000000000000000000010");
     will_return(wrap_fgets, "/tmp/file\n");
 #else
-    expect_value(__wrap_fgets, __stream, (FILE*)2345);
+    expect_value_count(__wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(__wrap_fgets, "00000000000000000000000000000010");
     will_return(__wrap_fgets, "/tmp/file\n");
 #endif
     will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
@@ -2370,9 +2453,6 @@ void test_fim_db_delete_not_scanned(void **state) {
     expect_value(__wrap_fclose, _File, (FILE*)2345);
     will_return(__wrap_fclose, 1);
 
-    expect_string(__wrap_remove, filename, "/tmp/file");
-    will_return(__wrap_remove, 0);
-
     ret = fim_db_delete_not_scanned(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
 
     assert_int_equal(ret, FIMDB_OK);
@@ -2383,14 +2463,17 @@ void test_fim_db_delete_not_scanned(void **state) {
 void test_fim_db_process_missing_entry(void **state) {
     test_fim_db_insert_data *test_data = *state;
     test_data->tmp_file->fd = (FILE*)2345;
+    test_data->tmp_file->elements = 1;
     int ret;
 
     will_return(__wrap_fseek, 0);
 #ifdef WIN32
-    expect_value(wrap_fgets, __stream, (FILE*)2345);
+    expect_value_count(wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(wrap_fgets, "00000000000000000000000000000010");
     will_return(wrap_fgets, "/tmp/file\n");
 #else
-    expect_value(__wrap_fgets, __stream, (FILE*)2345);
+    expect_value_count(__wrap_fgets, __stream, (FILE*)2345, 2);
+    will_return(__wrap_fgets, "00000000000000000000000000000010");
     will_return(__wrap_fgets, "/tmp/file\n");
 #endif
     will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
@@ -2408,9 +2491,6 @@ void test_fim_db_process_missing_entry(void **state) {
 
     expect_value(__wrap_fclose, _File, (FILE*)2345);
     will_return(__wrap_fclose, 1);
-
-    expect_string(__wrap_remove, filename, "/tmp/file");
-    will_return(__wrap_remove, 0);
 
     ret = fim_db_process_missing_entry(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store, FIM_REALTIME, NULL);
 
@@ -2460,11 +2540,11 @@ void test_fim_db_callback_save_path_disk(void **state) {
 
 #ifndef TEST_WINAGENT
     expect_value(__wrap_fprintf, __stream, 2345);
-    expect_string(__wrap_fprintf, formatted_msg, "/test/path\n");
+    expect_string(__wrap_fprintf, formatted_msg, "00000000000000000000000000000011/test/path\n");
     will_return(__wrap_fprintf, 11);
 #else
     expect_value(wrap_fprintf, __stream, 2345);
-    expect_string(wrap_fprintf, formatted_msg, "/test/path\n");
+    expect_string(wrap_fprintf, formatted_msg, "00000000000000000000000000000011/test/path\n");
     will_return(wrap_fprintf, 11);
 #endif
 
@@ -2480,12 +2560,12 @@ void test_fim_db_callback_save_path_disk_error(void **state) {
 
 #ifndef TEST_WINAGENT
     expect_value(__wrap_fprintf, __stream, 2345);
-    expect_string(__wrap_fprintf, formatted_msg, "/test/path\n");
-    will_return(__wrap_fprintf, 0);
+    expect_string(__wrap_fprintf, formatted_msg, "00000000000000000000000000000011/test/path\n");
+    will_return(__wrap_fprintf, -1);
 #else
     expect_value(wrap_fprintf, __stream, 2345);
-    expect_string(wrap_fprintf, formatted_msg, "/test/path\n");
-    will_return(wrap_fprintf, 0);
+    expect_string(wrap_fprintf, formatted_msg, "00000000000000000000000000000011/test/path\n");
+    will_return(wrap_fprintf, -1);
 #endif
 
     errno = 0;
@@ -2683,13 +2763,20 @@ void test_fim_db_create_temp_file_disk(void **state) {
     will_return(__wrap_os_random, 2345);
 
 #ifdef TEST_WINAGENT
-    expect_string(__wrap_fopen, path, "tmp/tmp_19283746523452345");
+    expect_string(__wrap_wfopen, __filename, "tmp/tmp_19283746523452345");
 #else
-    expect_string(__wrap_fopen, path, "/var/ossec/tmp/tmp_19283746523452345");
+    expect_string(__wrap_wfopen, __filename, "/var/ossec/tmp/tmp_19283746523452345");
 #endif
 
-    expect_string(__wrap_fopen, mode, "w+");
-    will_return(__wrap_fopen, 1);
+    expect_string(__wrap_wfopen, __modes, "w+");
+    will_return(__wrap_wfopen, 1);
+
+#ifdef TEST_WINAGENT
+    expect_string(__wrap_remove, filename, "tmp/tmp_19283746523452345");
+#else
+    expect_string(__wrap_remove, filename, "/var/ossec/tmp/tmp_19283746523452345");
+#endif
+    will_return(__wrap_remove, 0);
 
     fim_tmp_file *ret = fim_db_create_temp_file(FIM_DB_DISK);
     state[1] = ret;
@@ -2704,13 +2791,13 @@ void test_fim_db_create_temp_file_disk_error(void **state) {
     will_return(__wrap_os_random, 2345);
 
 #ifdef TEST_WINAGENT
-    expect_string(__wrap_fopen, path, "tmp/tmp_19283746523452345");
+    expect_string(__wrap_wfopen, __filename, "tmp/tmp_19283746523452345");
 #else
-    expect_string(__wrap_fopen, path, "/var/ossec/tmp/tmp_19283746523452345");
+    expect_string(__wrap_wfopen, __filename, "/var/ossec/tmp/tmp_19283746523452345");
 #endif
 
-    expect_string(__wrap_fopen, mode, "w+");
-    will_return(__wrap_fopen, 0);
+    expect_string(__wrap_wfopen, __modes, "w+");
+    will_return(__wrap_wfopen, 0);
 
 #ifdef TEST_WINAGENT
     expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage 'tmp/tmp_19283746523452345': Success (0)");
@@ -2718,6 +2805,37 @@ void test_fim_db_create_temp_file_disk_error(void **state) {
     expect_string(__wrap__merror, formatted_msg, "Failed to create temporal storage '/var/ossec/tmp/tmp_19283746523452345': Success (0)");
 #endif
 
+
+    fim_tmp_file *ret = fim_db_create_temp_file(FIM_DB_DISK);
+
+    assert_null(ret);
+}
+
+void test_fim_db_create_temp_file_disk_fail_to_remove_open_file(void **state) {
+
+    will_return(__wrap_os_random, 2345);
+
+#ifdef TEST_WINAGENT
+    expect_string(__wrap_wfopen, __filename, "tmp/tmp_19283746523452345");
+#else
+    expect_string(__wrap_wfopen, __filename, "/var/ossec/tmp/tmp_19283746523452345");
+#endif
+
+    expect_string(__wrap_wfopen, __modes, "w+");
+    will_return(__wrap_wfopen, 1);
+
+#ifdef TEST_WINAGENT
+    expect_string(__wrap_remove, filename, "tmp/tmp_19283746523452345");
+#else
+    expect_string(__wrap_remove, filename, "/var/ossec/tmp/tmp_19283746523452345");
+#endif
+    will_return(__wrap_remove, -1);
+
+#ifdef TEST_WINAGENT
+    expect_string(__wrap__merror, formatted_msg, "Failed to remove 'tmp/tmp_19283746523452345': Success (0)");
+#else
+    expect_string(__wrap__merror, formatted_msg, "Failed to remove '/var/ossec/tmp/tmp_19283746523452345': Success (0)");
+#endif
 
     fim_tmp_file *ret = fim_db_create_temp_file(FIM_DB_DISK);
 
@@ -2744,27 +2862,6 @@ void test_fim_db_clean_file_disk() {
 
     expect_value(__wrap_fclose, _File, file->fd);
     will_return(__wrap_fclose, 1);
-
-    expect_string(__wrap_remove, filename, file->path);
-    will_return(__wrap_remove, 1);
-
-    fim_db_clean_file(&file, FIM_DB_DISK);
-
-    assert_null(file);
-}
-
-void test_fim_db_clean_file_disk_error() {
-    fim_tmp_file *file = calloc(1, sizeof(fim_tmp_file));
-    file->path = calloc(PATH_MAX, sizeof(char));
-    sprintf(file->path, "test");
-
-    expect_value(__wrap_fclose, _File, file->fd);
-    will_return(__wrap_fclose, 1);
-
-    expect_string(__wrap_remove, filename, file->path);
-    will_return(__wrap_remove, -1);
-
-    expect_string(__wrap__merror, formatted_msg, "Failed to remove 'test': Success (0)");
 
     fim_db_clean_file(&file, FIM_DB_DISK);
 
@@ -2892,6 +2989,9 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_fim_db_delete_range_success, test_fim_tmp_file_setup_disk, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_delete_range_error, test_fim_tmp_file_setup_disk, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_delete_range_path_error, test_fim_tmp_file_setup_disk, test_fim_db_teardown),
+        cmocka_unit_test_setup_teardown(test_fim_db_delete_range_fail_to_reposition_file, test_fim_tmp_file_setup_disk, test_fim_db_teardown),
+        cmocka_unit_test_setup_teardown(test_fim_db_delete_range_fail_to_read_line_length, test_fim_tmp_file_setup_disk, test_fim_db_teardown),
+        cmocka_unit_test_setup_teardown(test_fim_db_delete_range_fail_to_read_line, test_fim_tmp_file_setup_disk, test_fim_db_teardown),
         // fim_db_delete_not_scanned
         cmocka_unit_test_setup_teardown(test_fim_db_delete_not_scanned, test_fim_tmp_file_setup_disk, test_fim_db_teardown),
         // fim_db_process_missing_entry
@@ -2919,10 +3019,10 @@ int main(void) {
         // fim_db_create_temp_file
         cmocka_unit_test_teardown(test_fim_db_create_temp_file_disk, teardown_fim_tmp_file_disk),
         cmocka_unit_test(test_fim_db_create_temp_file_disk_error),
+        cmocka_unit_test(test_fim_db_create_temp_file_disk_fail_to_remove_open_file),
         cmocka_unit_test_teardown(test_fim_db_create_temp_file_memory, teardown_fim_tmp_file_memory),
         // fim_db_clean_file
         cmocka_unit_test(test_fim_db_clean_file_disk),
-        cmocka_unit_test(test_fim_db_clean_file_disk_error),
         cmocka_unit_test(test_fim_db_clean_file_memory),
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);


### PR DESCRIPTION
|Related issue|
|---|
|#5689|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims at fixing issue #5689.

Temporary files created by FIM are now immediately removed after being opened, this ensures no other threads can access the same file and deletes it once the thread that is using it closes the handle, (this includes stopping the agent).

While fixing this issue, we realized that on Windows systems the max length we were using to read from the temporary files was 260 characters. This was causing an issue when synchronizing and sending delete events on registry keys with a length over 260. We fixed this problem by adding 32 characters at the start of every line which show how long the path actually is and creating a buffer of said length.

Some other minor improvements to how we handle reading of this temporary files were also added.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Dr. Memory