### PR TITLE
Fix GET /manager/configuration/validation timeout issue

### DIFF
--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -274,7 +274,7 @@ def validate_ossec_conf():
             api_socket = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
             api_socket.bind(api_socket_path)
             # Timeout
-            api_socket.settimeout(5)
+            api_socket.settimeout(10)
         except OSError as e:
             extra_msg = f'Socket: WAZUH_PATH/{api_socket_relative_path}. Error: {e.strerror}'
             raise WazuhInternalError(1013, extra_message=extra_msg)


### PR DESCRIPTION
Hello team,

this PR closes #6530. It fixes the issue related to  `GET /manager/configuration/validation` reported by an user. The problem was the Configuration validation process performed in Core may take more than 5 seconds to finish if executed in a slow environment. The solution, as discusses with the team, is to increment our API socket timeout value from 5s to 10s. See the issue for more details.

This change applies to `validation` function in `manager.py`, so only `GET /manager/configuration/validation` and `GET /cluster/configuration/validation` would be affected by this.

