### PR TITLE
Improve memory usage when creating cluster messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
 
 - **Framework:**
   - Deprecated `update_ruleset` script. ([#6904](https://github.com/wazuh/wazuh/issues/6904))
+  
+### Fixed
+
+- Improved memory usage when creating cluster messages. ([#6736](https://github.com/wazuh/wazuh/pull/6736))
+
 
 ## [v4.1.0]
 
@@ -65,7 +70,6 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed a `cluster_control` bug that caused an error message when running `wazuh-clusterd` in foreground. ([#6724](https://github.com/wazuh/wazuh/pull/6724))
-- Improved memory usage when creating cluster messages. ([#6736](https://github.com/wazuh/wazuh/pull/6736))
 
 - **API:**
   - Fixed an error with `/groups/{group_id}/config` endpoints (GET and PUT) when using complex `localfile` configurations. ([#6276](https://github.com/wazuh/wazuh/pull/6383))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed a `cluster_control` bug that caused an error message when running `wazuh-clusterd` in foreground. ([#6724](https://github.com/wazuh/wazuh/pull/6724))
+- Avoid memory leaks when creating cluster messages. ([#6736](https://github.com/wazuh/wazuh/pull/6736))
 
 - **API:**
   - Fixed an error with `/groups/{group_id}/config` endpoints (GET and PUT) when using complex `localfile` configurations. ([#6276](https://github.com/wazuh/wazuh/pull/6383))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed a `cluster_control` bug that caused an error message when running `wazuh-clusterd` in foreground. ([#6724](https://github.com/wazuh/wazuh/pull/6724))
-- Avoid memory leaks when creating cluster messages. ([#6736](https://github.com/wazuh/wazuh/pull/6736))
+- Improved memory usage when creating cluster messages. ([#6736](https://github.com/wazuh/wazuh/pull/6736))
 
 - **API:**
   - Fixed an error with `/groups/{group_id}/config` endpoints (GET and PUT) when using complex `localfile` configurations. ([#6276](https://github.com/wazuh/wazuh/pull/6383))


### PR DESCRIPTION
|Related issue|
|---|
| #6476 |

Hi team,

This PR closes #6476. I have learnt to use `pympler` and find possible memory leaks. In the related issue I posted a Python example of use of `pympler` with a memory leak example (using a mutable type as a default parameter in a function).

I have improved the memory usage when building cluster messages. The cluster code was using a 10 MB `bitearray` for carrying out message builds. This led to memory leaks when this `bitearray` was using less than his size (almost always).

With my changes, the message is more dynamic and we don't have any memory leaks in the cluster message creation.

The following Python script shows the old memory allocation and the new one when creating a cluster message in a summary table:

```
import struct
import random

from pympler import tracker

# variables used for the message creation
data = b'data'
command = b'command'
counter = random.SystemRandom().randint(0, 2 ** 32 - 1)
cmd_len = 12
header_len = cmd_len + 8
request_chunk = 5242880
header_format = '!2I{}s'.format(cmd_len)

# initialize summary tracker
memory_tracker = tracker.SummaryTracker()

# Initial summaries
print("\nInitial summaries")
memory_tracker.print_diff()
memory_tracker.print_diff()


# Memory leak
out_msg = bytearray(header_len + request_chunk * 2)
out_msg[:header_len] = struct.pack(header_format, counter, len(data), command)
out_msg[header_len:header_len + len(data)] = data

# Actual message size
#       types |   # objects |   total size
# =========== | =========== | ============
#   bytearray |           1 |     10.00 MB

print("\nActual message object")
memory_tracker.print_diff()
print("\nMake the diff empty")
memory_tracker.print_diff()


# NO Memory leak, difference with the last message
out_msg = bytearray(header_len + len(data))
out_msg[:header_len] = struct.pack(header_format, counter, len(data), command)
out_msg[header_len:header_len + len(data)] = data

# Message size difference. It will depend on the msg sent
#       types |   # objects |        total size
# =========== | =========== | =================
#   bytearray |           0 |   -10485756     B

print("\nNew message object")
memory_tracker.print_diff()
```

As we can see, the old message size was 10 MB (=10485760). With `pympler` we can see the difference when recreating the message in a dynamic way (adding the data length instead of introducing the data in a static array with a bigger size). The difference for this example is -10485756 B, which means the new message size is 10485760-10485756 = `4 B`.

- Unit test results:

```
framework/wazuh/tests/test_cluster.py .......                            [100%]
============================== 7 passed in 0.11s ===============================
```

```
framework/wazuh/core/cluster/tests/test_cluster.py ...................   [ 34%]
framework/wazuh/core/cluster/tests/test_common.py .......                [ 47%]
framework/wazuh/core/cluster/tests/test_control.py .....                 [ 56%]
framework/wazuh/core/cluster/tests/test_local_client.py .                [ 58%]
framework/wazuh/core/cluster/tests/test_utils.py .......                 [ 70%]
framework/wazuh/core/cluster/tests/test_worker.py .........FF.....       [100%]
Only 2 failed tests in test_worker.py, non related to the changes I did
```

```
framework/wazuh/core/cluster/dapi/tests/test_dapi.py
======================= 22 passed, 11 warnings in 0.83s ========================
```

Regards,
Manuel.
