### PR TITLE
Add GeoIP information to Office365 events

### DIFF
--- a/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/alerts/ingest/pipeline.json
@@ -39,6 +39,15 @@
       }
     },
     {
+      "geoip": {
+        "field": "data.office_365.ActorIpAddress",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
       "date": {
         "field": "timestamp",
         "target_field": "@timestamp",

--- a/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
+++ b/extensions/filebeat/7.x/wazuh-module/archives/ingest/pipeline.json
@@ -39,6 +39,15 @@
       }
     },
     {
+      "geoip": {
+        "field": "data.office_365.ActorIpAddress",
+        "target_field": "GeoLocation",
+        "properties": ["city_name", "country_name", "region_name", "location"],
+        "ignore_missing": true,
+        "ignore_failure": true
+      }
+    },
+    {
       "date": {
         "field": "timestamp",
         "target_field": "@timestamp",


### PR DESCRIPTION
Hi team,

This PR adds a processor to the alerts and archives Filebeat pipelines to add GeoIP information for Office365 events.

Let me know if you have any questions.

Best regards,
Sergio.