### PR TITLE
Changes to clean manager tables when an update occur

### DIFF
--- a/src/wazuh_db/schema_upgrade_v6.sql
+++ b/src/wazuh_db/schema_upgrade_v6.sql
@@ -8,6 +8,15 @@
  * and/or modify it under the terms of GPLv2.
 */
 
+DELETE FROM sys_osinfo;
+DELETE FROM sys_netiface;
+DELETE FROM sys_netproto;
+DELETE FROM sys_netaddr;
+DELETE FROM sys_ports;
+DELETE FROM sys_programs;
+DELETE FROM sys_hotfixes;
+DELETE FROM sys_processes;
+
 ALTER TABLE sys_osinfo ADD COLUMN os_patch TEXT DEFAULT NULL;
 
 ALTER TABLE sys_netiface ADD COLUMN checksum TEXT DEFAULT NULL;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #6853|

For this new version it is necessary to clean the tables, since the consistency is verified by means of the checksum field, and having it empty generates inconsistencies in the algorithm.


Actual result: tables with data in manager db's.
Expected result: empty tables after upgrade.
The bug was discovered in: Upgrade test.

