### PR TITLE
Fix disconnection sync on master

### DIFF
--- a/src/monitord/monitor_actions.c
+++ b/src/monitord/monitor_actions.c
@@ -50,8 +50,9 @@ void monitor_agents_disconnection(){
     int *agents_array;
     char str_agent_id[12];
 
+    //The master will disconnect and alert the agents on its own DB. Thus, synchronization is not required.
     agents_array = wdb_disconnect_agents(time(0) - mond.global.agents_disconnection_time,
-                                         worker_node?"syncreq":"synced", &sock);
+                                         "synced", &sock);
     if (mond.monitor_agents != 0 && agents_array) {
         for (int i = 0; agents_array[i] != -1; i++) {
             snprintf(str_agent_id, 12, "%d", agents_array[i]);

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -114,7 +114,8 @@ void HandleSecure()
     }
 
     // Reset all the agents' connection status in Wazuh DB
-    if (OS_SUCCESS != wdb_reset_agents_connection(logr.worker_node ? "syncreq" : "synced", NULL))
+    // The master will disconnect and alert the agents on its own DB. Thus, synchronization is not required.
+    if (OS_SUCCESS != wdb_reset_agents_connection("synced", NULL))
         mwarn("Unable to reset the agents' connection status. Possible incorrect statuses until the agents get connected to the manager.");
 
     // Create message handler thread pool


### PR DESCRIPTION
## Description
This PR modifies the synchronization status when monitored sets agents to disconnected to let the master disconnect and alert the agents based on its own DataBase.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Manual testing


