### PR TITLE
Improve local_server.py code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
   - Refactored framework to work with new upgrade module. ([#5537](https://github.com/wazuh/wazuh/issues/5537))
   - Refactored agent upgrade CLI to work with new ugprade module. It distributes petitions in a clustered environment. ([#5675](https://github.com/wazuh/wazuh/issues/5675))
   - Changed rule and decoder details structure to support PCRE2. ([#6318](https://github.com/wazuh/wazuh/issues/6318))
+  - Improved LocalServer code and added agent key polling methods. ([#6477](https://github.com/wazuh/wazuh/issues/6477))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ All notable changes to this project will be documented in this file.
   - Refactored framework to work with new upgrade module. ([#5537](https://github.com/wazuh/wazuh/issues/5537))
   - Refactored agent upgrade CLI to work with new ugprade module. It distributes petitions in a clustered environment. ([#5675](https://github.com/wazuh/wazuh/issues/5675))
   - Changed rule and decoder details structure to support PCRE2. ([#6318](https://github.com/wazuh/wazuh/issues/6318))
-  - Improved LocalServer code and added agent key polling methods. ([#6477](https://github.com/wazuh/wazuh/issues/6477))
 
 ### Changed
 


### PR DESCRIPTION
|Related issue|
|---|
|#6477|

## Description

Hello team!

This PR migrates and implement the changes for `local_server.py` module performed in [this commit](https://github.com/wazuh/wazuh/pull/4481/files#diff-55e3d7666b4b0af6c1062a11e457614093f7d00844adc6ddb222837db45cd6da).  

It includes:
- Improvements in the code and its organization.
- Methods used for agent key polling.

## Tests
### Integration tests
#### test_cluster_endpoints.tavern.yaml
```
pytest -vv test_cluster_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-53-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 56 items                                                                                                                                                                                           

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                                                                   [  1%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                                                    [  3%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                                                     [  5%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                                                          [  7%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                                                                                             [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                                                                                                 [ 10%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                                                                                                 [ 12%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                                                                                               [ 14%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                                                                                             [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                                                                                             [ 17%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                                                                                                          [ 19%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                                                         [ 21%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                                                        [ 23%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                                                       [ 25%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                                                     [ 26%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/api/config PASSED                                                                                                                                     [ 28%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/api/config PASSED                                                                                                                                  [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                                                            [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[master-node] PASSED                                                                                                                   [ 33%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[worker1] PASSED                                                                                                                       [ 35%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[worker2] PASSED                                                                                                                       [ 37%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[master-node] PASSED                                                                                                                [ 39%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[worker1] PASSED                                                                                                                    [ 41%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[worker2] PASSED                                                                                                                    [ 42%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[master-node] PASSED                                                                                                                   [ 44%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[worker1] PASSED                                                                                                                       [ 46%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[worker2] PASSED                                                                                                                       [ 48%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/wrong_node/files PASSED                                                                                                                               [ 50%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                                                                                                    [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                                                                                                        [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                                                                                                        [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                                                                                                    [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                                                                                                        [ 58%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                                                                                                        [ 60%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                                                                                                [ 62%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                                                                                                [ 64%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                                                                                                   [ 66%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                                                                                                       [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                                                                                                       [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                                                                                               [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                                                                                                         [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                                                                                                             [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                                                                                                             [ 76%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                                                                                            [ 78%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                                                                                                [ 80%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                                                                                                [ 82%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                                                                                                           [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                                                                                               [ 85%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                                                                                               [ 87%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                                                                                            [ 89%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                                                                                                [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                                                                                                [ 92%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                                                                                                  [ 94%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                                                                                                      [ 96%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                                                                                                      [ 98%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                                                        [100%]

================================================================================ 56 passed, 72 warnings in 260.19s (0:04:20) =================================================================================
```

### Unittests
```
python3 -m pytest wazuh/core/cluster/tests/
=============================================== test session starts ===============================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 55 items                                                                                                

wazuh/core/cluster/tests/test_cluster.py ...................                                                [ 34%]
wazuh/core/cluster/tests/test_common.py .......                                                             [ 47%]
wazuh/core/cluster/tests/test_control.py .....                                                              [ 56%]
wazuh/core/cluster/tests/test_local_client.py .                                                             [ 58%]
wazuh/core/cluster/tests/test_utils.py .......                                                              [ 70%]
wazuh/core/cluster/tests/test_worker.py ................                                                    [100%]

========================================= 55 passed, 2 warnings in 0.41s ==========================================
```

Regards,
Selu.