### PR TITLE
6351 processes sync

### DIFF
--- a/src/wazuh_modules/syscollector/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/syscollectorImp.cpp
@@ -14,24 +14,24 @@
 constexpr auto PACKAGES_SQL_STATEMENT
 {
     R"(CREATE TABLE packages(
-    `name` TEXT,
-    `version` TEXT,
-    `vendor` TEXT,
-    `install_time` TEXT,
-    `location` TEXT,
-    `architecture` TEXT,
-    `groups` TEXT,
-    `description` TEXT,
-    `size` TEXT,
-    `priority` TEXT,
-    `multiarch` TEXT,
-    `source` TEXT,
-    `checksum` TEXT,
-    PRIMARY KEY (`name`,'version','architecture')) WITHOUT ROWID;)"
+    name TEXT,
+    version TEXT,
+    vendor TEXT,
+    install_time TEXT,
+    location TEXT,
+    architecture TEXT,
+    groups TEXT,
+    description TEXT,
+    size TEXT,
+    priority TEXT,
+    multiarch TEXT,
+    source TEXT,
+    checksum TEXT,
+    PRIMARY KEY (name,version,architecture)) WITHOUT ROWID;)"
 };
 constexpr auto PROCESSES_SQL_STATEMENT
 {
-    R"(CREATE TABLE IF NOT EXISTS processes (
+    R"(CREATE TABLE processes (
     pid BIGINT,
     name TEXT,
     state TEXT,

--- a/src/wazuh_modules/syscollector/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/syscollectorImp.cpp
@@ -67,12 +67,14 @@ static void updateAndNotifyChanges(const DBSYNC_HANDLE handle, const std::string
 {
     const std::map<ReturnTypeCallback, std::string> operationsMap
     {
+        // LCOV_EXCL_START
         {MODIFIED, "MODIFIED"},
         {DELETED , "DELETED "},
         {INSERTED, "INSERTED"},
         {MAX_ROWS, "MAX_ROWS"},
         {DB_ERROR, "DB_ERROR"},
         {SELECTED, "SELECTED"},
+        // LCOV_EXCL_STOP
     };
     constexpr auto queueSize{4096};
     const auto callback
@@ -92,11 +94,13 @@ static void updateAndNotifyChanges(const DBSYNC_HANDLE handle, const std::string
             }
             else
             {
+                // LCOV_EXCL_START
                 nlohmann::json msg;
                 msg["type"] = table;
                 msg["operation"] = operationsMap.at(result);
                 msg["data"] = data;
                 std::cout << msg.dump() << std::endl;
+                // LCOV_EXCL_STOP
             }
         }
     };

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -52,7 +52,7 @@ TEST_F(SyscollectorImpTest, intervalSeconds)
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "100s"};
 }
@@ -64,7 +64,7 @@ TEST_F(SyscollectorImpTest, intervalMinutes)
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "100m"};
 }
@@ -76,7 +76,7 @@ TEST_F(SyscollectorImpTest, intervalDays)
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1d"};
 }
@@ -88,7 +88,7 @@ TEST_F(SyscollectorImpTest, intervalUnknownUnit)
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1y"};
 }
@@ -112,7 +112,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1h", true, false};
 }
@@ -124,7 +124,7 @@ TEST_F(SyscollectorImpTest, noOs)
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, os()).Times(0);
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1h", true, true, false};
 }
@@ -136,7 +136,7 @@ TEST_F(SyscollectorImpTest, noNetwork)
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
     EXPECT_CALL(*spInfoWrapper, networks()).Times(0);
-    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1h", true, true, true, false};
 }
@@ -148,7 +148,7 @@ TEST_F(SyscollectorImpTest, noPackages)
     EXPECT_CALL(*spInfoWrapper, packages()).Times(0);
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
     EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, false};
 }
@@ -160,7 +160,7 @@ TEST_F(SyscollectorImpTest, noPorts)
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
     EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).Times(0);   
     Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, true, false};
 }
@@ -172,7 +172,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
     EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, true, true, false};
 }
@@ -196,7 +196,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
     EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillOnce(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, true, true, true, true, false};
 }
@@ -208,7 +208,7 @@ TEST_F(SyscollectorImpTest, scanOnInverval)
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return("networks"));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return("os"));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1s"};
     std::this_thread::sleep_for(std::chrono::seconds{3});

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -209,7 +209,10 @@ TEST_F(SyscollectorImpTest, scanOnInverval)
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return("networks"));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return("os"));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"({"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0})")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1s"};
-    std::this_thread::sleep_for(std::chrono::seconds{3});
+    std::this_thread::sleep_for(std::chrono::seconds{5});
 }


### PR DESCRIPTION
|Related issue|
|---|
|#6351|

## **Description**

This issue aims to make use of the generic synchronization libraries, to use the synchronization solution algorithm that both shared modules provide.

These changes have to be made in the various implementations according to the operating system targeted for this feature.

## **DoD**
- [X] Implementation
- [X] **Run testtool on Win**
![image](https://user-images.githubusercontent.com/54002291/98959773-5f98f280-24e2-11eb-92de-78ee289322d0.png)
- [X] **Run testtool on Linux**
![image](https://user-images.githubusercontent.com/54002291/98958574-2e6bf280-24e1-11eb-976c-a7051452d557.png)
- [X] **RTR syscollector**
![image](https://user-images.githubusercontent.com/54002291/98957903-79393a80-24e0-11eb-9180-5972833941d9.png)

