### PR TITLE
Fixed strings starting by [ when building JSON alerts

### DIFF
--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -192,15 +192,17 @@ void W_JSON_AddField(cJSON *root, const char *key, const char *value) {
 
         free(current);
     } else if (!cJSON_GetObjectItem(root, key)) {
-        char *string_end =  NULL;
+        const char *jsonErrPtr;
+        cJSON * value_json = NULL;
+
         if (*value == '[' &&
-           (string_end = memchr(value, '\0', OS_MAXSTR)) &&
-           (string_end != NULL) &&
-           (']' == *(string_end - 1)))
-        {
-            const char *jsonErrPtr;
-            cJSON_AddItemToObject(root, key, cJSON_ParseWithOpts(value, &jsonErrPtr, 0));
+           (value_json = cJSON_ParseWithOpts(value, &jsonErrPtr, 0), value_json) &&
+           (*jsonErrPtr == '\0')) {
+            cJSON_AddItemToObject(root, key, value_json);
         } else {
+            if (value_json) {
+                cJSON_Delete(value_json);
+            }
             cJSON_AddStringToObject(root, key, value);
         }
     }

--- a/src/unit_tests/shared/test_string_op.c
+++ b/src/unit_tests/shared/test_string_op.c
@@ -118,6 +118,84 @@ void test_w_remove_substr(void **state)
     }
 }
 
+// Tests W_JSON_AddField
+
+void test_W_JSON_AddField_nest_object(void **state)
+{
+    cJSON * root = cJSON_CreateObject();
+    cJSON_AddObjectToObject(root, "test");
+    const char * key = "test.files";
+    const char * value = "[\"file1\",\"file2\",\"file3\"]";
+    char * output = NULL;
+
+    W_JSON_AddField(root, key, value);
+    output = cJSON_PrintUnformatted(root);
+    assert_string_equal(output, "{\"test\":{\"files\":[\"file1\",\"file2\",\"file3\"]}}");
+
+    os_free(output);
+    cJSON_Delete(root);
+}
+
+void test_W_JSON_AddField_nest_no_object(void **state)
+{
+    cJSON * root = cJSON_CreateObject();
+    const char * key = "test.files";
+    const char * value = "[\"file1\",\"file2\",\"file3\"]";
+    char * output = NULL;
+
+    W_JSON_AddField(root, key, value);
+    output = cJSON_PrintUnformatted(root);
+    assert_string_equal(output, "{\"test\":{\"files\":[\"file1\",\"file2\",\"file3\"]}}");
+
+    os_free(output);
+    cJSON_Delete(root);
+}
+
+void test_W_JSON_AddField_JSON_valid(void **state)
+{
+    cJSON * root = cJSON_CreateObject();
+    const char * key = "files";
+    const char * value = "[\"file1\",\"file2\",\"file3\"]";
+    char * output = NULL;
+
+    W_JSON_AddField(root, key, value);
+    output = cJSON_PrintUnformatted(root);
+    assert_string_equal(output, "{\"files\":[\"file1\",\"file2\",\"file3\"]}");
+
+    os_free(output);
+    cJSON_Delete(root);
+}
+
+void test_W_JSON_AddField_JSON_invalid(void **state)
+{
+    cJSON * root = cJSON_CreateObject();
+    const char * key = "files";
+    const char * value = "[\"file1\",\"file2\"],\"file3\"]";
+    char * output = NULL;
+
+    W_JSON_AddField(root, key, value);
+    output = cJSON_PrintUnformatted(root);
+    assert_string_equal(output, "{\"files\":\"[\\\"file1\\\",\\\"file2\\\"],\\\"file3\\\"]\"}");
+    
+    os_free(output);
+    cJSON_Delete(root);
+}
+
+void test_W_JSON_AddField_string_time(void **state)
+{
+    cJSON * root = cJSON_CreateObject();
+    const char * key = "time";
+    const char * value = "[28/Oct/2020:10:22:11 +0000]";
+    char * output = NULL;
+
+    W_JSON_AddField(root, key, value);
+    output = cJSON_PrintUnformatted(root);
+    assert_string_equal(output, "{\"time\":\"[28/Oct/2020:10:22:11 +0000]\"}");
+
+    os_free(output);
+    cJSON_Delete(root);
+}
+
 /* Tests */
 
 int main(void) {
@@ -132,6 +210,12 @@ int main(void) {
         cmocka_unit_test(test_os_snprintf_more_parameters),
         // Tests w_remove_substr
         cmocka_unit_test(test_w_remove_substr),
+        // Tests W_JSON_AddField
+        cmocka_unit_test(test_W_JSON_AddField_nest_object),
+        cmocka_unit_test(test_W_JSON_AddField_nest_no_object),
+        cmocka_unit_test(test_W_JSON_AddField_JSON_valid),
+        cmocka_unit_test(test_W_JSON_AddField_JSON_invalid),
+        cmocka_unit_test(test_W_JSON_AddField_string_time),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
|Related issue|
|---|
|#6621|


## Description

Some strings starting by '[' are missing when building a JSON alert. For that, I change the conditions to add the string. The conditions are:
- the string starts by '['
- the string can be translated to cJSON
- the translated string finishes by '\0'

## Logs example

```
{"integration": "aws", "aws": {"log_info": {"aws_account_alias": "", "log_file": "s3_server_access/2020-10-28-11-42-23-9C61392AA02516A9", "s3bucket": "wazuh-aws-wodle-access-logs"}, "bucket_owner": "3ab1235e25ea9e94ff9b7e4e379ba6b0c872cd36c096e1ac8cce7df433b47101", "bucket": "wazuh-aws-wodle", "time": "[28/Oct/2020:10:22:11 +0000]", "remote_ip": "88.22.139.28", "requester": "arn:aws:iam::166157441623:user/user", "request_id": "6424EEA81647BF3D", "operation": "REST.GET.BUCKET", "key": "-", "request_uri": "GET /wazuh-aws-wodle?list-type=2&max-keys=300&fetch-owner=true&prefix=guardduty%2F2019%2F02%2F02%2F01%2F&delimiter=%2F HTTP/1.1", "http_status": "200", "error_code": "-", "bytes_sent": "1977", "object_size": "-", "total_time": "56", "turn_around_time": "55", "referer": "-", "user_agent": "S3Console/0.4, aws-internal/3 aws-sdk-java/1.11.864 Linux/4.9.217-0.3.ac.206.84.332.metal1.x86_64 OpenJDK_64-Bit_Server_VM/25.262-b10 java/1.8.0_262 vendor/Oracle_Corporation", "version_id": "-", "host_id": "vV3E1O5+m0Onr+nLTeEQ3DdEcj/mhSrF74bN+CxxyF3fDUH1yL5+xD+cocvFY=", "signature_version": "SigV4", "cipher_suite": "ECDHE-RSA-AES128-SHA", "authentication_type": "AuthHeader", "host_header": "s3.amazonaws.com", "source": "s3_server_access"}}

{"integration": "aws", "aws": {"log_info": {"aws_account_alias": "", "log_file": "s3_server_access/2020-10-28-11-42-23-9C61392AA02516A9", "s3bucket": "wazuh-aws-wodle-access-logs"}, "bucket_owner": "3ab1235e25ea9e94ff9b7e4e379ba6b0c872cd36c096e1ac8cce7df433b47101", "bucket": "wazuh-aws-wodle", "test": "[\"1\",\"2\"],\"3\"]", "remote_ip": "88.22.139.28", "requester": "arn:aws:iam::166157441623:user/user", "request_id": "6424EEA81647BF3D", "operation": "REST.GET.BUCKET", "key": "-", "request_uri": "GET /wazuh-aws-wodle?list-type=2&max-keys=300&fetch-owner=true&prefix=guardduty%2F2019%2F02%2F02%2F01%2F&delimiter=%2F HTTP/1.1", "http_status": "200", "error_code": "-", "bytes_sent": "1977", "object_size": "-", "total_time": "56", "turn_around_time": "55", "referer": "-", "user_agent": "S3Console/0.4, aws-internal/3 aws-sdk-java/1.11.864 Linux/4.9.217-0.3.ac.206.84.332.metal1.x86_64 OpenJDK_64-Bit_Server_VM/25.262-b10 java/1.8.0_262 vendor/Oracle_Corporation", "version_id": "-", "host_id": "vV3E1O5+m0Onr+nLTeEQ3DdEcj/mhSrF74bN+CxxyF3fDUH1yL5+xD+cocvFY=", "signature_version": "SigV4", "cipher_suite": "ECDHE-RSA-AES128-SHA", "authentication_type": "AuthHeader", "host_header": "s3.amazonaws.com", "source": "s3_server_access"}}

{"integration": "aws", "aws": {"log_info": {"aws_account_alias": "", "log_file": "s3_server_access/2020-10-28-11-42-23-9C61392AA02516A9", "s3bucket": "wazuh-aws-wodle-access-logs"}, "bucket_owner": "3ab1235e25ea9e94ff9b7e4e379ba6b0c872cd36c096e1ac8cce7df433b47101", "bucket": "wazuh-aws-wodle", "test": "[\"1\",\"2\",\"3\"]", "remote_ip": "88.22.139.28", "requester": "arn:aws:iam::166157441623:user/user", "request_id": "6424EEA81647BF3D", "operation": "REST.GET.BUCKET", "key": "-", "request_uri": "GET /wazuh-aws-wodle?list-type=2&max-keys=300&fetch-owner=true&prefix=guardduty%2F2019%2F02%2F02%2F01%2F&delimiter=%2F HTTP/1.1", "http_status": "200", "error_code": "-", "bytes_sent": "1977", "object_size": "-", "total_time": "56", "turn_around_time": "55", "referer": "-", "user_agent": "S3Console/0.4, aws-internal/3 aws-sdk-java/1.11.864 Linux/4.9.217-0.3.ac.206.84.332.metal1.x86_64 OpenJDK_64-Bit_Server_VM/25.262-b10 java/1.8.0_262 vendor/Oracle_Corporation", "version_id": "-", "host_id": "vV3E1O5+m0Onr+nLTeEQ3DdEcj/mhSrF74bN+CxxyF3fDUH1yL5+xD+cocvFY=", "signature_version": "SigV4", "cipher_suite": "ECDHE-RSA-AES128-SHA", "authentication_type": "AuthHeader", "host_header": "s3.amazonaws.com", "source": "s3_server_access"}}
```

## Alerts example
```
{"timestamp":"2020-11-20T13:15:04.240+0100","rule":{"level":0,"description":"AWS alert.","id":"80200","firedtimes":2,"mail":false,"groups":["amazon","aws"]},"agent":{"id":"000","name":"host"},"manager":{"name":"host"},"id":"1605874504.195228","decoder":{"name":"json"},"data":{"integration":"aws","aws":{"log_info":{"log_file":"s3_server_access/2020-10-28-11-42-23-9C61392AA02516A9","s3bucket":"wazuh-aws-wodle-access-logs"},"bucket_owner":"3ab1235e25ea9e94ff9b7e4e379ba6b0c872cd36c096e1ac8cce7df433b47101","bucket":"wazuh-aws-wodle","time":"[28/Oct/2020:10:22:11 +0000]","remote_ip":"88.22.139.28","requester":"arn:aws:iam::166157441623:user/user","request_id":"6424EEA81647BF3D","operation":"REST.GET.BUCKET","key":"-","request_uri":"GET /wazuh-aws-wodle?list-type=2&max-keys=300&fetch-owner=true&prefix=guardduty%2F2019%2F02%2F02%2F01%2F&delimiter=%2F HTTP/1.1","http_status":"200","error_code":"-","bytes_sent":"1977","object_size":"-","total_time":"56","turn_around_time":"55","referer":"-","user_agent":"S3Console/0.4, aws-internal/3 aws-sdk-java/1.11.864 Linux/4.9.217-0.3.ac.206.84.332.metal1.x86_64 OpenJDK_64-Bit_Server_VM/25.262-b10 java/1.8.0_262 vendor/Oracle_Corporation","version_id":"-","host_id":"vV3E1O5+m0Onr+nLTeEQ3DdEcj/mhSrF74bN+CxxyF3fDUH1yL5+xD+cocvFY=","signature_version":"SigV4","cipher_suite":"ECDHE-RSA-AES128-SHA","authentication_type":"AuthHeader","host_header":"s3.amazonaws.com","source":"s3_server_access"}},"location":"/var/ossec/logs/test.log"}

{"timestamp":"2020-11-20T13:18:04.405+0100","rule":{"level":3,"description":"AWS alert.","id":"80200","firedtimes":3,"mail":false,"groups":["amazon","aws"]},"agent":{"id":"000","name":"host"},"manager":{"name":"host"},"id":"1605874684.197734","decoder":{"name":"json"},"data":{"integration":"aws","aws":{"log_info":{"log_file":"s3_server_access/2020-10-28-11-42-23-9C61392AA02516A9","s3bucket":"wazuh-aws-wodle-access-logs"},"bucket_owner":"3ab1235e25ea9e94ff9b7e4e379ba6b0c872cd36c096e1ac8cce7df433b47101","bucket":"wazuh-aws-wodle","test":"[\"1\",\"2\"],\"3\"]","remote_ip":"88.22.139.28","requester":"arn:aws:iam::166157441623:user/user","request_id":"6424EEA81647BF3D","operation":"REST.GET.BUCKET","key":"-","request_uri":"GET /wazuh-aws-wodle?list-type=2&max-keys=300&fetch-owner=true&prefix=guardduty%2F2019%2F02%2F02%2F01%2F&delimiter=%2F HTTP/1.1","http_status":"200","error_code":"-","bytes_sent":"1977","object_size":"-","total_time":"56","turn_around_time":"55","referer":"-","user_agent":"S3Console/0.4, aws-internal/3 aws-sdk-java/1.11.864 Linux/4.9.217-0.3.ac.206.84.332.metal1.x86_64 OpenJDK_64-Bit_Server_VM/25.262-b10 java/1.8.0_262 vendor/Oracle_Corporation","version_id":"-","host_id":"vV3E1O5+m0Onr+nLTeEQ3DdEcj/mhSrF74bN+CxxyF3fDUH1yL5+xD+cocvFY=","signature_version":"SigV4","cipher_suite":"ECDHE-RSA-AES128-SHA","authentication_type":"AuthHeader","host_header":"s3.amazonaws.com","source":"s3_server_access"}},"location":"/var/ossec/logs/test.log"}

{"timestamp":"2020-11-20T13:18:04.405+0100","rule":{"level":3,"description":"AWS alert.","id":"80200","firedtimes":3,"mail":false,"groups":["amazon","aws"]},"agent":{"id":"000","name":"host"},"manager":{"name":"host"},"id":"1605874684.197734","decoder":{"name":"json"},"data":{"integration":"aws","aws":{"log_info":{"log_file":"s3_server_access/2020-10-28-11-42-23-9C61392AA02516A9","s3bucket":"wazuh-aws-wodle-access-logs"},"bucket_owner":"3ab1235e25ea9e94ff9b7e4e379ba6b0c872cd36c096e1ac8cce7df433b47101","bucket":"wazuh-aws-wodle","test":[\"1\",\"2\",\"3\"],"remote_ip":"88.22.139.28","requester":"arn:aws:iam::166157441623:user/user","request_id":"6424EEA81647BF3D","operation":"REST.GET.BUCKET","key":"-","request_uri":"GET /wazuh-aws-wodle?list-type=2&max-keys=300&fetch-owner=true&prefix=guardduty%2F2019%2F02%2F02%2F01%2F&delimiter=%2F HTTP/1.1","http_status":"200","error_code":"-","bytes_sent":"1977","object_size":"-","total_time":"56","turn_around_time":"55","referer":"-","user_agent":"S3Console/0.4, aws-internal/3 aws-sdk-java/1.11.864 Linux/4.9.217-0.3.ac.206.84.332.metal1.x86_64 OpenJDK_64-Bit_Server_VM/25.262-b10 java/1.8.0_262 vendor/Oracle_Corporation","version_id":"-","host_id":"vV3E1O5+m0Onr+nLTeEQ3DdEcj/mhSrF74bN+CxxyF3fDUH1yL5+xD+cocvFY=","signature_version":"SigV4","cipher_suite":"ECDHE-RSA-AES128-SHA","authentication_type":"AuthHeader","host_header":"s3.amazonaws.com","source":"s3_server_access"}},"location":"/var/ossec/logs/test.log"}
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] The data flow works as expected (agent-manager)
- [x] Add unit tests