### PR TITLE
Fix race condition when removing a session in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Allow negation of expressions in rules ([#6258](https://github.com/wazuh/wazuh/pull/6258))
 - Support for PCRE2 regular expressions in rules and decoders ([#6480](https://github.com/wazuh/wazuh/pull/6480))
+- Added new **ruleset test module**. Allow testing and verification of rules and decoders using Wazuh User Interface. ([#5337](https://github.com/wazuh/wazuh/issues/5337))
 
 - Added new **upgrade module**. WPK upgrade feature has been moved to this module, which offers support for cluster architecture and simultaneous upgrades. ([#5387](https://github.com/wazuh/wazuh/issues/5387))
 - Added new **task module**. This module stores and manages all the tasks that are executed in the agents. ([#5386](https://github.com/wazuh/wazuh/issues/5386))

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -114,9 +114,7 @@ typedef struct w_logtest_connection_t {
 
     pthread_mutex_t mutex;      ///< Mutex to prevent race condition in accept syscall
     int sock;                   ///< The open connection with logtest queue
-
-    pthread_mutex_t mutex_hash_table;  ///< Mutex to prevent race condition in hash table and active client
-    int active_client;                 ///< Number of current clients
+    int active_client;          ///< Number of current clients
 
 } w_logtest_connection_t;
 

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -82,7 +82,7 @@ typedef struct w_logtest_session_t {
 
     char *token;                            ///< Client ID
     time_t last_connection;                 ///< Timestamp of the last query
-    pthread_mutex_t in_use;                ///< To prevent remove the session when it is in use
+    pthread_mutex_t mutex;                  ///< Prevent race condition between get a session and remove it
 
     RuleNode *rule_list;                    ///< Rule list
     OSDecoderNode *decoderlist_forpname;    ///< Decoder list to match logs which have a program name
@@ -190,11 +190,10 @@ int w_logtest_rulesmatching_phase(Eventinfo * lf, w_logtest_session_t * session,
 
 /**
  * @brief Create resources necessary to service client
- * @param token client identifier
  * @param msg_error contains the message to send to the client in case of invalid rules or decoder otherwise, it's null
  * @return NULL on failure, otherwise a w_logtest_session_t object which represents to the client
  */
-w_logtest_session_t *w_logtest_initialize_session(char * token, OSList * list_msg);
+w_logtest_session_t *w_logtest_initialize_session(OSList * list_msg);
 
 /**
  * @brief Free resources after client closes connection
@@ -271,19 +270,6 @@ void w_logtest_add_msg_response(cJSON* response, OSList* list_msg, int* error_co
  * @return char* new token string
  */
 char* w_logtest_generate_token();
-
-/**
- * @brief Get a session for a request
- *
- * Search for an active session based on the request token. If session expires
- * or the token is invalid, returns a new session
- *
- * @param req request for a session
- * @param list_msg list of \ref os_analysisd_log_msg_t for store messages
- * @param connection Manager of connections
- * @return new session or NULL on error
- */
-w_logtest_session_t * w_logtest_get_session(cJSON * req, OSList * list_msg, w_logtest_connection_t * connection);
 
 /**
  * @brief Register a session as active in connection

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -82,7 +82,7 @@ typedef struct w_logtest_session_t {
 
     char *token;                            ///< Client ID
     time_t last_connection;                 ///< Timestamp of the last query
-    pthread_rwlock_t in_use;                ///< To prevent remove the session when it is in use
+    pthread_mutex_t in_use;                ///< To prevent remove the session when it is in use
 
     RuleNode *rule_list;                    ///< Rule list
     OSDecoderNode *decoderlist_forpname;    ///< Decoder list to match logs which have a program name

--- a/src/analysisd/logtest.h
+++ b/src/analysisd/logtest.h
@@ -11,6 +11,7 @@
 #define LOGTEST_H
 
 #include "shared.h"
+#include "../headers/pthreads_op.h"
 #include "config.h"
 #include "rules.h"
 #include "config.h"
@@ -81,8 +82,7 @@ typedef struct w_logtest_session_t {
 
     char *token;                            ///< Client ID
     time_t last_connection;                 ///< Timestamp of the last query
-    bool expired;                           ///< Indicates that the session expired and will be deleted
-    pthread_mutex_t mutex;                  ///< Prevent race condition between get a session and remove it for inactivity
+    pthread_rwlock_t in_use;                ///< To prevent remove the session when it is in use
 
     RuleNode *rule_list;                    ///< Rule list
     OSDecoderNode *decoderlist_forpname;    ///< Decoder list to match logs which have a program name

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1680,7 +1680,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                         goto cleanup;
                     }
 
-                    free(dstgeoip);
+                    os_free(dstgeoip);
                     dstgeoip = NULL;
                 }
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1681,7 +1681,6 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     }
 
                     os_free(dstgeoip);
-                    dstgeoip = NULL;
                 }
 
                 /* Add in URL */

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -45,7 +45,7 @@ __attribute__((noreturn))
 static void help_logtest(void)
 {
     print_header();
-    print_out("\nSince Wazuh v4.0.0 this binary is deprecated. Use wazuh-logtest instead\n");
+    print_out("\nSince Wazuh v4.1.0 this binary is deprecated. Use wazuh-logtest instead\n");
     print_out("  %s: -[Vhdtva] [-c config] [-D dir] [-U rule:alert:decoder]", ARGV0);
     print_out("    -V          Version and license message");
     print_out("    -h          This help message");
@@ -474,7 +474,7 @@ int main(int argc, char **argv)
     minfo(STARTUP_MSG, (int)getpid());
 
     /* Inform that binary is deprecated */
-    print_out("\nSince Wazuh v4.0.0 this binary is deprecated. Use wazuh-logtest instead\n");
+    print_out("\nSince Wazuh v4.1.0 this binary is deprecated. Use wazuh-logtest instead\n");
 
     /* Going to main loop */
     OS_ReadMSG(ut_str);

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -513,13 +513,15 @@
 #define LOGTEST_ERROR_JSON_REQUIRED_SFIELD          "(7308): '%s' JSON field is required and must be a string"
 #define LOGTEST_ERROR_TOKEN_INVALID                 "(7309): '%s' is not a valid token"
 #define LOGTEST_ERROR_RESPONSE                      "(7310): Failure to sending response to client [%i] %s."
-#define LOGTEST_ERROR_INITIALIZE_SESSION            "(7311): Failure to initializing session '%s'"
+#define LOGTEST_ERROR_INITIALIZE_SESSION            "(7311): Failure to initializing session"
 #define LOGTEST_ERROR_PROCESS_EVENT                 "(7312): Failed to process the event"
 #define LOGTEST_ERROR_FIELD_NOT_FOUND               "(7313): '%s' JSON field not found"
 #define LOGTEST_ERROR_RECV_MSG_EMPTY_TO             "(7314): Failure to receive message: empty or reception timeout"
 #define LOGTEST_ERROR_RECV_MSG_OVERSIZE             "(7315): Failure to receive message: size is bigger than expected"
 #define LOGTEST_ERROR_TOKEN_INVALID_TYPE            "(7316): Failure to remove session. token JSON field must be a string"
 #define LOGTEST_ERROR_FIELD_NOT_VALID               "(7317): '%s' JSON field value is not valid"
+#define LOGTEST_ERROR_REMOVE_SESSION                "(7318): Failure to remove session '%s'"
+
 /* Modules messages */
 #define WM_UPGRADE_JSON_PARSE_ERROR                 "(8101): Cannot parse JSON: '%s'"
 #define WM_UPGRADE_UNDEFINED_ACTION_ERRROR          "(8102): No action defined for command: '%s'"

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -87,7 +87,10 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap
                              -Wl,--wrap,CreateThread -Wl,--wrap,pthread_join -Wl,--wrap,unlink \
                              -Wl,--wrap,Eventinfo_to_jsonstr -Wl,--wrap,cJSON_Parse -Wl,--wrap,ParseRuleComment \
                              -Wl,--wrap,Accumulate -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddBoolToObject \
-                             -Wl,--wrap,OSHash_SetFreeDataPointer")
+                             -Wl,--wrap,OSHash_SetFreeDataPointer -Wl,--wrap,OSHash_Delete \
+                             -Wl,--wrap,pthread_rwlock_init -Wl,--wrap,pthread_rwlock_rdlock \
+                             -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,pthread_rwlock_wrlock \
+                             -Wl,--wrap,pthread_mutex_trylock -Wl,--wrap,OSHash_Get")
 
 LIST(APPEND analysisd_names "test_logtest-config")
 LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nproc -Wl,--wrap,cJSON_CreateObject \

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -986,6 +986,19 @@ void test_w_logtest_check_inactive_sessions_remove(void **state)
 }
 
 /* w_logtest_remove_old_session */
+void test_w_logtest_remove_old_session_Begin_fail(void ** state) {
+
+    w_logtest_connection_t connection;
+
+    connection.active_client = 2;
+    w_logtest_conf.max_sessions = 1;
+
+    will_return(__wrap_OSHash_Begin, NULL);
+
+    w_logtest_remove_old_session(&connection);
+
+}
+
 void test_w_logtest_remove_old_session_one(void ** state) {
 
     w_logtest_connection_t connection;
@@ -4911,6 +4924,7 @@ int main(void)
         cmocka_unit_test(test_w_logtest_check_inactive_sessions_no_remove),
         cmocka_unit_test(test_w_logtest_check_inactive_sessions_remove),
         // Test w_logtest_remove_old_session
+        cmocka_unit_test(test_w_logtest_remove_old_session_Begin_fail),
         cmocka_unit_test(test_w_logtest_remove_old_session_one),
         cmocka_unit_test(test_w_logtest_remove_old_session_many),
         // Test w_logtest_register_session


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [x] Stress test for affected components
