### PR TITLE
Vulnerability Detector: Check value is not null before atoi function

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2470,8 +2470,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, "2020");
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
 
@@ -2507,8 +2507,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_rh(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, "2020");
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
 
@@ -2544,8 +2544,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_prepare_deb(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, "2020");
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
 
@@ -2582,8 +2582,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_error_step(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, "2020");
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -2627,8 +2627,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_step_done(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, "2020");
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -2668,8 +2668,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_no_data(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, "2020");
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -2735,8 +2735,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_bad_version(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 2020);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -2802,8 +2802,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_not_fixed(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 2020);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -2887,8 +2887,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_not_vulnerable(void **sta
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 2020);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -2968,8 +2968,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_error_comparing(void **st
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 2020);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -3056,8 +3056,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_vulnerable(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 2020);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -3147,8 +3147,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_insert_package_error(void **state
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 2020);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -3231,8 +3231,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_duplicated_package(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, 2020);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -3326,8 +3326,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_external_vendor(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, "2020");
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -8484,8 +8484,8 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_oval_vulnerabilitie
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, "2020");
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
 
@@ -8530,8 +8530,8 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_nvd_vulnerabilities
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, "2020");
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -8612,8 +8612,8 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_rm_false_positivies
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, "2020");
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -8724,8 +8724,8 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_send_agent_report_e
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, "2020");
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 
@@ -8870,8 +8870,8 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_OK(void **state)
 
     will_return(__wrap_sqlite3_step, SQLITE_ROW);
 
-    expect_value(__wrap_sqlite3_column_int, iCol, 0);
-    will_return(__wrap_sqlite3_column_int, "2020");
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "2020");
 
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1812,6 +1812,7 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
     time_t start_time;
     int vuln_count = 0;
     int nvd_year = 0;
+    char * nvd_year_str = NULL;
 
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_START_OVAL_AG_AN, atoi(agents_it->agent_id));
 
@@ -1829,7 +1830,10 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
         return OS_INVALID;
     }
 
-    nvd_year = sqlite3_column_int(stmt, 0);
+    nvd_year_str = (char *)sqlite3_column_text(stmt, 0);
+    if (nvd_year_str) {
+        nvd_year = atoi(nvd_year_str);
+    }
 
     wdb_finalize(stmt);
 


### PR DESCRIPTION
|Related issue|
|---|
|-|

## Description

Some VD integration tests failed because an `atoi` function received a null value. We fixed this problem in this commit fa90f4f30bc7be1e5410386a5dca3ea5c233573b but there is one UT that fails occasionally due to this fix. To solve it,  we have decided not to avoid the atoi function and to check the value before.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Modified unit tests
- [x] No segfault found in integration tests
