### PR TITLE
Fix cluster-control error when running wazuh-clusterd in foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,14 +34,12 @@ All notable changes to this project will be documented in this file.
   - Refactored framework to work with new upgrade module. ([#5537](https://github.com/wazuh/wazuh/issues/5537))
   - Refactored agent upgrade CLI to work with new ugprade module. It distributes petitions in a clustered environment. ([#5675](https://github.com/wazuh/wazuh/issues/5675))
   - Changed rule and decoder details structure to support PCRE2. ([#6318](https://github.com/wazuh/wazuh/issues/6318))
+  - Changed access to agent's status ([#6326](https://github.com/wazuh/wazuh/issues/6326))
   - Improved AWS Config integration to avoid performance issues by removing alert fields with variables such as Instance ID in its name. ([#6537](https://github.com/wazuh/wazuh/issues/6537))
 
-### Changed
-
-- **Framework:**
-  - Changed access to agent's status ([#6326](https://github.com/wazuh/wazuh/issues/6326))
-
 ### Fixed
+
+- Fixed a `cluster_control` CLI bug that caused an error message when running `wazuh-clusterd` in foreground. ([#6724](https://github.com/wazuh/wazuh/pull/6724))
 
 - **API:**
   - Fixed an error with `/groups/{group_id}/config` endpoints (GET and PUT) when using complex `localfile` configurations. ([#6276](https://github.com/wazuh/wazuh/pull/6383))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed a `cluster_control` CLI bug that caused an error message when running `wazuh-clusterd` in foreground. ([#6724](https://github.com/wazuh/wazuh/pull/6724))
+- Fixed a `cluster_control` bug that caused an error message when running `wazuh-clusterd` in foreground. ([#6724](https://github.com/wazuh/wazuh/pull/6724))
 
 - **API:**
   - Fixed an error with `/groups/{group_id}/config` endpoints (GET and PUT) when using complex `localfile` configurations. ([#6276](https://github.com/wazuh/wazuh/pull/6383))

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -115,10 +115,15 @@ def get_manager_status() -> typing.Dict:
         elif exists(join(run_dir, f'{process}.start')):
             data[process] = 'starting'
         elif pidfile:
-            process_pid = pidfile_regex.match(pidfile[0]).group(1)
-            # if a pidfile exists but the process is not running, it means the process crashed and
-            # wasn't able to remove its own pidfile.
-            data[process] = 'running' if exists(join('/proc', process_pid)) else 'failed'
+            # Iterate on pidfiles looking for the pidfile which has his pid in /proc,
+            # if the loop finishes, all pidfiles exist but their processes are not running,
+            # it means each process crashed and was not able to remove its own pidfile.
+            data[process] = 'failed'
+            for pid in pidfile:
+                if exists(join('/proc', pidfile_regex.match(pid).group(1))):
+                    data[process] = 'running'
+                    break
+
         else:
             data[process] = 'stopped'
 


### PR DESCRIPTION
|Related issue|
|---|
| #5011 |

In this PR, I have changed the `get_manager_status` function in `/framework/wazuh/core/cluster/utils.py`.

Before the change, the function was comparing only the first process pidfile in `/var/ossec/var/run` with the pids in `/proc.` This was a bad behavior and the cause of the error.

If the process (let's say `wazuh-clusterd`, which is our example) crashes or is closed by force, his pidfile will remain in `/var/ossec/var/run` but his pid will not be in `/proc`. With the behavior mentioned before, if the process were closed or crashed, the new processes would not be compared with the pids in `/proc`, only the old one (the crashed/closed one) would be compared. That way, neither the `get_manager_status` function nor the `cluster-control `CLI were retrieving real information.

Now all the processes pidfiles are compared with all pids in `/proc`. This way if `wazuh-clusterd` is running, `cluster-control` will always show the cluster information.

MANUAL TESTS:

- All cluster-control arguments are working.
- Wazuh-clusterd in the background -> cluster-control works
- Wazuh-clusterd in the foreground -> cluster-control works
- Different errors reported in a comment in the related issue.