### PR TITLE
[Framework] Fix rootcheck framework queries

### DIFF
--- a/framework/wazuh/core/rootcheck.py
+++ b/framework/wazuh/core/rootcheck.py
@@ -75,6 +75,12 @@ class WazuhDBQueryRootcheck(WazuhDBQuery):
                            self.min_select_fields if field in db_tuple and db_tuple[field] is not None}
                           for db_tuple in self._data], 'totalItems': self.total_items}
 
+    def _process_filter(self, field_name, field_filter, q_filter):
+        if field_name == "status":
+            self._filter_status(q_filter)
+        else:
+            super()._process_filter(field_name, field_filter, q_filter)
+
     @staticmethod
     def _pass_filter(db_filter):
         return False

--- a/framework/wazuh/sca.py
+++ b/framework/wazuh/sca.py
@@ -141,8 +141,8 @@ def get_sca_checks(policy_id=None, agent_list=None, q="", offset=0, limit=common
                     if (select is None or extra_field in select) \
                             and set(field_translations.keys()) & group_list[0].keys():
                         check_dict[extra_field] = [dict(zip(field_translations.values(), x))
-                                                   for x in set((map(itemgetter(*field_translations.keys()),
-                                                                     group_list)))]
+                                                   for x in sorted(set(map(itemgetter(*field_translations.keys()),
+                                                                           group_list)))]
 
                 sca_checks.append(check_dict)
         else:

--- a/framework/wazuh/tests/test_sca.py
+++ b/framework/wazuh/tests/test_sca.py
@@ -192,10 +192,9 @@ def test_sca_checks_select_and_q(mock_agent, mock_sca_agent):
     """
     with patch('wazuh.core.utils.WazuhDBConnection') as mock_wdb:
         mock_wdb.return_value = InitWDBSocketMock(sql_schema_file='schema_sca_test.sql')
-        result = get_sca_checks('cis_debian', agent_list=['000'], q="compliance.value!=9.2",
+        result = get_sca_checks('cis_debian', agent_list=['000'], q="rules.type!=file",
                                 select=['compliance', 'policy_id', 'result', 'rules']).to_dict()
-        for affected_item in result['affected_items']:
-            assert any(map(lambda x: x['type'] != '9.2', affected_item['rules']))
+        assert result['affected_items'][0]['rules'][1]['type'] != 'file'
         assert set(result['affected_items'][0].keys()).issubset({'compliance', 'policy_id', 'result', 'rules'})
 
 

--- a/framework/wazuh/tests/test_sca.py
+++ b/framework/wazuh/tests/test_sca.py
@@ -192,9 +192,10 @@ def test_sca_checks_select_and_q(mock_agent, mock_sca_agent):
     """
     with patch('wazuh.core.utils.WazuhDBConnection') as mock_wdb:
         mock_wdb.return_value = InitWDBSocketMock(sql_schema_file='schema_sca_test.sql')
-        result = get_sca_checks('cis_debian', agent_list=['000'], q="rules.type!=file",
+        result = get_sca_checks('cis_debian', agent_list=['000'], q="compliance.value!=9.2",
                                 select=['compliance', 'policy_id', 'result', 'rules']).to_dict()
-        assert result['affected_items'][0]['rules'][0]['type'] != 'file'
+        for affected_item in result['affected_items']:
+            assert any(map(lambda x: x['type'] != '9.2', affected_item['rules']))
         assert set(result['affected_items'][0].keys()).issubset({'compliance', 'policy_id', 'result', 'rules'})
 
 


### PR DESCRIPTION
Hello team,

The SDK rootcheck unit tests were failing and we thought it was due to outdated tests but it was not the case. The framework was indeed broken.

These 2 PRs were merged almost simultaneously and caused unresolved conflicts:
- https://github.com/wazuh/wazuh/pull/6496
- https://github.com/wazuh/wazuh/pull/6479

In addition, the SDK sca unit tests that failed randomly were fixed as well. This was not related to the code.

# Tests results
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 1572 items                                                                                                                                                                        

wazuh/core/cluster/dapi/tests/test_dapi.py ......................                                                                                                                     [  1%]
wazuh/core/cluster/tests/test_cluster.py ...................                                                                                                                          [  2%]
wazuh/core/cluster/tests/test_common.py .......                                                                                                                                       [  3%]
wazuh/core/cluster/tests/test_control.py .....                                                                                                                                        [  3%]
wazuh/core/cluster/tests/test_local_client.py .                                                                                                                                       [  3%]
wazuh/core/cluster/tests/test_utils.py .......                                                                                                                                        [  3%]
wazuh/core/cluster/tests/test_worker.py ................                                                                                                                              [  4%]
wazuh/core/tests/test_active_response.py ............                                                                                                                                 [  5%]
wazuh/core/tests/test_agent.py ...................................................................................................................................................... [ 15%]
.                                                                                                                                                                                     [ 15%]
wazuh/core/tests/test_cdb_list.py .................................                                                                                                                   [ 17%]
wazuh/core/tests/test_common.py .......                                                                                                                                               [ 17%]
wazuh/core/tests/test_configuration.py ..................................                                                                                                             [ 19%]
wazuh/core/tests/test_decoder.py ................                                                                                                                                     [ 20%]
wazuh/core/tests/test_input_validator.py ...                                                                                                                                          [ 21%]
wazuh/core/tests/test_logtest.py ..                                                                                                                                                   [ 21%]
wazuh/core/tests/test_manager.py ................................                                                                                                                     [ 23%]
wazuh/core/tests/test_ossec_queue.py ...................                                                                                                                              [ 24%]
wazuh/core/tests/test_pyDaemonModule.py ......                                                                                                                                        [ 24%]
wazuh/core/tests/test_results.py ........................................                                                                                                             [ 27%]
wazuh/core/tests/test_rootcheck.py ..........                                                                                                                                         [ 28%]
wazuh/core/tests/test_rule.py ......................                                                                                                                                  [ 29%]
wazuh/core/tests/test_syscollector.py ...                                                                                                                                             [ 29%]
wazuh/core/tests/test_utils.py ...................................................................................................................................................... [ 39%]
............................................................                                                                                                                          [ 43%]
wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                            [ 44%]
wazuh/core/tests/test_wdb.py .....................                                                                                                                                    [ 45%]
wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                              [ 45%]
wazuh/rbac/tests/test_decorators.py .........................................................................................................                                         [ 52%]
wazuh/rbac/tests/test_default_configuration.py ..................................................                                                                                     [ 55%]
wazuh/rbac/tests/test_orm.py .....................................................                                                                                                    [ 59%]
wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                     [ 59%]
wazuh/tests/test_active_response.py .........                                                                                                                                         [ 60%]
wazuh/tests/test_agent.py ...................................................................................                                                                         [ 65%]
wazuh/tests/test_cdb_list.py ...............................................                                                                                                          [ 68%]
wazuh/tests/test_ciscat.py ..                                                                                                                                                         [ 68%]
wazuh/tests/test_cluster.py .......                                                                                                                                                   [ 69%]
wazuh/tests/test_decoders.py ...............................                                                                                                                          [ 71%]
wazuh/tests/test_group.py ........                                                                                                                                                    [ 71%]
wazuh/tests/test_logtest.py ......                                                                                                                                                    [ 72%]
wazuh/tests/test_manager.py ........................................                                                                                                                  [ 74%]
wazuh/tests/test_mitre.py ........................................................................................................................................................... [ 84%]
.........................                                                                                                                                                             [ 86%]
wazuh/tests/test_rootcheck.py .................................................                                                                                                       [ 89%]
wazuh/tests/test_rule.py ....................................................                                                                                                         [ 92%]
wazuh/tests/test_sca.py .......                                                                                                                                                       [ 92%]
wazuh/tests/test_security.py .....................................................................                                                                                    [ 97%]
wazuh/tests/test_stats.py .............                                                                                                                                               [ 98%]
wazuh/tests/test_syscheck.py ..................                                                                                                                                       [ 99%]
wazuh/tests/test_syscollector.py ............                                                                                                                                         [100%]

======================================================================= 1572 passed, 15 warnings in 220.74s (0:03:40) =======================================================================

```

Regards,
Víctor.