### PR TITLE
Add task actor to wazuh_db and the structure of the parser function for each command of task manager.

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -224,6 +224,8 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define WDB_GLOB_NAME   "global"
 #define WDB_MITRE_NAME  "mitre"
 #define WDB_PROF_NAME   ".template.db"
+#define WDB_TASK_DIR    "queue/tasks"
+#define WDB_TASK_NAME   "tasks"
 
 /* Diff queue */
 #ifndef WIN32

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -342,6 +342,13 @@ end:
     return wdb;
 }
 
+// Opens tasks database and stores it in DB pool. It returns a locked database or NULL
+wdb_t * wdb_open_tasks() {
+    wdb_t * wdb = NULL;
+    /* Add open task db logic */
+    return wdb;
+}
+
 /* Create database for agent from profile. Returns 0 on success or -1 on error. */
 int wdb_create_agent_db2(const char * agent_id) {
     char path[OS_FLSIZE + 1];

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -285,6 +285,15 @@ sqlite3* wdb_open_agent(int id_agent, const char *name);
 // Open database for agent and store in DB pool. It returns a locked database or NULL
 wdb_t * wdb_open_agent2(int agent_id);
 
+/**
+ * @brief Open task database and store in DB poll.
+ *
+ * It is opened every time a query to Task database is done.
+ *
+ * @return wdb_t* Database Structure that store task database or NULL on failure.
+ */
+wdb_t * wdb_open_tasks();
+
 /* Get agent name from location string */
 char* wdb_agent_loc2name(const char *location);
 
@@ -1688,5 +1697,93 @@ cJSON* wdb_global_get_agents_to_disconnect(wdb_t *wdb, int keep_alive);
  * @retval -1 The table "agent" is missing or an error occurred.
  */
 int wdb_global_check_manager_keepalive(wdb_t *wdb);
+
+/**
+ * @brief Function to parse the insert upgrade request.
+ *
+ * @param [in] wdb The global struct database.
+ * @param parameters JSON with the parameters
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+int wdb_parse_task_upgrade(wdb_t* wdb, const cJSON *parameters, char* output);
+
+/**
+ * @brief Function to parse the insert upgrade_custom request.
+ *
+ * @param [in] wdb The global struct database.
+ * @param parameters JSON with the parameters
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+int wdb_parse_task_upgrade_custom(wdb_t* wdb, const cJSON *parameters, char* output);
+
+/**
+ * @brief Function to parse the upgrade_get_status request.
+ *
+ * @param [in] wdb The global struct database.
+ * @param parameters JSON with the parameters
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+int wdb_parse_task_upgrade_get_status(wdb_t* wdb, const cJSON *parameters, char* output);
+
+/**
+ * @brief Function to parse the upgrade_update_status request.
+ *
+ * @param [in] wdb The global struct database.
+ * @param parameters JSON with the parameters
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+int wdb_parse_task_upgrade_update_status(wdb_t* wdb, const cJSON *parameters, char* output);
+
+/**
+ * @brief Function to parse the upgrade_result request.
+ *
+ * @param [in] wdb The global struct database.
+ * @param parameters JSON with the parameters
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+int wdb_parse_task_upgrade_result(wdb_t* wdb, const cJSON *parameters, char* output);
+
+/**
+ * @brief Function to parse the upgrade_cancel_tasks request.
+ *
+ * @param [in] wdb The global struct database.
+ * @param parameters JSON with the parameters
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+int wdb_parse_task_upgrade_cancel_tasks(wdb_t* wdb, const cJSON *parameters, char* output);
+
+/**
+ * @brief Function to parse the set_timeout request.
+ *
+ * @param [in] wdb The global struct database.
+ * @param parameters JSON with the parameters
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+int wdb_parse_task_set_timeout(wdb_t* wdb, const cJSON *parameters, char* output);
+
+/**
+ * @brief Function to parse the delete_old request.
+ *
+ * @param [in] wdb The global struct database.
+ * @param parameters JSON with the parameters
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output);
 
 #endif

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -670,6 +670,186 @@ int wdb_parse(char * input, char * output) {
         }
         wdb_leave(wdb);
         return result;
+    } else if (strcmp(actor, "task") == 0) {
+        cJSON *parameters_json = NULL;
+        const char *json_err;
+        query = next;
+
+        mdebug2("Task query: %s", query);
+
+        if (wdb = wdb_open_tasks(), !wdb) {
+            mdebug2("Couldn't open DB task: %s/%s.db", WDB_TASK_DIR, WDB_TASK_NAME);
+            snprintf(output, OS_MAXSTR + 1, "err Couldn't open DB task");
+            return OS_INVALID;
+        }
+
+        if (next = wstr_chr(query, ' '), !next) {
+            mdebug1("Invalid DB query syntax.");
+            mdebug2("DB query error near: %s", query);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+            wdb_leave(wdb);
+            return OS_INVALID;
+        }
+
+        *next++ = '\0';
+
+        if (!strcmp("upgrade", query)) {
+            if (!next) {
+                mdebug1("Task DB Invalid DB query syntax.");
+                mdebug2("Task DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+
+            // Detect parameters
+            if (parameters_json = cJSON_ParseWithOpts(next, &json_err, 0), !parameters_json) {
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+            result = wdb_parse_task_upgrade(wdb, parameters_json, output);
+            cJSON_Delete(parameters_json);
+        } else if (!strcmp("upgrade_custom", query)) {
+            if (!next) {
+                mdebug1("Task DB Invalid DB query syntax.");
+                mdebug2("Task DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+
+            // Detect parameters
+            if (parameters_json = cJSON_ParseWithOpts(next, &json_err, 0), !parameters_json) {
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+            result = wdb_parse_task_upgrade_custom(wdb, parameters_json, output);
+            cJSON_Delete(parameters_json);
+        } else if (!strcmp("upgrade_get_status", query)) {
+            if (!next) {
+                mdebug1("Task DB Invalid DB query syntax.");
+                mdebug2("Task DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+
+            // Detect parameters
+            if (parameters_json = cJSON_ParseWithOpts(next, &json_err, 0), !parameters_json) {
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+            result = wdb_parse_task_upgrade_get_status(wdb, parameters_json, output);
+            cJSON_Delete(parameters_json);
+        } else if (!strcmp("upgrade_update_status", query)) {
+            if (!next) {
+                mdebug1("Task DB Invalid DB query syntax.");
+                mdebug2("Task DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+
+            // Detect parameters
+            if (parameters_json = cJSON_ParseWithOpts(next, &json_err, 0), !parameters_json) {
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+            result = wdb_parse_task_upgrade_update_status(wdb, parameters_json, output);
+            cJSON_Delete(parameters_json);
+        } else if (!strcmp("upgrade_result", query)) {
+            if (!next) {
+                mdebug1("Task DB Invalid DB query syntax.");
+                mdebug2("Task DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+
+            // Detect parameters
+            if (parameters_json = cJSON_ParseWithOpts(next, &json_err, 0), !parameters_json) {
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+            result = wdb_parse_task_upgrade_result(wdb, parameters_json, output);
+            cJSON_Delete(parameters_json);
+        } else if (!strcmp("upgrade_cancel_tasks", query)) {
+            if (!next) {
+                mdebug1("Task DB Invalid DB query syntax.");
+                mdebug2("Task DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+
+            // Detect parameters
+            if (parameters_json = cJSON_ParseWithOpts(next, &json_err, 0), !parameters_json) {
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+            result = wdb_parse_task_upgrade_cancel_tasks(wdb, parameters_json, output);
+            cJSON_Delete(parameters_json);
+        } else if (!strcmp("set_timeout", query)) {
+            if (!next) {
+                mdebug1("Task DB Invalid DB query syntax.");
+                mdebug2("Task DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+
+            // Detect parameters
+            if (parameters_json = cJSON_ParseWithOpts(next, &json_err, 0), !parameters_json) {
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+            result = wdb_parse_task_set_timeout(wdb, parameters_json, output);
+            cJSON_Delete(parameters_json);
+        } else if (!strcmp("delete_old", query)) {
+            if (!next) {
+                mdebug1("Task DB Invalid DB query syntax.");
+                mdebug2("Task DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+
+            // Detect parameters
+            if (parameters_json = cJSON_ParseWithOpts(next, &json_err, 0), !parameters_json) {
+                wdb_leave(wdb);
+                return OS_INVALID;
+            }
+            result = wdb_parse_task_delete_old(wdb, parameters_json, output);
+            cJSON_Delete(parameters_json);
+        } else if (!strcmp("sql", query)) {
+            if (!next) {
+                mdebug1("Task DB Invalid DB query syntax.");
+                mdebug2("Task DB query error near: %s", query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+                result = OS_INVALID;
+            } else {
+                sql = next;
+
+                if (data = wdb_exec(wdb->db, sql), data) {
+                    out = cJSON_PrintUnformatted(data);
+                    snprintf(output, OS_MAXSTR + 1, "ok %s", out);
+                    os_free(out);
+                    cJSON_Delete(data);
+                } else {
+                    mdebug1("Tasks DB Cannot execute SQL query; err database %s/%s.db: %s", WDB_TASK_DIR, WDB_TASK_NAME, sqlite3_errmsg(wdb->db));
+                    mdebug2("Tasks DB SQL query: %s", sql);
+                    snprintf(output, OS_MAXSTR + 1, "err Cannot execute Tasks database query; %s", sqlite3_errmsg(wdb->db));
+                    result = OS_INVALID;
+                }
+            }
+        } else {
+            mdebug1("Invalid DB query syntax.");
+            mdebug2("Task DB query error near: %s", query);
+            snprintf(output, OS_MAXSTR + 1, "err Invalid DB query syntax, near '%.32s'", query);
+            result = OS_INVALID;
+        }
+        wdb_leave(wdb);
+        return result;
     } else {
         mdebug1("DB(%s) Invalid DB query actor: %s", sagent_id, actor);
         snprintf(output, OS_MAXSTR + 1, "err Invalid DB query actor: '%.32s'", actor);
@@ -5088,5 +5268,37 @@ int wdb_parse_global_disconnect_agents(wdb_t* wdb, char* input, char* output) {
     os_free(out);
     cJSON_Delete(agents);
 
+    return OS_SUCCESS;
+}
+
+int wdb_parse_task_upgrade(wdb_t* wdb, const cJSON *parameters, char* output) {
+    return OS_SUCCESS;
+}
+
+int wdb_parse_task_upgrade_custom(wdb_t* wdb, const cJSON *parameters, char* output) {
+    return OS_SUCCESS;
+}
+
+int wdb_parse_task_upgrade_get_status(wdb_t* wdb, const cJSON *parameters, char* output) {
+    return OS_SUCCESS;
+}
+
+int wdb_parse_task_upgrade_update_status(wdb_t* wdb, const cJSON *parameters, char* output) {
+    return OS_SUCCESS;
+}
+
+int wdb_parse_task_upgrade_result(wdb_t* wdb, const cJSON *parameters, char* output) {
+    return OS_SUCCESS;
+}
+
+int wdb_parse_task_upgrade_cancel_tasks(wdb_t* wdb, const cJSON *parameters, char* output) {
+    return OS_SUCCESS;
+}
+
+int wdb_parse_task_set_timeout(wdb_t* wdb, const cJSON *parameters, char* output) {
+    return OS_SUCCESS;
+}
+
+int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output) {
     return OS_SUCCESS;
 }


### PR DESCRIPTION
|Related issue|
|---|
|#6619|

This PR add:

- "task" actor to wdb_parser() function.

- Structure of the parser function for each command of task manager.

- Structure of wdb_open_tasks() function to open tasks db.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

