### PR TITLE
Fixed a bug that cause false positive due to changes in timezone

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -500,6 +500,8 @@
 #define FIM_DB_ERROR_RM_RANGE                       "(6708): Failed to delete a range of paths between '%s' and '%s'"
 #define FIM_DB_ERROR_RM_NOT_SCANNED                 "(6709): Failed to delete from db all unscanned files."
 #define FIM_ERROR_WHODATA_INIT                      "(6710): Failed to start the Whodata engine. Directories/files will be monitored in Realtime mode"
+#define FIM_WARN_OPEN_HANDLE_FILE                   "(6711): Could not open handle for '(%s)', which returned (%lu)."
+#define FIM_WARN_GET_FILETIME                       "(6712): Could not get the filetime of the file '(%s)', which returned (%lu)."
 
 /* Wazuh Logtest error messsages */
 #define LOGTEST_ERROR_BIND_SOCK                     "(7300): Unable to bind to socket '%s'. Errno: (%d) %s"

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -496,6 +496,15 @@ int get_creation_date(char *dir, SYSTEMTIME *utc);
 
 
 /**
+ * @brief Get the modification date object. (Windows)
+ *
+ * @param file Path of the file.
+ * @return long long date of modification format.
+ */
+long long get_UTC_modification_time(const char *file);
+
+
+/**
  * @brief Move to the directory where this executable lives in. (Windows)
  *
  */

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1269,6 +1269,28 @@ end:
 }
 
 
+long long get_UTC_modification_time(const char *file){
+    HANDLE hdle;
+    FILETIME modification_date;
+
+    if (hdle = CreateFile(file, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL), hdle == INVALID_HANDLE_VALUE) {
+        mferror(FIM_WARN_OPEN_HANDLE_FILE, file, GetLastError());
+        return 0;
+    }
+
+    if (!GetFileTime(hdle, NULL, NULL, &modification_date)) {
+        CloseHandle(hdle);
+        mferror(FIM_WARN_GET_FILETIME, file, GetLastError());
+        return 0;
+    }
+
+    CloseHandle(hdle);
+    long long ret_val = get_windows_file_time_epoch(modification_date);
+
+    return ret_val;
+}
+
+
 char *basename_ex(char *path)
 {
     return (PathFindFileNameA(path));

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -765,7 +765,11 @@ fim_entry_data * fim_get_data(const char *file, fim_element *item) {
 #endif
 
     if (item->configuration & CHECK_MTIME) {
+#ifdef WIN32
+        data->mtime = (time_t)get_UTC_modification_time(file);
+#else
         data->mtime = item->statbuf.st_mtime;
+#endif
     }
 
 #ifdef WIN32


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4167|


## Description

Thi PR fix a false positive in Windows with file system NTFS. When a UTC time zone changes, the next scan will be generate some modified events from files that have not changed. The problem was that the stat function got the date of modification relative to the time zone. So when you change it, this data changes. Fixed using Windows API functions that do not return the UTC modification date of the file.


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
- [ ] Source installation
- [ ] Review logs syntax and correct language

- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory

