### PR TITLE
Fix remove reserved roles from non-reserved rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **API:**
+  - Fixed an error with `POST /security/roles/{role_id}/rules` when removing role-rule relationships. ([#6594](https://github.com/wazuh/wazuh/issues/6594))
+
 - **Core:**
   - Fixed a bug in Remoted that limited the maximum agent number to `MAX_AGENTS-3` instead of `MAX_AGENTS-2`. ([#4560](https://github.com/wazuh/wazuh/pull/4560))
   - Fixed an error in the network library when handling disconnected sockets. ([#6444](https://github.com/wazuh/wazuh/pull/6444))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - **API:**
-  - Fixed an error with `POST /security/roles/{role_id}/rules` when removing role-rule relationships. ([#6594](https://github.com/wazuh/wazuh/issues/6594))
+  - Fixed an error with `POST /security/roles/{role_id}/rules` when removing role-rule relationships with admin resources. ([#6594](https://github.com/wazuh/wazuh/issues/6594))
 
 - **Core:**
   - Fixed a bug in Remoted that limited the maximum agent number to `MAX_AGENTS-3` instead of `MAX_AGENTS-2`. ([#4560](https://github.com/wazuh/wazuh/pull/4560))

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -13708,7 +13708,7 @@ paths:
                         - 1
                       users:
                         - 1
-                      rule:
+                      rules:
                         - 1
                     - id: 2
                       name: 'normal_user'
@@ -13717,7 +13717,7 @@ paths:
                         - 5
                       users:
                         - 3
-                      rule:
+                      rules:
                         - 3
                   total_affected_items: 2
                 message: "All specified roles were returned"
@@ -13768,10 +13768,6 @@ paths:
                   affected_items:
                     - id: 2
                       name: normal_user
-                      policies: []
-                      rule:
-                        MATCH:
-                          definition: limit_access
                   total_affected_items: 1
                 message: "Role was successfully created"
                 error: 0
@@ -13820,28 +13816,13 @@ paths:
                     - id: 4
                       name: administrator
                       policies:
-                        - id: 4
-                          name: administratorPolicy
-                          policy:
-                            actions:
-                              - agent:delete
-                            effect: allow
-                            resources:
-                              - agent:id:*
-                        - id: 5
-                          name: normalPolicy
-                          policy:
-                            actions:
-                              - agent:delete
-                            effect: deny
-                            resources:
-                              - agent:id:*
-                      rule:
-                        MATCH:
-                          definition: administratorRule
+                        - 4
+                        - 5
+                      rules:
+                        - 8
                       users:
-                        - normal
-                        - rbac
+                        - 101
+                        - 104
                   failed_items: []
                   total_affected_items: 1
                   total_failed_items: 0
@@ -13898,9 +13879,8 @@ paths:
                     - id: 5
                       name: normal8
                       policies: []
-                      rule:
-                        MATCH:
-                          definition: normalRule8
+                      rules:
+                        - 100
                   total_affected_items: 1
                 message: "Role was successfully updated"
                 error: 0
@@ -14322,16 +14302,8 @@ paths:
                         resources:
                           - role:id:1
                       roles:
-                        - id: 3
-                          name: technical
-                          rule:
-                            MATCH:
-                              definition: technicalRule
-                        - id: 6
-                          name: ossec
-                          rule:
-                            MATCH:
-                              definition: ossecRule
+                        - 3
+                        - 6
                   failed_items: []
                   total_affected_items: 1
                   total_failed_items: 0
@@ -14548,29 +14520,10 @@ paths:
                     - id: 3
                       name: normal
                       policies:
-                        - id: 2
-                          name: normal_policy
-                          policy:
-                            actions:
-                              - agent:delete
-                            effect: allow
-                            resources:
-                              - agent:id:001
-                              - agent:id:002
-                              - agent:id:003
-                        - id: 3
-                          name: normal_policy1
-                          policy:
-                            actions:
-                              - agent:delete1
-                            effect: allow
-                            resources:
-                              - agent:id:001
-                              - agent:id:002
-                              - agent:id:003
-                      rule:
-                        MATCH:
-                          definition: normalRule
+                        - 2
+                        - 3
+                      rules:
+                        - 5
                       users: []
                   failed_items: []
                   total_affected_items: 2
@@ -14616,9 +14569,8 @@ paths:
                     - id: 3
                       name: normal
                       policies: []
-                      rule:
-                        MATCH:
-                          definition: normalRule
+                      rules:
+                        - 1
                       users: []
                   failed_items: []
                   total_affected_items: 2

--- a/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
@@ -205,7 +205,7 @@ stages:
           total_failed_items: 1
 
   # DELETE /security/roles/{role_id}/rules/{rule_id}
-  - name: Try to delete a non-existent role-rule (reserved rule)
+  - name: Try to delete a non-existent role-rule (reserved role)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/roles/3/rules"
@@ -222,7 +222,7 @@ stages:
           affected_items: [ ]
           failed_items:
             - error:
-                code: 4008
+                code: 4022
               id: !anything
           total_failed_items: 1
 

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -521,7 +521,7 @@ class WazuhException(Exception):
         # User management
         5000: {'message': 'The user could not be created',
                'remediation': 'Please check that the user does not exist, '
-                              'to do this you can use the `GET /security/users/{username}` call'},
+                              'to do this you can use the `GET /security/users` call'},
         5001: {'message': 'The user does not exist',
                'remediation': 'The user can be created with the endpoint POST /security/users'},
         5002: {'message': 'There are no users in the system'},

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -1825,6 +1825,10 @@ class RolesPoliciesManager:
             Order to be applied in case of multiples roles in the same user
         force_admin : bool
             By default, changing an administrator roles is not allowed. If True, it will be applied to admin roles too
+        atomic : bool
+            This parameter indicates if the operation is atomic. If this function is called within
+            a loop or a function composed of several operations, atomicity cannot be guaranteed.
+            And it must be the most external function that ensures it
 
         Returns
         -------
@@ -2158,7 +2162,7 @@ class RolesRulesManager:
     all the methods needed for the roles-rules administration.
     """
 
-    def add_rule_to_role(self, rule_id: int, role_id: int, atomic: bool = True):
+    def add_rule_to_role(self, rule_id: int, role_id: int, atomic: bool = True, force_admin: bool = False):
         """Add a relation between one specified role and one specified rule.
 
         Parameters
@@ -2171,6 +2175,8 @@ class RolesRulesManager:
             This parameter indicates if the operation is atomic. If this function is called within
             a loop or a function composed of several operations, atomicity cannot be guaranteed.
             And it must be the most external function that ensures it
+        force_admin : bool
+            By default, changing an administrator roles is not allowed. If True, it will be applied to admin roles too
 
         Returns
         -------
@@ -2178,18 +2184,20 @@ class RolesRulesManager:
         """
         try:
             # Create a rule-role relationship if both exist
-            rule = self.session.query(Rules).filter_by(id=rule_id).first()
-            if rule is None:
-                return SecurityError.RULE_NOT_EXIST
-            role = self.session.query(Roles).filter_by(id=role_id).first()
-            if role is None:
-                return SecurityError.ROLE_NOT_EXIST
-            if self.session.query(RolesRules).filter_by(rule_id=rule_id, role_id=role_id).first() is None:
-                role.rules.append(rule)
-                atomic and self.session.commit()
-                return True
-            else:
-                return SecurityError.ALREADY_EXIST
+            if int(rule_id) > max_id_reserved or force_admin:
+                rule = self.session.query(Rules).filter_by(id=rule_id).first()
+                if rule is None:
+                    return SecurityError.RULE_NOT_EXIST
+                role = self.session.query(Roles).filter_by(id=role_id).first()
+                if role is None:
+                    return SecurityError.ROLE_NOT_EXIST
+                if self.session.query(RolesRules).filter_by(rule_id=rule_id, role_id=role_id).first() is None:
+                    role.rules.append(rule)
+                    atomic and self.session.commit()
+                    return True
+                else:
+                    return SecurityError.ALREADY_EXIST
+            return SecurityError.ADMIN_RESOURCES
         except (IntegrityError, InvalidRequestError):
             self.session.rollback()
             return SecurityError.INVALID
@@ -2286,7 +2294,7 @@ class RolesRulesManager:
         True -> Success | False -> Failure | Role not exists | Rule not exist s| Non-existent relationship
         """
         try:
-            if role_id > max_id_reserved:  # Required rule
+            if int(rule_id) > max_id_reserved:  # Required rule
                 rule = self.session.query(Rules).filter_by(id=rule_id).first()
                 if rule is None:
                     return SecurityError.RULE_NOT_EXIST

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -2480,4 +2480,4 @@ with open(os.path.join(default_path, "relationships.yaml"), 'r') as stream:
         for d_role_name, payload in default_relationships[next(iter(default_relationships))]['roles'].items():
             for d_rule_name in payload['rule_ids']:
                 rrum.add_rule_to_role(role_id=rm.get_role(name=d_role_name)['id'],
-                                      rule_id=rum.get_rule_by_name(d_rule_name)['id'])
+                                      rule_id=rum.get_rule_by_name(d_rule_name)['id'], force_admin=True)


### PR DESCRIPTION
|Related issue|
|---|
|#6594|

Hi team,

This PR closes #6594. In this PR we have fixed an error with the roles-rules relationships. Before this fix it was possible to associate a reserved role to a non-reserved rule. However, when you tried to remove this relationship, an error occurred because it was not possible to remove a reserved role from any relationship.

## Test results
### Integrated tests
```
adriiiprodri@wazuh python3 -m pytest -x test_security_DELETE_endpoints.tavern.yaml 
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/api/test/integration, configfile: pytest.ini
plugins: metadata-1.10.0, html-2.1.1, tavern-1.7.0
collected 15 items

test_security_DELETE_endpoints.tavern.yaml ...............                                                                                                          [100%]

=============================================================== 15 passed, 16 warnings in 116.48s (0:01:56) ===============================================================


adriiiprodri@wazuh python3 -m pytest -x test_security_GET_endpoints.tavern.yaml
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/api/test/integration, configfile: pytest.ini
plugins: metadata-1.10.0, html-2.1.1, tavern-1.7.0
collected 18 items

test_security_GET_endpoints.tavern.yaml ..................

=============================================================== 18 passed, 19 warnings in 100.01s (0:01:40) ===============================================================


adriiiprodri@wazuh python3 -m pytest -x test_security_PUT_endpoints.tavern.yaml 
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/api/test/integration, configfile: pytest.ini
plugins: metadata-1.10.0, html-2.1.1, tavern-1.7.0
collected 8 items

test_security_PUT_endpoints.tavern.yaml ........                                                                                                                    [100%]

================================================================ 8 passed, 9 warnings in 100.53s (0:01:40) ================================================================


adriiiprodri@wazuh python3 -m pytest -x test_security_POST_endpoints.tavern.yaml
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/api/test/integration, configfile: pytest.ini
plugins: metadata-1.10.0, html-2.1.1, tavern-1.7.0
collected 6 items

test_security_POST_endpoints.tavern.yaml ......                                                                                                                     [100%]

================================================================ 6 passed, 7 warnings in 111.22s (0:01:51) ================================================================


adriiiprodri@wazuh python3 -m pytest -x test_rbac_black_security_endpoints.tavern.yaml 
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/api/test/integration, configfile: pytest.ini
plugins: metadata-1.10.0, html-2.1.1, tavern-1.7.0
collected 24 items

test_rbac_black_security_endpoints.tavern.yaml ........................

=============================================================== 24 passed, 25 warnings in 167.60s (0:02:47) ===============================================================


adriiiprodri@wazuh python3 -m pytest -x test_rbac_white_security_endpoints.tavern.yaml
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/api/test/integration, configfile: pytest.ini
plugins: metadata-1.10.0, html-2.1.1, tavern-1.7.0
collected 24 items

test_rbac_white_security_endpoints.tavern.yaml ........................

=============================================================== 24 passed, 25 warnings in 122.04s (0:02:02) ===============================================================
```

### Unittests
```
 adriiiprodri@wazuh python3 -m pytest wazuh/tests/test_security.py 
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/framework
plugins: metadata-1.10.0, html-2.1.1, tavern-1.7.0
collected 69 items                                                                                                                                                        

wazuh/tests/test_security.py .....................................................................                                                                  [100%]

=========================================================================== 69 passed in 58.81s ===========================================================================

adriiiprodri@wazuh python3 -m pytest wazuh/rbac/tests/test_orm.py 
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/framework
plugins: metadata-1.10.0, html-2.1.1, tavern-1.7.0
collected 53 items                                                                                                                                                        

wazuh/rbac/tests/test_orm.py .....................................................                                                                                  [100%]

=========================================================================== 53 passed in 48.70s ===========================================================================
```