### PR TITLE
Fixing issues reported by Coverity scan

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -166,7 +166,8 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         || !strcmp(*nodes[i]->values, CLB_BUCKET_TYPE) || !strcmp(*nodes[i]->values, NLB_BUCKET_TYPE)) {
                         os_strdup(*nodes[i]->values, cur_bucket->type);
                     } else {
-                        mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s', '%s', '%s', '%s', '%s' or '%s'",
+                        mterror(WM_AWS_LOGTAG, "Invalid bucket type '%s'. Valid ones are '%s', '%s', '%s', '%s', '%s', "
+                                               "'%s', %s', %s', %s' or '%s'",
                             *nodes[i]->values, CLOUDTRAIL_BUCKET_TYPE, CONFIG_BUCKET_TYPE, GUARDDUTY_BUCKET_TYPE, VPCFLOW_BUCKET_TYPE,
                             WAF_BUCKET_TYPE, CISCO_UMBRELLA_BUCKET_TYPE, CUSTOM_BUCKET_TYPE, ALB_BUCKET_TYPE, CLB_BUCKET_TYPE, NLB_BUCKET_TYPE);
                         OS_ClearNode(children);
@@ -397,7 +398,7 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
         } else if (is_sched_tag(nodes[i]->element)) {
             // Do nothing
         } else {
-            merror("No such tag '%s' at module '%s'.", nodes[i]->element, WM_AWS_CONTEXT.name);	
+            merror("No such tag '%s' at module '%s'.", nodes[i]->element, WM_AWS_CONTEXT.name);
             return OS_INVALID;
         }
     }

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -634,9 +634,13 @@ int OS_SetSendTimeout(int socket, int seconds)
  * Return 0 on success or OS_SOCKTERR on error.
  */
 int OS_SendSecureTCP(int sock, uint32_t size, const void * msg) {
-    int retval;
-    void * buffer;
+    int retval = OS_SOCKTERR;
+    void* buffer = NULL;
     size_t bufsz = size + sizeof(uint32_t);
+
+    if (sock < 0) {
+        return retval;
+    }
 
     os_malloc(bufsz, buffer);
     *(uint32_t *)buffer = wnet_order(size);

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -453,7 +453,7 @@ os_info *get_unix_version()
                 while (fgets(buff, sizeof(buff) - 1, version_release)) {
                     if(regexec(&regexCompiled, buff, 2, match, 0) == 0){
                         match_size = match[1].rm_eo - match[1].rm_so;
-                        info->os_version = malloc(match_size +1);
+                        os_malloc(match_size + 1, info->os_version);
                         snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                         break;
                     }
@@ -482,7 +482,7 @@ os_info *get_unix_version()
             while (fgets(buff, sizeof(buff) - 1, version_release)) {
                 if(regexec(&regexCompiled, buff, 2, match, 0) == 0){
                     match_size = match[1].rm_eo - match[1].rm_so;
-                    info->os_version = malloc(match_size +1);
+                    os_malloc(match_size + 1, info->os_version);
                     snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                     break;
                 }
@@ -500,7 +500,7 @@ os_info *get_unix_version()
             while (fgets(buff, sizeof(buff) - 1, version_release)) {
                 if(regexec(&regexCompiled, buff, 2, match, 0) == 0){
                     match_size = match[1].rm_eo - match[1].rm_so;
-                    info->os_version = malloc(match_size +1);
+                    os_malloc(match_size + 1, info->os_version);
                     snprintf(info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                     break;
                 }
@@ -531,7 +531,7 @@ os_info *get_unix_version()
 
                 if(regexec(&regexCompiled, buff, 2, match, 0) == 0){
                     match_size = match[1].rm_eo - match[1].rm_so;
-                    info->os_version = malloc(match_size +1);
+                    os_malloc(match_size + 1, info->os_version);
                     snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                     break;
                 }
@@ -562,7 +562,7 @@ os_info *get_unix_version()
             while (fgets(buff, sizeof(buff) - 1, version_release)) {
                 if(regexec(&regexCompiled, buff, 2, match, 0) == 0){
                     match_size = match[1].rm_eo - match[1].rm_so;
-                    info->os_version = malloc(match_size +1);
+                    os_malloc(match_size + 1, info->os_version);
                     snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                     break;
                 }
@@ -580,7 +580,7 @@ os_info *get_unix_version()
             while (fgets(buff, sizeof(buff) - 1, version_release)) {
                 if(regexec(&regexCompiled, buff, 2, match, 0) == 0){
                     match_size = match[1].rm_eo - match[1].rm_so;
-                    info->os_version = malloc(match_size +1);
+                    os_malloc(match_size + 1, info->os_version);
                     snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                     break;
                 }
@@ -598,7 +598,7 @@ os_info *get_unix_version()
             while (fgets(buff, sizeof(buff) - 1, version_release)) {
                 if(regexec(&regexCompiled, buff, 2, match, 0) == 0){
                     match_size = match[1].rm_eo - match[1].rm_so;
-                    info->os_version = malloc(match_size +1);
+                    os_malloc(match_size + 1, info->os_version);
                     snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                     break;
                 }
@@ -616,7 +616,7 @@ os_info *get_unix_version()
             while (fgets(buff, sizeof(buff) - 1, version_release)) {
                 if(regexec(&regexCompiled, buff, 2, match, 0) == 0){
                     match_size = match[1].rm_eo - match[1].rm_so;
-                    info->os_version = malloc(match_size +1);
+                    os_malloc(match_size + 1, info->os_version);
                     snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                     break;
                 }
@@ -634,7 +634,7 @@ os_info *get_unix_version()
             while (fgets(buff, sizeof(buff) - 1, version_release)) {
                 if(regexec(&regexCompiled, buff, 2, match, 0) == 0){
                     match_size = match[1].rm_eo - match[1].rm_so;
-                    info->os_version = malloc(match_size +1);
+                    os_malloc(match_size + 1, info->os_version);
                     snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                     break;
                 }
@@ -699,7 +699,7 @@ os_info *get_unix_version()
                         if(build){
                             strtok_r(buff, ">", &save_ptr);
                             id=strtok_r(NULL, "<", &save_ptr);
-                            w_strdup(id, info->os_build); 
+                            w_strdup(id, info->os_build);
                             if(info->os_build == NULL){
                                 mdebug1("Cannot read OS build from file %s.", MAC_SERVERVERSION);
                             }
@@ -737,7 +737,7 @@ os_info *get_unix_version()
                     fclose(os_release);
                 }
                 //cmd
-                else{ 
+                else{
                     if (cmd_output_ver = popen("sw_vers -productName", "r"), cmd_output_ver) {
                         if(fgets(buff, sizeof(buff) - 1, cmd_output_ver) == NULL){
                             mdebug1("Cannot read from command output (sw_vers -productName).");
@@ -769,7 +769,7 @@ os_info *get_unix_version()
                     } else if (w_regexec("([0-9][0-9]*\\.?[0-9]*)\\.*", buff, 2, match)){
                         match_size = match[1].rm_eo - match[1].rm_so;
                         char *kern = NULL;
-                        kern = malloc(match_size +1);
+                        os_malloc(match_size + 1, kern);
                         snprintf(kern, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                         w_strdup(OSX_ReleaseName(atoi(kern)), info->os_codename);
                         free(kern);
@@ -815,7 +815,7 @@ os_info *get_unix_version()
                         mdebug1("Cannot read from command output (uname -r).");
                     } else if (w_regexec("B\\.([0-9][0-9]*\\.[0-9]*)", buff, 2, match)){
                         match_size = match[1].rm_eo - match[1].rm_so;
-                        info->os_version = malloc(match_size +1);
+                        os_malloc(match_size + 1, info->os_version);
                         snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                     }
                     pclose(cmd_output_ver);
@@ -830,7 +830,7 @@ os_info *get_unix_version()
                         mdebug1("Cannot read from command output (uname -r).");
                     } else if (w_regexec("([0-9][0-9]*\\.?[0-9]*)\\.*", buff, 2, match)){
                         match_size = match[1].rm_eo - match[1].rm_so;
-                        info->os_version = malloc(match_size +1);
+                        os_malloc(match_size + 1, info->os_version);
                         snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
                     }
                     pclose(cmd_output_ver);
@@ -866,13 +866,13 @@ os_info *get_unix_version()
         // Get os_major
         if (w_regexec("^([0-9]+)\\.*", info->os_version, 2, match)) {
             match_size = match[1].rm_eo - match[1].rm_so;
-            info->os_major = malloc(match_size +1);
+            os_malloc(match_size + 1, info->os_major);
             snprintf(info->os_major, match_size + 1, "%.*s", match_size, info->os_version + match[1].rm_so);
         }
         // Get os_minor
         if (w_regexec("^[0-9]+\\.([0-9]+)\\.*", info->os_version, 2, match)) {
             match_size = match[1].rm_eo - match[1].rm_so;
-            info->os_minor = malloc(match_size +1);
+            os_malloc(match_size + 1, info->os_minor);
             snprintf(info->os_minor, match_size + 1, "%.*s", match_size, info->os_version + match[1].rm_so);
         }
         // Get os_patch

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2231,10 +2231,7 @@ char *wm_vuldet_clean_version(const char *version) {
     data = strtok(NULL, ":");
     data = strtok((data) ? data : dup, "-");
 
-    if(data) {
-        os_calloc(1, strlen(data) + 1, clean_version);
-        strcpy(clean_version, data);
-    }
+    w_strdup(data, clean_version);
     os_free(dup);
 
     return clean_version;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2231,8 +2231,10 @@ char *wm_vuldet_clean_version(const char *version) {
     data = strtok(NULL, ":");
     data = strtok((data) ? data : dup, "-");
 
-    os_calloc(1, strlen(data) + 1, clean_version);
-    strcpy(clean_version, data);
+    if(data) {
+        os_calloc(1, strlen(data) + 1, clean_version);
+        strcpy(clean_version, data);
+    }
     os_free(dup);
 
     return clean_version;
@@ -2256,9 +2258,9 @@ int vw_vuldet_filter_vulnerabilities(vu_feed feed, const char *vendor, const cha
 
     if (target_sw) {
         // Check target_sw whitelist
-        target = (feed != FEED_MAC)? (char **)vu_linux_target_sw_wl : (char **)vu_mac_target_sw_wl;    
+        target = (feed != FEED_MAC)? (char **)vu_linux_target_sw_wl : (char **)vu_mac_target_sw_wl;
         target_sw_len = (feed != FEED_MAC)? array_size(vu_linux_target_sw_wl) : array_size(vu_mac_target_sw_wl);
-        
+
         for(target_sw_it = 0; target_sw_it < target_sw_len; ++target_sw_it) {
             if(!strcmp(target[target_sw_it], target_sw)) {
                 return 0;

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -782,8 +782,8 @@ void wm_fluent_poll_server(wm_fluent_t * fluent) {
     }
 
     // Peek connection
-
-    switch (fluent->shared_key ? SSL_read(fluent->ssl, buffer, sizeof(buffer)) : recv(fluent->client_sock, buffer, sizeof(buffer), 0)) {
+    ssize_t ret = fluent->shared_key ? SSL_read(fluent->ssl, buffer, sizeof(buffer)) : recv(fluent->client_sock, buffer, sizeof(buffer), 0);
+    switch (ret) {
     case -1:
         // No input data. This is the normal case.
         break;


### PR DESCRIPTION
|Related issue|
|---|
|#6824|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes some of the issues reported by the static code analysis tool Coverity. These are the ones that were fixed:

 -  `CID 215595:  API usage errors  (PW.TOO_MANY_PRINTF_ARGS)` **wmodules-aws.c**: There were some "%s" missing in the error message `
- `CID 214164:  Null pointer dereferences  (NULL_RETURNS)` **wm_vuln_detector_nvd.c**: A pointer value wasn't checked before using
- `CID 209840:    (NULL_RETURNS)` **version_op.c**: The `os_malloc()` method now exits in case of a NULL pointer
- `CID 209330:  Error handling issues  (CHECKED_RETURN)` **wm_fluent.c**: This false positive was silenced 

Some of them are considered as false positives and were ignored:
- `CID 214884:  Program hangs  (SLEEP)`: using the sleep function when a mutex is locked isn't considered an issue in that section of the code
- `CID 205343:  High impact security  (SQLI)`: the **wdb_parse()** function always receives internal messages, and only the daemons perform queries to the database. 

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
