### PR TITLE
[API] Raise the correct exception when trying to remove an admin user

### DIFF
--- a/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
@@ -542,7 +542,7 @@ stages:
           affected_items: []
           failed_items:
             - error:
-                code: 5008
+                code: 5004
               id:
                 - 99
           total_affected_items: 0

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -16,7 +16,7 @@ from wazuh.core.utils import process_array
 from wazuh.rbac.decorators import expose_resources
 from wazuh.rbac.orm import AuthenticationManager, PoliciesManager, RolesManager, RolesPoliciesManager, \
     TokenManager, UserRolesManager, RolesRulesManager, RulesManager
-from wazuh.rbac.orm import SecurityError
+from wazuh.rbac.orm import SecurityError, max_id_reserved
 
 # Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character:
 _user_password = re.compile(r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$')
@@ -210,7 +210,7 @@ def remove_users(user_ids):
         for user_id in user_ids:
             user_id = int(user_id)
             current_user = auth.get_user(common.current_user.get())
-            if not isinstance(current_user, bool) and user_id == int(current_user['id']):
+            if not isinstance(current_user, bool) and user_id == int(current_user['id']) and user_id > max_id_reserved:
                 result.add_failed_item(id_=user_id, error=WazuhError(5008))
                 continue
             user = auth.get_user_id(user_id)

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -395,7 +395,7 @@ get_rbac_actions:
           - GET /lists
           - GET /lists/files
       logtest:run:
-        description: Use logtest tool
+        description: Run logtest tool or end a logtest session
         resources:
           - "*:*"
         example:


### PR DESCRIPTION
Hello team, 
this closes #6636 .

As reported, trying to remove the user you are logged (being an admin user) would raise a generic exception. Now we are handling it properly:

## New user trying to remove itself

### Request
```
curl --request DELETE \
  --url 'https://localhost:55050/security/users?user_ids=100&wait_for_complete=true' \
  --header 'authorization: Bearer <TOKEN>'
```

### API response
```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 5008,
          "message": "The current user cannot be deleted",
          "remediation": "You can delete this user with the administrator user (wazuh) or any other user with the necessary permissions"
        },
        "id": [
          100
        ]
      }
    ]
  },
  "message": "No user was deleted",
  "error": 1
}
```

## Admin user trying to remove itself

### Request
```
curl --request DELETE \
  --url 'https://localhost:55050/security/users?user_ids=1&wait_for_complete=true' \
  --header 'authorization: Bearer <TOKEN>'
```

### API response
```json
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 5004,
          "message": "The user could not be removed or updated",
          "remediation": "Administrator users cannot be removed or updated"
        },
        "id": [
          1
        ]
      }
    ]
  },
  "message": "No user was deleted",
  "error": 1
}
```

# Test results
## Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 69 items                                                                                                                                                                          

framework/wazuh/tests/test_security.py .....................................................................                                                                          [100%]

============================================================================= 69 passed, 12 warnings in 53.05s ==============================================================================

```

## Integration tests
```
test_security_DELETE_endpoints
	 15 passed, 17 warnings

test_security_GET_endpoints
	 18 passed, 21 warnings

test_security_POST_endpoints
	 6 passed, 8 warnings

test_security_PUT_endpoints
	 8 passed, 10 warnings

```

## Integration tests (QA)
These tests were performed with the changes in https://github.com/wazuh/wazuh-qa/pull/935

```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.6.8, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /vagrant/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.10.0, html-2.0.1, testinfra-5.0.0
collected 16 items                                                                                                                                                                          

test_rbac/test_add_old_resource.py ....                                                                                                                                               [ 25%]
test_rbac/test_admin_resources.py ....                                                                                                                                                [ 50%]
test_rbac/test_policy_position.py .                                                                                                                                                   [ 56%]
test_rbac/test_remove_relationship.py ...                                                                                                                                             [ 75%]
test_rbac/test_remove_resource.py ....                                                                                                                                                [100%]

============================================================================= 16 passed, 16 warnings in 53.48s ==============================================================================
```

Regards,
Víctor.