### PR TITLE
[Framework] Add support to negate and type regex attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - **Framework:**
   - Refactored agent upgrade module. ([#5537](https://github.com/wazuh/wazuh/issues/5537))
   - Refactored agent upgrade CLI. ([#5675](https://github.com/wazuh/wazuh/issues/5675))
+  - Changed rule and decoder details structure. ([#6318](https://github.com/wazuh/wazuh/issues/6318))
 
 ### Fixed
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2795,14 +2795,14 @@ components:
           description: "Decoder definition fields"
           properties:
             program_name:
-              type: string
+              type: object
               nullable: true
             parent:
               type: string
             prematch:
-              type: string
+              type: object
             regex:
-              type: array
+              type: object
               items:
                 type: string
             order:
@@ -11171,7 +11171,8 @@ paths:
                       name: wazuh
                       position: 0
                       details:
-                        prematch: "^wazuh: "
+                        prematch:
+                          pattern: "^wazuh: "
                     - filename: 0005-wazuh_decoders.xml
                       relative_dirname: ruleset/decoders
                       status: enabled
@@ -11179,9 +11180,10 @@ paths:
                       position: 1
                       details:
                         parent: wazuh
-                        prematch: "^Agent buffer:"
+                        prematch:
+                          pattern: "^Agent buffer:"
                         regex:
-                          - "^ '(\\S+)'."
+                          pattern: "^ '(\\S+)'."
                         order: level
                   total_affected_items: 2
                   failed_items: []

--- a/framework/wazuh/core/tests/data/decoders/test3_decoders.xml
+++ b/framework/wazuh/core/tests/data/decoders/test3_decoders.xml
@@ -1,0 +1,17 @@
+<!--
+- JSON Decoders
+- Copyright (C) 2015-2019, Wazuh Inc.
+- April 21, 2017.
+-
+- This program is a free software; you can redistribute it
+- and/or modify it under the terms of the GNU General Public
+- License (version 2) as published by the FSF - Free Software
+- Foundation.
+-->
+
+<decoder name="test">
+  <program_name type="osregex">test_program_name</program_name>
+  <prematch>test_prematch</prematch>
+  <regex type="pcre2">test_regex</regex>
+  <order>test_order</order>
+</decoder>

--- a/framework/wazuh/core/tests/data/rules/9999-rules_regex_test.xml
+++ b/framework/wazuh/core/tests/data/rules/9999-rules_regex_test.xml
@@ -1,0 +1,21 @@
+<!--
+  -  Rules config
+  -  Author: Daniel Cid.
+  -  Updated by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  Copyright (C) 2009 Trend Micro Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+<var name="TEST_WILDCARD">this is a wildcard</var>
+
+<group name="dev">
+  <rule id="999999" level="5">
+    <id>$TEST_WILDCARD</id>
+    <field name="test_field_name" type="osmatch">test_field_value</field>
+    <match>test_match_1</match>
+    <match type="osregex">test_match_2</match>
+    <match negate="yes">test_match_3</match>
+    <regex type="osregex">test_regex</regex>
+    <description>description1</description>
+  </rule>
+</group>

--- a/framework/wazuh/core/tests/test_decoder.py
+++ b/framework/wazuh/core/tests/test_decoder.py
@@ -82,3 +82,25 @@ def test_load_decoders_from_file(filename, relative_dirname, status, permissions
     finally:
         # Set file permissions back to 777 after test if the file exists
         os.path.exists(full_file_path) and os.chmod(full_file_path, old_permissions)
+
+
+@patch('wazuh.core.common.ossec_path', new=test_data_path)
+def test_load_decoders_from_file_details():
+    decoder_file = 'test3_decoders.xml'
+    decoder_path = 'decoders'
+    details_result = {
+        'program_name': {
+            'pattern': 'test_program_name',
+            'type': 'osregex'
+        },
+        'prematch': {
+            'pattern': 'test_prematch'
+        },
+        'regex': {
+            'pattern': 'test_regex',
+            'type': 'pcre2'
+        },
+        'order': 'test_order'
+    }
+    result = decoder.load_decoders_from_file(decoder_file, decoder_path, 'enabled')
+    assert result[0]['details'] == details_result

--- a/framework/wazuh/core/tests/test_rule.py
+++ b/framework/wazuh/core/tests/test_rule.py
@@ -45,22 +45,6 @@ def test_add_detail(detail, value, details):
     assert value in details[detail]
 
 
-@pytest.mark.parametrize('detail, value, attribs, details', [
-    ('new', '4', {'attrib': 'attrib_value'}, {'actual': '3'}),
-    ('actual', '4', {'new_attrib': 'attrib_value', 'new_attrib2': 'whatever'}, {'actual': {'pattern': '3'}}),
-])
-def test_add_dynamic_detail(detail, value, attribs, details):
-    """Test add_dynamic_detail core rule function."""
-    rule.add_dynamic_detail(detail, value, attribs, details)
-    assert detail in details.keys()
-    if detail == next(iter(details.keys())):
-        assert details[detail]['pattern'].endswith(value)
-    else:
-        assert details[detail]['pattern'] == value
-    for key, value in attribs.items():
-        assert details[detail][key] == value
-
-
 @pytest.mark.parametrize('status, expected_result', [
     ('enabled', 'enabled'),
     ('disabled', 'disabled'),

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1487,3 +1487,19 @@ def test_get_files(mock_glob):
 
     assert 'etc/ossec.conf' in result
     assert all('/var/ossec' not in x for x in result)
+
+
+@pytest.mark.parametrize('detail, value, attribs, details', [
+    ('new', '4', {'attrib': 'attrib_value'}, {'actual': '3'}),
+    ('actual', '4', {'new_attrib': 'attrib_value', 'new_attrib2': 'whatever'}, {'actual': {'pattern': '3'}}),
+])
+def test_add_dynamic_detail(detail, value, attribs, details):
+    """Test add_dynamic_detail core rule function."""
+    add_dynamic_detail(detail, value, attribs, details)
+    assert detail in details.keys()
+    if detail == next(iter(details.keys())):
+        assert details[detail]['pattern'].endswith(value)
+    else:
+        assert details[detail]['pattern'] == value
+    for key, value in attribs.items():
+        assert details[detail][key] == value

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1475,6 +1475,7 @@ def test_select_array(select, required_fields, expected_result):
     except WazuhError as e:
         assert e.code == 1724
 
+
 @patch('wazuh.core.common.ossec_path', new='/var/ossec')
 @patch('wazuh.core.utils.glob.glob')
 def test_get_files(mock_glob):

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1384,3 +1384,28 @@ def get_files():
     files.add('etc/ossec.conf')
 
     return files
+
+
+def add_dynamic_detail(detail, value, attribs, details):
+    """Add a detail with attributes (i.e. regex with negate or type).
+
+    Parameters
+    ----------
+    detail : str
+        Name of the detail.
+    value : str
+        Detail value.
+    attribs : dict
+        Dictionary with the XML attributes.
+    details : dict
+        Dictionary with all the current details.
+    """
+    if detail in details:
+        new_pattern = details[detail]['pattern'] + value
+        details[detail].clear()
+        details[detail]['pattern'] = new_pattern
+    else:
+        details[detail] = dict()
+        details[detail]['pattern'] = value
+
+    details[detail].update(attribs)


### PR DESCRIPTION
Hello team, this closes #6318 .

With this PR the framework will parse the new attributes for some tags in rules and decoders and change their structure. These tags will be a dictionary now with at least the key `pattern` (its value). `type` and `negate` will be added in case the resource is not using their default values.

This PR implied changes in the rule, decoder and utils core framework modules, some refactor and new tests. An example of the new structure would be the following:

### Decoder
```xml
<decoder name="local_decoder_example">
  <program_name>demo</program_name>
  <regex type="pcre2">^Hello ([A-Za-z])</regex>
  <order>name</order>
</decoder>

```

### API response
```json
{
  "data": {
    "affected_items": [
      {
        "filename": "local_decoder.xml",
        "relative_dirname": "etc/decoders",
        "status": "enabled",
        "name": "local_decoder_example",
        "position": 0,
        "details": {
          "program_name": {
            "pattern": "demo"
          },
          "regex": {
            "pattern": "^Hello ([A-Za-z])",
            "type": "pcre2"
          },
          "order": "name"
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected decoders were returned",
  "error": 0
}
```

### Rules
```xml
<group name="dev">
 <rule id="111111" level="5">
    <field name="field_name">field1</field>
    <match>match1</match>
    <match>match2</match>
    <regex>regex1</regex>
    <description>description1</description>
  </rule>

  <rule id="222222" level="5">
    <field name="random_field_name" type="osmatch">field1</field>
    <match>match1</match>
    <match type="osregex">match2</match>
    <match negate="yes">match3</match>
    <regex type="osregex">regex1</regex>
    <description>description1</description>
  </rule>
</group>

```

### API response
```json
{
  "data": {
    "affected_items": [
      {
        "filename": "local_rules.xml",
        "relative_dirname": "etc/rules",
        "id": 111111,
        "level": 5,
        "status": "enabled",
        "details": {
          "field_name": {
            "pattern": "field1"
          },
          "match": {
            "pattern": "match1|match2"
          },
          "regex": {
            "pattern": "regex1"
          }
        },
        "pci_dss": [],
        "gpg13": [],
        "gdpr": [],
        "hipaa": [],
        "nist_800_53": [],
        "tsc": [],
        "mitre": [],
        "groups": [
          "dev"
        ],
        "description": "description1"
      },
      {
        "filename": "local_rules.xml",
        "relative_dirname": "etc/rules",
        "id": 222222,
        "level": 5,
        "status": "enabled",
        "details": {
          "random_field_name": {
            "pattern": "field1",
            "type": "osmatch"
          },
          "match": {
            "pattern": "match1match2match3",
            "negate": "yes"
          },
          "regex": {
            "pattern": "regex1",
            "type": "osregex"
          }
        },
        "pci_dss": [],
        "gpg13": [],
        "gdpr": [],
        "hipaa": [],
        "nist_800_53": [],
        "tsc": [],
        "mitre": [],
        "groups": [
          "dev"
        ],
        "description": "description1"
      }
    ],
    "total_affected_items": 2,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected rules were returned",
  "error": 0
}
```

# Tests performed
## Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /home/vicferpoy/env/unittest-env/bin/python3
cachedir: .pytest_cache
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0, cov-2.10.1
collected 244 items                                                                                                                                                                         

test_utils.py::test_previous_moth[1] PASSED                                                                                                                                           [  0%]
test_utils.py::test_previous_moth[2] PASSED                                                                                                                                           [  0%]
test_utils.py::test_previous_moth[-1] PASSED                                                                                                                                          [  1%]
test_utils.py::test_find_nth[string_1_-_-1-6] PASSED                                                                                                                                  [  1%]
test_utils.py::test_find_nth[string_2_-_-2-8] PASSED                                                                                                                                  [  2%]
test_utils.py::test_find_nth[string_3_-_-3--1] PASSED                                                                                                                                 [  2%]
test_utils.py::test_find_nth[string4-_-1--1] PASSED                                                                                                                                   [  2%]
test_utils.py::test_execute PASSED                                                                                                                                                    [  3%]
test_utils.py::test_execute_ko[error_effect0-1000] PASSED                                                                                                                             [  3%]
test_utils.py::test_execute_ko[Exception-1002] PASSED                                                                                                                                 [  4%]
test_utils.py::test_execute_ko[error_effect2-1003] PASSED                                                                                                                             [  4%]
test_utils.py::test_execute_ko[error_effect3-1004] PASSED                                                                                                                             [  4%]
test_utils.py::test_execute_ko[error_effect4-1004] PASSED                                                                                                                             [  5%]
test_utils.py::test_cut_array[array0-2] PASSED                                                                                                                                        [  5%]
test_utils.py::test_cut_array[array1-None] PASSED                                                                                                                                     [  6%]
test_utils.py::test_cut_array[array2-None] PASSED                                                                                                                                     [  6%]
test_utils.py::test_cut_array[array3-1] PASSED                                                                                                                                        [  6%]
test_utils.py::test_process_array[array0-3-None-None-] PASSED                                                                                                                         [  7%]
test_utils.py::test_process_array[array1-2-one-sort_by1-contains=one] PASSED                                                                                                          [  7%]
test_utils.py::test_process_array[array2-2-one-+-two=two] PASSED                                                                                                                      [  8%]
test_utils.py::test_cut_array_ko[11-0-1405] PASSED                                                                                                                                    [  8%]
test_utils.py::test_cut_array_ko[0-0-1406] PASSED                                                                                                                                     [  9%]
test_utils.py::test_cut_array_ko[5--1-1400] PASSED                                                                                                                                    [  9%]
test_utils.py::test_cut_array_ko[-1-0-1401] PASSED                                                                                                                                    [  9%]
test_utils.py::test_sort_array_type PASSED                                                                                                                                            [ 10%]
test_utils.py::test_sort_array_error[array0-None-asc-1402] PASSED                                                                                                                     [ 10%]
test_utils.py::test_sort_array_error[{}-None-random-1402] PASSED                                                                                                                      [ 11%]
test_utils.py::test_sort_array_error[array2-sort_by2-False-1403] PASSED                                                                                                               [ 11%]
test_utils.py::test_sort_array[-None-True-None-] PASSED                                                                                                                               [ 11%]
test_utils.py::test_sort_array[array1-None-True-None-output1] PASSED                                                                                                                  [ 12%]
test_utils.py::test_sort_array[array2-None-False-None-output2] PASSED                                                                                                                 [ 12%]
test_utils.py::test_sort_array[array3-sort_by3-True-allowed_sort_field3-output3] PASSED                                                                                               [ 13%]
test_utils.py::test_sort_array[array4-sort_by4-False-allowed_sort_field4-output4] PASSED                                                                                              [ 13%]
test_utils.py::test_get_values[object0-None] PASSED                                                                                                                                   [ 13%]
test_utils.py::test_get_values[object1-fields1] PASSED                                                                                                                                [ 14%]
test_utils.py::test_get_values[object2-None] PASSED                                                                                                                                   [ 14%]
test_utils.py::test_get_values[object3-None] PASSED                                                                                                                                   [ 15%]
test_utils.py::test_search_array[array0-e-False-2] PASSED                                                                                                                             [ 15%]
test_utils.py::test_search_array[array1-name-False-1] PASSED                                                                                                                          [ 15%]
test_utils.py::test_search_array[array2-unknown-False-0] PASSED                                                                                                                       [ 16%]
test_utils.py::test_search_array[array3-test-True-1] PASSED                                                                                                                           [ 16%]
test_utils.py::test_search_array[array4-unknown-True-2] PASSED                                                                                                                        [ 17%]
test_utils.py::test_filemode PASSED                                                                                                                                                   [ 17%]
test_utils.py::test_tail PASSED                                                                                                                                                       [ 18%]
test_utils.py::test_chmod_r PASSED                                                                                                                                                    [ 18%]
test_utils.py::test_chown_r PASSED                                                                                                                                                    [ 18%]
test_utils.py::test_safe_move[ownership0-None-None] PASSED                                                                                                                            [ 19%]
test_utils.py::test_safe_move[ownership1-time1-None] PASSED                                                                                                                           [ 19%]
test_utils.py::test_safe_move[ownership2-None-432] PASSED                                                                                                                             [ 20%]
test_utils.py::test_safe_move[ownership3-time3-432] PASSED                                                                                                                            [ 20%]
test_utils.py::test_safe_move_exception PASSED                                                                                                                                        [ 20%]
test_utils.py::test_mkdir_with_mode[/var/test_path-True] PASSED                                                                                                                       [ 21%]
test_utils.py::test_mkdir_with_mode[./var/test_path/-False] PASSED                                                                                                                    [ 21%]
test_utils.py::test_mkdir_with_mode_ko[/var/test_path-True] PASSED                                                                                                                    [ 22%]
test_utils.py::test_mkdir_with_mode_ko[/var/test_path/-False] PASSED                                                                                                                  [ 22%]
test_utils.py::test_md5 PASSED                                                                                                                                                        [ 22%]
test_utils.py::test_protected_get_hashing_algorithm_ko PASSED                                                                                                                         [ 23%]
test_utils.py::test_get_hash PASSED                                                                                                                                                   [ 23%]
test_utils.py::test_get_hash_ko PASSED                                                                                                                                                [ 24%]
test_utils.py::test_get_hash_str PASSED                                                                                                                                               [ 24%]
test_utils.py::test_get_fields_to_nest PASSED                                                                                                                                         [ 25%]
test_utils.py::test_plain_dict_to_nested_dict PASSED                                                                                                                                  [ 25%]
test_utils.py::test_load_wazuh_xml PASSED                                                                                                                                             [ 25%]
test_utils.py::test_version_ok[Wazuh v3.5.0-Wazuh v3.5.2] PASSED                                                                                                                      [ 26%]
test_utils.py::test_version_ok[Wazuh v3.6.1-Wazuh v3.6.3] PASSED                                                                                                                      [ 26%]
test_utils.py::test_version_ok[Wazuh v3.7.2-Wazuh v3.8.0] PASSED                                                                                                                      [ 27%]
test_utils.py::test_version_ok[Wazuh v3.8.0-Wazuh v3.8.1] PASSED                                                                                                                      [ 27%]
test_utils.py::test_version_ok[Wazuh v3.9.0-Wazuh v3.9.2] PASSED                                                                                                                      [ 27%]
test_utils.py::test_version_ok[Wazuh v3.9.10-Wazuh v3.9.14] PASSED                                                                                                                    [ 28%]
test_utils.py::test_version_ok[Wazuh v3.10.1-Wazuh v3.10.10] PASSED                                                                                                                   [ 28%]
test_utils.py::test_version_ok[Wazuh v4.10.10-Wazuh v4.11.0] PASSED                                                                                                                   [ 29%]
test_utils.py::test_version_ok[Wazuh v5.1.15-Wazuh v5.2.0] PASSED                                                                                                                     [ 29%]
test_utils.py::test_version_ok[v3.6.0-v3.6.1] PASSED                                                                                                                                  [ 29%]
test_utils.py::test_version_ok[v3.9.1-v3.9.2] PASSED                                                                                                                                  [ 30%]
test_utils.py::test_version_ok[v4.0.0-v4.0.1] PASSED                                                                                                                                  [ 30%]
test_utils.py::test_version_ok[3.6.0-3.6.1] PASSED                                                                                                                                    [ 31%]
test_utils.py::test_version_ok[3.9.0-3.9.2] PASSED                                                                                                                                    [ 31%]
test_utils.py::test_version_ok[4.0.0-4.0.1] PASSED                                                                                                                                    [ 31%]
test_utils.py::test_version_ko[v3.6.0-v.3.6.1] PASSED                                                                                                                                 [ 32%]
test_utils.py::test_version_ko[Wazuh v4-Wazuh v5] PASSED                                                                                                                              [ 32%]
test_utils.py::test_version_ko[Wazuh v3.9-Wazuh v3.10] PASSED                                                                                                                         [ 33%]
test_utils.py::test_version_ko[ABC v3.10.1-ABC v3.10.12] PASSED                                                                                                                       [ 33%]
test_utils.py::test_version_ko[Wazuhv3.9.0-Wazuhv3.9.2] PASSED                                                                                                                        [ 34%]
test_utils.py::test_version_ko[3.9-3.10] PASSED                                                                                                                                       [ 34%]
test_utils.py::test_version_ko[3.9.0-3.10] PASSED                                                                                                                                     [ 34%]
test_utils.py::test_version_ko[3.10-4.2] PASSED                                                                                                                                       [ 35%]
test_utils.py::test_version_ko[3-3.9.1] PASSED                                                                                                                                        [ 35%]
test_utils.py::test_same_version[Wazuh v3.10.10-Wazuh v3.10.10] PASSED                                                                                                                [ 36%]
test_utils.py::test_same_version[Wazuh v5.1.15-Wazuh v5.1.15] PASSED                                                                                                                  [ 36%]
test_utils.py::test_same_version[v3.6.0-v3.6.0] PASSED                                                                                                                                [ 36%]
test_utils.py::test_same_version[v3.9.2-v3.9.2] PASSED                                                                                                                                [ 37%]
test_utils.py::test_WazuhVersion_to_array PASSED                                                                                                                                      [ 37%]
test_utils.py::test_WazuhVersion__str__ PASSED                                                                                                                                        [ 38%]
test_utils.py::test_WazuhVersion__ge__[Wazuh v3.5.2-Wazuh v4.0.0] PASSED                                                                                                              [ 38%]
test_utils.py::test_WazuhVersion__ge__[Wazuh v3.10.0-alpha-Wazuh v3.10.0] PASSED                                                                                                      [ 38%]
test_utils.py::test_WazuhVersion__ge__[Wazuh v3.10.0-alpha4-Wazuh v3.10.0-beta4] PASSED                                                                                               [ 39%]
test_utils.py::test_WazuhVersion__ge__[Wazuh v3.10.0-alpha3-Wazuh v3.10.0-alpha4] PASSED                                                                                              [ 39%]
test_utils.py::test_get_timeframe_in_seconds[10s] PASSED                                                                                                                              [ 40%]
test_utils.py::test_get_timeframe_in_seconds[20m] PASSED                                                                                                                              [ 40%]
test_utils.py::test_get_timeframe_in_seconds[30h] PASSED                                                                                                                              [ 40%]
test_utils.py::test_get_timeframe_in_seconds[5d] PASSED                                                                                                                               [ 41%]
test_utils.py::test_get_timeframe_in_seconds[10] PASSED                                                                                                                               [ 41%]
test_utils.py::test_failed_test_get_timeframe_in_seconds PASSED                                                                                                                       [ 42%]
test_utils.py::test_WazuhDBQuery__init__[True] PASSED                                                                                                                                 [ 42%]
test_utils.py::test_WazuhDBQuery__init__[False] PASSED                                                                                                                                [ 43%]
test_utils.py::test_WazuhDBQuery_protected_clean_filter[query_filter0-expected_query_filter0-expected_wef0] PASSED                                                                    [ 43%]
test_utils.py::test_WazuhDBQuery_protected_clean_filter[query_filter1-expected_query_filter1-expected_wef1] PASSED                                                                    [ 43%]
test_utils.py::test_WazuhDBQuery_protected_add_limit_to_query[1-False-None] PASSED                                                                                                    [ 44%]
test_utils.py::test_WazuhDBQuery_protected_add_limit_to_query[0-True-1406] PASSED                                                                                                     [ 44%]
test_utils.py::test_WazuhDBQuery_protected_add_limit_to_query[100-True-1405] PASSED                                                                                                   [ 45%]
test_utils.py::test_WazuhDBQuery_protected_sort_query PASSED                                                                                                                          [ 45%]
test_utils.py::test_WazuhDBQuery_protected_add_sort_to_query[None-False-None] PASSED                                                                                                  [ 45%]
test_utils.py::test_WazuhDBQuery_protected_add_sort_to_query[sort1-False-None] PASSED                                                                                                 [ 46%]
test_utils.py::test_WazuhDBQuery_protected_add_sort_to_query[sort2-False-None] PASSED                                                                                                 [ 46%]
test_utils.py::test_WazuhDBQuery_protected_add_sort_to_query[sort3-True-1403] PASSED                                                                                                  [ 47%]
test_utils.py::test_WazuhDBQuery_protected_add_search_to_query PASSED                                                                                                                 [ 47%]
test_utils.py::test_WazuhDBQuery_protected_parse_select_filter[None-False-None] PASSED                                                                                                [ 47%]
test_utils.py::test_WazuhDBQuery_protected_parse_select_filter[selector_fields1-False-None] PASSED                                                                                    [ 48%]
test_utils.py::test_WazuhDBQuery_protected_parse_select_filter[selector_fields2-True-1724] PASSED                                                                                     [ 48%]
test_utils.py::test_WazuhDBQuery_protected_add_select_to_query PASSED                                                                                                                 [ 49%]
test_utils.py::test_WazuhDBQuery_protected_parse_query[os.name=ubuntu;os.version>12e-False-None] PASSED                                                                               [ 49%]
test_utils.py::test_WazuhDBQuery_protected_parse_query[os.name=debian;os.version>12e),(os.name=ubuntu;os.version>12e)-False-None] PASSED                                              [ 50%]
test_utils.py::test_WazuhDBQuery_protected_parse_query[bad_query-True-1407] PASSED                                                                                                    [ 50%]
test_utils.py::test_WazuhDBQuery_protected_parse_query[os.bad_field=ubuntu-True-1408] PASSED                                                                                          [ 50%]
test_utils.py::test_WazuhDBQuery_protected_parse_query[os.name=!ubuntu-True-1409] PASSED                                                                                              [ 51%]
test_utils.py::test_WazuhDBQuery_protected_parse_legacy_filters[filter_0] PASSED                                                                                                      [ 51%]
test_utils.py::test_WazuhDBQuery_protected_parse_legacy_filters[filter_1] PASSED                                                                                                      [ 52%]
test_utils.py::test_WazuhDBQuery_parse_filters[filter0-os.name=ubuntu] PASSED                                                                                                         [ 52%]
test_utils.py::test_WazuhDBQuery_parse_filters[filter1-os.version>12e] PASSED                                                                                                         [ 52%]
test_utils.py::test_WazuhDBQuery_protected_process_filter[status-None-None] PASSED                                                                                                    [ 53%]
test_utils.py::test_WazuhDBQuery_protected_process_filter[date1-None-q_filter1] PASSED                                                                                                [ 53%]
test_utils.py::test_WazuhDBQuery_protected_process_filter[os.name-field-q_filter2] PASSED                                                                                             [ 54%]
test_utils.py::test_WazuhDBQuery_protected_process_filter[os.name-None-q_filter3] PASSED                                                                                              [ 54%]
test_utils.py::test_WazuhDBQuery_protected_process_filter[os.name-field-q_filter4] PASSED                                                                                             [ 54%]
test_utils.py::test_WazuhDBQuery_protected_add_filters_to_query PASSED                                                                                                                [ 55%]
test_utils.py::test_WazuhDBQuery_protected_get_total_items PASSED                                                                                                                     [ 55%]
test_utils.py::test_WazuhDBQuery_protected_get_total_items_mitre PASSED                                                                                                               [ 56%]
test_utils.py::test_WazuhDBQuery_substitute_params PASSED                                                                                                                             [ 56%]
test_utils.py::test_WazuhDBQuery_protected_get_data PASSED                                                                                                                            [ 56%]
test_utils.py::test_WazuhDBQuery_protected_format_data_into_dictionary PASSED                                                                                                         [ 57%]
test_utils.py::test_WazuhDBQuery_protected_filter_status PASSED                                                                                                                       [ 57%]
test_utils.py::test_WazuhDBQuery_protected_filter_date[date_filter0-os.name-10-False] PASSED                                                                                          [ 58%]
test_utils.py::test_WazuhDBQuery_protected_filter_date[date_filter1-os.name-10-False] PASSED                                                                                          [ 58%]
test_utils.py::test_WazuhDBQuery_protected_filter_date[date_filter2-os.name-10-True] PASSED                                                                                           [ 59%]
test_utils.py::test_WazuhDBQuery_general_run[execute_value0-expected_result0] PASSED                                                                                                  [ 59%]
test_utils.py::test_WazuhDBQuery_general_run[execute_value1-expected_result1] PASSED                                                                                                  [ 59%]
test_utils.py::test_WazuhDBQuery_general_run[execute_value2-expected_result2] PASSED                                                                                                  [ 60%]
test_utils.py::test_WazuhDBQuery_oversized_run[execute_value0-rbac_ids0-False-final_rbac_ids0-expected_result0] PASSED                                                                [ 60%]
test_utils.py::test_WazuhDBQuery_oversized_run[execute_value1-rbac_ids1-True-final_rbac_ids1-expected_result1] PASSED                                                                 [ 61%]
test_utils.py::test_WazuhDBQuery_oversized_run[execute_value2-rbac_ids2-True-final_rbac_ids2-expected_result2] PASSED                                                                 [ 61%]
test_utils.py::test_WazuhDBQuery_reset PASSED                                                                                                                                         [ 61%]
test_utils.py::test_WazuhDBQuery_protected_default_query PASSED                                                                                                                       [ 62%]
test_utils.py::test_WazuhDBQuery_protected_default_count_query PASSED                                                                                                                 [ 62%]
test_utils.py::test_WazuhDBQuery_protected_pass_filter[all] PASSED                                                                                                                    [ 63%]
test_utils.py::test_WazuhDBQuery_protected_pass_filter[other_filter] PASSED                                                                                                           [ 63%]
test_utils.py::test_WazuhDBQueryDistinct_protected_default_query PASSED                                                                                                               [ 63%]
test_utils.py::test_WazuhDBQueryDistinct_protected_default_count_query PASSED                                                                                                         [ 64%]
test_utils.py::test_WazuhDBQueryDistinct_protected_add_filters_to_query PASSED                                                                                                        [ 64%]
test_utils.py::test_WazuhDBQueryDistinct_protected_add_select_to_query[select0] PASSED                                                                                                [ 65%]
test_utils.py::test_WazuhDBQueryDistinct_protected_add_select_to_query[select1] PASSED                                                                                                [ 65%]
test_utils.py::test_WazuhDBQueryDistinct_protected_format_data_into_dictionary PASSED                                                                                                 [ 65%]
test_utils.py::test_WazuhDBQueryGroupBy__init__ PASSED                                                                                                                                [ 66%]
test_utils.py::test_WazuhDBQueryGroupBy_protected_get_total_items PASSED                                                                                                              [ 66%]
test_utils.py::test_WazuhDBQueryGroupBy_protected_add_select_to_query PASSED                                                                                                          [ 67%]
test_utils.py::test_filter_array_by_query[name=firewall-0] PASSED                                                                                                                     [ 67%]
test_utils.py::test_filter_array_by_query[count=1-0] PASSED                                                                                                                           [ 68%]
test_utils.py::test_filter_array_by_query[name~a-3] PASSED                                                                                                                            [ 68%]
test_utils.py::test_filter_array_by_query[count<0-0] PASSED                                                                                                                           [ 68%]
test_utils.py::test_filter_array_by_query[count>3-0] PASSED                                                                                                                           [ 69%]
test_utils.py::test_filter_array_by_query[count=3;name~test-0] PASSED                                                                                                                 [ 69%]
test_utils.py::test_filter_array_by_query[count!=0;count!=3-0] PASSED                                                                                                                 [ 70%]
test_utils.py::test_filter_array_by_query[wrong_param=default-0] PASSED                                                                                                               [ 70%]
test_utils.py::test_filter_array_by_query[wrong_param!=default-0] PASSED                                                                                                              [ 70%]
test_utils.py::test_filter_array_by_query[wrong_param2~test-0] PASSED                                                                                                                 [ 71%]
test_utils.py::test_filter_array_by_query[name~test;mergedSum~2acdb-1] PASSED                                                                                                         [ 71%]
test_utils.py::test_filter_array_by_query[name=dmz-1] PASSED                                                                                                                          [ 72%]
test_utils.py::test_filter_array_by_query[name~def-1] PASSED                                                                                                                          [ 72%]
test_utils.py::test_filter_array_by_query[count=3-1] PASSED                                                                                                                           [ 72%]
test_utils.py::test_filter_array_by_query[count>2-1] PASSED                                                                                                                           [ 73%]
test_utils.py::test_filter_array_by_query[count>0-1] PASSED                                                                                                                           [ 73%]
test_utils.py::test_filter_array_by_query[count!=0-1] PASSED                                                                                                                          [ 74%]
test_utils.py::test_filter_array_by_query[name~test;mergedSum~2acdb,name=dmz-2] PASSED                                                                                                [ 74%]
test_utils.py::test_filter_array_by_query[name=dmz,name=default-2] PASSED                                                                                                             [ 75%]
test_utils.py::test_filter_array_by_query[name~test-2] PASSED                                                                                                                         [ 75%]
test_utils.py::test_filter_array_by_query[count<3;name~test-2] PASSED                                                                                                                 [ 75%]
test_utils.py::test_filter_array_by_query[name~d-2] PASSED                                                                                                                            [ 76%]
test_utils.py::test_filter_array_by_query[name!=dmz;name!=default-2] PASSED                                                                                                           [ 76%]
test_utils.py::test_filter_array_by_query[count=0;name!=dmz-2] PASSED                                                                                                                 [ 77%]
test_utils.py::test_filter_array_by_query[count=0-3] PASSED                                                                                                                           [ 77%]
test_utils.py::test_filter_array_by_query[count<3-3] PASSED                                                                                                                           [ 77%]
test_utils.py::test_filter_array_by_query[count<1-3] PASSED                                                                                                                           [ 78%]
test_utils.py::test_filter_array_by_query[count!=3-3] PASSED                                                                                                                          [ 78%]
test_utils.py::test_filter_array_by_query[count>10,count<3-3] PASSED                                                                                                                  [ 79%]
test_utils.py::test_filter_array_by_query[configSum~29,count=3-3] PASSED                                                                                                              [ 79%]
test_utils.py::test_filter_array_by_query[name~test,count>0-3] PASSED                                                                                                                 [ 79%]
test_utils.py::test_filter_array_by_query[count<4-4] PASSED                                                                                                                           [ 80%]
test_utils.py::test_filter_array_by_query[count>0,count<4-4] PASSED                                                                                                                   [ 80%]
test_utils.py::test_filter_array_by_query[name~def,count=0-4] PASSED                                                                                                                  [ 81%]
test_utils.py::test_filter_array_by_query[configSum~29,configSum~ab-4] PASSED                                                                                                         [ 81%]
test_utils.py::test_filter_array_by_query[nameGfirewall--1] PASSED                                                                                                                    [ 81%]
test_utils.py::test_select_array[select0-required_fields0-expected_result0] PASSED                                                                                                    [ 82%]
test_utils.py::test_select_array[select1-None-None] PASSED                                                                                                                            [ 82%]
test_utils.py::test_select_array[select2-None-None] PASSED                                                                                                                            [ 83%]
test_utils.py::test_get_files PASSED                                                                                                                                                  [ 83%]
test_utils.py::test_add_dynamic_detail[new-4-attribs0-details0] PASSED                                                                                                                [ 84%]
test_utils.py::test_add_dynamic_detail[actual-4-attribs1-details1] PASSED                                                                                                             [ 84%]
test_rule.py::test_add_detail[new-4-details0] PASSED                                                                                                                                  [ 84%]
test_rule.py::test_add_detail[actual-4-details1] PASSED                                                                                                                               [ 85%]
test_rule.py::test_check_status[enabled-enabled] PASSED                                                                                                                               [ 85%]
test_rule.py::test_check_status[disabled-disabled] PASSED                                                                                                                             [ 86%]
test_rule.py::test_check_status[all-all0] PASSED                                                                                                                                      [ 86%]
test_rule.py::test_check_status[all-all1] PASSED                                                                                                                                      [ 86%]
test_rule.py::test_check_status[None-all] PASSED                                                                                                                                      [ 87%]
test_rule.py::test_check_status[unexistent-expected_result5] PASSED                                                                                                                   [ 87%]
test_rule.py::test_load_rules_from_file[0010-rules_config.xml-tests/data/rules-enabled-None] PASSED                                                                                   [ 88%]
test_rule.py::test_load_rules_from_file[0015-ossec_rules.xml-tests/data/rules-enabled-None] PASSED                                                                                    [ 88%]
test_rule.py::test_load_rules_from_file[0225-mcafee_av_rules.xml-tests/data/rules-enabled-None] PASSED                                                                                [ 88%]
test_rule.py::test_load_rules_from_file[0260-nginx_rules.xml-tests/data/rules-enabled-None] PASSED                                                                                    [ 89%]
test_rule.py::test_load_rules_from_file[0350-amazon_rules.xml-tests/data/rules-enabled-None] PASSED                                                                                   [ 89%]
test_rule.py::test_load_rules_from_file[noexists.xml-tests/data/rules-enabled-exception5] PASSED                                                                                      [ 90%]
test_rule.py::test_load_rules_from_file_details PASSED                                                                                                                                [ 90%]
test_rule.py::test_load_rules_from_file_permissions PASSED                                                                                                                            [ 90%]
test_rule.py::test_load_rules_from_file_unknown PASSED                                                                                                                                [ 91%]
test_rule.py::test_remove_files[tmp_data0-parameters0-expected_result0] PASSED                                                                                                        [ 91%]
test_rule.py::test_remove_files[tmp_data1-parameters1-expected_result1] PASSED                                                                                                        [ 92%]
test_rule.py::test_format_rule_decoder_file[0015-ossec_rules.xml-etc/rules-enabled] PASSED                                                                                            [ 92%]
test_rule.py::test_format_rule_decoder_file[0350-amazon_rules.xml-etc/rules-enabled] PASSED                                                                                           [ 93%]
test_rule.py::test_set_groups[groups0-general_groups0] PASSED                                                                                                                         [ 93%]
test_decoder.py::test_add_detail[parent-wazuh-details0-expected_result0] PASSED                                                                                                       [ 93%]
test_decoder.py::test_add_detail[prematch-^Agent buffer:-details1-expected_result1] PASSED                                                                                            [ 94%]
test_decoder.py::test_add_detail[regex-regex01-details2-expected_result2] PASSED                                                                                                      [ 94%]
test_decoder.py::test_add_detail[regex-regex02-details3-expected_result3] PASSED                                                                                                      [ 95%]
test_decoder.py::test_add_detail[order-level-details4-expected_result4] PASSED                                                                                                        [ 95%]
test_decoder.py::test_check_status[None-all] PASSED                                                                                                                                   [ 95%]
test_decoder.py::test_check_status[all-all] PASSED                                                                                                                                    [ 96%]
test_decoder.py::test_check_status[enabled-enabled] PASSED                                                                                                                            [ 96%]
test_decoder.py::test_check_status[disabled-disabled] PASSED                                                                                                                          [ 97%]
test_decoder.py::test_check_status[wrong-expected_result4] PASSED                                                                                                                     [ 97%]
test_decoder.py::test_load_decoders_from_file[test1_decoders.xml-decoders-all-777-None] PASSED                                                                                        [ 97%]
test_decoder.py::test_load_decoders_from_file[test2_decoders.xml-decoders-enabled-777-None] PASSED                                                                                    [ 98%]
test_decoder.py::test_load_decoders_from_file[wrong_decoders.xml-decoders-all-777-exception2] PASSED                                                                                  [ 98%]
test_decoder.py::test_load_decoders_from_file[non_existing.xml-decoders-disabled-777-exception3] PASSED                                                                               [ 99%]
test_decoder.py::test_load_decoders_from_file[test1_decoders.xml-decoders-all-0-exception4] PASSED                                                                                    [ 99%]
test_decoder.py::test_load_decoders_from_file_details PASSED                                                                                                                          [100%]

==================================================================================== 244 passed in 0.76s ====================================================================================
```

## Integration tests
```
test_decoders_endpoints
	 1 failed, 22 passed, 29 warnings

test_rbac_black_decoders_endpoints
	 4 passed, 6 warnings

test_rbac_black_rules_endpoints
	 6 passed, 8 warnings

test_rbac_white_decoders_endpoints
	 4 passed, 6 warnings

test_rbac_white_rules_endpoints
	 6 passed, 8 warnings

test_rules_endpoints
	 13 passed, 15 warnings

```

One of the `GET /decoders` integration tests is failing due to a lack of functionality in the `q` parameter for the `process_array` function. This will be fixed in another issue.

Regards,
Víctor.