### PR TITLE
[Development] Vulnerability-Detector: Add a new MacOS product name

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5258,7 +5258,7 @@ int wm_vuldet_discard_kernel_package(agent_software *agent, const char *name,
 }
 
 int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent) {
-    const char *product_name = NULL;
+    const char *product_name[MAX_PRODUCT_NAMES] = {0};
     const char *vendor = NULL;
 
     if (!db) {
@@ -5280,38 +5280,41 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
         case FEED_XENIAL:
         case FEED_BIONIC:
         case FEED_FOCAL:
-            product_name = PR_UBUNTU;
+            product_name[0] = PR_UBUNTU;
             vendor = V_UBUNTU;
         break;
         case FEED_STRETCH:
         case FEED_BUSTER:
-            product_name = PR_DEBIAN;
+            product_name[0] = PR_DEBIAN;
             vendor = V_DEBIAN;
         break;
         case FEED_RHEL5:
         case FEED_RHEL6:
         case FEED_RHEL7:
         case FEED_RHEL8:
-            product_name = PR_REDHAT;
+            product_name[0] = PR_REDHAT;
             vendor = V_REDHAT;
         break;
         case FEED_MAC:
             vendor = "apple";
             if (!strcmp(agent->os_name, "Mac OS X Server")) {
-                product_name = "mac_os_x_server";
+                product_name[0] = "mac_os_x_server";
             } else {
-                product_name = "mac_os_x";
+                product_name[0] = "mac_os_x";
+                product_name[1] = "mac_os";
             }
         break;
         default:
             return 1;
     }
 
-    // Generate os package
-    if (agent->os_release) {
-        if (wm_vuldet_insert_agent_data(db, agent, NULL, vendor, product_name, NULL, agent->os_release, NULL, agent->arch, NULL, NULL)) {
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_INSERT_DATA_ERR, product_name);
-            return OS_INVALID;
+    for (int i = 0; product_name[i] != NULL; i++) {
+        // Generate os package
+        if (agent->os_release) {
+            if (wm_vuldet_insert_agent_data(db, agent, NULL, vendor, product_name[i], NULL, agent->os_release, NULL, agent->arch, NULL, NULL)) {
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_INSERT_DATA_ERR, product_name[i]);
+                return OS_INVALID;
+            }
         }
     }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -86,6 +86,7 @@
 #define VU_SRC_NVD 1 // CVE found using the NVD as source feed.
 #define VU_SRC_OVAL 2 // CVE found using an OVAL as source feed.
 #define MAX_RELATED_PKGS 5 // Max number of related packages (children, siblings...)
+#define MAX_PRODUCT_NAMES 4 // Max numebr of products available per vendor feed.
 
 // CPE helper action flags
 #define CPE_DIC_REP_VEN                                 1 << 0

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2291,7 +2291,8 @@ int wm_vuldet_check_generic_package(sqlite3 *dbCVE, vu_feed feed, char *pkg_name
         !strcmp(pkg_reference, PR_KERNEL)) {
         query = vu_queries[VU_GET_GENERIC_PACKAGE_OS];
         os_package = true;
-    } else if (!strcmp(pkg_reference, "mac_os_x") || !strcmp(pkg_reference, "mac_os_x_server")) {
+    } else if (!strcmp(pkg_reference, "mac_os_x") || !strcmp(pkg_reference, "mac_os_x_server") ||
+        !strcmp(pkg_reference, "mac_os")) {
         query = vu_queries[VU_GET_GENERIC_PACKAGE_OS_MAC];
     } else {
         if (feed == FEED_MAC) {
@@ -2530,7 +2531,8 @@ int wm_vuldet_check_specific_package(sqlite3 *dbCVE, vu_feed feed, char *pkg_nam
         !strcmp(pkg_reference, PR_KERNEL)) {
         query = vu_queries[VU_GET_SPECIFIC_PACKAGE_OS];
         os_package = true;
-    } else if (!strcmp(pkg_reference, "mac_os_x") || !strcmp(pkg_reference, "mac_os_x_server")) {
+    } else if (!strcmp(pkg_reference, "mac_os_x") || !strcmp(pkg_reference, "mac_os_x_server") 
+        || !strcmp(pkg_reference, "mac_os")) {
         query = vu_queries[VU_GET_SPECIFIC_PACKAGE_OS_MAC];
         os_package = true;
     } else {


### PR DESCRIPTION
## Description

VDT was discarding some vulnerabilities due to a missing dependency. Said dependency was MacOS itself, yet the product name wasn't between the supported ones.

The new product name is: `mac_os`.

Now CVEs such as [CVE-2020-6797](https://nvd.nist.gov/vuln/detail/CVE-2020-6798#range-4501887) are shown correctly.

## Logs/Alerts example

```
/13 12:11:10 wazuh-modulesd:vulnerability-detector[49234] wm_vuln_detector_nvd.c:2471 at wm_vuldet_check_generic_package(): DEBUG: (5458): Package 'mac_os' inserted into the vulnerability 'CVE-2020-6797'. Version (10.15.1) 'equal' '*' (feed 'NVD').
2020/11/13 12:11:10 wazuh-modulesd:vulnerability-detector[49234] wm_vuln_detector_nvd.c:2471 at wm_vuldet_check_generic_package(): DEBUG: (5458): Package 'firefox' inserted into the vulnerability 'CVE-2020-6797'. Version (72.0) 'less than' '73.0' (feed 'NVD').
2020/11/13 12:11:10 wazuh-modulesd:vulnerability-detector[49234] wm_vuln_detector.c:1637 at wm_vuldet_linux_rm_nvd_not_vulnerable_packages(): DEBUG: (5464): Package 'mac_os' not vulnerable to 'CVE-2020-6797' since it is a dependency not vulnerable.
2020/11/13 12:11:11 wazuh-modulesd:vulnerability-detector[49234] wm_vuln_detector.c:1469 at wm_vuldet_send_cve_report(): DEBUG: (5468): The 'firefox' package (72.0) from agent '003' is vulnerable to 'CVE-2020-6797'. Condition: 'Package less than 73.0'
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)

