### PR TITLE
Add function in task manager module to send message to wazuh_db

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -274,5 +274,8 @@
 #define MOD_TASK_INCOMMING_MESSAGE          "(8204): Incomming message: '%s'"
 #define MOD_TASK_RESPONSE_MESSAGE           "(8205): Response to message: '%s'"
 #define MOD_TASK_DISABLED_WORKER            "(8207): Module Task Manager only runs on Master nodes in cluster configuration."
+#define MOD_TASK_TASKS_DB_ERROR_IN_QUERY    "(8208): Tasks DB Error reported in the result of the query, message: '%s'"
+#define MOD_TASK_TASKS_DB_ERROR_EXECUTE     "(8209): Tasks DB Cannot execute SQL query: err database '%s/%s.db'"
+#define MOD_TASK_TASKS_DB_SQL_QUERY         "(8210): Tasks DB SQL query: '%s'"
 
 #endif /* DEBUG_MESSAGES_H */

--- a/src/wazuh_modules/task_manager/wm_task_manager.h
+++ b/src/wazuh_modules/task_manager/wm_task_manager.h
@@ -32,6 +32,7 @@ typedef enum _error_code {
     WM_TASK_INVALID_COMMAND,
     WM_TASK_DATABASE_NO_TASK,
     WM_TASK_DATABASE_ERROR,
+    WM_TASK_PARSE_ERROR,
     WM_TASK_UNKNOWN_ERROR
 } error_code;
 

--- a/src/wazuh_modules/task_manager/wm_task_manager_parsing.c
+++ b/src/wazuh_modules/task_manager/wm_task_manager_parsing.c
@@ -116,6 +116,7 @@ static const char *error_codes[] = {
     [WM_TASK_INVALID_COMMAND] = "Invalid command",
     [WM_TASK_DATABASE_NO_TASK] = "No task in DB",
     [WM_TASK_DATABASE_ERROR] = "Database error",
+    [WM_TASK_PARSE_ERROR] = "Parse DB response error",
     [WM_TASK_UNKNOWN_ERROR] = "Unknown error"
 };
 


### PR DESCRIPTION
|Related issue|
|---|
|#6620|


This PR add a function in task manager module to send message to wazuh_db.


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
 
