### PR TITLE
Setting the agents as syncreq in global.db when monitord disconnect them

### DIFF
--- a/src/monitord/monitor_actions.c
+++ b/src/monitord/monitor_actions.c
@@ -50,7 +50,8 @@ void monitor_agents_disconnection(){
     int *agents_array;
     char str_agent_id[12];
 
-    agents_array = wdb_disconnect_agents(time(0) - mond.global.agents_disconnection_time, &sock);
+    agents_array = wdb_disconnect_agents(time(0) - mond.global.agents_disconnection_time,
+                                         !mond.monitor_agents?"syncreq":"synced", &sock);
     if (mond.monitor_agents != 0 && agents_array) {
         for (int i = 0; agents_array[i] != -1; i++) {
             snprintf(str_agent_id, 12, "%d", agents_array[i]);

--- a/src/monitord/monitor_actions.c
+++ b/src/monitord/monitor_actions.c
@@ -51,7 +51,7 @@ void monitor_agents_disconnection(){
     char str_agent_id[12];
 
     agents_array = wdb_disconnect_agents(time(0) - mond.global.agents_disconnection_time,
-                                         !mond.monitor_agents?"syncreq":"synced", &sock);
+                                         worker_node?"syncreq":"synced", &sock);
     if (mond.monitor_agents != 0 && agents_array) {
         for (int i = 0; agents_array[i] != -1; i++) {
             snprintf(str_agent_id, 12, "%d", agents_array[i]);

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -21,6 +21,7 @@
 
 /* Global variables */
 monitor_config mond;
+bool worker_node;
 OSHash* agents_to_alert_hash;
 monitor_time_control mond_time_control;
 

--- a/src/monitord/monitord.h
+++ b/src/monitord/monitord.h
@@ -167,6 +167,7 @@ typedef struct _monitor_time_control {
 
 /* Global variables */
 extern monitor_config mond;
+extern bool worker_node;
 extern OSHash* agents_to_alert_hash;
 
 

--- a/src/unit_tests/monitord/test_monitor_actions.c
+++ b/src/unit_tests/monitord/test_monitor_actions.c
@@ -232,6 +232,7 @@ void test_monitor_agents_disconnection(void **state) {
     mond.monitor_agents = 1;
 
     expect_value(__wrap_wdb_disconnect_agents, keepalive, last_keepalive - mond.global.agents_disconnection_time);
+    expect_string(__wrap_wdb_disconnect_agents, sync_status, "synced");
     will_return(__wrap_wdb_disconnect_agents, agents_array_test);
 
     will_return_count(__wrap_time, 1604403550, -1);

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -4579,7 +4579,7 @@ void test_wdb_get_agents_by_connection_status_success(void **state)
 /* Tests wdb_disconnect_agents */
 
 void test_wdb_disconnect_agents_wdbc_query_error(void **state) {
-    const char *query_str = "global disconnect-agents 0 100";
+    const char *query_str = "global disconnect-agents 0 100 syncreq";
     const char *response = "err";
 
     // Calling Wazuh DB
@@ -4589,13 +4589,13 @@ void test_wdb_disconnect_agents_wdbc_query_error(void **state) {
     will_return(__wrap_wdbc_query_ex, response);
     will_return(__wrap_wdbc_query_ex, OS_INVALID);
 
-    int *array = wdb_disconnect_agents(100, NULL);
+    int *array = wdb_disconnect_agents(100, "syncreq", NULL);
 
     assert_null(array);
 }
 
 void test_wdb_disconnect_agents_wdbc_parse_error(void **state) {
-    const char *query_str = "global disconnect-agents 0 100";
+    const char *query_str = "global disconnect-agents 0 100 syncreq";
     const char *response = "err";
 
     // Calling Wazuh DB
@@ -4609,13 +4609,13 @@ void test_wdb_disconnect_agents_wdbc_parse_error(void **state) {
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
 
-    int *array = wdb_disconnect_agents(100, NULL);
+    int *array = wdb_disconnect_agents(100, "syncreq", NULL);
 
     assert_null(array);
 }
 
 void test_wdb_disconnect_agents_success(void **state) {
-    const char *query_str = "global disconnect-agents 0 100";
+    const char *query_str = "global disconnect-agents 0 100 syncreq";
 
     // Setting the payload
     set_payload = 1;
@@ -4632,7 +4632,7 @@ void test_wdb_disconnect_agents_success(void **state) {
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
-    int *array = wdb_disconnect_agents(100, NULL);
+    int *array = wdb_disconnect_agents(100, "syncreq", NULL);
 
     assert_int_equal(1, array[0]);
     assert_int_equal(2, array[1]);

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -4599,11 +4599,12 @@ void test_wdb_global_get_agents_to_disconnect_transaction_fail(void **state)
     char *output = NULL;
     int last_id = 0;
     int keepalive = 100;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, &output);
+    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
 
     assert_string_equal(output, "Cannot begin transaction");
     os_free(output);
@@ -4616,12 +4617,13 @@ void test_wdb_global_get_agents_to_disconnect_cache_fail(void **state)
     char *output = NULL;
     int last_id = 0;
     int keepalive = 100;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, &output);
+    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
 
     assert_string_equal(output, "Cannot cache statement");
     os_free(output);
@@ -4634,6 +4636,7 @@ void test_wdb_global_get_agents_to_disconnect_bind1_fail(void **state)
     char *output = NULL;
     int last_id = 0;
     int keepalive = 100;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -4643,7 +4646,7 @@ void test_wdb_global_get_agents_to_disconnect_bind1_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, &output);
+    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
 
     assert_string_equal(output, "Cannot bind sql statement");
     os_free(output);
@@ -4656,6 +4659,7 @@ void test_wdb_global_get_agents_to_disconnect_bind2_fail(void **state)
     char *output = NULL;
     int last_id = 0;
     int keepalive = 100;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -4668,7 +4672,7 @@ void test_wdb_global_get_agents_to_disconnect_bind2_fail(void **state)
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, &output);
+    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
 
     assert_string_equal(output, "Cannot bind sql statement");
     os_free(output);
@@ -4681,6 +4685,7 @@ void test_wdb_global_get_agents_to_disconnect_no_agents(void **state)
     char *output = NULL;
     int last_id = 0;
     int keepalive = 0;
+    const char *sync_status = "synced";
 
     will_return(__wrap_wdb_begin2, 1);
     will_return(__wrap_wdb_stmt_cache, 1);
@@ -4694,7 +4699,7 @@ void test_wdb_global_get_agents_to_disconnect_no_agents(void **state)
     will_return(__wrap_wdb_exec_stmt, NULL);
     expect_function_call_any(__wrap_cJSON_Delete);
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, &output);
+    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
 
     assert_string_equal(output, "");
     os_free(output);
@@ -4711,6 +4716,7 @@ void test_wdb_global_get_agents_to_disconnect_success(void **state)
     char str_agt_id[] = "10";
     int last_id = 0;
     int keepalive = 100;
+    const char *sync_status = "synced";
 
     root = cJSON_CreateArray();
     json_agent = cJSON_CreateObject();
@@ -4753,7 +4759,7 @@ void test_wdb_global_get_agents_to_disconnect_success(void **state)
     expect_value(__wrap_sqlite3_bind_int, value, keepalive);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, &output);
+    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
 
     assert_string_equal(output, str_agt_id);
     os_free(output);
@@ -4771,6 +4777,7 @@ void test_wdb_global_get_agents_to_disconnect_update_status_fail(void **state)
     int agent_id = 10;
     int last_id = 0;
     int keepalive = 100;
+    const char *sync_status = "synced";
 
     root = cJSON_CreateArray();
     cJSON_AddItemToArray(root, json_agent = cJSON_CreateObject());
@@ -4807,7 +4814,7 @@ void test_wdb_global_get_agents_to_disconnect_update_status_fail(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "SQLite: ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "Cannot set connection_status for agent 10");
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, &output);
+    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
 
     assert_string_equal(output, "Cannot set connection_status for agent 10");
     os_free(output);
@@ -4825,6 +4832,7 @@ void test_wdb_global_get_agents_to_disconnect_full(void **state)
     int agent_id = 1000;
     int last_id = 0;
     int keepalive = 100;
+    const char *sync_status = "synced";
 
     // Mocking many agents to create an array bigger than WDB_MAX_RESPONSE_SIZE
     root = cJSON_CreateArray();
@@ -4847,7 +4855,7 @@ void test_wdb_global_get_agents_to_disconnect_full(void **state)
     will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, -1);
     will_return_count(__wrap_wdb_step, SQLITE_DONE, -1);
 
-    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, &output);
+    int result = wdb_global_get_agents_to_disconnect(data->wdb, last_id, keepalive, sync_status, &output);
 
     assert_non_null(output);
     os_free(output);

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -1980,7 +1980,7 @@ void test_wdb_parse_global_disconnect_agents_keepalive_error(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_parse_global_disconnect_agents_success(void **state)
+void test_wdb_parse_global_disconnect_agents_sync_status_error(void **state)
 {
     int ret = 0;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -1988,8 +1988,25 @@ void test_wdb_parse_global_disconnect_agents_success(void **state)
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents 0 100");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments sync_status not found.");
+
+    ret = wdb_parse(query, data->output);
+
+    assert_string_equal(data->output, "err Invalid arguments sync_status not found");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_disconnect_agents_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global disconnect-agents 0 100 syncreq";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: disconnect-agents 0 100 syncreq");
     expect_value(__wrap_wdb_global_get_agents_to_disconnect, last_agent_id, 0);
     expect_value(__wrap_wdb_global_get_agents_to_disconnect, keep_alive, 100);
+    expect_string(__wrap_wdb_global_get_agents_to_disconnect, sync_status, "syncreq");
     will_return(__wrap_wdb_global_get_agents_to_disconnect, "1,2,3,4,5");
     will_return(__wrap_wdb_global_get_agents_to_disconnect, WDBC_OK);
 
@@ -2153,6 +2170,7 @@ void test_wdb_parse_reset_agents_connection_query_error(void **state)
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: reset-agents-connection syncreq");
+    expect_string(__wrap_wdb_global_reset_agents_connection, sync_status, "syncreq");
     will_return(__wrap_wdb_global_reset_agents_connection, OS_INVALID);
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Global DB Cannot execute SQL query; err database queue/db/global.db: ERROR MESSAGE");
@@ -2171,6 +2189,7 @@ void test_wdb_parse_reset_agents_connection_success(void **state)
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: reset-agents-connection syncreq");
+    expect_string(__wrap_wdb_global_reset_agents_connection, sync_status, "syncreq");
     will_return(__wrap_wdb_global_reset_agents_connection, OS_SUCCESS);
 
     ret = wdb_parse(query, data->output);
@@ -2358,6 +2377,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_last_id_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_keepalive_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_sync_status_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_disconnect_agents_success, test_setup, test_teardown),
         /* Tests wdb_parse_global_get_all_agents */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_all_agents_syntax_error, test_setup, test_teardown),

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agent_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agent_wrappers.c
@@ -24,8 +24,9 @@ int __wrap_wdb_find_agent(const char *name, const char *ip, __attribute__((unuse
     return mock();
 }
 
-int* __wrap_wdb_disconnect_agents(int keepalive, __attribute__((unused)) int *sock) {
+int* __wrap_wdb_disconnect_agents(int keepalive, const char *sync_status, __attribute__((unused)) int *sock) {
     check_expected(keepalive);
+    check_expected(sync_status);
     return mock_ptr_type(int*);
 }
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agent_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agent_wrappers.h
@@ -15,7 +15,7 @@
 
 cJSON* __wrap_wdb_get_agent_labels(int id, int *sock);
 int __wrap_wdb_find_agent(const char *name, const char *ip, __attribute__((unused)) int *sock);
-int* __wrap_wdb_disconnect_agents(int keepalive, __attribute__((unused)) int *sock);
+int* __wrap_wdb_disconnect_agents(int keepalive, const char *sync_status, __attribute__((unused)) int *sock);
 cJSON* __wrap_wdb_get_agent_info(int id,  __attribute__((unused)) int *sock);
 int* __wrap_wdb_get_agents_by_connection_status(const char* status, __attribute__((unused)) int *sock);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -14,13 +14,13 @@
 #include <cmocka.h>
 
 int __wrap_wdb_global_insert_agent(__attribute__((unused)) wdb_t *wdb,
-                            int id,
-                            char* name,
-                            char* ip,
-                            char* register_ip,
-                            char* internal_key,
-                            char* group,
-                            int date_add) {
+                                   int id,
+                                   char* name,
+                                   char* ip,
+                                   char* register_ip,
+                                   char* internal_key,
+                                   char* group,
+                                   int date_add) {
     check_expected(id);
     check_expected(name);
     check_expected(ip);
@@ -41,25 +41,25 @@ int __wrap_wdb_global_update_agent_name(__attribute__((unused)) wdb_t *wdb,
     return mock();
 }
 
-int __wrap_wdb_global_update_agent_version( __attribute__((unused)) wdb_t *wdb,
-                                            int id,
-                                            const char *os_name,
-                                            const char *os_version,
-                                            const char *os_major,
-                                            const char *os_minor,
-                                            const char *os_codename,
-                                            const char *os_platform,
-                                            const char *os_build,
-                                            const char *os_uname,
-                                            const char *os_arch,
-                                            const char *version,
-                                            const char *config_sum,
-                                            const char *merged_sum,
-                                            const char *manager_host,
-                                            const char *node_name,
-                                            const char *agent_ip,
-                                            const char *connection_status,
-                                            const char *sync_status) {
+int __wrap_wdb_global_update_agent_version(__attribute__((unused)) wdb_t *wdb,
+                                           int id,
+                                           const char *os_name,
+                                           const char *os_version,
+                                           const char *os_major,
+                                           const char *os_minor,
+                                           const char *os_codename,
+                                           const char *os_platform,
+                                           const char *os_build,
+                                           const char *os_uname,
+                                           const char *os_arch,
+                                           const char *version,
+                                           const char *config_sum,
+                                           const char *merged_sum,
+                                           const char *manager_host,
+                                           const char *node_name,
+                                           const char *agent_ip,
+                                           const char *connection_status,
+                                           const char *sync_status) {
     check_expected(id);
     check_expected(os_name);
     check_expected(os_version);
@@ -82,22 +82,22 @@ int __wrap_wdb_global_update_agent_version( __attribute__((unused)) wdb_t *wdb,
     return mock();
 }
 
-cJSON* __wrap_wdb_global_get_agent_labels(  __attribute__((unused)) wdb_t *wdb,
-                                            int id) {
+cJSON* __wrap_wdb_global_get_agent_labels(__attribute__((unused)) wdb_t *wdb,
+                                          int id) {
     check_expected(id);
     return mock_ptr_type(cJSON*);
 }
 
-int __wrap_wdb_global_del_agent_labels( __attribute__((unused)) wdb_t *wdb,
-                                        int id) {
+int __wrap_wdb_global_del_agent_labels(__attribute__((unused)) wdb_t *wdb,
+                                       int id) {
     check_expected(id);
     return mock();
 }
 
-int __wrap_wdb_global_set_agent_label(  __attribute__((unused)) wdb_t *wdb,
-                                        int id,
-                                        char* key,
-                                        char* value){
+int __wrap_wdb_global_set_agent_label(__attribute__((unused)) wdb_t *wdb,
+                                      int id,
+                                      char* key,
+                                      char* value){
     check_expected(id);
     check_expected(key);
     check_expected(value);
@@ -122,14 +122,14 @@ int __wrap_wdb_global_update_agent_connection_status(__attribute__((unused)) wdb
     return mock();
 }
 
-int __wrap_wdb_global_delete_agent( __attribute__((unused)) wdb_t *wdb,
-                                    int id) {
+int __wrap_wdb_global_delete_agent(__attribute__((unused)) wdb_t *wdb,
+                                   int id) {
     check_expected(id);
     return mock();
 }
 
-cJSON* __wrap_wdb_global_select_agent_name( __attribute__((unused)) wdb_t *wdb,
-                                            int id) {
+cJSON* __wrap_wdb_global_select_agent_name(__attribute__((unused)) wdb_t *wdb,
+                                           int id) {
     check_expected(id);
     return mock_ptr_type(cJSON*);
 }
@@ -140,8 +140,8 @@ cJSON* __wrap_wdb_global_select_agent_group(__attribute__((unused)) wdb_t *wdb,
     return mock_ptr_type(cJSON*);
 }
 
-int __wrap_wdb_global_delete_agent_belong(  __attribute__((unused)) wdb_t *wdb,
-                                            int id) {
+int __wrap_wdb_global_delete_agent_belong(__attribute__((unused)) wdb_t *wdb,
+                                          int id) {
     check_expected(id);
     return mock();
 }
@@ -154,9 +154,9 @@ cJSON* __wrap_wdb_global_find_agent(__attribute__((unused)) wdb_t *wdb,
     return mock_ptr_type(cJSON*);
 }
 
-int __wrap_wdb_global_update_agent_group(       __attribute__((unused)) wdb_t *wdb,
-                                                int id,
-                                                char *group) {
+int __wrap_wdb_global_update_agent_group(__attribute__((unused)) wdb_t *wdb,
+                                         int id,
+                                         char *group) {
     check_expected(id);
     check_expected(group);
     return mock();
@@ -168,22 +168,22 @@ cJSON* __wrap_wdb_global_find_group(__attribute__((unused)) wdb_t *wdb,
     return mock_ptr_type(cJSON*);
 }
 
-int __wrap_wdb_global_insert_agent_group(   __attribute__((unused)) wdb_t *wdb,
-                                            char *group_name) {
+int __wrap_wdb_global_insert_agent_group(__attribute__((unused)) wdb_t *wdb,
+                                         char *group_name) {
     check_expected(group_name);
     return mock();
 }
 
-int __wrap_wdb_global_insert_agent_belong(  __attribute__((unused)) wdb_t *wdb,
-                                            int id_group,
-                                            int id_agent) {
+int __wrap_wdb_global_insert_agent_belong(__attribute__((unused)) wdb_t *wdb,
+                                          int id_group,
+                                          int id_agent) {
     check_expected(id_group);
     check_expected(id_agent);
     return mock();
 }
 
-int __wrap_wdb_global_delete_group_belong(   __attribute__((unused)) wdb_t *wdb,
-                                            char *group_name) {
+int __wrap_wdb_global_delete_group_belong(__attribute__((unused)) wdb_t *wdb,
+                                          char *group_name) {
     check_expected(group_name);
     return mock();
 }
@@ -215,16 +215,16 @@ wdbc_result __wrap_wdb_global_sync_agent_info_get(__attribute__((unused)) wdb_t 
 }
 
 int __wrap_wdb_global_sync_agent_info_set(__attribute__((unused)) wdb_t *wdb,
-                                            cJSON *json_agent) {
+                                          cJSON *json_agent) {
     char *str_agent = cJSON_PrintUnformatted(json_agent);
     check_expected(str_agent);
     os_free(str_agent);
     return mock();
 }
 
-wdbc_result __wrap_wdb_global_get_all_agents(   __attribute__((unused)) wdb_t *wdb,
-                                                int* last_agent_id,
-                                                char **output) {
+wdbc_result __wrap_wdb_global_get_all_agents(__attribute__((unused)) wdb_t *wdb,
+                                             int* last_agent_id,
+                                             char **output) {
     check_expected(*last_agent_id);
     os_strdup(mock_ptr_type(char*), *output);
     return mock();
@@ -236,13 +236,14 @@ cJSON* __wrap_wdb_global_get_agent_info(__attribute__((unused)) wdb_t *wdb,
     return mock_ptr_type(cJSON*);
 }
 
-int __wrap_wdb_global_reset_agents_connection( __attribute__((unused)) wdb_t *wdb) {
+int __wrap_wdb_global_reset_agents_connection(__attribute__((unused)) wdb_t *wdb, const char *sync_status) {
+    check_expected(sync_status);
     return mock();
 }
-wdbc_result __wrap_wdb_global_get_agents_by_connection_status (__attribute__((unused)) wdb_t *wdb,
-                                                               int last_agent_id,
-                                                               const char* connection_status,
-                                                               char **output) {
+wdbc_result __wrap_wdb_global_get_agents_by_connection_status(__attribute__((unused)) wdb_t *wdb,
+                                                              int last_agent_id,
+                                                              const char* connection_status,
+                                                              char **output) {
     check_expected(last_agent_id);
     check_expected(connection_status);
     os_strdup(mock_ptr_type(char*), *output);
@@ -252,9 +253,11 @@ wdbc_result __wrap_wdb_global_get_agents_by_connection_status (__attribute__((un
 wdbc_result __wrap_wdb_global_get_agents_to_disconnect(__attribute__((unused)) wdb_t *wdb,
                                                   int last_agent_id,
                                                   int keep_alive,
+                                                  const char *sync_status,
                                                   char **output) {
     check_expected(last_agent_id);
     check_expected(keep_alive);
+    check_expected(sync_status);
     os_strdup(mock_ptr_type(char*), *output);
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -18,24 +18,24 @@ int __wrap_wdb_global_insert_agent(wdb_t *wdb, int id, char* name, char* ip, cha
 int __wrap_wdb_global_update_agent_name(wdb_t *wdb, int id, char* name);
 
 int __wrap_wdb_global_update_agent_version(wdb_t *wdb,
-                                    int id,
-                                    const char *os_name,
-                                    const char *os_version,
-                                    const char *os_major,
-                                    const char *os_minor,
-                                    const char *os_codename,
-                                    const char *os_platform,
-                                    const char *os_build,
-                                    const char *os_uname,
-                                    const char *os_arch,
-                                    const char *version,
-                                    const char *config_sum,
-                                    const char *merged_sum,
-                                    const char *manager_host,
-                                    const char *node_name,
-                                    const char *agent_ip,
-                                    const char *connection_status,
-                                    const char *sync_status);
+                                           int id,
+                                           const char *os_name,
+                                           const char *os_version,
+                                           const char *os_major,
+                                           const char *os_minor,
+                                           const char *os_codename,
+                                           const char *os_platform,
+                                           const char *os_build,
+                                           const char *os_uname,
+                                           const char *os_arch,
+                                           const char *version,
+                                           const char *config_sum,
+                                           const char *merged_sum,
+                                           const char *manager_host,
+                                           const char *node_name,
+                                           const char *agent_ip,
+                                           const char *connection_status,
+                                           const char *sync_status);
 
 cJSON* __wrap_wdb_global_get_agent_labels(wdb_t *wdb, int id);
 
@@ -81,11 +81,11 @@ wdbc_result __wrap_wdb_global_get_all_agents(wdb_t *wdb, int* last_agent_id, cha
 
 cJSON* __wrap_wdb_global_get_agent_info(wdb_t *wdb, int id);
 
-int __wrap_wdb_global_reset_agents_connection(wdb_t *wdb);
+int __wrap_wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_status);
 
-wdbc_result __wrap_wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, char **output);
+wdbc_result __wrap_wdb_global_get_agents_by_connection_status(wdb_t *wdb, int last_agent_id, const char* connection_status, char **output);
 
-wdbc_result __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, char **output);
+wdbc_result __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, char **output);
 
 int __wrap_wdb_global_check_manager_keepalive(wdb_t *wdb);
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -648,10 +648,11 @@ int* wdb_get_agents_by_connection_status(const char* connection_status, int *soc
  * The array is heap-allocated memory that must be freed by the caller.
  *
  * @param [in] keepalive The keepalive threshold before which an agent should be set as disconnected.
+ * @param [in] sync_status String with the cluster synchronization status to be set.
  * @param [in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Pointer to the array, on success. NULL if no agents were set as disconnected or an error ocurred.
  */
-int* wdb_disconnect_agents(int keepalive, int *sock);
+int* wdb_disconnect_agents(int keepalive, const char *sync_status, int *sock);
 
 /**
  * @brief Create database for agent from profile.
@@ -1680,7 +1681,7 @@ int wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_status);
  */
 wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, char **output);
 
-/*
+/**
  * @brief Gets all the agents' IDs (excluding the manager) that satisfy the keepalive condition to be disconnected.
  *        Response is prepared in one chunk,
  *        if the size of the chunk exceeds WDB_MAX_RESPONSE_SIZE parsing stops and reports the amount of agents obtained.
@@ -1688,10 +1689,11 @@ wdbc_result wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_age
  *
  * @param [in] wdb The Global struct database.
  * @param [in] last_agent_id ID where to start querying.
+ * @param [in] sync_status The value of sync_status.
  * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
  * @return wdbc_result to represent if all agents has being obtained.
  */
-wdbc_result wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, char **output);
+wdbc_result wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, char **output);
 
 // Finalize a statement securely
 #define wdb_finalize(x) { if (x) { sqlite3_finalize(x); x = NULL; } }

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -45,7 +45,7 @@ static const char *global_db_commands[] = {
     [WDB_DELETE_GROUP_BELONG] = "global delete-group-belong %s",
     [WDB_RESET_AGENTS_CONNECTION] = "global reset-agents-connection %s",
     [WDB_GET_AGENTS_BY_CONNECTION_STATUS] = "global get-agents-by-connection-status %d %s",
-    [WDB_DISCONNECT_AGENTS] = "global disconnect-agents %d %d"
+    [WDB_DISCONNECT_AGENTS] = "global disconnect-agents %d %d %s"
 };
 
 int wdb_insert_agent(int id,
@@ -1152,7 +1152,7 @@ int* wdb_get_agents_by_connection_status (const char* connection_status, int *so
     return array;
 }
 
-int* wdb_disconnect_agents(int keepalive, int *sock) {
+int* wdb_disconnect_agents(int keepalive, const char *sync_status, int *sock) {
     char wdbquery[WDBQUERY_SIZE] = "";
     char wdboutput[WDBOUTPUT_SIZE] = "";
     int last_id = 0;
@@ -1163,7 +1163,7 @@ int* wdb_disconnect_agents(int keepalive, int *sock) {
 
     while (status == WDBC_DUE) {
         // Query WazuhDB
-        snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_DISCONNECT_AGENTS], last_id, keepalive);
+        snprintf(wdbquery, sizeof(wdbquery), global_db_commands[WDB_DISCONNECT_AGENTS], last_id, keepalive, sync_status);
         if (wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, sizeof(wdboutput)) == 0) {
             // Parse result
             char* payload = NULL;

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1058,7 +1058,7 @@ cJSON* wdb_global_get_agent_info(wdb_t *wdb, int id) {
     return result;
 }
 
-wdbc_result wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, char **output) {
+wdbc_result wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, char **output) {
     sqlite3_stmt* agent_stmt = NULL;
     unsigned response_size = 0;
     wdbc_result status = WDBC_UNKNOWN;
@@ -1115,9 +1115,8 @@ wdbc_result wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, i
                     //Save size and last ID
                     response_size += id_len+1;
                     last_agent_id = json_id->valueint;
-                    //Set connection status as disconnected. The disconnections only happen in the master node
-                    //so, is not necessary to set the agent as syncreq
-                    if (OS_SUCCESS != wdb_global_update_agent_connection_status(wdb, last_agent_id, "disconnected", "synced")) {
+                    //Set connection status as disconnected.
+                    if (OS_SUCCESS != wdb_global_update_agent_connection_status(wdb, last_agent_id, "disconnected", sync_status)) {
                         merror("Cannot set connection_status for agent %d", last_agent_id);
                         snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s %d", "Cannot set connection_status for agent", last_agent_id);
                         status = WDBC_ERROR;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5062,6 +5062,7 @@ int wdb_parse_reset_agents_connection(wdb_t * wdb, char* input, char * output) {
 int wdb_parse_global_disconnect_agents(wdb_t* wdb, char* input, char* output) {
     int last_id = 0;
     int keep_alive = 0;
+    char *sync_status = NULL;
     char* out = NULL;
     char *next = NULL;
     const char delim[2] = " ";
@@ -5085,10 +5086,19 @@ int wdb_parse_global_disconnect_agents(wdb_t* wdb, char* input, char* output) {
     }
     keep_alive = atoi(next);
 
-    wdbc_result status = wdb_global_get_agents_to_disconnect(wdb, last_id, keep_alive, &out);
+    /* Get sync_status*/
+    next = strtok_r(NULL, delim, &savedptr);
+    if (next == NULL) {
+        mdebug1("Invalid arguments sync_status not found.");
+        snprintf(output, OS_MAXSTR + 1, "err Invalid arguments sync_status not found");
+        return OS_INVALID;
+    }
+    sync_status = next;
+
+    wdbc_result status = wdb_global_get_agents_to_disconnect(wdb, last_id, keep_alive, sync_status, &out);
     snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[status], out);
 
-    os_free(out)
+    os_free(out);
 
     return OS_SUCCESS;
 }


### PR DESCRIPTION
|Related issue|
|---|
| #6600 |

## Description

This PR includes all the necessary changes to make the `disconnect-agents` Wazuh DB command be able to also set the `sync_status`.

In addition, the calls to this command were updated in order to properly set the `sync_status`.

For more details check the **requirements** section of issue #6600.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade