### PR TITLE
Add template for API/framework issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-framework.md
+++ b/.github/ISSUE_TEMPLATE/api-framework.md
@@ -20,8 +20,6 @@ For questions related to the user experience, please refer:
 Please fill the table above. Feel free to extend it at your convenience.
 -->
 
-
-
 ## Checks
 
 - **Unit tests** without failures. Updated and/or expanded if there are new functions/methods/outputs:

--- a/.github/ISSUE_TEMPLATE/api-framework.md
+++ b/.github/ISSUE_TEMPLATE/api-framework.md
@@ -1,0 +1,48 @@
+---
+name: API/Framework issue 
+about: Report a bug or make a feature request.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+|Wazuh version|Component|
+|---|---|
+| X.Y.Z-rev | Wazuh component |
+
+<!--
+Whenever possible, issues should be created for bug reporting and feature requests.
+For questions related to the user experience, please refer:
+- Wazuh mailing list: https://groups.google.com/forum/#!forum/wazuh
+- Join Wazuh on Slack: https://wazuh.com/community/join-us-on-slack
+
+Please fill the table above. Feel free to extend it at your convenience.
+-->
+
+
+
+<!--
+Depending on the affected components by this issue, the following checks should be selected and marked.
+-->
+
+- **Unit tests** without failures. Updated and/or expanded if there are new functions/methods/outputs:
+  - [ ] Cluster (`framework/wazuh/core/cluster/tests/` & `framework/wazuh/core/cluster/dapi/tests/`)
+  - [ ] Core (`framework/wazuh/core/tests/`)
+  - [ ] SDK (`framework/wazuh/tests/`)
+  - [ ] RBAC (`framework/wazuh/rbac/tests/`)
+  - [ ] API (`api/api/tests/`)
+- **API tavern integration tests** without failures. Updated and/or expanded if needed (`api/test/integration/`):
+  - [ ] Affected tests 
+  - [ ] Affected RBAC (black and white) tests
+- [ ] **Changelog** (`CHANGELOG.md`)
+- [ ] **Documentation** (`/wazuh-documentation/source/user-manual/api`)
+    
+
+<!-- If changes are made to any of the following components, uncomment the corresponding line 
+- [ ] **Integration tests** without failures for API configuration (`/wazuh-qa/tests/integration/test_api/test_config/`)
+- [ ] **System tests** for agent enrollment process (`/wazuh-qa/tests/system/test_cluster/test_agent_enrollment`)
+- [ ] **System tests** for agent info sync process in cluster (`/wazuh-qa/tests/system/test_cluster/test_agent_info_sync`)
+- [ ] **System tests** for agent key polling (`/wazuh-qa/tests/system/test_cluster/test_agent_key_polling`)
+- [ ] **System tests** for JWT invalidation (`/wazuh-qa/tests/system/test_jwt_invalidation`)
+-->

--- a/.github/ISSUE_TEMPLATE/api-framework.md
+++ b/.github/ISSUE_TEMPLATE/api-framework.md
@@ -22,18 +22,18 @@ Please fill the table above. Feel free to extend it at your convenience.
 
 ## Checks
 
-- **Unit tests** without failures. Updated and/or expanded if there are new functions/methods/outputs:
+### wazuh/wazuh
+- Unit tests without failures. Updated and/or expanded if there are new functions/methods/outputs:
   - [ ] Cluster (`framework/wazuh/core/cluster/tests/` & `framework/wazuh/core/cluster/dapi/tests/`)
   - [ ] Core (`framework/wazuh/core/tests/`)
   - [ ] SDK (`framework/wazuh/tests/`)
   - [ ] RBAC (`framework/wazuh/rbac/tests/`)
   - [ ] API (`api/api/tests/`)
-- **API tavern integration tests** without failures. Updated and/or expanded if needed (`api/test/integration/`):
+- API tavern integration tests without failures. Updated and/or expanded if needed (`api/test/integration/`):
   - [ ] Affected tests 
   - [ ] Affected RBAC (black and white) tests
-- [ ] **Changelog** (`CHANGELOG.md`)
-- [ ] **Documentation** (`/wazuh-documentation/source/user-manual/api`)
-    
+- [ ] Review of spec.yaml examples and schemas (`api/api/spec/spec.yaml`)
+- [ ] Changelog (`CHANGELOG.md`)
 <!-- If changes are made to any of the following components, uncomment the corresponding line 
 - [ ] **Integration tests** without failures for API configuration (`/wazuh-qa/tests/integration/test_api/test_config/`)
 - [ ] **System tests** for agent enrollment process (`/wazuh-qa/tests/system/test_cluster/test_agent_enrollment`)
@@ -41,3 +41,7 @@ Please fill the table above. Feel free to extend it at your convenience.
 - [ ] **System tests** for agent key polling (`/wazuh-qa/tests/system/test_cluster/test_agent_key_polling`)
 - [ ] **System tests** for JWT invalidation (`/wazuh-qa/tests/system/test_jwt_invalidation`)
 -->
+
+### wazuh/wazuh-documentation
+- [ ] Migration from 3.X for changed endpoints (`source/user-manual/api/equivalence.rst`)
+- [ ] Update RBAC reference with new/modified actions/resources/relationships (`source/user-manual/api/rbac/reference.rst`)

--- a/.github/ISSUE_TEMPLATE/api-framework.md
+++ b/.github/ISSUE_TEMPLATE/api-framework.md
@@ -22,9 +22,7 @@ Please fill the table above. Feel free to extend it at your convenience.
 
 
 
-<!--
-Depending on the affected components by this issue, the following checks should be selected and marked.
--->
+## Checks
 
 - **Unit tests** without failures. Updated and/or expanded if there are new functions/methods/outputs:
   - [ ] Cluster (`framework/wazuh/core/cluster/tests/` & `framework/wazuh/core/cluster/dapi/tests/`)
@@ -38,7 +36,6 @@ Depending on the affected components by this issue, the following checks should 
 - [ ] **Changelog** (`CHANGELOG.md`)
 - [ ] **Documentation** (`/wazuh-documentation/source/user-manual/api`)
     
-
 <!-- If changes are made to any of the following components, uncomment the corresponding line 
 - [ ] **Integration tests** without failures for API configuration (`/wazuh-qa/tests/integration/test_api/test_config/`)
 - [ ] **System tests** for agent enrollment process (`/wazuh-qa/tests/system/test_cluster/test_agent_enrollment`)


### PR DESCRIPTION
|Related issue|
|---|
|#6577|

## Description

Hello team!

This PR adds an issue template with some useful check boxes to remember and verify the different steps to perform before opening a framework or API PR.

Framework issues would look like this from now on:
![imagen](https://user-images.githubusercontent.com/23361101/98967816-3772b900-250d-11eb-95e0-a4edae761442.png)

There are also some checkboxes which are commented out by default and can be used in some issues which need to run wazuh-qa tests:
```
<!-- If changes are made to any of the following components, uncomment the corresponding line 
- [ ] **Integration tests** without failures for API configuration (`/wazuh-qa/tests/integration/test_api/test_config/`)
- [ ] **System tests** for agent enrollment process (`/wazuh-qa/tests/system/test_cluster/test_agent_enrollment`)
- [ ] **System tests** for agent info sync process in cluster (`/wazuh-qa/tests/system/test_cluster/test_agent_info_sync`)
- [ ] **System tests** for agent key polling (`/wazuh-qa/tests/system/test_cluster/test_agent_key_polling`)
- [ ] **System tests** for JWT invalidation (`/wazuh-qa/tests/system/test_jwt_invalidation`)
-->
```

Best regards,
Selu.