### PR TITLE
Unify chunks logic on WazuhDB

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -36,8 +36,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
 
 list(APPEND wdb_tests_names "test_wdb_global")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
-                            -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 \
-                            -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,wdb_step -Wl,--wrap,sqlite3_bind_text \
+                            -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int \
+                            -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,wdb_exec_stmt_sized -Wl,--wrap,wdb_step -Wl,--wrap,sqlite3_bind_text \
                             -Wl,--wrap,sqlite3_bind_parameter_index -Wl,--wrap,cJSON_Delete -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int")
 
 list(APPEND wdb_tests_names "test_wdb_agent")

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -55,7 +55,9 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
 list(APPEND wdb_tests_names "test_wdb")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,pthread_mutex_lock \
                              -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Delete_ex \
-                             -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_close_v2")
+                             -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_close_v2 -Wl,--wrap,sqlite3_step \
+                             -Wl,--wrap,sqlite3_column_count -Wl,--wrap,sqlite3_column_type -Wl,--wrap,sqlite3_column_name -Wl,--wrap,sqlite3_column_double \
+                             -Wl,--wrap,sqlite3_column_text")
 
 list(APPEND wdb_tests_names "test_wdb_upgrade")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,wdb_metadata_table_check \

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -4264,6 +4264,7 @@ void test_wdb_agent_belongs_first_time_success(void **state) {
 
     __real_cJSON_Delete(root);
     __real_cJSON_Delete(root2);
+    __real_cJSON_Delete(test_json);
     __real_cJSON_Delete(id1);
 }
 

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -4619,7 +4619,11 @@ void test_wdb_disconnect_agents_success(void **state) {
 
     // Setting the payload
     set_payload = 1;
-    strncpy(test_payload, "ok 1,2,3", 9);
+    strcpy(test_payload, "ok [{\"id\":1},{\"id\":2},{\"id\":3}]");
+    cJSON* test_json = __real_cJSON_Parse(test_payload+3);
+    cJSON* id1 = cJSON_CreateNumber(1);
+    cJSON* id2 = cJSON_CreateNumber(2);
+    cJSON* id3 = cJSON_CreateNumber(3);
 
     // Calling Wazuh DB
     expect_any(__wrap_wdbc_query_ex, *sock);
@@ -4631,15 +4635,136 @@ void test_wdb_disconnect_agents_success(void **state) {
     // Parsing Wazuh DB result
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
+    will_return(__wrap_cJSON_Parse, test_json);
+    will_return(__wrap_cJSON_GetObjectItem, id1);
+    will_return(__wrap_cJSON_GetObjectItem, id2);
+    will_return(__wrap_cJSON_GetObjectItem, id3);
+    //JJP: Shouldnt cJSON_Delete wrapper call the __real?
+    expect_function_call(__wrap_cJSON_Delete);
 
     int *array = wdb_disconnect_agents(100, "syncreq", NULL);
 
+    assert_non_null(array);
     assert_int_equal(1, array[0]);
     assert_int_equal(2, array[1]);
     assert_int_equal(3, array[2]);
     assert_int_equal(-1, array[3]);
 
     os_free(array);
+    __real_cJSON_Delete(test_json);
+    __real_cJSON_Delete(id1);
+    __real_cJSON_Delete(id2);
+    __real_cJSON_Delete(id3);
+
+    // Cleaning payload
+    set_payload = 0;
+    memset(test_payload, '\0', OS_MAXSTR);
+}
+
+/* Tests wdb_parse_chunk_to_int */
+
+void test_wdb_parse_chunk_to_int_ok(void **state) {
+    int* array = NULL;
+    int last_item = 0;
+    int last_len = 0;
+
+    // Setting the payload
+    set_payload = 1;
+    strcpy(test_payload, "ok [{\"id\":1}]");
+    cJSON* test_json = __real_cJSON_Parse(test_payload+3);
+    cJSON* id1 = cJSON_CreateNumber(1);
+
+    // Parsing result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+    will_return(__wrap_cJSON_Parse, test_json);
+    will_return(__wrap_cJSON_GetObjectItem, id1);
+    //JJP: Shouldnt cJSON_Delete wrapper call the __real?
+    expect_function_call(__wrap_cJSON_Delete);
+
+    wdbc_result status = wdb_parse_chunk_to_int(test_payload, &array, "id", &last_item, &last_len);
+
+    assert_int_equal(WDBC_OK, status);
+    assert_non_null(array);
+    assert_int_equal(1, array[0]);
+
+    os_free(array);
+    __real_cJSON_Delete(test_json);
+    __real_cJSON_Delete(id1);
+
+    // Cleaning payload
+    set_payload = 0;
+    memset(test_payload, '\0', OS_MAXSTR);
+}
+
+void test_wdb_parse_chunk_to_int_due(void **state) {
+    int* array = NULL;
+    int last_item = 0;
+    int last_len = 0;
+
+    // Setting the payload
+    set_payload = 1;
+    strcpy(test_payload, "due [{\"id\":1}]");
+    cJSON* test_json1 = __real_cJSON_Parse(test_payload+4);
+    cJSON* id1 = cJSON_CreateNumber(1);
+
+    // Parsing result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_DUE);
+    will_return(__wrap_cJSON_Parse, test_json1);
+    will_return(__wrap_cJSON_GetObjectItem, id1);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    wdbc_result status = wdb_parse_chunk_to_int(test_payload, &array, "id", &last_item, &last_len);
+    assert_int_equal(WDBC_DUE, status);
+
+    // Setting second payload
+    strcpy(test_payload, "ok [{\"id\":2}]");
+    cJSON* test_json2 = __real_cJSON_Parse(test_payload+3);
+    cJSON* id2 = cJSON_CreateNumber(2);
+    // Parsing result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+    will_return(__wrap_cJSON_Parse, test_json2);
+    will_return(__wrap_cJSON_GetObjectItem, id2);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    status = wdb_parse_chunk_to_int(test_payload, &array, "id", &last_item, &last_len);
+    assert_int_equal(WDBC_OK, status);
+    assert_non_null(array);
+    assert_int_equal(1, array[0]);
+    assert_int_equal(2, array[1]);
+    assert_int_equal(-1, array[2]);
+
+    os_free(array);
+    __real_cJSON_Delete(test_json1);
+    __real_cJSON_Delete(id1);
+    __real_cJSON_Delete(test_json2);
+    __real_cJSON_Delete(id2);
+
+    // Cleaning payload
+    set_payload = 0;
+    memset(test_payload, '\0', OS_MAXSTR);
+}
+
+void test_wdb_parse_chunk_to_int_err(void **state) {
+    int* array = NULL;
+    int last_item = 0;
+    int last_len = 0;
+
+    // Setting the payload
+    set_payload = 1;
+    strcpy(test_payload, "ok [{\"id\":1}]");
+
+    // Parsing result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+    will_return(__wrap_cJSON_Parse, NULL);
+
+    wdbc_result status = wdb_parse_chunk_to_int(test_payload, &array, "id", &last_item, &last_len);
+
+    assert_int_equal(WDBC_ERROR, status);
+    assert_null(array);
 
     // Cleaning payload
     set_payload = 0;
@@ -4803,6 +4928,10 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_disconnect_agents_wdbc_query_error, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_disconnect_agents_wdbc_parse_error, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_disconnect_agents_success, setup_wdb_agent, teardown_wdb_agent),
+        /* Tests wdb_parse_chunk_to_int */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_int_ok, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_int_due, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_chunk_to_int_err, setup_wdb_agent, teardown_wdb_agent),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -2712,7 +2712,11 @@ void test_wdb_get_all_agents_success(void **state) {
 
     // Setting the payload
     set_payload = 1;
-    strncpy(test_payload, "ok 1,2,3\0", 9);
+    strcpy(test_payload, "ok [{\"id\":1},{\"id\":2},{\"id\":3}]");
+    cJSON* test_json = __real_cJSON_Parse(test_payload+3);
+    cJSON* id1 = cJSON_CreateNumber(1);
+    cJSON* id2 = cJSON_CreateNumber(2);
+    cJSON* id3 = cJSON_CreateNumber(3);
 
     // Calling Wazuh DB
     expect_any(__wrap_wdbc_query_ex, *sock);
@@ -2724,15 +2728,25 @@ void test_wdb_get_all_agents_success(void **state) {
     // Parsing Wazuh DB result
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
+    will_return(__wrap_cJSON_Parse, test_json);
+    will_return(__wrap_cJSON_GetObjectItem, id1);
+    will_return(__wrap_cJSON_GetObjectItem, id2);
+    will_return(__wrap_cJSON_GetObjectItem, id3);
+    expect_function_call(__wrap_cJSON_Delete);
 
     int *array = wdb_get_all_agents(false, NULL);
 
+    assert_non_null(array);
     assert_int_equal(1, array[0]);
     assert_int_equal(2, array[1]);
     assert_int_equal(3, array[2]);
     assert_int_equal(-1, array[3]);
 
     os_free(array);
+    __real_cJSON_Delete(test_json);
+    __real_cJSON_Delete(id1);
+    __real_cJSON_Delete(id2);
+    __real_cJSON_Delete(id3);
 
     // Cleaning payload
     set_payload = 0;
@@ -4147,7 +4161,9 @@ void test_wdb_agent_belongs_first_time_success(void **state) {
 
     // Setting the payload
     set_payload = 1;
-    strncpy(test_payload, "ok 1", 8);
+    strcpy(test_payload, "ok [{\"id\":1}]");
+    cJSON* test_json = __real_cJSON_Parse(test_payload+3);
+    cJSON* id1 = cJSON_CreateNumber(1);
 
     // Calling Wazuh DB
     expect_any(__wrap_wdbc_query_ex, *sock);
@@ -4159,6 +4175,9 @@ void test_wdb_agent_belongs_first_time_success(void **state) {
     // Parsing Wazuh DB result
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
+    will_return(__wrap_cJSON_Parse, test_json);
+    will_return(__wrap_cJSON_GetObjectItem, id1);
+    expect_function_call(__wrap_cJSON_Delete);
 
     //// Call to wdb_get_agent_group
     cJSON *root = NULL;
@@ -4245,6 +4264,7 @@ void test_wdb_agent_belongs_first_time_success(void **state) {
 
     __real_cJSON_Delete(root);
     __real_cJSON_Delete(root2);
+    __real_cJSON_Delete(id1);
 }
 
 /* Tests get_agent_date_added */
@@ -4469,7 +4489,7 @@ void test_wdb_reset_agents_connection_success(void **state)
 
 /* Tests wdb_get_agents_by_connection_status */
 
-void test_wdb_get_agents_by_connection_status_query_response(void **state)
+void test_wdb_get_agents_by_connection_status_query_error(void **state)
 {
     const char *query_str = "global get-agents-by-connection-status 0 active";
     const char *response = "err";
@@ -4507,50 +4527,17 @@ void test_wdb_get_agents_by_connection_status_parse_error(void **state)
     assert_null(array);
 }
 
-void test_wdb_get_agents_by_connection_status_due_query_success(void **state)
-{
-    const char *query_str1 = "global get-agents-by-connection-status 0 active";
-    const char *query_str2 = "global get-agents-by-connection-status 2 active";
-    const char *response1 = "due 1,2";
-    const char *response2 = "ok 3,4";
-
-    // Calling Wazuh DB first time
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str1);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response1);
-    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
-
-    // Calling Wazuh DB second time
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str2);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response2);
-    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
-
-    // Parsing Wazuh DB result
-    expect_any_count(__wrap_wdbc_parse_result, result, -1);
-    will_return(__wrap_wdbc_parse_result, WDBC_DUE);
-    will_return(__wrap_wdbc_parse_result, WDBC_OK);
-
-    int *array = wdb_get_agents_by_connection_status("active", NULL);
-
-    assert_non_null(array);
-    assert_int_equal(1, array[0]);
-    assert_int_equal(2, array[1]);
-    assert_int_equal(3, array[2]);
-    assert_int_equal(4, array[3]);
-    assert_int_equal(-1, array[4]);
-    os_free(array);
-}
-
 void test_wdb_get_agents_by_connection_status_success(void **state)
 {
     const char *query_str = "global get-agents-by-connection-status 0 active";
 
     // Setting the payload
     set_payload = 1;
-    strncpy(test_payload, "ok 1,2\0", 9);
+    strcpy(test_payload, "ok [{\"id\":1},{\"id\":2},{\"id\":3}]");
+    cJSON* test_json = __real_cJSON_Parse(test_payload+3);
+    cJSON* id1 = cJSON_CreateNumber(1);
+    cJSON* id2 = cJSON_CreateNumber(2);
+    cJSON* id3 = cJSON_CreateNumber(3);
 
     // Calling Wazuh DB
     expect_any(__wrap_wdbc_query_ex, *sock);
@@ -4562,14 +4549,25 @@ void test_wdb_get_agents_by_connection_status_success(void **state)
     // Parsing Wazuh DB result
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
+    will_return(__wrap_cJSON_Parse, test_json);
+    will_return(__wrap_cJSON_GetObjectItem, id1);
+    will_return(__wrap_cJSON_GetObjectItem, id2);
+    will_return(__wrap_cJSON_GetObjectItem, id3);
+    expect_function_call(__wrap_cJSON_Delete);
 
     int *array = wdb_get_agents_by_connection_status("active", NULL);
 
     assert_non_null(array);
     assert_int_equal(1, array[0]);
     assert_int_equal(2, array[1]);
-    assert_int_equal(-1, array[2]);
+    assert_int_equal(3, array[2]);
+    assert_int_equal(-1, array[3]);
+
     os_free(array);
+    __real_cJSON_Delete(test_json);
+    __real_cJSON_Delete(id1);
+    __real_cJSON_Delete(id2);
+    __real_cJSON_Delete(id3);
 
     // Cleaning payload
     set_payload = 0;
@@ -4918,10 +4916,9 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_reset_agents_connection_error_result, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_reset_agents_connection_success, setup_wdb_agent, teardown_wdb_agent),
         /* Tests wdb_get_agents_by_connection_status */
-        cmocka_unit_test_setup_teardown(test_wdb_get_agents_by_connection_status_query_response, setup_wdb_agent, teardown_wdb_agent),
+        cmocka_unit_test_setup_teardown(test_wdb_get_agents_by_connection_status_query_error, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_get_agents_by_connection_status_parse_error, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_get_agents_by_connection_status_success, setup_wdb_agent, teardown_wdb_agent),
-        cmocka_unit_test_setup_teardown(test_wdb_get_agents_by_connection_status_due_query_success, setup_wdb_agent, teardown_wdb_agent),
         /* Tests wdb_disconnect_agents */
         cmocka_unit_test_setup_teardown(test_wdb_disconnect_agents_wdbc_query_error, setup_wdb_agent, teardown_wdb_agent),
         cmocka_unit_test_setup_teardown(test_wdb_disconnect_agents_wdbc_parse_error, setup_wdb_agent, teardown_wdb_agent),

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -4639,7 +4639,6 @@ void test_wdb_disconnect_agents_success(void **state) {
     will_return(__wrap_cJSON_GetObjectItem, id1);
     will_return(__wrap_cJSON_GetObjectItem, id2);
     will_return(__wrap_cJSON_GetObjectItem, id3);
-    //JJP: Shouldnt cJSON_Delete wrapper call the __real?
     expect_function_call(__wrap_cJSON_Delete);
 
     int *array = wdb_disconnect_agents(100, "syncreq", NULL);
@@ -4679,7 +4678,6 @@ void test_wdb_parse_chunk_to_int_ok(void **state) {
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
     will_return(__wrap_cJSON_Parse, test_json);
     will_return(__wrap_cJSON_GetObjectItem, id1);
-    //JJP: Shouldnt cJSON_Delete wrapper call the __real?
     expect_function_call(__wrap_cJSON_Delete);
 
     wdbc_result status = wdb_parse_chunk_to_int(test_payload, &array, "id", &last_item, &last_len);

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -4596,7 +4596,6 @@ void test_wdb_global_get_agent_info_success(void **state)
 void test_wdb_global_get_agents_to_disconnect_transaction_fail(void **state)
 {
     test_struct_t *data  = (test_struct_t *)*state;
-    char *output = NULL;
     int last_id = 0;
     int keepalive = 100;
     const char *sync_status = "synced";
@@ -4604,17 +4603,16 @@ void test_wdb_global_get_agents_to_disconnect_transaction_fail(void **state)
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &status);
 
-    assert_string_equal(output, "Cannot begin transaction");
-    os_free(output);
-    assert_int_equal(result, WDBC_ERROR);
+    assert_int_equal(status, WDBC_ERROR);
+    assert_null(result);
 }
 
 void test_wdb_global_get_agents_to_disconnect_cache_fail(void **state)
 {
     test_struct_t *data  = (test_struct_t *)*state;
-    char *output = NULL;
     int last_id = 0;
     int keepalive = 100;
     const char *sync_status = "synced";
@@ -4623,17 +4621,16 @@ void test_wdb_global_get_agents_to_disconnect_cache_fail(void **state)
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &status);
 
-    assert_string_equal(output, "Cannot cache statement");
-    os_free(output);
-    assert_int_equal(result, WDBC_ERROR);
+    assert_int_equal(status, WDBC_ERROR);
+    assert_null(result);
 }
 
 void test_wdb_global_get_agents_to_disconnect_bind1_fail(void **state)
 {
     test_struct_t *data  = (test_struct_t *)*state;
-    char *output = NULL;
     int last_id = 0;
     int keepalive = 100;
     const char *sync_status = "synced";
@@ -4646,17 +4643,16 @@ void test_wdb_global_get_agents_to_disconnect_bind1_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &status);
 
-    assert_string_equal(output, "Cannot bind sql statement");
-    os_free(output);
-    assert_int_equal(result, WDBC_ERROR);
+    assert_int_equal(status, WDBC_ERROR);
+    assert_null(result);
 }
 
 void test_wdb_global_get_agents_to_disconnect_bind2_fail(void **state)
 {
     test_struct_t *data  = (test_struct_t *)*state;
-    char *output = NULL;
     int last_id = 0;
     int keepalive = 100;
     const char *sync_status = "synced";
@@ -4672,195 +4668,202 @@ void test_wdb_global_get_agents_to_disconnect_bind2_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &status);
 
-    assert_string_equal(output, "Cannot bind sql statement");
-    os_free(output);
-    assert_int_equal(result, WDBC_ERROR);
+    assert_int_equal(status, WDBC_ERROR);
+    assert_null(result);
 }
 
-void test_wdb_global_get_agents_to_disconnect_no_agents(void **state)
+void test_wdb_global_get_agents_to_disconnect_ok(void **state)
 {
     test_struct_t *data  = (test_struct_t *)*state;
-    char *output = NULL;
+    const int agents_amount = 10;
     int last_id = 0;
     int keepalive = 0;
     const char *sync_status = "synced";
+    cJSON* root = cJSON_CreateArray();
+    for (int i=0; i<agents_amount; i++){
+        cJSON* json_agent = cJSON_CreateObject();
+        cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
+        cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(i));
+    }
 
+    //Preparing statement
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
-
     expect_value(__wrap_sqlite3_bind_int, index, 1);
     expect_value(__wrap_sqlite3_bind_int, value, last_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, keepalive);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-    will_return(__wrap_wdb_exec_stmt, NULL);
-    expect_function_call_any(__wrap_cJSON_Delete);
+    //Executing statement
+    expect_value(__wrap_wdb_exec_stmt_sized, max_size, WDB_MAX_RESPONSE_SIZE);
+    will_return(__wrap_wdb_exec_stmt_sized, SQLITE_DONE);
+    will_return(__wrap_wdb_exec_stmt_sized, root);
+    //Setting agents as disconnected
+    will_return_count(__wrap_wdb_begin2, 1, agents_amount);
+    will_return_count(__wrap_wdb_stmt_cache, 1, agents_amount);
+    expect_value_count(__wrap_sqlite3_bind_text, pos, 1, agents_amount);
+    expect_string_count(__wrap_sqlite3_bind_text, buffer, "disconnected", agents_amount);
+    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, agents_amount);
+    expect_value_count(__wrap_sqlite3_bind_int, index, 2, agents_amount);
+    expect_in_range_count(__wrap_sqlite3_bind_int, value, 0, agents_amount, agents_amount);
+    will_return_count(__wrap_sqlite3_bind_int, SQLITE_OK, agents_amount);
+    will_return_count(__wrap_wdb_step, SQLITE_DONE, agents_amount);
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &status);
 
-    assert_string_equal(output, "");
-    os_free(output);
-    assert_int_equal(result, WDBC_OK);
+    assert_int_equal(status, WDBC_OK);
+    assert_non_null(result);
+
+    __real_cJSON_Delete(root);
 }
 
-void test_wdb_global_get_agents_to_disconnect_success(void **state)
+void test_wdb_global_get_agents_to_disconnect_due(void **state)
 {
     test_struct_t *data  = (test_struct_t *)*state;
-    char *output = NULL;
-    cJSON *root = NULL;
-    cJSON *json_agent = NULL;
-    int agent_id = 10;
-    char str_agt_id[] = "10";
+    const int agents_amount = 10;
     int last_id = 0;
     int keepalive = 100;
     const char *sync_status = "synced";
+    cJSON* root = cJSON_CreateArray();
+    for (int i=0; i<agents_amount; i++){
+        cJSON* json_agent = cJSON_CreateObject();
+        cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
+        cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(i));
+    }
 
-    root = cJSON_CreateArray();
-    json_agent = cJSON_CreateObject();
-    cJSON_AddNumberToObject(json_agent, "id", agent_id);
-    cJSON_AddItemToArray(root, json_agent);
-
-    will_return_count(__wrap_wdb_begin2, 1, -1);
-    will_return_count(__wrap_wdb_stmt_cache, 1, -1);
-
+    //Preparing statement
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
     expect_value(__wrap_sqlite3_bind_int, value, last_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, keepalive);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    //Executing statement
+    expect_value(__wrap_wdb_exec_stmt_sized, max_size, WDB_MAX_RESPONSE_SIZE);
+    will_return(__wrap_wdb_exec_stmt_sized, SQLITE_ROW);
+    will_return(__wrap_wdb_exec_stmt_sized, root);
+    //Setting agents as disconnected
+    will_return_count(__wrap_wdb_begin2, 1, agents_amount);
+    will_return_count(__wrap_wdb_stmt_cache, 1, agents_amount);
+    expect_value_count(__wrap_sqlite3_bind_text, pos, 1, agents_amount);
+    expect_string_count(__wrap_sqlite3_bind_text, buffer, "disconnected", agents_amount);
+    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, agents_amount);
+    expect_value_count(__wrap_sqlite3_bind_int, index, 2, agents_amount);
+    expect_in_range_count(__wrap_sqlite3_bind_int, value, 0, agents_amount, agents_amount);
+    will_return_count(__wrap_sqlite3_bind_int, SQLITE_OK, agents_amount);
+    will_return_count(__wrap_wdb_step, SQLITE_DONE, agents_amount);
 
-    // Mocking one valid agent
-    will_return(__wrap_wdb_exec_stmt, root);
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &status);
 
-    // Required for wdb_global_update_agent_connection_status()
-    expect_value(__wrap_sqlite3_bind_text, pos, 1);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "disconnected");
-    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_text, pos, 2);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "synced");
-    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 3);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-    will_return(__wrap_wdb_step, SQLITE_DONE);
+    assert_int_equal(status, WDBC_DUE);
+    assert_non_null(result);
 
-    // No more agents
-    will_return(__wrap_wdb_exec_stmt, NULL);
-    expect_function_call_any(__wrap_cJSON_Delete);
+    __real_cJSON_Delete(root);
+}
 
+void test_wdb_global_get_agents_to_disconnect_err(void **state)
+{
+    test_struct_t *data  = (test_struct_t *)*state;
+    int last_id = 0;
+    int keepalive = 0;
+
+    //Preparing statement
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
+    expect_value(__wrap_sqlite3_bind_int, value, last_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, keepalive);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    //Executing statement
+    expect_value(__wrap_wdb_exec_stmt_sized, max_size, WDB_MAX_RESPONSE_SIZE);
+    will_return(__wrap_wdb_exec_stmt_sized, SQLITE_ERROR);
+    will_return(__wrap_wdb_exec_stmt_sized, NULL);
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &status);
 
-    assert_string_equal(output, str_agt_id);
-    os_free(output);
+    assert_int_equal(status, WDBC_ERROR);
+    assert_null(result);
+}
+
+void test_wdb_global_get_agents_to_disconnect_invalid_elements(void **state)
+{
+    test_struct_t *data  = (test_struct_t *)*state;
+    int last_id = 0;
+    int keepalive = 100;
+    const char *sync_status = "synced";
+    cJSON* root = cJSON_CreateArray();
+    cJSON* json_agent = cJSON_CreateObject();
+    cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
+
+    //Preparing statement
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, last_id);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_int, value, keepalive);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    //Executing statement
+    expect_value(__wrap_wdb_exec_stmt_sized, max_size, WDB_MAX_RESPONSE_SIZE);
+    will_return(__wrap_wdb_exec_stmt_sized, SQLITE_DONE);
+    will_return(__wrap_wdb_exec_stmt_sized, root);
+    //Element error
+    expect_string(__wrap__merror, formatted_msg, "Invalid element returned by disconnect query");
+
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &status);
+
+    assert_int_equal(status, WDBC_ERROR);
+    assert_non_null(result);
+
     __real_cJSON_Delete(root);
-    assert_int_equal(result, WDBC_OK);
 }
 
 void test_wdb_global_get_agents_to_disconnect_update_status_fail(void **state)
 {
     test_struct_t *data  = (test_struct_t *)*state;
-    char *output = NULL;
-    cJSON *root = NULL;
-    cJSON *json_agent = NULL;
-    cJSON *json_labels = NULL;
-    int agent_id = 10;
     int last_id = 0;
     int keepalive = 100;
     const char *sync_status = "synced";
-
-    root = cJSON_CreateArray();
+    cJSON* root = cJSON_CreateArray();
+    cJSON* json_agent = cJSON_CreateObject();
     cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
-    cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(agent_id));
+>>>>>>> Add wdb_global_get_agents_to_disconnect UT
 
-    will_return_count(__wrap_wdb_begin2, 1, -1);
-    will_return_count(__wrap_wdb_stmt_cache, 1, -1);
-
+    //Preparing statement
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
     expect_value(__wrap_sqlite3_bind_int, index, 1);
     expect_value(__wrap_sqlite3_bind_int, value, last_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, keepalive);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-
-    // Required for wdb_global_update_agent_connection_status()
-    expect_value(__wrap_sqlite3_bind_text, pos, 1);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "disconnected");
-    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_text, pos, 2);
-    expect_string(__wrap_sqlite3_bind_text, buffer, "synced");
-    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
-    expect_value(__wrap_sqlite3_bind_int, index, 3);
-    expect_value(__wrap_sqlite3_bind_int, value, agent_id);
-    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
-
-    // Mocking one valid agent
-    will_return(__wrap_wdb_exec_stmt, root);
-    expect_function_call_any(__wrap_cJSON_Delete);
-
-    // Required for wdb_global_set_sync_status()
-    will_return(__wrap_wdb_step, SQLITE_ERROR);
-    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
-    expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
+    will_return(__wrap_wdb_exec_stmt_sized, root);
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, -1);
+    expect_any(__wrap__mdebug1, formatted_msg);
     expect_string(__wrap__merror, formatted_msg, "Cannot set connection_status for agent 10");
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &status);
 
-    assert_string_equal(output, "Cannot set connection_status for agent 10");
-    os_free(output);
+    assert_int_equal(status, WDBC_ERROR);
+    assert_non_null(result);
+
     __real_cJSON_Delete(root);
-    __real_cJSON_Delete(json_labels);
-    assert_int_equal(result, WDBC_ERROR);
-}
-
-void test_wdb_global_get_agents_to_disconnect_full(void **state)
-{
-    test_struct_t *data  = (test_struct_t *)*state;
-    char *output = NULL;
-    cJSON *root = NULL;
-    cJSON *json_agent = NULL;
-    int agent_id = 1000;
-    int last_id = 0;
-    int keepalive = 100;
-    const char *sync_status = "synced";
-
-    // Mocking many agents to create an array bigger than WDB_MAX_RESPONSE_SIZE
-    root = cJSON_CreateArray();
-    json_agent = cJSON_CreateObject();
-    cJSON_AddNumberToObject(json_agent, "id", agent_id);
-    cJSON_AddItemToArray(root, json_agent);
-    will_return_count(__wrap_wdb_exec_stmt, root, -1);
-
-    expect_function_call_any(__wrap_cJSON_Delete);
-    will_return_count(__wrap_wdb_begin2, 1, -1);
-    will_return_count(__wrap_wdb_stmt_cache, 1, -1);
-
-    expect_any_count(__wrap_sqlite3_bind_int, index, -1);
-    expect_any_count(__wrap_sqlite3_bind_int, value, -1);
-    will_return_count(__wrap_sqlite3_bind_int, SQLITE_OK, -1);
-
-    // Required for wdb_global_update_agent_connection_status()
-    expect_any_count(__wrap_sqlite3_bind_text, pos, -1);
-    expect_any_count(__wrap_sqlite3_bind_text, buffer, -1);
-    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, -1);
-    will_return_count(__wrap_wdb_step, SQLITE_DONE, -1);
-
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
-
-    assert_non_null(output);
-    os_free(output);
-    __real_cJSON_Delete(root);
-    assert_int_equal(result, WDBC_DUE);
 }
 
 /* Tests wdb_global_get_all_agents */
@@ -5494,10 +5497,11 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_to_disconnect_cache_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_to_disconnect_bind1_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_to_disconnect_bind2_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_to_disconnect_no_agents, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_to_disconnect_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_to_disconnect_ok, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_to_disconnect_due, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_to_disconnect_err, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_to_disconnect_update_status_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_to_disconnect_full, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_get_agents_to_disconnect_invalid_elements, test_setup, test_teardown),
         /* Tests wdb_global_get_all_agents */
         cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_cache_fail, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -4685,8 +4685,9 @@ void test_wdb_global_get_agents_to_disconnect_ok(void **state)
     cJSON* root = cJSON_CreateArray();
     for (int i=0; i<agents_amount; i++){
         cJSON* json_agent = cJSON_CreateObject();
-        cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
         cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(i));
+        cJSON_AddItemToArray(root, json_agent);
+
     }
 
     //Preparing statement
@@ -4732,8 +4733,8 @@ void test_wdb_global_get_agents_to_disconnect_due(void **state)
     cJSON* root = cJSON_CreateArray();
     for (int i=0; i<agents_amount; i++){
         cJSON* json_agent = cJSON_CreateObject();
-        cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
         cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(i));
+        cJSON_AddItemToArray(root, json_agent);
     }
 
     //Preparing statement
@@ -4804,7 +4805,7 @@ void test_wdb_global_get_agents_to_disconnect_invalid_elements(void **state)
     const char *sync_status = "synced";
     cJSON* root = cJSON_CreateArray();
     cJSON* json_agent = cJSON_CreateObject();
-    cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
+    cJSON_AddItemToArray(root, json_agent);
 
     //Preparing statement
     will_return(__wrap_wdb_begin2, 1);
@@ -4839,8 +4840,8 @@ void test_wdb_global_get_agents_to_disconnect_update_status_fail(void **state)
     const char *sync_status = "synced";
     cJSON* root = cJSON_CreateArray();
     cJSON* json_agent = cJSON_CreateObject();
-    cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
->>>>>>> Add wdb_global_get_agents_to_disconnect UT
+    cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(10));
+    cJSON_AddItemToArray(root, json_agent);
 
     //Preparing statement
     will_return(__wrap_wdb_begin2, 1);
@@ -4926,8 +4927,8 @@ void test_wdb_global_get_all_agents_ok(void **state)
     cJSON* root = cJSON_CreateArray();
     for (int i=0; i<agents_amount; i++){
         cJSON* json_agent = cJSON_CreateObject();
-        cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
         cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(i));
+        cJSON_AddItemToArray(root, json_agent);
     }
 
     //Preparing statement
@@ -4958,8 +4959,9 @@ void test_wdb_global_get_all_agents_due(void **state)
     cJSON* root = cJSON_CreateArray();
     for (int i=0; i<agents_amount; i++){
         cJSON* json_agent = cJSON_CreateObject();
-        cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
         cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(i));
+        cJSON_AddItemToArray(root, json_agent);
+
     }
 
     //Preparing statement
@@ -5220,8 +5222,8 @@ void test_wdb_global_get_agents_by_connection_status_ok(void **state)
     cJSON* root = cJSON_CreateArray();
     for (int i=0; i<agents_amount; i++){
         cJSON* json_agent = cJSON_CreateObject();
-        cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
         cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(i));
+        cJSON_AddItemToArray(root, json_agent);
     }
 
     //Preparing statement
@@ -5256,8 +5258,8 @@ void test_wdb_global_get_agents_by_connection_status_due(void **state)
     cJSON* root = cJSON_CreateArray();
     for (int i=0; i<agents_amount; i++){
         cJSON* json_agent = cJSON_CreateObject();
-        cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
         cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(i));
+        cJSON_AddItemToArray(root, json_agent);
     }
 
     //Preparing statement

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -4687,7 +4687,6 @@ void test_wdb_global_get_agents_to_disconnect_ok(void **state)
         cJSON* json_agent = cJSON_CreateObject();
         cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(i));
         cJSON_AddItemToArray(root, json_agent);
-
     }
 
     //Preparing statement
@@ -4704,15 +4703,20 @@ void test_wdb_global_get_agents_to_disconnect_ok(void **state)
     will_return(__wrap_wdb_exec_stmt_sized, SQLITE_DONE);
     will_return(__wrap_wdb_exec_stmt_sized, root);
     //Setting agents as disconnected
-    will_return_count(__wrap_wdb_begin2, 1, agents_amount);
-    will_return_count(__wrap_wdb_stmt_cache, 1, agents_amount);
-    expect_value_count(__wrap_sqlite3_bind_text, pos, 1, agents_amount);
-    expect_string_count(__wrap_sqlite3_bind_text, buffer, "disconnected", agents_amount);
-    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, agents_amount);
-    expect_value_count(__wrap_sqlite3_bind_int, index, 2, agents_amount);
-    expect_in_range_count(__wrap_sqlite3_bind_int, value, 0, agents_amount, agents_amount);
-    will_return_count(__wrap_sqlite3_bind_int, SQLITE_OK, agents_amount);
-    will_return_count(__wrap_wdb_step, SQLITE_DONE, agents_amount);
+    for (int i=0; i<agents_amount; i++){
+        will_return(__wrap_wdb_begin2, 1);
+        will_return(__wrap_wdb_stmt_cache, 1);
+        expect_value(__wrap_sqlite3_bind_text, pos, 1);
+        expect_string(__wrap_sqlite3_bind_text, buffer, "disconnected");
+        will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+        expect_value(__wrap_sqlite3_bind_text, pos, 2);
+        expect_string(__wrap_sqlite3_bind_text, buffer, "synced");
+        will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+        expect_value(__wrap_sqlite3_bind_int, index, 3);
+        expect_in_range(__wrap_sqlite3_bind_int, value, 0, agents_amount);
+        will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+        will_return(__wrap_wdb_step, SQLITE_DONE);
+    }
 
     wdbc_result status = WDBC_UNKNOWN;
     cJSON* result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &status);
@@ -4751,15 +4755,20 @@ void test_wdb_global_get_agents_to_disconnect_due(void **state)
     will_return(__wrap_wdb_exec_stmt_sized, SQLITE_ROW);
     will_return(__wrap_wdb_exec_stmt_sized, root);
     //Setting agents as disconnected
-    will_return_count(__wrap_wdb_begin2, 1, agents_amount);
-    will_return_count(__wrap_wdb_stmt_cache, 1, agents_amount);
-    expect_value_count(__wrap_sqlite3_bind_text, pos, 1, agents_amount);
-    expect_string_count(__wrap_sqlite3_bind_text, buffer, "disconnected", agents_amount);
-    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, agents_amount);
-    expect_value_count(__wrap_sqlite3_bind_int, index, 2, agents_amount);
-    expect_in_range_count(__wrap_sqlite3_bind_int, value, 0, agents_amount, agents_amount);
-    will_return_count(__wrap_sqlite3_bind_int, SQLITE_OK, agents_amount);
-    will_return_count(__wrap_wdb_step, SQLITE_DONE, agents_amount);
+    for (int i=0; i<agents_amount; i++){
+        will_return(__wrap_wdb_begin2, 1);
+        will_return(__wrap_wdb_stmt_cache, 1);
+        expect_value(__wrap_sqlite3_bind_text, pos, 1);
+        expect_string(__wrap_sqlite3_bind_text, buffer, "disconnected");
+        will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+        expect_value(__wrap_sqlite3_bind_text, pos, 2);
+        expect_string(__wrap_sqlite3_bind_text, buffer, "synced");
+        will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+        expect_value(__wrap_sqlite3_bind_int, index, 3);
+        expect_in_range(__wrap_sqlite3_bind_int, value, 0, agents_amount);
+        will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+        will_return(__wrap_wdb_step, SQLITE_DONE);
+    }
 
     wdbc_result status = WDBC_UNKNOWN;
     cJSON* result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &status);
@@ -4775,6 +4784,7 @@ void test_wdb_global_get_agents_to_disconnect_err(void **state)
     test_struct_t *data  = (test_struct_t *)*state;
     int last_id = 0;
     int keepalive = 0;
+    const char *sync_status = "synced";
 
     //Preparing statement
     will_return(__wrap_wdb_begin2, 1);
@@ -4852,7 +4862,11 @@ void test_wdb_global_get_agents_to_disconnect_update_status_fail(void **state)
     expect_value(__wrap_sqlite3_bind_int, index, 2);
     expect_value(__wrap_sqlite3_bind_int, value, keepalive);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+    //Executing statement
+    expect_value(__wrap_wdb_exec_stmt_sized, max_size, WDB_MAX_RESPONSE_SIZE);
+    will_return(__wrap_wdb_exec_stmt_sized, SQLITE_DONE);
     will_return(__wrap_wdb_exec_stmt_sized, root);
+    //Disconnect query error
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_any(__wrap__mdebug1, formatted_msg);

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2076,16 +2076,20 @@ void test_wdb_parse_global_get_all_agents_success(void **state)
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char query[OS_BUFFER_SIZE] = "global get-all-agents last_id 1";
+    cJSON* root = cJSON_CreateArray();
+    cJSON* json_agent = cJSON_CreateObject();
+    cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
+    cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(10));
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-all-agents last_id 1");
-    expect_value(__wrap_wdb_global_get_all_agents, *last_agent_id, 1);
-    will_return(__wrap_wdb_global_get_all_agents, "1,2,3,4,5");
+    expect_value(__wrap_wdb_global_get_all_agents, last_agent_id, 1);
     will_return(__wrap_wdb_global_get_all_agents, WDBC_OK);
+    will_return(__wrap_wdb_global_get_all_agents, root);
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, "ok 1,2,3,4,5");
+    assert_string_equal(data->output, "ok [{\"id\":10}]");
     assert_int_equal(ret, OS_SUCCESS);
 }
 
@@ -2242,17 +2246,21 @@ void test_wdb_parse_global_get_agents_by_connection_status_query_success(void **
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char query[OS_BUFFER_SIZE] = "global get-agents-by-connection-status 0 active";
+    cJSON* root = cJSON_CreateArray();
+    cJSON* json_agent = cJSON_CreateObject();
+    cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
+    cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(10));
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agents-by-connection-status 0 active");
     expect_value(__wrap_wdb_global_get_agents_by_connection_status, last_agent_id, 0);
     expect_string(__wrap_wdb_global_get_agents_by_connection_status, connection_status, "active");
-    will_return(__wrap_wdb_global_get_agents_by_connection_status, "MESSAGE");
     will_return(__wrap_wdb_global_get_agents_by_connection_status, WDBC_OK);
+    will_return(__wrap_wdb_global_get_agents_by_connection_status, root);
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, "ok MESSAGE");
+    assert_string_equal(data->output, "ok [{\"id\":10}]");
     assert_int_equal(ret, OS_SUCCESS);
 }
 

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2001,18 +2001,22 @@ void test_wdb_parse_global_disconnect_agents_success(void **state)
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
     char query[OS_BUFFER_SIZE] = "global disconnect-agents 0 100 syncreq";
+    cJSON* root = cJSON_CreateArray();
+    cJSON* json_agent = cJSON_CreateObject();
+    cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
+    cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(10));
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents 0 100 syncreq");
     expect_value(__wrap_wdb_global_get_agents_to_disconnect, last_agent_id, 0);
     expect_value(__wrap_wdb_global_get_agents_to_disconnect, keep_alive, 100);
     expect_string(__wrap_wdb_global_get_agents_to_disconnect, sync_status, "syncreq");
-    will_return(__wrap_wdb_global_get_agents_to_disconnect, "1,2,3,4,5");
     will_return(__wrap_wdb_global_get_agents_to_disconnect, WDBC_OK);
+    will_return(__wrap_wdb_global_get_agents_to_disconnect, root);
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, "ok 1,2,3,4,5");
+    assert_string_equal(data->output, "ok [{\"id\":10}]");
     assert_int_equal(ret, OS_SUCCESS);
 }
 

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2003,8 +2003,8 @@ void test_wdb_parse_global_disconnect_agents_success(void **state)
     char query[OS_BUFFER_SIZE] = "global disconnect-agents 0 100 syncreq";
     cJSON* root = cJSON_CreateArray();
     cJSON* json_agent = cJSON_CreateObject();
-    cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
     cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(10));
+    cJSON_AddItemToArray(root, json_agent);
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents 0 100 syncreq");
@@ -2078,8 +2078,8 @@ void test_wdb_parse_global_get_all_agents_success(void **state)
     char query[OS_BUFFER_SIZE] = "global get-all-agents last_id 1";
     cJSON* root = cJSON_CreateArray();
     cJSON* json_agent = cJSON_CreateObject();
-    cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
     cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(10));
+    cJSON_AddItemToArray(root, json_agent);
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-all-agents last_id 1");
@@ -2248,8 +2248,9 @@ void test_wdb_parse_global_get_agents_by_connection_status_query_success(void **
     char query[OS_BUFFER_SIZE] = "global get-agents-by-connection-status 0 active";
     cJSON* root = cJSON_CreateArray();
     cJSON* json_agent = cJSON_CreateObject();
-    cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
     cJSON_AddItemToObject(json_agent, "id", cJSON_CreateNumber(10));
+    cJSON_AddItemToArray(root, json_agent);
+
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agents-by-connection-status 0 active");

--- a/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.c
+++ b/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.c
@@ -46,7 +46,7 @@ int __wrap_sqlite3_bind_text(__attribute__((unused)) sqlite3_stmt* pStmt,
 int __wrap_sqlite3_bind_parameter_index(__attribute__((unused)) sqlite3_stmt * stmt,
                                         const char *zName) {
     check_expected(zName);
-    
+
     return mock();
 }
 
@@ -137,6 +137,22 @@ int __wrap_sqlite3_reset(__attribute__((unused)) sqlite3_stmt *pStmt) {
 
 int __wrap_sqlite3_step(__attribute__((unused)) sqlite3_stmt * stmt){
     return mock();
+}
+
+int __wrap_sqlite3_column_count(__attribute__((unused)) sqlite3_stmt *pStmt){
+    return mock();
+}
+
+int __wrap_sqlite3_column_type(__attribute__((unused)) sqlite3_stmt *pStmt,
+                               int i){
+    check_expected(i);
+    return mock();
+}
+
+const char* __wrap_sqlite3_column_name(__attribute__((unused)) sqlite3_stmt *pStmt,
+                                       int N){
+    check_expected(N);
+    return mock_ptr_type(char *);
 }
 
 int __wrap_sqlite3_changes(__attribute__((unused)) sqlite3 * db){

--- a/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.h
+++ b/src/unit_tests/wrappers/externals/sqlite/sqlite3_wrappers.h
@@ -75,4 +75,10 @@ int __wrap_sqlite3_reset(sqlite3_stmt *pStmt);
 
 int __wrap_sqlite3_step(sqlite3_stmt * stmt);
 
+int __wrap_sqlite3_column_count(sqlite3_stmt *pStmt);
+
+int __wrap_sqlite3_column_type(sqlite3_stmt *pStmt, int i);
+
+const char* __wrap_sqlite3_column_name(sqlite3_stmt *pStmt, int N);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -250,16 +250,15 @@ wdbc_result __wrap_wdb_global_get_agents_by_connection_status(__attribute__((unu
     return mock();
 }
 
-wdbc_result __wrap_wdb_global_get_agents_to_disconnect(__attribute__((unused)) wdb_t *wdb,
+cJSON* __wrap_wdb_global_get_agents_to_disconnect(__attribute__((unused)) wdb_t *wdb,
                                                   int last_agent_id,
                                                   int keep_alive,
                                                   const char *sync_status,
-                                                  char **output) {
+                                                  wdbc_result* status) {
     check_expected(last_agent_id);
     check_expected(keep_alive);
     check_expected(sync_status);
-    os_strdup(mock_ptr_type(char*), *output);
-    return mock();
+    *status = mock();
 }
 
 int __wrap_wdb_global_check_manager_keepalive(wdb_t *wdb) {

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -260,6 +260,7 @@ cJSON* __wrap_wdb_global_get_agents_to_disconnect(__attribute__((unused)) wdb_t 
     check_expected(keep_alive);
     check_expected(sync_status);
     *status = mock();
+    return mock_ptr_type(cJSON*);
 }
 
 int __wrap_wdb_global_check_manager_keepalive(wdb_t *wdb) {

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -222,12 +222,12 @@ int __wrap_wdb_global_sync_agent_info_set(__attribute__((unused)) wdb_t *wdb,
     return mock();
 }
 
-wdbc_result __wrap_wdb_global_get_all_agents(__attribute__((unused)) wdb_t *wdb,
-                                             int* last_agent_id,
-                                             char **output) {
-    check_expected(*last_agent_id);
-    os_strdup(mock_ptr_type(char*), *output);
-    return mock();
+cJSON* __wrap_wdb_global_get_all_agents(   __attribute__((unused)) wdb_t *wdb,
+                                                int last_agent_id,
+                                                wdbc_result* status) {
+    check_expected(last_agent_id);
+    *status = mock();
+    return mock_ptr_type(cJSON*);
 }
 
 cJSON* __wrap_wdb_global_get_agent_info(__attribute__((unused)) wdb_t *wdb,
@@ -240,14 +240,15 @@ int __wrap_wdb_global_reset_agents_connection(__attribute__((unused)) wdb_t *wdb
     check_expected(sync_status);
     return mock();
 }
-wdbc_result __wrap_wdb_global_get_agents_by_connection_status(__attribute__((unused)) wdb_t *wdb,
-                                                              int last_agent_id,
-                                                              const char* connection_status,
-                                                              char **output) {
+
+cJSON* __wrap_wdb_global_get_agents_by_connection_status (__attribute__((unused)) wdb_t *wdb,
+                                                               int last_agent_id,
+                                                               const char* connection_status,
+                                                               wdbc_result* status) {
     check_expected(last_agent_id);
     check_expected(connection_status);
-    os_strdup(mock_ptr_type(char*), *output);
-    return mock();
+    *status = mock();
+    return mock_ptr_type(cJSON*);
 }
 
 cJSON* __wrap_wdb_global_get_agents_to_disconnect(__attribute__((unused)) wdb_t *wdb,

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -83,11 +83,7 @@ cJSON* __wrap_wdb_global_get_agent_info(wdb_t *wdb, int id);
 
 int __wrap_wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_status);
 
-<<<<<<< HEAD
-wdbc_result __wrap_wdb_global_get_agents_by_connection_status(wdb_t *wdb, int last_agent_id, const char* connection_status, char **output);
-=======
 cJSON* __wrap_wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, wdbc_result* status);
->>>>>>> Add wdb_agent and wdb_global_parser UT
 
 cJSON* __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, wdbc_result* status);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -77,13 +77,17 @@ wdbc_result __wrap_wdb_global_sync_agent_info_get(wdb_t *wdb, int* last_agent_id
 
 int __wrap_wdb_global_sync_agent_info_set(wdb_t *wdb,cJSON * json_agent);
 
-wdbc_result __wrap_wdb_global_get_all_agents(wdb_t *wdb, int* last_agent_id, char **output);
+cJSON* __wrap_wdb_global_get_all_agents(wdb_t *wdb, int last_agent_id, wdbc_result* status);
 
 cJSON* __wrap_wdb_global_get_agent_info(wdb_t *wdb, int id);
 
 int __wrap_wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_status);
 
+<<<<<<< HEAD
 wdbc_result __wrap_wdb_global_get_agents_by_connection_status(wdb_t *wdb, int last_agent_id, const char* connection_status, char **output);
+=======
+cJSON* __wrap_wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, wdbc_result* status);
+>>>>>>> Add wdb_agent and wdb_global_parser UT
 
 cJSON* __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, wdbc_result* status);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -85,7 +85,7 @@ int __wrap_wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_statu
 
 wdbc_result __wrap_wdb_global_get_agents_by_connection_status(wdb_t *wdb, int last_agent_id, const char* connection_status, char **output);
 
-wdbc_result __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, char **output);
+cJSON* __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, wdbc_result* status);
 
 int __wrap_wdb_global_check_manager_keepalive(wdb_t *wdb);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -91,6 +91,14 @@ cJSON * __wrap_wdb_exec_stmt(__attribute__((unused)) sqlite3_stmt *stmt) {
     return mock_ptr_type(cJSON *);
 }
 
+cJSON * __wrap_wdb_exec_stmt_sized(__attribute__((unused)) sqlite3_stmt *stmt,
+                                   size_t max_size,
+                                   int* status) {
+    check_expected(max_size);
+    *status = mock();
+    return mock_ptr_type(cJSON *);
+}
+
 int __wrap_wdbc_parse_result(char *result, char **payload) {
     check_expected(result);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -25,7 +25,7 @@ int __wrap_wdb_fim_update_date_entry(wdb_t* socket, const char *path);
 
 int __wrap_wdb_finalize();
 
-int  __wrap_wdb_step(__attribute__((unused)) sqlite3_stmt *stmt);
+int  __wrap_wdb_step(sqlite3_stmt *stmt);
 
 int __wrap_wdb_scan_info_fim_checks_control(wdb_t* socket, const char *last_check);
 
@@ -41,7 +41,9 @@ int __wrap_wdb_syscheck_save(wdb_t *wdb, int ftype, char *checksum, const char *
 
 int __wrap_wdb_syscheck_save2(wdb_t *wdb, const char *payload);
 
-cJSON * __wrap_wdb_exec_stmt(__attribute__((unused)) sqlite3_stmt *stmt);
+cJSON * __wrap_wdb_exec_stmt(sqlite3_stmt *stmt);
+
+cJSON * __wrap_wdb_exec_stmt_sized(sqlite3_stmt *stmt, size_t max_size, int* status);
 
 int __wrap_wdbc_parse_result(char *result, char **payload);
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -832,7 +832,7 @@ cJSON* wdb_exec_row_stmt(sqlite3_stmt * stmt, int* status) {
     return result;
 }
 
-cJSON* wdb_exec_stmt_sized(sqlite3_stmt * stmt, size_t max_size, int* status) {
+cJSON* wdb_exec_stmt_sized(sqlite3_stmt * stmt, const size_t max_size, int* status) {
     if (!stmt) {
         mdebug1("Invalid SQL statement.");
         *status = SQLITE_ERROR;

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -833,7 +833,6 @@ cJSON* wdb_exec_row_stmt(sqlite3_stmt * stmt, int* status) {
 }
 
 cJSON* wdb_exec_stmt_sized(sqlite3_stmt * stmt, size_t max_size, int* status) {
-    //JJP: TODO When socket limit is finally eliminated, this logic can add the last item that didnt fetch in response.
     if (!stmt) {
         mdebug1("Invalid SQL statement.");
         *status = SQLITE_ERROR;

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -141,8 +141,10 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GET_AGENT_INFO] = "SELECT * FROM agent WHERE id = ?;",
-    [WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT] = "SELECT id FROM agent WHERE id > ? AND connection_status = 'active' AND last_keepalive < ? LIMIT 1;",
+    [WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT] = "SELECT id FROM agent WHERE id > ? AND connection_status = 'active' AND last_keepalive < ?;",
     [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected', sync_status = ? where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",
+    [WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT] = "SELECT id FROM agent WHERE id > ? AND connection_status = 'active' AND last_keepalive < ?;",
+    [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected' where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",
     [WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE] = "SELECT COUNT(*) FROM agent WHERE id=0 AND last_keepalive=253402300799;",
     [WDB_STMT_PRAGMA_JOURNAL_WAL] = "PRAGMA journal_mode=WAL;",
 };
@@ -793,6 +795,83 @@ void wdb_close_old() {
     w_mutex_unlock(&pool_mutex);
 }
 
+cJSON* wdb_exec_row_stmt(sqlite3_stmt * stmt, int* status) {
+    cJSON* result = NULL;
+
+    //JJP: Puedo sacar esto
+    if (!stmt) {
+        mdebug1("Invalid SQL statement.");
+        return NULL;
+    }
+
+    int _status = sqlite3_step(stmt);
+    if (SQLITE_ROW == _status) {
+        int count = sqlite3_column_count(stmt);
+        if (count > 0) {
+            result = cJSON_CreateObject();
+
+            for (int i = 0; i < count; i++) {
+                switch (sqlite3_column_type(stmt, i)) {
+                case SQLITE_INTEGER:
+                case SQLITE_FLOAT:
+                    cJSON_AddNumberToObject(result, sqlite3_column_name(stmt, i), sqlite3_column_double(stmt, i));
+                    break;
+
+                case SQLITE_TEXT:
+                case SQLITE_BLOB:
+                    cJSON_AddStringToObject(result, sqlite3_column_name(stmt, i), (const char *)sqlite3_column_text(stmt, i));
+                    break;
+
+                case SQLITE_NULL:
+                default:
+                    ;
+                }
+            }
+        }
+    }
+    else if (SQLITE_DONE != _status) {
+        mdebug1("SQL statement execution failed");
+    }
+
+    if (status) {
+        *status = _status;
+    }
+
+    return result;
+}
+
+cJSON* wdb_exec_stmt_sized(sqlite3_stmt * stmt, size_t max_size, int* status) {
+    if (!stmt) {
+        mdebug1("Invalid SQL statement.");
+        *status = SQLITE_ERROR;
+        return NULL;
+    }
+
+    cJSON* result = cJSON_CreateArray();
+    int result_size = 2; //'[]' json array
+    cJSON* row = NULL;
+    do {
+        row = wdb_exec_row_stmt(stmt, status);
+        if (row) {
+            char *row_str = cJSON_PrintUnformatted(row);
+            size_t row_len = strlen(row_str)+1;
+            //JJP: Por performance puedo usar cJSON_PrintBuffered ya que ya se el tamanho del json, o directamente el tamanho del socket
+            //Check if new agent fits in response
+            if (result_size+row_len < max_size) {
+                cJSON_AddItemToArray(result, row);
+                result_size += row_len;
+            }
+            else {
+                cJSON_Delete(row);
+                row = NULL;
+            }
+            os_free(row_str);
+        }
+    }while (row != NULL);
+
+    return result;
+}
+
 cJSON * wdb_exec_stmt(sqlite3_stmt * stmt) {
     int r;
     int count;
@@ -806,6 +885,7 @@ cJSON * wdb_exec_stmt(sqlite3_stmt * stmt) {
     }
 
     result = cJSON_CreateArray();
+    //JJP: Pasar a wdb_exec_row_stmt
 
     while (r = sqlite3_step(stmt), r == SQLITE_ROW) {
         if (count = sqlite3_column_count(stmt), count > 0) {

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -138,7 +138,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_SYNC_REQ_GET] = "SELECT id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, last_keepalive, connection_status FROM agent WHERE id > ? AND sync_status = 'syncreq' LIMIT 1;",
     [WDB_STMT_GLOBAL_SYNC_SET] = "UPDATE agent SET sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_INFO] = "UPDATE agent SET config_sum = :config_sum, ip = :ip, manager_host = :manager_host, merged_sum = :merged_sum, name = :name, node_name = :node_name, os_arch = :os_arch, os_build = :os_build, os_codename = :os_codename, os_major = :os_major, os_minor = :os_minor, os_name = :os_name, os_platform = :os_platform, os_uname = :os_uname, os_version = :os_version, version = :version, last_keepalive = :last_keepalive, connection_status = :connection_status, sync_status = :sync_status WHERE id = :id;",
-    [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ? LIMIT 1;",
+    [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GET_AGENT_INFO] = "SELECT * FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected', sync_status = ? where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -139,7 +139,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_SYNC_SET] = "UPDATE agent SET sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_INFO] = "UPDATE agent SET config_sum = :config_sum, ip = :ip, manager_host = :manager_host, merged_sum = :merged_sum, name = :name, node_name = :node_name, os_arch = :os_arch, os_build = :os_build, os_codename = :os_codename, os_major = :os_major, os_minor = :os_minor, os_name = :os_name, os_platform = :os_platform, os_uname = :os_uname, os_version = :os_version, version = :version, last_keepalive = :last_keepalive, connection_status = :connection_status, sync_status = :sync_status WHERE id = :id;",
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ?;",
-    [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ? LIMIT 1;",
+    [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ?;",
     [WDB_STMT_GLOBAL_GET_AGENT_INFO] = "SELECT * FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected', sync_status = ? where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",
     [WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT] = "SELECT id FROM agent WHERE id > ? AND connection_status = 'active' AND last_keepalive < ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -390,6 +390,20 @@ int wdb_sca_policy_sha256(wdb_t * wdb, char *id, char * output);
 void wdb_free_agent_info_data(agent_info_data *agent_data);
 
 /**
+ * @brief Function to parse a chunk response that containing the status of the query and a json array.
+ *        This function will create or realloc an int array to place the values of the chunk.
+ *        This values are obtained based on the provided json item string.
+ *
+ * @param [in] input The chunk obtained from WazuhDB to be parsed.
+ * @param [out] output An int array containing the parsed values. Must be freed by the caller.
+ * @param [in] item Json string to search elements on the chunks.
+ * @param [out] last_item Value of the last parsed item. If NULL no value is written.
+ * @param [out] last_size Size of the returned array. If NULL no value is written.
+ * @return JSON array with the statement execution results. NULL On error.
+ */
+wdbc_result wdb_parse_chunk_to_int(char* input, int** output, const char* item, int* last_item, int* last_size);
+
+/**
  * @brief Insert agent to the global.db.
  *
  * @param[in] id The agent ID.
@@ -654,9 +668,6 @@ int* wdb_get_agents_by_connection_status(const char* connection_status, int *soc
  */
 int* wdb_disconnect_agents(int keepalive, const char *sync_status, int *sock);
 
-//JJP: Doxygen and location
-wdbc_result wdb_parse_chunk_to_int(char* input, int** output, const char* item, int* last_item, int* last_size);
-
 /**
  * @brief Create database for agent from profile.
  *
@@ -890,14 +901,26 @@ void wdb_close_old();
 int wdb_remove_database(const char * agent_id);
 
 /**
- * @brief Function to execute a one row of an SQL statement and save the result in a JSON array.
+ * @brief Function to execute one row of an SQL statement and save the result in a JSON array.
  *
  * @param [in] stmt The SQL statement to be executed.
+ * @param [out] status The status code of the statement execution. If NULL no value is written.
  * @return JSON array with the statement execution results. NULL On error.
  */
 cJSON* wdb_exec_row_stmt(sqlite3_stmt * stmt, int* status);
 
-//JJP: Doxygen
+/**
+ * @brief Function to execute a SQL statement and save the result in a JSON array limited by size.
+ *        Each step of the statemente will be printed to know the size.
+ *        The result of each step will be placed in returned result while fits.
+ *
+ * @param [in] stmt The SQL statement to be executed.
+ * @param [out] status The status code of the statement execution.
+ *                     SQLITE_DONE means the statement is completed.
+ *                     SQLITE_ROW means the statement has pending elements.
+ *                     SQLITE_ERROR means an error occurred.
+ * @return JSON array with the statement execution results. NULL On error.
+ */
 cJSON * wdb_exec_stmt_sized(sqlite3_stmt * stmt, size_t max_size, int* status);
 
 /**
@@ -1656,7 +1679,7 @@ int wdb_global_sync_agent_info_set(wdb_t *wdb, cJSON *agent_info);
  */
 cJSON* wdb_global_get_agent_info(wdb_t *wdb, int id);
 
-/**JJP: Change Doxygen
+/**
  * @brief Gets every agent ID.
  *        Response is prepared in one chunk,
  *        if the size of the chunk exceeds WDB_MAX_RESPONSE_SIZE parsing stops and reports the amount of agents obtained.
@@ -1664,8 +1687,9 @@ cJSON* wdb_global_get_agent_info(wdb_t *wdb, int id);
  *
  * @param [in] wdb The Global struct database.
  * @param [in] last_agent_id ID where to start querying.
- * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
- * @return wdbc_result to represent if all agents has being obtained or any error occurred.
+ * @param [out] status wdbc_result to represent if all agents has being obtained or any error occurred.
+ * @retval JSON with agents IDs on success.
+ * @retval NULL on error.
  */
 cJSON* wdb_global_get_all_agents(wdb_t *wdb, int last_agent_id, wdbc_result* status);
 
@@ -1681,7 +1705,7 @@ cJSON* wdb_global_get_all_agents(wdb_t *wdb, int last_agent_id, wdbc_result* sta
  */
 int wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_status);
 
-/**JJP: Fix Doxygen
+/**
  * @brief Function to get the id of every agent with a specific connection_status.
  *        Response is prepared in one chunk, if the size of the chunk exceeds WDB_MAX_RESPONSE_SIZE
  *        parsing stops and reports the amount of agents obtained.
@@ -1690,8 +1714,9 @@ int wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_status);
  * @param [in] wdb The Global struct database.
  * @param [in] last_agent_id ID where to start querying.
  * @param [in] connection_status Connection status of the agents requested.
- * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
- * @return wdbc_result to represent if all agents has being obtained or any error occurred.
+ * @param [out] status wdbc_result to represent if all agents has being obtained or any error occurred.
+ * @retval JSON with agents IDs on success.
+ * @retval NULL on error.
  */
 cJSON* wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, wdbc_result* status);
 
@@ -1704,8 +1729,9 @@ cJSON* wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id
  * @param [in] wdb The Global struct database.
  * @param [in] last_agent_id ID where to start querying.
  * @param [in] sync_status The value of sync_status.
- * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
- * @return wdbc_result to represent if all agents has being obtained.
+ * @param [out] status wdbc_result to represent if all agents has being obtained or any error occurred.
+ * @retval JSON with agents IDs on success.
+ * @retval NULL on error.
  */
 cJSON* wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, wdbc_result* status);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -654,6 +654,9 @@ int* wdb_get_agents_by_connection_status(const char* connection_status, int *soc
  */
 int* wdb_disconnect_agents(int keepalive, const char *sync_status, int *sock);
 
+//JJP: Doxygen and location
+wdbc_result wdb_parse_chunk_to_int(char* input, int* output, const char* item, int* last_item, int* last_size);
+
 /**
  * @brief Create database for agent from profile.
  *

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -887,6 +887,17 @@ void wdb_close_old();
 int wdb_remove_database(const char * agent_id);
 
 /**
+ * @brief Function to execute a one row of an SQL statement and save the result in a JSON array.
+ *
+ * @param [in] stmt The SQL statement to be executed.
+ * @return JSON array with the statement execution results. NULL On error.
+ */
+cJSON* wdb_exec_row_stmt(sqlite3_stmt * stmt, int* status);
+
+//JJP: Doxygen
+cJSON * wdb_exec_stmt_sized(sqlite3_stmt * stmt, size_t max_size, int* status);
+
+/**
  * @brief Function to execute a SQL statement and save the result in a JSON array.
  *
  * @param [in] stmt The SQL statement to be executed.
@@ -1693,7 +1704,7 @@ wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_age
  * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
  * @return wdbc_result to represent if all agents has being obtained.
  */
-wdbc_result wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, char **output);
+cJSON* wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, wdbc_result* status);
 
 // Finalize a statement securely
 #define wdb_finalize(x) { if (x) { sqlite3_finalize(x); x = NULL; } }

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1656,7 +1656,7 @@ int wdb_global_sync_agent_info_set(wdb_t *wdb, cJSON *agent_info);
  */
 cJSON* wdb_global_get_agent_info(wdb_t *wdb, int id);
 
-/**
+/**JJP: Change Doxygen
  * @brief Gets every agent ID.
  *        Response is prepared in one chunk,
  *        if the size of the chunk exceeds WDB_MAX_RESPONSE_SIZE parsing stops and reports the amount of agents obtained.
@@ -1667,7 +1667,7 @@ cJSON* wdb_global_get_agent_info(wdb_t *wdb, int id);
  * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
  * @return wdbc_result to represent if all agents has being obtained or any error occurred.
  */
-wdbc_result wdb_global_get_all_agents(wdb_t *wdb, int* last_agent_id, char **output);
+cJSON* wdb_global_get_all_agents(wdb_t *wdb, int last_agent_id, wdbc_result* status);
 
 /**
  * @brief Function to reset connection_status column of every agent (excluding the manager).

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -655,7 +655,7 @@ int* wdb_get_agents_by_connection_status(const char* connection_status, int *soc
 int* wdb_disconnect_agents(int keepalive, const char *sync_status, int *sock);
 
 //JJP: Doxygen and location
-wdbc_result wdb_parse_chunk_to_int(char* input, int* output, const char* item, int* last_item, int* last_size);
+wdbc_result wdb_parse_chunk_to_int(char* input, int** output, const char* item, int* last_item, int* last_size);
 
 /**
  * @brief Create database for agent from profile.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -390,9 +390,9 @@ int wdb_sca_policy_sha256(wdb_t * wdb, char *id, char * output);
 void wdb_free_agent_info_data(agent_info_data *agent_data);
 
 /**
- * @brief Function to parse a chunk response that containing the status of the query and a json array.
+ * @brief Function to parse a chunk response that contains the status of the query and a json array.
  *        This function will create or realloc an int array to place the values of the chunk.
- *        This values are obtained based on the provided json item string.
+ *        These values are obtained based on the provided json item string.
  *
  * @param [in] input The chunk obtained from WazuhDB to be parsed.
  * @param [out] output An int array containing the parsed values. Must be freed by the caller.
@@ -921,7 +921,7 @@ cJSON* wdb_exec_row_stmt(sqlite3_stmt * stmt, int* status);
  *                     SQLITE_ERROR means an error occurred.
  * @return JSON array with the statement execution results. NULL On error.
  */
-cJSON * wdb_exec_stmt_sized(sqlite3_stmt * stmt, size_t max_size, int* status);
+cJSON * wdb_exec_stmt_sized(sqlite3_stmt * stmt, const size_t max_size, int* status);
 
 /**
  * @brief Function to execute a SQL statement and save the result in a JSON array.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1681,7 +1681,7 @@ cJSON* wdb_global_get_all_agents(wdb_t *wdb, int last_agent_id, wdbc_result* sta
  */
 int wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_status);
 
-/**
+/**JJP: Fix Doxygen
  * @brief Function to get the id of every agent with a specific connection_status.
  *        Response is prepared in one chunk, if the size of the chunk exceeds WDB_MAX_RESPONSE_SIZE
  *        parsing stops and reports the amount of agents obtained.
@@ -1693,7 +1693,7 @@ int wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_status);
  * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
  * @return wdbc_result to represent if all agents has being obtained or any error occurred.
  */
-wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, char **output);
+cJSON* wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, wdbc_result* status);
 
 /**
  * @brief Gets all the agents' IDs (excluding the manager) that satisfy the keepalive condition to be disconnected.

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -559,6 +559,10 @@ int* wdb_get_all_agents(bool include_manager, int *sock) {
         }
     }
 
+    if (status == WDBC_ERROR) {
+        os_free(array);
+    }
+
     if (!sock) {
         wdbc_close(&aux_sock);
     }
@@ -1099,6 +1103,10 @@ int* wdb_get_agents_by_connection_status (const char* connection_status, int *so
         }
     }
 
+    if (status == WDBC_ERROR) {
+        os_free(array);
+    }
+
     if (!sock) {
         wdbc_close(&aux_sock);
     }
@@ -1134,13 +1142,9 @@ wdbc_result wdb_parse_chunk_to_int(char* input, int** output, const char* item, 
         }
     }
 
-    // If status is WDBC_OK terminate the output array
-    if (status == WDBC_OK) {
+    //Always finalize the array
+    if(*output) {
         (*output)[len] = -1;
-    }
-    // If status is any error, freed the output array
-    else if (status != WDBC_DUE) {
-        os_free(*output);
     }
 
     if (last_size) *last_size = len;
@@ -1167,6 +1171,10 @@ int* wdb_disconnect_agents(int keepalive, const char *sync_status, int *sock) {
         else {
             status = WDBC_ERROR;
         }
+    }
+
+    if (status == WDBC_ERROR) {
+        os_free(array);
     }
 
     if (!sock) {

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -1092,34 +1092,11 @@ int* wdb_get_agents_by_connection_status (const char* connection_status, int *so
         // Query WazuhDB
         snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_GET_AGENTS_BY_CONNECTION_STATUS], last_id, connection_status);
         if (wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, sizeof(wdboutput)) == 0) {
-            // Parse result
-            char* payload = NULL;
-            status = wdbc_parse_result(wdboutput, &payload);
-            if (status == WDBC_OK || status == WDBC_DUE) {
-                const char delim = ',';
-                const char sdelim[] = { delim, '\0' };
-                //Realloc new size
-                int new_len = os_strcnt(payload, delim)+1;
-                os_realloc(array, sizeof(int)*(len+new_len+1), array);
-                //Append IDs to array
-                char* agent_id = NULL;
-                char *savedptr = NULL;
-                for (agent_id = strtok_r(payload, sdelim, &savedptr); agent_id; agent_id = strtok_r(NULL, sdelim, &savedptr)) {
-                    array[len] = atoi(agent_id);
-                    last_id = array[len];
-                    len++;
-                }
-            }
+            status = wdb_parse_chunk_to_int(wdboutput, &array, "id", &last_id, &len);
         }
         else {
             status = WDBC_ERROR;
         }
-    }
-    if (status == WDBC_OK) {
-        array[len] = -1;
-    }
-    else {
-        os_free(array);
     }
 
     if (!sock) {

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -12,7 +12,7 @@
 #include "wdb.h"
 
 // List of agent information fields in global DB
-// The ":" is used for paramter binding
+// The ":" is used for parameter binding
 static const char *global_db_agent_fields[] = {
     ":config_sum",
     ":ip",
@@ -1197,7 +1197,7 @@ int wdb_global_check_manager_keepalive(wdb_t *wdb) {
 }
 
 cJSON* wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, wdbc_result* status) {
-    //Prepare SQL queryi
+    //Prepare SQL query
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
         mdebug1("Cannot begin transaction");
         *status = WDBC_ERROR;

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1196,87 +1196,36 @@ int wdb_global_check_manager_keepalive(wdb_t *wdb) {
     }
 }
 
-wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, char **output) {
-    wdbc_result status = WDBC_UNKNOWN;
-    unsigned response_size = 0;
-
-    os_calloc(WDB_MAX_RESPONSE_SIZE, sizeof(char), *output);
-    char *response_aux = *output;
-
+cJSON* wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, wdbc_result* status) {
+    //Prepare SQL queryi
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
         mdebug1("Cannot begin transaction");
-        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot begin transaction");
-        return WDBC_ERROR;
+        *status = WDBC_ERROR;
+        return NULL;
+    }
+    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS) < 0) {
+        mdebug1("Cannot cache statement");
+        *status = WDBC_ERROR;
+        return NULL;
+    }
+    sqlite3_stmt* stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS];
+    if (sqlite3_bind_int(stmt, 1, last_agent_id) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        *status = WDBC_ERROR;
+        return NULL;
+    }
+    if (sqlite3_bind_text(stmt, 2, connection_status, -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        *status = WDBC_ERROR;
+        return NULL;
     }
 
-    while (status == WDBC_UNKNOWN) {
-        //Prepare SQL query
-        if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS) < 0) {
-            mdebug1("Cannot cache statement");
-            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot cache statement");
-            status = WDBC_ERROR;
-            break;
-        }
-        sqlite3_stmt* stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS];
-        if (sqlite3_bind_int(stmt, 1, last_agent_id) != SQLITE_OK) {
-            merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
-            status = WDBC_ERROR;
-            break;
-        }
-        if (sqlite3_bind_text(stmt, 2, connection_status, -1, NULL) != SQLITE_OK) {
-            merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
-            status = WDBC_ERROR;
-            break;
-        }
+    //Execute SQL query limited by size
+    int sql_status = SQLITE_ERROR;
+    cJSON* result = wdb_exec_stmt_sized(stmt, WDB_MAX_RESPONSE_SIZE, &sql_status);
+    if (SQLITE_DONE == sql_status) *status = WDBC_OK;
+    else if (SQLITE_ROW == sql_status) *status = WDBC_DUE;
+    else *status = WDBC_ERROR;
 
-        //Get agent id
-        cJSON* sql_agents_response = wdb_exec_stmt(stmt);
-        if (sql_agents_response && sql_agents_response->child) {
-            cJSON* json_agent = sql_agents_response->child;
-            cJSON* json_id = cJSON_GetObjectItem(json_agent,"id");
-            if (cJSON_IsNumber(json_id)) {
-                //Get ID
-                int agent_id = json_id->valueint;
-
-                //Print Agent info
-                char *id_str = cJSON_PrintUnformatted(json_id);
-                unsigned id_len = strlen(id_str);
-
-                //Check if new agent fits in response
-                if (response_size+id_len+1 < WDB_MAX_RESPONSE_SIZE) {
-                    //Add new agent
-                    memcpy(response_aux, id_str, id_len);
-                    response_aux+=id_len;
-                    //Add separator
-                    *response_aux++ = ',';
-                    //Save size and last ID
-                    response_size += id_len+1;
-                    last_agent_id = agent_id;
-                }
-                else {
-                    //Pending agents but buffer is full
-                    status = WDBC_DUE;
-                }
-                os_free(id_str);
-            }
-        }
-        else {
-            //All agents have been obtained
-            status = WDBC_OK;
-        }
-        cJSON_Delete(sql_agents_response);
-    }
-
-    if (status != WDBC_ERROR) {
-        if (response_size > 0) {
-            //Remove last ','
-            response_aux--;
-        }
-        //Add string end
-        *response_aux = '\0';
-    }
-
-    return status;
+    return result;
 }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1058,93 +1058,61 @@ cJSON* wdb_global_get_agent_info(wdb_t *wdb, int id) {
     return result;
 }
 
-wdbc_result wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, char **output) {
-    sqlite3_stmt* agent_stmt = NULL;
-    unsigned response_size = 0;
-    wdbc_result status = WDBC_UNKNOWN;
+cJSON* wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, wdbc_result* status) {
+    sqlite3_stmt* stmt = NULL;
 
-    os_calloc(WDB_MAX_RESPONSE_SIZE, sizeof(char), *output);
-    char *response_aux = *output;
-
+    //Prepare SQL query
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
         mdebug1("Cannot begin transaction");
-        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot begin transaction");
-        return WDBC_ERROR;
+        *status = WDBC_ERROR;
+        return NULL;
     }
 
-    while (status == WDBC_UNKNOWN) {
-        //Prepare SQL query
-        if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT) < 0) {
-            mdebug1("Cannot cache statement");
-            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot cache statement");
-            status = WDBC_ERROR;
-            break;
-        }
-        agent_stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT];
-        if (sqlite3_bind_int(agent_stmt, 1, last_agent_id) != SQLITE_OK) {
-            merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
-            status = WDBC_ERROR;
-            break;
-        }
+    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT) < 0) {
+        mdebug1("Cannot cache statement");
+        *status = WDBC_ERROR;
+        return NULL;
+    }
 
-        if (sqlite3_bind_int(agent_stmt, 2, keep_alive) != SQLITE_OK) {
-            merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-            snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
-            status = WDBC_ERROR;
-            break;
-        }
+    stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT];
 
-        //Get agent id
-        cJSON* sql_agents_response = wdb_exec_stmt(agent_stmt);
-        if (sql_agents_response && sql_agents_response->child) {
-            cJSON* json_agent = sql_agents_response->child;
-            cJSON* json_id = cJSON_GetObjectItem(json_agent,"id");
-            if (cJSON_IsNumber(json_id)) {
-                //Print Agent info
-                char *id_str = cJSON_PrintUnformatted(json_id);
-                unsigned id_len = strlen(id_str);
+    if (sqlite3_bind_int(stmt, 1, last_agent_id) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        *status = WDBC_ERROR;
+        return NULL;
+    }
 
-                //Check if new agent fits in response
-                if (response_size+id_len+1 < WDB_MAX_RESPONSE_SIZE) {
-                    //Add new agent
-                    memcpy(response_aux, id_str, id_len);
-                    response_aux += id_len;
-                    //Add separator
-                    *response_aux++ = ',';
-                    //Save size and last ID
-                    response_size += id_len+1;
-                    last_agent_id = json_id->valueint;
-                    //Set connection status as disconnected.
-                    if (OS_SUCCESS != wdb_global_update_agent_connection_status(wdb, last_agent_id, "disconnected", sync_status)) {
-                        merror("Cannot set connection_status for agent %d", last_agent_id);
-                        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s %d", "Cannot set connection_status for agent", last_agent_id);
-                        status = WDBC_ERROR;
-                    }
-                }
-                else {
-                    //Pending agents but buffer is full
-                    status = WDBC_DUE;
-                }
-                os_free(id_str);
+    if (sqlite3_bind_int(stmt, 2, keep_alive) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        *status = WDBC_ERROR;
+        return NULL;
+    }
+
+    //Execute SQL query limited by size
+    int sql_status = SQLITE_ERROR;
+    cJSON* result = wdb_exec_stmt_sized(stmt, WDB_MAX_RESPONSE_SIZE, &sql_status);
+    if (SQLITE_DONE == sql_status) *status = WDBC_OK;
+    else if (SQLITE_ROW == sql_status) *status = WDBC_DUE;
+    else *status = WDBC_ERROR;
+
+    //Set every obtained agent as 'disconnected'
+    cJSON* agent = NULL;
+    cJSON_ArrayForEach(agent, result) {
+        cJSON* id = cJSON_GetObjectItem(agent,"id");
+        if (cJSON_IsNumber(id)) {
+            //Set connection status as disconnected
+            if (OS_SUCCESS != wdb_global_update_agent_connection_status(wdb, last_agent_id, "disconnected", sync_status)) {
+                merror("Cannot set connection_status for agent %d", id->valueint);
+                *status = WDBC_ERROR;
             }
         }
         else {
-            //All agents have been obtained
-            status = WDBC_OK;
+            merror("Invalid element returned by disconnect query");
+            *status = WDBC_ERROR;
         }
-        cJSON_Delete(sql_agents_response);
     }
 
-    if (status != WDBC_ERROR) {
-        if (response_size > 0) {
-            //Remove last ','
-            response_aux--;
-        }
-        //Add string end
-        *response_aux = '\0';
-    }
-    return status;
+    return result;
 }
 
 wdbc_result wdb_global_get_all_agents(wdb_t *wdb, int* last_agent_id, char **output) {

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5105,6 +5105,15 @@ int wdb_parse_global_disconnect_agents(wdb_t* wdb, char* input, char* output) {
     }
     keep_alive = atoi(next);
 
+    /* Get sync_status*/
+    next = strtok_r(NULL, delim, &savedptr);
+    if (next == NULL) {
+        mdebug1("Invalid arguments sync_status not found.");
+        snprintf(output, OS_MAXSTR + 1, "err Invalid arguments sync_status not found");
+        return OS_INVALID;
+    }
+    sync_status = next;
+
     // Execute command
     wdbc_result status = WDBC_UNKNOWN;
     cJSON* result = wdb_global_get_agents_to_disconnect(wdb, last_id, keep_alive, sync_status, &status);

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5020,7 +5020,6 @@ int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, ch
 
 int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output) {
     int last_id = 0;
-    char* out = NULL;
     char *next = NULL;
     const char delim[2] = " ";
     char *savedptr = NULL;
@@ -5040,9 +5039,20 @@ int wdb_parse_global_get_all_agents(wdb_t* wdb, char* input, char* output) {
     }
     last_id = atoi(next);
 
-    wdbc_result status = wdb_global_get_all_agents(wdb, &last_id, &out);
+    // Execute command
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_all_agents(wdb, last_id, &status);
+    if (!result) {
+        mdebug1("Error getting agents from global.db.");
+        snprintf(output, OS_MAXSTR + 1, "err Error getting agents from global.db.");
+        return OS_INVALID;
+    }
+
+    //Print response
+    char* out = cJSON_PrintUnformatted(result);
     snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[status], out);
 
+    cJSON_Delete(result);
     os_free(out)
 
     return OS_SUCCESS;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5013,8 +5013,8 @@ int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, ch
     wdbc_result status = WDBC_UNKNOWN;
     cJSON* result = wdb_global_get_agents_by_connection_status(wdb, last_id, connection_status, &status);
     if (!result) {
-        mdebug1("Error getting agents to be disconnected from global.db.");
-        snprintf(output, OS_MAXSTR + 1, "err Error getting agents to be disconnected from global.db.");
+        mdebug1("Error getting agents by connection status from global.db.");
+        snprintf(output, OS_MAXSTR + 1, "err Error getting agents by connection status from global.db.");
         return OS_INVALID;
     }
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5063,7 +5063,6 @@ int wdb_parse_global_disconnect_agents(wdb_t* wdb, char* input, char* output) {
     int last_id = 0;
     int keep_alive = 0;
     char *sync_status = NULL;
-    char* out = NULL;
     char *next = NULL;
     const char delim[2] = " ";
     char *savedptr = NULL;
@@ -5086,19 +5085,21 @@ int wdb_parse_global_disconnect_agents(wdb_t* wdb, char* input, char* output) {
     }
     keep_alive = atoi(next);
 
-    /* Get sync_status*/
-    next = strtok_r(NULL, delim, &savedptr);
-    if (next == NULL) {
-        mdebug1("Invalid arguments sync_status not found.");
-        snprintf(output, OS_MAXSTR + 1, "err Invalid arguments sync_status not found");
+    // Execute command
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_agents_to_disconnect(wdb, last_id, keep_alive, sync_status, &status);
+    if (!result) {
+        mdebug1("Error getting agents to be disconnected from global.db.");
+        snprintf(output, OS_MAXSTR + 1, "err Error getting agents to be disconnected from global.db.");
         return OS_INVALID;
     }
-    sync_status = next;
 
-    wdbc_result status = wdb_global_get_agents_to_disconnect(wdb, last_id, keep_alive, sync_status, &out);
+    //Print response
+    char* out = cJSON_PrintUnformatted(result);
     snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[status], out);
 
-    os_free(out);
+    cJSON_Delete(result);
+    os_free(out)
 
     return OS_SUCCESS;
 }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -4988,7 +4988,6 @@ int wdb_parse_global_get_agent_info(wdb_t* wdb, char* input, char* output) {
 int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, char* output) {
     int last_id = 0;
     char *connection_status = NULL;
-    char* out = NULL;
     char *next = NULL;
     const char delim[2] = " ";
     char *savedptr = NULL;
@@ -5010,9 +5009,20 @@ int wdb_parse_global_get_agents_by_connection_status(wdb_t* wdb, char* input, ch
     }
     connection_status = next;
 
-    wdbc_result status = wdb_global_get_agents_by_connection_status(wdb, last_id, connection_status, &out);
+    // Execute command
+    wdbc_result status = WDBC_UNKNOWN;
+    cJSON* result = wdb_global_get_agents_by_connection_status(wdb, last_id, connection_status, &status);
+    if (!result) {
+        mdebug1("Error getting agents to be disconnected from global.db.");
+        snprintf(output, OS_MAXSTR + 1, "err Error getting agents to be disconnected from global.db.");
+        return OS_INVALID;
+    }
+
+    //Print response
+    char* out = cJSON_PrintUnformatted(result);
     snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[status], out);
 
+    cJSON_Delete(result);
     os_free(out)
 
     return OS_SUCCESS;


### PR DESCRIPTION
|Related issue|
|---|
|6602|

## Description
This PR unifies the logic to create and parse chunks responses on WazuhDB and its clients:

- Creates a new **wdb_exec_stmt_sized** that will execute an SQL query and create a response as **wdb_exec_stmt** but limited by size. Doing so, the chunk logic is now global, and not part of each command or statement.
- Adapts wdb_global methods to use this new method instead of executing multiple  **wdb_exec_stmt** with size limitation.
- Creates a parser to extract the status and an array of data from a chunk response.
- Adapts wdb_agent methods to use this parser.
- Creates UT for all new methods.
- Adapts the UT of all modified methods.

## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [x] Review logs syntax and correct language
- [x] QA integration tests

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
