### PR TITLE
Fix analysisd user permission drop

### DIFF
--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -185,13 +185,17 @@ int ReadDecodeXML(const char *file, OSDecoderNode **decoderlist_pn,
     OSDecoderInfo *pi = NULL;
 
     /* Read the XML */
-    if ((i = OS_ReadXML(file, &xml)) < 0) {
-        if ((i == -2) && (strcmp(file, XML_LDECODER) == 0)) {
-            return (-2);
-        }
-
-        smerror(log_msg, XML_ERROR, file, xml.err, xml.err_line);
-        goto cleanup;
+    switch(OS_ReadXML(file, &xml)) {
+        case -2:
+            smwarn(log_msg, FOPEN_ERROR, file, errno, strerror(errno));
+            retval = 1;
+            goto cleanup;
+        case -1:
+            smerror(log_msg, XML_ERROR, file, xml.err, xml.err_line);
+            goto cleanup;
+        case 0:
+        default:
+            break;
     }
 
     /* Apply any variables found */

--- a/src/analysisd/lists.c
+++ b/src/analysisd/lists.c
@@ -51,9 +51,9 @@ int Lists_OP_LoadList(char *listfile, ListNode **cdblists, OSList* log_msg)
     FILE *txt_fd = fopen(a_filename, "r");
     if (!txt_fd)
     {
-        smerror(log_msg, FOPEN_ERROR, a_filename, errno, strerror(errno));
-        free(tmp_listnode_pt);
-        return -1;
+        smwarn(log_msg, FOPEN_ERROR, a_filename, errno, strerror(errno));
+        os_free(tmp_listnode_pt);
+        return 0;
     }
 
     fclose(txt_fd);

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -257,9 +257,17 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
     i = 0;
 
     /* Read the XML */
-    if (OS_ReadXML(rulepath, &xml) < 0) {
-        smerror(log_msg, XML_ERROR, rulepath, xml.err, xml.err_line);
-        goto cleanup;
+    switch(OS_ReadXML(rulepath, &xml)) {
+        case -2:
+            smwarn(log_msg, FOPEN_ERROR, rulepath, errno, strerror(errno));
+            retval = 0;
+            goto cleanup;
+        case -1:
+            smerror(log_msg, XML_ERROR, rulepath, xml.err, xml.err_line);
+            goto cleanup;
+        case 0:
+        default:
+            break;
     }
     mdebug2("Read xml for rule.");
 


### PR DESCRIPTION
## Description

Hi team!

This PR aims to do a correct user permission drop in `ossec-analysisd` and, at the same time, warning the user (`ossec.log`,`wazuh-logtest` and Wazuh API logtest endpoint in `messages` field) if a custom rule/decoder/list does not have the correct permissions, continuing the startup process without considering those files

`ossec-analysisd` user permission drop was moved next to group permission drop and chroot,  before rules/decoders/lists load.

## Incorrect privilege example
```
╭─root@wazuh-dev ~/repos/wazuh ‹fix-analysisd-user-permission-drop› 
╰─# chown root:root /var/ossec/etc/decoders/local_decoder.xml
╭─root@wazuh-dev ~/repos/wazuh ‹fix-analysisd-user-permission-drop› 
╰─# ls -la /var/ossec/etc/decoders/local_decoder.xml 
-rw-rw---- 1 root root 820 Nov 13 00:54 /var/ossec/etc/decoders/local_decoder.xml
╭─root@wazuh-dev ~/repos/wazuh ‹fix-analysisd-user-permission-drop› 
╰─# chown root:root /var/ossec/etc/rules/local_rules.xml     
╭─root@wazuh-dev ~/repos/wazuh ‹fix-analysisd-user-permission-drop› 
╰─# ls -la /var/ossec/etc/rules/local_rules.xml         
-rw-r----- 1 root root 502 Nov 13 00:54 /var/ossec/etc/rules/local_rules.xml
╭─root@wazuh-dev ~/repos/wazuh ‹fix-analysisd-user-permission-drop› 
╰─# /var/ossec/bin/ossec-analysisd -f                        
2020/11/13 01:29:27 ossec-analysisd: WARNING: (1103): Could not open file 'etc/decoders/local_decoder.xml' due to [(13)-(Permission denied)].
2020/11/13 01:29:28 ossec-analysisd: WARNING: (1103): Could not open file 'etc/rules/local_rules.xml' due to [(13)-(Permission denied)].
2020/11/13 01:29:28 ossec-analysisd: INFO: Total rules enabled: '4135'
2020/11/13 01:29:28 ossec-analysisd: INFO: Started (pid: 435725).
2020/11/13 01:29:34 ossec-analysisd: INFO: (7200): Logtest started
```

```
╭─root@wazuh-dev ~/repos/wazuh ‹fix-analysisd-user-permission-drop› 
╰─# /var/ossec/bin/wazuh-logtest -d
2020-11-13 01:31:08,675 wazuh-logtest[INFO] Starting wazuh-logtest v4.1.0
2020-11-13 01:31:08,675 wazuh-logtest[INFO] Type one log per line

Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
2020-11-13 01:31:10,271 wazuh-logtest[INFO] 
2020-11-13 01:31:10,271 wazuh-logtest[DEBUG] Request: {"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location": "master->/var/log/syslog", "log_format": "syslog", "event": "Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2"}}

2020-11-13 01:31:10,666 wazuh-logtest[DEBUG] Reply: {'token': '62dcb31f', 'messages': ["WARNING: (1103): Could not open file 'etc/decoders/local_decoder.xml' due to [(13)-(Permission denied)].", "WARNING: (1103): Could not open file 'etc/rules/local_rules.xml' due to [(13)-(Permission denied)].", "INFO: (7202): Session initialized with token '62dcb31f'"], 'output': {'timestamp': '2020-11-13T01:31:10.665+0000', 'rule': {'level': 5, 'description': 'sshd: authentication failed.', 'id': '5716', 'mitre': {'id': ['T1110']}, 'firedtimes': 1, 'mail': False, 'groups': ['syslog', 'sshd', 'authentication_failed'], 'pci_dss': ['10.2.4', '10.2.5'], 'gpg13': ['7.1'], 'gdpr': ['IV_35.7.d', 'IV_32.2'], 'hipaa': ['164.312.b'], 'nist_800_53': ['AU.14', 'AC.7'], 'tsc': ['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']}, 'agent': {'id': '000', 'name': 'wazuh-dev'}, 'manager': {'name': 'wazuh-dev'}, 'id': '1605231070.0', 'full_log': 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2', 'predecoder': {'program_name': 'sshd', 'timestamp': 'Dec 10 01:02:02', 'hostname': 'host'}, 'decoder': {'parent': 'sshd', 'name': 'sshd'}, 'data': {'srcip': '1.1.1.1', 'srcport': '1066', 'dstuser': 'root'}, 'location': 'master->/var/log/syslog'}, 'alert': True, 'codemsg': 1}

2020-11-13 01:31:10,666 wazuh-logtest[DEBUG] {
  "token": "62dcb31f",
  "messages": [
    "WARNING: (1103): Could not open file 'etc/decoders/local_decoder.xml' due to [(13)-(Permission denied)].",
    "WARNING: (1103): Could not open file 'etc/rules/local_rules.xml' due to [(13)-(Permission denied)].",
    "INFO: (7202): Session initialized with token '62dcb31f'"
  ],
  "output": {
    "timestamp": "2020-11-13T01:31:10.665+0000",
    "rule": {
      "level": 5,
      "description": "sshd: authentication failed.",
      "id": "5716",
      "mitre": {
        "id": [
          "T1110"
        ]
      },
      "firedtimes": 1,
      "mail": false,
      "groups": [
        "syslog",
        "sshd",
        "authentication_failed"
      ],
      "pci_dss": [
        "10.2.4",
        "10.2.5"
      ],
      "gpg13": [
        "7.1"
      ],
      "gdpr": [
        "IV_35.7.d",
        "IV_32.2"
      ],
      "hipaa": [
        "164.312.b"
      ],
      "nist_800_53": [
        "AU.14",
        "AC.7"
      ],
      "tsc": [
        "CC6.1",
        "CC6.8",
        "CC7.2",
        "CC7.3"
      ]
    },
    "agent": {
      "id": "000",
      "name": "wazuh-dev"
    },
    "manager": {
      "name": "wazuh-dev"
    },
    "id": "1605231070.0",
    "full_log": "Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2",
    "predecoder": {
      "program_name": "sshd",
      "timestamp": "Dec 10 01:02:02",
      "hostname": "host"
    },
    "decoder": {
      "parent": "sshd",
      "name": "sshd"
    },
    "data": {
      "srcip": "1.1.1.1",
      "srcport": "1066",
      "dstuser": "root"
    },
    "location": "master->/var/log/syslog"
  },
  "alert": true,
  "codemsg": 1
}
2020-11-13 01:31:10,666 wazuh-logtest[INFO] **Phase 1: Completed pre-decoding.
2020-11-13 01:31:10,666 wazuh-logtest[INFO]     full event: 'Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2'
2020-11-13 01:31:10,666 wazuh-logtest[INFO]     timestamp: 'Dec 10 01:02:02'
2020-11-13 01:31:10,666 wazuh-logtest[INFO]     hostname: 'host'
2020-11-13 01:31:10,666 wazuh-logtest[INFO]     program_name: 'sshd'
2020-11-13 01:31:10,667 wazuh-logtest[INFO] 
2020-11-13 01:31:10,667 wazuh-logtest[INFO] **Phase 2: Completed decoding.
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     name: 'sshd'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     parent: 'sshd'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     dstuser: 'root'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     srcip: '1.1.1.1'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     srcport: '1066'
2020-11-13 01:31:10,667 wazuh-logtest[INFO] 
2020-11-13 01:31:10,667 wazuh-logtest[INFO] **Phase 3: Completed filtering (rules).
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     id: '5716'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     level: '5'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     description: 'sshd: authentication failed.'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     groups: '['syslog', 'sshd', 'authentication_failed']'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     firedtimes: '1'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     gdpr: '['IV_35.7.d', 'IV_32.2']'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     gpg13: '['7.1']'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     hipaa: '['164.312.b']'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     mail: 'False'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     mitre: '{'id': ['T1110']}'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     nist_800_53: '['AU.14', 'AC.7']'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     pci_dss: '['10.2.4', '10.2.5']'
2020-11-13 01:31:10,667 wazuh-logtest[INFO]     tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']'
2020-11-13 01:31:10,667 wazuh-logtest[INFO] **Alert to be generated.
```

## Checks
- [X] Compilation without warnings in every supported platform
- [X] Scan-build report
- [X] Valgrind (memcheck and descriptor leaks check)
- [X] Integration tests
- [X] Unit tests
- [X] Ruleset unit tests


Regards,
Nico
