### PR TITLE
Update max_agents limitation in framework.

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1896,7 +1896,7 @@ components:
         max_agents:
           type: string
           minimum: 0
-          description: "Maximum number of agents that can be registered. This variable is defined at compilation time"
+          description: "Maximum number of agents that can be registered."
         openssl_support:
           type: string
         ruleset_version:
@@ -7908,7 +7908,7 @@ paths:
                       version: v3.9.0
                       compilation_date: "2019-03-06T11:24:59Z"
                       type: manager
-                      max_agents: 14000
+                      max_agents: unlimited
                       openssl_support: yes
                       ruleset_version: 3905
                       tz_offset: +0000
@@ -9174,7 +9174,7 @@ paths:
                       version: v3.9.0
                       compilation_date: "2019-03-06T11:24:59Z"
                       type: manager
-                      max_agents: 14000
+                      max_agents: unlimited
                       openssl_support: yes
                       ruleset_version: 3905
                       tz_offset: +0000

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2337,6 +2337,8 @@ components:
             - wazuh-modulesd:agent-key-polling
             - wazuh-modulesd:aws-s3
             - wazuh-modulesd:azure-logs
+            - wazuh-modulesd:agent-upgrade
+            - wazuh-modulesd:task-manager
             - wazuh-modulesd:ciscat
             - wazuh-modulesd:control
             - wazuh-modulesd:command

--- a/api/test/integration/test_agents_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_GET_endpoints.tavern.yaml
@@ -1226,7 +1226,6 @@ stages:
             disabled: !anystr
             force_insert: !anystr
             force_time: !anystr
-            limit_maxagents: !anystr
             port: !anyint
             purge: !anystr
             ssl_auto_negotiate: !anystr

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1296,7 +1296,6 @@ stages:
                 disabled: !anystr
                 force_insert: !anystr
                 force_time: !anystr
-                limit_maxagents: !anystr
                 port: !anyint
                 purge: !anystr
                 ssl_auto_negotiate: !anystr

--- a/framework/wazuh/__init__.py
+++ b/framework/wazuh/__init__.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from time import strftime
 
 from wazuh.core import common
-from wazuh.core.database import Connection
+from wazuh.core.wdb import WazuhDBConnection
 from wazuh.core.exception import WazuhException, WazuhError, WazuhInternalError
 
 """
@@ -51,7 +51,7 @@ class Wazuh:
         self.installation_date = common.installation_date
         self.type = common.install_type
         self.path = common.ossec_path
-        self.max_agents = 'N/A'
+        self.max_agents = 'unlimited'
         self.openssl_support = 'N/A'
         self.ruleset_version = None
         self.tz_offset = None
@@ -90,16 +90,10 @@ class Wazuh:
         """
         # info DB if possible
         try:
-            conn = Connection(common.database_path_global)
-
-            query = "SELECT * FROM info"
-            conn.execute(query)
-
-            for tuple_ in conn:
-                if hasattr(self, tuple_['key']):
-                    setattr(self, tuple_['key'], tuple_['value'])
+            wdb_conn = WazuhDBConnection()
+            open_ssl = wdb_conn.execute("global sql SELECT value FROM info WHERE key = 'openssl_support'")[0]['value']
+            self.openssl_support = open_ssl
         except Exception:
-            self.max_agents = "N/A"
             self.openssl_support = "N/A"
 
         # Ruleset version


### PR DESCRIPTION
|Related issue|
|---|
|#6550|

This PR closes #6550.

## Description

Hello team! 

After removing the limitation of the number of agents which can be registered, detailed in #6097, it is necessary to update some related parts of the framework.

I have also fixed the way in which the `open_ssl` support information is obtained since it was still being queried through SQLite in the old `global.db` path.

References to this limitation in the documentation have been removed in this PR https://github.com/wazuh/wazuh-documentation/pull/3077

## Tests output
### test_agents_GET_endpoints.tavern.yaml
```
pytest -vv test_agents_GET_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-52-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 90 items                                                                                                                                                                                           

test_agents_GET_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                              [  1%]
test_agents_GET_endpoints.tavern.yaml::GET /agents with single agent id PASSED                                                                                                                         [  2%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                                [  3%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                                     [  4%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                               [  5%]
test_agents_GET_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                              [  6%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[md5] PASSED                                                                                                                             [  7%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha1] PASSED                                                                                                                            [  8%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha224] PASSED                                                                                                                          [ 10%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha256] PASSED                                                                                                                          [ 11%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha384] PASSED                                                                                                                          [ 12%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha512] PASSED                                                                                                                          [ 13%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2b] PASSED                                                                                                                         [ 14%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2s] PASSED                                                                                                                         [ 15%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_224] PASSED                                                                                                                        [ 16%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_256] PASSED                                                                                                                        [ 17%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_384] PASSED                                                                                                                        [ 18%]
test_agents_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_512] PASSED                                                                                                                        [ 20%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                            [ 21%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[configSum] PASSED                                                                                                   [ 22%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[dateAdd] PASSED                                                                                                     [ 23%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[group] PASSED                                                                                                       [ 24%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[id] PASSED                                                                                                          [ 25%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[ip] PASSED                                                                                                          [ 26%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[lastKeepAlive] PASSED                                                                                               [ 27%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[manager] PASSED                                                                                                     [ 28%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[mergedSum] PASSED                                                                                                   [ 30%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[name] PASSED                                                                                                        [ 31%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[node_name] PASSED                                                                                                   [ 32%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.arch] PASSED                                                                                                     [ 33%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.build] PASSED                                                                                                    [ 34%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.codename] PASSED                                                                                                 [ 35%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.major] PASSED                                                                                                    [ 36%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.minor] PASSED                                                                                                    [ 37%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.name] PASSED                                                                                                     [ 38%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.platform] PASSED                                                                                                 [ 40%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.uname] PASSED                                                                                                    [ 41%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.version] PASSED                                                                                                  [ 42%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[registerIP] PASSED                                                                                                  [ 43%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status] PASSED                                                                                                      [ 44%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[version] PASSED                                                                                                     [ 45%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                                     [ 46%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                             [ 47%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[md5] PASSED                                                                                                            [ 48%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha1] PASSED                                                                                                           [ 50%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha224] PASSED                                                                                                         [ 51%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha256] PASSED                                                                                                         [ 52%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha384] PASSED                                                                                                         [ 53%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha512] PASSED                                                                                                         [ 54%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2b] PASSED                                                                                                        [ 55%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2s] PASSED                                                                                                        [ 56%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_224] PASSED                                                                                                       [ 57%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_256] PASSED                                                                                                       [ 58%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_384] PASSED                                                                                                       [ 60%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_512] PASSED                                                                                                       [ 61%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                                             [ 62%]
test_agents_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                                              [ 63%]
test_agents_GET_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                              [ 64%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                                     [ 65%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED                                                                                                              [ 66%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED                                                                                                                   [ 67%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED                                                                                                                   [ 68%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED                                                                                                                 [ 70%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED                                                                                                            [ 71%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED                                                                                                           [ 72%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED                                                                                                               [ 73%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                                     [ 74%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                               [ 75%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[dateAdd] PASSED                                                                                                             [ 76%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[id] PASSED                                                                                                                  [ 77%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[ip] PASSED                                                                                                                  [ 78%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[lastKeepAlive] PASSED                                                                                                       [ 80%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[manager] PASSED                                                                                                             [ 81%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[name] PASSED                                                                                                                [ 82%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[node_name] PASSED                                                                                                           [ 83%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.arch] PASSED                                                                                                             [ 84%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.build] PASSED                                                                                                            [ 85%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.codename] PASSED                                                                                                         [ 86%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.major] PASSED                                                                                                            [ 87%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.minor] PASSED                                                                                                            [ 88%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.name] PASSED                                                                                                             [ 90%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.platform] PASSED                                                                                                         [ 91%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.uname] PASSED                                                                                                            [ 92%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.version] PASSED                                                                                                          [ 93%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[registerIP] PASSED                                                                                                          [ 94%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status] PASSED                                                                                                              [ 95%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[version] PASSED                                                                                                             [ 96%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                               [ 97%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                                   [ 98%]
test_agents_GET_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                                               [100%]

================================================================================ 90 passed, 97 warnings in 147.05s (0:02:27) ================================================================================
```

### test_cluster_endpoints.tavern.yaml
```
pytest -vv test_cluster_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-52-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 56 items                                                                                                                                                                                           

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                                                                   [  1%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                                                    [  3%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                                                     [  5%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                                                          [  7%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                                                                                             [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                                                                                                 [ 10%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                                                                                                 [ 12%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                                                                                               [ 14%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                                                                                             [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                                                                                             [ 17%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                                                                                                          [ 19%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                                                         [ 21%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                                                        [ 23%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                                                       [ 25%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                                                     [ 26%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/api/config PASSED                                                                                                                                     [ 28%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/api/config PASSED                                                                                                                                  [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                                                            [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[master-node] PASSED                                                                                                                   [ 33%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[worker1] PASSED                                                                                                                       [ 35%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[worker2] PASSED                                                                                                                       [ 37%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[master-node] PASSED                                                                                                                [ 39%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[worker1] PASSED                                                                                                                    [ 41%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[worker2] PASSED                                                                                                                    [ 42%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[master-node] PASSED                                                                                                                   [ 44%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[worker1] PASSED                                                                                                                       [ 46%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[worker2] PASSED                                                                                                                       [ 48%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/wrong_node/files PASSED                                                                                                                               [ 50%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                                                                                                    [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                                                                                                        [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                                                                                                        [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                                                                                                    [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                                                                                                        [ 58%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                                                                                                        [ 60%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                                                                                                [ 62%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                                                                                                [ 64%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                                                                                                   [ 66%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                                                                                                       [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                                                                                                       [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                                                                                               [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] FAILED                                                                                                         [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] FAILED                                                                                                             [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] FAILED                                                                                                             [ 76%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                                                                                            [ 78%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                                                                                                [ 80%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                                                                                                [ 82%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                                                                                                           [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                                                                                               [ 85%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                                                                                               [ 87%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                                                                                            [ 89%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                                                                                                [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                                                                                                [ 92%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                                                                                                  [ 94%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                                                                                                      [ 96%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                                                                                                      [ 98%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                                                        [100%]

=========================================================================== 3 failed, 53 passed, 72 warnings in 312.63s (0:05:12) ============================================================================
```

There are multiple failures although not related to the modifications performed in this PR.

Best regards,
Selu.