### PR TITLE
Fix zombie process leak in Modulesd

### DIFF
--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -480,7 +480,17 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
                     }
 
                 } else { // Command finished
-                    retval = 0;
+                    if (WEXITSTATUS(status) == EXECVE_ERROR) {
+                        mdebug1("Invalid command: '%s': (%d) %s", command, errno, strerror(errno));
+                        retval = -1;
+                    } else {
+                        retval = 0;
+                    }
+
+                    if (exitcode) {
+                        *exitcode = WEXITSTATUS(status);
+                    }
+
                     break;
                 }
             } while(secs >= 0);

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -518,7 +518,24 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
                 }
             }
         } else {
-            retval = 0;
+            switch (waitpid(pid, &status, 0)) {
+            case -1:
+                merror("waitpid()");
+                retval = -1;
+                break;
+
+            default:
+                if (WEXITSTATUS(status) == EXECVE_ERROR) {
+                    mdebug1("Invalid command: '%s': (%d) %s", command, errno, strerror(errno));
+                    retval = -1;
+                } else {
+                    retval = 0;
+                }
+
+                if (exitcode) {
+                    *exitcode = WEXITSTATUS(status);
+                }
+            }
         }
 
         wm_remove_sid(pid);


### PR DESCRIPTION
This PR aims to fix two bugs in the subprocess execution component of Modulesd:

1. Enabling _ignore-output_ causes Modulesd to ignore the subprocess' exit code.
2. Having _ignore-output=yes_ and _timeout=0_ causes the program to leave zombie processes.

## Fixes

- Add a call to `waitpid()` in the case that _ignore-output_ is enabled and _timeout_ is disabled.
- Set the program exit code if the subprocess ends (no timeout).

## Tests

- [X] Compile manager on Linux.
- [X] Set a command module and run `wazuh-modulesd`.
- [X] Run `wazuh-modulesd` with AddressSanitizer.

### Configuration

```xml
<global>
  <logall>yes</logall>
</global>

<wodle name="command">
  <tag>test</tag>
  <disabled>no</disabled>
  <command>/var/ossec/etc/test.py</command>
  <interval>1s</interval>
  <ignore_output>yes</ignore_output>
  <timeout>0</timeout>
</wodle>
```

### Test battery

- `ignore_output=yes`, `timeout=0`
- `ignore_output=yes`, `timeout=10`
- `ignore_output=no`, `timeout=0`
- `ignore_output=no`, `timeout=10`

### Test requirements

- An exit code different than 0 must produce a warning, except on timeout.
- The timeout applies if set up.
- The test program's output appears in _archives.log_, except if ignored.
- No zombie processes must appear during more than one second (time delay before calling `waitpid`).