### PR TITLE
[API] Improve API debug mode log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
   - Added endpoints to query and manage Rootcheck data. ([#6496](https://github.com/wazuh/wazuh/pull/6496))
   - Added new endpoints to run the logtest tool and delete a logtest session ([#5984](https://github.com/wazuh/wazuh/pull/5984))
   - Added new framework modules to use the logtest tool ([#5870](https://github.com/wazuh/wazuh/pull/5870))
+  - Added debug2 mode for API log and improved debug mode. ([#6822](https://github.com/wazuh/wazuh/pull/6822))
 
 - **AWS Module:**
   - Added support for AWS load balancers (Application Load Balancer, Classic Load Balancer and Network Load Balancer). ([#6034](https://github.com/wazuh/wazuh/issues/6034))

--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -16,7 +16,7 @@ class AccessLogger(AbstractAccessLogger):
         self.logger.info(f'{request.get("user", "unknown_user")} '
                          f'{request.remote} '
                          f'"{request.method} {request.path}" '
-                         f'done in {time*1000}ms: {response.status}')
+                         f'done in {time:.3f}s: {response.status}')
 
 
 class APILogger(WazuhLogger):

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -67,7 +67,7 @@ def check_user(user, password, required_scopes=None):
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=True,
-                          logger=logging.getLogger('wazuh')
+                          logger=logging.getLogger('wazuh-api')
                           )
     data = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result())
 
@@ -137,7 +137,7 @@ def generate_token(user_id=None, data=None, run_as=False):
                           request_type='local_master',
                           is_async=False,
                           wait_for_complete=True,
-                          logger=logging.getLogger('wazuh')
+                          logger=logging.getLogger('wazuh-api')
                           )
     result = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result()).dikt
     timestamp = int(time())
@@ -220,7 +220,7 @@ def decode_token(token):
                               request_type='local_master',
                               is_async=False,
                               wait_for_complete=True,
-                              logger=logging.getLogger('wazuh')
+                              logger=logging.getLogger('wazuh-api')
                               )
         data = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result()).to_dict()
 
@@ -234,7 +234,7 @@ def decode_token(token):
                               request_type='local_master',
                               is_async=False,
                               wait_for_complete=True,
-                              logger=logging.getLogger('wazuh')
+                              logger=logging.getLogger('wazuh-api')
                               )
         result = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result())
 

--- a/api/api/controllers/active_response_controller.py
+++ b/api/api/controllers/active_response_controller.py
@@ -13,7 +13,7 @@ from api.models.base_model_ import Body
 from api.util import remove_nones_to_dict, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def run_command(request, agents_list='*', pretty=False, wait_for_complete=False):

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -19,7 +19,7 @@ from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.common import database_limit
 from wazuh.core.exception import WazuhError
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def delete_agents(request, pretty=False, wait_for_complete=False, agents_list=None, purge=False, status='all',

--- a/api/api/controllers/cdb_list_controller.py
+++ b/api/api/controllers/cdb_list_controller.py
@@ -12,7 +12,7 @@ from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh import cdb_list
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def get_lists(request, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0, limit: int = None,

--- a/api/api/controllers/ciscat_controller.py
+++ b/api/api/controllers/ciscat_controller.py
@@ -12,7 +12,7 @@ from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def get_agents_ciscat_results(request, agent_id: str, pretty: bool = False, wait_for_complete: bool = False,

--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -19,7 +19,7 @@ from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deseri
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def get_cluster_node(request, pretty=False, wait_for_complete=False):

--- a/api/api/controllers/decoder_controller.py
+++ b/api/api/controllers/decoder_controller.py
@@ -12,7 +12,7 @@ from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh import decoder as decoder_framework
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def get_decoders(request, decoder_names: list = None, pretty: bool = False, wait_for_complete: bool = False,

--- a/api/api/controllers/default_controller.py
+++ b/api/api/controllers/default_controller.py
@@ -12,7 +12,7 @@ from api.models.basic_info_model import BasicInfo
 from wazuh.core.results import WazuhResult
 from wazuh.core.security import load_spec
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def default_info(pretty=False):

--- a/api/api/controllers/experimental_controller.py
+++ b/api/api/controllers/experimental_controller.py
@@ -16,7 +16,7 @@ from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.exception import WazuhResourceNotFound
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 def check_experimental_feature_value(func):

--- a/api/api/controllers/logtest_controller.py
+++ b/api/api/controllers/logtest_controller.py
@@ -13,7 +13,7 @@ from api.util import remove_nones_to_dict, raise_if_exc
 from wazuh import logtest
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def run_logtest_tool(request, pretty: bool = False, wait_for_complete: bool = False):

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -19,7 +19,7 @@ from wazuh.core import common
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.exception import WazuhError
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def get_status(request, pretty=False, wait_for_complete=False):

--- a/api/api/controllers/mitre_controller.py
+++ b/api/api/controllers/mitre_controller.py
@@ -12,7 +12,7 @@ from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.common import database_limit
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def get_attack(request, pretty=False, wait_for_complete=False, offset=0, limit=database_limit,

--- a/api/api/controllers/overview_controller.py
+++ b/api/api/controllers/overview_controller.py
@@ -11,7 +11,7 @@ from api.util import raise_if_exc, remove_nones_to_dict
 from wazuh.agent import get_full_overview
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def get_overview_agents(request, pretty=False, wait_for_complete=False):

--- a/api/api/controllers/rootcheck_controller.py
+++ b/api/api/controllers/rootcheck_controller.py
@@ -11,7 +11,7 @@ from api.util import parse_api_param, remove_nones_to_dict, raise_if_exc
 from wazuh import rootcheck
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def put_rootcheck(request, pretty=False, wait_for_complete=False, agents_list='*'):

--- a/api/api/controllers/rule_controller.py
+++ b/api/api/controllers/rule_controller.py
@@ -14,7 +14,7 @@ from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh import rule as rule_framework
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 @cache(expires=api_conf['cache']['time'])

--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -13,7 +13,7 @@ import wazuh.sca as sca
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.common import database_limit
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=False, name=None, description=None,

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -24,7 +24,7 @@ from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.core.security import revoke_tokens
 from wazuh.rbac import preprocessor
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 auth_re = re.compile(r'basic (.*)', re.IGNORECASE)
 
 

--- a/api/api/controllers/syscheck_controller.py
+++ b/api/api/controllers/syscheck_controller.py
@@ -11,7 +11,7 @@ from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.syscheck import run, clear, files, last_scan
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def put_syscheck(request, agents_list='*', pretty=False, wait_for_complete=False):

--- a/api/api/controllers/syscollector_controller.py
+++ b/api/api/controllers/syscollector_controller.py
@@ -11,7 +11,7 @@ from api.encoder import dumps, prettify
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
-logger = logging.getLogger('wazuh')
+logger = logging.getLogger('wazuh-api')
 
 
 async def get_hardware_info(request, agent_id, pretty=False, wait_for_complete=False, select=None):

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -3,6 +3,7 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import concurrent.futures
+from json import JSONDecodeError
 
 from logging import getLogger
 from time import time
@@ -61,6 +62,17 @@ async def prevent_bruteforce_attack(request, attempts=5):
 
         if ip_stats[request.remote]['attempts'] >= attempts:
             ip_block.add(request.remote)
+
+
+@web.middleware
+async def request_logging(request, handler):
+    try:
+        body = await request.json()
+    except JSONDecodeError:
+        body = {}
+    logger.debug(f'Receiving request "{request.method} {request.path}" with parameters {dict(request.query)} '
+                 f'and body {body}')
+    return await handler(request)
 
 
 @web.middleware

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -17,7 +17,7 @@ from api.configuration import api_conf
 from api.util import raise_if_exc
 from wazuh.core.exception import WazuhTooManyRequests, WazuhPermissionError
 
-logger = getLogger('wazuh')
+logger = getLogger('wazuh-api')
 pool = concurrent.futures.ThreadPoolExecutor()
 
 

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -66,12 +66,13 @@ async def prevent_bruteforce_attack(request, attempts=5):
 
 @web.middleware
 async def request_logging(request, handler):
+    """Add request info to logging."""
+    logger.debug2(f'Receiving headers {dict(request.headers)}')
     try:
-        body = await request.json()
+        body = f' and body {await request.json()}'
     except JSONDecodeError:
-        body = {}
-    logger.debug(f'Receiving request "{request.method} {request.path}" with parameters {dict(request.query)} '
-                 f'and body {body}')
+        body = ''
+    logger.debug(f'Receiving request "{request.method} {request.path}" with parameters {dict(request.query)}{body}')
     return await handler(request)
 
 

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -8,6 +8,7 @@ import argparse
 import sys
 
 from api import alogging, configuration
+from api.middlewares import request_logging
 from wazuh.core import common
 
 
@@ -127,7 +128,7 @@ def start(foreground, root, config_file):
                 strict_validation=True,
                 validate_responses=False,
                 pass_context_arg_name='request',
-                options={"middlewares": [response_postprocessing, set_user_name, security_middleware]})
+                options={"middlewares": [response_postprocessing, set_user_name, security_middleware, request_logging]})
 
     # Enable CORS
     if api_conf['cors']['enabled']:
@@ -159,7 +160,8 @@ def start(foreground, root, config_file):
 def set_logging(log_path='logs/api.log', foreground_mode=False, debug_mode='info'):
     for logger_name in ('connexion.aiohttp_app', 'connexion.apis.aiohttp_api', 'wazuh'):
         api_logger = alogging.APILogger(log_path=log_path, foreground_mode=foreground_mode,
-                                        debug_level=debug_mode,
+                                        debug_level='info' if logger_name != 'wazuh'
+                                        and debug_mode != 'debug2' else debug_mode,
                                         logger_name=logger_name)
         api_logger.setup_logger()
 

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -8,7 +8,6 @@ import argparse
 import sys
 
 from api import alogging, configuration
-from api.middlewares import request_logging
 from wazuh.core import common
 
 
@@ -42,13 +41,14 @@ def start(foreground, root, config_file):
     from api import validator
     from api.api_exception import APIError
     from api.constants import CONFIG_FILE_PATH
-    from api.middlewares import set_user_name, security_middleware, response_postprocessing
+    from api.middlewares import set_user_name, security_middleware, response_postprocessing, request_logging
     from api.uri_parser import APIUriParser
     from api.util import to_relative_path
     from wazuh.core import pyDaemonModule
 
     configuration.api_conf.update(configuration.read_yaml_config(config_file=config_file))
     api_conf = configuration.api_conf
+    security_conf = configuration.security_conf
     log_path = api_conf['logs']['path']
 
     # Set up logger
@@ -147,6 +147,10 @@ def start(foreground, root, config_file):
     # Enable cache plugin
     if api_conf['cache']['enabled']:
         setup_cache(app.app)
+
+    # API configuration logging
+    logger.debug(f'Loaded API configuration: {api_conf}')
+    logger.debug(f'Loaded security API configuration: {security_conf}')
 
     # Start API
     app.run(port=api_conf['port'],

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -53,7 +53,7 @@ def start(foreground, root, config_file):
 
     # Set up logger
     set_logging(log_path=log_path, debug_mode=api_conf['logs']['level'], foreground_mode=foreground)
-    logger = logging.getLogger('wazuh')
+    logger = logging.getLogger('wazuh-api')
 
     # Set correct permissions on api.log file
     if os.path.exists(os.path.join(common.ossec_path, log_path)):
@@ -158,9 +158,9 @@ def start(foreground, root, config_file):
 
 
 def set_logging(log_path='logs/api.log', foreground_mode=False, debug_mode='info'):
-    for logger_name in ('connexion.aiohttp_app', 'connexion.apis.aiohttp_api', 'wazuh'):
+    for logger_name in ('connexion.aiohttp_app', 'connexion.apis.aiohttp_api', 'wazuh-api'):
         api_logger = alogging.APILogger(log_path=log_path, foreground_mode=foreground_mode,
-                                        debug_level='info' if logger_name != 'wazuh'
+                                        debug_level='info' if logger_name != 'wazuh-api'
                                         and debug_mode != 'debug2' else debug_mode,
                                         logger_name=logger_name)
         api_logger.setup_logger()

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -2,28 +2,22 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GP
 
+import copy
 import fcntl
 import hashlib
 import ipaddress
 from base64 import b64encode
 from datetime import date, datetime
-
 from json import dumps, loads
-from os import chown, chmod, path, makedirs, urandom, stat, remove
-from datetime import date, datetime, timedelta, timezone
 from os import chown, chmod, makedirs, urandom, stat, remove
 from os import listdir, path
 from platform import platform
 from shutil import copyfile, rmtree
 from time import time
 
-import copy
-from platform import platform
-
 from wazuh.core import common, configuration
 from wazuh.core.InputValidator import InputValidator
 from wazuh.core.cluster.utils import get_manager_status
-from wazuh.core.common import client_keys, shared_path, groups_path
 from wazuh.core.exception import WazuhException, WazuhError, WazuhInternalError, WazuhResourceNotFound
 from wazuh.core.ossec_queue import OssecQueue
 from wazuh.core.utils import chmod_r, WazuhVersion, plain_dict_to_nested_dict, get_fields_to_nest, WazuhDBQuery, \
@@ -1078,7 +1072,7 @@ def send_restart_command(agent_id):
 @common.context_cached('system_agents')
 def get_agents_info():
     """Get all agent IDs in the system."""
-    with open(client_keys, 'r') as f:
+    with open(common.client_keys, 'r') as f:
         result = {line.split(' ')[0] for line in f}
 
     result.add('000')
@@ -1092,8 +1086,8 @@ def get_groups():
     :return: List of group names
     """
     groups = set()
-    for shared_file in listdir(shared_path):
-        path.isdir(path.join(shared_path, shared_file)) and groups.add(shared_file)
+    for shared_file in listdir(common.shared_path):
+        path.isdir(path.join(common.shared_path, shared_file)) and groups.add(shared_file)
 
     return groups
 
@@ -1107,12 +1101,12 @@ def expand_group(group_name):
     """
     agents_ids = set()
     if group_name == '*':
-        for file in listdir(groups_path):
-            if path.getsize(path.join(groups_path, file)) > 0:
+        for file in listdir(common.groups_path):
+            if path.getsize(path.join(common.groups_path, file)) > 0:
                 agents_ids.add(file)
     else:
-        for file in listdir(groups_path):
-            with open(path.join(groups_path, file), 'r') as f:
+        for file in listdir(common.groups_path):
+            with open(path.join(common.groups_path, file), 'r') as f:
                 try:
                     if group_name in f.readlines()[0]:
                         agents_ids.add(file)

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -99,6 +99,19 @@ class DistributedAPI:
         self.local_client_arg = local_client_arg
         self.threadpool = ThreadPoolExecutor(max_workers=1)
 
+    def debug_log(self, message):
+        """Use debug or debug2 depending on the log type.
+
+        Parameters
+        ----------
+        message : str
+            Full log message.
+        """
+        if self.logger.name == 'wazuh-api':
+            self.logger.debug2(message)
+        else:
+            self.logger.debug(message)
+
     async def distribute_function(self) -> [Dict, exception.WazuhException]:
         """
         Distribute an API call.
@@ -110,9 +123,11 @@ class DistributedAPI:
         """
         try:
             if 'password' in self.f_kwargs:
-                self.logger.debug(f"Receiving parameters { {**self.f_kwargs, 'password': '****'} }")
+                self.debug_log(f"Receiving parameters { {**self.f_kwargs, 'password': '****'} }")
+            elif 'token_nbf_time' in self.f_kwargs:
+                self.debug_log(f"Receiving token {self.f_kwargs}")
             else:
-                self.logger.debug(f"Receiving parameters {self.f_kwargs}")
+                self.debug_log(f"Receiving parameters {self.f_kwargs}")
 
             is_dapi_enabled = self.cluster_items['distributed_api']['enabled']
             # First case: execute the request locally.
@@ -200,14 +215,14 @@ class DistributedAPI:
             JSON response.
         """
         def run_local():
-            self.logger.debug("Starting to execute request locally")
+            self.debug_log("Starting to execute request locally")
             common.rbac.set(self.rbac_permissions)
             common.broadcast.set(self.broadcasting)
             common.cluster_nodes.set(self.nodes)
             common.current_user.set(self.current_user)
             data = self.f(**self.f_kwargs)
             common.reset_context_cache()
-            self.logger.debug("Finished executing request locally")
+            self.debug_log("Finished executing request locally")
             return data
 
         try:
@@ -235,7 +250,7 @@ class DistributedAPI:
             except asyncio.TimeoutError:
                 raise exception.WazuhInternalError(3021)
 
-            self.logger.debug(f"Time calculating request result: {time.time() - before}s")
+            self.debug_log(f"Time calculating request result: {time.time() - before:.3f}s")
             return data
         except (exception.WazuhError, exception.WazuhResourceNotFound) as e:
             e.dapi_errors = self.get_error_info(e)

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -125,7 +125,7 @@ class DistributedAPI:
             if 'password' in self.f_kwargs:
                 self.debug_log(f"Receiving parameters { {**self.f_kwargs, 'password': '****'} }")
             elif 'token_nbf_time' in self.f_kwargs:
-                self.debug_log(f"Receiving token {self.f_kwargs}")
+                self.logger.debug(f"Decoded token {self.f_kwargs}")
             else:
                 self.debug_log(f"Receiving parameters {self.f_kwargs}")
 

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -16,6 +16,7 @@ with patch('wazuh.core.common.ossec_uid'):
         from wazuh.core.agent import *
         from wazuh.core.exception import WazuhException
         from api.util import remove_nones_to_dict
+        from wazuh.core.common import reset_context_cache
 
 from pwd import getpwnam
 from grp import getgrnam
@@ -1468,7 +1469,7 @@ def test_get_groups():
     expected_result = {'group-1', 'group-2'}
     shared = os.path.join(test_data_path, 'shared')
 
-    with patch('wazuh.core.agent.shared_path', new=shared):
+    with patch('wazuh.core.common.shared_path', new=shared):
         try:
             for group in list(expected_result):
                 os.makedirs(os.path.join(shared, group))
@@ -1502,7 +1503,7 @@ def test_expand_group(group, expected_agents):
     id_groups = {'000': 'group1', '001': 'group2', '002': 'group3', '004': '', '005': 'group3,group4', '006': ''}
     agent_groups = os.path.join(test_data_path, 'agent-groups')
 
-    with patch('wazuh.core.agent.groups_path', new=agent_groups):
+    with patch('wazuh.core.common.groups_path', new=agent_groups):
         try:
             os.makedirs(agent_groups)
             for id_, groups in id_groups.items():

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -66,7 +66,7 @@ def send_msg_to_wdb(msg, raw=False):
         {'os': {'name': 'Ubuntu', 'platform': 'ubuntu', 'version': '16.04.1 LTS'}, 'count': 1},
         {'os': {'name': 'unknown', 'platform': 'unknown', 'version': 'unknown'}, 'count': 2}]),
 ])
-@patch('wazuh.core.agent.client_keys', new=os.path.join(test_agent_path, 'client.keys'))
+@patch('wazuh.core.common.client_keys', new=os.path.join(test_agent_path, 'client.keys'))
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
 def test_agent_get_distinct_agents(socket_mock, send_mock, fields, expected_items):


### PR DESCRIPTION
Hello team,
this closes #6803 .

This PR improves the API debug mode log to reduce the flooding and add more useful information about the requests. It sucessfully supports `debug` and `debug2` modes with significant differences now:

- **debug**: Shows information about the requests. Query parameters and body if it is present.
- **debug2**: In addition to the `debug` information; debug mode for `DistributedAPI`, `openspec` and `aiohttp` is enabled too.

## Log samples
### INFO level (default)
```
2020/12/03 16:23:22 INFO: Listening on 0.0.0.0:55000..
2020/12/03 16:23:51 INFO: wazuh 172.18.0.1 "PUT /security/roles/100" done in 0.100s: 200
```

### DEBUG level
```
2020/12/03 16:25:22 DEBUG: Loaded API configuration: {'host': '0.0.0.0', 'port': 55000, 'behind_proxy_server': False, 'https': {'enabled': True, 'key': '/var/ossec/api/configuration/ssl/server.key', 'cert': '/var/ossec/api/configuration/ssl/server.crt', 'use_ca': False, 'ca': '/var/ossec/api/configuration/ssl/ca.crt'}, 'logs': {'level': 'debug2', 'path': '/var/ossec/logs/api.log'}, 'cors': {'enabled': False, 'source_route': '*', 'expose_headers': '*', 'allow_headers': '*', 'allow_credentials': False}, 'cache': {'enabled': True, 'time': 0.75}, 'access': {'max_login_attempts': 50, 'block_time': 300, 'max_request_per_minute': 300}, 'use_only_authd': False, 'drop_privileges': True, 'experimental_features': False}
2020/12/03 16:25:22 DEBUG: Loaded security API configuration: {'auth_token_exp_timeout': 3600, 'rbac_mode': 'white'}
2020/12/03 16:25:22 INFO: Listening on 0.0.0.0:55000..
2020/12/03 16:25:36 DEBUG: Receiving request "PUT /security/roles/100" with parameters {'wait_for_complete': 'true'} and body {'name': 'new_role_name'}
2020/12/03 16:25:36 DEBUG: Decoded token {'username': 'wazuh', 'roles': [1], 'token_nbf_time': 1607093147, 'run_as': False}
2020/12/03 16:25:36 INFO: wazuh 172.18.0.1 "PUT /security/roles/100" done in 0.092s: 200
```

### DEBUG2 level
```
2020/12/03 16:26:12 DEBUG: Adding spec json: //openapi.json
2020/12/03 16:26:12 DEBUG: Adding spec yaml: //openapi.yaml
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.default_controller.default_info
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.active_response_controller.run_command
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.agent_controller.delete_agents
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_agents
2020/12/03 16:26:12 DEBUG: ... Adding POST -> api.controllers.agent_controller.add_agent
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_agent_config
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.agent_controller.delete_single_agent_multiple_groups
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_sync_agent
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.agent_controller.delete_single_agent_single_group
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.agent_controller.put_agent_single_group
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_agent_key
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.agent_controller.restart_agent
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.agent_controller.put_upgrade_agents
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.agent_controller.put_upgrade_custom_agents
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_agent_upgrade
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.agent_controller.delete_multiple_agent_single_group
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.agent_controller.put_multiple_agent_single_group
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.agent_controller.restart_agents_by_group
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.agent_controller.delete_groups
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_list_group
2020/12/03 16:26:12 DEBUG: ... Adding POST -> api.controllers.agent_controller.post_group
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_agents_in_group
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_group_config
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.agent_controller.put_group_config
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_group_files
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_group_file_json
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_group_file_xml
2020/12/03 16:26:12 DEBUG: ... Adding POST -> api.controllers.agent_controller.insert_agent
2020/12/03 16:26:12 DEBUG: ... Adding POST -> api.controllers.agent_controller.post_new_agent
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_agent_no_group
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.agent_controller.restart_agents_by_node
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_agent_outdated
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.agent_controller.restart_agents
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_agent_fields
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_agent_summary_os
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.agent_controller.get_agent_summary_status
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.ciscat_controller.get_agents_ciscat_results
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_cluster_node
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_cluster_nodes
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_healthcheck
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_status
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_config
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_api_config
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.cluster_controller.put_api_config
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.cluster_controller.delete_api_config
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_status_node
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_info_node
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_configuration_node
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_stats_node
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_stats_hourly_node
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_stats_weekly_node
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_stats_analysisd_node
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_stats_remoted_node
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_log_node
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_log_summary_node
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_files_node
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.cluster_controller.put_files_node
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.cluster_controller.delete_files_node
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.cluster_controller.put_restart
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_conf_validation
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cluster_controller.get_node_config
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cdb_list_controller.get_lists
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.cdb_list_controller.get_lists_files
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.logtest_controller.run_logtest_tool
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.logtest_controller.end_logtest_session
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_status
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_configuration
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_stats
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_stats_hourly
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_stats_weekly
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_stats_analysisd
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_stats_remoted
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_log
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_log_summary
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_files
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.manager_controller.put_files
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.manager_controller.delete_files
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_api_config
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.manager_controller.put_api_config
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.manager_controller.delete_api_config
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.manager_controller.put_restart
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_conf_validation
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.manager_controller.get_manager_config_ondemand
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.mitre_controller.get_attack
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.rootcheck_controller.delete_rootcheck
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.rootcheck_controller.put_rootcheck
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.rootcheck_controller.get_rootcheck_agent
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.rootcheck_controller.get_last_scan_agent
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.rule_controller.get_rules
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.rule_controller.get_rules_groups
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.rule_controller.get_rules_requirement
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.rule_controller.get_rules_files
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.rule_controller.get_download_file
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.sca_controller.get_sca_agent
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.sca_controller.get_sca_checks
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.syscheck_controller.put_syscheck
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.syscheck_controller.get_syscheck_agent
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.syscheck_controller.delete_syscheck_agent
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.syscheck_controller.get_last_scan_agent
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.decoder_controller.get_decoders
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.decoder_controller.get_decoders_files
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.decoder_controller.get_download_file
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.decoder_controller.get_decoders_parents
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.experimental_controller.clear_syscheck_database
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.experimental_controller.get_cis_cat_results
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.experimental_controller.get_hardware_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.experimental_controller.get_network_address_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.experimental_controller.get_network_interface_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.experimental_controller.get_network_protocol_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.experimental_controller.get_os_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.experimental_controller.get_packages_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.experimental_controller.get_ports_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.experimental_controller.get_processes_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.experimental_controller.get_hotfixes_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.syscollector_controller.get_hardware_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.syscollector_controller.get_hotfix_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.syscollector_controller.get_network_address_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.syscollector_controller.get_network_interface_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.syscollector_controller.get_network_protocol_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.syscollector_controller.get_os_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.syscollector_controller.get_packages_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.syscollector_controller.get_ports_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.syscollector_controller.get_processes_info
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.security_controller.login_user
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.security_controller.logout_user
2020/12/03 16:26:12 DEBUG: ... Adding POST -> api.controllers.security_controller.login_user
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.security_controller.get_user_me
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.security_controller.get_user_me_policies
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.security_controller.revoke_all_tokens
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.security_controller.get_rbac_actions
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.security_controller.get_rbac_resources
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.security_controller.get_users
2020/12/03 16:26:12 DEBUG: ... Adding POST -> api.controllers.security_controller.create_user
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.security_controller.delete_users
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.security_controller.update_user
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.security_controller.get_roles
2020/12/03 16:26:12 DEBUG: ... Adding POST -> api.controllers.security_controller.add_role
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.security_controller.remove_roles
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.security_controller.update_role
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.security_controller.get_rules
2020/12/03 16:26:12 DEBUG: ... Adding POST -> api.controllers.security_controller.add_rule
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.security_controller.remove_rules
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.security_controller.update_rule
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.security_controller.get_policies
2020/12/03 16:26:12 DEBUG: ... Adding POST -> api.controllers.security_controller.add_policy
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.security_controller.remove_policies
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.security_controller.update_policy
2020/12/03 16:26:12 DEBUG: ... Adding POST -> api.controllers.security_controller.set_user_role
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.security_controller.remove_user_role
2020/12/03 16:26:12 DEBUG: ... Adding POST -> api.controllers.security_controller.set_role_policy
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.security_controller.remove_role_policy
2020/12/03 16:26:12 DEBUG: ... Adding POST -> api.controllers.security_controller.set_role_rule
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.security_controller.remove_role_rule
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.overview_controller.get_overview_agents
2020/12/03 16:26:12 DEBUG: ... Adding GET -> api.controllers.security_controller.get_security_config
2020/12/03 16:26:12 DEBUG: ... Adding PUT -> api.controllers.security_controller.put_security_config
2020/12/03 16:26:12 DEBUG: ... Adding DELETE -> api.controllers.security_controller.delete_security_config
2020/12/03 16:26:12 DEBUG: Loaded API configuration: {'host': '0.0.0.0', 'port': 55000, 'behind_proxy_server': False, 'https': {'enabled': True, 'key': '/var/ossec/api/configuration/ssl/server.key', 'cert': '/var/ossec/api/configuration/ssl/server.crt', 'use_ca': False, 'ca': '/var/ossec/api/configuration/ssl/ca.crt'}, 'logs': {'level': 'debug2', 'path': '/var/ossec/logs/api.log'}, 'cors': {'enabled': False, 'source_route': '*', 'expose_headers': '*', 'allow_headers': '*', 'allow_credentials': False}, 'cache': {'enabled': True, 'time': 0.75}, 'access': {'max_login_attempts': 50, 'block_time': 300, 'max_request_per_minute': 300}, 'use_only_authd': False, 'drop_privileges': True, 'experimental_features': False}
2020/12/03 16:26:12 DEBUG: Loaded security API configuration: {'auth_token_exp_timeout': 3600, 'rbac_mode': 'white'}
2020/12/03 16:26:12 DEBUG: Starting aiohttp HTTP server..
2020/12/03 16:26:12 INFO: Listening on 0.0.0.0:55000..
2020/12/03 16:26:27 DEBUG: Receiving request "PUT /security/roles/100" with parameters {'wait_for_complete': 'true'} and body {'name': 'new_role_name'}
2020/12/03 16:26:27 DEBUG: Getting data and status code
2020/12/03 16:26:27 DEBUG: Decoded token {'username': 'wazuh', 'roles': [1], 'token_nbf_time': 1607012047, 'run_as': False}
2020/12/03 16:26:27 DEBUG2: Starting to execute request locally
2020/12/03 16:26:27 DEBUG2: Finished executing request locally
2020/12/03 16:26:27 DEBUG2: Time calculating request result: 0.051s
2020/12/03 16:26:27 DEBUG2: Receiving parameters {}
2020/12/03 16:26:27 DEBUG2: Starting to execute request locally
2020/12/03 16:26:27 DEBUG2: Finished executing request locally
2020/12/03 16:26:27 DEBUG2: Time calculating request result: 0.002s
2020/12/03 16:26:27 DEBUG2: Receiving parameters {'name': 'new_role_name', 'role_id': '100'}
2020/12/03 16:26:27 DEBUG2: Starting to execute request locally
2020/12/03 16:26:27 DEBUG2: Finished executing request locally
2020/12/03 16:26:27 DEBUG2: Time calculating request result: 0.045s
2020/12/03 16:26:27 INFO: wazuh 172.18.0.1 "PUT /security/roles/100" done in 0.104s: 200
```

## Unit tests
### API
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 195 items                                                                                                                                                                         

test/test_alogging.py ........                                                                                                                                                        [  4%]
test/test_authentication.py ..........                                                                                                                                                [  9%]
test/test_configuration.py .......                                                                                                                                                    [ 12%]
test/test_util.py ...................................                                                                                                                                 [ 30%]
test/test_validator.py .......................................................................................................................................                        [100%]

============================================================================= 195 passed, 16 warnings in 0.86s ==============================================================================

```

### Framework
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 1573 items                                                                                                                                                                        

core/cluster/dapi/tests/test_dapi.py ......................                                                                                                                           [  1%]
core/cluster/tests/test_cluster.py ...................                                                                                                                                [  2%]
core/cluster/tests/test_common.py .......                                                                                                                                             [  3%]
core/cluster/tests/test_control.py .....                                                                                                                                              [  3%]
core/cluster/tests/test_local_client.py .                                                                                                                                             [  3%]
core/cluster/tests/test_utils.py .......                                                                                                                                              [  3%]
core/cluster/tests/test_worker.py ................                                                                                                                                    [  4%]
core/tests/test_active_response.py ............                                                                                                                                       [  5%]
core/tests/test_agent.py .......................................................................................................................................................      [ 15%]
core/tests/test_cdb_list.py .................................                                                                                                                         [ 17%]
core/tests/test_common.py .......                                                                                                                                                     [ 17%]
core/tests/test_configuration.py ..................................                                                                                                                   [ 19%]
core/tests/test_decoder.py ................                                                                                                                                           [ 20%]
core/tests/test_input_validator.py ...                                                                                                                                                [ 21%]
core/tests/test_logtest.py ..                                                                                                                                                         [ 21%]
core/tests/test_manager.py ................................                                                                                                                           [ 23%]
core/tests/test_ossec_queue.py ...................                                                                                                                                    [ 24%]
core/tests/test_pyDaemonModule.py ......                                                                                                                                              [ 24%]
core/tests/test_results.py ........................................                                                                                                                   [ 27%]
core/tests/test_rootcheck.py ..........                                                                                                                                               [ 28%]
core/tests/test_rule.py ......................                                                                                                                                        [ 29%]
core/tests/test_syscollector.py ...                                                                                                                                                   [ 29%]
core/tests/test_utils.py ............................................................................................................................................................ [ 39%]
......................................................                                                                                                                                [ 43%]
core/tests/test_wazuh_socket.py ....................                                                                                                                                  [ 44%]
core/tests/test_wdb.py .....................                                                                                                                                          [ 45%]
rbac/tests/test_auth_context.py ..                                                                                                                                                    [ 45%]
rbac/tests/test_decorators.py .........................................................................................................                                               [ 52%]
rbac/tests/test_default_configuration.py ..................................................                                                                                           [ 55%]
rbac/tests/test_orm.py .....................................................                                                                                                          [ 58%]
rbac/tests/test_preprocessor.py ...........                                                                                                                                           [ 59%]
tests/test_active_response.py .........                                                                                                                                               [ 60%]
tests/test_agent.py ....................................................................................                                                                              [ 65%]
tests/test_cdb_list.py ...............................................                                                                                                                [ 68%]
tests/test_ciscat.py ..                                                                                                                                                               [ 68%]
tests/test_cluster.py .......                                                                                                                                                         [ 69%]
tests/test_decoders.py ...............................                                                                                                                                [ 71%]
tests/test_group.py ........                                                                                                                                                          [ 71%]
tests/test_logtest.py ......                                                                                                                                                          [ 72%]
tests/test_manager.py ........................................                                                                                                                        [ 74%]
tests/test_mitre.py ................................................................................................................................................................. [ 84%]
...................                                                                                                                                                                   [ 86%]
tests/test_rootcheck.py .................................................                                                                                                             [ 89%]
tests/test_rule.py ....................................................                                                                                                               [ 92%]
tests/test_sca.py .......                                                                                                                                                             [ 92%]
tests/test_security.py .....................................................................                                                                                          [ 97%]
tests/test_stats.py .............                                                                                                                                                     [ 98%]
tests/test_syscheck.py ..................                                                                                                                                             [ 99%]
tests/test_syscollector.py ............                                                                                                                                               [100%]

======================================================================= 1573 passed, 15 warnings in 232.50s (0:03:52) =======================================================================

```

Regards,
Víctor.