### PR TITLE
[API][Framework] Improve agents overview endpoint

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -873,7 +873,8 @@ def get_full_overview() -> WazuhResult:
     stats_distinct_os = get_distinct_agents(fields=['os.name',
                                                     'os.platform', 'os.version'], q=q).affected_items
     stats_version = get_distinct_agents(fields=['version'], q=q).affected_items
-    summary = get_agents_summary_status()['data'] if 'data' in get_agents_summary_status() else dict()
+    agent_summary_status = get_agents_summary_status()
+    summary = agent_summary_status['data'] if 'data' in agent_summary_status else dict()
     try:
         last_registered_agent = [get_agents(limit=1,
                                             sort={'fields': ['dateAdd'], 'order': 'desc'},

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1715,6 +1715,7 @@ def get_groups():
     return groups
 
 
+@common.context_cached('system_expanded_groups')
 def expand_group(group_name):
     """Expand a certain group or all (*) of them
 


### PR DESCRIPTION
Hello team, 
this closes #6747 .

We noticed the overview endpoint was taking too much time on very big environments. To improve this, we have saved some of the core functions in cache and refactored the function. This will need a bigger cluster refactor as the issue is not resolved, but it is much faster.

# Tests performed
## Integration tests
```
test_agents_DELETE_endpoints.tavern.yaml 
	 7 passed, 9 warnings

test_agents_GET_endpoints.tavern.yaml 
	 90 passed, 97 warnings

test_agents_POST_endpoints.tavern.yaml 
	 5 passed, 7 warnings

test_agents_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings

test_overview_endpoints.tavern.yaml 
	 1 passed, 3 warnings

```

Regards,
Víctor.