### PR TITLE
SysCollector: Open other files if system information is incomplete from /etc/os-release

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -456,7 +456,12 @@ os_info *get_unix_version()
                 fclose(version_release);
             }
         }
-    } else {
+    }
+
+    if (!info->os_name || !info->os_version || !info->os_platform) {
+        os_free(info->os_name);
+        os_free(info->os_version);
+        os_free(info->os_platform);
         regex_t regexCompiled;
         regmatch_t match[2];
         int match_size;


### PR DESCRIPTION
|Related issue|
|---|
|#5731|

## Description

I modified the code to check other files when it is not possible to get the name, version or platform of the system from `/etc/os-release
`

## Logs/Alerts example

`sqlite3 /var/ossec/queue/db/002.db "select os_name, os_version, os_major, os_minor, os_platform from sys_osinfo;"`

> Debian GNU/Linux|10.4|10|4|debian

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] The data flow works as expected (agent-manager)
