### PR TITLE
Setting the agents as syncreq in global.db when they change the connection status

### DIFF
--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -175,7 +175,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
             w_mutex_unlock(&lastmsg_mutex);
             agent_id = atoi(key->id);
 
-            result = wdb_update_agent_keepalive(agent_id, AGENT_CS_PENDING, logr.worker_node?"syncreq":"synced", wdb_sock);
+            result = wdb_update_agent_connection_status(agent_id, AGENT_CS_PENDING, logr.worker_node?"syncreq":"synced", wdb_sock);
 
             if (OS_SUCCESS != result) {
                 mwarn("Unable to save last keepalive and set connection status as pending for agent: %s", key->id);

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -114,7 +114,7 @@ void HandleSecure()
     }
 
     // Reset all the agents' connection status in Wazuh DB
-    if (OS_SUCCESS != wdb_reset_agents_connection(NULL))
+    if (OS_SUCCESS != wdb_reset_agents_connection(logr.worker_node ? "syncreq" : "synced", NULL))
         mwarn("Unable to reset the agents' connection status. Possible incorrect statuses until the agents get connected to the manager.");
 
     // Create message handler thread pool

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -1805,12 +1805,13 @@ void test_wdb_update_agent_connection_status_error_json(void **state)
     int ret = 0;
     int id = 1;
     const char *connection_status = "active";
+    const char *sync_status = "synced";
 
     will_return(__wrap_cJSON_CreateObject, NULL);
 
     expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
 
-    ret = wdb_update_agent_connection_status(id, connection_status, NULL);
+    ret = wdb_update_agent_connection_status(id, connection_status, sync_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -1820,9 +1821,10 @@ void test_wdb_update_agent_connection_status_error_socket(void **state)
     int ret = 0;
     int id = 1;
     const char *connection_status = "active";
+    const char *sync_status = "synced";
 
-    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\"}");
-    const char *query_str = "global update-connection-status {\"id\":1,\"connection_status\":\"active\"}";
+    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}");
+    const char *query_str = "global update-connection-status {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1834,6 +1836,8 @@ void test_wdb_update_agent_connection_status_error_socket(void **state)
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "active");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "synced");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1848,9 +1852,9 @@ void test_wdb_update_agent_connection_status_error_socket(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error in the response from socket");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-connection-status {\"id\":1,\"connection_status\":\"active\"}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-connection-status {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}");
 
-    ret = wdb_update_agent_connection_status(id, connection_status, NULL);
+    ret = wdb_update_agent_connection_status(id, connection_status, sync_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -1860,9 +1864,10 @@ void test_wdb_update_agent_connection_status_error_sql_execution(void **state)
     int ret = 0;
     int id = 1;
     const char *connection_status = "active";
+    const char *sync_status = "synced";
 
-    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\"}");
-    const char *query_str = "global update-connection-status {\"id\":1,\"connection_status\":\"active\"}";
+    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}");
+    const char *query_str = "global update-connection-status {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1874,6 +1879,8 @@ void test_wdb_update_agent_connection_status_error_sql_execution(void **state)
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "active");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "synced");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1888,9 +1895,9 @@ void test_wdb_update_agent_connection_status_error_sql_execution(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-connection-status {\"id\":1,\"connection_status\":\"active\"}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global update-connection-status {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}");
 
-    ret = wdb_update_agent_connection_status(id, connection_status, NULL);
+    ret = wdb_update_agent_connection_status(id, connection_status, sync_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -1900,9 +1907,10 @@ void test_wdb_update_agent_connection_status_error_result(void **state)
     int ret = 0;
     int id = 1;
     const char *connection_status = "active";
+    const char *sync_status = "synced";
 
-    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\"}");
-    const char *query_str = "global update-connection-status {\"id\":1,\"connection_status\":\"active\"}";
+    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}");
+    const char *query_str = "global update-connection-status {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1914,6 +1922,8 @@ void test_wdb_update_agent_connection_status_error_result(void **state)
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "active");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "synced");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1931,7 +1941,7 @@ void test_wdb_update_agent_connection_status_error_result(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error reported in the result of the query");
 
-    ret = wdb_update_agent_connection_status(id, connection_status, NULL);
+    ret = wdb_update_agent_connection_status(id, connection_status, sync_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -1941,9 +1951,10 @@ void test_wdb_update_agent_connection_status_success(void **state)
     int ret = 0;
     int id = 1;
     const char *connection_status = "active";
+    const char *sync_status = "synced";
 
-    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\"}");
-    const char *query_str = "global update-connection-status {\"id\":1,\"connection_status\":\"active\"}";
+    const char *json_str = strdup("{\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}");
+    const char *query_str = "global update-connection-status {\"id\":1,\"connection_status\":\"active\",\"sync_status\":\"synced\"}";
     const char *response = "ok";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -1955,6 +1966,8 @@ void test_wdb_update_agent_connection_status_success(void **state)
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     expect_string(__wrap_cJSON_AddStringToObject, name, "connection_status");
     expect_string(__wrap_cJSON_AddStringToObject, string, "active");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "sync_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "synced");
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
@@ -1971,7 +1984,7 @@ void test_wdb_update_agent_connection_status_success(void **state)
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
-    ret = wdb_update_agent_connection_status(id, connection_status, NULL);
+    ret = wdb_update_agent_connection_status(id, connection_status, sync_status, NULL);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
@@ -4364,7 +4377,8 @@ void test_get_agent_date_added_success(void **state) {
 void test_wdb_reset_agents_connection_error_socket(void **state)
 {
     int ret = 0;
-    const char *query_str = "global reset-agents-connection";
+    const char *sync_status = "synced";
+    const char *query_str = "global reset-agents-connection synced";
     const char *response = "err";
 
     // Calling Wazuh DB
@@ -4376,9 +4390,9 @@ void test_wdb_reset_agents_connection_error_socket(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error in the response from socket");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global reset-agents-connection");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global reset-agents-connection synced");
 
-    ret = wdb_reset_agents_connection(NULL);
+    ret = wdb_reset_agents_connection(sync_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -4386,7 +4400,8 @@ void test_wdb_reset_agents_connection_error_socket(void **state)
 void test_wdb_reset_agents_connection_error_sql_execution(void **state)
 {
     int ret = 0;
-    const char *query_str = "global reset-agents-connection";
+    const char *sync_status = "synced";
+    const char *query_str = "global reset-agents-connection synced";
     const char *response = "err";
 
     // Calling Wazuh DB
@@ -4398,9 +4413,9 @@ void test_wdb_reset_agents_connection_error_sql_execution(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db");
-    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global reset-agents-connection");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB SQL query: global reset-agents-connection synced");
 
-    ret = wdb_reset_agents_connection(NULL);
+    ret = wdb_reset_agents_connection(sync_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -4408,7 +4423,8 @@ void test_wdb_reset_agents_connection_error_sql_execution(void **state)
 void test_wdb_reset_agents_connection_error_result(void **state)
 {
     int ret = 0;
-    const char *query_str = "global reset-agents-connection";
+    const char *sync_status = "synced";
+    const char *query_str = "global reset-agents-connection synced";
     const char *response = "err";
 
     // Calling Wazuh DB
@@ -4423,7 +4439,7 @@ void test_wdb_reset_agents_connection_error_result(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Error reported in the result of the query");
 
-    ret = wdb_reset_agents_connection(NULL);
+    ret = wdb_reset_agents_connection(sync_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
@@ -4431,7 +4447,8 @@ void test_wdb_reset_agents_connection_error_result(void **state)
 void test_wdb_reset_agents_connection_success(void **state)
 {
     int ret = 0;
-    const char *query_str = "global reset-agents-connection";
+    const char *sync_status = "synced";
+    const char *query_str = "global reset-agents-connection synced";
     const char *response = "ok";
 
     // Calling Wazuh DB
@@ -4445,7 +4462,7 @@ void test_wdb_reset_agents_connection_success(void **state)
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
-    ret = wdb_reset_agents_connection(NULL);
+    ret = wdb_reset_agents_connection(sync_status, NULL);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
@@ -4602,7 +4619,7 @@ void test_wdb_disconnect_agents_success(void **state) {
 
     // Setting the payload
     set_payload = 1;
-    strncpy(test_payload, "ok 1,2,3", 8);
+    strncpy(test_payload, "ok 1,2,3", 9);
 
     // Calling Wazuh DB
     expect_any(__wrap_wdbc_query_ex, *sock);

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -3012,11 +3012,12 @@ void test_wdb_global_update_agent_connection_status_transaction_fail(void **stat
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     const char *connection_status = "active";
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status);
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3026,12 +3027,13 @@ void test_wdb_global_update_agent_connection_status_cache_fail(void **state)
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     const char *connection_status = "active";
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status);
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3041,6 +3043,7 @@ void test_wdb_global_update_agent_connection_status_bind1_fail(void **state)
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     const char *connection_status = "active";
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -3051,7 +3054,7 @@ void test_wdb_global_update_agent_connection_status_bind1_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status);
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3061,6 +3064,7 @@ void test_wdb_global_update_agent_connection_status_bind2_fail(void **state)
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     const char *connection_status = "active";
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -3068,13 +3072,40 @@ void test_wdb_global_update_agent_connection_status_bind2_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status, sync_status);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_update_agent_connection_status_bind3_fail(void **state)
+{
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char *connection_status = "active";
+    const char *sync_status = "synced";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 3);
     expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
 
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
-    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status);
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3084,6 +3115,7 @@ void test_wdb_global_update_agent_connection_status_step_fail(void **state)
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     const char *connection_status = "active";
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -3091,7 +3123,10 @@ void test_wdb_global_update_agent_connection_status_step_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 3);
     expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
@@ -3099,7 +3134,7 @@ void test_wdb_global_update_agent_connection_status_step_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status);
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3109,6 +3144,7 @@ void test_wdb_global_update_agent_connection_status_success(void **state)
     int result = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     const char *connection_status = "active";
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -3116,12 +3152,15 @@ void test_wdb_global_update_agent_connection_status_success(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_value(__wrap_sqlite3_bind_text, buffer, connection_status);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 3);
     expect_value(__wrap_sqlite3_bind_int, value, 1);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status);
+    result = wdb_global_update_agent_connection_status(data->wdb, 1, connection_status, sync_status);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -4637,7 +4676,7 @@ void test_wdb_global_get_agents_to_disconnect_bind2_fail(void **state)
 }
 
 void test_wdb_global_get_agents_to_disconnect_no_agents(void **state)
-{      
+{
     test_struct_t *data  = (test_struct_t *)*state;
     char *output = NULL;
     int last_id = 0;
@@ -4663,7 +4702,7 @@ void test_wdb_global_get_agents_to_disconnect_no_agents(void **state)
 }
 
 void test_wdb_global_get_agents_to_disconnect_success(void **state)
-{ 
+{
     test_struct_t *data  = (test_struct_t *)*state;
     char *output = NULL;
     cJSON *root = NULL;
@@ -4695,7 +4734,10 @@ void test_wdb_global_get_agents_to_disconnect_success(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, "disconnected");
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "synced");
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 3);
     expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
@@ -4711,7 +4753,7 @@ void test_wdb_global_get_agents_to_disconnect_success(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, keepalive);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id,keepalive, &output);
+    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, &output);
 
     assert_string_equal(output, str_agt_id);
     os_free(output);
@@ -4720,7 +4762,7 @@ void test_wdb_global_get_agents_to_disconnect_success(void **state)
 }
 
 void test_wdb_global_get_agents_to_disconnect_update_status_fail(void **state)
-{  
+{
     test_struct_t *data  = (test_struct_t *)*state;
     char *output = NULL;
     cJSON *root = NULL;
@@ -4748,7 +4790,10 @@ void test_wdb_global_get_agents_to_disconnect_update_status_fail(void **state)
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, "disconnected");
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "synced");
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 3);
     expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
@@ -4772,7 +4817,7 @@ void test_wdb_global_get_agents_to_disconnect_update_status_fail(void **state)
 }
 
 void test_wdb_global_get_agents_to_disconnect_full(void **state)
-{    
+{
     test_struct_t *data  = (test_struct_t *)*state;
     char *output = NULL;
     cJSON *root = NULL;
@@ -5014,11 +5059,12 @@ void test_wdb_global_check_manager_keepalive_step_ok(void **state) {
 void test_wdb_global_reset_agents_connection_transaction_fail(void **state)
 {
     test_struct_t *data  = (test_struct_t *)*state;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    int result = wdb_global_reset_agents_connection(data->wdb);
+    int result = wdb_global_reset_agents_connection(data->wdb, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -5026,12 +5072,32 @@ void test_wdb_global_reset_agents_connection_transaction_fail(void **state)
 void test_wdb_global_reset_agents_connection_cache_fail(void **state)
 {
     test_struct_t *data  = (test_struct_t *)*state;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    int result = wdb_global_reset_agents_connection(data->wdb);
+    int result = wdb_global_reset_agents_connection(data->wdb, sync_status);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+void test_wdb_global_reset_agents_connection_bind_fail(void **state)
+{
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char *sync_status = "synced";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
+
+    int result = wdb_global_reset_agents_connection(data->wdb, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -5039,15 +5105,20 @@ void test_wdb_global_reset_agents_connection_cache_fail(void **state)
 void test_wdb_global_reset_agents_step_fail(void **state)
 {
     test_struct_t *data  = (test_struct_t *)*state;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
 
     will_return(__wrap_wdb_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
 
-    int result = wdb_global_reset_agents_connection(data->wdb);
+    int result = wdb_global_reset_agents_connection(data->wdb, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -5055,12 +5126,16 @@ void test_wdb_global_reset_agents_step_fail(void **state)
 void test_wdb_global_reset_agents_connection_success(void **state)
 {
     test_struct_t *data  = (test_struct_t *)*state;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_value(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     will_return(__wrap_wdb_step, SQLITE_DONE);
 
-    int result = wdb_global_reset_agents_connection(data->wdb);
+    int result = wdb_global_reset_agents_connection(data->wdb, sync_status);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -5314,6 +5389,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_connection_status_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_connection_status_bind1_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_connection_status_bind2_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_connection_status_bind3_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_connection_status_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_connection_status_success, test_setup, test_teardown),
         /* Tests wdb_global_delete_agent */
@@ -5429,6 +5505,7 @@ int main()
         /* Tests wdb_global_reset_agents_connection */
         cmocka_unit_test_setup_teardown(test_wdb_global_reset_agents_connection_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_reset_agents_connection_cache_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_reset_agents_connection_bind_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_reset_agents_step_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_reset_agents_connection_success, test_setup, test_teardown),
         /* Tests wdb_global_get_agents_by_connection_status */

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -121,7 +121,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_LABELS_DEL] = "DELETE FROM labels WHERE id = ?;",
     [WDB_STMT_GLOBAL_LABELS_SET] = "INSERT INTO labels (id, key, value) VALUES (?,?,?);",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE] = "UPDATE agent SET last_keepalive = CASE WHEN last_keepalive IS NULL THEN 0 ELSE STRFTIME('%s', 'NOW') END, connection_status = ?, sync_status = ? WHERE id = ?;",
-    [WDB_STMT_GLOBAL_UPDATE_AGENT_CONNECTION_STATUS] = "UPDATE agent SET connection_status = ? WHERE id = ?;",
+    [WDB_STMT_GLOBAL_UPDATE_AGENT_CONNECTION_STATUS] = "UPDATE agent SET connection_status = ?, sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_DELETE_AGENT] = "DELETE FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_SELECT_AGENT_NAME] = "SELECT name FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_SELECT_AGENT_GROUP] = "SELECT `group` FROM agent WHERE id = ?;",
@@ -142,7 +142,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GET_AGENT_INFO] = "SELECT * FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT] = "SELECT id FROM agent WHERE id > ? AND connection_status = 'active' AND last_keepalive < ? LIMIT 1;",
-    [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected' where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",
+    [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected', sync_status = ? where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",
     [WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE] = "SELECT COUNT(*) FROM agent WHERE id=0 AND last_keepalive=253402300799;",
     [WDB_STMT_PRAGMA_JOURNAL_WAL] = "PRAGMA journal_mode=WAL;",
 };

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -465,10 +465,11 @@ int wdb_update_agent_keepalive(int id, const char *connection_status, const char
  *
  * @param[in] id Id of the agent for whom the connection status must be updated.
  * @param[in] connection_status String with the connection status to be set.
+ * @param[in] sync_status String with the cluster synchronization status to be set.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return OS_SUCCESS on success or OS_INVALID on failure.
  */
-int wdb_update_agent_connection_status(int id, const char *connection_status, int *sock);
+int wdb_update_agent_connection_status(int id, const char *connection_status, const char *sync_status, int *sock);
 
 /**
  * @brief Update agent group. If the group is not specified, it is set to NULL.
@@ -617,11 +618,13 @@ int wdb_remove_group_from_belongs_db(const char *name, int *sock);
  * @brief Reset the connection_status column of every agent (excluding the manager).
  *        If connection_status is pending or connected it will be changed to disconnected.
  *        If connection_status is disconnected or never_connected it will not be changed.
+ *        It also set the 'sync_status' with the specified value.
  *
+ * @param[in] sync_status String with the cluster synchronization status to be set.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns OS_SUCCESS on success or OS_INVALID on failure.
  */
-int wdb_reset_agents_connection(int *sock);
+int wdb_reset_agents_connection(const char *sync_status, int *sock);
 
 /**
  * @brief Returns an array containing the ID of every agent (excluding the manager) that matches
@@ -637,10 +640,10 @@ int wdb_reset_agents_connection(int *sock);
 int* wdb_get_agents_by_connection_status(const char* connection_status, int *sock);
 
 /**
- * @brief Set agents as disconnected based on the keepalive and return an array containing 
- * the ID of every agent that had been set as disconnected. 
+ * @brief Set agents as disconnected based on the keepalive and return an array containing
+ * the ID of every agent that had been set as disconnected.
  * This method creates and sends a command to WazuhDB to set as disconnected all the
- * agents (excluding the manager) with a last_keepalive before the specified keepalive threshold. 
+ * agents (excluding the manager) with a last_keepalive before the specified keepalive threshold.
  * If the response is bigger than the capacity of the socket, multiple commands will be sent until every agent is covered.
  * The array is heap-allocated memory that must be freed by the caller.
  *
@@ -1236,11 +1239,12 @@ int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output);
  * @brief Function to parse the reset agent connection status request.
  *
  * @param [in] wdb The global struct database.
+ * @param [in] input String with the 'sync_status'.
  * @param [out] output Response of the query.
  * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.
  */
-int wdb_parse_reset_agents_connection(wdb_t * wdb, char * output);
+int wdb_parse_reset_agents_connection(wdb_t * wdb, char* input, char * output);
 
 /**
  * @brief Function to parse the get agents by connection status request.
@@ -1459,20 +1463,21 @@ int wdb_global_set_agent_label(wdb_t *wdb, int id, char* key, char* value);
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
  * @param [in] connection_status The agent's connection status.
- * @param [in] status The value of sync_status
+ * @param [in] sync_status The value of sync_status
  * @return Returns 0 on success or -1 on error.
  */
 int wdb_global_update_agent_keepalive(wdb_t *wdb, int id, const char *connection_status, const char *sync_status);
 
 /**
- * @brief Function to update an agent connection status.
+ * @brief Function to update an agent connection status and the synchronization status.
  *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID.
  * @param [in] connection_status The connection status to be set.
+ * @param [in] sync_status The value of sync_status
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_global_update_agent_connection_status(wdb_t *wdb, int id, const char* connection_status);
+int wdb_global_update_agent_connection_status(wdb_t *wdb, int id, const char* connection_status, const char *sync_status);
 
 /**
  * @brief Function to delete an agent from the agent table.
@@ -1599,7 +1604,7 @@ cJSON* wdb_global_select_agent_keepalive(wdb_t *wdb, char* name, char* ip);
  *
  * @param [in] wdb The Global struct database.
  * @param [in] id The agent ID
- * @param [in] status The value of sync_status
+ * @param [in] sync_status The value of sync_status
  * @return 0 On success. -1 On error.
  */
 int wdb_global_set_sync_status(wdb_t *wdb, int id, const char *sync_status);
@@ -1653,11 +1658,13 @@ wdbc_result wdb_global_get_all_agents(wdb_t *wdb, int* last_agent_id, char **out
  * @brief Function to reset connection_status column of every agent (excluding the manager).
  *        If connection_status is pending or connected it will be changed to disconnected.
  *        If connection_status is disconnected or never_connected it will not be changed.
+ *        It also set the 'sync_status' with the specified value.
  *
  * @param [in] wdb The Global struct database.
+ * @param [in] sync_status The value of sync_status.
  * @return 0 On success. -1 On error.
  */
-int wdb_global_reset_agents_connection(wdb_t *wdb);
+int wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_status);
 
 /**
  * @brief Function to get the id of every agent with a specific connection_status.

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -650,7 +650,14 @@ int wdb_parse(char * input, char * output) {
             }
         }
         else if (strcmp(query, "reset-agents-connection") == 0) {
-            result = wdb_parse_reset_agents_connection(wdb, output);
+            if (!next) {
+                mdebug1("Global DB Invalid DB query syntax for reset-agents-connection.");
+                mdebug2("Global DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                result = OS_INVALID;
+            } else {
+                result = wdb_parse_reset_agents_connection(wdb, next, output);
+            }
         }
         else if (strcmp(query, "get-agents-by-connection-status") == 0) {
             if (!next) {
@@ -4492,6 +4499,7 @@ int wdb_parse_global_update_connection_status(wdb_t * wdb, char * input, char * 
     const char *error = NULL;
     cJSON *j_id = NULL;
     cJSON *j_connection_status = NULL;
+    cJSON *j_sync_status = NULL;
 
     agent_data = cJSON_ParseWithOpts(input, &error, TRUE);
     if (!agent_data) {
@@ -4502,13 +4510,15 @@ int wdb_parse_global_update_connection_status(wdb_t * wdb, char * input, char * 
     } else {
         j_id = cJSON_GetObjectItem(agent_data, "id");
         j_connection_status = cJSON_GetObjectItem(agent_data, "connection_status");
+        j_sync_status = cJSON_GetObjectItem(agent_data, "sync_status");
 
-        if (cJSON_IsNumber(j_id) && cJSON_IsString(j_connection_status)) {
+        if (cJSON_IsNumber(j_id) && cJSON_IsString(j_connection_status) && cJSON_IsString(j_sync_status)) {
             // Getting each field
             int id = j_id->valueint;
             char *connection_status = j_connection_status->valuestring;
+            char *sync_status = j_sync_status->valuestring;
 
-            if (OS_SUCCESS != wdb_global_update_agent_connection_status(wdb, id, connection_status)) {
+            if (OS_SUCCESS != wdb_global_update_agent_connection_status(wdb, id, connection_status, sync_status)) {
                 mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB_GLOB_NAME, sqlite3_errmsg(wdb->db));
                 snprintf(output, OS_MAXSTR + 1, "err Cannot execute Global database query; %s", sqlite3_errmsg(wdb->db));
                 cJSON_Delete(agent_data);
@@ -5038,8 +5048,8 @@ int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output) {
     return OS_SUCCESS;
 }
 
-int wdb_parse_reset_agents_connection(wdb_t * wdb, char * output) {
-    if (OS_SUCCESS != wdb_global_reset_agents_connection(wdb)) {
+int wdb_parse_reset_agents_connection(wdb_t * wdb, char* input, char * output) {
+    if (OS_SUCCESS != wdb_global_reset_agents_connection(wdb, input)) {
         mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB_GLOB_NAME, sqlite3_errmsg(wdb->db));
         snprintf(output, OS_MAXSTR + 1, "err Cannot execute Global database query; %s", sqlite3_errmsg(wdb->db));
         return OS_INVALID;


### PR DESCRIPTION
|Related issue|
|---|
| #6600 |

## Description

This PR includes all the necessary changes to make the `update-connection-status` and `reset-agents-connection` Wazuh DB commands be able to also set the `sync_status`.

In addition, the calls to these commands were updated in order to properly set the `sync_status`.

For more details check the **requirements** section of issue #6600.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade