### PR TITLE
Fix special character in default policies file. 

### DIFF
--- a/framework/wazuh/rbac/default/policies.yaml
+++ b/framework/wazuh/rbac/default/policies.yaml
@@ -104,7 +104,7 @@ default_policies:
         effect: allow
 
   ciscat_read:
-    description: Allow read agent’s ciscat results information.
+    description: Allow read agent's ciscat results information.
     policies:
       ciscat:
         actions:
@@ -176,7 +176,7 @@ default_policies:
         effect: allow
 
   sca_read:
-    description: Allow read agent’s sca information.
+    description: Allow read agent's sca information.
     policies:
       sca:
         actions:

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -183,9 +183,9 @@ get_rbac_actions:
             - agent:group:mediterranean
           effect: allow
         related_endpoints:
-          - PUT /agents/{agent_id}/upgrade
-          - PUT /agents/{agent_id}/upgrade_custom
-          - GET /agents/{agent_id}/upgrade_result
+          - PUT /agents/upgrade
+          - PUT /agents/upgrade_custom
+          - GET /agents/upgrade_result
       group:delete:
         description: Delete agent groups
         resources:


### PR DESCRIPTION
|Related issue|
|---|
|#6559|

## Description
Hi team! 

Like explained in #6559, the special character in the description of some default policies have been replaced by `'`, so that there are no future problems with encoding.

As I had to run the security tests and the RBAC catalog was not completely updated, I took the opportunity to fix it as well.  

## Tests
### Test RBAC
```
pytest wazuh/rbac/tests/
======================================================= test session starts ========================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 220 items                                                                                                                

wazuh/rbac/tests/test_auth_context.py ..                                                                                     [  0%]
wazuh/rbac/tests/test_decorators.py ........................................................................................ [ 40%]
.................                                                                                                            [ 48%]
wazuh/rbac/tests/test_default_configuration.py .................................................                             [ 70%]
wazuh/rbac/tests/test_orm.py .....................................................                                           [ 95%]
wazuh/rbac/tests/test_preprocessor.py ...........                                                                            [100%]

========================================================= warnings summary =========================================================
wazuh/rbac/tests/test_auth_context.py::test_auth_roles
  /home/selu/Git/wazuh/framework/wazuh/rbac/auth_context.py:177: FutureWarning: Possible nested set at position 2
    regex = re.compile(regex)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================ 220 passed, 1 warning in 167.56s (0:02:47) ============================================
```

### Test security
```
python3 -m pytest wazuh/tests/test_security.py
======================================================= test session starts ========================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 69 items                                                                                                                 

wazuh/tests/test_security.py .....................................................................                           [100%]

========================================================= warnings summary =========================================================
wazuh/tests/test_security.py::test_security[get_policies-params0-expected_result0]
  /home/selu/.local/lib/python3.8/site-packages/aiohttp/helpers.py:107: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def noop(*args, **kwargs):  # type: ignore

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================== 69 passed, 1 warning in 51.27s ==================================================
```

Regards,
Selu.