### PR TITLE
Fix makefile to clean libpcre2 when clean-external

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1967,6 +1967,7 @@ ifneq ($(wildcard external/*/*),)
 	rm -f $(msgpack_o) $(EXTERNAL_MSGPACK)libmsgpack.a
 	-${MAKE} -C $(EXTERNAL_BZIP2) clean
 	-cd ${EXTERNAL_LIBPLIST} && ${MAKE} clean && rm -rf bin/*
+	-cd ${EXTERNAL_LIBPCRE2} && ${MAKE} distclean && rm include/*
 
 ifneq ($(wildcard external/libdb/build_unix/*),)
 	cd ${EXTERNAL_LIBDB} && ${MAKE} realclean


### PR DESCRIPTION
|Related issue|
|---|
| #6737  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team!

This PR aims to add `libpcre2` to makefile's `clean-external` option.

## Configuration options

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
