### PR TITLE
Fix race condition in Remoted when setting umask

### DIFF
--- a/src/headers/agent_op.h
+++ b/src/headers/agent_op.h
@@ -59,8 +59,12 @@ int os_write_agent_info(const char *agent_name, const char *agent_ip, const char
 /* Read agent group. Returns 0 on success or -1 on failure. */
 int get_agent_group(const char *id, char *group, size_t size);
 
+#ifndef CLIENT
+
 /* Set agent group. Returns 0 on success or -1 on failure. */
 int set_agent_group(const char * id, const char * group);
+
+#endif
 
 /* Create multigroup dir. Returns 0 on success or -1 on failure. */
 int create_multigroup_dir(const char * multigroup);

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -311,6 +311,10 @@ int set_agent_group(const char * id, const char * group) {
         return -1;
     }
 
+    if (fchmod(fileno(fp), 0660) < 0) {
+        merror(CHMOD_ERROR, path, errno, strerror(errno));
+    }
+
     fprintf(fp, "%s\n", group);
     fclose(fp);
 

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -291,6 +291,8 @@ int get_agent_group(const char *id, char *group, size_t size) {
     return result;
 }
 
+#ifndef CLIENT
+
 /* Set agent group. Returns 0 on success or -1 on failure. */
 int set_agent_group(const char * id, const char * group) {
     char path[PATH_MAX];
@@ -322,6 +324,8 @@ int set_agent_group(const char * id, const char * group) {
 
     return 0;
 }
+
+#endif
 
 int set_agent_multigroup(char * group){
     int oldmask;

--- a/src/unit_tests/wazuh_modules/scheduling/wmodules_scheduling_helpers.c
+++ b/src/unit_tests/wazuh_modules/scheduling/wmodules_scheduling_helpers.c
@@ -17,7 +17,7 @@ extern time_t __real_time(time_t *_time);
 
 time_t __wrap_time(time_t *_time){
     if(!current_time){
-        current_time = __real_time(NULL);
+        current_time = 1606797884;
     }
     return current_time;
 }


### PR DESCRIPTION
|Related issue|
|---|
|#4010|

This PR aims to fie a race condition in Remoted that let it create agent-groups files with incorrect permissions, as described in the issue above.

## Fix

Event setting `umask` to `006` to achieve default permissions `rw-rw----`, we add `chmod` on each file to ensure that they get the correct permissions.

## Tests

- [X] Compile manager for Linux from sources.
- [X] Connect an agent and check the permissions of its agent-groups file.

Please note that we did not manage to reproduce this issue, but we expect this PR to fix the bug described.