### PR TITLE
Updating the get-agents-by-connection-status command with the chunks logic

### DIFF
--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -239,11 +239,14 @@ cJSON* __wrap_wdb_global_get_agent_info(__attribute__((unused)) wdb_t *wdb,
 int __wrap_wdb_global_reset_agents_connection( __attribute__((unused)) wdb_t *wdb) {
     return mock();
 }
-
-cJSON* __wrap_wdb_global_get_agents_by_connection_status(__attribute__((unused)) wdb_t* wdb,
-                                                         const char* status) {
-    check_expected(status);
-    return mock_ptr_type(cJSON*);
+wdbc_result __wrap_wdb_global_get_agents_by_connection_status (__attribute__((unused)) wdb_t *wdb,
+                                                               int last_agent_id,
+                                                               const char* connection_status,
+                                                               char **output) {
+    check_expected(last_agent_id);
+    check_expected(connection_status);
+    os_strdup(mock_ptr_type(char*), *output);
+    return mock();
 }
 
 cJSON* __wrap_wdb_global_get_agents_to_disconnect(__attribute__((unused)) wdb_t *wdb,

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -83,7 +83,7 @@ cJSON* __wrap_wdb_global_get_agent_info(wdb_t *wdb, int id);
 
 int __wrap_wdb_global_reset_agents_connection(wdb_t *wdb);
 
-cJSON* __wrap_wdb_global_get_agents_by_connection_status(wdb_t* wdb, const char* status);
+wdbc_result __wrap_wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, char **output);
 
 cJSON* __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int keep_alive);
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -139,7 +139,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_SYNC_SET] = "UPDATE agent SET sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_INFO] = "UPDATE agent SET config_sum = :config_sum, ip = :ip, manager_host = :manager_host, merged_sum = :merged_sum, name = :name, node_name = :node_name, os_arch = :os_arch, os_build = :os_build, os_codename = :os_codename, os_major = :os_major, os_minor = :os_minor, os_name = :os_name, os_platform = :os_platform, os_uname = :os_uname, os_version = :os_version, version = :version, last_keepalive = :last_keepalive, connection_status = :connection_status, sync_status = :sync_status WHERE id = :id;",
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ? LIMIT 1;",
-    [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ?;",
+    [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GET_AGENT_INFO] = "SELECT * FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT] = "SELECT id FROM agent WHERE id > 0 AND connection_status = 'active' AND last_keepalive < ?;",
     [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected' where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -139,7 +139,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_SYNC_SET] = "UPDATE agent SET sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_INFO] = "UPDATE agent SET config_sum = :config_sum, ip = :ip, manager_host = :manager_host, merged_sum = :merged_sum, name = :name, node_name = :node_name, os_arch = :os_arch, os_build = :os_build, os_codename = :os_codename, os_major = :os_major, os_minor = :os_minor, os_name = :os_name, os_platform = :os_platform, os_uname = :os_uname, os_version = :os_version, version = :version, last_keepalive = :last_keepalive, connection_status = :connection_status, sync_status = :sync_status WHERE id = :id;",
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ? LIMIT 1;",
-    [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > 0 AND connection_status = ?;",
+    [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ?;",
     [WDB_STMT_GLOBAL_GET_AGENT_INFO] = "SELECT * FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT] = "SELECT id FROM agent WHERE id > 0 AND connection_status = 'active' AND last_keepalive < ?;",
     [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected' where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1662,7 +1662,7 @@ int wdb_global_reset_agents_connection(wdb_t *wdb);
  * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
  * @return wdbc_result to represent if all agents has being obtained or any error occurred.
  */
-wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int* last_agent_id, const char* connection_status, char **output);
+wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, char **output);
 
 /*
  * @brief Gets all the agents' IDs (excluding the manager) that satisfy the keepalive condition to be disconnected.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -630,7 +630,7 @@ int wdb_reset_agents_connection(int *sock);
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Pointer to the array, on success. NULL on errors.
  */
-int* wdb_get_agents_by_connection_status(const char* status, int *sock);
+int* wdb_get_agents_by_connection_status(const char* connection_status, int *sock);
 
 /**
  * @brief This method creates and sends a command to WazuhDB to set as disconnected all the
@@ -1241,7 +1241,7 @@ int wdb_parse_reset_agents_connection(wdb_t * wdb, char * output);
  *
  * @param wdb The global struct database.
  * @param [in] wdb The global struct database.
- * @param [in] input String with 'connection_status'.
+ * @param [in] input String with 'last_id' and 'connection_status'.
  * @param [out] output Response of the query in JSON format.
  * @retval 0 Success: Response contains the value.
  * @retval -1 On error: Response contains details of the error.
@@ -1656,13 +1656,14 @@ int wdb_global_reset_agents_connection(wdb_t *wdb);
 /**
  * @brief Function to get the id of every agent with a specific connection_status.
  *
- * @param wdb The Global struct database.
- * @param status Connection status of the agents requested.
- * @retval JSON with every agent ID on success.
- * @retval NULL on error.
+ * @param [in] wdb The Global struct database.
+ * @param [in] last_agent_id ID where to start querying.
+ * @param [in] connection_status Connection status of the agents requested.
+ * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
+ * @return wdbc_result to represent if all agents has being obtained or any error occurred.
  */
+wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int* last_agent_id, const char* connection_status, char **output);
 
-cJSON* wdb_global_get_agents_by_connection_status(wdb_t *wdb, const char* status);
 /*
  * @brief Gets all the agents' IDs (excluding the manager) that satisfy the keepalive condition to be disconnected.
  *

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -624,9 +624,13 @@ int wdb_remove_group_from_belongs_db(const char *name, int *sock);
 int wdb_reset_agents_connection(int *sock);
 
 /**
- * @brief Get every agent (excluding the manager) that matches the specified connection status.
+ * @brief Returns an array containing the ID of every agent (excluding the manager) that matches
+ *        the specified connection status, ended with -1.
+ *        This method creates and sends a command to WazuhDB to receive the ID of every agent.
+ *        If the response is bigger than the capacity of the socket, multiple commands will be sent until every
+ *        agent ID is obtained. The array is heap allocated memory that must be freed by the caller.
  *
- * @param[in] status The connection status.
+ * @param[in] connection_status The connection status.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Pointer to the array, on success. NULL on errors.
  */
@@ -1655,6 +1659,9 @@ int wdb_global_reset_agents_connection(wdb_t *wdb);
 
 /**
  * @brief Function to get the id of every agent with a specific connection_status.
+ *        Response is prepared in one chunk, if the size of the chunk exceeds WDB_MAX_RESPONSE_SIZE
+ *        parsing stops and reports the amount of agents obtained.
+ *        Multiple calls to this function can be required to fully obtain all agents.
  *
  * @param [in] wdb The Global struct database.
  * @param [in] last_agent_id ID where to start querying.

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -44,7 +44,7 @@ static const char *global_db_commands[] = {
     [WDB_DELETE_AGENT_BELONG] = "global delete-agent-belong %d",
     [WDB_DELETE_GROUP_BELONG] = "global delete-group-belong %s",
     [WDB_RESET_AGENTS_CONNECTION] = "global reset-agents-connection",
-    [WDB_GET_AGENTS_BY_CONNECTION_STATUS] = "global get-agents-by-connection-status last_id %d %s",
+    [WDB_GET_AGENTS_BY_CONNECTION_STATUS] = "global get-agents-by-connection-status %d %s",
     [WDB_DISCONNECT_AGENTS] = "global disconnect-agents %d"
 };
 

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -44,7 +44,7 @@ static const char *global_db_commands[] = {
     [WDB_DELETE_AGENT_BELONG] = "global delete-agent-belong %d",
     [WDB_DELETE_GROUP_BELONG] = "global delete-group-belong %s",
     [WDB_RESET_AGENTS_CONNECTION] = "global reset-agents-connection",
-    [WDB_GET_AGENTS_BY_CONNECTION_STATUS] = "global get-agents-by-connection-status %s",
+    [WDB_GET_AGENTS_BY_CONNECTION_STATUS] = "global get-agents-by-connection-status last_id %d %s",
     [WDB_DISCONNECT_AGENTS] = "global disconnect-agents %d"
 };
 
@@ -1096,61 +1096,52 @@ int wdb_reset_agents_connection(int *sock) {
     return result;
 }
 
-int* wdb_get_agents_by_connection_status(const char* status, int *sock) {
-    char* wdbquery = NULL;
-    char* wdboutput = NULL;
-    char* payload = NULL;
-    char* merged_payload = NULL;
-    int* array = NULL;
-    wdbc_result result = WDBC_UNKNOWN;
+int* wdb_get_agents_by_connection_status (const char* connection_status, int *sock) {
+    char wdbquery[WDBQUERY_SIZE] = "";
+    char wdboutput[WDBOUTPUT_SIZE] = "";
+    int last_id = 0;
+    int *array = NULL;
+    int len = 0;
+    wdbc_result status = WDBC_DUE;
     int aux_sock = -1;
-    int* query_sock = sock?sock:&aux_sock;
 
-    //Get the response from WazuhDB
-    os_malloc(WDBQUERY_SIZE, wdbquery);
-    os_malloc(WDBOUTPUT_SIZE, wdboutput);
-    snprintf(wdbquery, WDBQUERY_SIZE, global_db_commands[WDB_GET_AGENTS_BY_CONNECTION_STATUS], status);
-    result = wdbc_query_parse(query_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE, &payload);
-    os_free(wdbquery);
-
-    //Check if there is pending data on WazuhDB
-    if (result == WDBC_DUE) {
-        os_strdup(payload, merged_payload);
-        while (result == WDBC_DUE) {
-            char* pending_response = NULL;
-            char* pending_payload = NULL;
-            os_malloc(WDBOUTPUT_SIZE, pending_response);
-            result = wdbc_query_parse(query_sock, "continue", pending_response, WDBOUTPUT_SIZE, &pending_payload);
-            wm_strcat(&merged_payload, pending_payload, 0);
-            os_free(pending_response);
+    while (status == WDBC_DUE) {
+        // Query WazuhDB
+        snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_GET_AGENTS_BY_CONNECTION_STATUS], last_id, connection_status);
+        if (wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, sizeof(wdboutput)) == 0) {
+            // Parse result
+            char* payload = NULL;
+            status = wdbc_parse_result(wdboutput, &payload);
+            if (status == WDBC_OK || status == WDBC_DUE) {
+                const char delim = ',';
+                const char sdelim[] = { delim, '\0' };
+                //Realloc new size
+                int new_len = os_strcnt(payload, delim)+1;
+                os_realloc(array, sizeof(int)*(len+new_len+1), array);
+                //Append IDs to array
+                char* agent_id = NULL;
+                char *savedptr = NULL;
+                for (agent_id = strtok_r(payload, sdelim, &savedptr); agent_id; agent_id = strtok_r(NULL, sdelim, &savedptr)) {
+                    array[len] = atoi(agent_id);
+                    last_id = array[len];
+                    len++;
+                }
+            }
         }
-        payload = merged_payload;
+        else {
+            status = WDBC_ERROR;
+        }
+    }
+    if (status == WDBC_OK) {
+        array[len] = -1;
+    }
+    else {
+        os_free(array);
     }
 
     if (!sock) {
         wdbc_close(&aux_sock);
     }
-
-    if (result == WDBC_OK) {
-        //Iterate over json array
-        cJSON* root = cJSON_Parse(payload);
-        os_calloc(cJSON_GetArraySize(root)+1, sizeof(*array), array);
-        int* aux = array;
-        cJSON *item = root ? root->child : 0;
-        while (item)
-        {
-            cJSON *json_id = cJSON_GetObjectItem(item, "id");
-            if (cJSON_IsNumber(json_id)) {
-                *aux++ = json_id->valueint;
-            }
-            item = item->next;
-        }
-        *aux = -1;
-        cJSON_Delete(root);
-    }
-
-    os_free(wdboutput);
-    os_free(merged_payload);
 
     return array;
 }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1210,7 +1210,7 @@ int wdb_global_check_manager_keepalive(wdb_t *wdb) {
     }
 }
 
-wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int* last_agent_id, const char* connection_status, char **output) {
+wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, char **output) {
     wdbc_result status = WDBC_UNKNOWN;
     unsigned response_size = 0;
 
@@ -1232,7 +1232,7 @@ wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int* last_ag
             break;
         }
         sqlite3_stmt* stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS];
-        if (sqlite3_bind_int(stmt, 1, *last_agent_id) != SQLITE_OK) {
+        if (sqlite3_bind_int(stmt, 1, last_agent_id) != SQLITE_OK) {
             merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
             snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
             status = WDBC_ERROR;
@@ -1267,7 +1267,7 @@ wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int* last_ag
                     *response_aux++ = ',';
                     //Save size and last ID
                     response_size += id_len+1;
-                    *last_agent_id = agent_id;
+                    last_agent_id = agent_id;
                 }
                 else {
                     //Pending agents but buffer is full

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1210,32 +1210,87 @@ int wdb_global_check_manager_keepalive(wdb_t *wdb) {
     }
 }
 
-cJSON* wdb_global_get_agents_by_connection_status(wdb_t* wdb, const char* status) {
-    sqlite3_stmt *stmt = NULL;
-    cJSON * result = NULL;
+wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int* last_agent_id, const char* connection_status, char **output) {
+    wdbc_result status = WDBC_UNKNOWN;
+    unsigned response_size = 0;
+
+    os_calloc(WDB_MAX_RESPONSE_SIZE, sizeof(char), *output);
+    char *response_aux = *output;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
         mdebug1("Cannot begin transaction");
-        return NULL;
+        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot begin transaction");
+        return WDBC_ERROR;
     }
 
-    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS) < 0) {
-        mdebug1("Cannot cache statement");
-        return NULL;
+    while (status == WDBC_UNKNOWN) {
+        //Prepare SQL query
+        if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS) < 0) {
+            mdebug1("Cannot cache statement");
+            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot cache statement");
+            status = WDBC_ERROR;
+            break;
+        }
+        sqlite3_stmt* stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS];
+        if (sqlite3_bind_int(stmt, 1, *last_agent_id) != SQLITE_OK) {
+            merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
+            status = WDBC_ERROR;
+            break;
+        }
+        if (sqlite3_bind_text(stmt, 2, connection_status, -1, NULL) != SQLITE_OK) {
+            merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
+            status = WDBC_ERROR;
+            break;
+        }
+
+        //Get agent id
+        cJSON* sql_agents_response = wdb_exec_stmt(stmt);
+        if (sql_agents_response && sql_agents_response->child) {
+            cJSON* json_agent = sql_agents_response->child;
+            cJSON* json_id = cJSON_GetObjectItem(json_agent,"id");
+            if (cJSON_IsNumber(json_id)) {
+                //Get ID
+                int agent_id = json_id->valueint;
+
+                //Print Agent info
+                char *id_str = cJSON_PrintUnformatted(json_id);
+                unsigned id_len = strlen(id_str);
+
+                //Check if new agent fits in response
+                if (response_size+id_len+1 < WDB_MAX_RESPONSE_SIZE) {
+                    //Add new agent
+                    memcpy(response_aux, id_str, id_len);
+                    response_aux+=id_len;
+                    //Add separator
+                    *response_aux++ = ',';
+                    //Save size and last ID
+                    response_size += id_len+1;
+                    *last_agent_id = agent_id;
+                }
+                else {
+                    //Pending agents but buffer is full
+                    status = WDBC_DUE;
+                }
+                os_free(id_str);
+            }
+        }
+        else {
+            //All agents have been obtained
+            status = WDBC_OK;
+        }
+        cJSON_Delete(sql_agents_response);
     }
 
-    stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS];
-
-    if (sqlite3_bind_text(stmt, 1, status, -1, NULL) != SQLITE_OK) {
-        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-        return NULL;
+    if (status != WDBC_ERROR) {
+        if (response_size > 0) {
+            //Remove last ','
+            response_aux--;
+        }
+        //Add string end
+        *response_aux = '\0';
     }
 
-    result = wdb_exec_stmt(stmt);
-
-    if (!result) {
-        mdebug1("wdb_exec_stmt(): %s", sqlite3_errmsg(wdb->db));
-    }
-
-    return result;
+    return status;
 }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -4985,12 +4985,6 @@ int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, ch
 
     /* Get last_id*/
     next = strtok_r(input, delim, &savedptr);
-    if (next == NULL || strcmp(next, "last_id") != 0) {
-        mdebug1("Invalid arguments 'last_id' not found.");
-        snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'last_id' not found");
-        return OS_INVALID;
-    }
-    next = strtok_r(NULL, delim, &savedptr);
     if (next == NULL) {
         mdebug1("Invalid arguments 'last_id' not found.");
         snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'last_id' not found");
@@ -5006,7 +5000,7 @@ int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, ch
     }
     connection_status = next;
 
-    wdbc_result status = wdb_global_get_agents_by_connection_status(wdb, &last_id, connection_status, &out);
+    wdbc_result status = wdb_global_get_agents_by_connection_status(wdb, last_id, connection_status, &out);
     snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[status], out);
 
     os_free(out)

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -4976,27 +4976,42 @@ int wdb_parse_global_get_agent_info(wdb_t* wdb, char* input, char* output) {
 }
 
 int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, char* output) {
-    cJSON *agents = NULL;
-    char *out = NULL;
+    int last_id = 0;
+    char *connection_status = NULL;
+    char* out = NULL;
+    char *next = NULL;
+    const char delim[2] = " ";
+    char *savedptr = NULL;
 
-    if (agents = wdb_global_get_agents_by_connection_status(wdb, input), !agents) {
-        mdebug1("Error getting agent information from global.db.");
-        snprintf(output, OS_MAXSTR + 1, "err Error getting agent information from global.db.");
+    /* Get last_id*/
+    next = strtok_r(input, delim, &savedptr);
+    if (next == NULL || strcmp(next, "last_id") != 0) {
+        mdebug1("Invalid arguments 'last_id' not found.");
+        snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'last_id' not found");
         return OS_INVALID;
     }
-    #if 0
-    *output = cJSON_PrintUnformatted(agents);
-    cJSON_Delete(agents);
+    next = strtok_r(NULL, delim, &savedptr);
+    if (next == NULL) {
+        mdebug1("Invalid arguments 'last_id' not found.");
+        snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'last_id' not found");
+        return OS_INVALID;
+    }
+    last_id = atoi(next);
+    /* Get connection status */
+    next = strtok_r(NULL, delim, &savedptr);
+    if (next == NULL) {
+        mdebug1("Invalid arguments 'connection_status' not found.");
+        snprintf(output, OS_MAXSTR + 1, "err Invalid arguments 'connection_status' not found");
+        return OS_INVALID;
+    }
+    connection_status = next;
 
-    return WDBC_OK;
-    #else
-    out = cJSON_PrintUnformatted(agents);
-    snprintf(output, OS_MAXSTR + 1, "ok %s", out);
-    os_free(out);
-    cJSON_Delete(agents);
+    wdbc_result status = wdb_global_get_agents_by_connection_status(wdb, &last_id, connection_status, &out);
+    snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[status], out);
+
+    os_free(out)
 
     return OS_SUCCESS;
-    #endif
 }
 
 int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output) {


### PR DESCRIPTION
|Related issue|
|---|
|#6563|

## Description

This PR updates the _wdb_get_agents_by_connection_status()_ method to work with a chunks logic in case of a query result too big for the socket size. These are the main changes:
- The query in **wdb.c**
- The method _wdb_global_get_agents_by_connection_status()_ in **wdb_global.c**
- The method _wdb_parse_global_get_agents_by_connection_status()_ in **wdb_parser.c**
- The method _wdb_get_agents_by_connection_status()_ in **wdb_agent.c**
- The corresponding UT

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  
- [x] Added unit tests (for new features)
