### PR TITLE
Vulnerability Detector: Compared vendor with official vendors

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -91,6 +91,7 @@
 #define VU_NO_HOTFIX_DISABLED "(5483): No MSU data found, so the Windows hotfixes scan will be disabled for agent '%.3d'"
 #define VU_METADATA_CLEAN     "(5484): Cleaning metadata for target '%s'"
 #define VU_UNS_OS             "(5485): Agent '%.3d' has an unsupported OS: '%s'"
+#define VU_PACKAGE_TP_SOURCE  "(5486): Discarded package '%s' from a third-party source ('%s') for agent '%.3d'"
 
 /* File integrity monitoring debug messages */
 #define FIM_DIFF_SKIPPED                    "(6200): Diff execution skipped for containing insecure characters."

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2215,12 +2215,9 @@ void wm_vuldet_compare_vendors_official_vendor(void **state)
     int ret;
     int i;
     char * official_vendors[] = {
-        "canonical",
-        "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
-        "Name Surname <user@debian.org>",
-        "Debian Adduser Developers <adduser@packages.debian.org>",
         "Red Hat, Inc.",
-        "CentOS"
+        "CentOS",
+        "Fedora Project"
     };
     int array_size = sizeof(official_vendors)/sizeof(official_vendors[0]);
 

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -3358,7 +3358,10 @@ void test_wm_vuldet_linux_oval_vulnerabilities_external_vendor(void **state)
     expect_value(__wrap_sqlite3_column_text, iCol, 7);
     will_return(__wrap_sqlite3_column_text, "10");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
-    will_return(__wrap_sqlite3_column_text, "MariaDB");
+    will_return(__wrap_sqlite3_column_text, "third-party");
+
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5486): Discarded package 'package' from a third-party source ('third-party') for agent '000'");
 
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
 

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2201,7 +2201,7 @@ void test_wm_vuldet_generate_os_and_kernel_package_release_end(void **state)
 
 /* wm_vuldet_compare_vendors */
 
-void wm_vuldet_compare_vendors_external_vendor(void **state) 
+void test_wm_vuldet_compare_vendors_external_vendor(void **state) 
 {
     int ret;
     char * vendor = "External";
@@ -2210,16 +2210,15 @@ void wm_vuldet_compare_vendors_external_vendor(void **state)
     assert_int_equal(ret, 1);
 }
 
-void wm_vuldet_compare_vendors_official_vendor(void **state) 
+void test_wm_vuldet_compare_vendors_official_vendor(void **state) 
 {
     int ret;
     int i;
     char * official_vendors[] = {
         "Red Hat, Inc.",
-        "CentOS",
-        "Fedora Project"
+        "CentOS"
     };
-    int array_size = sizeof(official_vendors)/sizeof(official_vendors[0]);
+    int array_size = array_size(official_vendors);
 
     for (i = 0; i < array_size; i++) {
         ret = wm_vuldet_compare_vendors(official_vendors[i]);
@@ -3327,8 +3326,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_external_vendor(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_text, iCol, 0);
-    will_return(__wrap_sqlite3_column_text, "2020");
+    expect_value(__wrap_sqlite3_column_int, iCol, 0);
+    will_return(__wrap_sqlite3_column_int, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -16983,8 +16982,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_kernel_package_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_release_end, setup_agent_software, teardown_agent_software),
         // Tests wm_vuldet_compare_vendors
-        cmocka_unit_test(wm_vuldet_compare_vendors_external_vendor),
-        cmocka_unit_test(wm_vuldet_compare_vendors_official_vendor),
+        cmocka_unit_test(test_wm_vuldet_compare_vendors_external_vendor),
+        cmocka_unit_test(test_wm_vuldet_compare_vendors_official_vendor),
         // Tests wm_checks_package_vulnerability
         cmocka_unit_test(test_wm_checks_package_vulnerability_no_version_b),
         cmocka_unit_test(test_wm_checks_package_vulnerability_big_version_a),

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -88,6 +88,7 @@ int wm_insert_MSU_metadata(feed_metadata *msu, update_node *update);
 feed_metadata * wm_vuldet_fetch_MSU_metadata(update_node *update);
 bool wm_vuldet_update_MSU(update_node *update);
 int wm_vuldet_fetch_MSU(update_node *update, char *repo);
+int wm_vuldet_compare_vendors(char * vendor);
 
 /* setup/teardown */
 
@@ -2198,6 +2199,37 @@ void test_wm_vuldet_generate_os_and_kernel_package_release_end(void **state)
     assert_int_equal(ret, 0);
 }
 
+/* wm_vuldet_compare_vendors */
+
+void wm_vuldet_compare_vendors_external_vendor(void **state) 
+{
+    int ret;
+    char * vendor = "External";
+
+    ret = wm_vuldet_compare_vendors(vendor);
+    assert_int_equal(ret, 1);
+}
+
+void wm_vuldet_compare_vendors_official_vendor(void **state) 
+{
+    int ret;
+    int i;
+    char * official_vendors[] = {
+        "canonical",
+        "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+        "Name Surname <user@debian.org>",
+        "Debian Adduser Developers <adduser@packages.debian.org>",
+        "Red Hat, Inc.",
+        "CentOS"
+    };
+    int array_size = sizeof(official_vendors)/sizeof(official_vendors[0]);
+
+    for (i = 0; i < array_size; i++) {
+        ret = wm_vuldet_compare_vendors(official_vendors[i]);
+        assert_int_equal(ret, 0);
+    }
+}
+
 /* wm_checks_package_vulnerability */
 
 void test_wm_checks_package_vulnerability_no_version_b(void **state)
@@ -3278,6 +3310,71 @@ void test_wm_vuldet_linux_oval_vulnerabilities_duplicated_package(void **state)
     assert_int_equal(OS_SUCCESS, ret);
 
     wm_vuldet_free_cve_node(vuln_pkg);
+}
+
+void test_wm_vuldet_linux_oval_vulnerabilities_external_vendor(void **state)
+{
+    sqlite3 *db = (sqlite3 *)1;
+    agent_software *agent = *state;
+    OSHash *cve_table = (OSHash *)1;
+
+    agent->dist = FEED_REDHAT;
+    agent->dist_ver = FEED_RHEL7;
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(5456): Analyzing OVAL vulnerabilities for agent '000'");
+
+    will_return(__wrap_time, (time_t)1);
+
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
+
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return_always(__wrap_sqlite3_bind_int, 0);
+    // building query
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "RHEL7");
+    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "CVE-2020-1234");
+    expect_value(__wrap_sqlite3_column_text, iCol, 1);
+    will_return(__wrap_sqlite3_column_text, "package");
+    expect_value(__wrap_sqlite3_column_text, iCol, 2);
+    will_return(__wrap_sqlite3_column_text, "source");
+    expect_value(__wrap_sqlite3_column_text, iCol, 3);
+    will_return(__wrap_sqlite3_column_text, "5.1.2");
+    expect_value(__wrap_sqlite3_column_text, iCol, 4);
+    will_return(__wrap_sqlite3_column_text, "x64");
+    expect_value(__wrap_sqlite3_column_text, iCol, 5);
+    will_return(__wrap_sqlite3_column_text, "unexisting relation");
+    expect_value(__wrap_sqlite3_column_text, iCol, 6);
+    will_return(__wrap_sqlite3_column_text, "5.1.1");
+    expect_value(__wrap_sqlite3_column_text, iCol, 7);
+    will_return(__wrap_sqlite3_column_text, "10");
+    expect_value(__wrap_sqlite3_column_text, iCol, 8);
+    will_return(__wrap_sqlite3_column_text, "MariaDB");
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(5457): The OVAL found a total of '0' potential vulnerabilities for agent '000'");
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
+    will_return(__wrap_time, (time_t)1);
+    expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");
+
+    int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
+
+    assert_int_equal(OS_SUCCESS, ret);
 }
 
 /* wm_vuldet_build_nvd_report_condition */
@@ -16888,6 +16985,9 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_os_package_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_kernel_package_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_generate_os_and_kernel_package_release_end, setup_agent_software, teardown_agent_software),
+        // Tests wm_vuldet_compare_vendors
+        cmocka_unit_test(wm_vuldet_compare_vendors_external_vendor),
+        cmocka_unit_test(wm_vuldet_compare_vendors_official_vendor),
         // Tests wm_checks_package_vulnerability
         cmocka_unit_test(test_wm_checks_package_vulnerability_no_version_b),
         cmocka_unit_test(test_wm_checks_package_vulnerability_big_version_a),
@@ -16917,6 +17017,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_vulnerable, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_insert_package_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_duplicated_package, setup_agent_software, teardown_agent_software),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_linux_oval_vulnerabilities_external_vendor, setup_agent_software, teardown_agent_software),
         // Tests wm_vuldet_build_nvd_report
         cmocka_unit_test(test_wm_vuldet_build_nvd_report_condition_both_including),
         cmocka_unit_test(test_wm_vuldet_build_nvd_report_condition_both_excluding),

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -45,7 +45,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_FIM_FIND_DATE_ENTRIES] = "SELECT file, changes, size, perm, uid, gid, md5, sha1, uname, gname, mtime, inode, sha256, date, attributes, symbolic_path FROM fim_entry WHERE date < ?;",
     [WDB_STMT_FIM_GET_ATTRIBUTES] = "SELECT file, attributes from fim_entry WHERE attributes IS NOT '0';",
     [WDB_STMT_FIM_UPDATE_ATTRIBUTES] = "UPDATE fim_entry SET attributes = ? WHERE file = ?;",
-    [WDB_STMT_OSINFO_INSERT] = "INSERT INTO sys_osinfo (scan_id, scan_time, hostname, architecture, os_name, os_version, os_codename, os_major, os_minor, os_build, os_platform, sysname, release, version, os_release, os_patch) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+    [WDB_STMT_OSINFO_INSERT] = "INSERT INTO sys_osinfo (scan_id, scan_time, hostname, architecture, os_name, os_version, os_codename, os_major, os_minor,  os_patch, os_build, os_platform, sysname, release, version, os_release) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
     [WDB_STMT_OSINFO_DEL] = "DELETE FROM sys_osinfo;",
     [WDB_STMT_PROGRAM_INSERT] = "INSERT INTO sys_programs (scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, architecture, multiarch, source, description, location, triaged) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
     [WDB_STMT_PROGRAM_DEL] = "DELETE FROM sys_programs WHERE scan_id != ?;",

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -2612,16 +2612,16 @@ int wdb_parse_osinfo(wdb_t * wdb, char * input, char * output) {
             return -1;
         }
 
-        os_patch = curr;
+        os_release = curr;
         *next++ = '\0';
 
-        if (!strcmp(os_patch, "NULL"))
-            os_patch = NULL;
+        if (!strcmp(os_release, "NULL"))
+            os_release = NULL;
 
         if (!strcmp(next, "NULL"))
-            os_release = NULL;
+            os_patch = NULL;
         else
-            os_release = next;
+            os_patch = next;
 
         if (result = wdb_osinfo_save(wdb, scan_id, scan_time, hostname, architecture, os_name, os_version, os_codename, os_major, os_minor, os_patch, os_build, os_platform, sysname, release, version, os_release), result < 0) {
             mdebug1("Cannot save OS information.");

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -319,8 +319,7 @@ const char *vu_vendor_list_ubuntu_debian[] = {
 
 const char *vu_vendor_list_redhat[] = {
     "Red Hat, Inc.",
-    "CentOS",
-    "Fedora Project"
+    "CentOS"
 };
 
 const char *vu_package_dist[] = {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -280,6 +280,13 @@ STATIC void wm_vuldet_json_msu_parser_vuln(cJSON *json_feed, vu_msu_vul_entry **
 STATIC int wm_vulndet_insert_msu_dep_entry(sqlite3 *db, vu_msu_dep_entry *dep);
 STATIC void wm_vuln_check_msu_type(vu_msu_vul_entry *msu, cJSON *patchs);
 
+/**
+ * @brief Compares the package's vendor with the official vendors.
+ * 
+ * @param vendor the package's vendor
+ * @return 0 if the vendor matches with an official vendor or 1 if it is a external vendor.
+ */
+STATIC int wm_vuldet_compare_vendors(char * vendor);
 
 int wdb_vuldet_sock = -1;
 int *vu_queue;
@@ -1895,6 +1902,11 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
         // If we have a source version, use it to find vulnerabilities.
         if (source && src_version) {
             version = src_version;
+        }
+
+        // We discard the package if its vendor is a external vendor.
+        if (vendor && wm_vuldet_compare_vendors(vendor)) {
+            continue;
         }
 
         *condition = '\0';
@@ -7517,6 +7529,29 @@ bool wm_vuldet_check_enabled_msu(sqlite3 *db) {
 clean:
     wdb_finalize(stmt);
     return (count)? true : false;
+}
+
+int wm_vuldet_compare_vendors(char * vendor) {
+    int vendor_len = 0;
+    int vendor_it = 0;
+    int external_vendor = 1;
+
+    vendor_len = sizeof(vu_vendor_list_redhat) / sizeof(vu_vendor_list_redhat[0]);
+    for (vendor_it = 0; vendor_it < vendor_len; ++vendor_it) {
+        if (!strcmp(vendor, vu_vendor_list_redhat[vendor_it])) {
+            external_vendor = 0;
+            break;
+        }
+    }
+    vendor_len = sizeof(vu_vendor_list_ubuntu_debian) / sizeof(vu_vendor_list_ubuntu_debian[0]);
+    for (vendor_it = 0; vendor_it < vendor_len; ++vendor_it) {
+        if (strcasestr(vendor, vu_vendor_list_ubuntu_debian[vendor_it])) {
+            external_vendor = 0;
+            break;
+        }
+    }
+
+    return external_vendor;
 }
 
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -319,7 +319,8 @@ const char *vu_vendor_list_ubuntu_debian[] = {
 
 const char *vu_vendor_list_redhat[] = {
     "Red Hat, Inc.",
-    "CentOS"
+    "CentOS",
+    "Fedora Project"
 };
 
 const char *vu_package_dist[] = {
@@ -1905,7 +1906,7 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
         }
 
         // We discard the package if its vendor is a external vendor.
-        if (vendor && wm_vuldet_compare_vendors(vendor)) {
+        if (agents_it->dist == FEED_REDHAT && vendor && wm_vuldet_compare_vendors(vendor)) {
             continue;
         }
 
@@ -7539,13 +7540,6 @@ int wm_vuldet_compare_vendors(char * vendor) {
     vendor_len = sizeof(vu_vendor_list_redhat) / sizeof(vu_vendor_list_redhat[0]);
     for (vendor_it = 0; vendor_it < vendor_len; ++vendor_it) {
         if (!strcmp(vendor, vu_vendor_list_redhat[vendor_it])) {
-            external_vendor = 0;
-            break;
-        }
-    }
-    vendor_len = sizeof(vu_vendor_list_ubuntu_debian) / sizeof(vu_vendor_list_ubuntu_debian[0]);
-    for (vendor_it = 0; vendor_it < vendor_len; ++vendor_it) {
-        if (strcasestr(vendor, vu_vendor_list_ubuntu_debian[vendor_it])) {
             external_vendor = 0;
             break;
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1906,6 +1906,7 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
 
         // We discard the package if its vendor is a external vendor.
         if (agents_it->dist == FEED_REDHAT && vendor && wm_vuldet_compare_vendors(vendor)) {
+            mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACKAGE_TP_SOURCE, package, vendor, atoi(agents_it->agent_id));
             continue;
         }
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -7537,7 +7537,7 @@ int wm_vuldet_compare_vendors(char * vendor) {
     int vendor_it = 0;
     int external_vendor = 1;
 
-    vendor_len = sizeof(vu_vendor_list_redhat) / sizeof(vu_vendor_list_redhat[0]);
+    vendor_len = array_size(vu_vendor_list_redhat);
     for (vendor_it = 0; vendor_it < vendor_len; ++vendor_it) {
         if (!strcmp(vendor, vu_vendor_list_redhat[vendor_it])) {
             external_vendor = 0;


### PR DESCRIPTION
|Related issue|
|---|
|#6435|

## Description

I have created a function that compares the package's vendor with the official vendors from de OVAL feeds. If the vendor does not match with any of them, the package is discarded.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind

<!-- Checks for huge PRs that affect the product more generally -->
- [x] The data flow works as expected (agent-manager)
- [x] Added unit tests
