### PR TITLE
Registry UT: test_create_db

### DIFF
--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -108,20 +108,24 @@ set(CREATE_DB_BASE_FLAGS "-Wl,--wrap,_minfo -Wl,--wrap,_merror -Wl,--wrap,_mwarn
                           -Wl,--wrap,HasFilesystem -Wl,--wrap,fim_db_get_path -Wl,--wrap,fim_db_get_paths_from_inode \
                           -Wl,--wrap,delete_target_file -Wl,--wrap,fim_db_insert -Wl,--wrap,OS_MD5_SHA1_SHA256_File \
                           -Wl,--wrap,seechanges_addfile -Wl,--wrap,fim_db_delete_not_scanned \
-                          -Wl,--wrap,fim_db_set_all_unscanned -Wl,--wrap,fim_db_set_scanned -Wl,--wrap,get_user \
+                          -Wl,--wrap,fim_db_set_all_unscanned -Wl,--wrap,fim_db_set_scanned \
                           -Wl,--wrap,get_group -Wl,--wrap,fim_db_remove_path -Wl,--wrap,isChroot \
                           -Wl,--wrap,fim_db_get_not_scanned -Wl,--wrap,fim_db_set_all_unscanned \
                           -Wl,--wrap,fim_db_get_count_file_entry -Wl,--wrap,fim_db_get_path_range \
                           -Wl,--wrap,fim_db_process_missing_entry -Wl,--wrap,send_log_msg -Wl,--wrap,IsDir \
-                          -Wl,--wrap,DirSize -Wl,--wrap,seechanges_get_diff_path -Wl,--wrap,stat")
+                          -Wl,--wrap,DirSize -Wl,--wrap,seechanges_get_diff_path -Wl,--wrap,stat \
+                          -Wl,--wrap,fim_file_diff -Wl,--wrap,fim_diff_process_delete_file \
+                          -Wl,--wrap,fim_db_get_count_entries")
 
 list(APPEND syscheckd_tests_names "test_create_db")
 if(${TARGET} STREQUAL "winagent")
   list(APPEND syscheckd_tests_flags "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=w_get_file_permissions \
                                      -Wl,--wrap=decode_win_permissions,--wrap=pthread_mutex_lock \
-                                     -Wl,--wrap=pthread_mutex_unlock,--wrap=w_get_file_attrs,--wrap=os_winreg_check")
+                                     -Wl,--wrap=pthread_mutex_unlock,--wrap=w_get_file_attrs,--wrap=os_winreg_check \
+                                     -Wl,--wrap,get_file_user -Wl,--wrap,fim_registry_scan")
 else()
-  list(APPEND syscheckd_tests_flags "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=lstat -Wl,--wrap=count_watches")
+  list(APPEND syscheckd_tests_flags "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=lstat -Wl,--wrap=count_watches \
+                                     -Wl,--wrap,get_user")
 endif()
 
 if(NOT ${TARGET} STREQUAL "winagent")

--- a/src/unit_tests/syscheckd/expect_fim_diff_changes.c
+++ b/src/unit_tests/syscheckd/expect_fim_diff_changes.c
@@ -28,7 +28,3 @@ void expect_fim_diff_delete_compress_folder(struct dirent *dir) {
     will_return(__wrap_readdir, dir);
     will_return(__wrap_readdir, NULL);
 }
-
-void expect_fim_diff_process_delete_file(struct dirent *dir) {
-    expect_fim_diff_delete_compress_folder(dir);
-}

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1240,9 +1240,9 @@ static void test_fim_file_add(void **state) {
     struct stat buf;
 
 #ifdef TEST_WINAGENT
-    char file_path[256] = "c:\\windows\\system32\\cmd.exe";
+    char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
 #else
-    char file_path[256] = "/bin/ls";
+    char file_path[OS_SIZE_256] = "/bin/ls";
 #endif
 
     buf.st_mode = S_IFREG | 00444 ;
@@ -1298,9 +1298,9 @@ static void test_fim_file_modify(void **state) {
     int ret;
 
 #ifdef TEST_WINAGENT
-    char file_path[256] = "c:\\windows\\system32\\cmd.exe";
+    char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
 #else
-    char file_path[256] = "/bin/ls";
+    char file_path[OS_SIZE_256] = "/bin/ls";
 #endif
     fim_data->item->index = 1;
     fim_data->item->configuration = CHECK_SIZE |
@@ -1380,13 +1380,13 @@ static void test_fim_file_modify(void **state) {
 static void test_fim_file_no_attributes(void **state) {
     fim_data_t *fim_data = *state;
     int ret;
-    char buffer1[295];
-    char buffer2[300];
+    char buffer1[OS_SIZE_512];
+    char buffer2[OS_SIZE_512];
 
 #ifdef TEST_WINAGENT
-    char file_path[256] = "c:\\windows\\system32\\cmd.exe";
+    char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
 #else
-    char file_path[256] = "/bin/ls";
+    char file_path[OS_SIZE_256] = "/bin/ls";
 #endif
     fim_data->item->index = 1;
 
@@ -1416,8 +1416,8 @@ static void test_fim_file_no_attributes(void **state) {
                                         0x400,
                                         -1);
 
-    snprintf(buffer1, 295, FIM_HASHES_FAIL, file_path);
-    snprintf(buffer2, 300, FIM_GET_ATTRIBUTES, file_path);
+    snprintf(buffer1, OS_SIZE_256, FIM_HASHES_FAIL, file_path);
+    snprintf(buffer2, OS_SIZE_256, FIM_GET_ATTRIBUTES, file_path);
 
     expect_string(__wrap__mdebug1, formatted_msg, buffer1);
     expect_string(__wrap__mdebug1, formatted_msg, buffer2);
@@ -1435,9 +1435,9 @@ static void test_fim_file_error_on_insert(void **state) {
     int ret;
 
 #ifdef TEST_WINAGENT
-    char file_path[256] = "c:\\windows\\system32\\cmd.exe";
+    char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
 #else
-    char file_path[256] = "/bin/ls";
+    char file_path[OS_SIZE_256] = "/bin/ls";
 #endif
 
     fim_data->item->index = 1;
@@ -2510,14 +2510,13 @@ static void test_fim_checker_fim_regular(void **state) {
 
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
 
-    char expanded_path[100];
+    char expanded_path[OS_SIZE_128];
 
     fim_data->item->index = 7;
 
     fim_data->item->statbuf.st_size = 1500;
 
-    if(!ExpandEnvironmentStrings(path, expanded_path, 100)){
-
+    if(!ExpandEnvironmentStrings(path, expanded_path, OS_SIZE_128)){
         fail();
     }
     expect_string(__wrap_stat, __file, expanded_path);
@@ -2770,7 +2769,7 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
 static void test_fim_scan_db_full_double_scan(void **state) {
 
     struct dirent *file = *state;
-    char test_file_path[160];
+    char test_file_path[OS_SIZE_256];
 
     char expanded_dirs[10][OS_SIZE_1024];
     char directories[10][OS_SIZE_256] = {
@@ -3816,11 +3815,11 @@ static void test_fim_realtime_event_file_exists(void **state) {
 
 static void test_fim_realtime_event_file_missing(void **state) {
 #ifdef TEST_WINAGENT
-    char start[10] = "/test\\";
-    char top[10] = "/test]";
+    char start[OS_SIZE_32] = "/test\\";
+    char top[OS_SIZE_32] = "/test]";
 #else
-    char start[10] = "/test/";
-    char top[10] = "/test0";
+    char start[OS_SIZE_32] = "/test/";
+    char top[OS_SIZE_32] = "/test0";
 #endif
 
 #ifndef TEST_WINAGENT
@@ -3874,11 +3873,11 @@ static void test_fim_whodata_event_file_exists(void **state) {
 static void test_fim_whodata_event_file_missing(void **state) {
     fim_data_t *fim_data = *state;
 #ifdef TEST_WINAGENT
-    char start[20] = "./test/test.file\\";
-    char top[20] = "./test/test.file]";
+    char start[OS_SIZE_32] = "./test/test.file\\";
+    char top[OS_SIZE_32] = "./test/test.file]";
 #else
-    char start[20] = "./test/test.file/";
-    char top[20] = "./test/test.file0";
+    char start[OS_SIZE_32] = "./test/test.file/";
+    char top[OS_SIZE_32] = "./test/test.file0";
 #endif
 
 #ifndef TEST_WINAGENT
@@ -3939,11 +3938,11 @@ static void test_fim_whodata_event_file_missing(void **state) {
 
 static void test_fim_process_missing_entry_no_data(void **state) {
 #ifdef TEST_WINAGENT
-    char start[10] = "/test\\";
-    char top[10] = "/test]";
+    char start[OS_SIZE_32] = "/test\\";
+    char top[OS_SIZE_32] = "/test]";
 #else
-    char start[10] = "/test/";
-    char top[10] = "/test0";
+    char start[OS_SIZE_32] = "/test/";
+    char top[OS_SIZE_32] = "/test0";
 #endif
 
 #ifdef TEST_WINAGENT
@@ -3966,11 +3965,11 @@ static void test_fim_process_missing_entry_no_data(void **state) {
 
 static void test_fim_process_missing_entry_failure(void **state) {
 #ifdef TEST_WINAGENT
-    char start[10] = "/test\\";
-    char top[10] = "/test]";
+    char start[OS_SIZE_32] = "/test\\";
+    char top[OS_SIZE_32] = "/test]";
 #else
-    char start[10] = "/test/";
-    char top[10] = "/test0";
+    char start[OS_SIZE_32] = "/test/";
+    char top[OS_SIZE_32] = "/test0";
 #endif
 
     fim_tmp_file *file = calloc(1, sizeof(fim_tmp_file));

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -26,7 +26,7 @@
 #include "../wrappers/wazuh/syscheckd/run_check_wrappers.h"
 #include "../wrappers/wazuh/syscheckd/run_realtime_wrappers.h"
 #include "../wrappers/wazuh/syscheckd/fim_diff_changes_wrappers.h"
-#include "../wrappers/wazuh/syscheckd/win-registry_wrappers.h"
+#include "../wrappers/wazuh/syscheckd/registry.h"
 #include "../wrappers/wazuh/os_crypto/md5_op_wrappers.h"
 #include "../wrappers/wazuh/shared/file_op_wrappers.h"
 
@@ -47,7 +47,7 @@ typedef struct __fim_data_s {
     fim_file_data *local_data; // Used on certain tests, not affected by group setup/teardown
     struct dirent *entry;       // Used on fim_directory tests, not affected by group setup/teardown
     cJSON *json;
-}fim_data_t;
+} fim_data_t;
 
 /* redefinitons/wrapping */
 
@@ -236,7 +236,6 @@ static int setup_fim_entry(void **state) {
     if(fim_data->fentry = calloc(1, sizeof(fim_entry)), fim_data->fentry == NULL)
         return -1;
     fim_data->fentry->type = FIM_TYPE_FILE;
-    os_calloc(1, sizeof(fim_file_data), fim_data->fentry->file_entry.data);
 
     if(fim_data->local_data = calloc(1, sizeof(fim_file_data)), fim_data->local_data == NULL)
         return -1;
@@ -244,14 +243,26 @@ static int setup_fim_entry(void **state) {
     fim_data->fentry->file_entry.data = fim_data->local_data;
     fim_data->fentry->file_entry.path = NULL;
 
-    return 0;
-}
+    fim_data->item->index = 1;
+    fim_data->item->configuration = CHECK_SIZE |
+                                    CHECK_PERM  |
+                                    CHECK_OWNER |
+                                    CHECK_GROUP |
+                                    CHECK_MD5SUM |
+                                    CHECK_SHA1SUM |
+                                    CHECK_SHA256SUM;
 
-static int teardown_fim_entry(void **state) {
-    fim_data_t *fim_data = *state;
+    fim_data->fentry->file_entry.path = strdup("file");
+    fim_data->fentry->file_entry.data = fim_data->local_data;
 
-    free_entry(fim_data->fentry);
-
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
     return 0;
 }
 
@@ -376,9 +387,49 @@ static int teardown_fim_scan_realtime(void **state) {
 
     return 0;
 }
+
 #endif
 
+static int setup_fim_tmp_file(void **state) {
+    fim_tmp_file *file = malloc(sizeof(fim_tmp_file));
+    if (file == NULL) {
+        return 1;
+    }
+    file->elements = 1;
+    *state = file;
+    return 0;
+}
+
+static int teardown_fim_tmp_file(void **state){
+    fim_tmp_file *file = *state;
+    free(file);
+    return 0;
+}
+
 /* Auxiliar functions */
+void expect_get_data (char *user, char *group, char *file_path, int calculate_checksums) {
+#ifndef TEST_WINAGENT
+    expect_get_user(0, user);
+    expect_get_group(0, group);
+#else
+    expect_get_file_user(file_path, "0", user);
+    expect_w_get_file_permissions(file_path, "permissions", 0);
+
+    expect_string(__wrap_decode_win_permissions, raw_perm, "permissions");
+    will_return(__wrap_decode_win_permissions, "decoded_perms");
+#endif
+    if (calculate_checksums) {
+        expect_OS_MD5_SHA1_SHA256_File_call(file_path,
+                                            syscheck.prefilter_cmd,
+                                            "d41d8cd98f00b204e9800998ecf8427e",
+                                            "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                                            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                                            OS_BINARY,
+                                            0x400,
+                                            0);
+    }
+}
+
 /**
  * @brief This function will prepare the successfull execution of the double scan in Windows tests
  * @param test_file_path File path that will be used in the function fim_db_insert.
@@ -387,7 +438,7 @@ static int teardown_fim_scan_realtime(void **state) {
  */
 void prepare_win_double_scan_success (char *test_file_path, char *dir_file_path, struct dirent *file) {
 
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 
     // check_deleted_files
     expect_value(__wrap_fim_db_get_not_scanned, fim_sql, syscheck.database);
@@ -412,24 +463,14 @@ void prepare_win_double_scan_success (char *test_file_path, char *dir_file_path,
     // fim_file
     {
         // fim_get_data
-
-        expect_string(__wrap_w_get_file_permissions, file_path, test_file_path);
-        will_return(__wrap_w_get_file_permissions, "permissions");
-        will_return(__wrap_w_get_file_permissions, 0);
-
-        expect_string(__wrap_decode_win_permissions, raw_perm, "permissions");
-        will_return(__wrap_decode_win_permissions, "decoded_perms");
-
-        expect_string(__wrap_w_get_file_attrs, file_path, test_file_path);
-        will_return(__wrap_w_get_file_attrs, 123456);
-
-        expect_string(__wrap_get_user, path, test_file_path);
-        will_return(__wrap_get_user, "0");
-        will_return(__wrap_get_user, strdup("user"));
+        expect_get_data(strdup("user"), "group", test_file_path, 0);
 
         expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
         expect_string(__wrap_fim_db_get_path, file_path, test_file_path);
-        will_return(__wrap_fim_db_get_path, 0);
+        will_return(__wrap_fim_db_get_path, NULL);
+
+        expect_string(__wrap_w_get_file_attrs, file_path, test_file_path);
+        will_return(__wrap_w_get_file_attrs, 123456);
 
         expect_value(__wrap_fim_db_insert, fim_sql, syscheck.database);
         expect_string(__wrap_fim_db_insert, file_path, test_file_path);
@@ -448,10 +489,7 @@ static void test_fim_json_event(void **state) {
     fim_data_t *fim_data = *state;
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606061);
-    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 12345678);
-    will_return(__wrap_fim_db_get_paths_from_inode, NULL);
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606061, 12345678, NULL);
 #endif
 
     fim_data->json = fim_json_event(
@@ -511,10 +549,7 @@ static void test_fim_json_event_whodata(void **state) {
     syscheck.opts[1] |= CHECK_SEECHANGES;
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606061);
-    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 12345678);
-    will_return(__wrap_fim_db_get_paths_from_inode, NULL);
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606061, 12345678, NULL);
 #endif
 
     fim_data->json = fim_json_event(
@@ -590,10 +625,8 @@ static void test_fim_json_event_hardlink_one_path(void **state) {
     paths[1] = NULL;
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606061);
-    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 12345678);
-    will_return(__wrap_fim_db_get_paths_from_inode, paths);
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606061, 12345678, paths);
+
 #endif
 
     fim_data->json = fim_json_event(
@@ -655,10 +688,7 @@ static void test_fim_json_event_hardlink_two_paths(void **state) {
     paths[2] = NULL;
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606061);
-    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 12345678);
-    will_return(__wrap_fim_db_get_paths_from_inode, paths);
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606061, 12345678, paths);
 #endif
 
     fim_data->json = fim_json_event(
@@ -1173,31 +1203,6 @@ static void test_fim_configuration_directory_not_found(void **state) {
     assert_int_equal(ret, -1);
 }
 
-#ifdef TEST_WINAGENT
-static void test_fim_configuration_directory_registry_not_found(void **state) {
-    int ret;
-
-    const char *path = "invalid";
-    const char *entry = "registry";
-
-    expect_string(__wrap__mdebug2, formatted_msg, "(6319): No configuration found for (registry):'invalid'");
-
-    ret = fim_configuration_directory(path, entry);
-
-    assert_int_equal(ret, -1);
-}
-
-static void test_fim_configuration_directory_registry_found(void **state) {
-    char *path = "[x32] HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnce";
-    const char * entry = "registry";
-    int ret;
-
-    ret = fim_configuration_directory(path, entry);
-
-    assert_int_equal(ret, 20);
-}
-#endif
-
 static void test_init_fim_data_entry(void **state) {
     fim_data_t *fim_data = *state;
 
@@ -1217,10 +1222,28 @@ static void test_init_fim_data_entry(void **state) {
     assert_int_equal(fim_data->local_data->hash_sha256[0], 0);
 }
 
+static void expect_fim_db_insert(fdb_t *db, const char *file_path, int ret) {
+    expect_value(__wrap_fim_db_insert, fim_sql, db);
+    expect_string(__wrap_fim_db_insert, file_path, file_path);
+    will_return(__wrap_fim_db_insert, ret);
+}
+
+static void expect_fim_db_set_scanned(fdb_t *db, const char *file_path, int ret) {
+    expect_value(__wrap_fim_db_set_scanned, fim_sql, db);
+    expect_string(__wrap_fim_db_set_scanned, path, file_path);
+    will_return(__wrap_fim_db_set_scanned, ret);
+}
+
 static void test_fim_file_add(void **state) {
     fim_data_t *fim_data = *state;
     int ret;
     struct stat buf;
+
+#ifdef TEST_WINAGENT
+    char file_path[256] = "c:\\windows\\system32\\cmd.exe";
+#else
+    char file_path[256] = "/bin/ls";
+#endif
 
     buf.st_mode = S_IFREG | 00444 ;
     buf.st_size = 1000;
@@ -1244,64 +1267,25 @@ static void test_fim_file_add(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    // Inside fim_get_data
-#ifndef TEST_WINAGENT
-    expect_value(__wrap_get_user, uid, 0);
-    will_return(__wrap_get_user, strdup("user"));
-
-    expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "group");
-#else
-    will_return(__wrap_get_user, "0");
-    will_return(__wrap_get_user, strdup("user"));
-    expect_string(__wrap_get_user, path, "file");
-
-    expect_string(__wrap_w_get_file_permissions, file_path, "file");
-    will_return(__wrap_w_get_file_permissions, "permissions");
-    will_return(__wrap_w_get_file_permissions, 0);
-
-    expect_string(__wrap_decode_win_permissions, raw_perm, "permissions");
-    will_return(__wrap_decode_win_permissions, "decoded_perms");
-#endif
-
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, fname, "file");
-#ifndef TEST_WINAGENT
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, prefilter_cmd, "/bin/ls");
-#else
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, prefilter_cmd, "c:\\windows\\system32\\cmd.exe");
-#endif
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, md5output, "d41d8cd98f00b204e9800998ecf8427e");
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, sha1output, "da39a3ee5e6b4b0d3255bfef95601890afd80709");
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, sha256output, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-    expect_value(__wrap_OS_MD5_SHA1_SHA256_File, mode, OS_BINARY);
-    expect_value(__wrap_OS_MD5_SHA1_SHA256_File, max_size, 0x400);
-    will_return(__wrap_OS_MD5_SHA1_SHA256_File, 0);
+    expect_get_data(strdup("user"), "group", file_path, 1);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path, file_path, "file");
+    expect_string(__wrap_fim_db_get_path, file_path, file_path);
     will_return(__wrap_fim_db_get_path, NULL);
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 1234);
-    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 2345);
-    will_return(__wrap_fim_db_get_paths_from_inode, NULL);
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 1234, 2345, NULL);
 #endif
+    expect_fim_file_diff(file_path, strdup("diff"));
 
-    expect_string(__wrap_seechanges_addfile, filename, "file");
-    will_return(__wrap_seechanges_addfile, strdup("diff"));
+    expect_fim_db_insert(syscheck.database, file_path, FIMDB_OK);
 
-    expect_value(__wrap_fim_db_insert, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_insert, file_path, "file");
-    will_return(__wrap_fim_db_insert, 0);
+    expect_fim_db_set_scanned(syscheck.database, file_path, FIMDB_OK);
 
-    expect_value(__wrap_fim_db_set_scanned, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_set_scanned, path, "file");
-    will_return(__wrap_fim_db_set_scanned, 0);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
-    ret = fim_file("file", fim_data->item, NULL, 1);
+    ret = fim_file(file_path, fim_data->item, NULL, 1);
 
     fim_data->item->configuration &= ~CHECK_SEECHANGES;
 
@@ -1313,6 +1297,11 @@ static void test_fim_file_modify(void **state) {
     fim_data_t *fim_data = *state;
     int ret;
 
+#ifdef TEST_WINAGENT
+    char file_path[256] = "c:\\windows\\system32\\cmd.exe";
+#else
+    char file_path[256] = "/bin/ls";
+#endif
     fim_data->item->index = 1;
     fim_data->item->configuration = CHECK_SIZE |
                                     CHECK_PERM  |
@@ -1348,55 +1337,38 @@ static void test_fim_file_modify(void **state) {
 #endif
     // Inside fim_get_data
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_get_user, uid, 0);
-    will_return(__wrap_get_user, strdup("user"));
+    expect_get_user(0, strdup("user"));
 
-    expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "group");
+    expect_get_group(0, strdup("group"));
 #else
-    will_return(__wrap_get_user, "0");
-    will_return(__wrap_get_user, strdup("user"));
-    expect_string(__wrap_get_user, path, "file");
 
-    expect_string(__wrap_w_get_file_permissions, file_path, "file");
-    will_return(__wrap_w_get_file_permissions, "permissions");
-    will_return(__wrap_w_get_file_permissions, 0);
+    expect_get_file_user("file", "0", strdup("user"));
+    expect_w_get_file_permissions("file", "permissions", 0);
 
     expect_string(__wrap_decode_win_permissions, raw_perm, "permissions");
     will_return(__wrap_decode_win_permissions, "decoded_perms");
 #endif
 
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, fname, "file");
-#ifndef TEST_WINAGENT
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, prefilter_cmd, "/bin/ls");
-#else
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, prefilter_cmd, "c:\\windows\\system32\\cmd.exe");
-#endif
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, md5output, "d41d8cd98f00b204e9800998ecf8427e");
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, sha1output, "da39a3ee5e6b4b0d3255bfef95601890afd80709");
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, sha256output, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-    expect_value(__wrap_OS_MD5_SHA1_SHA256_File, mode, OS_BINARY);
-    expect_value(__wrap_OS_MD5_SHA1_SHA256_File, max_size, 0x400);
-    will_return(__wrap_OS_MD5_SHA1_SHA256_File, 0);
+    expect_OS_MD5_SHA1_SHA256_File_call("file",
+                                        file_path,
+                                        "d41d8cd98f00b204e9800998ecf8427e",
+                                        "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                                        OS_BINARY,
+                                        0x400,
+                                        0);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, "file");
     will_return(__wrap_fim_db_get_path, fim_data->fentry);
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 1234);
-    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 2345);
-    will_return(__wrap_fim_db_get_paths_from_inode, NULL);
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 1234, 2345, NULL);
 #endif
+    expect_fim_db_insert(syscheck.database, "file", FIMDB_OK);
 
-    expect_value(__wrap_fim_db_insert, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_insert, file_path, "file");
-    will_return(__wrap_fim_db_insert, 0);
+    expect_fim_db_set_scanned(syscheck.database, "file", FIMDB_OK);
 
-    expect_value(__wrap_fim_db_set_scanned, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_set_scanned, path, "file");
-    will_return(__wrap_fim_db_set_scanned, 0);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -1408,51 +1380,52 @@ static void test_fim_file_modify(void **state) {
 static void test_fim_file_no_attributes(void **state) {
     fim_data_t *fim_data = *state;
     int ret;
+    char buffer1[295];
+    char buffer2[300];
 
+#ifdef TEST_WINAGENT
+    char file_path[256] = "c:\\windows\\system32\\cmd.exe";
+#else
+    char file_path[256] = "/bin/ls";
+#endif
     fim_data->item->index = 1;
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
     // Inside fim_get_data
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_get_user, uid, 0);
-    will_return(__wrap_get_user, strdup("user"));
-
-    expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "group");
+    expect_get_user(0, strdup("user"));
+    expect_get_group(0, strdup("group"));
 #else
-    will_return(__wrap_get_user, "0");
-    will_return(__wrap_get_user, strdup("user"));
-    expect_string(__wrap_get_user, path, "file");
+    expect_get_file_user(file_path, "0", strdup("user"));
 
-    expect_string(__wrap_w_get_file_permissions, file_path, "file");
-    will_return(__wrap_w_get_file_permissions, "permissions");
-    will_return(__wrap_w_get_file_permissions, 0);
+    expect_w_get_file_permissions(file_path, "permissions", 0);
+
 
     expect_string(__wrap_decode_win_permissions, raw_perm, "permissions");
     will_return(__wrap_decode_win_permissions, "decoded_perms");
 #endif
 
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, fname, "file");
-#ifndef TEST_WINAGENT
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, prefilter_cmd, "/bin/ls");
-#else
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, prefilter_cmd, "c:\\windows\\system32\\cmd.exe");
-#endif
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, md5output, "d41d8cd98f00b204e9800998ecf8427e");
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, sha1output, "da39a3ee5e6b4b0d3255bfef95601890afd80709");
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, sha256output, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-    expect_value(__wrap_OS_MD5_SHA1_SHA256_File, mode, OS_BINARY);
-    expect_value(__wrap_OS_MD5_SHA1_SHA256_File, max_size, 0x400);
-    will_return(__wrap_OS_MD5_SHA1_SHA256_File, -1);
+    expect_OS_MD5_SHA1_SHA256_File_call(file_path,
+                                        syscheck.prefilter_cmd,
+                                        "d41d8cd98f00b204e9800998ecf8427e",
+                                        "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                                        OS_BINARY,
+                                        0x400,
+                                        -1);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6324): Couldn't generate hashes for 'file'");
-    expect_string(__wrap__mdebug1, formatted_msg, "(6331): Couldn't get attributes for file: 'file'");
+    snprintf(buffer1, 295, FIM_HASHES_FAIL, file_path);
+    snprintf(buffer2, 300, FIM_GET_ATTRIBUTES, file_path);
+
+    expect_string(__wrap__mdebug1, formatted_msg, buffer1);
+    expect_string(__wrap__mdebug1, formatted_msg, buffer2);
 
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
-    ret = fim_file("file", fim_data->item, NULL, 1);
+    ret = fim_file(file_path, fim_data->item, NULL, 1);
 
     assert_int_equal(ret, 0);
 }
@@ -1460,6 +1433,12 @@ static void test_fim_file_no_attributes(void **state) {
 static void test_fim_file_error_on_insert(void **state) {
     fim_data_t *fim_data = *state;
     int ret;
+
+#ifdef TEST_WINAGENT
+    char file_path[256] = "c:\\windows\\system32\\cmd.exe";
+#else
+    char file_path[256] = "/bin/ls";
+#endif
 
     fim_data->item->index = 1;
     fim_data->item->configuration = CHECK_SIZE |
@@ -1496,24 +1475,15 @@ static void test_fim_file_error_on_insert(void **state) {
 #endif
     // Inside fim_get_data
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_get_user, uid, 0);
-    will_return(__wrap_get_user, strdup("user"));
-
-    expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "group");
+    expect_get_user(0, strdup("user"));
+    expect_get_group(0, "group");
 #else
-    will_return(__wrap_get_user, "0");
-    will_return(__wrap_get_user, strdup("user"));
-    expect_string(__wrap_get_user, path, "file");
-
-    expect_string(__wrap_w_get_file_permissions, file_path, "file");
-    will_return(__wrap_w_get_file_permissions, "permissions");
-    will_return(__wrap_w_get_file_permissions, 0);
+    expect_get_file_user("file", "0", strdup("user"));
+    expect_w_get_file_permissions("file", "permissions", 0);
 
     expect_string(__wrap_decode_win_permissions, raw_perm, "permissions");
     will_return(__wrap_decode_win_permissions, "decoded_perms");
 #endif
-
     expect_string(__wrap_OS_MD5_SHA1_SHA256_File, fname, "file");
 #ifndef TEST_WINAGENT
     expect_string(__wrap_OS_MD5_SHA1_SHA256_File, prefilter_cmd, "/bin/ls");
@@ -1532,10 +1502,7 @@ static void test_fim_file_error_on_insert(void **state) {
     will_return(__wrap_fim_db_get_path, fim_data->fentry);
 
 #ifndef TEST_WINAGENT
-    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 1234);
-    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 2345);
-    will_return(__wrap_fim_db_get_paths_from_inode, NULL);
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 1234, 2345, NULL);
 #endif
 
     expect_value(__wrap_fim_db_insert, fim_sql, syscheck.database);
@@ -1674,17 +1641,7 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
 
     char *diff_path = "/var/ossec/queue/diff/local/media/test.file";
 
-    expect_string(__wrap_seechanges_get_diff_path, path, path);
-    will_return(__wrap_seechanges_get_diff_path, strdup(diff_path));
-
-    expect_string(__wrap_IsDir, file, diff_path);
-    will_return(__wrap_IsDir, 0);
-
-    expect_string(__wrap_DirSize, path, diff_path);
-    will_return(__wrap_DirSize, 200);
-
-    expect_string(__wrap_delete_target_file, path, path);
-    will_return(__wrap_delete_target_file, 0);
+    expect_fim_diff_process_delete_file(path, 0);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, "/media/test.file");
@@ -1750,10 +1707,7 @@ static void test_fim_checker_fim_regular(void **state) {
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
 
-    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 999);
-    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 1);
-    will_return(__wrap_fim_db_get_paths_from_inode, NULL);
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 999, 1, NULL);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, "/media/test.file");
@@ -1799,10 +1753,8 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, "group");
 
-    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 999);
-    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 1);
-    will_return(__wrap_fim_db_get_paths_from_inode, NULL);
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 999, 1, NULL);
+
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, "/media/test.file");
@@ -2036,7 +1988,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
         it++;
     }
 
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 
     // check_deleted_files
     expect_value(__wrap_fim_db_get_not_scanned, fim_sql, syscheck.database);
@@ -2065,18 +2017,14 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     // fim_file
     {
         // fim_get_data
-        expect_value(__wrap_get_user, uid, 0);
-        will_return(__wrap_get_user, strdup("user"));
-        expect_value(__wrap_get_group, gid, 0);
-        will_return(__wrap_get_group, "group");
+        expect_get_user(0, strdup("user"));
+        expect_get_group(0, strdup("group"));
 
         expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
         expect_string(__wrap_fim_db_get_path, file_path, "/boot/test_file");
-        will_return(__wrap_fim_db_get_path, 0);
+        will_return(__wrap_fim_db_get_path, FIMDB_OK);
 
-        expect_value(__wrap_fim_db_insert, fim_sql, syscheck.database);
-        expect_string(__wrap_fim_db_insert, file_path, "/boot/test_file");
-        will_return(__wrap_fim_db_insert, FIMDB_FULL);
+        expect_fim_db_insert(syscheck.database, "/boot/test_file", FIMDB_FULL);
         // fim_json_event
         expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
         expect_any(__wrap_fim_db_get_paths_from_inode, inode);
@@ -2091,7 +2039,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     will_return(__wrap_fim_db_set_all_unscanned, 0);
 
     // fim_check_db_state
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
     expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
     will_return(__wrap_send_log_msg, 1);
@@ -2149,7 +2097,7 @@ static void test_fim_scan_no_realtime(void **state) {
         it++;
     }
 
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 
     expect_value(__wrap_fim_db_get_not_scanned, fim_sql, syscheck.database);
     expect_value(__wrap_fim_db_get_not_scanned, storage, FIM_DB_DISK);
@@ -2159,7 +2107,7 @@ static void test_fim_scan_no_realtime(void **state) {
     expect_value(__wrap_fim_db_set_all_unscanned, fim_sql, syscheck.database);
     will_return(__wrap_fim_db_set_all_unscanned, 0);
 
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6342): Maximum number of files to be monitored: '50000'");
 
@@ -2209,7 +2157,7 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
         it++;
     }
 
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 
     // check_deleted_files
     expect_value(__wrap_fim_db_get_not_scanned, fim_sql, syscheck.database);
@@ -2221,7 +2169,7 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
     will_return(__wrap_fim_db_set_all_unscanned, 0);
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6342): Maximum number of files to be monitored: '50000'");
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 
     expect_function_call(__wrap_count_watches);
     will_return(__wrap_count_watches, 6);
@@ -2288,12 +2236,12 @@ static void test_fim_scan_realtime_enabled(void **state) {
     will_return(__wrap_fim_db_set_all_unscanned, 0);
 
     // fim_scan
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6342): Maximum number of files to be monitored: '50000'");
 
     // fim_check_db_state
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 
     // fim_scan
     expect_function_call(__wrap_count_watches);
@@ -2338,7 +2286,7 @@ static void test_fim_scan_db_free(void **state) {
         it++;
     }
 
-    will_return(__wrap_fim_db_get_count_entry_path, 1000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 1000);
 
     // check_deleted_files
     expect_value(__wrap_fim_db_get_not_scanned, fim_sql, syscheck.database);
@@ -2348,7 +2296,7 @@ static void test_fim_scan_db_free(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6342): Maximum number of files to be monitored: '50000'");
 
-    will_return(__wrap_fim_db_get_count_entry_path, 1000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 1000);
 
     expect_string(__wrap__minfo, formatted_msg, "(6038): Sending DB back to normal alert.");
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":1000,\"alert_type\":\"normal\"}");
@@ -2486,6 +2434,7 @@ static void test_fim_checker_deleted_file(void **state) {
     fim_checker(expanded_path, fim_data->item, NULL, 1);
 
     errno = 0;
+
     assert_int_equal(fim_data->item->configuration, 53759);
     assert_int_equal(fim_data->item->index, 7);
 }
@@ -2533,17 +2482,8 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
 
     char *diff_path = "queue/diff/local/c\\windows\\system32\\drivers\\etc\\test.exe";
 
-    expect_string(__wrap_seechanges_get_diff_path, path, expanded_path);
-    will_return(__wrap_seechanges_get_diff_path, strdup(diff_path));
+    expect_fim_diff_process_delete_file(expanded_path, 0);
 
-    expect_string(__wrap_IsDir, file, diff_path);
-    will_return(__wrap_IsDir, 0);
-
-    expect_string(__wrap_DirSize, path, diff_path);
-    will_return(__wrap_DirSize, 200);
-
-    expect_string(__wrap_delete_target_file, path, expanded_path);
-    will_return(__wrap_delete_target_file, 0);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
@@ -2569,33 +2509,29 @@ static void test_fim_checker_fim_regular(void **state) {
     fim_data_t *fim_data = *state;
 
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
-    char expanded_path[OS_MAXSTR];
+
+    char expanded_path[100];
+
     fim_data->item->index = 7;
+
     fim_data->item->statbuf.st_size = 1500;
 
+    if(!ExpandEnvironmentStrings(path, expanded_path, 100)){
+
+        fail();
+    }
     expect_string(__wrap_stat, __file, expanded_path);
     will_return(__wrap_stat, S_IFREG);
-    will_return(__wrap_stat, 0);
 
-    if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
-        fail();
+    will_return(__wrap_stat, 0);
 
     str_lowercase(expanded_path);
 
     expect_string(__wrap_HasFilesystem, path, expanded_path);
+
     will_return(__wrap_HasFilesystem, 0);
-
     // Inside fim_file
-    will_return(__wrap_get_user, "0");
-    will_return(__wrap_get_user, strdup("user"));
-    expect_string(__wrap_get_user, path, expanded_path);
-
-    expect_string(__wrap_w_get_file_permissions, file_path, expanded_path);
-    will_return(__wrap_w_get_file_permissions, "permissions");
-    will_return(__wrap_w_get_file_permissions, 0);
-
-    expect_string(__wrap_decode_win_permissions, raw_perm, "permissions");
-    will_return(__wrap_decode_win_permissions, "decoded_perms");
+    expect_get_data(strdup("user"), "group", expanded_path, 0);
 
     expect_string(__wrap_w_get_file_attrs, file_path, expanded_path);
     will_return(__wrap_w_get_file_attrs, 123456);
@@ -2613,8 +2549,8 @@ static void test_fim_checker_fim_regular(void **state) {
     will_return(__wrap_fim_db_insert, 0);
 
     expect_value(__wrap_fim_db_set_scanned, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_set_scanned, path, expanded_path);
     will_return(__wrap_fim_db_set_scanned, 0);
+    expect_string(__wrap_fim_db_set_scanned, path, expanded_path);
 
     fim_checker(expanded_path, fim_data->item, fim_data->w_evt, 1);
 
@@ -2703,16 +2639,8 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     will_return(__wrap_HasFilesystem, 0);
 
     // Inside fim_file
-    will_return(__wrap_get_user, "0");
-    will_return(__wrap_get_user, strdup("user"));
-    expect_string(__wrap_get_user, path, expanded_path);
+    expect_get_data(strdup("user"), "group", expanded_path, 0);
 
-    expect_string(__wrap_w_get_file_permissions, file_path, expanded_path);
-    will_return(__wrap_w_get_file_permissions, "permissions");
-    will_return(__wrap_w_get_file_permissions, 0);
-
-    expect_string(__wrap_decode_win_permissions, raw_perm, "permissions");
-    will_return(__wrap_decode_win_permissions, "decoded_perms");
 
     expect_string(__wrap_w_get_file_attrs, file_path, expanded_path);
     will_return(__wrap_w_get_file_attrs, 123456);
@@ -2807,16 +2735,7 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
     fim_data->item->mode = FIM_REALTIME;
 
     // Inside fim_file
-    will_return(__wrap_get_user, "0");
-    will_return(__wrap_get_user, strdup("user"));
-    expect_string(__wrap_get_user, path, "c:\\test.file");
-
-    expect_string(__wrap_w_get_file_permissions, file_path, "c:\\test.file");
-    will_return(__wrap_w_get_file_permissions, "permissions");
-    will_return(__wrap_w_get_file_permissions, 0);
-
-    expect_string(__wrap_decode_win_permissions, raw_perm, "permissions");
-    will_return(__wrap_decode_win_permissions, "decoded_perms");
+    expect_get_data(strdup("user"), "", path, 0);
 
     expect_string(__wrap_w_get_file_attrs, file_path, "c:\\test.file");
     will_return(__wrap_w_get_file_attrs, 123456);
@@ -2903,7 +2822,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     prepare_win_double_scan_success(test_file_path, expanded_dirs[0], file);
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6342): Maximum number of files to be monitored: '50000'");
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 
     expect_string(__wrap__mwarn, formatted_msg, "(6927): Sending DB 100% full alert.");
     expect_string(__wrap_send_log_msg, msg, "wazuh: FIM DB: {\"file_limit\":50000,\"file_count\":50000,\"alert_type\":\"full\"}");
@@ -2959,7 +2878,7 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
         will_return(__wrap_readdir, NULL);
     }
 
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 
     // check_deleted_files
     expect_value(__wrap_fim_db_get_not_scanned, fim_sql, syscheck.database);
@@ -2970,7 +2889,7 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
     expect_value(__wrap_fim_db_set_all_unscanned, fim_sql, syscheck.database);
     will_return(__wrap_fim_db_set_all_unscanned, 0);
 
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
     expect_string(__wrap__mdebug2, formatted_msg, "(6342): Maximum number of files to be monitored: '50000'");
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6345): Folders monitored with real-time engine: 0");
@@ -3026,15 +2945,14 @@ static void test_fim_scan_db_free(void **state) {
         will_return(__wrap_readdir, NULL);
     }
 
-    will_return(__wrap_fim_db_get_count_entry_path, 1000);
-
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 1000);
     // check_deleted_files
     expect_value(__wrap_fim_db_get_not_scanned, fim_sql, syscheck.database);
     expect_value(__wrap_fim_db_get_not_scanned, storage, FIM_DB_DISK);
     will_return(__wrap_fim_db_get_not_scanned, NULL);
     will_return(__wrap_fim_db_get_not_scanned, FIMDB_OK);
 
-    will_return(__wrap_fim_db_get_count_entry_path, 1000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 1000);
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6342): Maximum number of files to be monitored: '50000'");
 
@@ -3117,7 +3035,9 @@ static void test_fim_check_db_state_normal_to_empty(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 0);
+
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 0);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3133,7 +3053,7 @@ static void test_fim_check_db_state_empty_to_empty(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 0);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 0);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3149,7 +3069,7 @@ static void test_fim_check_db_state_empty_to_full(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3169,7 +3089,7 @@ static void test_fim_check_db_state_full_to_empty(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 0);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 0);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3189,7 +3109,7 @@ static void test_fim_check_db_state_empty_to_90_percentage(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 46000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 46000);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3209,7 +3129,7 @@ static void test_fim_check_db_state_90_percentage_to_empty(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 0);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 0);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3229,7 +3149,7 @@ static void test_fim_check_db_state_empty_to_80_percentage(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 41000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 41000);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3249,7 +3169,7 @@ static void test_fim_check_db_state_80_percentage_to_empty(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 0);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 0);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3269,7 +3189,7 @@ static void test_fim_check_db_state_empty_to_normal(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 10000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 10000);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3285,7 +3205,7 @@ static void test_fim_check_db_state_normal_to_normal(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 20000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 20000);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3301,7 +3221,7 @@ static void test_fim_check_db_state_normal_to_full(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3321,7 +3241,8 @@ static void test_fim_check_db_state_full_to_normal(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 10000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 10000);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3341,7 +3262,8 @@ static void test_fim_check_db_state_normal_to_90_percentage(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 46000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 46000);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3361,7 +3283,8 @@ static void test_fim_check_db_state_90_percentage_to_normal(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 10000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 10000);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3381,7 +3304,7 @@ static void test_fim_check_db_state_normal_to_80_percentage(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 41000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 41000);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3401,7 +3324,8 @@ static void test_fim_check_db_state_80_percentage_to_80_percentage(void **state)
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 42000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 42000);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3417,7 +3341,7 @@ static void test_fim_check_db_state_80_percentage_to_full(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3437,7 +3361,8 @@ static void test_fim_check_db_state_full_to_80_percentage(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 41000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 41000);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3457,7 +3382,7 @@ static void test_fim_check_db_state_80_percentage_to_90_percentage(void **state)
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 46000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 46000);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3477,7 +3402,8 @@ static void test_fim_check_db_state_90_percentage_to_90_percentage(void **state)
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 48000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 48000);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3493,7 +3419,7 @@ static void test_fim_check_db_state_90_percentage_to_full(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 50000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 50000);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3513,7 +3439,8 @@ static void test_fim_check_db_state_full_to_full(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 60000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 60000);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3529,7 +3456,8 @@ static void test_fim_check_db_state_full_to_90_percentage(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 46000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 46000);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3549,7 +3477,7 @@ static void test_fim_check_db_state_90_percentage_to_80_percentage(void **state)
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 41000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 41000);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3569,7 +3497,7 @@ static void test_fim_check_db_state_80_percentage_to_normal(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    will_return(__wrap_fim_db_get_count_entry_path, 10000);
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, 10000);
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -3675,38 +3603,7 @@ static void test_fim_get_data(void **state) {
                                     CHECK_SHA1SUM |
                                     CHECK_SHA256SUM;
 
-#ifndef TEST_WINAGENT
-    expect_value(__wrap_get_user, uid, 0);
-    will_return(__wrap_get_user, strdup("user"));
-
-    expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "group");
-#else
-    will_return(__wrap_get_user, "0");
-    will_return(__wrap_get_user, strdup("user"));
-    expect_string(__wrap_get_user, path, "test");
-
-    expect_string(__wrap_w_get_file_permissions, file_path, "test");
-    will_return(__wrap_w_get_file_permissions, "permissions");
-    will_return(__wrap_w_get_file_permissions, 0);
-
-    expect_string(__wrap_decode_win_permissions, raw_perm, "permissions");
-    will_return(__wrap_decode_win_permissions, "decoded_perms");
-#endif
-
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, fname, "test");
-#ifndef TEST_WINAGENT
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, prefilter_cmd, "/bin/ls");
-#else
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, prefilter_cmd, "c:\\windows\\system32\\cmd.exe");
-#endif
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, md5output, "d41d8cd98f00b204e9800998ecf8427e");
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, sha1output, "da39a3ee5e6b4b0d3255bfef95601890afd80709");
-    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, sha256output, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-    expect_value(__wrap_OS_MD5_SHA1_SHA256_File, mode, OS_BINARY);
-    expect_value(__wrap_OS_MD5_SHA1_SHA256_File, max_size, 0x400);
-    will_return(__wrap_OS_MD5_SHA1_SHA256_File, 0);
-
+    expect_get_data(strdup("user"), "group", "test", 1);
     fim_data->local_data = fim_get_data("test", fim_data->item);
 
 #ifndef TEST_WINAGENT
@@ -3739,24 +3636,8 @@ static void test_fim_get_data_no_hashes(void **state) {
                                     CHECK_OWNER |
                                     CHECK_GROUP;
 
-#ifndef TEST_WINAGENT
-    expect_value(__wrap_get_user, uid, 0);
-    will_return(__wrap_get_user, strdup("user"));
+    expect_get_data(strdup("user"), "group", "test", 0);
 
-    expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "group");
-#else
-    will_return(__wrap_get_user, "0");
-    will_return(__wrap_get_user, strdup("user"));
-    expect_string(__wrap_get_user, path, "test");
-
-    expect_string(__wrap_w_get_file_permissions, file_path, "test");
-    will_return(__wrap_w_get_file_permissions, "permissions");
-    will_return(__wrap_w_get_file_permissions, 0);
-
-    expect_string(__wrap_decode_win_permissions, raw_perm, "permissions");
-    will_return(__wrap_decode_win_permissions, "decoded_perms");
-#endif
 
     fim_data->local_data = fim_get_data("test", fim_data->item);
 
@@ -3783,24 +3664,7 @@ static void test_fim_get_data_hash_error(void **state) {
     buf.st_gid = 0;
     fim_data->item->statbuf = buf;
 
-#ifndef TEST_WINAGENT
-    expect_value(__wrap_get_user, uid, 0);
-    will_return(__wrap_get_user, strdup("user"));
-
-    expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "group");
-#else
-    will_return(__wrap_get_user, "0");
-    will_return(__wrap_get_user, strdup("user"));
-    expect_string(__wrap_get_user, path, "test");
-
-    expect_string(__wrap_w_get_file_permissions, file_path, "test");
-    will_return(__wrap_w_get_file_permissions, "permissions");
-    will_return(__wrap_w_get_file_permissions, 0);
-
-    expect_string(__wrap_decode_win_permissions, raw_perm, "permissions");
-    will_return(__wrap_decode_win_permissions, "decoded_perms");
-#endif
+    expect_get_data(strdup("user"), "group", "test", 0);
 
     expect_string(__wrap_OS_MD5_SHA1_SHA256_File, fname, "test");
 #ifndef TEST_WINAGENT
@@ -3860,8 +3724,7 @@ static void test_fim_get_data_fail_to_get_file_premissions(void **state) {
 #endif
 
 static void test_check_deleted_files(void **state) {
-    fim_tmp_file *file = calloc(1, sizeof(fim_tmp_file));
-    file->elements = 1;
+    fim_tmp_file *file = *state;
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
@@ -3875,8 +3738,6 @@ static void test_check_deleted_files(void **state) {
     will_return(__wrap_fim_db_delete_not_scanned, FIMDB_OK);
 
     check_deleted_files();
-
-    free(file);
 }
 
 static void test_check_deleted_files_error(void **state) {
@@ -3954,6 +3815,13 @@ static void test_fim_realtime_event_file_exists(void **state) {
 }
 
 static void test_fim_realtime_event_file_missing(void **state) {
+#ifdef TEST_WINAGENT
+    char start[10] = "/test\\";
+    char top[10] = "/test]";
+#else
+    char start[10] = "/test/";
+    char top[10] = "/test0";
+#endif
 
 #ifndef TEST_WINAGENT
     expect_string(__wrap_lstat, filename, "/test");
@@ -3975,17 +3843,8 @@ static void test_fim_realtime_event_file_missing(void **state) {
     expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-#ifdef TEST_WINAGENT
-    expect_string(__wrap_fim_db_get_path_range, start, "/test\\");
-    expect_string(__wrap_fim_db_get_path_range, top, "/test]");
-#else
-    expect_string(__wrap_fim_db_get_path_range, start, "/test/");
-    expect_string(__wrap_fim_db_get_path_range, top, "/test0");
-#endif
-    expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
-    will_return(__wrap_fim_db_get_path_range, NULL);
-    will_return(__wrap_fim_db_get_path_range, FIMDB_ERR);
+    expect_wrapper_fim_db_get_path_range_call(syscheck.database, start, top, FIM_DB_DISK, NULL, FIMDB_ERR);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -4014,6 +3873,13 @@ static void test_fim_whodata_event_file_exists(void **state) {
 
 static void test_fim_whodata_event_file_missing(void **state) {
     fim_data_t *fim_data = *state;
+#ifdef TEST_WINAGENT
+    char start[20] = "./test/test.file\\";
+    char top[20] = "./test/test.file]";
+#else
+    char start[20] = "./test/test.file/";
+    char top[20] = "./test/test.file0";
+#endif
 
 #ifndef TEST_WINAGENT
     expect_string(__wrap_lstat, filename, fim_data->w_evt->path);
@@ -4043,49 +3909,27 @@ static void test_fim_whodata_event_file_missing(void **state) {
     expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_pthread_mutex_lock);
 
-    expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-#ifdef TEST_WINAGENT
-    expect_string(__wrap_fim_db_get_path_range, start, "./test/test.file\\");
-    expect_string(__wrap_fim_db_get_path_range, top, "./test/test.file]");
-#else
-    expect_string(__wrap_fim_db_get_path_range, start, "./test/test.file/");
-    expect_string(__wrap_fim_db_get_path_range, top, "./test/test.file0");
-#endif
-    expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
-    will_return(__wrap_fim_db_get_path_range, NULL);
-    will_return(__wrap_fim_db_get_path_range, FIMDB_ERR);
-
+    expect_wrapper_fim_db_get_path_range_call(syscheck.database, start, top, FIM_DB_DISK, NULL, FIMDB_ERR);
     expect_function_call(__wrap_pthread_mutex_unlock);
 #else
-    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_get_paths_from_inode, inode, 606060);
-    expect_value(__wrap_fim_db_get_paths_from_inode, dev, 12345678);
-    will_return(__wrap_fim_db_get_paths_from_inode, paths);
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606060, 12345678, paths);
 
     // Inside fim_process_missing_entry
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, "./test/test.file");
     will_return(__wrap_fim_db_get_path, NULL);
 
-    expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path_range, start, "./test/test.file/");
-    expect_string(__wrap_fim_db_get_path_range, top, "./test/test.file0");
-    expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
-    will_return(__wrap_fim_db_get_path_range, NULL);
-    will_return(__wrap_fim_db_get_path_range, FIMDB_ERR);
+    expect_wrapper_fim_db_get_path_range_call(syscheck.database, start, top, FIM_DB_DISK, NULL, FIMDB_ERR);
 
     for(int i = 0; paths[i]; i++) {
         // Inside fim_process_missing_entry
+
         expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
         expect_string(__wrap_fim_db_get_path, file_path, paths[i]);
         will_return(__wrap_fim_db_get_path, NULL);
 
-        expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-        expect_string(__wrap_fim_db_get_path_range, start, "./test/test.file/");
-        expect_string(__wrap_fim_db_get_path_range, top, "./test/test.file0");
-        expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
-        will_return(__wrap_fim_db_get_path_range, NULL);
-        will_return(__wrap_fim_db_get_path_range, FIMDB_ERR);
+        expect_wrapper_fim_db_get_path_range_call(syscheck.database, start, top, FIM_DB_DISK, NULL, FIMDB_ERR);
+
     }
 #endif
 
@@ -4095,6 +3939,14 @@ static void test_fim_whodata_event_file_missing(void **state) {
 
 static void test_fim_process_missing_entry_no_data(void **state) {
 #ifdef TEST_WINAGENT
+    char start[10] = "/test\\";
+    char top[10] = "/test]";
+#else
+    char start[10] = "/test/";
+    char top[10] = "/test0";
+#endif
+
+#ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
@@ -4104,17 +3956,8 @@ static void test_fim_process_missing_entry_no_data(void **state) {
     expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-#ifdef TEST_WINAGENT
-    expect_string(__wrap_fim_db_get_path_range, start, "/test\\");
-    expect_string(__wrap_fim_db_get_path_range, top, "/test]");
-#else
-    expect_string(__wrap_fim_db_get_path_range, start, "/test/");
-    expect_string(__wrap_fim_db_get_path_range, top, "/test0");
-#endif
-    expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
-    will_return(__wrap_fim_db_get_path_range, NULL);
-    will_return(__wrap_fim_db_get_path_range, FIMDB_ERR);
+    expect_wrapper_fim_db_get_path_range_call(syscheck.database, start, top, FIM_DB_DISK, NULL, FIMDB_ERR);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -4122,6 +3965,13 @@ static void test_fim_process_missing_entry_no_data(void **state) {
 }
 
 static void test_fim_process_missing_entry_failure(void **state) {
+#ifdef TEST_WINAGENT
+    char start[10] = "/test\\";
+    char top[10] = "/test]";
+#else
+    char start[10] = "/test/";
+    char top[10] = "/test0";
+#endif
 
     fim_tmp_file *file = calloc(1, sizeof(fim_tmp_file));
     file->elements = 1;
@@ -4131,21 +3981,13 @@ static void test_fim_process_missing_entry_failure(void **state) {
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, "/test");
     will_return(__wrap_fim_db_get_path, NULL);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-#ifdef TEST_WINAGENT
-    expect_string(__wrap_fim_db_get_path_range, start, "/test\\");
-    expect_string(__wrap_fim_db_get_path_range, top, "/test]");
-#else
-    expect_string(__wrap_fim_db_get_path_range, start, "/test/");
-    expect_string(__wrap_fim_db_get_path_range, top, "/test0");
-#endif
-    expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
-    will_return(__wrap_fim_db_get_path_range, file);
-    will_return(__wrap_fim_db_get_path_range, FIMDB_OK);
+    expect_wrapper_fim_db_get_path_range_call(syscheck.database, start, top, FIM_DB_DISK, file, FIMDB_OK);
+
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
@@ -4264,8 +4106,8 @@ int main(void) {
         cmocka_unit_test_teardown(test_fim_scan_info_json_end, teardown_delete_json),
 
         /* fim_get_checksum */
-        cmocka_unit_test_setup_teardown(test_fim_get_checksum, setup_fim_entry, teardown_fim_entry),
-        cmocka_unit_test_setup_teardown(test_fim_get_checksum_wrong_size, setup_fim_entry, teardown_fim_entry),
+        cmocka_unit_test_setup(test_fim_get_checksum, setup_fim_entry),
+        cmocka_unit_test_setup(test_fim_get_checksum_wrong_size, setup_fim_entry),
 
         /* fim_check_depth */
         cmocka_unit_test(test_fim_check_depth_success),
@@ -4276,55 +4118,51 @@ int main(void) {
         cmocka_unit_test(test_fim_configuration_directory_no_path),
         cmocka_unit_test(test_fim_configuration_directory_file),
         cmocka_unit_test(test_fim_configuration_directory_not_found),
-#ifdef TEST_WINAGENT
-        cmocka_unit_test(test_fim_configuration_directory_registry_not_found),
-        // cmocka_unit_test(test_fim_configuration_directory_registry_found),
-#endif
 
         /* init_fim_data_entry */
-        cmocka_unit_test_setup_teardown(test_init_fim_data_entry, setup_fim_entry, teardown_fim_entry),
+        cmocka_unit_test_setup(test_init_fim_data_entry, setup_fim_entry),
 
         /* fim_file */
-        // cmocka_unit_test(test_fim_file_add),
-        // cmocka_unit_test_setup(test_fim_file_modify, setup_fim_entry),
-        // cmocka_unit_test(test_fim_file_no_attributes),
-        // cmocka_unit_test_setup(test_fim_file_error_on_insert, setup_fim_entry),
+        cmocka_unit_test(test_fim_file_add),
+        cmocka_unit_test_setup(test_fim_file_modify, setup_fim_entry),
+        cmocka_unit_test(test_fim_file_no_attributes),
+        cmocka_unit_test_setup(test_fim_file_error_on_insert, setup_fim_entry),
 
         /* fim_scan */
-        // cmocka_unit_test_setup_teardown(test_fim_scan_db_full_double_scan, setup_fim_double_scan, teardown_fim_double_scan),
-        // cmocka_unit_test_setup_teardown(test_fim_scan_db_full_not_double_scan, setup_fim_not_double_scan, teardown_fim_not_double_scan),
-        // cmocka_unit_test(test_fim_scan_db_free),
-        // cmocka_unit_test_setup_teardown(test_fim_scan_no_limit, setup_file_limit, teardown_file_limit),
+        cmocka_unit_test_setup_teardown(test_fim_scan_db_full_double_scan, setup_fim_double_scan, teardown_fim_double_scan),
+        cmocka_unit_test_setup_teardown(test_fim_scan_db_full_not_double_scan, setup_fim_not_double_scan, teardown_fim_not_double_scan),
+        cmocka_unit_test(test_fim_scan_db_free),
+        cmocka_unit_test_setup_teardown(test_fim_scan_no_limit, setup_file_limit, teardown_file_limit),
 
         /* fim_check_db_state */
-        // cmocka_unit_test(test_fim_check_db_state_normal_to_empty),
-        // cmocka_unit_test(test_fim_check_db_state_empty_to_empty),
-        // cmocka_unit_test(test_fim_check_db_state_empty_to_full),
-        // cmocka_unit_test(test_fim_check_db_state_full_to_empty),
-        // cmocka_unit_test(test_fim_check_db_state_empty_to_90_percentage),
-        // cmocka_unit_test(test_fim_check_db_state_90_percentage_to_empty),
-        // cmocka_unit_test(test_fim_check_db_state_empty_to_80_percentage),
-        // cmocka_unit_test(test_fim_check_db_state_80_percentage_to_empty),
-        // cmocka_unit_test(test_fim_check_db_state_empty_to_normal),
-        // cmocka_unit_test(test_fim_check_db_state_normal_to_normal),
-        // cmocka_unit_test(test_fim_check_db_state_normal_to_full),
-        // cmocka_unit_test(test_fim_check_db_state_full_to_normal),
-        // cmocka_unit_test(test_fim_check_db_state_normal_to_90_percentage),
-        // cmocka_unit_test(test_fim_check_db_state_90_percentage_to_normal),
-        // cmocka_unit_test(test_fim_check_db_state_normal_to_80_percentage),
-        // cmocka_unit_test(test_fim_check_db_state_80_percentage_to_80_percentage),
-        // cmocka_unit_test(test_fim_check_db_state_80_percentage_to_full),
-        // cmocka_unit_test(test_fim_check_db_state_full_to_80_percentage),
-        // cmocka_unit_test(test_fim_check_db_state_80_percentage_to_90_percentage),
-        // cmocka_unit_test(test_fim_check_db_state_90_percentage_to_90_percentage),
-        // cmocka_unit_test(test_fim_check_db_state_90_percentage_to_full),
-        // cmocka_unit_test(test_fim_check_db_state_full_to_full),
-        // cmocka_unit_test(test_fim_check_db_state_full_to_90_percentage),
-        // cmocka_unit_test(test_fim_check_db_state_90_percentage_to_80_percentage),
-        // cmocka_unit_test(test_fim_check_db_state_80_percentage_to_normal),
+        cmocka_unit_test(test_fim_check_db_state_normal_to_empty),
+        cmocka_unit_test(test_fim_check_db_state_empty_to_empty),
+        cmocka_unit_test(test_fim_check_db_state_empty_to_full),
+        cmocka_unit_test(test_fim_check_db_state_full_to_empty),
+        cmocka_unit_test(test_fim_check_db_state_empty_to_90_percentage),
+        cmocka_unit_test(test_fim_check_db_state_90_percentage_to_empty),
+        cmocka_unit_test(test_fim_check_db_state_empty_to_80_percentage),
+        cmocka_unit_test(test_fim_check_db_state_80_percentage_to_empty),
+        cmocka_unit_test(test_fim_check_db_state_empty_to_normal),
+        cmocka_unit_test(test_fim_check_db_state_normal_to_normal),
+        cmocka_unit_test(test_fim_check_db_state_normal_to_full),
+        cmocka_unit_test(test_fim_check_db_state_full_to_normal),
+        cmocka_unit_test(test_fim_check_db_state_normal_to_90_percentage),
+        cmocka_unit_test(test_fim_check_db_state_90_percentage_to_normal),
+        cmocka_unit_test(test_fim_check_db_state_normal_to_80_percentage),
+        cmocka_unit_test(test_fim_check_db_state_80_percentage_to_80_percentage),
+        cmocka_unit_test(test_fim_check_db_state_80_percentage_to_full),
+        cmocka_unit_test(test_fim_check_db_state_full_to_80_percentage),
+        cmocka_unit_test(test_fim_check_db_state_80_percentage_to_90_percentage),
+        cmocka_unit_test(test_fim_check_db_state_90_percentage_to_90_percentage),
+        cmocka_unit_test(test_fim_check_db_state_90_percentage_to_full),
+        cmocka_unit_test(test_fim_check_db_state_full_to_full),
+        cmocka_unit_test(test_fim_check_db_state_full_to_90_percentage),
+        cmocka_unit_test(test_fim_check_db_state_90_percentage_to_80_percentage),
+        cmocka_unit_test(test_fim_check_db_state_80_percentage_to_normal),
 #ifndef TEST_WINAGENT
-        // cmocka_unit_test_setup_teardown(test_fim_scan_no_realtime, setup_fim_scan_realtime, teardown_fim_scan_realtime),
-        // cmocka_unit_test_setup_teardown(test_fim_scan_realtime_enabled, setup_fim_scan_realtime, teardown_fim_scan_realtime),
+        cmocka_unit_test_setup_teardown(test_fim_scan_no_realtime, setup_fim_scan_realtime, teardown_fim_scan_realtime),
+        cmocka_unit_test_setup_teardown(test_fim_scan_realtime_enabled, setup_fim_scan_realtime, teardown_fim_scan_realtime),
 #endif
 
         /* fim_checker */
@@ -4333,13 +4171,13 @@ int main(void) {
         cmocka_unit_test(test_fim_checker_invalid_fim_mode),
         cmocka_unit_test(test_fim_checker_over_max_recursion_level),
         cmocka_unit_test(test_fim_checker_deleted_file),
-        // cmocka_unit_test_setup(test_fim_checker_deleted_file_enoent, setup_fim_entry),
+        cmocka_unit_test_setup(test_fim_checker_deleted_file_enoent, setup_fim_entry),
 #ifndef TEST_WINAGENT
         cmocka_unit_test(test_fim_checker_no_file_system),
 #endif
-        // cmocka_unit_test(test_fim_checker_fim_regular),
-        // cmocka_unit_test(test_fim_checker_fim_regular_warning),
-        // cmocka_unit_test(test_fim_checker_fim_regular_ignore),
+        cmocka_unit_test(test_fim_checker_fim_regular),
+        cmocka_unit_test(test_fim_checker_fim_regular_warning),
+        cmocka_unit_test(test_fim_checker_fim_regular_ignore),
         cmocka_unit_test(test_fim_checker_fim_regular_restrict),
         cmocka_unit_test_setup_teardown(test_fim_checker_fim_directory, setup_struct_dirent, teardown_struct_dirent),
 #ifndef TEST_WINAGENT
@@ -4353,32 +4191,32 @@ int main(void) {
         cmocka_unit_test(test_fim_directory_opendir_error),
 
         /* fim_get_data */
-        // cmocka_unit_test_teardown(test_fim_get_data, teardown_local_data),
-        // cmocka_unit_test_teardown(test_fim_get_data_no_hashes, teardown_local_data),
-        // cmocka_unit_test(test_fim_get_data_hash_error),
+        cmocka_unit_test_teardown(test_fim_get_data, teardown_local_data),
+        cmocka_unit_test_teardown(test_fim_get_data_no_hashes, teardown_local_data),
+        cmocka_unit_test(test_fim_get_data_hash_error),
 #ifdef TEST_WINAGENT
         cmocka_unit_test(test_fim_get_data_fail_to_get_file_premissions),
 #endif
 
         /* check_deleted_files */
-        cmocka_unit_test(test_check_deleted_files),
-        cmocka_unit_test(test_check_deleted_files_error),
+        cmocka_unit_test_setup_teardown(test_check_deleted_files, setup_fim_tmp_file, teardown_fim_tmp_file),
+        cmocka_unit_test_setup_teardown(test_check_deleted_files_error, setup_fim_tmp_file, teardown_fim_tmp_file),
 
         /* free_inode */
         cmocka_unit_test(test_free_inode_data),
         cmocka_unit_test(test_free_inode_data_null),
 
         /* fim_realtime_event */
-        cmocka_unit_test_setup_teardown(test_fim_realtime_event_file_exists, setup_fim_entry, teardown_fim_entry),
-        // cmocka_unit_test(test_fim_realtime_event_file_missing),
+        cmocka_unit_test_setup(test_fim_realtime_event_file_exists, setup_fim_entry),
+        cmocka_unit_test(test_fim_realtime_event_file_missing),
 
         /* fim_whodata_event */
         cmocka_unit_test(test_fim_whodata_event_file_exists),
-        // cmocka_unit_test(test_fim_whodata_event_file_missing),
+        cmocka_unit_test(test_fim_whodata_event_file_missing),
 
         /* fim_process_missing_entry */
-        // cmocka_unit_test(test_fim_process_missing_entry_no_data),
-        // cmocka_unit_test(test_fim_process_missing_entry_failure),
+        cmocka_unit_test(test_fim_process_missing_entry_no_data),
+        cmocka_unit_test(test_fim_process_missing_entry_failure),
         cmocka_unit_test_setup(test_fim_process_missing_entry_data_exists, setup_fim_entry),
 
         /* fim_diff_folder_size */
@@ -4386,8 +4224,8 @@ int main(void) {
 
     };
     const struct CMUnitTest root_monitor_tests[] = {
-        // cmocka_unit_test(test_fim_checker_root_ignore_file_under_recursion_level),
-        // cmocka_unit_test(test_fim_checker_root_file_within_recursion_level),
+        cmocka_unit_test(test_fim_checker_root_ignore_file_under_recursion_level),
+        cmocka_unit_test(test_fim_checker_root_file_within_recursion_level),
     };
     int retval;
 

--- a/src/unit_tests/syscheckd/test_fim.h
+++ b/src/unit_tests/syscheckd/test_fim.h
@@ -14,6 +14,5 @@ void expect_fim_send_msg(char mq, const char *location, const char *msg, int ret
 void expect_send_syscheck_msg(const char *msg);
 
 void expect_fim_diff_delete_compress_folder(struct dirent *dir);
-void expect_fim_diff_process_delete_file(struct dirent *dir);
 
 #endif // __TEST_FIM_H

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -532,7 +532,7 @@ void test_fim_link_update(void **state) {
     int pos = 0;
     char *link_path = "/folder/test";
 
-    expect_fim_db_get_path_range_call(syscheck.database, "/boot/", "/boot0", FIM_DB_DISK, NULL, FIMDB_OK);
+    expect_wrapper_fim_db_get_path_range_call(syscheck.database, "/boot/", "/boot0", FIM_DB_DISK, NULL, FIMDB_OK);
     expect_realtime_adddir_call(link_path, 0, 0);
 
     expect_fim_checker_call(link_path, 0, 0);
@@ -548,7 +548,7 @@ void test_fim_link_update_already_added(void **state) {
     int pos = 0;
     char *link_path = "/folder/test";
 
-    expect_fim_db_get_path_range_call(syscheck.database, "/folder/test/", "/folder/test0", FIM_DB_DISK, NULL, FIMDB_OK);
+    expect_wrapper_fim_db_get_path_range_call(syscheck.database, "/folder/test/", "/folder/test0", FIM_DB_DISK, NULL, FIMDB_OK);
     expect_string(__wrap__mdebug1, formatted_msg, "(6234): Directory '/folder/test' already monitored, ignoring link '(null)'");
 
     fim_link_update(pos, link_path);
@@ -566,7 +566,7 @@ void test_fim_link_check_delete(void **state) {
     will_return(__wrap_lstat, 0);
     will_return(__wrap_lstat, 0);
 
-    expect_fim_db_get_path_range_call(syscheck.database, "/etc/", "/etc0", FIM_DB_DISK, NULL, FIMDB_OK);
+    expect_wrapper_fim_db_get_path_range_call(syscheck.database, "/etc/", "/etc0", FIM_DB_DISK, NULL, FIMDB_OK);
     expect_fim_configuration_directory_call("/etc", "file", -1);
 
     fim_link_check_delete(pos);
@@ -631,8 +631,8 @@ void test_fim_link_delete_range(void **state) {
 
     fim_tmp_file *tmp_file = *state;
 
-    expect_fim_db_get_path_range_call(syscheck.database, "/media/", "/media0", FIM_DB_DISK, tmp_file, FIMDB_OK);
-    expect_fim_db_delete_range_call(syscheck.database, FIM_DB_DISK, tmp_file, FIMDB_OK);
+    expect_wrapper_fim_db_get_path_range_call(syscheck.database, "/media/", "/media0", FIM_DB_DISK, tmp_file, FIMDB_OK);
+    expect_wrapper_fim_db_delete_range_call(syscheck.database, FIM_DB_DISK, tmp_file, FIMDB_OK);
 
     fim_link_delete_range(pos);
 }
@@ -642,10 +642,10 @@ void test_fim_link_delete_range_error(void **state) {
 
     fim_tmp_file *tmp_file = *state;
 
-    expect_fim_db_get_path_range_call(syscheck.database, "/media/", "/media0", FIM_DB_DISK, tmp_file, FIMDB_ERR);
+    expect_wrapper_fim_db_get_path_range_call(syscheck.database, "/media/", "/media0", FIM_DB_DISK, tmp_file, FIMDB_ERR);
     expect_string(__wrap__merror, formatted_msg, "(6708): Failed to delete a range of paths between '/media/' and '/media0'");
 
-    expect_fim_db_delete_range_call(syscheck.database, FIM_DB_DISK, tmp_file, FIMDB_ERR);
+    expect_wrapper_fim_db_delete_range_call(syscheck.database, FIM_DB_DISK, tmp_file, FIMDB_ERR);
     expect_string(__wrap__merror, formatted_msg, "(6708): Failed to delete a range of paths between '/media/' and '/media0'");
 
     fim_link_delete_range(pos);

--- a/src/unit_tests/wrappers/wazuh/os_crypto/md5_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/md5_op_wrappers.c
@@ -35,3 +35,22 @@ int __wrap_OS_MD5_SHA1_SHA256_File(const char *fname, const char *prefilter_cmd,
 
     return mock();
 }
+
+void expect_OS_MD5_SHA1_SHA256_File_call(char *file,
+                                         char *prefilter_cmd,
+                                         char *md5,
+                                         char *sha1,
+                                         char *sha256,
+                                         int mode,
+                                         int max_size,
+                                         int ret) {
+
+    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, fname, file);
+    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, prefilter_cmd, prefilter_cmd);
+    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, md5output, md5);
+    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, sha1output, sha1);
+    expect_string(__wrap_OS_MD5_SHA1_SHA256_File, sha256output, sha256);
+    expect_value(__wrap_OS_MD5_SHA1_SHA256_File, mode, mode);
+    expect_value(__wrap_OS_MD5_SHA1_SHA256_File, max_size, max_size);
+    will_return(__wrap_OS_MD5_SHA1_SHA256_File, ret);
+}

--- a/src/unit_tests/wrappers/wazuh/os_crypto/md5_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/md5_op_wrappers.h
@@ -23,4 +23,15 @@ int __wrap_OS_MD5_File(const char *fname, os_md5 output, int mode);
 int __wrap_OS_MD5_SHA1_SHA256_File(const char *fname, const char *prefilter_cmd, os_md5 md5output, os_sha1 sha1output,
                                    os_sha256 sha256output, int mode, size_t max_size);
 
+/**
+ * @brief This function loads the expect and will return of the function OS_MD5_SHA1_SHA256_File
+ */
+void expect_OS_MD5_SHA1_SHA256_File_call(char *file,
+                                         char *prefilter_cmd,
+                                         char *md5,
+                                         char *sha1,
+                                         char *sha256,
+                                         int mode,
+                                         int max_size,
+                                         int ret);
 #endif

--- a/src/unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.c
@@ -42,6 +42,14 @@ char *__wrap_get_user(const char *path, char **sid) {
 
     return mock_type(char*);
 }
+
+char *__wrap_get_file_user(const char *path, char **sid) {
+    check_expected(path);
+    *sid = mock_type(char *);
+
+    return mock_type(char *);
+}
+
 #endif
 
 unsigned int __wrap_w_directory_exists(const char *path) {
@@ -59,3 +67,34 @@ int __wrap_w_get_file_permissions(const char *file_path, char *permissions, int 
     snprintf(permissions, perm_size, "%s", mock_type(char*));
     return mock();
 }
+
+void expect_get_group(int gid, char *ret) {
+    expect_value(__wrap_get_group, gid, gid);
+    will_return(__wrap_get_group, ret);
+}
+
+#ifdef WIN32
+void expect_get_user(const char *path, char **sid, char *user) {
+    expect_string(__wrap_get_user, path, path);
+    will_return(__wrap_get_user, sid);
+    will_return(__wrap_get_user, user);
+}
+
+void expect_get_file_user(const char *path, char *sid, char *user) {
+    expect_string(__wrap_get_file_user, path, path);
+    will_return(__wrap_get_file_user, sid);
+    will_return(__wrap_get_file_user, user);
+}
+
+void expect_w_get_file_permissions(const char *file_path, char *perms, int ret) {
+    expect_string(__wrap_w_get_file_permissions, file_path, file_path);
+    will_return(__wrap_w_get_file_permissions, perms);
+    will_return(__wrap_w_get_file_permissions, ret);
+}
+#else
+
+void expect_get_user(int uid, char *ret) {
+    expect_value(__wrap_get_user, uid, uid);
+    will_return(__wrap_get_user, ret);
+}
+#endif

--- a/src/unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.h
@@ -21,6 +21,8 @@ const char *__wrap_get_group(int gid);
 char *__wrap_get_user(int uid);
 #else
 char *__wrap_get_user(const char *path, char **sid);
+
+char *__wrap_get_file_user(const char *path, char **sid);
 #endif
 
 unsigned int __wrap_w_directory_exists(const char *path);
@@ -29,4 +31,32 @@ unsigned int __wrap_w_get_file_attrs(const char *file_path);
 
 int __wrap_w_get_file_permissions(const char *file_path, char *permissions, int perm_size);
 
-#endif
+#ifdef WIN32
+/**
+ * @brief This function loads the expect and will return of the function get_user
+ */
+void expect_get_user(const char *path, char **sid, char *user);
+
+/**
+ * @brief This function loads the expect and will return of the function get_user
+ */
+void expect_get_file_user(const char *path, char *sid, char *user);
+
+/**
+ * @brief This function loads the expect and will return of the function w_get_file_permissions
+ */
+void expect_w_get_file_permissions(const char *file_path, char *perms, int ret);
+
+#else
+/**
+ * @brief This function loads the expect and will return of the function get_user
+ */
+void expect_get_user(int uid, char *ret);
+#endif /*WIN32*/
+
+/**
+ * @brief This function loads the expect and will return of the function get_group
+ */
+void expect_get_group(int gid, char *ret);
+
+#endif /*SYSCHECK_OP_WRAPPERS_H*/

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -113,7 +113,7 @@ int __wrap_fim_db_get_first_path(fdb_t * fim_sql, int type, char **path) {
 }
 
 int __wrap_fim_db_get_path_range(fdb_t *fim_sql,
-                                 int type,
+                                 fim_type type,
                                  char *start,
                                  char *top,
                                  fim_tmp_file **file,
@@ -213,27 +213,9 @@ int __wrap_fim_db_sync_path_range(fdb_t *fim_sql,
     return mock();
 }
 
-void expect_fim_db_get_path_range_call(const fdb_t *db,
-                                       const char *start_str,
-                                       const char *top_str,
-                                       int storage,
-                                       fim_tmp_file *tmp_file,
-                                       int ret) {
-
-    expect_value(__wrap_fim_db_get_path_range, fim_sql, db);
-    expect_value(__wrap_fim_db_get_path_range, type, FIM_TYPE_FILE);
-    expect_string(__wrap_fim_db_get_path_range, start, start_str);
-    expect_string(__wrap_fim_db_get_path_range, top, top_str);
-    expect_value(__wrap_fim_db_get_path_range, storage, storage);
-    will_return(__wrap_fim_db_get_path_range, tmp_file);
-    will_return(__wrap_fim_db_get_path_range, ret);
-}
-
-void expect_fim_db_delete_range_call(const fdb_t *db, int storage, const fim_tmp_file *file, int ret){
-    expect_value(__wrap_fim_db_delete_range, fim_sql, db);
-    expect_value(__wrap_fim_db_delete_range, storage, storage);
-    expect_memory(__wrap_fim_db_delete_range, file, file, sizeof(file));
-    will_return(__wrap_fim_db_delete_range, ret);
+int __wrap_fim_db_get_count_entries(fdb_t *fim_sql) {
+    check_expected_ptr(fim_sql);
+    return mock();
 }
 
 #ifndef WIN32
@@ -264,10 +246,44 @@ int __wrap_fim_db_read_line_from_file(fim_tmp_file *file, int storage, int it, c
     *buffer = mock_type(char *);
 
     return mock();
-
 }
 
 void __wrap_fim_db_clean_file(fim_tmp_file **file, int storage) {
     check_expected_ptr(file);
     check_expected(storage);
+}
+
+void expect_wrapper_fim_db_get_path_range_call(const fdb_t *db,
+                                       const char *start_str,
+                                       const char *top_str,
+                                       int storage,
+                                       fim_tmp_file *tmp_file,
+                                       int ret) {
+
+    expect_value(__wrap_fim_db_get_path_range, fim_sql, db);
+    expect_value(__wrap_fim_db_get_path_range, type, FIM_TYPE_FILE);
+    expect_string(__wrap_fim_db_get_path_range, start, start_str);
+    expect_string(__wrap_fim_db_get_path_range, top, top_str);
+    expect_value(__wrap_fim_db_get_path_range, storage, storage);
+    will_return(__wrap_fim_db_get_path_range, tmp_file);
+    will_return(__wrap_fim_db_get_path_range, ret);
+}
+
+void expect_wrapper_fim_db_delete_range_call(const fdb_t *db, int storage, const fim_tmp_file *file, int ret){
+    expect_value(__wrap_fim_db_delete_range, fim_sql, db);
+    expect_value(__wrap_fim_db_delete_range, storage, storage);
+    expect_memory(__wrap_fim_db_delete_range, file, file, sizeof(file));
+    will_return(__wrap_fim_db_delete_range, ret);
+}
+
+void expect_wrapper_fim_db_get_count_entries(const fdb_t *db, int ret) {
+    expect_value(__wrap_fim_db_get_count_entries, fim_sql, db);
+    will_return(__wrap_fim_db_get_count_entries, ret);
+}
+
+void expect_wrapper_fim_db_get_paths_from_inode(fdb_t *db, int inode, int dev, char **ret) {
+    expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, db);
+    expect_value(__wrap_fim_db_get_paths_from_inode, inode, inode);
+    expect_value(__wrap_fim_db_get_paths_from_inode, dev, dev);
+    will_return(__wrap_fim_db_get_paths_from_inode, ret);
 }

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -52,7 +52,7 @@ fim_entry *__wrap_fim_db_get_path(fdb_t *fim_sql,
                                   const char *file_path);
 
 int __wrap_fim_db_get_path_range(fdb_t *fim_sql,
-                                 int type,
+                                 fim_type type,
                                  char *start,
                                  char *top,
                                  fim_tmp_file **file,
@@ -94,20 +94,8 @@ int __wrap_fim_db_sync_path_range(fdb_t *fim_sql,
                                   fim_tmp_file *file,
                                   int storage);
 
-/**
- * @brief This function loads the expect and will_return calls for the wrapper of fim_db_get_path_range
- */
-void expect_fim_db_get_path_range_call(const fdb_t *db,
-                                       const char *start_str,
-                                       const char *top_str,
-                                       int storage,
-                                       fim_tmp_file *tmp_file,
-                                       int ret);
+int __wrap_fim_db_get_count_entries(fdb_t *fim_sql);
 
-/**
- * @brief This function loads the expect and will_return calls for the wrapper of fim_db_delete_range
- */
-void expect_fim_db_delete_range_call(const fdb_t *db, int storage, const fim_tmp_file *file, int ret);
 
 #ifndef WIN32
 fim_entry *__wrap_fim_db_get_entry_from_sync_msg(fdb_t *fim_sql,
@@ -122,4 +110,28 @@ int __wrap_fim_db_read_line_from_file(fim_tmp_file *file, int storage, int it, c
 
 void __wrap_fim_db_clean_file(fim_tmp_file **file, int storage);
 
+/**
+ * @brief This function loads the expect and will_return calls for the wrapper of fim_db_get_path_range
+ */
+void expect_wrapper_fim_db_get_path_range_call(const fdb_t *db,
+                                       const char *start_str,
+                                       const char *top_str,
+                                       int storage,
+                                       fim_tmp_file *tmp_file,
+                                       int ret);
+
+/**
+ * @brief This function loads the expect and will_return calls for the wrapper of fim_db_delete_range
+ */
+void expect_wrapper_fim_db_delete_range_call(const fdb_t *db, int storage, const fim_tmp_file *file, int ret);
+
+/**
+ * @brief This function loads the expect and will_return calls for the wrapper of fim_db_get_count_entries
+ */
+void expect_wrapper_fim_db_get_count_entries(const fdb_t *fim_sql, int ret);
+
+/**
+ * @brief This function loads the expect and will_return calls for the wrapper of fim_db_get_paths_from_inode
+ */
+void expect_wrapper_fim_db_get_paths_from_inode(fdb_t *db, int inode, int dev, char **ret);
 #endif

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_diff_changes_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_diff_changes_wrappers.c
@@ -13,14 +13,24 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-char *__wrap_seechanges_addfile(const char *filename) {
+char *__wrap_fim_file_diff(const char *filename) {
     check_expected(filename);
 
-    return mock_type(char*);
+    return mock_type(char *);
 }
 
-char *__wrap_seechanges_get_diff_path(char *path) {
-    check_expected(path);
+char *__wrap_fim_diff_process_delete_file(const char *filename) {
+    check_expected(filename);
 
-    return mock_type(char*);
+    return mock_type(char *);
+}
+
+void expect_fim_file_diff(const char *filename, char *ret) {
+    expect_string(__wrap_fim_file_diff, filename, filename);
+    will_return(__wrap_fim_file_diff, ret);
+}
+
+void expect_fim_diff_process_delete_file(const char *filename, char *ret) {
+    expect_string(__wrap_fim_diff_process_delete_file, filename, filename);
+    will_return(__wrap_fim_diff_process_delete_file, ret);
 }

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_diff_changes_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_diff_changes_wrappers.h
@@ -11,8 +11,18 @@
 #ifndef DIFF_CHANGES_WRAPPERS_H
 #define DIFF_CHANGES_WRAPPERS_H
 
-char *__wrap_seechanges_addfile(const char *filename);
+char *__wrap_fim_file_diff(const char *filename);
 
-char *__wrap_seechanges_get_diff_path(char *path);
+char *__wrap_fim_diff_process_delete_file(const char *file_name);
+
+/**
+ * @brief This function loads the expect and will return of the function fim_file_diff
+ */
+void expect_fim_file_diff(const char *filename, char *ret);
+
+/**
+ * @brief This function loads the expect and will return of the function fim_file_diff
+ */
+void expect_fim_diff_process_delete_file(const char *filename, char *ret);
 
 #endif /* DIFF_CHANGES_WRAPPERS_H */

--- a/src/unit_tests/wrappers/wazuh/syscheckd/registry.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/registry.c
@@ -7,10 +7,12 @@
  * Foundation
  */
 
+#include "registry.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
 
-#ifndef WIN_REGISTRY_WRAPPERS_H
-#define WIN_REGISTRY_WRAPPERS_H
-
-void __wrap_os_winreg_check();
-
-#endif
+void __wrap_fim_registry_scan() {
+    return;
+}

--- a/src/unit_tests/wrappers/wazuh/syscheckd/registry.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/registry.h
@@ -7,10 +7,10 @@
  * Foundation
  */
 
-#include "win-registry_wrappers.h"
-#include <stddef.h>
-#include <stdarg.h>
-#include <setjmp.h>
-#include <cmocka.h>
 
-void __wrap_os_winreg_check() {}
+#ifndef WIN_REGISTRY_WRAPPERS_H
+#define WIN_REGISTRY_WRAPPERS_H
+
+void __wrap_fim_registry_scan();
+
+#endif


### PR DESCRIPTION
|Related issue|
|---|
|#6336|

## Description

After the development of #5576, the unit tests need to be adapted. This PR aims to adapt the tests in the file `test_create_db.c`
Closes #6336
## Linux tests
```
[==========] Running 98 test(s).
[ RUN      ] test_fim_json_event
[       OK ] test_fim_json_event
[ RUN      ] test_fim_json_event_whodata
[       OK ] test_fim_json_event_whodata
[ RUN      ] test_fim_json_event_no_changes
[       OK ] test_fim_json_event_no_changes
[ RUN      ] test_fim_json_event_hardlink_one_path
[       OK ] test_fim_json_event_hardlink_one_path
[ RUN      ] test_fim_json_event_hardlink_two_paths
[       OK ] test_fim_json_event_hardlink_two_paths
[ RUN      ] test_fim_attributes_json
[       OK ] test_fim_attributes_json
[ RUN      ] test_fim_attributes_json_without_options
[       OK ] test_fim_attributes_json_without_options
[ RUN      ] test_fim_entry_json
[       OK ] test_fim_entry_json
[ RUN      ] test_fim_entry_json_null_path
Expected assertion key != NULL occurred
[       OK ] test_fim_entry_json_null_path
[ RUN      ] test_fim_entry_json_null_data
Expected assertion entry != NULL occurred
[       OK ] test_fim_entry_json_null_data
[ RUN      ] test_fim_json_compare_attrs
[       OK ] test_fim_json_compare_attrs
[ RUN      ] test_fim_json_compare_attrs_without_options
[       OK ] test_fim_json_compare_attrs_without_options
[ RUN      ] test_fim_audit_json
[       OK ] test_fim_audit_json
[ RUN      ] test_fim_check_ignore_strncasecmp
[       OK ] test_fim_check_ignore_strncasecmp
[ RUN      ] test_fim_check_ignore_regex
[       OK ] test_fim_check_ignore_regex
[ RUN      ] test_fim_check_ignore_failure
[       OK ] test_fim_check_ignore_failure
[ RUN      ] test_fim_check_restrict_success
[       OK ] test_fim_check_restrict_success
[ RUN      ] test_fim_check_restrict_failure
[       OK ] test_fim_check_restrict_failure
[ RUN      ] test_fim_check_restrict_null_filename
[       OK ] test_fim_check_restrict_null_filename
[ RUN      ] test_fim_check_restrict_null_restriction
[       OK ] test_fim_check_restrict_null_restriction
[ RUN      ] test_fim_scan_info_json_start
[       OK ] test_fim_scan_info_json_start
[ RUN      ] test_fim_scan_info_json_end
[       OK ] test_fim_scan_info_json_end
[ RUN      ] test_fim_get_checksum
[       OK ] test_fim_get_checksum
[ RUN      ] test_fim_get_checksum_wrong_size
[       OK ] test_fim_get_checksum_wrong_size
[ RUN      ] test_fim_check_depth_success
[       OK ] test_fim_check_depth_success
[ RUN      ] test_fim_check_depth_failure_strlen
[       OK ] test_fim_check_depth_failure_strlen
[ RUN      ] test_fim_check_depth_failure_null_directory
[       OK ] test_fim_check_depth_failure_null_directory
[ RUN      ] test_fim_configuration_directory_no_path
[       OK ] test_fim_configuration_directory_no_path
[ RUN      ] test_fim_configuration_directory_file
[       OK ] test_fim_configuration_directory_file
[ RUN      ] test_fim_configuration_directory_not_found
[       OK ] test_fim_configuration_directory_not_found
[ RUN      ] test_init_fim_data_entry
[       OK ] test_init_fim_data_entry
[ RUN      ] test_fim_file_add
[       OK ] test_fim_file_add
[ RUN      ] test_fim_file_modify
[       OK ] test_fim_file_modify
[ RUN      ] test_fim_file_no_attributes
[       OK ] test_fim_file_no_attributes
[ RUN      ] test_fim_file_error_on_insert
[       OK ] test_fim_file_error_on_insert
[ RUN      ] test_fim_scan_db_full_double_scan
[       OK ] test_fim_scan_db_full_double_scan
[ RUN      ] test_fim_scan_db_full_not_double_scan
[       OK ] test_fim_scan_db_full_not_double_scan
[ RUN      ] test_fim_scan_db_free
[       OK ] test_fim_scan_db_free
[ RUN      ] test_fim_scan_no_limit
[       OK ] test_fim_scan_no_limit
[ RUN      ] test_fim_check_db_state_normal_to_empty
[       OK ] test_fim_check_db_state_normal_to_empty
[ RUN      ] test_fim_check_db_state_empty_to_empty
[       OK ] test_fim_check_db_state_empty_to_empty
[ RUN      ] test_fim_check_db_state_empty_to_full
[       OK ] test_fim_check_db_state_empty_to_full
[ RUN      ] test_fim_check_db_state_full_to_empty
[       OK ] test_fim_check_db_state_full_to_empty
[ RUN      ] test_fim_check_db_state_empty_to_90_percentage
[       OK ] test_fim_check_db_state_empty_to_90_percentage
[ RUN      ] test_fim_check_db_state_90_percentage_to_empty
[       OK ] test_fim_check_db_state_90_percentage_to_empty
[ RUN      ] test_fim_check_db_state_empty_to_80_percentage
[       OK ] test_fim_check_db_state_empty_to_80_percentage
[ RUN      ] test_fim_check_db_state_80_percentage_to_empty
[       OK ] test_fim_check_db_state_80_percentage_to_empty
[ RUN      ] test_fim_check_db_state_empty_to_normal
[       OK ] test_fim_check_db_state_empty_to_normal
[ RUN      ] test_fim_check_db_state_normal_to_normal
[       OK ] test_fim_check_db_state_normal_to_normal
[ RUN      ] test_fim_check_db_state_normal_to_full
[       OK ] test_fim_check_db_state_normal_to_full
[ RUN      ] test_fim_check_db_state_full_to_normal
[       OK ] test_fim_check_db_state_full_to_normal
[ RUN      ] test_fim_check_db_state_normal_to_90_percentage
[       OK ] test_fim_check_db_state_normal_to_90_percentage
[ RUN      ] test_fim_check_db_state_90_percentage_to_normal
[       OK ] test_fim_check_db_state_90_percentage_to_normal
[ RUN      ] test_fim_check_db_state_normal_to_80_percentage
[       OK ] test_fim_check_db_state_normal_to_80_percentage
[ RUN      ] test_fim_check_db_state_80_percentage_to_80_percentage
[       OK ] test_fim_check_db_state_80_percentage_to_80_percentage
[ RUN      ] test_fim_check_db_state_80_percentage_to_full
[       OK ] test_fim_check_db_state_80_percentage_to_full
[ RUN      ] test_fim_check_db_state_full_to_80_percentage
[       OK ] test_fim_check_db_state_full_to_80_percentage
[ RUN      ] test_fim_check_db_state_80_percentage_to_90_percentage
[       OK ] test_fim_check_db_state_80_percentage_to_90_percentage
[ RUN      ] test_fim_check_db_state_90_percentage_to_90_percentage
[       OK ] test_fim_check_db_state_90_percentage_to_90_percentage
[ RUN      ] test_fim_check_db_state_90_percentage_to_full
[       OK ] test_fim_check_db_state_90_percentage_to_full
[ RUN      ] test_fim_check_db_state_full_to_full
[       OK ] test_fim_check_db_state_full_to_full
[ RUN      ] test_fim_check_db_state_full_to_90_percentage
[       OK ] test_fim_check_db_state_full_to_90_percentage
[ RUN      ] test_fim_check_db_state_90_percentage_to_80_percentage
[       OK ] test_fim_check_db_state_90_percentage_to_80_percentage
[ RUN      ] test_fim_check_db_state_80_percentage_to_normal
[       OK ] test_fim_check_db_state_80_percentage_to_normal
[ RUN      ] test_fim_scan_no_realtime
[       OK ] test_fim_scan_no_realtime
[ RUN      ] test_fim_scan_realtime_enabled
[       OK ] test_fim_scan_realtime_enabled
[ RUN      ] test_fim_checker_scheduled_configuration_directory_error
[       OK ] test_fim_checker_scheduled_configuration_directory_error
[ RUN      ] test_fim_checker_not_scheduled_configuration_directory_error
[       OK ] test_fim_checker_not_scheduled_configuration_directory_error
[ RUN      ] test_fim_checker_invalid_fim_mode
[       OK ] test_fim_checker_invalid_fim_mode
[ RUN      ] test_fim_checker_over_max_recursion_level
[       OK ] test_fim_checker_over_max_recursion_level
[ RUN      ] test_fim_checker_deleted_file
[       OK ] test_fim_checker_deleted_file
[ RUN      ] test_fim_checker_deleted_file_enoent
[       OK ] test_fim_checker_deleted_file_enoent
[ RUN      ] test_fim_checker_no_file_system
[       OK ] test_fim_checker_no_file_system
[ RUN      ] test_fim_checker_fim_regular
[       OK ] test_fim_checker_fim_regular
[ RUN      ] test_fim_checker_fim_regular_warning
[       OK ] test_fim_checker_fim_regular_warning
[ RUN      ] test_fim_checker_fim_regular_ignore
[       OK ] test_fim_checker_fim_regular_ignore
[ RUN      ] test_fim_checker_fim_regular_restrict
[       OK ] test_fim_checker_fim_regular_restrict
[ RUN      ] test_fim_checker_fim_directory
[       OK ] test_fim_checker_fim_directory
[ RUN      ] test_fim_checker_fim_directory_on_max_recursion_level
[       OK ] test_fim_checker_fim_directory_on_max_recursion_level
[ RUN      ] test_fim_directory
[       OK ] test_fim_directory
[ RUN      ] test_fim_directory_ignore
[       OK ] test_fim_directory_ignore
[ RUN      ] test_fim_directory_nodir
[       OK ] test_fim_directory_nodir
[ RUN      ] test_fim_directory_opendir_error
[       OK ] test_fim_directory_opendir_error
[ RUN      ] test_fim_get_data
[       OK ] test_fim_get_data
[ RUN      ] test_fim_get_data_no_hashes
[       OK ] test_fim_get_data_no_hashes
[ RUN      ] test_fim_get_data_hash_error
[       OK ] test_fim_get_data_hash_error
[ RUN      ] test_check_deleted_files
[       OK ] test_check_deleted_files
[ RUN      ] test_check_deleted_files_error
[       OK ] test_check_deleted_files_error
[ RUN      ] test_free_inode_data
[       OK ] test_free_inode_data
[ RUN      ] test_free_inode_data_null
[       OK ] test_free_inode_data_null
[ RUN      ] test_fim_realtime_event_file_exists
[       OK ] test_fim_realtime_event_file_exists
[ RUN      ] test_fim_realtime_event_file_missing
[       OK ] test_fim_realtime_event_file_missing
[ RUN      ] test_fim_whodata_event_file_exists
[       OK ] test_fim_whodata_event_file_exists
[ RUN      ] test_fim_whodata_event_file_missing
[       OK ] test_fim_whodata_event_file_missing
[ RUN      ] test_fim_process_missing_entry_no_data
[       OK ] test_fim_process_missing_entry_no_data
[ RUN      ] test_fim_process_missing_entry_failure
[       OK ] test_fim_process_missing_entry_failure
[ RUN      ] test_fim_process_missing_entry_data_exists
[       OK ] test_fim_process_missing_entry_data_exists
[ RUN      ] test_fim_diff_folder_size
[       OK ] test_fim_diff_folder_size
[==========] 98 test(s) run.
[  PASSED  ] 98 test(s).
[==========] Running 2 test(s).
[ RUN      ] test_fim_checker_root_ignore_file_under_recursion_level
[       OK ] test_fim_checker_root_ignore_file_under_recursion_level
[ RUN      ] test_fim_checker_root_file_within_recursion_level
[       OK ] test_fim_checker_root_file_within_recursion_level
[==========] 2 test(s) run.
[  PASSED  ] 2 test(s).
```

#Windows tests
```
[==========] Running 95 test(s).
[ RUN      ] test_fim_json_event
[       OK ] test_fim_json_event
[ RUN      ] test_fim_json_event_whodata
[       OK ] test_fim_json_event_whodata
[ RUN      ] test_fim_json_event_no_changes
[       OK ] test_fim_json_event_no_changes
[ RUN      ] test_fim_json_event_hardlink_one_path
[       OK ] test_fim_json_event_hardlink_one_path
[ RUN      ] test_fim_json_event_hardlink_two_paths
[       OK ] test_fim_json_event_hardlink_two_paths
[ RUN      ] test_fim_attributes_json
[       OK ] test_fim_attributes_json
[ RUN      ] test_fim_attributes_json_without_options
[       OK ] test_fim_attributes_json_without_options
[ RUN      ] test_fim_entry_json
[       OK ] test_fim_entry_json
[ RUN      ] test_fim_entry_json_null_path
Expected assertion key != NULL occurred
[       OK ] test_fim_entry_json_null_path
[ RUN      ] test_fim_entry_json_null_data
Expected assertion entry != NULL occurred
[       OK ] test_fim_entry_json_null_data
[ RUN      ] test_fim_json_compare_attrs
[       OK ] test_fim_json_compare_attrs
[ RUN      ] test_fim_json_compare_attrs_without_options
[       OK ] test_fim_json_compare_attrs_without_options
[ RUN      ] test_fim_audit_json
[       OK ] test_fim_audit_json
[ RUN      ] test_fim_check_ignore_strncasecmp
[       OK ] test_fim_check_ignore_strncasecmp
[ RUN      ] test_fim_check_ignore_regex
[       OK ] test_fim_check_ignore_regex
[ RUN      ] test_fim_check_ignore_failure
[       OK ] test_fim_check_ignore_failure
[ RUN      ] test_fim_check_restrict_success
[       OK ] test_fim_check_restrict_success
[ RUN      ] test_fim_check_restrict_failure
[       OK ] test_fim_check_restrict_failure
[ RUN      ] test_fim_check_restrict_null_filename
[       OK ] test_fim_check_restrict_null_filename
[ RUN      ] test_fim_check_restrict_null_restriction
[       OK ] test_fim_check_restrict_null_restriction
[ RUN      ] test_fim_scan_info_json_start
[       OK ] test_fim_scan_info_json_start
[ RUN      ] test_fim_scan_info_json_end
[       OK ] test_fim_scan_info_json_end
[ RUN      ] test_fim_get_checksum
[       OK ] test_fim_get_checksum
[ RUN      ] test_fim_get_checksum_wrong_size
[       OK ] test_fim_get_checksum_wrong_size
[ RUN      ] test_fim_check_depth_success
[       OK ] test_fim_check_depth_success
[ RUN      ] test_fim_check_depth_failure_strlen
[       OK ] test_fim_check_depth_failure_strlen
[ RUN      ] test_fim_check_depth_failure_null_directory
[       OK ] test_fim_check_depth_failure_null_directory
[ RUN      ] test_fim_configuration_directory_no_path
[       OK ] test_fim_configuration_directory_no_path
[ RUN      ] test_fim_configuration_directory_file
[       OK ] test_fim_configuration_directory_file
[ RUN      ] test_fim_configuration_directory_not_found
[       OK ] test_fim_configuration_directory_not_found
[ RUN      ] test_init_fim_data_entry
[       OK ] test_init_fim_data_entry
[ RUN      ] test_fim_file_add
[       OK ] test_fim_file_add
[ RUN      ] test_fim_file_modify
[       OK ] test_fim_file_modify
[ RUN      ] test_fim_file_no_attributes
[       OK ] test_fim_file_no_attributes
[ RUN      ] test_fim_file_error_on_insert
[       OK ] test_fim_file_error_on_insert
[ RUN      ] test_fim_scan_db_full_double_scan
[       OK ] test_fim_scan_db_full_double_scan
[ RUN      ] test_fim_scan_db_full_not_double_scan
[       OK ] test_fim_scan_db_full_not_double_scan
[ RUN      ] test_fim_scan_db_free
[       OK ] test_fim_scan_db_free
[ RUN      ] test_fim_scan_no_limit
[       OK ] test_fim_scan_no_limit
[ RUN      ] test_fim_check_db_state_normal_to_empty
[       OK ] test_fim_check_db_state_normal_to_empty
[ RUN      ] test_fim_check_db_state_empty_to_empty
[       OK ] test_fim_check_db_state_empty_to_empty
[ RUN      ] test_fim_check_db_state_empty_to_full
[       OK ] test_fim_check_db_state_empty_to_full
[ RUN      ] test_fim_check_db_state_full_to_empty
[       OK ] test_fim_check_db_state_full_to_empty
[ RUN      ] test_fim_check_db_state_empty_to_90_percentage
[       OK ] test_fim_check_db_state_empty_to_90_percentage
[ RUN      ] test_fim_check_db_state_90_percentage_to_empty
[       OK ] test_fim_check_db_state_90_percentage_to_empty
[ RUN      ] test_fim_check_db_state_empty_to_80_percentage
[       OK ] test_fim_check_db_state_empty_to_80_percentage
[ RUN      ] test_fim_check_db_state_80_percentage_to_empty
[       OK ] test_fim_check_db_state_80_percentage_to_empty
[ RUN      ] test_fim_check_db_state_empty_to_normal
[       OK ] test_fim_check_db_state_empty_to_normal
[ RUN      ] test_fim_check_db_state_normal_to_normal
[       OK ] test_fim_check_db_state_normal_to_normal
[ RUN      ] test_fim_check_db_state_normal_to_full
[       OK ] test_fim_check_db_state_normal_to_full
[ RUN      ] test_fim_check_db_state_full_to_normal
[       OK ] test_fim_check_db_state_full_to_normal
[ RUN      ] test_fim_check_db_state_normal_to_90_percentage
[       OK ] test_fim_check_db_state_normal_to_90_percentage
[ RUN      ] test_fim_check_db_state_90_percentage_to_normal
[       OK ] test_fim_check_db_state_90_percentage_to_normal
[ RUN      ] test_fim_check_db_state_normal_to_80_percentage
[       OK ] test_fim_check_db_state_normal_to_80_percentage
[ RUN      ] test_fim_check_db_state_80_percentage_to_80_percentage
[       OK ] test_fim_check_db_state_80_percentage_to_80_percentage
[ RUN      ] test_fim_check_db_state_80_percentage_to_full
[       OK ] test_fim_check_db_state_80_percentage_to_full
[ RUN      ] test_fim_check_db_state_full_to_80_percentage
[       OK ] test_fim_check_db_state_full_to_80_percentage
[ RUN      ] test_fim_check_db_state_80_percentage_to_90_percentage
[       OK ] test_fim_check_db_state_80_percentage_to_90_percentage
[ RUN      ] test_fim_check_db_state_90_percentage_to_90_percentage
[       OK ] test_fim_check_db_state_90_percentage_to_90_percentage
[ RUN      ] test_fim_check_db_state_90_percentage_to_full
[       OK ] test_fim_check_db_state_90_percentage_to_full
[ RUN      ] test_fim_check_db_state_full_to_full
[       OK ] test_fim_check_db_state_full_to_full
[ RUN      ] test_fim_check_db_state_full_to_90_percentage
[       OK ] test_fim_check_db_state_full_to_90_percentage
[ RUN      ] test_fim_check_db_state_90_percentage_to_80_percentage
[       OK ] test_fim_check_db_state_90_percentage_to_80_percentage
[ RUN      ] test_fim_check_db_state_80_percentage_to_normal
[       OK ] test_fim_check_db_state_80_percentage_to_normal
[ RUN      ] test_fim_checker_scheduled_configuration_directory_error
[       OK ] test_fim_checker_scheduled_configuration_directory_error
[ RUN      ] test_fim_checker_not_scheduled_configuration_directory_error
[       OK ] test_fim_checker_not_scheduled_configuration_directory_error
[ RUN      ] test_fim_checker_invalid_fim_mode
[       OK ] test_fim_checker_invalid_fim_mode
[ RUN      ] test_fim_checker_over_max_recursion_level
[       OK ] test_fim_checker_over_max_recursion_level
[ RUN      ] test_fim_checker_deleted_file
[       OK ] test_fim_checker_deleted_file
[ RUN      ] test_fim_checker_deleted_file_enoent
[       OK ] test_fim_checker_deleted_file_enoent
[ RUN      ] test_fim_checker_fim_regular
[       OK ] test_fim_checker_fim_regular
[ RUN      ] test_fim_checker_fim_regular_warning
[       OK ] test_fim_checker_fim_regular_warning
[ RUN      ] test_fim_checker_fim_regular_ignore
[       OK ] test_fim_checker_fim_regular_ignore
[ RUN      ] test_fim_checker_fim_regular_restrict
[       OK ] test_fim_checker_fim_regular_restrict
[ RUN      ] test_fim_checker_fim_directory
[       OK ] test_fim_checker_fim_directory
[ RUN      ] test_fim_directory
[       OK ] test_fim_directory
[ RUN      ] test_fim_directory_ignore
[       OK ] test_fim_directory_ignore
[ RUN      ] test_fim_directory_nodir
[       OK ] test_fim_directory_nodir
[ RUN      ] test_fim_directory_opendir_error
[       OK ] test_fim_directory_opendir_error
[ RUN      ] test_fim_get_data
[       OK ] test_fim_get_data
[ RUN      ] test_fim_get_data_no_hashes
[       OK ] test_fim_get_data_no_hashes
[ RUN      ] test_fim_get_data_hash_error
[       OK ] test_fim_get_data_hash_error
[ RUN      ] test_fim_get_data_fail_to_get_file_premissions
[       OK ] test_fim_get_data_fail_to_get_file_premissions
[ RUN      ] test_check_deleted_files
[       OK ] test_check_deleted_files
[ RUN      ] test_check_deleted_files_error
[       OK ] test_check_deleted_files_error
[ RUN      ] test_free_inode_data
[       OK ] test_free_inode_data
[ RUN      ] test_free_inode_data_null
[       OK ] test_free_inode_data_null
[ RUN      ] test_fim_realtime_event_file_exists
[       OK ] test_fim_realtime_event_file_exists
[ RUN      ] test_fim_realtime_event_file_missing
[       OK ] test_fim_realtime_event_file_missing
[ RUN      ] test_fim_whodata_event_file_exists
[       OK ] test_fim_whodata_event_file_exists
[ RUN      ] test_fim_whodata_event_file_missing
[       OK ] test_fim_whodata_event_file_missing
[ RUN      ] test_fim_process_missing_entry_no_data
[       OK ] test_fim_process_missing_entry_no_data
[ RUN      ] test_fim_process_missing_entry_failure
[       OK ] test_fim_process_missing_entry_failure
[ RUN      ] test_fim_process_missing_entry_data_exists
[       OK ] test_fim_process_missing_entry_data_exists
[ RUN      ] test_fim_diff_folder_size
[       OK ] test_fim_diff_folder_size
[==========] 95 test(s) run.
[  PASSED  ] 95 test(s).
[==========] Running 2 test(s).
[ RUN      ] test_fim_checker_root_ignore_file_under_recursion_level
[       OK ] test_fim_checker_root_ignore_file_under_recursion_level
[ RUN      ] test_fim_checker_root_file_within_recursion_level
[       OK ] test_fim_checker_root_file_within_recursion_level
[==========] 2 test(s) run.
[  PASSED  ] 2 test(s).
```