### PR TITLE
Fixed warning in Wazuh DB when upgrading the global database

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -65,7 +65,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,remove -Wl,--wrap,opendir -Wl,--wrap,readdir -Wl,--wrap,closedir -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,fgets \
                              -Wl,--wrap,wdb_init -Wl,--wrap,wdb_close -Wl,--wrap,wdb_create_global -Wl,--wrap,wdb_pool_append -Wl,--wrap,chmod -Wl,--wrap,stat \
                              -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,time -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,sqlite3_close_v2 \
-                             -Wl,--wrap,wdb_global_check_manager_keepalive")
+                             -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int -Wl,--wrap,sqlite3_finalize")
 
 list(APPEND wdb_tests_names "test_wdb_metadata")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_errmsg \

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -5021,46 +5021,6 @@ void test_wdb_global_get_all_agents_err(void **state)
     assert_null(result);
 }
 
-/* Tests wdb_global_check_manager_keepalive */
-
-void test_wdb_global_check_manager_keepalive_stmt_error(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    will_return(__wrap_wdb_stmt_cache, -1);
-    expect_string(__wrap__merror, formatted_msg, "DB(global) Can't cache statement");
-
-    assert_int_equal(wdb_global_check_manager_keepalive(data->wdb), -1);
-}
-
-void test_wdb_global_check_manager_keepalive_step_error(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    will_return(__wrap_wdb_stmt_cache, 10);
-    will_return(__wrap_sqlite3_step, SQLITE_ERROR);
-
-    assert_int_equal(wdb_global_check_manager_keepalive(data->wdb), -1);
-}
-
-void test_wdb_global_check_manager_keepalive_step_nodata(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    will_return(__wrap_wdb_stmt_cache, 10);
-    will_return(__wrap_sqlite3_step, SQLITE_DONE);
-
-    assert_int_equal(wdb_global_check_manager_keepalive(data->wdb), 0);
-}
-
-void test_wdb_global_check_manager_keepalive_step_ok(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    will_return(__wrap_wdb_stmt_cache, 10);
-    will_return(__wrap_sqlite3_step, SQLITE_ROW);
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 1);
-
-    assert_int_equal(wdb_global_check_manager_keepalive(data->wdb), 1);
-}
-
 /* Tests wdb_global_reset_agents_connection */
 
 void test_wdb_global_reset_agents_connection_transaction_fail(void **state)
@@ -5536,11 +5496,6 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_ok, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_due, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_get_all_agents_err, test_setup, test_teardown),
-        /* Tests wdb_global_check_manager_keepalive */
-        cmocka_unit_test_setup_teardown(test_wdb_global_check_manager_keepalive_stmt_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_check_manager_keepalive_step_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_check_manager_keepalive_step_nodata, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_global_check_manager_keepalive_step_ok, test_setup, test_teardown),
         /* Tests wdb_global_reset_agents_connection */
         cmocka_unit_test_setup_teardown(test_wdb_global_reset_agents_connection_transaction_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_reset_agents_connection_cache_fail, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_upgrade.c
+++ b/src/unit_tests/wazuh_db/test_wdb_upgrade.c
@@ -118,7 +118,7 @@ void test_wdb_upgrade_global_update_success(void **state)
     expect_string(__wrap_wdb_sql_exec, sql_exec, schema_global_upgrade_v2_sql);
     will_return(__wrap_wdb_sql_exec, 0);
 
-    // wdb_global_check_manager_keepalive
+    // wdb_upgrade_check_manager_keepalive
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
     expect_value(__wrap_sqlite3_column_int, iCol, 0);
@@ -138,7 +138,7 @@ void test_wdb_upgrade_global_update_delete_old_version(void **state)
     expect_string(__wrap_wdb_metadata_table_check, key, "metadata");
     will_return(__wrap_wdb_metadata_table_check, 0);
 
-    // wdb_global_check_manager_keepalive
+    // wdb_upgrade_check_manager_keepalive
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
@@ -186,7 +186,7 @@ void test_wdb_upgrade_global_update_fail(void **state)
     will_return(__wrap_wdb_sql_exec, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Failed to update global.db to version 1");
 
-    // wdb_global_check_manager_keepalive
+    // wdb_upgrade_check_manager_keepalive
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
     expect_value(__wrap_sqlite3_column_int, iCol, 0);
@@ -599,39 +599,39 @@ void test_wdb_backup_global_qlite3_open_v2_fail(void **state)
     assert_int_equal(ret, NULL);
 }
 
-/* Tests wdb_global_check_manager_keepalive */
+/* Tests wdb_upgrade_check_manager_keepalive */
 
-void test_wdb_global_check_manager_keepalive_prepare_error(void **state) {
+void test_wdb_upgrade_check_manager_keepalive_prepare_error(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     will_return(__wrap_sqlite3_prepare_v2, -1);
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_prepare_v2(): ERROR MESSAGE");
 
-    assert_int_equal(wdb_global_check_manager_keepalive(data->wdb), OS_INVALID);
+    assert_int_equal(wdb_upgrade_check_manager_keepalive(data->wdb), OS_INVALID);
 }
 
-void test_wdb_global_check_manager_keepalive_step_error(void **state) {
+void test_wdb_upgrade_check_manager_keepalive_step_error(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_step, SQLITE_ERROR);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    assert_int_equal(wdb_global_check_manager_keepalive(data->wdb), OS_INVALID);
+    assert_int_equal(wdb_upgrade_check_manager_keepalive(data->wdb), OS_INVALID);
 }
 
-void test_wdb_global_check_manager_keepalive_step_nodata(void **state) {
+void test_wdb_upgrade_check_manager_keepalive_step_nodata(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    assert_int_equal(wdb_global_check_manager_keepalive(data->wdb), OS_SUCCESS);
+    assert_int_equal(wdb_upgrade_check_manager_keepalive(data->wdb), OS_SUCCESS);
 }
 
-void test_wdb_global_check_manager_keepalive_step_ok(void **state) {
+void test_wdb_upgrade_check_manager_keepalive_step_ok(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -640,7 +640,7 @@ void test_wdb_global_check_manager_keepalive_step_ok(void **state) {
     will_return(__wrap_sqlite3_column_int, 1);
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
-    assert_int_equal(wdb_global_check_manager_keepalive(data->wdb), 1);
+    assert_int_equal(wdb_upgrade_check_manager_keepalive(data->wdb), 1);
 }
 
 
@@ -668,10 +668,10 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_backup_global_close_fail, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_backup_global_create_fail, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_backup_global_qlite3_open_v2_fail, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_global_check_manager_keepalive_prepare_error, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_global_check_manager_keepalive_step_error, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_global_check_manager_keepalive_step_nodata, setup_wdb, teardown_wdb),
-        cmocka_unit_test_setup_teardown(test_wdb_global_check_manager_keepalive_step_ok, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_check_manager_keepalive_prepare_error, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_check_manager_keepalive_step_error, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_check_manager_keepalive_step_nodata, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_upgrade_check_manager_keepalive_step_ok, setup_wdb, teardown_wdb),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -262,8 +262,3 @@ cJSON* __wrap_wdb_global_get_agents_to_disconnect(__attribute__((unused)) wdb_t 
     *status = mock();
     return mock_ptr_type(cJSON*);
 }
-
-int __wrap_wdb_global_check_manager_keepalive(wdb_t *wdb) {
-    (void)wdb;
-    return mock();
-}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -87,6 +87,4 @@ cJSON* __wrap_wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_a
 
 cJSON* __wrap_wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, wdbc_result* status);
 
-int __wrap_wdb_global_check_manager_keepalive(wdb_t *wdb);
-
 #endif

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -143,7 +143,6 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GET_AGENT_INFO] = "SELECT * FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected', sync_status = ? where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",
     [WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT] = "SELECT id FROM agent WHERE id > ? AND connection_status = 'active' AND last_keepalive < ?;",
-    [WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE] = "SELECT COUNT(*) FROM agent WHERE id=0 AND last_keepalive=253402300799;",
     [WDB_STMT_PRAGMA_JOURNAL_WAL] = "PRAGMA journal_mode=WAL;",
 };
 

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -160,7 +160,6 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_GET_AGENT_INFO,
     WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT,
     WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS,
-    WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE,
     WDB_STMT_PRAGMA_JOURNAL_WAL,
     WDB_STMT_SIZE // This must be the last constant
 } wdb_stmt;
@@ -1742,7 +1741,7 @@ cJSON* wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int ke
 /**
  * @brief Check the agent 0 status in the global database
  *
- * The table "agent" must have a tuple with id=0 and last_keepalive=1999/12/31 23:59:59 UTC.
+ * The table "agent" must have a tuple with id=0 and last_keepalive=9999/12/31 23:59:59 UTC.
  * Otherwise, the database is either corrupt or old.
  *
  * @return Number of tuples matching that condition.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1344,6 +1344,19 @@ wdb_t * wdb_backup_global(wdb_t *wdb, int version);
 int wdb_create_backup_global(int version);
 
 /**
+ * @brief Check the agent 0 status in the global database
+ *
+ * The table "agent" must have a tuple with id=0 and last_keepalive=9999/12/31 23:59:59 UTC.
+ * Otherwise, the database is either corrupt or old.
+ *
+ * @return Number of tuples matching that condition.
+ * @retval 1 The agent 0 status is OK.
+ * @retval 0 No tuple matching conditions exists.
+ * @retval -1 The table "agent" is missing or an error occurred.
+ */
+int wdb_upgrade_check_manager_keepalive(wdb_t *wdb);
+
+/**
  * @brief Query the checksum of a data range
  *
  * Check that the accumulated checksum of every item between begin and
@@ -1737,18 +1750,5 @@ cJSON* wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int ke
 
 // Finalize a statement securely
 #define wdb_finalize(x) { if (x) { sqlite3_finalize(x); x = NULL; } }
-
-/**
- * @brief Check the agent 0 status in the global database
- *
- * The table "agent" must have a tuple with id=0 and last_keepalive=9999/12/31 23:59:59 UTC.
- * Otherwise, the database is either corrupt or old.
- *
- * @return Number of tuples matching that condition.
- * @retval 1 The agent 0 status is OK.
- * @retval 0 No tuple matching conditions exists.
- * @retval -1 The table "agent" is missing or an error occurred.
- */
-int wdb_global_check_manager_keepalive(wdb_t *wdb);
 
 #endif

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1175,27 +1175,6 @@ int wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_status) {
     }
 }
 
-// Check the agent 0 status in the global database
-int wdb_global_check_manager_keepalive(wdb_t *wdb) {
-    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE) < 0) {
-        merror("DB(%s) Can't cache statement", wdb->id);
-        return -1;
-    }
-
-    sqlite3_stmt *stmt = wdb->stmt[WDB_STMT_GLOBAL_CHECK_MANAGER_KEEPALIVE];
-
-    switch (sqlite3_step(stmt)) {
-    case SQLITE_ROW:
-        return sqlite3_column_int(stmt, 0);
-
-    case SQLITE_DONE:
-        return 0;
-
-    default:
-        return -1;
-    }
-}
-
 cJSON* wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, wdbc_result* status) {
     //Prepare SQL query
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -86,7 +86,7 @@ wdb_t * wdb_upgrade_global(wdb_t *wdb) {
         return wdb;
     case 0:
         // The table doesn't exist. Checking if version is 3.10 to upgrade or recreate
-        if (wdb_global_check_manager_keepalive(wdb) != 1) {
+        if (wdb_upgrade_check_manager_keepalive(wdb) != 1) {
             wdb = wdb_backup_global(wdb, -1);
             return wdb;
         }
@@ -349,7 +349,7 @@ int wdb_adjust_v4(wdb_t *wdb) {
 }
 
 // Check the presence of manager's keepalive in the global database
-int wdb_global_check_manager_keepalive(wdb_t *wdb) {
+int wdb_upgrade_check_manager_keepalive(wdb_t *wdb) {
     sqlite3_stmt *stmt = NULL;
     int result = -1;
 


### PR DESCRIPTION
|Related issue|
|---|
|#6698|

## Description

There were some issues in the upgrade process of the **global.db** database due a pending statement.
This PR finalizes the query inside the **wdb_global_check_manager_keepalive()** method to allow a proper upgrade.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
