### PR TITLE
[RBAC] Handle SQLAlchemy exception when the RBAC database is not accessible

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -236,7 +236,7 @@ class DistributedAPI:
             except asyncio.TimeoutError:
                 raise exception.WazuhInternalError(3021)
             except OperationalError:
-                raise exception.WazuhError(2008)
+                raise exception.WazuhInternalError(2008)
 
             self.logger.debug(f"Time calculating request result: {time.time() - before}s")
             return data

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -27,6 +27,7 @@ from wazuh.core import common, exception
 from wazuh.core.cluster import local_client, common as c_common
 from wazuh.core.exception import WazuhException, WazuhClusterError, WazuhError
 from wazuh.core.wazuh_socket import wazuh_sendsync
+from sqlalchemy.exc import OperationalError
 
 
 class DistributedAPI:
@@ -234,6 +235,8 @@ class DistributedAPI:
                 data = await asyncio.wait_for(task, timeout=timeout)
             except asyncio.TimeoutError:
                 raise exception.WazuhInternalError(3021)
+            except OperationalError:
+                raise exception.WazuhError(2008)
 
             self.logger.debug(f"Time calculating request result: {time.time() - before}s")
             return data

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -390,6 +390,8 @@ class WazuhException(Exception):
         2005: {'message': 'Could not connect to wdb socket'},
         2006: {'message': 'Received JSON from Wazuh DB is not correctly formatted'},
         2007: {'message': 'Error retrieving data from Wazuh DB'},
+        2008: {'message': 'Corrupted RBAC database',
+               'remediation': 'Restart the Wazuh service to restore the RBAC database to default'},
 
         # Cluster
         3000: 'Cluster',


### PR DESCRIPTION
Hello team,
this closes #6790 .

We are handling properly all kind of exceptions when the RBAC database is not accessible.

- API
```json
{
  "title": "Bad Request",
  "detail": "Corrupted RBAC database",
  "remediation": "Restart the Wazuh service to restore the RBAC database to default",
  "dapi_errors": {
    "master-node": {
      "error": "Corrupted RBAC database"
    }
  },
  "error": 2008
}
```

- Log
```
2020/12/01 16:21:01 INFO: unknown_user 172.18.0.1 "GET /security/user/authenticate" done in 13.999999999214197ms: 400
```

# Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 22 items                                                                                                                                                                          

wazuh/core/cluster/dapi/tests/test_dapi.py ......................                                                                                                                     [100%]

============================================================================== 22 passed, 11 warnings in 0.47s ==============================================================================

==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 221 items                                                                                                                                                                         

wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                              [  0%]
wazuh/rbac/tests/test_decorators.py .........................................................................................................                                         [ 48%]
wazuh/rbac/tests/test_default_configuration.py ..................................................                                                                                     [ 71%]
wazuh/rbac/tests/test_orm.py .....................................................                                                                                                    [ 95%]
wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                     [100%]

======================================================================== 221 passed, 1 warning in 170.34s (0:02:50) =========================================================================


```
Regards,
Víctor.