### PR TITLE
Refactor symbolic links code and save resolved path only when follow is enabled

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -964,18 +964,21 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             }
 
             while (g.gl_pathv[gindex]) {
-                char *resolved_path = NULL;
+                char *resolved_path = realpath(g.gl_pathv[gindex], NULL);
 
-                if (resolved_path = realpath(g.gl_pathv[gindex], NULL), resolved_path) {
-                    if (!strcmp(resolved_path, g.gl_pathv[gindex])) {
-                        dump_syscheck_entry(syscheck, g.gl_pathv[gindex], opts, 0, restrictfile, recursion_limit,
-                                            clean_tag, NULL, tmp_diff_size);
-                    } else {
+                if (resolved_path != NULL) {
+                    if (strcmp(resolved_path, g.gl_pathv[gindex]) != 0 && (opts & CHECK_FOLLOW)) {
                         dump_syscheck_entry(syscheck, resolved_path, opts, 0, restrictfile, recursion_limit, clean_tag,
                                             g.gl_pathv[gindex], tmp_diff_size);
                     }
+                    else {
+                        dump_syscheck_entry(syscheck, g.gl_pathv[gindex], opts, 0, restrictfile, recursion_limit,
+                                            clean_tag, NULL, tmp_diff_size);
+                    }
+
                     os_free(resolved_path);
-                } else {
+                }
+                else {
                     mdebug1("Could not check the real path of '%s' due to [(%d)-(%s)].",
                             g.gl_pathv[gindex], errno, strerror(errno));
                 }
@@ -988,7 +991,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         else {
             char *resolved_path = realpath(real_path, NULL);
 
-            if (resolved_path && strcmp(resolved_path, real_path)) {
+            if (resolved_path != NULL && strcmp(resolved_path, real_path) != 0 && (opts & CHECK_FOLLOW)) {
                 dump_syscheck_entry(syscheck, resolved_path, opts, 0, restrictfile, recursion_limit, clean_tag,
                                     real_path, tmp_diff_size);
             }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -146,24 +146,23 @@ void dump_syscheck_entry(syscheck_config *syscheck, char *entry, int vals, int r
 
         if (syscheck->dir == NULL) {
             os_calloc(2, sizeof(char *), syscheck->dir);
-            os_calloc(strlen(entry) + 2, sizeof(char), syscheck->dir[0]);
-            if (link && !(CHECK_FOLLOW & vals)) {
-                // Taking the link itself if follow_symbolic_link is not enabled
-                snprintf(syscheck->dir[0], strlen(link) + 1, "%s", link);
-            }
-            else {
-                snprintf(syscheck->dir[0], strlen(entry) + 1, "%s", entry);
-            }
+
+            // If a symbolic link is configured, `link` is the configured path
+            // and `entry` is the resolved path
+            os_strdup(link == NULL ? entry : link, syscheck->dir[pl]);
+
             syscheck->dir[1] = NULL;
 
 #ifdef WIN32
             os_calloc(2, sizeof(whodata_dir_status), syscheck->wdata.dirs_status);
 #endif
             os_calloc(2, sizeof(char *), syscheck->symbolic_links);
+
             syscheck->symbolic_links[0] = NULL;
             syscheck->symbolic_links[1] = NULL;
-            if (link) {
-                os_strdup(link, syscheck->symbolic_links[0]);
+
+            if (link != NULL && (CHECK_FOLLOW & vals)) {
+                os_strdup(entry, syscheck->symbolic_links[0]);
             }
 
             os_calloc(2, sizeof(int), syscheck->opts);
@@ -189,16 +188,12 @@ void dump_syscheck_entry(syscheck_config *syscheck, char *entry, int vals, int r
             while (syscheck->dir[pl] != NULL) {
                 pl++;
             }
+
             os_realloc(syscheck->dir, (pl + 2) * sizeof(char *), syscheck->dir);
+
+            os_strdup(link == NULL ? entry : link, syscheck->dir[pl]);
+
             syscheck->dir[pl + 1] = NULL;
-            os_calloc(strlen(entry) + 2, sizeof(char), syscheck->dir[pl]);
-            if (link && !(CHECK_FOLLOW & vals)) {
-                // Taking the link itself if follow_symbolic_link is not enabled
-                snprintf(syscheck->dir[pl], strlen(link) + 1, "%s", link);
-            }
-            else {
-                snprintf(syscheck->dir[pl], strlen(entry) + 1, "%s", entry);
-            }
 
 #ifdef WIN32
             os_realloc(syscheck->wdata.dirs_status, (pl + 2) * sizeof(whodata_dir_status),
@@ -207,10 +202,12 @@ void dump_syscheck_entry(syscheck_config *syscheck, char *entry, int vals, int r
 #endif
 
             os_realloc(syscheck->symbolic_links, (pl + 2) * sizeof(char *), syscheck->symbolic_links);
+
             syscheck->symbolic_links[pl] = NULL;
             syscheck->symbolic_links[pl + 1] = NULL;
-            if (link) {
-                os_strdup(link, syscheck->symbolic_links[pl]);
+
+            if (link != NULL && (CHECK_FOLLOW & vals)) {
+                os_strdup(entry, syscheck->symbolic_links[pl]);
             }
 
             os_realloc(syscheck->opts, (pl + 2) * sizeof(int),
@@ -244,10 +241,15 @@ void dump_syscheck_entry(syscheck_config *syscheck, char *entry, int vals, int r
             syscheck->tag[pl] = NULL;
             syscheck->tag[pl + 1] = NULL;
         } else {
-            if (link) {
-                os_free(syscheck->symbolic_links[pl]);
-                os_strdup(link, syscheck->symbolic_links[pl]);
+            os_free(syscheck->dir[pl]);
+            os_free(syscheck->symbolic_links[pl]);
+
+            os_strdup(link == NULL ? entry : link, syscheck->dir[pl]);
+
+            if (link != NULL && (CHECK_FOLLOW & vals)) {
+                os_strdup(entry, syscheck->symbolic_links[pl]);
             }
+
             syscheck->opts[pl] = vals;
 
             if (diff_size == -1) {

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -970,15 +970,13 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                     if (strcmp(resolved_path, g.gl_pathv[gindex]) != 0 && (opts & CHECK_FOLLOW)) {
                         dump_syscheck_entry(syscheck, resolved_path, opts, 0, restrictfile, recursion_limit, clean_tag,
                                             g.gl_pathv[gindex], tmp_diff_size);
-                    }
-                    else {
+                    } else {
                         dump_syscheck_entry(syscheck, g.gl_pathv[gindex], opts, 0, restrictfile, recursion_limit,
                                             clean_tag, NULL, tmp_diff_size);
                     }
 
                     os_free(resolved_path);
-                }
-                else {
+                } else {
                     mdebug1("Could not check the real path of '%s' due to [(%d)-(%s)].",
                             g.gl_pathv[gindex], errno, strerror(errno));
                 }
@@ -994,8 +992,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             if (resolved_path != NULL && strcmp(resolved_path, real_path) != 0 && (opts & CHECK_FOLLOW)) {
                 dump_syscheck_entry(syscheck, resolved_path, opts, 0, restrictfile, recursion_limit, clean_tag,
                                     real_path, tmp_diff_size);
-            }
-            else {
+            } else {
                 dump_syscheck_entry(syscheck, real_path, opts, 0, restrictfile, recursion_limit, clean_tag, NULL,
                                     tmp_diff_size);
             }

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -126,7 +126,7 @@
 #define FIM_WHODATA_SCAN                    "(6231): The '%s' directory has been scanned after detecting event of new files."
 #define FIM_WHODATA_SCAN_ABORTED            "(6232): Scanning of the '%s' directory is aborted because something has gone wrong."
 #define FIM_WHODATA_CHECKTHREAD             "(6233): Checking thread set to '%d' seconds."
-#define FIM_LINK_ALREADY_ADDED              "(6234): Directory '%s' already monitored, ignoring link '%s'"
+#define FIM_LINK_ALREADY_ADDED              "(6234): Directory '%s' already monitored, ignoring link."
 #define FIM_WHODATA_FULLQUEUE               "(6235): Real-time Whodata events queue for Windows is full. Removing the first '%d'"
 #define FIM_WHODATA_EVENT_DELETED           "(6236): '%d' events have been deleted from the whodata list."
 #define FIM_WHODATA_EVENTQUEUE_VALUES       "(6237): Whodata event queue values for Windows -> max_size:'%d' | max_remove:'%d' | alert_threshold:'%d'",

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -47,7 +47,7 @@
 #define FIM_WINREGISTRY_START               "(6031): Registry integrity monitoring scan started"
 #define FIM_WINREGISTRY_ENDED               "(6032): Registry integrity monitoring scan ended"
 #define FIM_LINKCHECK_START                 "(6033): Starting symbolic link updater. Interval '%d'."
-#define FIM_LINKCHECK_CHANGED               "(6034): Updating the symbolic link from '%s': '%s' to '%s'."
+#define FIM_LINKCHECK_CHANGED               "(6034): Updating symbolic link '%s': from '%s' to '%s'."
 #define FIM_WHODATA_VOLUMES                 "(6036): Analyzing Windows volumes"
 
 #define FIM_DB_NORMAL_ALERT                 "(6038): Sending DB back to normal alert."

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -57,7 +57,6 @@ void fim_scan() {
     clock_t cputime_start;
     unsigned int nodes_count;
     struct fim_element item;
-    char *path;
 
     cputime_start = clock();
     gettime(&start);
@@ -77,15 +76,13 @@ void fim_scan() {
         item.mode = FIM_SCHEDULED;
         item.index = it;
 
-        // Assign to `path` the resolved link path if there is one, `dir` instead
-        os_strdup(fim_get_real_path(it), path);
-
-        fim_checker(path, &item, NULL, 1);
+        fim_checker(fim_get_real_path(it), &item, NULL, 1);
 #ifndef WIN32
         if (syscheck.opts[it] & REALTIME_ACTIVE) {
-            realtime_adddir(path, 0, (syscheck.opts[it] & CHECK_FOLLOW) ? 1 : 0);
+            realtime_adddir(fim_get_real_path(it), 0, (syscheck.opts[it] & CHECK_FOLLOW) ? 1 : 0);
         }
 #endif
+
         it++;
     }
 
@@ -113,9 +110,7 @@ void fim_scan() {
                 item.mode = FIM_SCHEDULED;
                 item.index = it;
 
-                os_strdup(fim_get_real_path(it), path);
-
-                fim_checker(path, &item, NULL, 0);
+                fim_checker(fim_get_real_path(it), &item, NULL, 0);
                 it++;
 
                 w_mutex_lock(&syscheck.fim_entry_mutex);

--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -557,9 +557,9 @@ int fim_db_delete_not_scanned(fdb_t * fim_sql, fim_tmp_file *file, pthread_mutex
                                     (void *) true, (void *) FIM_SCHEDULED, NULL);
 }
 
-int fim_db_delete_range(fdb_t * fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage) {
+int fim_db_delete_range(fdb_t * fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage, fim_event_mode mode) {
     return fim_db_process_read_file(fim_sql, file, mutex, fim_db_remove_path, storage,
-                                    (void *) false, (void *) FIM_SCHEDULED, NULL);
+                                    (void *) false, (void *) mode, NULL);
 }
 
 int fim_db_process_missing_entry(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage, fim_event_mode mode, whodata_evt * w_evt) {

--- a/src/syscheckd/fim_db.h
+++ b/src/syscheckd/fim_db.h
@@ -328,11 +328,12 @@ int fim_db_get_path_range(fdb_t *fim_sql, char *start, char *top,
  * @param file  Structure of the file which contains all the paths.
  * @param mutex
  * @param storage 1 Store database in memory, disk otherwise.
+ * @param mode FIM mode (scheduled, realtime or whodata)
  *
  * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
 int fim_db_delete_range(fdb_t * fim_sql, fim_tmp_file *file,
-                        pthread_mutex_t *mutex, int storage);
+                        pthread_mutex_t *mutex, int storage, fim_event_mode mode);
 
 /**
  * @brief Remove a range of paths from database if they have a

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -683,8 +683,10 @@ STATIC void fim_link_delete_range(int pos) {
     w_mutex_unlock(&syscheck.fim_entry_mutex);
 
     if (file && file->elements) {
+        fim_event_mode mode = FIM_MODE(syscheck.opts[pos]);
+
         if (fim_db_delete_range(syscheck.database, file,
-                                &syscheck.fim_entry_mutex, syscheck.database_store) != FIMDB_OK) {
+                                &syscheck.fim_entry_mutex, syscheck.database_store, mode) != FIMDB_OK) {
             merror(FIM_DB_ERROR_RM_RANGE, first_entry, last_entry);
         }
     }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -542,12 +542,10 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
                     if (strcmp(real_path, syscheck.symbolic_links[i])) {
                         minfo(FIM_LINKCHECK_CHANGED, syscheck.dir[i], syscheck.symbolic_links[i], real_path);
                         fim_link_update(i, real_path);
-                    }
-                    else {
+                    } else {
                         mdebug1(FIM_LINKCHECK_NOCHANGE, syscheck.symbolic_links[i]);
                     }
-                }
-                else {
+                } else {
                     // Broken link
                     char path[PATH_MAX];
 
@@ -560,8 +558,7 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
                         fim_link_silent_scan(path, config);
                     }
                 }
-            }
-            else {
+            } else {
                 // Check real_path to reload broken link.
                 if (real_path) {
                     fim_link_reload_broken_link(real_path, i);
@@ -612,8 +609,7 @@ STATIC void fim_link_check_delete(int pos) {
         }
 
         mdebug1(FIM_STAT_FAILED, syscheck.symbolic_links[pos], errno, strerror(errno));
-    }
-    else {
+    } else {
         fim_link_delete_range(pos);
 
         if (syscheck.realtime && syscheck.realtime->dirtb) {
@@ -635,7 +631,7 @@ STATIC void fim_delete_realtime_watches(__attribute__((unused)) int pos) {
     int watch_conf;
 
     assert(watch_to_delete != NULL);
-    dir_conf = fim_configuration_directory(syscheck.dir[pos], "file");
+    dir_conf = fim_configuration_directory(syscheck.symbolic_links[pos], "file");
 
     if (dir_conf > -1) {
         w_mutex_lock(&syscheck.fim_realtime_mutex);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -329,7 +329,7 @@ static int _base_line = 0;
         // Directories in Windows configured with real-time add recursive watches
         for (int i = 0; syscheck.dir[i]; i++) {
             if (syscheck.opts[i] & REALTIME_ACTIVE) {
-                realtime_adddir(syscheck.dir[i], 0, (syscheck.opts[i] & CHECK_FOLLOW) ? 1 : 0);
+                realtime_adddir(syscheck.dir[i], 0, 0);
             }
         }
 #endif
@@ -431,14 +431,14 @@ int fim_whodata_initialize() {
         if (syscheck.opts[i] & WHODATA_ACTIVE) {
 
 #ifdef WIN_WHODATA // Whodata on Windows
-            if(realtime_adddir(syscheck.dir[i], i + 1, (syscheck.opts[i] & CHECK_FOLLOW) ? 1 : 0) == -2) {
+            if(realtime_adddir(syscheck.dir[i], i + 1, 0) == -2) {
                 syscheck.wdata.dirs_status[i].status &= ~WD_CHECK_WHODATA;
                 syscheck.opts[i] &= ~WHODATA_ACTIVE;
                 syscheck.wdata.dirs_status[i].status |= WD_CHECK_REALTIME;
                 syscheck.realtime_change = 1;
             }
 #else // Whodata on Linux
-            realtime_adddir(syscheck.dir[i], i + 1, (syscheck.opts[i] & CHECK_FOLLOW) ? 1 : 0);
+            realtime_adddir(fim_get_real_path(i), i + 1, (syscheck.opts[i] & CHECK_FOLLOW) ? 1 : 0);
 #endif
 
         }
@@ -530,33 +530,28 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
 
         w_mutex_lock(&syscheck.fim_scan_mutex);
         for (i = 0; syscheck.dir[i]; i++) {
-            if (!syscheck.symbolic_links[i]) {
+            if (!syscheck.symbolic_links[i] || !(CHECK_FOLLOW & syscheck.opts[i])) {
                 continue;
             }
 
-            if (CHECK_FOLLOW & syscheck.opts[i]) {
-                real_path = realpath(syscheck.symbolic_links[i], NULL);
-            }
-            else {
-                // Taking the link itself if follow_symbolic_link is not enabled
-                os_calloc(strlen(syscheck.symbolic_links[i]) + 1, sizeof(char), real_path);
-                snprintf(real_path, strlen(syscheck.symbolic_links[i]) + 1, "%s", syscheck.symbolic_links[i]);
-            }
+            real_path = realpath(syscheck.dir[i], NULL);
 
-            if (*syscheck.dir[i]) {
+            if (*syscheck.symbolic_links[i]) {
                 if (real_path) {
                     // Check if link has changed
-                    if (strcmp(real_path, syscheck.dir[i])) {
-                        minfo(FIM_LINKCHECK_CHANGED, syscheck.dir[i], syscheck.symbolic_links[i], real_path);
+                    if (strcmp(real_path, syscheck.symbolic_links[i])) {
+                        minfo(FIM_LINKCHECK_CHANGED, syscheck.symbolic_links[i], syscheck.dir[i], real_path);
                         fim_link_update(i, real_path);
-                    } else {
-                        mdebug1(FIM_LINKCHECK_NOCHANGE, syscheck.dir[i]);
                     }
-                } else {
+                    else {
+                        mdebug1(FIM_LINKCHECK_NOCHANGE, syscheck.symbolic_links[i]);
+                    }
+                }
+                else {
                     // Broken link
                     char path[PATH_MAX];
 
-                    snprintf(path, PATH_MAX, "%s", syscheck.dir[i]);
+                    snprintf(path, PATH_MAX, "%s", syscheck.symbolic_links[i]);
                     fim_link_check_delete(i);
 
                     int config = fim_configuration_directory(path, "file");
@@ -565,14 +560,17 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
                         fim_link_silent_scan(path, config);
                     }
                 }
-            } else {
+            }
+            else {
                 // Check real_path to reload broken link.
                 if (real_path) {
                     fim_link_reload_broken_link(real_path, i);
                 }
             }
+
             os_free(real_path);
         }
+
         w_mutex_unlock(&syscheck.fim_scan_mutex);
         mdebug1(FIM_LINKCHECK_FINALIZE);
     }
@@ -591,15 +589,14 @@ STATIC void fim_link_update(int pos, char *new_path) {
     // Check if the updated path of the link is already in the configuration
     for (i = 0; syscheck.dir[i] != NULL; i++) {
         if (strcmp(new_path, syscheck.dir[i]) == 0) {
-            mdebug1(FIM_LINK_ALREADY_ADDED, syscheck.dir[i], syscheck.symbolic_links[pos]);
-            *syscheck.dir[pos] = '\0';
+            mdebug1(FIM_LINK_ALREADY_ADDED, syscheck.symbolic_links[i], syscheck.dir[pos]);
+            *syscheck.symbolic_links[pos] = '\0';
             return;
         }
     }
 
-    os_free(syscheck.dir[pos]);
-    os_calloc(strlen(new_path) + 1, sizeof(char), syscheck.dir[pos]);
-    snprintf(syscheck.dir[pos], strlen(new_path) + 1, "%s", new_path);
+    os_free(syscheck.symbolic_links[pos]);
+    os_strdup(new_path, syscheck.symbolic_links[pos]);
 
     // Add new entries without alert.
     fim_link_silent_scan(new_path, pos);
@@ -608,19 +605,22 @@ STATIC void fim_link_update(int pos, char *new_path) {
 STATIC void fim_link_check_delete(int pos) {
     struct stat statbuf;
 
-    if (w_stat(syscheck.dir[pos], &statbuf) < 0) {
+    if (w_stat(syscheck.symbolic_links[pos], &statbuf) < 0) {
         if (errno == ENOENT) {
-            *syscheck.dir[pos] = '\0';
+            *syscheck.symbolic_links[pos] = '\0';
             return;
         }
-        mdebug1(FIM_STAT_FAILED, syscheck.dir[pos], errno, strerror(errno));
-    } else {
+
+        mdebug1(FIM_STAT_FAILED, syscheck.symbolic_links[pos], errno, strerror(errno));
+    }
+    else {
         fim_link_delete_range(pos);
 
         if (syscheck.realtime && syscheck.realtime->dirtb) {
             fim_delete_realtime_watches(pos);
         }
-        *syscheck.dir[pos] = '\0';
+
+        *syscheck.symbolic_links[pos] = '\0';
     }
 }
 
@@ -675,22 +675,20 @@ STATIC void fim_link_delete_range(int pos) {
     char last_entry[PATH_MAX]  = {0};
     fim_tmp_file * file = NULL;
 
-    snprintf(first_entry, PATH_MAX, "%s/", syscheck.dir[pos]);
-    snprintf(last_entry, PATH_MAX, "%s0", syscheck.dir[pos]);
+    snprintf(first_entry, PATH_MAX, "%s/", syscheck.symbolic_links[pos]);
+    snprintf(last_entry, PATH_MAX, "%s0", syscheck.symbolic_links[pos]);
 
     w_mutex_lock(&syscheck.fim_entry_mutex);
 
-    if (fim_db_get_path_range(syscheck.database, first_entry,
-        last_entry, &file, syscheck.database_store) != FIMDB_OK) {
+    if (fim_db_get_path_range(syscheck.database, first_entry, last_entry, &file, syscheck.database_store) != FIMDB_OK) {
         merror(FIM_DB_ERROR_RM_RANGE, first_entry, last_entry);
     }
 
     w_mutex_unlock(&syscheck.fim_entry_mutex);
 
-
     if (file && file->elements) {
         if (fim_db_delete_range(syscheck.database, file,
-            &syscheck.fim_entry_mutex, syscheck.database_store) != FIMDB_OK) {
+                                &syscheck.fim_entry_mutex, syscheck.database_store) != FIMDB_OK) {
             merror(FIM_DB_ERROR_RM_RANGE, first_entry, last_entry);
         }
     }
@@ -704,7 +702,7 @@ STATIC void fim_link_silent_scan(char *path, int pos) {
     item->mode = FIM_SCHEDULED;
 
     if (syscheck.opts[pos] & REALTIME_ACTIVE) {
-        realtime_adddir(path, 0, (syscheck.opts[pos] & CHECK_FOLLOW) ? 1 : 0);
+        realtime_adddir(path, 0, 1);    // This is acting always on links, so `followsl` will always be `1`
     }
 
     fim_checker(path, item, NULL, 0);
@@ -718,16 +716,16 @@ STATIC void fim_link_reload_broken_link(char *path, int index) {
     for (element = 0; syscheck.dir[element]; element++) {
         if (strcmp(path, syscheck.dir[element]) == 0) {
             // If a configuration directory exists don't reload
-            mdebug1(FIM_LINK_ALREADY_ADDED,
-                  syscheck.dir[element], syscheck.symbolic_links[index]);
+            mdebug1(FIM_LINK_ALREADY_ADDED, syscheck.dir[element], syscheck.symbolic_links[index]);
             found = 1;
         }
     }
+
     // Reload broken link
     if (!found) {
         os_free(syscheck.dir[index]);
-        os_calloc(strlen(path) + 1, sizeof(char), syscheck.dir[index]);
-        snprintf(syscheck.dir[index], strlen(path) + 1, "%s", path);
+        os_strdup(path, syscheck.symbolic_links[index]);
+
         // Add new entries without alert.
         fim_link_silent_scan(path, index);
     }
@@ -748,7 +746,7 @@ void set_whodata_mode_changes() {
             // At this point the directories in whodata mode that have been deconfigured are added to realtime
             syscheck.wdata.dirs_status[i].status &= ~WD_CHECK_REALTIME;
             syscheck.opts[i] |= REALTIME_ACTIVE;
-            if (realtime_adddir(syscheck.dir[i], 0, (syscheck.opts[i] & CHECK_FOLLOW) ? 1 : 0) != 1) {
+            if (realtime_adddir(syscheck.dir[i], 0, 0) != 1) {
                 merror(FIM_ERROR_REALTIME_ADDDIR_FAILED, syscheck.dir[i]);
             } else {
                 mdebug1(FIM_REALTIME_MONITORING, syscheck.dir[i]);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -540,7 +540,7 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
                 if (real_path) {
                     // Check if link has changed
                     if (strcmp(real_path, syscheck.symbolic_links[i])) {
-                        minfo(FIM_LINKCHECK_CHANGED, syscheck.symbolic_links[i], syscheck.dir[i], real_path);
+                        minfo(FIM_LINKCHECK_CHANGED, syscheck.dir[i], syscheck.symbolic_links[i], real_path);
                         fim_link_update(i, real_path);
                     }
                     else {
@@ -589,7 +589,7 @@ STATIC void fim_link_update(int pos, char *new_path) {
     // Check if the updated path of the link is already in the configuration
     for (i = 0; syscheck.dir[i] != NULL; i++) {
         if (strcmp(new_path, syscheck.dir[i]) == 0) {
-            mdebug1(FIM_LINK_ALREADY_ADDED, syscheck.symbolic_links[i], syscheck.dir[pos]);
+            mdebug1(FIM_LINK_ALREADY_ADDED, syscheck.dir[i]);
             *syscheck.symbolic_links[pos] = '\0';
             return;
         }
@@ -716,7 +716,7 @@ STATIC void fim_link_reload_broken_link(char *path, int index) {
     for (element = 0; syscheck.dir[element]; element++) {
         if (strcmp(path, syscheck.dir[element]) == 0) {
             // If a configuration directory exists don't reload
-            mdebug1(FIM_LINK_ALREADY_ADDED, syscheck.dir[element], syscheck.symbolic_links[index]);
+            mdebug1(FIM_LINK_ALREADY_ADDED, syscheck.dir[element]);
             found = 1;
         }
     }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -723,7 +723,7 @@ STATIC void fim_link_reload_broken_link(char *path, int index) {
 
     // Reload broken link
     if (!found) {
-        os_free(syscheck.dir[index]);
+        os_free(syscheck.symbolic_links[index]);
         os_strdup(path, syscheck.symbolic_links[index]);
 
         // Add new entries without alert.

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -903,4 +903,13 @@ void fim_check_db_state();
  */
 void fim_diff_folder_size();
 
+/**
+ * @brief Get path from syscheck.dir or syscheck.symbolic_links, depending on whether there is a resolved path
+ * configured in syscheck.symbolic_links or not.
+ *
+ * @param position Position of the directory in the structure
+ * @return syscheck.symbolic_links[position] if not NULL, syscheck.dir[position] otherwise
+ */
+char *fim_get_real_path(int position);
+
 #endif /* SYSCHECK_H */

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -223,31 +223,31 @@ int add_audit_rules_syscheck(bool first_time) {
 
     while (syscheck.dir[i] != NULL) {
         // Check if dir[i] is set in whodata mode and isn't a broken link (syscheck.dir[i] = '\0')
-        if (syscheck.opts[i] & WHODATA_ACTIVE && *syscheck.dir[i]) {
+        if (syscheck.opts[i] & WHODATA_ACTIVE && *fim_get_real_path(i)) {
             int retval;
             if (W_Vector_length(audit_added_rules) < syscheck.max_audit_entries) {
-                int found = search_audit_rule(syscheck.dir[i], "wa", AUDIT_KEY);
+                int found = search_audit_rule(fim_get_real_path(i), "wa", AUDIT_KEY);
                 if (found == 0) {
-                    if (retval = audit_add_rule(syscheck.dir[i], AUDIT_KEY), retval > 0) {
+                    if (retval = audit_add_rule(fim_get_real_path(i), AUDIT_KEY), retval > 0) {
                         w_mutex_lock(&audit_rules_mutex);
-                        if(!W_Vector_insert_unique(audit_added_rules, syscheck.dir[i])) {
-                            mdebug1(FIM_AUDIT_NEWRULE, syscheck.dir[i]);
+                        if(!W_Vector_insert_unique(audit_added_rules, fim_get_real_path(i))) {
+                            mdebug1(FIM_AUDIT_NEWRULE, fim_get_real_path(i));
                         } else {
-                            mdebug1(FIM_AUDIT_RELOADED, syscheck.dir[i]);
+                            mdebug1(FIM_AUDIT_RELOADED, fim_get_real_path(i));
                         }
                         w_mutex_unlock(&audit_rules_mutex);
                         rules_added++;
                     } else {
                         if (first_time) {
-                            mwarn(FIM_WARN_WHODATA_ADD_RULE, syscheck.dir[i]);
+                            mwarn(FIM_WARN_WHODATA_ADD_RULE, fim_get_real_path(i));
                         } else {
-                            mdebug1(FIM_WARN_WHODATA_ADD_RULE, syscheck.dir[i]);
+                            mdebug1(FIM_WARN_WHODATA_ADD_RULE, fim_get_real_path(i));
                         }
                     }
                 } else if (found == 1) {
                     w_mutex_lock(&audit_rules_mutex);
-                    if(!W_Vector_insert_unique(audit_added_rules, syscheck.dir[i])) {
-                        mdebug1(FIM_AUDIT_RULEDUP, syscheck.dir[i]);
+                    if(!W_Vector_insert_unique(audit_added_rules, fim_get_real_path(i))) {
+                        mdebug1(FIM_AUDIT_RULEDUP, fim_get_real_path(i));
                     }
                     w_mutex_unlock(&audit_rules_mutex);
                     rules_added++;
@@ -258,9 +258,9 @@ int add_audit_rules_syscheck(bool first_time) {
                 static bool reported = false;
 
                 if (first_time || !reported) {
-                    merror(FIM_ERROR_WHODATA_MAXNUM_WATCHES, syscheck.dir[i], syscheck.max_audit_entries);
+                    merror(FIM_ERROR_WHODATA_MAXNUM_WATCHES, fim_get_real_path(i), syscheck.max_audit_entries);
                 } else {
-                    mdebug1(FIM_ERROR_WHODATA_MAXNUM_WATCHES, syscheck.dir[i], syscheck.max_audit_entries);
+                    mdebug1(FIM_ERROR_WHODATA_MAXNUM_WATCHES, fim_get_real_path(i), syscheck.max_audit_entries);
                 }
 
                 reported = true;

--- a/src/syscheckd/syscheck_audit.c
+++ b/src/syscheckd/syscheck_audit.c
@@ -222,8 +222,8 @@ int add_audit_rules_syscheck(bool first_time) {
     }
 
     while (syscheck.dir[i] != NULL) {
-        // Check if dir[i] is set in whodata mode and isn't a broken link (syscheck.dir[i] = '\0')
-        if (syscheck.opts[i] & WHODATA_ACTIVE && *fim_get_real_path(i)) {
+        // Check if dir[i] is set in whodata mode
+        if (syscheck.opts[i] & WHODATA_ACTIVE) {
             int retval;
             if (W_Vector_length(audit_added_rules) < syscheck.max_audit_entries) {
                 int found = search_audit_rule(fim_get_real_path(i), "wa", AUDIT_KEY);
@@ -266,6 +266,7 @@ int add_audit_rules_syscheck(bool first_time) {
                 reported = true;
             }
         }
+
         i++;
     }
 

--- a/src/unit_tests/syscheckd/test_fim_db.c
+++ b/src/unit_tests/syscheckd/test_fim_db.c
@@ -2271,7 +2271,8 @@ void test_fim_db_delete_range_success(void **state) {
     expect_string(__wrap_remove, filename, "/tmp/file");
     will_return(__wrap_remove, 0);
 
-    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
+    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex,
+                              syscheck.database_store, FIM_SCHEDULED);
 
     assert_int_equal(ret, FIMDB_OK);
 }
@@ -2307,7 +2308,8 @@ void test_fim_db_delete_range_error(void **state) {
     expect_string(__wrap_remove, filename, "/tmp/file");
     will_return(__wrap_remove, 0);
 
-    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
+    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex,
+                              syscheck.database_store, FIM_SCHEDULED);
 
     assert_int_equal(ret, FIMDB_OK);
 }
@@ -2334,7 +2336,8 @@ void test_fim_db_delete_range_path_error(void **state) {
     expect_string(__wrap_remove, filename, "/tmp/file");
     will_return(__wrap_remove, 0);
 
-    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
+    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex,
+                              syscheck.database_store, FIM_SCHEDULED);
 
     assert_int_equal(ret, FIMDB_OK);
 }

--- a/src/unit_tests/syscheckd/test_fim_db.c
+++ b/src/unit_tests/syscheckd/test_fim_db.c
@@ -2335,7 +2335,8 @@ void test_fim_db_delete_range_path_error(void **state) {
     expect_value(__wrap_fclose, _File, (FILE*)2345);
     will_return(__wrap_fclose, 1);
 
-    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
+    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex,
+                              syscheck.database_store, FIM_SCHEDULED);
 
     assert_int_equal(ret, FIMDB_ERR);
 }
@@ -2386,7 +2387,8 @@ void test_fim_db_delete_range_fail_to_read_line_length(void **state) {
     expect_value(__wrap_fclose, _File, (FILE*)2345);
     will_return(__wrap_fclose, 1);
 
-    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
+    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex,
+                              syscheck.database_store, FIM_SCHEDULED);
 
     assert_int_equal(ret, FIMDB_ERR);
 }
@@ -2417,7 +2419,8 @@ void test_fim_db_delete_range_fail_to_read_line(void **state) {
     expect_value(__wrap_fclose, _File, (FILE*)2345);
     will_return(__wrap_fclose, 1);
 
-    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex, syscheck.database_store);
+    ret = fim_db_delete_range(test_data->fim_sql, test_data->tmp_file, &syscheck.fim_entry_mutex,
+                              syscheck.database_store, FIM_SCHEDULED);
 
     assert_int_equal(ret, FIMDB_ERR);
 }

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -60,7 +60,7 @@ int __wrap_audit_restore(void) {
 }
 #endif
 
-/* Setup */
+/* Setup/Teardown */
 
 static int setup_group(void ** state) {
 #ifdef TEST_WINAGENT
@@ -117,17 +117,60 @@ static int setup_group(void ** state) {
 }
 
 #ifndef TEST_WINAGENT
+
+static int setup_symbolic_links(void **state) {
+    syscheck.dir[1] = strdup("/link");
+    syscheck.symbolic_links[1] = strdup("/folder");
+    syscheck.opts[1] |= REALTIME_ACTIVE;
+
+    if (syscheck.dir[1] == NULL || syscheck.symbolic_links[1] == NULL) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int teardown_symbolic_links(void **state) {
+    syscheck.dir[1] = strdup("/etc");
+    syscheck.opts[1] &= ~REALTIME_ACTIVE;
+
+    if (syscheck.symbolic_links[1] != NULL) {
+        free(syscheck.symbolic_links[1]);
+        syscheck.symbolic_links[1] = NULL;
+    }
+
+    if (syscheck.dir[1] == NULL) {
+        return -1;
+    }
+
+    return 0;
+}
+
 static int setup_tmp_file(void **state) {
     fim_tmp_file *tmp_file = calloc(1, sizeof(fim_tmp_file));
     tmp_file->elements = 1;
+
+    if (setup_symbolic_links(NULL) < 0) {
+        return -1;
+    }
 
     *state = tmp_file;
 
     return 0;
 }
-#endif
 
-/* teardown */
+static int teardown_tmp_file(void **state) {
+    fim_tmp_file *tmp_file = *state;
+    free(tmp_file);
+
+    if (teardown_symbolic_links(NULL) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+#endif
 
 static int teardown_group(void **state) {
 #ifdef TEST_WINAGENT
@@ -144,15 +187,6 @@ static int teardown_group(void **state) {
 
     return 0;
 }
-
-#ifndef TEST_WINAGENT
-static int teardown_tmp_file(void **state) {
-    fim_tmp_file *tmp_file = *state;
-    free(tmp_file);
-
-    return 0;
-}
-#endif
 
 /* tests */
 
@@ -608,100 +642,113 @@ void test_fim_send_scan_info(void **state) {
 void test_fim_link_update(void **state) {
     (void) state;
 
-    int pos = 0;
-    char *link_path = "/folder/test";
+    int pos = 1;
+    char *new_path = "/new_path";
 
     expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path_range, start, "/boot/");
-    expect_string(__wrap_fim_db_get_path_range, top, "/boot0");
+    expect_string(__wrap_fim_db_get_path_range, start, "/folder/");
+    expect_string(__wrap_fim_db_get_path_range, top, "/folder0");
     expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
     will_return(__wrap_fim_db_get_path_range, NULL);
     will_return(__wrap_fim_db_get_path_range, FIMDB_OK);
 
-    expect_string(__wrap_realtime_adddir, dir, link_path);
+    expect_string(__wrap_realtime_adddir, dir, new_path);
     expect_value(__wrap_realtime_adddir, whodata, 0);
     will_return(__wrap_realtime_adddir, 0);
 
-    expect_string(__wrap_fim_checker, path, link_path);
+    expect_string(__wrap_fim_checker, path, new_path);
     expect_value(__wrap_fim_checker, w_evt, 0);
     expect_value(__wrap_fim_checker, report, 0);
 
-    fim_link_update(pos, link_path);
+    fim_link_update(pos, new_path);
 
-    assert_string_equal(syscheck.dir[pos], link_path);
+    assert_string_equal(syscheck.dir[pos], "/link");
+    assert_string_equal(syscheck.symbolic_links[pos], new_path);
 }
 
 void test_fim_link_update_already_added(void **state) {
     (void) state;
 
-    int pos = 0;
-    char *link_path = "/folder/test";
+    int pos = 1;
+    char *link_path = "/link";
+    char error_msg[OS_SIZE_128];
 
     expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path_range, start, "/folder/test/");
-    expect_string(__wrap_fim_db_get_path_range, top, "/folder/test0");
+    expect_string(__wrap_fim_db_get_path_range, start, "/folder/");
+    expect_string(__wrap_fim_db_get_path_range, top, "/folder0");
     expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
     will_return(__wrap_fim_db_get_path_range, NULL);
     will_return(__wrap_fim_db_get_path_range, FIMDB_OK);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6234): Directory '/folder/test' already monitored, ignoring link '(null)'");
+    snprintf(error_msg, OS_SIZE_128, FIM_LINK_ALREADY_ADDED, link_path);
+
+    expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
     fim_link_update(pos, link_path);
 
-    assert_string_equal(syscheck.dir[pos], "");
+    assert_string_equal(syscheck.dir[pos], link_path);
+    assert_string_equal(syscheck.symbolic_links[pos], "");
 }
 
 void test_fim_link_check_delete(void **state) {
     (void) state;
 
     int pos = 1;
-    char *link_path = "/etc";
+    char *link_path = "/link";
+    char *pointed_folder = "/folder";
 
-    expect_string(__wrap_lstat, filename, link_path);
+    expect_string(__wrap_lstat, filename, syscheck.symbolic_links[pos]);
     will_return(__wrap_lstat, 0);
     will_return(__wrap_lstat, 0);
 
     expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path_range, start, "/etc/");
-    expect_string(__wrap_fim_db_get_path_range, top, "/etc0");
+    expect_string(__wrap_fim_db_get_path_range, start, "/folder/");
+    expect_string(__wrap_fim_db_get_path_range, top, "/folder0");
     expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
     will_return(__wrap_fim_db_get_path_range, NULL);
     will_return(__wrap_fim_db_get_path_range, FIMDB_OK);
 
-    expect_string(__wrap_fim_configuration_directory, path, "/etc");
+    expect_string(__wrap_fim_configuration_directory, path, pointed_folder);
     expect_string(__wrap_fim_configuration_directory, entry, "file");
     will_return(__wrap_fim_configuration_directory, -1);
 
     fim_link_check_delete(pos);
 
-    assert_string_equal(syscheck.dir[pos], "");
+    assert_string_equal(syscheck.dir[pos], link_path);
+    assert_string_equal(syscheck.symbolic_links[pos], "");
 }
 
 void test_fim_link_check_delete_lstat_error(void **state) {
     (void) state;
 
-    int pos = 2;
-    char *link_path = "/home";
+    int pos = 1;
+    char *link_path = "/link";
+    char *pointed_folder = "/folder";
+    char error_msg[OS_SIZE_128];
 
-    expect_string(__wrap_lstat, filename, link_path);
+    expect_string(__wrap_lstat, filename, pointed_folder);
     will_return(__wrap_lstat, 0);
     will_return(__wrap_lstat, -1);
     errno = 0;
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6222): Stat() function failed on: '/home' due to [(0)-(Success)]");
+    snprintf(error_msg, OS_SIZE_128, FIM_STAT_FAILED, pointed_folder, 0, "Success");
+
+    expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
     fim_link_check_delete(pos);
 
     assert_string_equal(syscheck.dir[pos], link_path);
+    assert_string_equal(syscheck.symbolic_links[pos], pointed_folder);
 }
 
 void test_fim_link_check_delete_noentry_error(void **state) {
     (void) state;
 
-    int pos = 2;
-    char *link_path = "/home";
+    int pos = 1;
+    char *link_path = "/link";
+    char *pointed_folder = "/folder";
 
-    expect_string(__wrap_lstat, filename, link_path);
+    expect_string(__wrap_lstat, filename, pointed_folder);
     will_return(__wrap_lstat, 0);
     will_return(__wrap_lstat, -1);
 
@@ -711,15 +758,18 @@ void test_fim_link_check_delete_noentry_error(void **state) {
 
     errno = 0;
 
-    assert_string_equal(syscheck.dir[pos], "");
+    assert_string_equal(syscheck.dir[pos], link_path);
+    assert_string_equal(syscheck.symbolic_links[pos], "");
 }
 
 void test_fim_delete_realtime_watches(void **state) {
     (void) state;
 
     unsigned int pos = 1;
+    char *link_path = "/link";
+    char *pointed_folder = "/folder";
 
-    expect_string(__wrap_fim_configuration_directory, path, "");
+    expect_string(__wrap_fim_configuration_directory, path, pointed_folder);
     expect_string(__wrap_fim_configuration_directory, entry, "file");
     will_return(__wrap_fim_configuration_directory, 0);
     expect_string(__wrap_fim_configuration_directory, path, "data");
@@ -734,13 +784,12 @@ void test_fim_delete_realtime_watches(void **state) {
 }
 
 void test_fim_link_delete_range(void **state) {
-    int pos = 3;
-
+    int pos = 1;
     fim_tmp_file *tmp_file = *state;
 
     expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path_range, start, "/media/");
-    expect_string(__wrap_fim_db_get_path_range, top, "/media0");
+    expect_string(__wrap_fim_db_get_path_range, start, "/folder/");
+    expect_string(__wrap_fim_db_get_path_range, top, "/folder0");
     expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
     will_return(__wrap_fim_db_get_path_range, tmp_file);
     will_return(__wrap_fim_db_get_path_range, FIMDB_OK);
@@ -754,25 +803,27 @@ void test_fim_link_delete_range(void **state) {
 }
 
 void test_fim_link_delete_range_error(void **state) {
-    int pos = 3;
-
+    int pos = 1;
+    char error_msg[OS_SIZE_128];
     fim_tmp_file *tmp_file = *state;
 
+    snprintf(error_msg, OS_SIZE_128, FIM_DB_ERROR_RM_RANGE, "/folder/", "/folder0");
+
     expect_value(__wrap_fim_db_get_path_range, fim_sql, syscheck.database);
-    expect_string(__wrap_fim_db_get_path_range, start, "/media/");
-    expect_string(__wrap_fim_db_get_path_range, top, "/media0");
+    expect_string(__wrap_fim_db_get_path_range, start, "/folder/");
+    expect_string(__wrap_fim_db_get_path_range, top, "/folder0");
     expect_value(__wrap_fim_db_get_path_range, storage, FIM_DB_DISK);
     will_return(__wrap_fim_db_get_path_range, tmp_file);
     will_return(__wrap_fim_db_get_path_range, FIMDB_ERR);
 
-    expect_string(__wrap__merror, formatted_msg, "(6708): Failed to delete a range of paths between '/media/' and '/media0'");
+    expect_string(__wrap__merror, formatted_msg, error_msg);
 
     expect_value(__wrap_fim_db_delete_range, fim_sql, syscheck.database);
     expect_value(__wrap_fim_db_delete_range, storage, FIM_DB_DISK);
     expect_memory(__wrap_fim_db_delete_range, file, tmp_file, sizeof(tmp_file));
     will_return(__wrap_fim_db_delete_range, FIMDB_ERR);
 
-    expect_string(__wrap__merror, formatted_msg, "(6708): Failed to delete a range of paths between '/media/' and '/media0'");
+    expect_string(__wrap__merror, formatted_msg, error_msg);
 
     fim_link_delete_range(pos);
 }
@@ -781,7 +832,7 @@ void test_fim_link_silent_scan(void **state) {
     (void) state;
 
     int pos = 3;
-    char *link_path = "/folder/test";
+    char *link_path = "/link";
 
     expect_string(__wrap_realtime_adddir, dir, link_path);
     expect_value(__wrap_realtime_adddir, whodata, 0);
@@ -797,29 +848,40 @@ void test_fim_link_silent_scan(void **state) {
 void test_fim_link_reload_broken_link_already_monitored(void **state) {
     (void) state;
 
-    int pos = 4;
-    char *link_path = "/usr/bin";
+    int pos = 1;
+    char *link_path = "/link";
+    char *pointed_folder = "/folder";
+    char error_msg[OS_SIZE_128];
 
-    expect_string(__wrap__mdebug1, formatted_msg, "(6234): Directory '/usr/bin' already monitored, ignoring link '(null)'");
+    snprintf(error_msg, OS_SIZE_128, FIM_LINK_ALREADY_ADDED, link_path);
+
+    expect_string(__wrap__mdebug1, formatted_msg, error_msg);
 
     fim_link_reload_broken_link(link_path, pos);
 
     assert_string_equal(syscheck.dir[pos], link_path);
+    assert_string_equal(syscheck.symbolic_links[pos], pointed_folder);
 }
 
 void test_fim_link_reload_broken_link_reload_broken(void **state) {
     (void) state;
 
-    int pos = 5;
-    char *link_path = "/test";
+    int pos = 1;
+    char *link_path = "/link";
+    char *pointed_folder = "/new_path";
 
-    expect_string(__wrap_fim_checker, path, link_path);
+    expect_string(__wrap_fim_checker, path, pointed_folder);
     expect_value(__wrap_fim_checker, w_evt, 0);
     expect_value(__wrap_fim_checker, report, 0);
 
-    fim_link_reload_broken_link(link_path, pos);
+    expect_string(__wrap_realtime_adddir, dir, pointed_folder);
+    expect_value(__wrap_realtime_adddir, whodata, 0);
+    will_return(__wrap_realtime_adddir, 0);
+
+    fim_link_reload_broken_link(pointed_folder, pos);
 
     assert_string_equal(syscheck.dir[pos], link_path);
+    assert_string_equal(syscheck.symbolic_links[pos], pointed_folder);
 }
 #endif
 
@@ -849,17 +911,17 @@ int main(void) {
         cmocka_unit_test(test_send_syscheck_msg_0_eps),
         cmocka_unit_test(test_fim_send_scan_info),
 #ifndef TEST_WINAGENT
-        cmocka_unit_test(test_fim_link_update),
-        cmocka_unit_test(test_fim_link_update_already_added),
-        cmocka_unit_test(test_fim_link_check_delete),
-        cmocka_unit_test(test_fim_link_check_delete_lstat_error),
-        cmocka_unit_test(test_fim_link_check_delete_noentry_error),
-        cmocka_unit_test(test_fim_delete_realtime_watches),
+        cmocka_unit_test_setup_teardown(test_fim_link_update, setup_symbolic_links, teardown_symbolic_links),
+        cmocka_unit_test_setup_teardown(test_fim_link_update_already_added, setup_symbolic_links, teardown_symbolic_links),
+        cmocka_unit_test_setup_teardown(test_fim_link_check_delete, setup_symbolic_links, teardown_symbolic_links),
+        cmocka_unit_test_setup_teardown(test_fim_link_check_delete_lstat_error, setup_symbolic_links, teardown_symbolic_links),
+        cmocka_unit_test_setup_teardown(test_fim_link_check_delete_noentry_error, setup_symbolic_links, teardown_symbolic_links),
+        cmocka_unit_test_setup_teardown(test_fim_delete_realtime_watches, setup_symbolic_links, teardown_symbolic_links),
         cmocka_unit_test_setup_teardown(test_fim_link_delete_range, setup_tmp_file, teardown_tmp_file),
         cmocka_unit_test_setup_teardown(test_fim_link_delete_range_error, setup_tmp_file, teardown_tmp_file),
-        cmocka_unit_test(test_fim_link_silent_scan),
-        cmocka_unit_test(test_fim_link_reload_broken_link_already_monitored),
-        cmocka_unit_test(test_fim_link_reload_broken_link_reload_broken),
+        cmocka_unit_test_setup_teardown(test_fim_link_silent_scan, setup_symbolic_links, teardown_symbolic_links),
+        cmocka_unit_test_setup_teardown(test_fim_link_reload_broken_link_already_monitored, setup_symbolic_links, teardown_symbolic_links),
+        cmocka_unit_test_setup_teardown(test_fim_link_reload_broken_link_reload_broken, setup_symbolic_links, teardown_symbolic_links),
 #endif
     };
 

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -119,6 +119,11 @@ static int setup_group(void ** state) {
 #ifndef TEST_WINAGENT
 
 static int setup_symbolic_links(void **state) {
+    if (syscheck.dir[1] != NULL) {
+        free(syscheck.dir[1]);
+        syscheck.dir[1] = NULL;
+    }
+
     syscheck.dir[1] = strdup("/link");
     syscheck.symbolic_links[1] = strdup("/folder");
     syscheck.opts[1] |= REALTIME_ACTIVE;
@@ -131,13 +136,18 @@ static int setup_symbolic_links(void **state) {
 }
 
 static int teardown_symbolic_links(void **state) {
-    syscheck.dir[1] = strdup("/etc");
-    syscheck.opts[1] &= ~REALTIME_ACTIVE;
+    if (syscheck.dir[1] != NULL) {
+        free(syscheck.dir[1]);
+        syscheck.dir[1] = NULL;
+    }
 
     if (syscheck.symbolic_links[1] != NULL) {
         free(syscheck.symbolic_links[1]);
         syscheck.symbolic_links[1] = NULL;
     }
+
+    syscheck.dir[1] = strdup("/etc");
+    syscheck.opts[1] &= ~REALTIME_ACTIVE;
 
     if (syscheck.dir[1] == NULL) {
         return -1;

--- a/src/unit_tests/syscheckd/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/test_syscheck_audit.c
@@ -134,6 +134,32 @@ static int teardown_hc_success(void **state) {
     return 0;
 }
 
+static int setup_add_audit_rules(void **state) {
+    syscheck.symbolic_links = calloc(2, sizeof(char *));
+
+    if (syscheck.symbolic_links == NULL) {
+        return -1;
+    }
+
+    syscheck.symbolic_links[0] = NULL;
+
+    return 0;
+}
+
+static int teardown_add_audit_rules(void **state) {
+    if (syscheck.symbolic_links[0] != NULL) {
+        free(syscheck.symbolic_links[0]);
+        syscheck.symbolic_links[0] = NULL;
+    }
+
+    if (syscheck.symbolic_links != NULL) {
+        free(syscheck.symbolic_links);
+        syscheck.symbolic_links = NULL;
+    }
+
+    return 0;
+}
+
 /* tests */
 
 
@@ -1202,15 +1228,20 @@ void test_get_process_parent_info_failed(void **state) {
     will_return(__wrap_readlink, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Failure to obtain the cwd of the process: '1515'. Error: File exists");
 
-    state[0] = parent_name;
-    state[1] = parent_cwd;
-    state[2] = NULL;
-
     get_parent_process_info("1515", &parent_name, &parent_cwd);
 
     assert_string_equal(parent_name, "");
     assert_string_equal(parent_cwd, "");
 
+    if (parent_name != NULL) {
+        free(parent_name);
+        parent_name = NULL;
+    }
+
+    if (parent_cwd != NULL) {
+        free(parent_cwd);
+        parent_cwd = NULL;
+    }
 }
 
 void test_get_process_parent_info_passsed(void **state) {
@@ -1227,12 +1258,18 @@ void test_get_process_parent_info_passsed(void **state) {
 
     get_parent_process_info("1515", &parent_name, &parent_cwd);
 
-    state[0] = parent_name;
-    state[1] = parent_cwd;
-    state[2] = NULL;
-
     assert_string_equal(parent_name, "");
     assert_string_equal(parent_cwd, "");
+
+    if (parent_name != NULL) {
+        free(parent_name);
+        parent_name = NULL;
+    }
+
+    if (parent_cwd != NULL) {
+        free(parent_cwd);
+        parent_cwd = NULL;
+    }
 }
 
 void test_audit_parse(void **state) {
@@ -2550,12 +2587,12 @@ int main(void) {
         cmocka_unit_test(test_audit_get_id_begin_error),
         cmocka_unit_test(test_audit_get_id_end_error),
         cmocka_unit_test(test_init_regex),
-        cmocka_unit_test(test_add_audit_rules_syscheck_added),
-        cmocka_unit_test(test_add_audit_rules_syscheck_not_added),
-        cmocka_unit_test(test_add_audit_rules_syscheck_not_added_new),
-        cmocka_unit_test(test_add_audit_rules_syscheck_not_added_error),
-        cmocka_unit_test(test_add_audit_rules_syscheck_not_added_first_error),
-        cmocka_unit_test(test_add_audit_rules_syscheck_max),
+        cmocka_unit_test_setup_teardown(test_add_audit_rules_syscheck_added, setup_add_audit_rules, teardown_add_audit_rules),
+        cmocka_unit_test_setup_teardown(test_add_audit_rules_syscheck_not_added, setup_add_audit_rules, teardown_add_audit_rules),
+        cmocka_unit_test_setup_teardown(test_add_audit_rules_syscheck_not_added_new, setup_add_audit_rules, teardown_add_audit_rules),
+        cmocka_unit_test_setup_teardown(test_add_audit_rules_syscheck_not_added_error, setup_add_audit_rules, teardown_add_audit_rules),
+        cmocka_unit_test_setup_teardown(test_add_audit_rules_syscheck_not_added_first_error, setup_add_audit_rules, teardown_add_audit_rules),
+        cmocka_unit_test_setup_teardown(test_add_audit_rules_syscheck_max, setup_add_audit_rules, teardown_add_audit_rules),
         cmocka_unit_test(test_filterkey_audit_events_custom),
         cmocka_unit_test(test_filterkey_audit_events_discard),
         cmocka_unit_test(test_filterkey_audit_events_fim),
@@ -2568,15 +2605,15 @@ int main(void) {
         cmocka_unit_test_teardown(test_gen_audit_path6, free_string),
         cmocka_unit_test_teardown(test_gen_audit_path7, free_string),
         cmocka_unit_test_teardown(test_gen_audit_path8, free_string),
-        cmocka_unit_test_teardown(test_get_process_parent_info_failed, free_string),
-        cmocka_unit_test_teardown(test_get_process_parent_info_passsed, free_string),
+        cmocka_unit_test(test_get_process_parent_info_failed),
+        cmocka_unit_test(test_get_process_parent_info_passsed),
         cmocka_unit_test(test_audit_parse),
         cmocka_unit_test(test_audit_parse3),
         cmocka_unit_test(test_audit_parse4),
         cmocka_unit_test(test_audit_parse_hex),
         cmocka_unit_test(test_audit_parse_empty_fields),
-        cmocka_unit_test(test_audit_parse_delete),
-        cmocka_unit_test(test_audit_parse_delete_recursive),
+        cmocka_unit_test_setup_teardown(test_audit_parse_delete, setup_add_audit_rules, teardown_add_audit_rules),
+        cmocka_unit_test_setup_teardown(test_audit_parse_delete_recursive, setup_add_audit_rules, teardown_add_audit_rules),
         cmocka_unit_test(test_audit_parse_mv),
         cmocka_unit_test(test_audit_parse_mv_hex),
         cmocka_unit_test(test_audit_parse_rm),

--- a/src/unit_tests/syscheckd/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/test_win_whodata.c
@@ -201,6 +201,9 @@ static int setup_whodata_callback_group(void ** state) {
     if (syscheck.dir = calloc(2, sizeof(char *)), !syscheck.dir)
         return -1;
 
+    if (syscheck.symbolic_links = calloc(2, sizeof(char *)), !syscheck.symbolic_links)
+        return -1;
+
     if (syscheck.opts = calloc(1, sizeof(int *)), !syscheck.opts)
         return -1;
 


### PR DESCRIPTION
| Related issue |
| ------------- |
| #6320         |

## Description

This pull request does a refactor of all the code involkved in symbolic links in FIM. Previously, FIM would store the link path in `syscheck.symbolic_links` and the resolved path in `syscheck.dir`, this modified what the user had configured. Now, all the configured paths are stored only in `syscheck.dir` and the resolved paths, if any, are stored in `syscheck.symbolic_links`.

Another fix, helped by the refactor, prevents from storing resolved paths if `follow_symbolic_link` is disabled, therefore fixing the original problem described in #6320.

This pull request closes #6320.

## Logs/Alerts example

This message has changed:

```
INFO: (6034): Updating the symbolic link from '/nono': '/linko' to '/otra'.
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
