### PR TITLE
Fix wazuh-logtest event's location

### DIFF
--- a/framework/scripts/wazuh-logtest.py
+++ b/framework/scripts/wazuh-logtest.py
@@ -210,7 +210,7 @@ class WazuhSocket:
 
 
 class WazuhLogtest:
-    def __init__(self, location="master->/var/log/syslog", log_format="syslog"):
+    def __init__(self, location="stdin", log_format="syslog"):
         """Top level class to interact with wazuh-logtest feature, part of ossec-analysisd
 
         Args:


### PR DESCRIPTION
## Description

Hi team!

This PR aims to use `stdin` value as `location` for `wazuh-logtest`  to be compatible with `ossec-logtest`. This is also useful for negation tests of `location` in `runtest.py` (wazuh-ruleset) 

Regards,
Nico
