### PR TITLE
Change the minor limits of the agents_disconnection_time and agents_disconnection_alert_time settings - Implementation

### DIFF
--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -664,7 +664,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
             if (Config) {
                 long time = w_parse_time(node[i]->content);
 
-                if (time < 20) {
+                if (time < 1) {
                     merror(XML_VALUEERR, node[i]->element, node[i]->content);
                     return (OS_INVALID);
                 } else {
@@ -677,7 +677,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
             if (Config) {
                 long time = w_parse_time(node[i]->content);
 
-                if (time < 120) {
+                if (time < 0) {
                     merror(XML_VALUEERR, node[i]->element, node[i]->content);
                     return (OS_INVALID);
                 } else {


### PR DESCRIPTION
|Related issue|
|---|
| #6539 |
## Description
This PR change minimum accepted values for the configs below:
**agents_disconnection_time**: 1
**agents_disconnection_alert_time**: 0 (Alerts can be generated as soon as an agent got disconnected)

## Tests
The changes only impact the configuration.
Check that Monitord keeps working as expected with **agents_disconnection_time = 1**
Check that Monitord keeps working as expected with **agents_disconnection_alert_time = 0**