### PR TITLE
[Framework] Improve q parameter for process_array function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
 - **Wazuh API:**
   - Added endpoints to query and manage Rootcheck data.  ([#6496](https://github.com/wazuh/wazuh/pull/6496))
 
+- **Framework:**
+  - Improved `q` parameter on rules, decoders and cdb-lists modules to allow multiple nested fields. ([#6560](https://github.com/wazuh/wazuh/pull/6560))
+
 ### Changed
 
 - Removed the limit of agents that a manager can support. ([#6097](https://github.com/wazuh/wazuh/issues/6097))

--- a/api/test/integration/test_decoders_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoders_endpoints.tavern.yaml
@@ -289,7 +289,7 @@ stages:
       verify: False
       <<: *get_decoders
       params:
-        q: 'details.prematch~wazuh;filename=0005-wazuh_decoders.xml;position<5'
+        q: 'details.prematch.pattern~wazuh;filename=0005-wazuh_decoders.xml;position<5'
     response:
       status_code: 200
       json:

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -67,7 +67,16 @@ input_array = [
         "configSum": {
             "nestedSum1": {
                 "nestedSum11": "value"
-            }
+            },
+            "nestedSum2": [
+                {
+                    "nestedSum21": "value1"
+                },
+                {
+                    "nestedSum21": "value2"
+                }
+
+            ]
         }
     }]
 
@@ -1438,6 +1447,8 @@ def test_WazuhDBQueryGroupBy_protected_add_select_to_query(mock_parse, mock_add,
     ('nameGfirewall', -1),
     ('mergedSum.nestedSum1=value', 2),
     ('configSum.nestedSum1.nestedSum11=value', 1),
+    ('configSum.nestedSum2.nestedSum21=value1', 1),
+    ('configSum.nestedSum2.nestedSum21=value2', 1)
 ])
 def test_filter_array_by_query(q, return_length):
     """Test filter by query in an array."""

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -25,26 +25,51 @@ with patch('wazuh.core.common.ossec_uid'):
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
 # input data for testing q filter
-input_array = [{"count": 3,
-                "name": "default",
-                "mergedSum": "a7d19a28cd5591eade763e852248197b",
-                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
-                },
-               {"count": 0,
-                "name": "dmz",
-                "mergedSum": "dd77862c4a41ae1b3854d67143f3d3e4",
-                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
-                },
-               {"count": 0,
-                "name": "testsagentconf",
-                "mergedSum": "2acdb385658097abb9528aa5ec18c490",
-                "configSum": "297b4cea942e0b7d2d9c59f9433e3e97"
-                },
-               {"count": 0,
-                "name": "testsagentconf2",
-                "mergedSum": "391ae29c1b0355c610f45bf133d5ea55",
-                "configSum": "297b4cea942e0b7d2d9c59f9433e3e97"
-                }]
+input_array = [
+    {
+        "count": 3,
+        "name": "default",
+        "mergedSum": "a7d19a28cd5591eade763e852248197b",
+        "configSum": "ab73af41699f13fdd81903b5f23d8d00"
+    },
+    {
+        "count": 0,
+        "name": "dmz",
+        "mergedSum": "dd77862c4a41ae1b3854d67143f3d3e4",
+        "configSum": "ab73af41699f13fdd81903b5f23d8d00"
+    },
+    {
+        "count": 0,
+        "name": "testsagentconf",
+        "mergedSum": "2acdb385658097abb9528aa5ec18c490",
+        "configSum": "297b4cea942e0b7d2d9c59f9433e3e97"
+    },
+    {
+        "count": 0,
+        "name": "testsagentconf2",
+        "mergedSum": "391ae29c1b0355c610f45bf133d5ea55",
+        "configSum": "297b4cea942e0b7d2d9c59f9433e3e97"
+    },
+    {
+        "count": 0,
+        "name": "test_nested1",
+        "mergedSum": {
+            "nestedSum1": "value"
+        },
+        "configSum": "0000000000000000000000000000000"
+    },
+    {
+        "count": 0,
+        "name": "test_nested2",
+        "mergedSum": {
+            "nestedSum1": "value"
+        },
+        "configSum": {
+            "nestedSum1": {
+                "nestedSum11": "value"
+            }
+        }
+    }]
 
 
 # MOCK DATA
@@ -1394,23 +1419,25 @@ def test_WazuhDBQueryGroupBy_protected_add_select_to_query(mock_parse, mock_add,
     ('count!=0', 1),
     ('name~test;mergedSum~2acdb,name=dmz', 2),
     ('name=dmz,name=default', 2),
-    ('name~test', 2),
-    ('count<3;name~test', 2),
-    ('name~d', 2),
-    ('name!=dmz;name!=default', 2),
-    ('count=0;name!=dmz', 2),
-    ('count=0', 3),
-    ('count<3', 3),
-    ('count<1', 3),
-    ('count!=3', 3),
-    ('count>10,count<3', 3),
+    ('name~test', 4),
+    ('count<3;name~test', 4),
+    ('name~d', 4),
+    ('name!=dmz;name!=default', 4),
+    ('count=0;name!=dmz', 4),
+    ('count=0', 5),
+    ('count<3', 5),
+    ('count<1', 5),
+    ('count!=3', 5),
+    ('count>10,count<3', 5),
     ('configSum~29,count=3', 3),
-    ('name~test,count>0', 3),
-    ('count<4', 4),
-    ('count>0,count<4', 4),
-    ('name~def,count=0', 4),
+    ('name~test,count>0', 5),
+    ('count<4', 6),
+    ('count>0,count<4', 6),
+    ('name~def,count=0', 6),
     ('configSum~29,configSum~ab', 4),
-    ('nameGfirewall', -1)
+    ('nameGfirewall', -1),
+    ('mergedSum.nestedSum1=value', 2),
+    ('configSum.nestedSum1.nestedSum11=value', 1),
 ])
 def test_filter_array_by_query(q, return_length):
     """Test filter by query in an array."""

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -114,7 +114,7 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
             # Workaround for too long sca_checks results until the chunk algorithm is implemented (1/2)
             db_query = WazuhDBQuerySCA(agent_id=agent_list[0], offset=0, limit=None, sort=None, filters=filters,
                                        search=None, select=full_select, count=True, get_data=True,
-                                       query=f"policy_id={policy_id}" if q == "" else f"policy_id={policy_id};{q}",
+                                       query=f"policy_id={policy_id}",
                                        default_query=default_query_sca_check,
                                        default_sort_field='policy_id', fields=fields_translation, count_field='id')
             result_dict = db_query.run()
@@ -156,7 +156,8 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
                              sort_by=sort['fields'] if sort else ['policy_id'],
                              sort_ascending=False if sort and sort['order'] == 'desc' else True,
                              offset=offset,
-                             limit=limit)
+                             limit=limit,
+                             q=q)
 
         result.affected_items = data['items']
         result.total_affected_items = data['totalItems']

--- a/framework/wazuh/tests/data/decoders/test1_decoders.xml
+++ b/framework/wazuh/tests/data/decoders/test1_decoders.xml
@@ -1,0 +1,49 @@
+<!--
+  -  Wazuh decoders
+  -  Created by Wazuh, Inc.
+  -  Copyright (C) 2015-2019, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<decoder name="wazuh">
+  <prematch>^wazuh: </prematch>
+</decoder>
+
+<decoder name="agent-buffer">
+  <parent>wazuh</parent>
+  <prematch offset="after_parent">^Agent buffer:</prematch>
+  <regex offset="after_prematch">^ '(\S+)'.</regex>
+  <order>level</order>
+</decoder>
+
+<decoder name="agent-upgrade">
+  <parent>wazuh</parent>
+  <prematch offset="after_parent">^Upgrade procedure |^Custom installation </prematch>
+  <regex offset="after_prematch">on agent (\d\d\d)\s\((\S+)\):\s(\w+)</regex>
+  <order>agent.id, agent.name, status</order>
+</decoder>
+
+<decoder name="agent-upgrade">
+  <parent>wazuh</parent>
+  <regex>aborted:\s(\.+)$|failed:\s(\.+)$|lost:\s(\.+)$</regex>
+  <order>error</order>
+</decoder>
+
+<decoder name="agent-upgrade">
+  <parent>wazuh</parent>
+  <regex>started.\sCurrent\sversion:\sWazuh\s(\.+)$</regex>
+  <order>agent.cur_version</order>
+</decoder>
+
+<decoder name="agent-upgrade">
+  <parent>wazuh</parent>
+  <regex>succeeded.\sNew\sversion:\sWazuh\s(\.+)$</regex>
+  <order>agent.new_version</order>
+</decoder>
+
+<decoder name="agent-restart" test_tag="test">
+  <parent>wazuh</parent>
+  <prematch offset="after_parent">^Invalid remote configuration:</prematch>
+  <regex offset="after_prematch">^ '(\S+)'.</regex>
+  <order>module</order>
+</decoder>

--- a/framework/wazuh/tests/data/decoders/test2_decoders.xml
+++ b/framework/wazuh/tests/data/decoders/test2_decoders.xml
@@ -1,0 +1,15 @@
+<!--
+- JSON Decoders
+- Copyright (C) 2015-2019, Wazuh Inc.
+- April 21, 2017.
+-
+- This program is a free software; you can redistribute it
+- and/or modify it under the terms of the GNU General Public
+- License (version 2) as published by the FSF - Free Software
+- Foundation.
+-->
+
+<decoder name="json">
+  <prematch>^{\s*"</prematch>
+  <plugin_decoder>JSON_Decoder</plugin_decoder>
+</decoder>

--- a/framework/wazuh/tests/data/decoders/wrong_decoders.xml
+++ b/framework/wazuh/tests/data/decoders/wrong_decoders.xml
@@ -1,0 +1,15 @@
+<!--
+- JSON Decoders
+- Copyright (C) 2015-2019, Wazuh Inc.
+- April 21, 2017.
+-
+- This program is a free software; you can redistribute it
+- and/or modify it under the terms of the GNU General Public
+- License (version 2) as published by the FSF - Free Software
+- Foundation.
+-->
+
+<decoder name=7>
+  <prematch>^{\s*"</prematch>
+  <plugin_decoder>JSON_Decoder</plugin_decoder>
+</decoder>

--- a/framework/wazuh/tests/test_decoders.py
+++ b/framework/wazuh/tests/test_decoders.py
@@ -28,14 +28,14 @@ with patch('wazuh.core.common.getgrnam'):
 test_data_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 decoder_ossec_conf = {
     'ruleset': {
-        'decoder_dir': ['core/tests/data/decoders'],
+        'decoder_dir': ['tests/data/decoders'],
         'decoder_exclude': 'test2_decoders.xml'
     }
 }
 
 decoder_ossec_conf_2 = {
     'ruleset': {
-        'decoder_dir': ['core/tests/data/decoders'],
+        'decoder_dir': ['tests/data/decoders'],
         'decoder_exclude': 'wrong_decoders.xml'
     }
 }
@@ -60,13 +60,13 @@ def mock_ossec_path():
     (None, 'disabled', None, None, False, {'json'}, 0),
     (['agent-upgrade', 'non_existing', 'json'], 'enabled', None, None, False, {'agent-upgrade'}, 1),
     (None, None, 'test1_decoders.xml', None, False, {'agent-buffer', 'agent-upgrade', 'wazuh', 'agent-restart'}, 0),
-    (None, None, 'test2_decoders.xml', 'core/tests/data/decoders', False, {'json'}, 0),
-    (None, 'all', None, 'core/tests/data/decoders', True, {'wazuh', 'json'}, 0),
+    (None, None, 'test2_decoders.xml', 'tests/data/decoders', False, {'json'}, 0),
+    (None, 'all', None, 'tests/data/decoders', True, {'wazuh', 'json'}, 0),
     (None, 'all', None, 'nothing_here', False, set(), 0)
 ])
 def test_get_decoders(names, status, filename, relative_dirname, parents, expected_names, expected_total_failed):
-    wrong_decoder_original_path = os.path.join(test_data_path, 'core/tests/data/decoders', 'wrong_decoders.xml')
-    wrong_decoder_tmp_path = os.path.join(test_data_path, 'core/tests/data', 'wrong_decoders.xml')
+    wrong_decoder_original_path = os.path.join(test_data_path, 'tests/data/decoders', 'wrong_decoders.xml')
+    wrong_decoder_tmp_path = os.path.join(test_data_path, 'tests/data', 'wrong_decoders.xml')
     try:
         os.rename(wrong_decoder_original_path, wrong_decoder_tmp_path)
         # UUT call
@@ -108,12 +108,12 @@ def test_get_decoders_files(conf, exception):
     ('all', None, None, {'test1_decoders.xml', 'test2_decoders.xml', 'wrong_decoders.xml'}),
     ('enabled', None, None, {'test1_decoders.xml', 'wrong_decoders.xml'}),
     ('disabled', None, None, {'test2_decoders.xml'}),
-    ('all', 'core/tests/data/decoders', None, {'test1_decoders.xml', 'test2_decoders.xml', 'wrong_decoders.xml'}),
+    ('all', 'tests/data/decoders', None, {'test1_decoders.xml', 'test2_decoders.xml', 'wrong_decoders.xml'}),
     ('all', 'wrong_path', None, set()),
-    ('disabled', 'core/tests/data/decoders', None, {'test2_decoders.xml'}),
-    (None, 'core/tests/data/decoders', 'test2_decoders.xml', {'test2_decoders.xml'}),
-    ('disabled', 'core/tests/data/decoders', 'test2_decoders.xml', {'test2_decoders.xml'}),
-    ('enabled', 'core/tests/data/decoders', 'test2_decoders.xml', set()),
+    ('disabled', 'tests/data/decoders', None, {'test2_decoders.xml'}),
+    (None, 'tests/data/decoders', 'test2_decoders.xml', {'test2_decoders.xml'}),
+    ('disabled', 'tests/data/decoders', 'test2_decoders.xml', {'test2_decoders.xml'}),
+    ('enabled', 'tests/data/decoders', 'test2_decoders.xml', set()),
     ('enabled', None, 'test1_decoders.xml', {'test1_decoders.xml'}),
     (None, None, ['test1_decoders.xml', 'test2_decoders.xml'], {'test1_decoders.xml', 'test2_decoders.xml'}),
     ('enabled', None, ['test1_decoders.xml', 'test2_decoders.xml'], {'test1_decoders.xml'}),
@@ -152,10 +152,10 @@ def test_get_file_exceptions():
     with pytest.raises(WazuhError, match=r'.* 1502 .*'):
         filename = 'test2_decoders.xml'
         old_permissions = stat.S_IMODE(os.lstat(os.path.join(
-            test_data_path, 'core/tests/data/decoders', filename)).st_mode)
+            test_data_path, 'tests/data/decoders', filename)).st_mode)
         try:
-            os.chmod(os.path.join(test_data_path, 'core/tests/data/decoders', filename), 000)
+            os.chmod(os.path.join(test_data_path, 'tests/data/decoders', filename), 000)
             # UUT 3rd call forcing a permissions error opening decoder file
             decoder.get_file(filename=filename)
         finally:
-            os.chmod(os.path.join(test_data_path, 'core/tests/data/decoders', filename), old_permissions)
+            os.chmod(os.path.join(test_data_path, 'tests/data/decoders', filename), old_permissions)


### PR DESCRIPTION
Hello team, 
this PR closes #6554 .

This PR adds the functionality that was lacking to the `process_array` function when using the `q` parameter:

- The `q` parameter used in `process_array` will allow multiple nested fields:

### Example
With the following curl:
```bash
curl --request GET \
  --url 'https://localhost:55000/rules?q=details.regex.pattern=dev' \
  --header 'authorization: Bearer <TOKEN>'
```

We get this response from the API:
```json
{
  "data": {
    "affected_items": [
      {
        "filename": "local_rules.xml",
        "relative_dirname": "etc/rules",
        "id": 111111,
        "level": 5,
        "status": "enabled",
        "details": {
          "regex": {
            "pattern": "dev",
            "type": "osregex"
          }
        },
        "pci_dss": [],
        "gpg13": [],
        "gdpr": [],
        "hipaa": [],
        "nist_800_53": [],
        "tsc": [],
        "mitre": [],
        "groups": [
          "dev"
        ],
        "description": "Dev custom rule"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected rules were returned",
  "error": 0
}
```

- We can iterate over arrays using the `q` parameter:

### Example
Keeping in mind that `compliance` has two different `key`:
```json
"compliance": [
          {
            "key": "cis",
            "value": "6.2.20"
          },
          {
            "key": "cis_csc",
            "value": "5.1"
          }
        ],
```

Using these two different curls:
```
curl --request GET \
  --url 'https://localhost:55050/sca/003/checks/cis_debian9_L1?wait_for_complete=true&=&q=id%3D3098%3Bcompliance.key%3Dcis' \
  --header 'authorization: Bearer <TOKEN>'
```

```
curl --request GET \
  --url 'https://localhost:55050/sca/003/checks/cis_debian9_L1?wait_for_complete=true&=&q=id%3D3098%3Bcompliance.key%3Dcis_csc' \
  --header 'authorization: Bearer <TOKEN>'
```

We get this response from the API:
```json
{
  "data": {
    "affected_items": [
      {
        "condition": "none",
        "result": "passed",
        "status": "",
        "remediation": "Remove all users from the shadow group, and change the primary group of any users with shadow as their primary group.",
        "file": "/etc/group",
        "policy_id": "cis_debian9_L1",
        "title": "Ensure shadow group is empty",
        "rationale": "Any users assigned to the shadow group would be granted read access to the /etc/shadow file. If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed passwords to break them. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts.",
        "reason": "",
        "description": "The shadow group allows system programs which require access the ability to read the /etc/shadow file. No users should be assigned to the shadow group.",
        "id": 3098,
        "compliance": [
          {
            "key": "cis",
            "value": "6.2.20"
          },
          {
            "key": "cis_csc",
            "value": "5.1"
          }
        ],
        "rules": [
          {
            "type": "file",
            "rule": "f:/etc/group -> !r:^# && r:shadow:\\w*:\\w*:\\S+"
          }
        ]
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected sca/policy information was returned",
  "error": 0
}
```

With an invalid `key`:
```
curl --request GET \
  --url 'https://localhost:55050/sca/003/checks/cis_debian9_L1?wait_for_complete=true&=&q=id%3D3098%3Bcompliance.key%3Dinvalid' \
  --header 'authorization: Bearer <TOKEN>'
```

```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "No sca/policy information was returned",
  "error": 0
}
```

- The `q` parameter allows `spaces`:

### Example
Using a `q` with spaces:
```
curl --request GET \
  --url 'https://localhost:55050/sca/003/checks/cis_debian9_L1?wait_for_complete=true&limit=1&=&q=status%3DNot%20applicable' \
  --header 'authorization: Bearer <TOKEN>'
```

We get this response from the API:
```json
{
  "data": {
    "affected_items": [
      {
        "condition": "all",
        "command": "/sbin/modprobe -n -v freevxfs,lsmod",
        "result": "",
        "status": "Not applicable",
        "remediation": "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vim /etc/modprobe.d/freevxfs.conf and add the following line: install freevxfs /bin/true Run the following command to unload the freevxfs module: # rmmod freevxfs",
        "policy_id": "cis_debian9_L1",
        "title": "Ensure mounting of freevxfs filesystems is disabled",
        "rationale": "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it.",
        "reason": "Invalid path or wrong permissions to run command '/sbin/modprobe -n -v freevxfs'",
        "description": "The freevxfs filesystem type is a free version of the Veritas type filesystem. This is the primary filesystem type for HP-UX operating systems.",
        "id": 3000,
        "compliance": [
          {
            "key": "cis",
            "value": "1.1.1.1"
          },
          {
            "key": "cis_csc",
            "value": "5.1"
          }
        ],
        "rules": [
          {
            "type": "numeric",
            "rule": "not c:lsmod -> r:freevxfs"
          },
          {
            "type": "command",
            "rule": "c:/sbin/modprobe -n -v freevxfs -> r:^install /bin/true"
          }
        ]
      }
    ],
    "total_affected_items": 44,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected sca/policy information was returned",
  "error": 0
}
```

# Tests performed

## Unit tests

```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0, cov-2.10.1
collected 7 items                                                                                                                                                                           

core/cluster/tests/test_utils.py .......                                                                                                                                              [100%]

===================================================================================== 7 passed in 0.04s =====================================================================================
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0, cov-2.10.1
collected 33 items                                                                                                                                                                          

core/tests/test_cdb_list.py .................................                                                                                                                         [100%]

==================================================================================== 33 passed in 0.07s =====================================================================================
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0, cov-2.10.1
collected 16 items                                                                                                                                                                          

core/tests/test_decoder.py ................                                                                                                                                           [100%]

==================================================================================== 16 passed in 0.04s =====================================================================================
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0, cov-2.10.1
collected 22 items                                                                                                                                                                          

core/tests/test_rule.py ......................                                                                                                                                        [100%]

==================================================================================== 22 passed in 0.06s =====================================================================================
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0, cov-2.10.1
collected 208 items                                                                                                                                                                         

core/tests/test_utils.py ............................................................................................................................................................ [ 75%]
....................................................                                                                                                                                  [100%]

==================================================================================== 208 passed in 0.53s ====================================================================================
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0, cov-2.10.1
collected 47 items                                                                                                                                                                          

tests/test_cdb_list.py ...............................................                                                                                                                [100%]

==================================================================================== 47 passed in 0.09s =====================================================================================
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0, cov-2.10.1
collected 31 items                                                                                                                                                                          

tests/test_decoders.py ...............................                                                                                                                                [100%]

==================================================================================== 31 passed in 0.07s =====================================================================================
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: asyncio-0.12.0, cov-2.10.1
collected 52 items                                                                                                                                                                          

tests/test_rule.py ....................................................                                                                                                               [100%]

==================================================================================== 52 passed in 0.26s =====================================================================================

```

## Integration tests
```
test_decoders_endpoints
	 23 passed, 29 warnings

test_lists_endpoints
	 2 passed, 4 warnings

test_rbac_black_decoders_endpoints
	 4 passed, 6 warnings

test_rbac_black_lists_endpoints
	 2 passed, 4 warnings

test_rbac_black_rules_endpoints
	 6 passed, 8 warnings

test_rbac_white_decoders_endpoints
	 4 passed, 6 warnings

test_rbac_white_lists_endpoints
	 2 passed, 4 warnings

test_rbac_white_rules_endpoints
	 6 passed, 8 warnings

test_rules_endpoints
	 13 passed, 15 warnings

```

Regards,
Víctor.