### PR TITLE
Stop a race condition when deleting multiple files

### DIFF
--- a/src/syscheckd/fim_db.c
+++ b/src/syscheckd/fim_db.c
@@ -1145,7 +1145,9 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
             goto end;
         }
 
+        w_mutex_lock(mutex);
         json_event = fim_json_event(entry->path, NULL, entry->data, pos, FIM_DELETE, mode, whodata_event, NULL);
+        w_mutex_unlock(mutex);
 
         if (!strcmp(FIM_ENTRY_TYPE[entry->data->entry_type], "file") && syscheck.opts[pos] & CHECK_SEECHANGES) {
             if (syscheck.disk_quota_enabled) {


### PR DESCRIPTION
|Related issue|
|---|
|#6684|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes the race condition described in the associated issue by adding a link on the corresponding mutex, preventing multiple threads from removing entries from the DB at random times.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- Memory tests for Windows
  - [x] Scan-build report

- [x] Stress test for affected components
