### PR TITLE
Add renamed rules and decoders to deprecated list for manager upgrade

### DIFF
--- a/src/init/wazuh/deprecated_ruleset.txt
+++ b/src/init/wazuh/deprecated_ruleset.txt
@@ -1,8 +1,11 @@
 decoders/0020-amazon_decoders.xml
 decoders/0005-json_decoders.xml
+decoders/0200-ossec_decoders.xml
 rules/0355-amazon-ec2_rules.xml
 rules/0370-amazon-iam_rules.xml
 rules/0465-amazon-s3_rules.xml
 rules/0470-suricata_rules.xml
 rules/0520-vulnerability-detector.xml
 rules/0565-ms_ipsec_rules_json.xml
+rules/0015-ossec_rules.xml
+rules/0016-wazuh_rules.xml


### PR DESCRIPTION
|Related issue|
|---|
|#6815|

#### Description
This PR adds the renamed rules and decoders (**0015-ossec_rules.xml**, **0016-wazuh_rules.xml** and **200-ossec_decoders.xml**) to the **deprecated_rules.txt** list to be deleted during the manager upgrade. 

#### Tests
- [x] Upgrade a manager and verify that these files were deleted