### PR TITLE
Fixing agents_disconnection_alert_time default value

### DIFF
--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -17,7 +17,7 @@
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
     <agents_disconnection_time>20s</agents_disconnection_time>
-    <agents_disconnection_alert_time>2m</agents_disconnection_alert_time
+    <agents_disconnection_alert_time>100s</agents_disconnection_alert_time
   </global>
 
   <alerts>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -17,7 +17,7 @@
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
     <agents_disconnection_time>20s</agents_disconnection_time>
-    <agents_disconnection_alert_time>2m</agents_disconnection_alert_time>
+    <agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
   </global>
 
   <alerts>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -17,7 +17,7 @@
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
     <agents_disconnection_time>20s</agents_disconnection_time>
-    <agents_disconnection_alert_time>2m</agents_disconnection_alert_time>
+    <agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
   </global>
 
   <!-- Choose between plain or json format (or both) for internal logs -->

--- a/etc/templates/config/generic/global.template
+++ b/etc/templates/config/generic/global.template
@@ -10,5 +10,5 @@
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
     <agents_disconnection_time>20s</agents_disconnection_time>
-    <agents_disconnection_alert_time>2m</agents_disconnection_alert_time>
+    <agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
   </global>

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -186,7 +186,7 @@ int MonitordConfig(const char *cfg, monitor_config *mond, int no_agents, short d
 
     /* Setting default agent's global configuration */
     mond->global.agents_disconnection_time = 20;
-    mond->global.agents_disconnection_alert_time = 120;
+    mond->global.agents_disconnection_alert_time = 100;
 
     modules |= CREPORTS;
 

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -41,7 +41,7 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
 
     /* Setting default values for global parameters */
     cfg->global.agents_disconnection_time = 20;
-    cfg->global.agents_disconnection_alert_time = 120;
+    cfg->global.agents_disconnection_alert_time = 100;
 
     if (ReadConfig(modules, cfgfile, cfg, NULL) < 0 ||
         ReadConfig(CGLOBAL, cfgfile, &cfg->global, NULL) < 0 ) {

--- a/src/unit_tests/monitord/test_monitor_actions.c
+++ b/src/unit_tests/monitord/test_monitor_actions.c
@@ -348,7 +348,7 @@ void test_monitor_agents_alert_message_sent() {
     will_return(__wrap_wdb_get_agent_info, j_agent_info);
 
     mond.global.agents_disconnection_time = 20;
-    mond.global.agents_disconnection_alert_time = 200;
+    mond.global.agents_disconnection_alert_time = 100;
     will_return(__wrap_time, 1000);
 
     // monitor_send_disconnection_msg

--- a/src/unit_tests/monitord/test_monitord.c
+++ b/src/unit_tests/monitord/test_monitord.c
@@ -400,7 +400,7 @@ void test_getMonitorGlobalOptions_success(void **state) {
     cJSON *object = NULL;
 
     // Arbitrary configuration
-    mond.global.agents_disconnection_time = 200;
+    mond.global.agents_disconnection_time = 20;
     mond.global.agents_disconnection_alert_time = 100;
 
     root = getMonitorGlobalOptions();
@@ -480,7 +480,7 @@ void test_MonitordConfig_success(void **state) {
 
     assert_int_equal(result, OS_SUCCESS);
     assert_int_equal(mond.global.agents_disconnection_time, 20);
-    assert_int_equal(mond.global.agents_disconnection_alert_time, 120);
+    assert_int_equal(mond.global.agents_disconnection_alert_time, 100);
 
     assert_null(mond.agents);
     assert_null(mond.smtpserver);


### PR DESCRIPTION
|Related issue|
|---|
| #6587 |

## Description

This PR fixes the `agents_disconnection_alert_time` setting default value in order to have agents disconnection alerts after 2 minutes of its last keepalive.

For more detail, check the **description** section of issue #6587.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade