### PR TITLE
Let the agent detect macOS Big Sur version name

### DIFF
--- a/src/headers/version_op.h
+++ b/src/headers/version_op.h
@@ -37,7 +37,7 @@ typedef struct os_info {
  * @param version Version number.
  * @return Reselase name.
  */
-char *OSX_ReleaseName(const int version);
+const char *OSX_ReleaseName(int version);
 
 
 /**

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -361,8 +361,8 @@ char *get_release_from_build(char *os_build) {
 
 #else
 
-char *OSX_ReleaseName(const int version) {
-    char *r_names[] = {
+const char *OSX_ReleaseName(int version) {
+    const char *R_NAMES[] = {
     /* 10 */ "Snow Leopard",
     /* 11 */ "Lion",
     /* 12 */ "Mountain Lion",
@@ -372,11 +372,17 @@ char *OSX_ReleaseName(const int version) {
     /* 16 */ "Sierra",
     /* 17 */ "High Sierra",
     /* 18 */ "Mojave",
-    /* 19 */ "Catalina"};
-    if (version >= 10 && version <= 19)
-        return r_names[version%10];
-    else
+    /* 19 */ "Catalina",
+    /* 20 */ "Big Sur",
+    };
+
+    version -= 10;
+
+    if (version >= 0 && (unsigned)version < sizeof(R_NAMES) / sizeof(char *)) {
+        return R_NAMES[version];
+    } else {
         return "Unknown";
+    }
 }
 
 

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -76,12 +76,32 @@ void test_get_unix_version_Ubuntu1904(void **state)
     assert_string_equal(ret->os_platform, "ubuntu");
     assert_string_equal(ret->sysname, "Linux");
 }
+
+void test_OSX_ReleaseName(void **state) {
+    (void)state;
+
+    assert_string_equal(OSX_ReleaseName(9), "Unknown");
+    assert_string_equal(OSX_ReleaseName(10), "Snow Leopard");
+    assert_string_equal(OSX_ReleaseName(11), "Lion");
+    assert_string_equal(OSX_ReleaseName(12), "Mountain Lion");
+    assert_string_equal(OSX_ReleaseName(13), "Mavericks");
+    assert_string_equal(OSX_ReleaseName(14), "Yosemite");
+    assert_string_equal(OSX_ReleaseName(15), "El Capitan");
+    assert_string_equal(OSX_ReleaseName(16), "Sierra");
+    assert_string_equal(OSX_ReleaseName(17), "High Sierra");
+    assert_string_equal(OSX_ReleaseName(18), "Mojave");
+    assert_string_equal(OSX_ReleaseName(19), "Catalina");
+    assert_string_equal(OSX_ReleaseName(20), "Big Sur");
+    assert_string_equal(OSX_ReleaseName(21), "Unknown");
+}
+
 #endif
 
 int main(void) {
     const struct CMUnitTest tests[] = {
 #ifdef __linux__
             cmocka_unit_test_teardown(test_get_unix_version_Ubuntu1904, delete_os_info),
+            cmocka_unit_test(test_OSX_ReleaseName),
 #endif
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);


### PR DESCRIPTION
|Related issue|
|---|
|#6597|

This PR adds macOS 11.0 "Big Sur" to the list of OS X names.

## Log

```
2020/11/14 21:55:39 ossec-agentd: INFO: Version detected -> Darwin |Vikmans-MacBook-Pro.local |20.1.0 |Darwin Kernel Version 20.1.0: Sat Oct 31 00:07:11 PDT 2020; root:xnu-7195.50.7~2/RELEASE_X86_64 |x86_64 [macOS|darwin: 11.0.1 (Big Sur)] - Wazuh v4.0.2
```

## Tests

- [X] Compile agent on macOS.
- [X] Install 4.0.2 from sources.
- [X] Run `ossec-agentd` and check the detected version.
- [X] Add unit tests for function `OSX_ReleaseName()`.
- [X] Run unit tests for agent on Linux.