### PR TITLE
[RBAC] Apply character length limitation to RBAC resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 - **Framework:**
   - Improved `q` parameter on rules, decoders and cdb-lists modules to allow multiple nested fields. ([#6560](https://github.com/wazuh/wazuh/pull/6560))
+  - Added character length limitation on RBAC resources. ([#6676](https://github.com/wazuh/wazuh/issues/6676))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 
 - **Framework:**
   - Improved `q` parameter on rules, decoders and cdb-lists modules to allow multiple nested fields. ([#6560](https://github.com/wazuh/wazuh/pull/6560))
-  - Added character length limitation on RBAC resources. ([#6676](https://github.com/wazuh/wazuh/issues/6676))
+  - Added character length limitation on RBAC resources at db level. ([#6676](https://github.com/wazuh/wazuh/issues/6676))
 
 ### Changed
 

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -11,7 +11,8 @@ from shutil import chown
 from time import time
 
 import yaml
-from sqlalchemy import create_engine, UniqueConstraint, Column, DateTime, String, Integer, ForeignKey, Boolean, or_
+from sqlalchemy import create_engine, UniqueConstraint, Column, DateTime, String, Integer, ForeignKey, Boolean, or_, \
+    CheckConstraint
 from sqlalchemy import desc
 from sqlalchemy.dialects.sqlite import TEXT
 from sqlalchemy.event import listens_for
@@ -264,11 +265,13 @@ class User(_Base):
     __tablename__ = 'users'
 
     id = Column('id', Integer, primary_key=True)
-    username = Column(String(32), nullable=False)
-    password = Column(String(256), nullable=False)
+    username = Column(String, nullable=False)
+    password = Column(String, nullable=False)
     allow_run_as = Column(Boolean, default=False, nullable=False)
     created_at = Column('created_at', DateTime, default=datetime.utcnow())
-    __table_args__ = (UniqueConstraint('username', name='username_restriction'),)
+    __table_args__ = (UniqueConstraint('username', name='username_restriction'),
+                      CheckConstraint('length(username) <= 64'),
+                      CheckConstraint('length(password) <= 256'))
 
     # Relations
     roles = relationship("Roles", secondary='user_roles', passive_deletes=True, cascade="all,delete", lazy="dynamic")
@@ -329,9 +332,10 @@ class Roles(_Base):
 
     # Schema
     id = Column('id', Integer, primary_key=True)
-    name = Column('name', String(20), nullable=False)
+    name = Column('name', String, nullable=False)
     created_at = Column('created_at', DateTime, default=datetime.utcnow())
-    __table_args__ = (UniqueConstraint('name', name='name_role'),)
+    __table_args__ = (UniqueConstraint('name', name='name_role'),
+                      CheckConstraint('length(name) <= 64'))
 
     # Relations
     policies = relationship("Policies", secondary='roles_policies', passive_deletes=True, cascade="all,delete",
@@ -383,10 +387,11 @@ class Rules(_Base):
 
     # Schema
     id = Column('id', Integer, primary_key=True)
-    name = Column('name', String(20), nullable=False)
+    name = Column('name', String, nullable=False)
     rule = Column('rule', TEXT, nullable=False)
     created_at = Column('created_at', DateTime, default=datetime.utcnow())
-    __table_args__ = (UniqueConstraint('name', name='rule_name'),)
+    __table_args__ = (UniqueConstraint('name', name='rule_name'),
+                      CheckConstraint('length(name) <= 64'))
 
     # Relations
     roles = relationship("Roles", secondary='roles_rules', passive_deletes=True, cascade="all,delete", lazy="dynamic")
@@ -430,11 +435,12 @@ class Policies(_Base):
 
     # Schema
     id = Column('id', Integer, primary_key=True)
-    name = Column('name', String(20), nullable=False)
+    name = Column('name', String, nullable=False)
     policy = Column('policy', TEXT, nullable=False)
     created_at = Column('created_at', DateTime, default=datetime.utcnow())
     __table_args__ = (UniqueConstraint('name', name='name_policy'),
-                      UniqueConstraint('policy', name='policy_definition'))
+                      UniqueConstraint('policy', name='policy_definition'),
+                      CheckConstraint('length(name) <= 64'))
 
     # Relations
     roles = relationship("Roles", secondary='roles_policies', passive_deletes=True, cascade="all,delete",

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -271,7 +271,7 @@ class User(_Base):
     created_at = Column('created_at', DateTime, default=datetime.utcnow())
     __table_args__ = (UniqueConstraint('username', name='username_restriction'),
                       CheckConstraint('length(username) <= 64'),
-                      CheckConstraint('length(password) <= 256'))
+                      CheckConstraint('length(password) <= 64'))
 
     # Relations
     roles = relationship("Roles", secondary='user_roles', passive_deletes=True, cascade="all,delete", lazy="dynamic")

--- a/framework/wazuh/rbac/tests/test_orm.py
+++ b/framework/wazuh/rbac/tests/test_orm.py
@@ -109,6 +109,9 @@ def test_add_user(db_setup):
         am.add_user(username='newUser1', password='testingA2!')
         assert am.get_user(username='newUser1')
 
+        # Too long name
+        assert not am.add_user('a'*65, 'Password1!')
+
         assert not am.add_user(username='newUser1', password='testingA2!')
 
         # Obtain not existent user
@@ -124,6 +127,9 @@ def test_add_role(db_setup):
         # New role
         rm.add_role('newRole1')
         assert rm.get_role('newRole1')
+
+        # Too long name
+        assert not rm.add_role('a'*65)
 
         # Obtain not existent role
         assert rm.get_role('noexist') == db_setup.SecurityError.ROLE_NOT_EXIST
@@ -147,6 +153,9 @@ def test_add_policy(db_setup):
         pm.add_policy(name='newPolicy1', policy=policy)
         assert pm.get_policy('newPolicy1')
 
+        # Too long name
+        assert not pm.add_policy('v'*65, policy)
+
         # Obtain not existent policy
         assert pm.get_policy('noexist') == db_setup.SecurityError.POLICY_NOT_EXIST
 
@@ -158,6 +167,9 @@ def test_add_rule(db_setup):
         rum.add_rule(name='test_rule', rule={'MATCH': {'admin': ['admin_role']}})
 
         assert rum.get_rule_by_name(rule_name='test_rule')
+
+        # Too long name
+        assert not rum.add_rule('a'*65, {'MATCH': {'admin': ['admin_role']}})
 
         # Obtain not existent role
         assert rum.get_rule(999) == db_setup.SecurityError.RULE_NOT_EXIST


### PR DESCRIPTION
Hello team,
this closes #6676 .

Although we limited the `name` field on every RBAC resource to 64 characters through the API spec, neither the framework or the database itself was doing it. We have replaced the schema to add a `CHECK CONSTRAINT`. For instance:

```sql
CREATE TABLE roles (
	id INTEGER NOT NULL, 
	name VARCHAR NOT NULL, 
	created_at DATETIME, 
	PRIMARY KEY (id), 
	CONSTRAINT name_role UNIQUE (name), 
	CHECK (length(name) <= 64)
);
```

Unit tests have been improved to check this as well.

# Unit tests
```
=================================================================================================================================================================================== test session starts ====================================================================================================================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 53 items                                                                                                                                                                                                                                                                                                                                                                         

wazuh/rbac/tests/test_orm.py .....................................................                                                                                                                                                                                                                                                                                                   [100%]

=================================================================================================================================================================================== 53 passed in 44.36s ====================================================================================================================================================================================
```

Regards,
Víctor.