### PR TITLE
Set maximum number of characters that can be used in RBAC names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - **API:**
   - `GET /agents/summary/os`, `GET /agents/summary/status` and `GET /overview/agents` will no longer consider `000` as an agent. ([#6574](https://github.com/wazuh/wazuh/pull/6574))
+  - Modified the number of characters that can be used in RBAC users, roles, rules and policies names. ([#6657](https://github.com/wazuh/wazuh/issues/6657))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - **API:**
   - `GET /agents/summary/os`, `GET /agents/summary/status` and `GET /overview/agents` will no longer consider `000` as an agent. ([#6574](https://github.com/wazuh/wazuh/pull/6574))
-  - Modified the number of characters that can be used in RBAC users, roles, rules and policies names. ([#6657](https://github.com/wazuh/wazuh/issues/6657))
+  - Increased to 64 the maximum number of characters that can be used in security users, roles, rules, and policies names. ([#6657](https://github.com/wazuh/wazuh/issues/6657))
 
 ### Fixed
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1661,6 +1661,8 @@ components:
         name:
           description: "Policy name"
           type: string
+          maxLength: 64
+          format: names
         policy:
           description: "New policy definition"
           type: object
@@ -1688,6 +1690,8 @@ components:
         name:
           description: "Policy name"
           type: string
+          maxLength: 64
+          format: names
         policy:
           description: "New policy definition"
           type: object
@@ -1755,12 +1759,16 @@ components:
         name:
           type: string
           description: "Role name"
+          maxLength: 64
+          format: names
     RolesRequest_no_required:
       type: object
       properties:
         name:
           type: string
           description: "Role name"
+          maxLength: 64
+          format: names
     SecurityRulesRequest:
       type: object
       required:
@@ -1770,6 +1778,8 @@ components:
         name:
           type: string
           description: "Rule name"
+          maxLength: 64
+          format: names
         rule:
           type: object
           description: "Rule body"
@@ -1779,6 +1789,8 @@ components:
         name:
           type: string
           description: "Rule name"
+          maxLength: 64
+          format: names
         rule:
           type: object
           description: "Rule body"
@@ -13513,7 +13525,7 @@ paths:
                 username:
                   type: string
                   minLength: 4
-                  maxLength: 20
+                  maxLength: 64
                   format: names
                 password:
                   type: string

--- a/api/test/integration/test_security_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_POST_endpoints.tavern.yaml
@@ -73,6 +73,19 @@ stages:
           total_affected_items: 1
 
   # POST /security/roles
+  - name: Add a too long named role
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: POST
+      json:
+        name: "test_very_long_role_name_so_the_request_fails_because_of_maximum_length"
+    response:
+      status_code: 400
+
+  # POST /security/roles
   - name: Add an existent role (name) to the system
     request:
       verify: False
@@ -201,6 +214,22 @@ stages:
                 FIND$:
                   definition: "normal_rule1"
           total_affected_items: 1
+
+  # POST /security/rules
+  - name: Add a too long named rule
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: POST
+      json:
+        name: "test_very_long_rule_name_so_the_request_fails_because_of_maximum_length"
+        rule:
+          FIND$:
+            definition: "long_named_rule"
+    response:
+      status_code: 400
 
 ---
 test_name: POST /security/policies
@@ -470,6 +499,25 @@ stages:
             - "agent:id:004"
             - "agent:id:005"
             - "agent:id:006"
+          effect: "allow"
+    response:
+      status_code: 400
+
+  # POST /security/policies
+  - name: Add a too long named policy
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: POST
+      json:
+        name: "test_very_long_policy_name_so_the_request_fails_because_of_maximum_length"
+        policy:
+          actions:
+            - "agent:read"
+          resources:
+            - "agent:id:000"
           effect: "allow"
     response:
       status_code: 400
@@ -743,6 +791,20 @@ stages:
       method: POST
     response:
       status_code: 200
+
+  - name: Add a too long named user
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      json:
+        username: "test_very_long_user_name_so_the_request_fails_because_of_maximum1"
+        password: "new_user1A!@#~½¬?¿ñàÀ"
+        allow_run_as: true
+      method: POST
+    response:
+      status_code: 400
 
   - name: Create a new user (user already exists)
     request:

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -52,6 +52,19 @@ stages:
           total_affected_items: 1
 
   # PUT /security/roles/{role_id}
+  - name: Modify a role in the system (using a very long name)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/roles/102"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        name: "test_very_long_role_name_so_the_request_fails_because_of_maximum_length"
+    response:
+      status_code: 400
+
+  # PUT /security/roles/{role_id}
   - name: Modify a role in the system (using same name for a different ID)
     request:
       verify: False
@@ -168,6 +181,19 @@ stages:
                   - agent:id:003
               roles: !anything
           total_affected_items: 1
+
+  # PUT /security/policies/{policy_id}
+  - name: Modify a policy in the system (using a very long name)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        name: "test_very_long_policy_name_so_the_request_fails_because_of_maximum_length"
+    response:
+      status_code: 400
 
   # PUT /security/policies/{policy_id}
   - name: Modify a policy in the system (without change name)
@@ -312,6 +338,19 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
+
+  # PUT /security/rules/{rule_id}
+  - name: Modify a rule in the system (using a very long name)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/rules/102"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        name: "test_very_long_rule_name_so_the_request_fails_because_of_maximum_length"
+    response:
+      status_code: 400
 
   # PUT /security/rules/{rule_id}
   - name: Modify a rule in the system (using same name for a different ID)


### PR DESCRIPTION
|Related issue|
|---|
|#6657|

## Description

Hello team!

As requested in #6657, this PR changes the maximum number of characters that can be used when adding a new user in the Wazuh API.

I found out that there was no characters limit in other fields like POST `/security/rules`, `/security/roles`, `/security/policies` and the PUT method of the same endpoints, so I have added it.  

I have added new integration tests that verify this behaviour.

## Output
Below can be seen the output when using names longer than 64 characters:

`POST /security/users`
```YAML
{
  "title": "Bad Request",
  "detail": "'test_very_long_user_name_so_the_request_fails_because_of_maximum2' is too long - 'username'"
}
```

## Tests
### Unittests
All unittests passed correctly, both framework and API.

### test_security_POST_endpoints.tavern.yaml
```
pytest -vv test_security_POST_endpoints.tavern.yaml
================================================================== test session starts ===================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-53-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 6 items                                                                                                                                        

test_security_POST_endpoints.tavern.yaml::POST /security/roles PASSED                                                                              [ 16%]
test_security_POST_endpoints.tavern.yaml::POST /security/rules PASSED                                                                              [ 33%]
test_security_POST_endpoints.tavern.yaml::POST /security/policies PASSED                                                                           [ 50%]
test_security_POST_endpoints.tavern.yaml::POST /security/roles/{role_id}/policies/{policy_id} PASSED                                               [ 66%]
test_security_POST_endpoints.tavern.yaml::POST /security/roles/{role_id}/rules PASSED                                                              [ 83%]
test_security_POST_endpoints.tavern.yaml::POST /security/user/{username}/roles/{role_id} PASSED                                                    [100%]

======================================================= 6 passed, 8 warnings in 108.89s (0:01:48) ========================================================
```

### test_security_POST_endpoints.tavern.yaml
```
pytest -vv test_security_PUT_endpoints.tavern.yaml
================================================================== test session starts ===================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-53-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 8 items                                                                                                                                        

test_security_PUT_endpoints.tavern.yaml::PUT /security/roles PASSED                                                                                [ 12%]
test_security_PUT_endpoints.tavern.yaml::PUT /security/policies PASSED                                                                             [ 25%]
test_security_PUT_endpoints.tavern.yaml::PUT /security/rules PASSED                                                                                [ 37%]
test_security_PUT_endpoints.tavern.yaml::PUT /security/user/revoke PASSED                                                                          [ 50%]
test_security_PUT_endpoints.tavern.yaml::DELETE /security/user/authenticate PASSED                                                                 [ 62%]
test_security_PUT_endpoints.tavern.yaml::PUT /security/users/{username} PASSED                                                                     [ 75%]
test_security_PUT_endpoints.tavern.yaml::PUT /security/config PASSED                                                                               [ 87%]
test_security_PUT_endpoints.tavern.yaml::PUT /security/config (Check) PASSED                                                                       [100%]


======================================================= 8 passed, 10 warnings in 114.58s (0:01:54) =======================================================
```

Best regards!
Selu.