### PR TITLE
[API][Framework] Fix distributed API calls when the cluster configuration is empty

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -497,7 +497,7 @@ class DistributedAPI:
                                                             filters=filters)['items']
             node_name = defaultdict(list)
             for element in system_agents:
-                node_name[element['node_name']].append(element['id'])
+                node_name[element.get('node_name', '')].append(element['id'])
 
             # Update node_name in case it is empty or a node has no agents
             if 'node_id' in self.f_kwargs:


### PR DESCRIPTION
Hello team,
this closes #6608 .

There was an API error when doing distributed calls and having the cluster configuration empty caused by an empty `node_name` in `global.db`. It works now:

# Example

```
curl --request GET \
  --url 'https://localhost:55000/agents/003/config/syscheck/syscheck?wait_for_complete=true' \
  --header 'authorization: Bearer <TOKEN>'
```

```json
{
  "data": {
    "syscheck": {
      "disabled": "no",
      "frequency": 43200,
      "skip_nfs": "yes",
      "skip_dev": "yes",
      "skip_sys": "yes",
      "skip_proc": "yes",
      "scan_on_start": "yes",
      "file_limit": {
        "enabled": "yes",
        "entries": 100000
      },
      "directories": [
        {
          "opts": [
            "check_md5sum",
            "check_sha1sum",
            "check_perm",
            "check_size",
            "check_owner",
            "check_group",
            "check_mtime",
            "check_inode",
            "check_sha256sum"
          ],
          "dir": "/bin",
          "recursion_level": 256
        },
        {
          "opts": [
            "check_md5sum",
            "check_sha1sum",
            "check_perm",
            "check_size",
            "check_owner",
            "check_group",
            "check_mtime",
            "check_inode",
            "check_sha256sum"
          ],
          "dir": "/boot",
          "recursion_level": 256
        },
        {
          "opts": [
            "check_md5sum",
            "check_sha1sum",
            "check_perm",
            "check_size",
            "check_owner",
            "check_group",
            "check_mtime",
            "check_inode",
            "check_sha256sum"
          ],
          "dir": "/etc",
          "recursion_level": 256
        },
        {
          "opts": [
            "check_md5sum",
            "check_sha1sum",
            "check_perm",
            "check_size",
            "check_owner",
            "check_group",
            "check_mtime",
            "check_inode",
            "check_sha256sum"
          ],
          "dir": "/sbin",
          "recursion_level": 256
        },
        {
          "opts": [
            "check_md5sum",
            "check_sha1sum",
            "check_perm",
            "check_size",
            "check_owner",
            "check_group",
            "check_mtime",
            "check_inode",
            "check_sha256sum"
          ],
          "dir": "/usr/bin",
          "recursion_level": 256
        },
        {
          "opts": [
            "check_md5sum",
            "check_sha1sum",
            "check_perm",
            "check_size",
            "check_owner",
            "check_group",
            "check_mtime",
            "check_inode",
            "check_sha256sum"
          ],
          "dir": "/usr/sbin",
          "recursion_level": 256
        }
      ],
      "nodiff": [
        "/etc/ssl/private.key"
      ],
      "ignore": [
        "/etc/mtab",
        "/etc/hosts.deny",
        "/etc/mail/statistics",
        "/etc/random-seed",
        "/etc/random.seed",
        "/etc/adjtime",
        "/etc/httpd/logs",
        "/etc/utmpx",
        "/etc/wtmpx",
        "/etc/cups/certs",
        "/etc/dumpdates",
        "/etc/svc/volatile"
      ],
      "ignore_sregex": [
        ".log$|.swp$"
      ],
      "whodata": {
        "restart_audit": "yes",
        "startup_healthcheck": "yes"
      },
      "allow_remote_prefilter_cmd": "no",
      "synchronization": {
        "enabled": "yes",
        "max_interval": 3600,
        "interval": 300,
        "response_timeout": 30,
        "queue_size": 16384,
        "max_eps": 10
      },
      "max_eps": 100,
      "process_priority": 10,
      "database": "disk"
    }
  },
  "error": 0
}
```

# Tests performed
## Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 77 items                                                                                                                                                                          

core/cluster/dapi/tests/test_dapi.py ......................                                                                                                                           [ 28%]
core/cluster/tests/test_cluster.py ...................                                                                                                                                [ 53%]
core/cluster/tests/test_common.py .......                                                                                                                                             [ 62%]
core/cluster/tests/test_control.py .....                                                                                                                                              [ 68%]
core/cluster/tests/test_local_client.py .                                                                                                                                             [ 70%]
core/cluster/tests/test_utils.py .......                                                                                                                                              [ 79%]
core/cluster/tests/test_worker.py ................                                                                                                                                    [100%]

============================================================================== 77 passed, 13 warnings in 0.68s ==============================================================================
```

## Integration tests
Basic integration tests were performed
```
test_agents_DELETE_endpoints.tavern.yaml 
	 7 passed, 9 warnings

test_agents_GET_endpoints.tavern.yaml 
	 90 passed, 97 warnings

test_agents_POST_endpoints.tavern.yaml 
	 5 passed, 7 warnings

test_agents_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings

test_cluster_endpoints.tavern.yaml 
	 56 passed, 72 warnings

test_security_DELETE_endpoints.tavern.yaml 
	 15 passed, 17 warnings

test_security_GET_endpoints.tavern.yaml 
	 18 passed, 21 warnings

test_security_POST_endpoints.tavern.yaml 
	 6 passed, 8 warnings

test_security_PUT_endpoints.tavern.yaml 
	 8 passed, 10 warnings

```

Regards,
Víctor.