### PR TITLE
Added firefox_esr into CPE Helper

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/cpe_helper.json
+++ b/src/wazuh_modules/vulnerability_detector/cpe_helper.json
@@ -99,6 +99,7 @@
                     "^Mozilla"
                 ],
                 "product": [
+                    "^Mozilla Firefox ([0-9]+\\.*[0-9]*\\.*[0-9]*) ESR",
                     "^Mozilla Firefox",
                     "^Mozilla Thunderbird",
                     "^SeaMonkey"
@@ -110,6 +111,7 @@
                     "mozilla"
                 ],
                 "product": [
+                    "firefox_esr",
                     "firefox",
                     "thunderbird",
                     "seamonkey"


### PR DESCRIPTION
|Related issue|
|---|
|#6562|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description


A regular expression has been added to the product field to match Firefox ESR. Now check in NVD that the product is _firefox_esr_ and compare its versions correctly.
<!--
Add a clear description of how the problem has been solved.
-->


## Logs/Alerts example

In the following example, I show how it matches correctly and shows the corresponding alert:

`vulnerability.package.generated_cpe: a:mozilla:firefox_esr:68.11.0::::::x86_64:
{"vulnerability":{"package":{"name":"Mozilla Firefox 68.11.0 ESR (x64 es-ES)","version":"68.11.0","generated_cpe":"a:mozilla:firefox_esr:68.11.0::::::x86_64:","architecture":"x86_64","condition":"less than 78.1"},"cvss":{"cvss2":{"vector":{"attack_vector":"network","access_complexity":"medium","authentication":"none","confidentiality_impact":"none","integrity_impact":"partial","availability":"none"},"base_score":4.3},"cvss3":{"vector":{"attack_vector":"network","access_complexity":"low","privileges_required":"none","user_interaction":"required","scope":"unchanged","confidentiality_impact":"none","integrity_impact":"high","availability":"none"},"base_score":6.5}},"cve":"CVE-2020-15653","title":"CVE-2020-15653 affects Mozilla Firefox 68.11.0 ESR (x64 es-ES)","rationale":"An iframe sandbox element with the allow-popups flag could be bypassed when using noopener links. This could have led to security issues for websites relying on sandbox configurations that allowed popups and hosted arbitrary content. This vulnerability affects Firefox ESR < 78.1, Firefox < 79, and Thunderbird < 78.1.","severity":"Medium","published":"2020-08-10","updated":"2020-08-18","cwe_reference":"NVD-CWE-Other","references":["http://lists.opensuse.org/opensuse-security-announce/2020-08/msg00025.html","https://bugzilla.mozilla.org/show_bug.cgi?id=1521542","https://usn.ubuntu.com/4443-1/","https://www.mozilla.org/security/advisories/mfsa2020-30/","https://www.mozilla.org/security/advisories/mfsa2020-32/","https://www.mozilla.org/security/advisories/mfsa2020-33/","https://nvd.nist.gov/vuln/detail/CVE-2020-15653"],"assigner":"cve@mitre.org","cve_version":"4.0"}}`

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Review logs syntax and correct language


<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions

