### PR TITLE
Fix NULL token warning when starting a logtest session without token

### DIFF
--- a/api/test/integration/test_logtest_endpoints.tavern.yaml
+++ b/api/test/integration/test_logtest_endpoints.tavern.yaml
@@ -41,7 +41,7 @@ stages:
           messages: !anything
           output: !anything
           alert: !anybool
-          codemsg: 1 # codemsg = 1 because there is a warning (token generated)
+          codemsg: 1 # codemsg = 1 because there is a warning (invalid token)
       save:
         json:
           returned_token: data.token
@@ -62,6 +62,8 @@ stages:
       status_code: 200
       json:
         <<: *logtest_json_response
+        data:
+          codemsg: 0 # codemsg = 0 because there are no warnings
 
   - name: Run logtest using a token from a running session
     request:
@@ -82,7 +84,7 @@ stages:
         <<: *logtest_json_response
         data:
           token: "{returned_token}"
-          codemsg: 0
+          codemsg: 0 # codemsg = 0 because there are no warnings
 
 
 ---

--- a/framework/wazuh/logtest.py
+++ b/framework/wazuh/logtest.py
@@ -32,11 +32,12 @@ def run_logtest(token=None, event=None, log_format=None, location=None):
     dict
         Logtest response after analyzing the event.
     """
+    local_vars = locals()
     # Token is not required
-    if locals()['token'] is None:
-        del locals()['token']
+    if local_vars['token'] is None:
+        del local_vars['token']
 
-    response = send_logtest_msg(command='log_processing', parameters=locals())
+    response = send_logtest_msg(command='log_processing', parameters=local_vars)
     if response['error'] != 0:
         raise WazuhError(code=7000, extra_message=response.get('message', 'Could not parse error message'))
 


### PR DESCRIPTION
Hi team,

This PR fixes an error that appears when you try to start a `wazuh-logtest `session without token. If you make a request similar to this:

`root@wazuh-master:/# curl -k -X PUT "https://localhost:55000/logtest?pretty=true" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d '{"event": "Oct 15 21:06:59 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928","location": "master->/var/log/syslog","log_format": "syslog"}'`

The response is the next one:

```
{
   "error": 0,
   "data": {
      "token": "d8df3b46",
      "messages": [
         "WARNING: (7309): 'null' is not a valid token",
         "INFO: (7202): Session initialized with token 'd8df3b46'"
      ],
      "output": {
         "timestamp": "2020-11-09T12:38:29.874+0000",
         "rule": {
            "level": 5,
            "description": "sshd: Attempt to login using a non-existent user",
            "id": "5710",
            "mitre": {
               "id": [
                  "T1110"
               ],
               "tactic": [
                  "Credential Access"
               ],
               "technique": [
                  "Brute Force"
               ]
            },
            "firedtimes": 1,
            "mail": false,
            "groups": [
               "syslog",
               "sshd",
               "invalid_login",
               "authentication_failed"
            ],
            "pci_dss": [
               "10.2.4",
               "10.2.5",
               "10.6.1"
            ],
            "gpg13": [
               "7.1"
            ],
            "gdpr": [
               "IV_35.7.d",
               "IV_32.2"
            ],
            "hipaa": [
               "164.312.b"
            ],
            "nist_800_53": [
               "AU.14",
               "AC.7",
               "AU.6"
            ],
            "tsc": [
               "CC6.1",
               "CC6.8",
               "CC7.2",
               "CC7.3"
            ]
         },
         "agent": {
            "id": "000",
            "name": "wazuh-master"
         },
         "manager": {
            "name": "wazuh-master"
         },
         "id": "1604925509.1662269",
         "cluster": {
            "name": "wazuh",
            "node": "master-node"
         },
         "full_log": "Oct 15 21:06:59 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928",
         "predecoder": {
            "program_name": "sshd",
            "timestamp": "Oct 15 21:06:59",
            "hostname": "linux-agent"
         },
         "decoder": {
            "parent": "sshd",
            "name": "sshd"
         },
         "data": {
            "srcip": "18.18.18.18",
            "srcport": "48928",
            "srcuser": "blimey"
         },
         "location": "master->/var/log/syslog"
      },
      "alert": true,
      "codemsg": 1
   }
}

```

The message `"WARNING: (7309): 'null' is not a valid token"` cannot appear because we are not introducing a token. This error was caused by an incorrect deletion of the parameter `token` when it is `None`.

Fixed in this PR. With this changes, the `messages` key would be:

```
"messages": [
         "INFO: (7202): Session initialized with token 'd8df3b46'"
      ],
```

- API integration tests:

```
test_logtest_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rbac_black_logtest_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rbac_white_logtest_endpoints.tavern.yaml 
	 2 passed, 4 warnings
```


- Unit tests passed:

```
framework/wazuh/tests/test_logtest.py ......                                                      [100%]

=========================================== 6 passed in 0.09s ===========================================
```

```
framework/wazuh/core/tests/test_logtest.py ..                                                     [100%]

=========================================== 2 passed in 0.07s ===========================================
```

Regards,
Manuel.
