### PR TITLE
Change disconnect-agents logic to work by chunks

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -4561,120 +4561,72 @@ void test_wdb_get_agents_by_connection_status_success(void **state)
 
 /* Tests wdb_disconnect_agents */
 
-void test_wdb_disconnect_agents_fail_response(void **state)
-{
-    const char *query_str = "global disconnect-agents 100";
+void test_wdb_disconnect_agents_wdbc_query_error(void **state) {
+    const char *query_str = "global disconnect-agents 0 100";
     const char *response = "err";
 
     // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_parse, sock);
-    expect_string(__wrap_wdbc_query_parse, query, query_str);
-    expect_value(__wrap_wdbc_query_parse, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_parse, response);
-    will_return(__wrap_wdbc_query_parse, WDBC_ERROR);
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_INVALID);
 
     int *array = wdb_disconnect_agents(100, NULL);
 
     assert_null(array);
-    os_free(array);
 }
 
-void test_wdb_disconnect_agents_empty_response(void **state)
-{
-    const char *query_str = "global disconnect-agents 100";
-    const char *response = "ok";
+void test_wdb_disconnect_agents_wdbc_parse_error(void **state) {
+    const char *query_str = "global disconnect-agents 0 100";
+    const char *response = "err";
 
     // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_parse, sock);
-    expect_string(__wrap_wdbc_query_parse, query, query_str);
-    expect_value(__wrap_wdbc_query_parse, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_parse, response);
-    will_return(__wrap_wdbc_query_parse, WDBC_OK);
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
 
-    // Parsing response
-    will_return(__wrap_cJSON_Parse, NULL);
-    expect_function_call(__wrap_cJSON_Delete);
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
 
     int *array = wdb_disconnect_agents(100, NULL);
 
-    assert_non_null(array);
-    assert_int_equal(-1, array[0]);
-    os_free(array);
+    assert_null(array);
 }
 
-void test_wdb_disconnect_agents_due_query_success(void **state)
-{
-    const char *query_str1 = "global disconnect-agents 100";
-    const char *query_str2 = "continue";
-    const char *response1 = "due [{\"id\":1},{\"id\":2},";
-    const char *response2 = "ok {\"id\":3},{\"id\":4}]";
-    cJSON* jsonresponse = __real_cJSON_Parse("[{\"id\":1},{\"id\":2},{\"id\":3},{\"id\":4}]");
+void test_wdb_disconnect_agents_success(void **state) {
+    const char *query_str = "global disconnect-agents 0 100";
 
-    // Calling Wazuh DB first time
-    expect_any(__wrap_wdbc_query_parse, sock);
-    expect_string(__wrap_wdbc_query_parse, query, query_str1);
-    expect_value(__wrap_wdbc_query_parse, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_parse, response1);
-    will_return(__wrap_wdbc_query_parse, WDBC_DUE);
+    // Setting the payload
+    set_payload = 1;
+    strncpy(test_payload, "ok 1,2,3", 8);
 
-    // Calling Wazuh DB second time
-    expect_any(__wrap_wdbc_query_parse, sock);
-    expect_string(__wrap_wdbc_query_parse, query, query_str2);
-    expect_value(__wrap_wdbc_query_parse, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_parse, response2);
-    will_return(__wrap_wdbc_query_parse, WDBC_OK);
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, test_payload);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
 
-    // Parsing response
-    will_return(__wrap_cJSON_Parse, jsonresponse);
-    cJSON *item = jsonresponse->child;
-    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(item, "id"));
-    item = item->next;
-    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(item, "id"));
-    item = item->next;
-    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(item, "id"));
-    item = item->next;
-    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(item, "id"));
-    expect_function_call(__wrap_cJSON_Delete);
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
     int *array = wdb_disconnect_agents(100, NULL);
 
-    assert_non_null(array);
     assert_int_equal(1, array[0]);
     assert_int_equal(2, array[1]);
     assert_int_equal(3, array[2]);
-    assert_int_equal(4, array[3]);
-    assert_int_equal(-1, array[4]);
+    assert_int_equal(-1, array[3]);
+
     os_free(array);
-    __real_cJSON_Delete(jsonresponse);
-}
 
-void test_wdb_disconnect_agents_success(void **state)
-{
-    const char *query_str = "global disconnect-agents 100";
-    const char *response = "ok [{\"id\":1},{\"id\":2}]";
-    cJSON* jsonresponse = __real_cJSON_Parse("[{\"id\":1},{\"id\":2}]");
-
-    // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_parse, sock);
-    expect_string(__wrap_wdbc_query_parse, query, query_str);
-    expect_value(__wrap_wdbc_query_parse, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_parse, response);
-    will_return(__wrap_wdbc_query_parse, WDBC_OK);
-
-    // Parsing response
-    will_return(__wrap_cJSON_Parse, jsonresponse);
-    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(jsonresponse->child, "id"));
-    will_return(__wrap_cJSON_GetObjectItem, __real_cJSON_GetObjectItem(jsonresponse->child->next, "id"));
-    expect_function_call(__wrap_cJSON_Delete);
-
-    int *array = wdb_disconnect_agents(100, NULL);
-
-    assert_non_null(array);
-    assert_int_equal(1, array[0]);
-    assert_int_equal(2, array[1]);
-    assert_int_equal(-1, array[2]);
-    os_free(array);
-    __real_cJSON_Delete(jsonresponse);
+    // Cleaning payload
+    set_payload = 0;
+    memset(test_payload, '\0', OS_MAXSTR);
 }
 
 int main()
@@ -4831,10 +4783,9 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_get_agents_by_connection_status_success, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_get_agents_by_connection_status_due_query_success, setup_wdb_agent, teardown_wdb_agent),
         /* Tests wdb_disconnect_agents */
-        cmocka_unit_test_setup_teardown(test_wdb_disconnect_agents_fail_response, setup_wdb_agent, teardown_wdb_agent),
-        cmocka_unit_test_setup_teardown(test_wdb_disconnect_agents_empty_response, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_disconnect_agents_wdbc_query_error, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_disconnect_agents_wdbc_parse_error, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_disconnect_agents_success, setup_wdb_agent, teardown_wdb_agent),
-        cmocka_unit_test_setup_teardown(test_wdb_disconnect_agents_due_query_success, setup_wdb_agent, teardown_wdb_agent)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -1937,10 +1937,8 @@ void test_wdb_parse_global_disconnect_agents_syntax_error(void **state)
     test_struct_t *data  = (test_struct_t *)*state;
     char query[OS_BUFFER_SIZE] = "global disconnect-agents";
 
-    // Logging command and opening database
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents");
     will_return(__wrap_wdb_open_global, data->wdb);
-    // Logging command syntax error
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents");
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for disconnect-agents.");
     expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: disconnect-agents");
 
@@ -1950,57 +1948,35 @@ void test_wdb_parse_global_disconnect_agents_syntax_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_global_disconnect_agents_error_getting_agents(void **state)
+void test_wdb_parse_global_disconnect_agents_last_id_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global disconnect-agents 100";
+    char query[OS_BUFFER_SIZE] = "global disconnect-agents ";
 
-    // Logging command and opening database
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents 100");
     will_return(__wrap_wdb_open_global, data->wdb);
-    // Getting the list of agents to disconnect
-    expect_value(__wrap_wdb_global_get_agents_to_disconnect, keep_alive, 100);
-    will_return(__wrap_wdb_global_get_agents_to_disconnect, NULL);
-    will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "Error getting agents to disconnect; err database queue/db/global.db: ERROR MESSAGE");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents ");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments last id not found.");
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, "err Error getting agents to disconnect; ERROR MESSAGE");
+    assert_string_equal(data->output, "err Invalid arguments last id not found");
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_global_disconnect_agents_error_setting_agent_to_disconnected(void **state)
+void test_wdb_parse_global_disconnect_agents_keepalive_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global disconnect-agents 100";
+    char query[OS_BUFFER_SIZE] = "global disconnect-agents 0";
 
-    cJSON *root = NULL;
-    cJSON *j_object = NULL;
-
-    root = cJSON_CreateArray();
-    j_object = cJSON_CreateObject();
-    cJSON_AddNumberToObject(j_object, "id", 1);
-    cJSON_AddItemToArray(root, j_object);
-
-    // Logging command and opening database
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents 100");
     will_return(__wrap_wdb_open_global, data->wdb);
-    // Getting the list of agents to disconnect
-    expect_value(__wrap_wdb_global_get_agents_to_disconnect, keep_alive, 100);
-    will_return(__wrap_wdb_global_get_agents_to_disconnect, root);
-    // Setting agents to disconnected
-    expect_value(__wrap_wdb_global_update_agent_connection_status, id, 1);
-    expect_string(__wrap_wdb_global_update_agent_connection_status, connection_status, AGENT_CS_DISCONNECTED);
-    will_return(__wrap_wdb_global_update_agent_connection_status, OS_INVALID);
-    will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "Error setting agent 1 as disconnected; err database queue/db/global.db: ERROR MESSAGE");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents 0");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments keepalive not found.");
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, "err Cannot set agent 1 as disconnected; ERROR MESSAGE");
+    assert_string_equal(data->output, "err Invalid arguments keepalive not found");
     assert_int_equal(ret, OS_INVALID);
 }
 
@@ -2008,36 +1984,18 @@ void test_wdb_parse_global_disconnect_agents_success(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
-    char query[OS_BUFFER_SIZE] = "global disconnect-agents 100";
+    char query[OS_BUFFER_SIZE] = "global disconnect-agents 0 100";
 
-    cJSON *root = NULL;
-    cJSON *j_object1 = NULL;
-    cJSON *j_object2 = NULL;
-
-    root = cJSON_CreateArray();
-    j_object1 = cJSON_CreateObject();
-    cJSON_AddNumberToObject(j_object1, "id", 1);
-    cJSON_AddItemToArray(root, j_object1);
-    j_object2 = cJSON_CreateObject();
-    cJSON_AddNumberToObject(j_object2, "id", 2);
-    cJSON_AddItemToArray(root, j_object2);
-
-    // Logging command and opening database
-    expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents 100");
     will_return(__wrap_wdb_open_global, data->wdb);
-    // Getting the list of agents to disconnect
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents 0 100");
+    expect_value(__wrap_wdb_global_get_agents_to_disconnect, last_agent_id, 0);
     expect_value(__wrap_wdb_global_get_agents_to_disconnect, keep_alive, 100);
-    will_return(__wrap_wdb_global_get_agents_to_disconnect, root);
-    // Setting agents to disconnected
-    will_return_always(__wrap_wdb_global_update_agent_connection_status, OS_SUCCESS);
-    expect_value(__wrap_wdb_global_update_agent_connection_status, id, 1);
-    expect_string(__wrap_wdb_global_update_agent_connection_status, connection_status, AGENT_CS_DISCONNECTED);
-    expect_value(__wrap_wdb_global_update_agent_connection_status, id, 2);
-    expect_string(__wrap_wdb_global_update_agent_connection_status, connection_status, AGENT_CS_DISCONNECTED);
+    will_return(__wrap_wdb_global_get_agents_to_disconnect, "1,2,3,4,5");
+    will_return(__wrap_wdb_global_get_agents_to_disconnect, WDBC_OK);
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, "ok [{\"id\":1},{\"id\":2}]");
+    assert_string_equal(data->output, "ok 1,2,3,4,5");
     assert_int_equal(ret, OS_SUCCESS);
 }
 
@@ -2379,9 +2337,10 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_set_label_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_sync_agent_info_set_success, test_setup, test_teardown),
         /* Tests wdb_parse_global_disconnect_agents */
+        
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_syntax_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_error_getting_agents, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_error_setting_agent_to_disconnected, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_last_id_error, test_setup, test_teardown),        
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_keepalive_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_success, test_setup, test_teardown),
         /* Tests wdb_parse_global_get_all_agents */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_all_agents_syntax_error, test_setup, test_teardown),

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -249,10 +249,14 @@ wdbc_result __wrap_wdb_global_get_agents_by_connection_status (__attribute__((un
     return mock();
 }
 
-cJSON* __wrap_wdb_global_get_agents_to_disconnect(__attribute__((unused)) wdb_t *wdb,
-                                                  int keep_alive) {
+wdbc_result __wrap_wdb_global_get_agents_to_disconnect(__attribute__((unused)) wdb_t *wdb,
+                                                  int last_agent_id,
+                                                  int keep_alive,
+                                                  char **output) {
+    check_expected(last_agent_id);
     check_expected(keep_alive);
-    return mock_ptr_type(cJSON*);
+    os_strdup(mock_ptr_type(char*), *output);
+    return mock();
 }
 
 int __wrap_wdb_global_check_manager_keepalive(wdb_t *wdb) {

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -85,7 +85,7 @@ int __wrap_wdb_global_reset_agents_connection(wdb_t *wdb);
 
 wdbc_result __wrap_wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, char **output);
 
-cJSON* __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int keep_alive);
+wdbc_result __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, char **output);
 
 int __wrap_wdb_global_check_manager_keepalive(wdb_t *wdb);
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -141,7 +141,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GET_AGENT_INFO] = "SELECT * FROM agent WHERE id = ?;",
-    [WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT] = "SELECT id FROM agent WHERE id > 0 AND connection_status = 'active' AND last_keepalive < ?;",
+    [WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT] = "SELECT id FROM agent WHERE id > ? AND connection_status = 'active' AND last_keepalive < ? LIMIT 1;",
     [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected' where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",
     [WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE] = "SELECT COUNT(*) FROM agent WHERE id=0 AND last_keepalive=253402300799;",
     [WDB_STMT_PRAGMA_JOURNAL_WAL] = "PRAGMA journal_mode=WAL;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -637,10 +637,12 @@ int wdb_reset_agents_connection(int *sock);
 int* wdb_get_agents_by_connection_status(const char* connection_status, int *sock);
 
 /**
- * @brief This method creates and sends a command to WazuhDB to set as disconnected all the
- * agents (excluding the manager) with a last_keepalive before the specified keepalive
- * threshold. Returns an array containing the ID of all the agents that had been set as disconnected.
- * The array is heap allocated memory that must be freed by the caller.
+ * @brief Set agents as disconnected based on the keepalive and return an array containing 
+ * the ID of every agent that had been set as disconnected. 
+ * This method creates and sends a command to WazuhDB to set as disconnected all the
+ * agents (excluding the manager) with a last_keepalive before the specified keepalive threshold. 
+ * If the response is bigger than the capacity of the socket, multiple commands will be sent until every agent is covered.
+ * The array is heap-allocated memory that must be freed by the caller.
  *
  * @param [in] keepalive The keepalive threshold before which an agent should be set as disconnected.
  * @param [in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
@@ -1213,8 +1215,8 @@ int wdb_parse_global_sync_agent_info_set(wdb_t * wdb, char * input, char * outpu
  * @brief Function to parse the disconnect-agents command data.
  *
  * @param [in] wdb The global struct database.
- * @param [in] input String with the time threshold before which consider an agent as disconnected.
- * @param [out] output Response of the command in JSON format with the list of agents that were set as disconnected.
+ * @param [in] input String with the time threshold before which consider an agent as disconnected and last id to continue.
+ * @param [out] output Response of the query.
  * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.
  */
@@ -1224,7 +1226,7 @@ int wdb_parse_global_disconnect_agents(wdb_t* wdb, char* input, char* output);
  * @brief Function to parse last_id get-all-agents.
  *
  * @param [in] wdb The global struct database.
- * @param [in] input String with last_id, condition, and keepalive.
+ * @param [in] input String with last_id.
  * @param [out] output Response of the query.
  * @return 0 Success: response contains the value. -1 On error: invalid DB query syntax.
  */
@@ -1673,12 +1675,16 @@ wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_age
 
 /*
  * @brief Gets all the agents' IDs (excluding the manager) that satisfy the keepalive condition to be disconnected.
+ *        Response is prepared in one chunk,
+ *        if the size of the chunk exceeds WDB_MAX_RESPONSE_SIZE parsing stops and reports the amount of agents obtained.
+ *        Multiple calls to this function can be required to fully obtain all agents.
  *
  * @param [in] wdb The Global struct database.
- * @param [in] keep_alive The value of keepalive threshold before which consider an agent as disconnected.
- * @return A pointer to a JSON with all the agents that satisfy the keepalive condition. Must be de-allocated by the caller.
+ * @param [in] last_agent_id ID where to start querying.
+ * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
+ * @return wdbc_result to represent if all agents has being obtained.
  */
-cJSON* wdb_global_get_agents_to_disconnect(wdb_t *wdb, int keep_alive);
+wdbc_result wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, char **output);
 
 // Finalize a statement securely
 #define wdb_finalize(x) { if (x) { sqlite3_finalize(x); x = NULL; } }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5050,37 +5050,35 @@ int wdb_parse_reset_agents_connection(wdb_t * wdb, char * output) {
 }
 
 int wdb_parse_global_disconnect_agents(wdb_t* wdb, char* input, char* output) {
+    int last_id = 0;
     int keep_alive = 0;
-    cJSON *agents = NULL;
-    cJSON *agent = NULL;
-    cJSON *id = NULL;
     char* out = NULL;
+    char *next = NULL;
+    const char delim[2] = " ";
+    char *savedptr = NULL;
 
-    keep_alive = atoi(input);
-
-    if (agents = wdb_global_get_agents_to_disconnect(wdb, keep_alive), !agents) {
-        mdebug1("Error getting agents to disconnect; err database %s/%s.db: %s", WDB2_DIR, WDB_GLOB_NAME, sqlite3_errmsg(wdb->db));
-        snprintf(output, OS_MAXSTR + 1, "err Error getting agents to disconnect; %s", sqlite3_errmsg(wdb->db));
+    /* Get last id*/
+    next = strtok_r(input, delim, &savedptr);
+    if (next == NULL) {
+        mdebug1("Invalid arguments last id not found.");
+        snprintf(output, OS_MAXSTR + 1, "err Invalid arguments last id not found");
         return OS_INVALID;
     }
+    last_id = atoi(next);
 
-    cJSON_ArrayForEach(agent, agents) {
-        id = cJSON_GetObjectItem(agent, "id");
-        if (cJSON_IsNumber(id)) {
-            if (OS_SUCCESS != wdb_global_update_agent_connection_status(wdb, id->valueint, AGENT_CS_DISCONNECTED)) {
-                mdebug1("Error setting agent %d as disconnected; err database %s/%s.db: %s",
-                         id->valueint, WDB2_DIR, WDB_GLOB_NAME, sqlite3_errmsg(wdb->db));
-                snprintf(output, OS_MAXSTR + 1, "err Cannot set agent %d as disconnected; %s", id->valueint, sqlite3_errmsg(wdb->db));
-                cJSON_Delete(agents);
-                return OS_INVALID;
-            }
-        }
+    /* Get keepalive*/
+    next = strtok_r(NULL, delim, &savedptr);
+    if (next == NULL) {
+        mdebug1("Invalid arguments keepalive not found.");
+        snprintf(output, OS_MAXSTR + 1, "err Invalid arguments keepalive not found");
+        return OS_INVALID;
     }
+    keep_alive = atoi(next);
 
-    out = cJSON_PrintUnformatted(agents);
-    snprintf(output, OS_MAXSTR + 1, "ok %s", out);
-    os_free(out);
-    cJSON_Delete(agents);
+    wdbc_result status = wdb_global_get_agents_to_disconnect(wdb, last_id, keep_alive, &out);
+    snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[status], out);
+
+    os_free(out)
 
     return OS_SUCCESS;
 }


### PR DESCRIPTION
|Related issue|
|---|
|6561|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR modifies the behavior of **disconnect-agents** command to return chunks of data to avoid a socket overflow.
Implements:

- Modification on wdb_global to generate the response by chunks
- Modification on wdb_global_parser to parse the new fields like last_id
- Modification on wdb_agents to iterate many times until cover whole agents
- UT for new functionality

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [X] Valgrind (memcheck and descriptor leaks check)
