### PR TITLE
6678 RSYNC high cpu usage

### DIFF
--- a/src/shared_modules/utils/threadDispatcher.h
+++ b/src/shared_modules/utils/threadDispatcher.h
@@ -115,8 +115,8 @@ namespace Utils
         }
         void cancel()
         {
-            joinThreads();
             m_queue.cancel();
+            joinThreads();
         }
 
         bool cancelled() const
@@ -138,11 +138,10 @@ namespace Utils
             while(m_running)
             {
                 std::function<void()> fnc;
-                if(m_queue.pop(fnc, false))
+                if(m_queue.pop(fnc))
                 {
                     fnc();
                 }
-                std::this_thread::yield();
             }
         }
         void joinThreads()


### PR DESCRIPTION
|Related issue|
|---|
|#6678|
closes #6678
## **Description**

This issue aims to fix the high usage of cpu by rsync module.

## **DoD**
- [X] Implementation
- [X] **Run testtool on Win**
![image](https://user-images.githubusercontent.com/54002291/99726815-c6477e80-2a95-11eb-9a68-efa92c7e4656.png)
- [X] **Run testtool on Linux**
![image](https://user-images.githubusercontent.com/54002291/99724169-fdb42c00-2a91-11eb-8b46-0c490fd771e9.png)
- [X] **RTR syscollector**
![image](https://user-images.githubusercontent.com/54002291/99729096-30155780-2a99-11eb-8f45-abebe0d37f86.png)
- [X] **RTR dbsync**
![image](https://user-images.githubusercontent.com/54002291/99729357-8e423a80-2a99-11eb-8f70-193fb286dda8.png)
- [X] **RTR rsync**
![image](https://user-images.githubusercontent.com/54002291/99729440-aade7280-2a99-11eb-921f-88eb92d9ba35.png)
- [X] **RTR utils**
![image](https://user-images.githubusercontent.com/54002291/99729476-bcc01580-2a99-11eb-9d9e-8c264230f8ed.png)

