### PR TITLE
Vulnerability-Detector: Overwrites current OS configuration

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -265,7 +265,7 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
     os_strdup(feed, upd->dist);
 
     if (upd_list[os_index]) {
-        mwarn("Duplicate OVAL configuration for '%s%s%s'", upd->dist, upd->version ? " " : "", upd->version ? upd->version : "");
+        mdebug1("Duplicate OVAL configuration for '%s%s%s'", upd->dist, upd->version ? " " : "", upd->version ? upd->version : "");
         wm_vuldet_free_update_node(upd_list[os_index]);
         free(upd_list[os_index]);
     }

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -266,8 +266,8 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
 
     if (upd_list[os_index]) {
         mwarn("Duplicate OVAL configuration for '%s%s%s'", upd->dist, upd->version ? " " : "", upd->version ? upd->version : "");
-        retval = OS_SUPP_SIZE;
-        goto end;
+        wm_vuldet_free_update_node(upd_list[os_index]);
+        free(upd_list[os_index]);
     }
 
     upd_list[os_index] = upd;

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -743,12 +743,14 @@ int wm_vuldet_provider_os_list(xml_node **node, vu_os_feed **feeds, char *pr_nam
             if (!strcmp(node[i]->element, XML_PATH)) {
                 feeds_it = *feeds;
                 while (feeds_it) {
+                    os_free(feeds_it->debian_json_path);
                     os_strdup(node[i]->content, feeds_it->debian_json_path);
                     feeds_it = feeds_it->next;
                 }
             } else if (!strcmp(node[i]->element, XML_URL)) {
                 feeds_it = *feeds;
                 while (feeds_it) {
+                    os_free(feeds_it->debian_json_url);
                     os_strdup(node[i]->content, feeds_it->debian_json_url);
                     for (j = 0; node[i]->attributes && node[i]->attributes[j]; j++) {
                         if (!strcmp(node[i]->attributes[j], XML_PORT)) {


### PR DESCRIPTION
|Related issue|
|---|
|#5178|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

In `wazuh-modulesd` configuration, now when you define the same **\<os\>** twice or more times in the same `provider` block or in different blocks with the same _provider name_, then the manager shows you the warning in the log, but it is overwritten with the last configuration of the duplicate **\<os\>** label and keep running.

## Configuration options

Next, I am going to show configuration examples, and in the section below, the alerts shown together with the active configuration. Examples:

- Configuration 1.
```xml
    <provider name="debian">
      <enabled>yes</enabled>
      <os url="http://local_repo/oval-definitions-stretch.xml">stretch</os>
      <os>stretch</os>
      <os>buster</os>
      <os url="http://local_repo/oval-definitions-buster.xml">buster</os>
      <update_interval>1h</update_interval>
    </provider>
```
- Configuration 2.

```xml
    <!-- Ubuntu OS vulnerabilities -->
    <provider name="canonical">
      <enabled>yes</enabled>
      <os>trusty</os>
      <os>xenial</os>
      <os>bionic</os>
      <os path="/example/oval.xml">bionic</os>
      <os>focal</os>
      <update_interval>1h</update_interval>
    </provider>

    <provider name="canonical">
      <enabled>yes</enabled>
      <os url="http://local_repo/oval-focal.xml">focal</os>
      <update_interval>2h</update_interval>
    </provider>
```

## Logs/Alerts example

- Configuration 1.

```
2020/11/20 09:32:51 wazuh-modulesd[280362] debug_op.c:69 at _log(): DEBUG: Logging module auto-initialized
2020/11/20 09:32:51 wazuh-modulesd[280362] wmodules-vuln-detector.c:268 at wm_vuldet_set_feed_version(): DEBUG: Duplicate OVAL configuration for 'debian STRETCH'
2020/11/20 09:32:51 wazuh-modulesd[280362] wmodules-vuln-detector.c:268 at wm_vuldet_set_feed_version(): DEBUG: Duplicate OVAL configuration for 'debian BUSTER'
Started wazuh-modulesd...
```
```
"providers": [{"name": "debian", "version": "STRETCH", "url": "https://www.debian.org/security/oval/oval-definitions-stretch.xml", "update_interval": 3600, "download_timeout": 300}, {"name": "debian", "version": "BUSTER", "url": "http://local_repo/oval-definitions-buster.xml", "update_interval": 3600, "download_timeout": 300}
```
- Configuration 2.
```
2020/11/20 09:28:41 wazuh-modulesd[279469] debug_op.c:69 at _log(): DEBUG: Logging module auto-initialized
2020/11/20 09:28:41 wazuh-modulesd[279469] wmodules-vuln-detector.c:268 at wm_vuldet_set_feed_version(): DEBUG: Duplicate OVAL configuration for 'canonical BIONIC'
2020/11/20 09:28:41 wazuh-modulesd[279469] wmodules-vuln-detector.c:268 at wm_vuldet_set_feed_version(): DEBUG: Duplicate OVAL configuration for 'canonical FOCAL'
Started wazuh-modulesd...
```

```
{"name": "canonical", "version": "TRUSTY", "url": "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml.bz2", "update_interval": 3600, "download_timeout": 300}, {"name": "canonical", "version": "XENIAL", "url": "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml.bz2", "update_interval": 3600, "download_timeout": 300}, {"name": "canonical", "version": "BIONIC", "path": "/example/oval.xml", "update_interval": 3600, "download_timeout": 300}, {"name": "canonical", "version": "FOCAL", "url": "http://local_repo/oval-focal.xml", "update_interval": 7200, "download_timeout": 300}
```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] The data flow works as expected (agent-manager)