### PR TITLE
6259 os and hardware sync

### DIFF
--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -36,11 +36,11 @@ public:
 TEST_F(SyscollectorImpTest, defaultCtor)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"name":"TEXT", "version":"TEXT", "vendor":"TEXT", "install_time":"TEXT", "location":"TEXT", "architecture":"TEXT", "groups":"TEXT", "description":"TEXT", "size":"TEXT", "priority":"TEXT", "multiarch":"TEXT", "source":"TEXT"}])")));
-    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return("processes"));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));
     Syscollector syscollector{spInfoWrapper, "5s"};
 }
@@ -48,9 +48,9 @@ TEST_F(SyscollectorImpTest, defaultCtor)
 TEST_F(SyscollectorImpTest, intervalSeconds)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
-    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
@@ -60,9 +60,9 @@ TEST_F(SyscollectorImpTest, intervalSeconds)
 TEST_F(SyscollectorImpTest, intervalMinutes)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
-    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
@@ -72,9 +72,9 @@ TEST_F(SyscollectorImpTest, intervalMinutes)
 TEST_F(SyscollectorImpTest, intervalDays)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
-    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
@@ -84,9 +84,9 @@ TEST_F(SyscollectorImpTest, intervalDays)
 TEST_F(SyscollectorImpTest, intervalUnknownUnit)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
-    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
@@ -110,7 +110,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
-    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
@@ -120,7 +120,7 @@ TEST_F(SyscollectorImpTest, noHardware)
 TEST_F(SyscollectorImpTest, noOs)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, os()).Times(0);
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
@@ -132,9 +132,9 @@ TEST_F(SyscollectorImpTest, noOs)
 TEST_F(SyscollectorImpTest, noNetwork)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
-    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, networks()).Times(0);
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
@@ -144,10 +144,10 @@ TEST_F(SyscollectorImpTest, noNetwork)
 TEST_F(SyscollectorImpTest, noPackages)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).Times(0);
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, false};
@@ -156,10 +156,10 @@ TEST_F(SyscollectorImpTest, noPackages)
 TEST_F(SyscollectorImpTest, noPorts)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).Times(0);   
     Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, true, false};
@@ -168,10 +168,10 @@ TEST_F(SyscollectorImpTest, noPorts)
 TEST_F(SyscollectorImpTest, noPortsAll)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, true, true, false};
@@ -180,10 +180,10 @@ TEST_F(SyscollectorImpTest, noPortsAll)
 TEST_F(SyscollectorImpTest, noProcesses)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, processes()).Times(0);
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));
     Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, true, true, true, false};
@@ -192,10 +192,10 @@ TEST_F(SyscollectorImpTest, noProcesses)
 TEST_F(SyscollectorImpTest, noHotfixes)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillOnce(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillOnce(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillOnce(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, ports()).WillOnce(Return("ports"));    
     Syscollector syscollector{spInfoWrapper, "1h", true, true, true, true, true, true, true, true, false};
@@ -204,10 +204,10 @@ TEST_F(SyscollectorImpTest, noHotfixes)
 TEST_F(SyscollectorImpTest, scanOnInverval)
 {
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
-    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return("hardware"));
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14"}])")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return("networks"));
-    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return("os"));
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(R"({"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));
     EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":20,"vm_size":0}])")));


### PR DESCRIPTION
|Related issue|
|---|
|#6259|
Closes #6259 
## **Description**

This issue aims to make use of the generic synchronization libraries, to use the synchronization solution algorithm that both shared modules provide.

These changes have to be made in the various implementations according to the operating system targeted for this feature.

## **DoD**
- [X] Implementation
- [X] **Run testtool on Win**
![image](https://user-images.githubusercontent.com/54002291/98984175-9aaa1e80-2500-11eb-95ed-e53079a114ea.png)
- [X] **Run testtool on Linux**
![image](https://user-images.githubusercontent.com/54002291/98981282-849a5f00-24fc-11eb-9ccc-43988fc095e7.png)
- [X] **RTR syscollector**
![image](https://user-images.githubusercontent.com/54002291/98980605-94657380-24fb-11eb-82b2-4795e4ad2217.png)

