### PR TITLE
Fix unit tests for analysisd_syscheck for registry scan

### DIFF
--- a/src/unit_tests/analysisd/test_analysisd_syscheck.c
+++ b/src/unit_tests/analysisd/test_analysisd_syscheck.c
@@ -121,6 +121,102 @@ static int teardown_fim_event_cjson(void **state) {
     return 0;
 }
 
+static int setup_event_info(void **state) {
+    Eventinfo *lf = calloc(1, sizeof(Eventinfo));
+    if(lf == NULL)
+        return -1;
+    if(lf->fields = calloc(FIM_NFIELDS, sizeof(DynamicField)), lf->fields == NULL)
+        return -1;
+
+    lf->nfields = FIM_NFIELDS;
+
+    if(lf->decoder_info = calloc(1, sizeof(OSDecoderInfo)), lf->decoder_info == NULL)
+        return -1;
+    if(lf->decoder_info->fields = calloc(FIM_NFIELDS, sizeof(char*)), lf->decoder_info->fields == NULL)
+        return -1;
+    if(lf->full_log = calloc(OS_MAXSTR, sizeof(char)), lf->full_log == NULL)
+        return -1;
+
+    if(lf->decoder_info->fields[FIM_FILE] = strdup("file"), lf->decoder_info->fields[FIM_FILE] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_HARD_LINKS] = strdup("hard_links"), lf->decoder_info->fields[FIM_HARD_LINKS] == NULL)
+        return -1;
+    if (lf->decoder_info->fields[FIM_MODE] = strdup("mode"), lf->decoder_info->fields[FIM_MODE] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_SIZE] = strdup("size"), lf->decoder_info->fields[FIM_SIZE] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_PERM] = strdup("perm"), lf->decoder_info->fields[FIM_PERM] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_UID] = strdup("uid"), lf->decoder_info->fields[FIM_UID] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_GID] = strdup("gid"), lf->decoder_info->fields[FIM_GID] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_MD5] = strdup("md5"), lf->decoder_info->fields[FIM_MD5] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_SHA1] = strdup("sha1"), lf->decoder_info->fields[FIM_SHA1] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_UNAME] = strdup("uname"), lf->decoder_info->fields[FIM_UNAME] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_GNAME] = strdup("gname"), lf->decoder_info->fields[FIM_GNAME] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_MTIME] = strdup("mtime"), lf->decoder_info->fields[FIM_MTIME] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_INODE] = strdup("inode"), lf->decoder_info->fields[FIM_INODE] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_SHA256] = strdup("sha256"), lf->decoder_info->fields[FIM_SHA256] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_DIFF] = strdup("diff"), lf->decoder_info->fields[FIM_DIFF] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_ATTRS] = strdup("attrs"), lf->decoder_info->fields[FIM_ATTRS] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_CHFIELDS] = strdup("chfields"), lf->decoder_info->fields[FIM_CHFIELDS] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_USER_ID] = strdup("user_id"), lf->decoder_info->fields[FIM_USER_ID] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_USER_NAME] = strdup("user_name"), lf->decoder_info->fields[FIM_USER_NAME] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_GROUP_ID] = strdup("group_id"), lf->decoder_info->fields[FIM_GROUP_ID] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_GROUP_NAME] = strdup("group_name"), lf->decoder_info->fields[FIM_GROUP_NAME] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_PROC_NAME] = strdup("proc_name"), lf->decoder_info->fields[FIM_PROC_NAME] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_AUDIT_ID] = strdup("audit_id"), lf->decoder_info->fields[FIM_AUDIT_ID] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_AUDIT_NAME] = strdup("audit_name"), lf->decoder_info->fields[FIM_AUDIT_NAME] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_EFFECTIVE_UID] = strdup("effective_uid"), lf->decoder_info->fields[FIM_EFFECTIVE_UID] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_EFFECTIVE_NAME] = strdup("effective_name"), lf->decoder_info->fields[FIM_EFFECTIVE_NAME] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_PPID] = strdup("ppid"), lf->decoder_info->fields[FIM_PPID] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_PROC_ID] = strdup("proc_id"), lf->decoder_info->fields[FIM_PROC_ID] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_TAG] = strdup("tag"), lf->decoder_info->fields[FIM_TAG] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_SYM_PATH] = strdup("sym_path"), lf->decoder_info->fields[FIM_SYM_PATH] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_AUDIT_CWD] = strdup("cwd"), lf->decoder_info->fields[FIM_AUDIT_CWD] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_PROC_PNAME] = strdup("parent_name"), lf->decoder_info->fields[FIM_PROC_PNAME] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_AUDIT_PCWD] = strdup("parent_cwd"), lf->decoder_info->fields[FIM_AUDIT_PCWD] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_REGISTRY_ARCH] = strdup("arch"), lf->decoder_info->fields[FIM_REGISTRY_ARCH] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_REGISTRY_VALUE_NAME] = strdup("value_name"), lf->decoder_info->fields[FIM_REGISTRY_VALUE_NAME] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_REGISTRY_VALUE_TYPE] = strdup("value_type"), lf->decoder_info->fields[FIM_REGISTRY_VALUE_TYPE] == NULL)
+        return -1;
+    if(lf->decoder_info->fields[FIM_ENTRY_TYPE] = strdup("entry_type"), lf->decoder_info->fields[FIM_ENTRY_TYPE] == NULL)
+        return -1;
+
+    *state = lf;
+
+    return 0;
+}
+
 static int setup_fim_data(void **state) {
     fim_data_t *data;
     const char *plain_event = "{\"type\":\"event\","
@@ -194,94 +290,111 @@ static int setup_fim_data(void **state) {
     if(data->event == NULL)
         return -1;
 
-    if(data->lf = calloc(1, sizeof(Eventinfo)), data->lf == NULL)
+    if (setup_event_info((void **)&data->lf) != 0) {
         return -1;
-    if(data->lf->fields = calloc(FIM_NFIELDS, sizeof(DynamicField)), data->lf->fields == NULL)
+    }
+
+    if (fim_init() != 1)
         return -1;
 
-    data->lf->nfields = FIM_NFIELDS;
+    *state = data;
 
-    if(data->lf->decoder_info = calloc(1, sizeof(OSDecoderInfo)), data->lf->decoder_info == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields = calloc(FIM_NFIELDS, sizeof(char*)), data->lf->decoder_info->fields == NULL)
-        return -1;
-    if(data->lf->full_log = calloc(OS_MAXSTR, sizeof(char)), data->lf->full_log == NULL)
+    return 0;
+}
+
+static int setup_registry_key_data(void **state) {
+    fim_data_t *data;
+    const char *plain_event = "{\"type\":\"event\","
+        "\"data\":{"
+            "\"path\":\"HKEY_LOCAL_MACHINE\\\\software\\\\test\","
+            "\"arch\":\"[x64]\","
+            "\"mode\":\"scheduled\","
+            "\"type\":\"added\","
+            "\"timestamp\":123456789,"
+            "\"changed_attributes\":["
+                "\"permission\",\"uid\","
+                "\"user_name\",\"gid\",\"group_name\","
+                "\"mtime\"],"
+            "\"tags\":\"tags\","
+            "\"old_attributes\":{"
+                "\"type\":\"registry_key\","
+                "\"perm\":\"old_perm\","
+                "\"user_name\":\"old_user_name\","
+                "\"group_name\":\"old_group_name\","
+                "\"uid\":\"old_uid\","
+                "\"gid\":\"old_gid\","
+                "\"mtime\":3456,"
+                "\"checksum\":\"old_checksum\"},"
+            "\"attributes\":{"
+                "\"type\":\"registry_key\","
+                "\"perm\":\"perm\","
+                "\"user_name\":\"user_name\","
+                "\"group_name\":\"group_name\","
+                "\"uid\":\"uid\","
+                "\"gid\":\"gid\","
+                "\"mtime\":6789,"
+                "\"checksum\":\"checksum\"}}}";
+
+    if(data = calloc(1, sizeof(fim_data_t)), data == NULL)
         return -1;
 
-    if(data->lf->decoder_info->fields[FIM_FILE] = strdup("file"), data->lf->decoder_info->fields[FIM_FILE] == NULL)
+    data->event = cJSON_Parse(plain_event);
+
+    if(data->event == NULL)
         return -1;
-    if(data->lf->decoder_info->fields[FIM_HARD_LINKS] = strdup("hard_links"), data->lf->decoder_info->fields[FIM_HARD_LINKS] == NULL)
+
+    if (setup_event_info((void **)&data->lf) != 0) {
         return -1;
-    if (data->lf->decoder_info->fields[FIM_MODE] = strdup("mode"), data->lf->decoder_info->fields[FIM_MODE] == NULL)
+    }
+
+    if (fim_init() != 1)
         return -1;
-    if(data->lf->decoder_info->fields[FIM_SIZE] = strdup("size"), data->lf->decoder_info->fields[FIM_SIZE] == NULL)
+
+    *state = data;
+
+    return 0;
+}
+
+static int setup_registry_value_data(void **state) {
+    fim_data_t *data;
+    const char *plain_event = "{\"type\":\"event\","
+        "\"data\":{"
+            "\"path\":\"HKEY_LOCAL_MACHINE\\\\software\\\\test\","
+            "\"arch\":\"[x64]\","
+            "\"value_name\":\"some:value\","
+            "\"value_type\":\"REG_SZ\","
+            "\"mode\":\"scheduled\","
+            "\"type\":\"added\","
+            "\"timestamp\":123456789,"
+            "\"changed_attributes\":["
+                "\"size\",\"md5\",\"sha1\",\"sha256\"],"
+            "\"tags\":\"tags\","
+            "\"old_attributes\":{"
+                "\"type\":\"registry_value\","
+                "\"size\":1234,"
+                "\"hash_md5\":\"old_hash_md5\","
+                "\"hash_sha1\":\"old_hash_sha1\","
+                "\"hash_sha256\":\"old_hash_sha256\","
+                "\"checksum\":\"old_checksum\"},"
+            "\"attributes\":{"
+                "\"type\":\"registry_value\","
+                "\"size\":4567,"
+                "\"hash_md5\":\"hash_md5\","
+                "\"hash_sha1\":\"hash_sha1\","
+                "\"hash_sha256\":\"hash_sha256\","
+                "\"checksum\":\"checksum\"}}}";
+
+    if(data = calloc(1, sizeof(fim_data_t)), data == NULL)
         return -1;
-    if(data->lf->decoder_info->fields[FIM_PERM] = strdup("perm"), data->lf->decoder_info->fields[FIM_PERM] == NULL)
+
+    data->event = cJSON_Parse(plain_event);
+
+    if(data->event == NULL)
         return -1;
-    if(data->lf->decoder_info->fields[FIM_UID] = strdup("uid"), data->lf->decoder_info->fields[FIM_UID] == NULL)
+
+    if (setup_event_info((void **)&data->lf) != 0) {
         return -1;
-    if(data->lf->decoder_info->fields[FIM_GID] = strdup("gid"), data->lf->decoder_info->fields[FIM_GID] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_MD5] = strdup("md5"), data->lf->decoder_info->fields[FIM_MD5] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_SHA1] = strdup("sha1"), data->lf->decoder_info->fields[FIM_SHA1] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_UNAME] = strdup("uname"), data->lf->decoder_info->fields[FIM_UNAME] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_GNAME] = strdup("gname"), data->lf->decoder_info->fields[FIM_GNAME] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_MTIME] = strdup("mtime"), data->lf->decoder_info->fields[FIM_MTIME] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_INODE] = strdup("inode"), data->lf->decoder_info->fields[FIM_INODE] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_SHA256] = strdup("sha256"), data->lf->decoder_info->fields[FIM_SHA256] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_DIFF] = strdup("diff"), data->lf->decoder_info->fields[FIM_DIFF] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_ATTRS] = strdup("attrs"), data->lf->decoder_info->fields[FIM_ATTRS] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_CHFIELDS] = strdup("chfields"), data->lf->decoder_info->fields[FIM_CHFIELDS] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_USER_ID] = strdup("user_id"), data->lf->decoder_info->fields[FIM_USER_ID] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_USER_NAME] = strdup("user_name"), data->lf->decoder_info->fields[FIM_USER_NAME] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_GROUP_ID] = strdup("group_id"), data->lf->decoder_info->fields[FIM_GROUP_ID] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_GROUP_NAME] = strdup("group_name"), data->lf->decoder_info->fields[FIM_GROUP_NAME] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_PROC_NAME] = strdup("proc_name"), data->lf->decoder_info->fields[FIM_PROC_NAME] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_AUDIT_ID] = strdup("audit_id"), data->lf->decoder_info->fields[FIM_AUDIT_ID] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_AUDIT_NAME] = strdup("audit_name"), data->lf->decoder_info->fields[FIM_AUDIT_NAME] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_EFFECTIVE_UID] = strdup("effective_uid"), data->lf->decoder_info->fields[FIM_EFFECTIVE_UID] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_EFFECTIVE_NAME] = strdup("effective_name"), data->lf->decoder_info->fields[FIM_EFFECTIVE_NAME] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_PPID] = strdup("ppid"), data->lf->decoder_info->fields[FIM_PPID] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_PROC_ID] = strdup("proc_id"), data->lf->decoder_info->fields[FIM_PROC_ID] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_TAG] = strdup("tag"), data->lf->decoder_info->fields[FIM_TAG] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_SYM_PATH] = strdup("sym_path"), data->lf->decoder_info->fields[FIM_SYM_PATH] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_AUDIT_CWD] = strdup("cwd"), data->lf->decoder_info->fields[FIM_AUDIT_CWD] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_PROC_PNAME] = strdup("parent_name"), data->lf->decoder_info->fields[FIM_PROC_PNAME] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_AUDIT_PCWD] = strdup("parent_cwd"), data->lf->decoder_info->fields[FIM_AUDIT_PCWD] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_REGISTRY_ARCH] = strdup("arch"), data->lf->decoder_info->fields[FIM_REGISTRY_ARCH] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_REGISTRY_VALUE_NAME] = strdup("value_name"), data->lf->decoder_info->fields[FIM_REGISTRY_VALUE_NAME] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_REGISTRY_VALUE_TYPE] = strdup("value_type"), data->lf->decoder_info->fields[FIM_REGISTRY_VALUE_TYPE] == NULL)
-        return -1;
-    if(data->lf->decoder_info->fields[FIM_ENTRY_TYPE] = strdup("entry_type"), data->lf->decoder_info->fields[FIM_ENTRY_TYPE] == NULL)
-        return -1;
+    }
 
     if (fim_init() != 1)
         return -1;
@@ -386,92 +499,9 @@ static int setup_decode_fim_event(void **state) {
                 "\"parent_name\":\"parent_name\","
                 "\"parent_cwd\":\"parent_cwd\"}}}";
 
-    if(data = calloc(1, sizeof(Eventinfo)), data == NULL)
+    if (setup_event_info((void **)&data) != 0) {
         return -1;
-
-    if(data->fields = calloc(FIM_NFIELDS, sizeof(DynamicField)), data->fields == NULL)
-        return -1;
-    if(data->decoder_info = calloc(1, sizeof(OSDecoderInfo)), data->decoder_info == NULL)
-        return -1;
-    if(data->decoder_info->fields = calloc(FIM_NFIELDS, sizeof(char*)), data->decoder_info->fields == NULL)
-        return -1;
-    if(data->full_log = calloc(OS_MAXSTR, sizeof(char)), data->full_log == NULL)
-        return -1;
-
-    if(data->decoder_info->fields[FIM_FILE] = strdup("file"), data->decoder_info->fields[FIM_FILE] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_HARD_LINKS] = strdup("hard_links"), data->decoder_info->fields[FIM_HARD_LINKS] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_SIZE] = strdup("size"), data->decoder_info->fields[FIM_SIZE] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_PERM] = strdup("perm"), data->decoder_info->fields[FIM_PERM] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_UID] = strdup("uid"), data->decoder_info->fields[FIM_UID] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_GID] = strdup("gid"), data->decoder_info->fields[FIM_GID] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_MD5] = strdup("md5"), data->decoder_info->fields[FIM_MD5] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_SHA1] = strdup("sha1"), data->decoder_info->fields[FIM_SHA1] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_UNAME] = strdup("uname"), data->decoder_info->fields[FIM_UNAME] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_GNAME] = strdup("gname"), data->decoder_info->fields[FIM_GNAME] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_MTIME] = strdup("mtime"), data->decoder_info->fields[FIM_MTIME] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_INODE] = strdup("inode"), data->decoder_info->fields[FIM_INODE] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_SHA256] = strdup("sha256"), data->decoder_info->fields[FIM_SHA256] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_DIFF] = strdup("diff"), data->decoder_info->fields[FIM_DIFF] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_ATTRS] = strdup("attrs"), data->decoder_info->fields[FIM_ATTRS] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_CHFIELDS] = strdup("chfields"), data->decoder_info->fields[FIM_CHFIELDS] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_USER_ID] = strdup("user_id"), data->decoder_info->fields[FIM_USER_ID] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_USER_NAME] = strdup("user_name"), data->decoder_info->fields[FIM_USER_NAME] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_GROUP_ID] = strdup("group_id"), data->decoder_info->fields[FIM_GROUP_ID] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_GROUP_NAME] = strdup("group_name"), data->decoder_info->fields[FIM_GROUP_NAME] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_PROC_NAME] = strdup("proc_name"), data->decoder_info->fields[FIM_PROC_NAME] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_AUDIT_ID] = strdup("audit_id"), data->decoder_info->fields[FIM_AUDIT_ID] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_AUDIT_NAME] = strdup("audit_name"), data->decoder_info->fields[FIM_AUDIT_NAME] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_EFFECTIVE_UID] = strdup("effective_uid"), data->decoder_info->fields[FIM_EFFECTIVE_UID] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_EFFECTIVE_NAME] = strdup("effective_name"), data->decoder_info->fields[FIM_EFFECTIVE_NAME] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_PPID] = strdup("ppid"), data->decoder_info->fields[FIM_PPID] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_PROC_ID] = strdup("proc_id"), data->decoder_info->fields[FIM_PROC_ID] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_TAG] = strdup("tag"), data->decoder_info->fields[FIM_TAG] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_SYM_PATH] = strdup("sym_path"), data->decoder_info->fields[FIM_SYM_PATH] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_AUDIT_CWD] = strdup("cwd"), data->decoder_info->fields[FIM_AUDIT_CWD] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_PROC_PNAME] = strdup("parent_name"), data->decoder_info->fields[FIM_PROC_PNAME] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_AUDIT_PCWD] = strdup("parent_cwd"), data->decoder_info->fields[FIM_AUDIT_PCWD] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_MODE] = strdup("mode"), data->decoder_info->fields[FIM_MODE] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_REGISTRY_ARCH] = strdup("arch"), data->decoder_info->fields[FIM_REGISTRY_ARCH] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_REGISTRY_VALUE_NAME] = strdup("value_name"), data->decoder_info->fields[FIM_REGISTRY_VALUE_NAME] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_REGISTRY_VALUE_TYPE] = strdup("value_type"), data->decoder_info->fields[FIM_REGISTRY_VALUE_TYPE] == NULL)
-        return -1;
-    if(data->decoder_info->fields[FIM_ENTRY_TYPE] = strdup("entry_type"), data->decoder_info->fields[FIM_ENTRY_TYPE] == NULL)
-        return -1;
+    }
 
     if(data->log = strdup(plain_event), data->log == NULL)
         return -1;
@@ -1361,6 +1391,143 @@ static void test_fim_generate_alert_full_alert(void **state) {
         "Group name was 'old_group_name', now it is 'group_name'\n"
         "Old modification time was: '3456', now it is '6789'\n"
         "Old inode was: '2345', now it is '5678'\n"
+        "Old md5sum was: 'old_hash_md5'\n"
+        "New md5sum is : 'hash_md5'\n"
+        "Old sha1sum was: 'old_hash_sha1'\n"
+        "New sha1sum is : 'hash_sha1'\n"
+        "Old sha256sum was: 'old_hash_sha256'\n"
+        "New sha256sum is : 'hash_sha256'\n");
+}
+
+static void test_fim_generate_alert_registry_key_alert(void **state) {
+    fim_data_t *input = *state;
+    char *event_type = "fim_event_type";
+    int ret;
+
+    cJSON *data = cJSON_GetObjectItem(input->event, "data");
+    cJSON *attributes = cJSON_GetObjectItem(data, "attributes");
+    cJSON *old_attributes = cJSON_GetObjectItem(data, "old_attributes");
+    cJSON *changed_attributes = cJSON_GetObjectItem(data, "changed_attributes");
+    cJSON *array_it;
+
+    input->lf->event_type = FIM_MODIFIED;
+
+    input->lf->fields[FIM_FILE].value = strdup("HKEY_LOCAL_MACHINE\\software\\test");
+    if (input->lf->fields[FIM_FILE].value == NULL)
+        fail();
+
+    input->lf->fields[FIM_REGISTRY_ARCH].value = strdup("[x64]");
+    if (input->lf->fields[FIM_REGISTRY_ARCH].value == NULL)
+        fail();
+
+    input->lf->fields[FIM_MODE].value = strdup("scheduled");
+    if (input->lf->fields[FIM_MODE].value == NULL)
+        fail();
+
+    if(input->lf->fields[FIM_ENTRY_TYPE].value = strdup("registry_key"), input->lf->fields[FIM_ENTRY_TYPE].value == NULL)
+        fail();
+
+    cJSON_ArrayForEach(array_it, changed_attributes) {
+        wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
+    }
+
+    ret = fim_generate_alert(input->lf, event_type, attributes, old_attributes, NULL);
+
+    assert_int_equal(ret, 0);
+
+    // Assert fim_fetch_attributes
+    /* assert new attributes */
+    assert_string_equal(input->lf->fields[FIM_MTIME].value, "6789");
+    assert_int_equal(input->lf->mtime_after, 6789);
+    assert_string_equal(input->lf->fields[FIM_PERM].value, "perm");
+    assert_string_equal(input->lf->fields[FIM_UNAME].value, "user_name");
+    assert_string_equal(input->lf->fields[FIM_GNAME].value, "group_name");
+    assert_string_equal(input->lf->fields[FIM_UID].value, "uid");
+    assert_string_equal(input->lf->fields[FIM_GID].value, "gid");
+
+    /* assert old attributes */
+    assert_int_equal(input->lf->mtime_before, 3456);
+    assert_string_equal(input->lf->perm_before, "old_perm");
+    assert_string_equal(input->lf->uname_before, "old_user_name");
+    assert_string_equal(input->lf->gname_before, "old_group_name");
+    assert_string_equal(input->lf->owner_before, "old_uid");
+    assert_string_equal(input->lf->gowner_before, "old_gid");
+
+    /* Assert actual output */
+    assert_string_equal(input->lf->full_log,
+        "Registry Key '[x64] HKEY_LOCAL_MACHINE\\software\\test' fim_event_type\n"
+        "Mode: scheduled\n"
+        "Changed attributes: permission,uid,user_name,gid,group_name,mtime\n"
+        "Permissions changed from 'old_perm' to 'perm'\n"
+        "Ownership was 'old_uid', now it is 'uid'\n"
+        "User name was 'old_user_name', now it is 'user_name'\n"
+        "Group ownership was 'old_gid', now it is 'gid'\n"
+        "Group name was 'old_group_name', now it is 'group_name'\n"
+        "Old modification time was: '3456', now it is '6789'\n");
+}
+
+static void test_fim_generate_alert_registry_value_alert(void **state) {
+    fim_data_t *input = *state;
+    char *event_type = "fim_event_type";
+    int ret;
+
+    cJSON *data = cJSON_GetObjectItem(input->event, "data");
+    cJSON *attributes = cJSON_GetObjectItem(data, "attributes");
+    cJSON *old_attributes = cJSON_GetObjectItem(data, "old_attributes");
+    cJSON *changed_attributes = cJSON_GetObjectItem(data, "changed_attributes");
+    cJSON *array_it;
+
+    input->lf->event_type = FIM_MODIFIED;
+
+    if(input->lf->fields[FIM_FILE].value = strdup("HKEY_LOCAL_MACHINE\\software\\test"), input->lf->fields[FIM_FILE].value == NULL)
+        fail();
+
+    input->lf->fields[FIM_REGISTRY_ARCH].value = strdup("[x64]");
+    if (input->lf->fields[FIM_REGISTRY_ARCH].value == NULL)
+        fail();
+
+    input->lf->fields[FIM_REGISTRY_VALUE_NAME].value = strdup("some:value");
+    if (input->lf->fields[FIM_REGISTRY_VALUE_NAME].value == NULL)
+        fail();
+
+    input->lf->fields[FIM_REGISTRY_VALUE_TYPE].value = strdup("REG_SZ");
+    if (input->lf->fields[FIM_REGISTRY_VALUE_TYPE].value == NULL)
+        fail();
+
+    input->lf->fields[FIM_MODE].value = strdup("scheduled");
+    if (input->lf->fields[FIM_MODE].value == NULL)
+        fail();
+
+    if(input->lf->fields[FIM_ENTRY_TYPE].value = strdup("registry_value"), input->lf->fields[FIM_ENTRY_TYPE].value == NULL)
+        fail();
+
+    cJSON_ArrayForEach(array_it, changed_attributes) {
+        wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
+    }
+
+    ret = fim_generate_alert(input->lf, event_type, attributes, old_attributes, NULL);
+
+    assert_int_equal(ret, 0);
+
+    // Assert fim_fetch_attributes
+    /* assert new attributes */
+    assert_string_equal(input->lf->fields[FIM_SIZE].value, "4567");
+    assert_string_equal(input->lf->fields[FIM_MD5].value, "hash_md5");
+    assert_string_equal(input->lf->fields[FIM_SHA1].value, "hash_sha1");
+    assert_string_equal(input->lf->fields[FIM_SHA256].value, "hash_sha256");
+
+    /* assert old attributes */
+    assert_string_equal(input->lf->size_before, "1234");
+    assert_string_equal(input->lf->md5_before, "old_hash_md5");
+    assert_string_equal(input->lf->sha1_before, "old_hash_sha1");
+    assert_string_equal(input->lf->sha256_before, "old_hash_sha256");
+
+    /* Assert actual output */
+    assert_string_equal(input->lf->full_log,
+        "Registry Value '[x64] HKEY_LOCAL_MACHINE\\software\\test\\some:value' fim_event_type\n"
+        "Mode: scheduled\n"
+        "Changed attributes: size,md5,sha1,sha256\n"
+        "Size changed from '1234' to '4567'\n"
         "Old md5sum was: 'old_hash_md5'\n"
         "New md5sum is : 'hash_md5'\n"
         "Old sha1sum was: 'old_hash_sha1'\n"
@@ -3589,6 +3756,8 @@ int main(void) {
 
         /* fim_generate_alert */
         cmocka_unit_test_setup_teardown(test_fim_generate_alert_full_alert, setup_fim_data, teardown_fim_data),
+        cmocka_unit_test_setup_teardown(test_fim_generate_alert_registry_key_alert, setup_registry_key_data, teardown_fim_data),
+        cmocka_unit_test_setup_teardown(test_fim_generate_alert_registry_value_alert, setup_registry_value_data, teardown_fim_data),
         cmocka_unit_test_setup_teardown(test_fim_generate_alert_type_not_modified, setup_fim_data, teardown_fim_data),
         cmocka_unit_test_setup_teardown(test_fim_generate_alert_invalid_element_in_attributes, setup_fim_data, teardown_fim_data),
         cmocka_unit_test_setup_teardown(test_fim_generate_alert_invalid_element_in_audit, setup_fim_data, teardown_fim_data),

--- a/src/unit_tests/analysisd/test_analysisd_syscheck.c
+++ b/src/unit_tests/analysisd/test_analysisd_syscheck.c
@@ -214,8 +214,6 @@ static int setup_fim_data(void **state) {
         return -1;
     if (data->lf->decoder_info->fields[FIM_MODE] = strdup("mode"), data->lf->decoder_info->fields[FIM_MODE] == NULL)
         return -1;
-    if (data->lf->fields[FIM_MODE].value = strdup("fim_mode"), data->lf->fields[FIM_MODE].value == NULL)
-        return -1;
     if(data->lf->decoder_info->fields[FIM_SIZE] = strdup("size"), data->lf->decoder_info->fields[FIM_SIZE] == NULL)
         return -1;
     if(data->lf->decoder_info->fields[FIM_PERM] = strdup("perm"), data->lf->decoder_info->fields[FIM_PERM] == NULL)
@@ -283,8 +281,6 @@ static int setup_fim_data(void **state) {
     if(data->lf->decoder_info->fields[FIM_REGISTRY_VALUE_TYPE] = strdup("value_type"), data->lf->decoder_info->fields[FIM_REGISTRY_VALUE_TYPE] == NULL)
         return -1;
     if(data->lf->decoder_info->fields[FIM_ENTRY_TYPE] = strdup("entry_type"), data->lf->decoder_info->fields[FIM_ENTRY_TYPE] == NULL)
-        return -1;
-    if(data->lf->fields[FIM_ENTRY_TYPE].value = strdup("file"), data->lf->fields[FIM_ENTRY_TYPE].value == NULL)
         return -1;
 
     if (fim_init() != 1)
@@ -1288,6 +1284,12 @@ static void test_fim_generate_alert_full_alert(void **state) {
     if(input->lf->fields[FIM_FILE].value = strdup("/a/file"), input->lf->fields[FIM_FILE].value == NULL)
         fail();
 
+    if (input->lf->fields[FIM_MODE].value = strdup("fim_mode"), input->lf->fields[FIM_MODE].value == NULL)
+        fail();
+
+    if(input->lf->fields[FIM_ENTRY_TYPE].value = strdup("file"), input->lf->fields[FIM_ENTRY_TYPE].value == NULL)
+        fail();
+
     if(input->lf->fields[FIM_HARD_LINKS].value = strdup("[\"/a/hard1.file\",\"/b/hard2.file\"]"),
        input->lf->fields[FIM_HARD_LINKS].value == NULL) {
 
@@ -1382,6 +1384,12 @@ static void test_fim_generate_alert_type_not_modified(void **state) {
     input->lf->event_type = FIM_ADDED;
 
     if(input->lf->fields[FIM_FILE].value = strdup("/a/file"), input->lf->fields[FIM_FILE].value == NULL)
+        fail();
+
+    if (input->lf->fields[FIM_MODE].value = strdup("fim_mode"), input->lf->fields[FIM_MODE].value == NULL)
+        fail();
+
+    if(input->lf->fields[FIM_ENTRY_TYPE].value = strdup("file"), input->lf->fields[FIM_ENTRY_TYPE].value == NULL)
         fail();
 
     cJSON_ArrayForEach(array_it, changed_attributes) {
@@ -1501,6 +1509,9 @@ static void test_fim_generate_alert_null_mode(void **state) {
     if(input->lf->fields[FIM_FILE].value = strdup("/a/file"), input->lf->fields[FIM_FILE].value == NULL)
         fail();
 
+    if(input->lf->fields[FIM_ENTRY_TYPE].value = strdup("file"), input->lf->fields[FIM_ENTRY_TYPE].value == NULL)
+        fail();
+
     cJSON_ArrayForEach(array_it, changed_attributes) {
         wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
     }
@@ -1577,6 +1588,12 @@ static void test_fim_generate_alert_null_event_type(void **state) {
     if(input->lf->fields[FIM_FILE].value = strdup("/a/file"), input->lf->fields[FIM_FILE].value == NULL)
         fail();
 
+    if (input->lf->fields[FIM_MODE].value = strdup("fim_mode"), input->lf->fields[FIM_MODE].value == NULL)
+        fail();
+
+    if(input->lf->fields[FIM_ENTRY_TYPE].value = strdup("file"), input->lf->fields[FIM_ENTRY_TYPE].value == NULL)
+        fail();
+
     cJSON_ArrayForEach(array_it, changed_attributes) {
         wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
     }
@@ -1649,6 +1666,12 @@ static void test_fim_generate_alert_null_attributes(void **state) {
     input->lf->event_type = FIM_MODIFIED;
 
     if(input->lf->fields[FIM_FILE].value = strdup("/a/file"), input->lf->fields[FIM_FILE].value == NULL)
+        fail();
+
+    if (input->lf->fields[FIM_MODE].value = strdup("fim_mode"), input->lf->fields[FIM_MODE].value == NULL)
+        fail();
+
+    if(input->lf->fields[FIM_ENTRY_TYPE].value = strdup("file"), input->lf->fields[FIM_ENTRY_TYPE].value == NULL)
         fail();
 
     cJSON_ArrayForEach(array_it, changed_attributes) {
@@ -1739,6 +1762,12 @@ static void test_fim_generate_alert_null_old_attributes(void **state) {
     if(input->lf->fields[FIM_FILE].value = strdup("/a/file"), input->lf->fields[FIM_FILE].value == NULL)
         fail();
 
+    if (input->lf->fields[FIM_MODE].value = strdup("fim_mode"), input->lf->fields[FIM_MODE].value == NULL)
+        fail();
+
+    if(input->lf->fields[FIM_ENTRY_TYPE].value = strdup("file"), input->lf->fields[FIM_ENTRY_TYPE].value == NULL)
+        fail();
+
     cJSON_ArrayForEach(array_it, changed_attributes) {
         wm_strcat(&input->lf->fields[FIM_CHFIELDS].value, cJSON_GetStringValue(array_it), ',');
     }
@@ -1826,6 +1855,12 @@ static void test_fim_generate_alert_null_audit(void **state) {
     input->lf->event_type = FIM_MODIFIED;
 
     if(input->lf->fields[FIM_FILE].value = strdup("/a/file"), input->lf->fields[FIM_FILE].value == NULL)
+        fail();
+
+    if (input->lf->fields[FIM_MODE].value = strdup("fim_mode"), input->lf->fields[FIM_MODE].value == NULL)
+        fail();
+
+    if(input->lf->fields[FIM_ENTRY_TYPE].value = strdup("file"), input->lf->fields[FIM_ENTRY_TYPE].value == NULL)
         fail();
 
     cJSON_ArrayForEach(array_it, changed_attributes) {

--- a/src/unit_tests/analysisd/test_analysisd_syscheck.c
+++ b/src/unit_tests/analysisd/test_analysisd_syscheck.c
@@ -2252,6 +2252,27 @@ static void test_fim_process_alert_no_event_type(void **state) {
     assert_int_equal(ret, -1);
 }
 
+static void test_fim_process_alert_invalid_entry_type(void **state) {
+    fim_data_t *input = *state;
+    _sdb sdb = {.socket = 10};
+    int ret;
+
+    cJSON *data = cJSON_GetObjectItem(input->event, "data");
+    cJSON *attributes = cJSON_GetObjectItem(data, "attributes");
+
+    cJSON_ReplaceItemInObject(attributes, "type", cJSON_CreateString("invalid"));
+
+    if(input->lf->agent_id = strdup("007"), input->lf->agent_id == NULL)
+        fail();
+
+    /* Inside fim_send_db_delete */
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid member 'type' in Syscheck attributes JSON payload");
+
+    ret = fim_process_alert(&sdb, input->lf, data);
+
+    assert_int_equal(ret, -1);
+}
+
 static void test_fim_process_alert_invalid_event_type(void **state) {
     fim_data_t *input = *state;
     _sdb sdb = {.socket = 10};
@@ -3582,6 +3603,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_fim_process_alert_modified_success, setup_fim_data, teardown_fim_data),
         cmocka_unit_test_setup_teardown(test_fim_process_alert_deleted_success, setup_fim_data, teardown_fim_data),
         cmocka_unit_test_setup_teardown(test_fim_process_alert_no_event_type, setup_fim_data, teardown_fim_data),
+        cmocka_unit_test_setup_teardown(test_fim_process_alert_invalid_entry_type, setup_fim_data, teardown_fim_data),
         cmocka_unit_test_setup_teardown(test_fim_process_alert_invalid_event_type, setup_fim_data, teardown_fim_data),
         cmocka_unit_test_setup_teardown(test_fim_process_alert_invalid_object, setup_fim_data, teardown_fim_data),
         cmocka_unit_test_setup_teardown(test_fim_process_alert_no_path, setup_fim_data, teardown_fim_data),


### PR DESCRIPTION
| Related issue  |
|---------------|
| #6424             |

## Description

This pull request fixes the existing unit tests for the syscheck decoder in analysisd. Only one new test has been added.

When checking with Valgrind, there will be around 3000 lost bytes because of having to use the `fim_init` function.

`test_fim_process_alert_no_path` is going to fail because a `NULL` path is not considered in the original code. This has already been described in #6451.

This pull request closes #6424.
