### PR TITLE
Fix error in Analysisd when getting the ossec group ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ All notable changes to this project will be documented in this file.
 
 - **API:**
   - Fixed an error with `/groups/{group_id}/config` endpoints (GET and PUT) when using complex `localfile` configurations. ([#6276](https://github.com/wazuh/wazuh/pull/6383))
+- **Core:**
+  - Fix error in Analysisd when getting the ossec group ID ([#6688](https://github.com/wazuh/wazuh/pull/6688))
 
 ### Removed
 
@@ -75,7 +77,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Wazuh API:
-    - Added new endpoints to run the logtest tool and delete a logtest session ([#5984](https://github.com/wazuh/wazuh/pull/5984))  
+    - Added new endpoints to run the logtest tool and delete a logtest session ([#5984](https://github.com/wazuh/wazuh/pull/5984))
 - Added new framework modules to use the logtest tool ([#5870](https://github.com/wazuh/wazuh/pull/5870))
 
 ## [v4.0.0] -

--- a/src/config/active-response.c
+++ b/src/config/active-response.c
@@ -59,28 +59,19 @@ int ReadActiveResponses(XML_NODE node, void *d1, void *d2)
     }
 
 #ifndef WIN32
-    struct group os_group = { .gr_name = NULL };
-    long int len =  sysconf(_SC_GETGR_R_SIZE_MAX);
-    len = len > 0 ? len : 1024;
-    struct group *result = NULL;
-    char *buffer;
-    os_malloc(len, buffer);
+    gid_t gid = Privsep_GetGroup(USER);
 
-    if (result = w_getgrnam(USER, &os_group, buffer, len), !result) {
-        os_free(buffer);
+    if (gid == (gid_t)-1) {
         merror("Could not get group name.");
         fclose(fp);
         return OS_INVALID;
     }
 
-    if ((chown(DEFAULTARPATH, (uid_t) - 1, result->gr_gid)) == -1) {
-        os_free(buffer);
+    if ((chown(DEFAULTARPATH, (uid_t) - 1, gid)) == -1) {
         merror("Could not change the group to ossec: %d.", errno);
         fclose(fp);
         return OS_INVALID;
     }
-
-    os_free(buffer);
 
 #endif
 


### PR DESCRIPTION
|Related issue|
|---|
|#6233|

The Active response configuration parser needs to change the group owner of _/var/ossec/etc/shared/ar.conf_. It uses `w_getgrnam` to retrieve the group ID of the user group "ossec".

That function is mid-level and requires the caller to allocate a memory buffer for the function to store the contents of _/etc/groups_. Depending on the C Library version and some particularities in the groups' file (not necessarily a large number of groups), the buffer size may be insufficient.

Fix: replace the call to `w_getgrnam` with `Privsep_GetGroup`. The new function uses a resizable buffer that grows when necessary.

## Tests

- [X] Compile the manager on Linux.
- [X] Run _ossec-analysisd_ from sources.
- [X] Check that the file _ar.conf_ has the same owner as before.
- [X] Run _ossec-analysisd_ with Valgrind and check that there are no memory issues.
- [X] Check that `Privsep_GetGroup` is covered by unit tests.

### ar.conf properties

```sh
# ls -l /var/ossec/etc/shared/ar.conf
-rw-r----- 1 root ossec 77 Nov 20 13:50 /var/ossec/etc/shared/ar.conf
```

### Valgrind report

```
==32132== LEAK SUMMARY:
==32132==    definitely lost: 0 bytes in 0 blocks
==32132==    indirectly lost: 0 bytes in 0 blocks
==32132==      possibly lost: 13,328 bytes in 49 blocks
==32132==    still reachable: 15,520,305 bytes in 79,622 blocks
==32132==         suppressed: 0 bytes in 0 blocks
```