### PR TITLE
Add `tailoring-file` option to `open-scap` wodle

### DIFF
--- a/src/config/wmodules-oscap.c
+++ b/src/config/wmodules-oscap.c
@@ -21,6 +21,7 @@ static const char *XML_SCAN_ON_START = "scan-on-start";
 static const char *XML_PROFILE = "profile";
 static const char *XML_XCCDF_ID = "xccdf-id";
 static const char *XML_DS_ID = "datastream-id";
+static const char *XML_TAILORING_FILE = "tailoring-file";
 static const char *XML_CPE = "cpe";
 static const char *XML_OVAL_ID = "oval-id";
 static const char *XML_DISABLED = "disabled";
@@ -178,6 +179,16 @@ int wm_oscap_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                     }
 
                     cur_eval->oval_id = strdup(children[j]->content);
+                } else if (!strcmp(children[j]->element, XML_TAILORING_FILE)) {
+                    free(cur_eval->tailoring_file);
+
+                    if (!strlen(children[j]->content)) {
+                        merror("Invalid content for tag '%s' at module '%s'.", XML_TAILORING_FILE, WM_OSCAP_CONTEXT.name);
+                        OS_ClearNode(children);
+                        return OS_INVALID;
+                    }
+
+                    cur_eval->tailoring_file = strdup(children[j]->content);
                 } else if (!strcmp(children[j]->element, XML_DS_ID)) {
                     free(cur_eval->ds_id);
 

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -172,6 +172,11 @@ void wm_oscap_run(wm_oscap_eval *eval) {
         wm_strcat(&command, eval->ds_id, ' ');
     }
 
+    if (eval->tailoring_file) {
+        wm_strcat(&command, "--tailoring-file", ' ');
+        wm_strcat(&command, eval->tailoring_file, ' ');
+    }
+
     if (eval->cpe) {
         wm_strcat(&command, "--cpe", ' ');
         wm_strcat(&command, eval->cpe, ' ');
@@ -310,6 +315,7 @@ cJSON *wm_oscap_dump(const wm_oscap *oscap) {
             if (ptr->path) cJSON_AddStringToObject(eval,"path",ptr->path);
             if (ptr->xccdf_id) cJSON_AddStringToObject(eval,"xccdf-id",ptr->xccdf_id);
             if (ptr->ds_id) cJSON_AddStringToObject(eval,"datastream-id",ptr->ds_id);
+            if (ptr->tailoring_file) cJSON_AddStringToObject(eval,"tailoring-file",ptr->tailoring_file);
             if (ptr->oval_id) cJSON_AddStringToObject(eval,"oval-id",ptr->oval_id);
             if (ptr->cpe) cJSON_AddStringToObject(eval,"cpe",ptr->cpe);
             cJSON_AddNumberToObject(eval,"timeout",ptr->timeout);
@@ -358,6 +364,7 @@ void wm_oscap_destroy(wm_oscap *oscap) {
         free(cur_eval->xccdf_id);
         free(cur_eval->oval_id);
         free(cur_eval->ds_id);
+        free(cur_eval->tailoring_file);
         free(cur_eval->cpe);
         free(cur_eval);
     }

--- a/src/wazuh_modules/wm_oscap.h
+++ b/src/wazuh_modules/wm_oscap.h
@@ -36,6 +36,7 @@ typedef struct wm_oscap_eval {
     char *path;                     // File path (string)
     char *xccdf_id;                 // XCCDF id
     char *ds_id;                    // Datastream id
+    char *tailoring_file;           // Tailoring file
     char *oval_id;                  // OVAL id
     char *cpe;                      // CPE dictionary
     wm_oscap_profile *profiles;     // Profiles (linked list)

--- a/wodles/oscap/oscap.py
+++ b/wodles/oscap/oscap.py
@@ -128,6 +128,8 @@ def oscap(profile=None):
         if arg_dsid:
             for arg_id in arg_dsid:
                 cmd.extend(["--datastream-id", arg_id])
+        if arg_tailoring_file:
+            cmd.extend(["--tailoring-file", arg_tailoring_file])
         if arg_cpe:
             cmd.extend(["--cpe", arg_cpe])
 
@@ -269,6 +271,7 @@ def usage():
     \t--oval-id             Select particular OVAL component.
     \t--ds-id               Use a datastream with that particular ID from the given datastream collection.
     \t--cpe                 Use given CPE dictionary for applicability checks.
+    \t--tailoring-file      Select tailoring file.  
 
     Other arguments:
     \t-v, --view-profiles  Do not launch oscap. Only show extracted profiles.
@@ -291,10 +294,11 @@ if __name__ == "__main__":
     arg_view_profiles = False
     debug = False
     arg_module = None
+    arg_tailoring_file = None
 
     # Reading arguments
     try:
-        opts, args = getopt(argv[1:], "p:x:o:vdh", ["xccdf=", "oval=", "profiles=", "xccdf-id=", "oval-id=", "ds-id=", "cpe=", "view-profiles", "debug", "help"])
+        opts, args = getopt(argv[1:], "p:x:o:vdh", ["xccdf=", "oval=", "profiles=", "xccdf-id=", "oval-id=", "ds-id=", "tailoring-file=", "cpe=", "view-profiles", "debug", "help"])
         n_args = len(opts)
         if not (1 <= n_args <= 5):
             print("Incorrect number of arguments.\nTry '--help' for more information.")
@@ -317,6 +321,11 @@ if __name__ == "__main__":
             else:
                 arg_file = "{0}/{1}".format(CONTENT_PATH, a)
             arg_module = 'oval'
+        elif o == "--tailoring-file":
+            if a[0] == '/' or a[0] == '.':
+                arg_tailoring_file = a
+            else:
+                arg_tailoring_file = "{0}/{1}".format(CONTENT_PATH, a)
         elif o in ("-p", "--profiles"):
             arg_profiles = a.split(",") if a != '_' else None
         elif o == "--xccdf-id":
@@ -340,9 +349,9 @@ if __name__ == "__main__":
             exit(1)
 
     if debug:
-        print("Arguments:\n\tPolicy: {0}\n\tProfiles: {1}\n\txccdf-id: {2}\n\tds-id: {3}\n\tcpe: {4}\n\tview-profiles: {5}\n".format(arg_file, arg_profiles,
+        print("Arguments:\n\tPolicy: {0}\n\tProfiles: {1}\n\txccdf-id: {2}\n\tds-id: {3}\n\tcpe: {4}\n\tview-profiles: {5}\n\ttailoring-file: {6}\n".format(arg_file, arg_profiles,
                                                                                                                                      arg_xccdfid, arg_dsid, arg_cpe,
-                                                                                                                                     arg_view_profiles))
+                                                                                                                                     arg_view_profiles,arg_tailoring_file))
     if not arg_module:
         print("No argument '--xccdf' or '--oval'.\nTry '--help' for more information.")
         exit(1)
@@ -384,6 +393,9 @@ if __name__ == "__main__":
         if arg_profiles:
             # Get profiles
             profiles = extract_profiles_from_file(arg_file)
+            if arg_tailoring_file:
+                for tailor_profile in extract_profiles_from_file(arg_tailoring_file):
+                    profiles.append(tailor_profile)
 
             for p in arg_profiles:
                 if p not in profiles:


### PR DESCRIPTION
Add tailoring-file option to `open-scap` wodle

|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/112 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds the optional configuration of a tailoring file to the `open-scap` wodle. It is optional and resolves its path the same way the `path` parameter does via the `content` folder or by supplying an absolute path. When provided, the `oscap.py` wrapper will parse the tailoring file and add any additional profiles to its own personal checks and will execute the proper `oscap eval` command with the `--tailoring-file` parameter.

## Configuration options

`<tailoring-file></tailoring-file>`
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
The following is a sample configuration in `agent.conf` which includes the parameter


```
<agent_config>

  <!-- Shared agent configuration here -->
<wodle name="open-scap">
  <disabled>no</disabled>
  <timeout>1800</timeout>
  <interval>1d</interval>
  <scan-on-start>yes</scan-on-start>
  <content type="xccdf" path="/var/ossec/wodles/oscap/content/ssg-ubuntu-1804-ds.xml">
        <datastream-id>scap_org.open-scap_datastream_from_xccdf_ssg-ubuntu1804-xccdf-1.2.xml</datastream-id>
        <xccdf-id>scap_org.open-scap_cref_ssg-ubuntu1804-xccdf-1.2.xml</xccdf-id>
        <profile>xccdf_org.ssgproject.content_profile_from_tailoring_file</profile>
        <tailoring-file>/var/ossec/wodles/oscap/content/ssg-ubuntu-1804-ds-tailoring.xml</tailoring-file>
  </content>

</wodle>
</agent_config>
```
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
