### PR TITLE
6121 - rsync dbsync thread and config of syscollector parameters.

### DIFF
--- a/src/wazuh_modules/syscollector/sysInfo.hpp
+++ b/src/wazuh_modules/syscollector/sysInfo.hpp
@@ -12,23 +12,22 @@
 #ifndef _SYS_INFO_HPP
 #define _SYS_INFO_HPP
 
-#include "json.hpp"
+#include "sysInfoInterface.h"
 
 constexpr auto KByte{1024};
 
-
-class SysInfo
+class SysInfo: public ISysInfo
 {
 public:
     SysInfo() = default;
     // LCOV_EXCL_START
     virtual ~SysInfo() = default;
     // LCOV_EXCL_STOP
-    nlohmann::json hardware();
-    nlohmann::json packages();
-    nlohmann::json os();
-    nlohmann::json processes();
-    nlohmann::json networks();
+    nlohmann::json hardware() override;
+    nlohmann::json packages() override;
+    nlohmann::json os() override;
+    nlohmann::json processes() override;
+    nlohmann::json networks() override;
 private:
     virtual std::string getSerialNumber() const;
     virtual std::string getCpuName() const;

--- a/src/wazuh_modules/syscollector/sysInfoInterface.h
+++ b/src/wazuh_modules/syscollector/sysInfoInterface.h
@@ -1,0 +1,31 @@
+/*
+ * Wazuh SysInfo
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * November 9, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _SYS_INFO_INTERFACE
+#define _SYS_INFO_INTERFACE
+
+#include "json.hpp"
+
+class ISysInfo
+{
+public:
+    ISysInfo() = default;
+    // LCOV_EXCL_START
+    virtual ~ISysInfo() = default;
+    // LCOV_EXCL_STOP
+    virtual nlohmann::json hardware() = 0;
+    virtual nlohmann::json packages() = 0;
+    virtual nlohmann::json os() = 0;
+    virtual nlohmann::json processes() = 0;
+    virtual nlohmann::json networks() = 0;
+};
+
+#endif //_SYS_INFO_INTERFACE

--- a/src/wazuh_modules/syscollector/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/syscollectorImp.cpp
@@ -11,45 +11,153 @@
 #include "syscollectorImp.h"
 #include <iostream>
 
-Syscollector::Syscollector(const std::chrono::milliseconds& timeout)
-: m_timeout{timeout}
-, m_running{true}
-, m_thread{std::bind(&Syscollector::sync, this)}
+
+bool Syscollector::sleepFor()
+{
+    bool ret{false};
+    std::unique_lock<std::mutex> lock{m_mutex};
+    if (m_intervalUnit == "s")
+    {
+        ret = !m_cv.wait_for(lock, std::chrono::seconds{m_intervalValue}, [&](){return m_running;});
+    }
+    else if (m_intervalUnit == "m")
+    {
+        ret = !m_cv.wait_for(lock, std::chrono::minutes{m_intervalValue}, [&](){return m_running;});
+    }
+    else if (m_intervalUnit == "h")
+    {
+        ret = !m_cv.wait_for(lock, std::chrono::hours{m_intervalValue}, [&](){return m_running;});
+    }
+    else if (m_intervalUnit == "d")
+    {
+        const auto daysToHours{m_intervalValue * 24ul};
+        ret = !m_cv.wait_for(lock, std::chrono::hours{daysToHours}, [&](){return m_running;});
+    }
+    else
+    {
+        ret = !m_cv.wait_for(lock, std::chrono::hours{1}, [&](){return m_running;});
+    }
+    return ret;
+}
+
+Syscollector::Syscollector(const std::shared_ptr<ISysInfo>& spInfo,
+                           const std::string& interval,
+                           const bool scanOnStart,
+                           const bool hardware,
+                           const bool os,
+                           const bool network,
+                           const bool packages,
+                           const bool ports,
+                           const bool portsAll,
+                           const bool processes,
+                           const bool hotfixes)
+: m_spInfo{spInfo}
+, m_intervalUnit{interval.back()}
+, m_intervalValue{std::stoull(interval)}
+, m_scanOnStart{scanOnStart}
+, m_hardware{hardware}
+, m_os{os}
+, m_network{network}
+, m_packages{packages}
+, m_ports{ports}
+, m_portsAll{portsAll}
+, m_processes{processes}
+, m_hotfixes{hotfixes}
+, m_running{false}
+, m_thread{std::bind(&Syscollector::syncThread, this)}
 {
 }
 
-
 Syscollector::~Syscollector()
 {
-    m_running = false;
+    std::unique_lock<std::mutex> lock{m_mutex};
+    m_running = true;
+    m_cv.notify_all();
+    lock.unlock();
     if (m_thread.joinable())
     {
         m_thread.join();
     }
 }
-
-void Syscollector::start()
+void Syscollector::scanHardware()
 {
-    while(m_running)
+    if (m_hardware)
     {
-        const auto& hw{m_info.hardware()};
-        const auto& packages{m_info.packages()};
-        const auto& processes{m_info.processes()};    
-        const auto& networks{m_info.networks()};       
-        const auto& os{m_info.os()};
-        std::cout << packages.dump() << std::endl;
+        const auto& hw{m_spInfo->hardware()};
         std::cout << hw.dump() << std::endl;
-        std::cout << processes.dump() << std::endl;
-        std::cout << networks.dump() << std::endl;
+    }
+}
+void Syscollector::scanOs()
+{
+    if(m_os)
+    {
+        const auto& os{m_spInfo->os()};
         std::cout << os.dump() << std::endl;
-        std::this_thread::sleep_for(m_timeout);
+    }
+}
+void Syscollector::scanNetwork()
+{
+    if (m_network)
+    {
+        const auto& networks{m_spInfo->networks()};
+        std::cout << networks.dump() << std::endl;
+    }
+}
+void Syscollector::scanPackages()
+{
+    if (m_packages)
+    {
+        const auto& packages{m_spInfo->packages()};
+        std::cout << packages.dump() << std::endl;
+        if (m_hotfixes)
+        {
+        }
+    }
+}
+void Syscollector::scanPorts()
+{
+    if (m_ports)
+    {
+        if (m_portsAll)
+        {
+        }
+    }
+}
+void Syscollector::scanProcesses()
+{
+    if (m_processes)
+    {
+        const auto& processes{m_spInfo->processes()};
+        std::cout << processes.dump() << std::endl;
     }
 }
 
-void Syscollector::sync()
+void Syscollector::scan()
 {
-    while(m_running)
+    scanHardware();
+    scanOs();
+    scanNetwork();
+    scanPackages();
+    scanPorts();
+    scanProcesses();
+}
+
+void Syscollector::start()
+{
+    if (m_scanOnStart)
     {
-        std::this_thread::sleep_for(m_timeout);
+        scan();
+    }
+    while(sleepFor())
+    {
+        scan();
+    }
+}
+
+void Syscollector::syncThread()
+{
+    while(sleepFor())
+    {
+        //sync Rsync
     }
 }

--- a/src/wazuh_modules/syscollector/syscollectorImp.h
+++ b/src/wazuh_modules/syscollector/syscollectorImp.h
@@ -12,22 +12,54 @@
 #define _SYSCOLLECTOR_IMP_H
 #include <chrono>
 #include <thread>
-#include <atomic>
-#include "sysInfo.hpp"
+#include <condition_variable>
+#include <mutex>
+#include <memory>
+#include "sysInfoInterface.h"
 #include "json.hpp"
 
 class Syscollector final
 {
 public:
-    Syscollector(const std::chrono::milliseconds& timeout);
+    Syscollector(const std::shared_ptr<ISysInfo>& spInfo,
+                 const std::string& inverval = "1h",
+                 const bool scanOnStart = true,
+                 const bool hardware = true,
+                 const bool os = true,
+                 const bool network = true,
+                 const bool packages = true,
+                 const bool ports = true,
+                 const bool portsAll = true,
+                 const bool processes = true,
+                 const bool hotfixes = true);
     void start();
     ~Syscollector();
 private:
-    void sync();
-    const std::chrono::milliseconds m_timeout;
-    std::atomic_bool                m_running;
-    std::thread                     m_thread;
-    SysInfo                         m_info;
+    bool sleepFor();
+    void scanHardware();
+    void scanOs();
+    void scanNetwork();
+    void scanPackages();
+    void scanPorts();
+    void scanProcesses();
+    void scan();
+    void syncThread();
+    const std::shared_ptr<ISysInfo>   m_spInfo;
+    const std::string                 m_intervalUnit;
+    const unsigned long long          m_intervalValue;
+    const bool                        m_scanOnStart;
+    const bool                        m_hardware;
+    const bool                        m_os;
+    const bool                        m_network;
+    const bool                        m_packages;
+    const bool                        m_ports;
+    const bool                        m_portsAll;
+    const bool                        m_processes;
+    const bool                        m_hotfixes;
+    bool                              m_running;
+    std::condition_variable           m_cv;
+    std::mutex                        m_mutex;
+    std::thread                       m_thread;
 };
 
 

--- a/src/wazuh_modules/syscollector/tests/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ project(unit_tests)
 include_directories(${CMAKE_SOURCE_DIR})
 
 add_subdirectory(sysInfo)
+add_subdirectory(sysCollectorImp)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   add_subdirectory(sysInfoNetworkLinux)

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 2.6.4)
+
+project(syscollectorimp_unit_test)
+
+set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage")
+
+file(GLOB SYSCOLLECTOR_IMP_UNIT_TEST_SRC
+    "*.cpp")
+
+file(GLOB SYSCOLLECTOR_IMP_SRC
+    "${CMAKE_SOURCE_DIR}/syscollectorImp.cpp")
+
+add_executable(syscollectorimp_unit_test 
+    ${SYSCOLLECTOR_IMP_UNIT_TEST_SRC}
+    ${SYSCOLLECTOR_IMP_SRC})
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    target_link_libraries(syscollectorimp_unit_test
+        debug gtestd
+        debug gmockd
+        debug gtest_maind
+        debug gmock_maind
+        optimized gtest
+        optimized gmock
+        optimized gtest_main
+        optimized gmock_main
+        pthread
+        sqlite3
+        cjson
+        -static-libgcc -static-libstdc++
+    )
+else()
+    target_link_libraries(syscollectorimp_unit_test
+        debug gtestd
+        debug gmockd
+        debug gtest_maind
+        debug gmock_maind
+        optimized gtest
+        optimized gmock
+        optimized gtest_main
+        optimized gmock_main
+        pthread
+        sqlite3
+        cjson
+        dl
+    )
+endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+
+add_test(NAME syscollectorimp_unit_test
+         COMMAND syscollectorimp_unit_test)

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/main.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/main.cpp
@@ -1,0 +1,7 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -1,0 +1,319 @@
+/*
+ * Wazuh SyscollectorImp
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * November 9, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+#include "syscollectorImp_test.h"
+#include "syscollectorImp.h"
+
+void SyscollectorImpTest::SetUp() {};
+
+void SyscollectorImpTest::TearDown()
+{
+};
+
+using ::testing::_;
+using ::testing::Return;
+
+class SysInfoWrapper: public ISysInfo
+{
+public:
+    SysInfoWrapper() = default;
+    ~SysInfoWrapper() = default;
+    MOCK_METHOD(nlohmann::json, hardware, (), (override));
+    MOCK_METHOD(nlohmann::json, packages, (), (override));
+    MOCK_METHOD(nlohmann::json, os, (), (override));    
+    MOCK_METHOD(nlohmann::json, networks, (), (override));    
+    MOCK_METHOD(nlohmann::json, processes, (), (override));    
+};
+
+TEST_F(SyscollectorImpTest, defaultCtor)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillOnce(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, intervalSeconds)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillOnce(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "100s"};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, intervalMinutes)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillOnce(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "100m"};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, intervalDays)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillOnce(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "1d"};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, intervalUnknownUnit)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillOnce(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "1y"};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, noScanOnStart)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, packages()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, networks()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, processes()).Times(0);
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "1h", false};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, noHardware)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, packages()).WillOnce(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "1h", true, false};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, noOs)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillOnce(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "1h", true, true, false};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, noNetwork)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillOnce(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, networks()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "1h", true, true, true, false};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, noPackages)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, false};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, noPorts)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillOnce(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, true, false};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, noPortsAll)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillOnce(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, true, true, false};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, noProcesses)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillOnce(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, processes()).Times(0);
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, true, true, true, false};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, noHotfixes)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillOnce(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, true, true, true, true, false};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}
+
+TEST_F(SyscollectorImpTest, scanOnInverval)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return("packages"));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return("networks"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return("processes"));
+    std::thread t1;
+    {
+        Syscollector syscollector{spInfoWrapper, "1s"};
+        t1 = std::thread{[&syscollector](){ syscollector.start(); }};
+        std::this_thread::sleep_for(std::chrono::seconds{3});
+    }
+    if (t1.joinable())
+    {
+        t1.join();
+    }
+}

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.h
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.h
@@ -1,0 +1,27 @@
+/*
+ * Wazuh SysInfo
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * November 9, 2020.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */ 
+#ifndef _SYSCOLLECTOR_IMP_TEST_H
+#define _SYSCOLLECTOR_IMP_TEST_H
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+class SyscollectorImpTest : public ::testing::Test {
+
+protected:
+
+    SyscollectorImpTest() = default;
+    virtual ~SyscollectorImpTest() = default;
+
+    void SetUp() override;
+    void TearDown() override;
+};
+
+#endif //_SYSCOLLECTOR_IMP_TEST_H

--- a/src/wazuh_modules/syscollector/testtool/main.cpp
+++ b/src/wazuh_modules/syscollector/testtool/main.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include "dbsync.h"
 #include "rsync.h"
+#include "sysInfo.hpp"
 #include "syscollectorImp.h"
 
 static void logFunction(const char* msg)
@@ -25,7 +26,21 @@ static void logFunction(const char* msg)
 int main(int argc, const char* argv[])
 {
     const std::chrono::milliseconds timeout{5000};
-    Syscollector sysCollector{timeout};
+    const auto spInfo{ std::make_shared<SysInfo>() };
+    Syscollector sysCollector
+    {
+        spInfo,
+        "1m",
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+    };
     try
     {
         rsync_initialize(logFunction);


### PR DESCRIPTION
|Related issue|
|---|
|#6121|

Closes #6121 
## **Description**

This issue aims to make use of the generic synchronization libraries, to use the synchronization solution algorithm that both shared modules provide.

These changes have to be made in the various implementations according to the operating system targeted for this feature.

## **DoD**
- [X] Implementation
- [X] **Run testtool on Win**
![image](https://user-images.githubusercontent.com/54002291/98627677-86dd9d00-22f3-11eb-9fd0-a571f8024ba9.png)
- [X] **Run testtool on Linux**
![image](https://user-images.githubusercontent.com/54002291/98626878-804e2600-22f1-11eb-906e-877e0bd1b86e.png)
- [X] **RTR syscollector**
![image](https://user-images.githubusercontent.com/54002291/98628522-880fc980-22f5-11eb-906c-ecfaaa7ee4cb.png)







