### PR TITLE
Vulnerability Detector: Added CPE macos to detect macOS Big Sur vulnerabilities

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector_nvd.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector_nvd.c
@@ -2457,6 +2457,164 @@ void test_wm_vuldet_check_generic_package_insert_package_mac_os_x_server(void **
     assert_int_equal(ret, 1);
 }
 
+void test_wm_vuldet_check_generic_package_insert_package_mac_os(void **state)
+{
+    sqlite3 *db = (sqlite3 *)1;
+    sqlite3_stmt *stmt = NULL;
+
+    char *pkg_name = NULL;
+    char *pkg_source = "mac_os";
+    char *pkg_version = "10.15.1";
+    char *pkg_arch = NULL;
+    char *pkg_vendor = NULL;
+    OSHash *cve_table = (OSHash *)1;
+    int8_t name_type = PACKAGE_SOURCE;
+    int i = 1;
+    int *vuln_count = &i;
+
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "mac_os");
+    will_return(__wrap_sqlite3_bind_text, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "CVE-0000-0000");
+    expect_value(__wrap_sqlite3_column_text, iCol, 1);
+    will_return(__wrap_sqlite3_column_text, "10.10.0");   //start_including
+    expect_value(__wrap_sqlite3_column_text, iCol, 2);
+    will_return(__wrap_sqlite3_column_text, NULL);      //start_excluding
+    expect_value(__wrap_sqlite3_column_text, iCol, 3);
+    will_return(__wrap_sqlite3_column_text, "10.15.1");   //end_including
+    expect_value(__wrap_sqlite3_column_text, iCol, 4);
+    will_return(__wrap_sqlite3_column_text, NULL);      //end_excluding
+    expect_value(__wrap_sqlite3_column_int, iCol, 5);
+    will_return(__wrap_sqlite3_column_int, 0);          //package_id
+    expect_value(__wrap_sqlite3_column_int, iCol, 6);
+    will_return(__wrap_sqlite3_column_int, 0);          //configuration_id
+    expect_value(__wrap_sqlite3_column_int, iCol, 7);
+    will_return(__wrap_sqlite3_column_int, 0);          //package_vulnerable
+    expect_value(__wrap_sqlite3_column_int, iCol, 8);
+    will_return(__wrap_sqlite3_column_int, 1000);       //parent
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, "OR");      //operator
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, "vendor");  //vendor
+    expect_value(__wrap_sqlite3_column_text, iCol, 11);
+    will_return(__wrap_sqlite3_column_text, "*");       //target_sw
+
+    will_return(__wrap_wm_checks_package_vulnerability, VU_VULNERABLE);
+
+    will_return(__wrap_wm_checks_package_vulnerability, VU_VULNERABLE);
+
+    //Siblings
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, 1000);
+    will_return(__wrap_sqlite3_bind_int, 0);
+    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    will_return(__wrap_sqlite3_bind_int, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_int, iCol, 0);
+    will_return(__wrap_sqlite3_column_int, 1);
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    will_return(__wrap_wm_vuldet_add_cve_node,0);
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'mac_os' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'less than or equal' '10.15.1' (feed 'NVD').");
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    int ret = wm_vuldet_check_generic_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    assert_int_equal(ret, 1);
+}
+
+void test_wm_vuldet_check_generic_package_insert_package_macos(void **state)
+{
+    sqlite3 *db = (sqlite3 *)1;
+    sqlite3_stmt *stmt = NULL;
+
+    char *pkg_name = NULL;
+    char *pkg_source = "macos";
+    char *pkg_version = "10.15.1";
+    char *pkg_arch = NULL;
+    char *pkg_vendor = NULL;
+    OSHash *cve_table = (OSHash *)1;
+    int8_t name_type = PACKAGE_SOURCE;
+    int i = 1;
+    int *vuln_count = &i;
+
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "macos");
+    will_return(__wrap_sqlite3_bind_text, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "CVE-0000-0000");
+    expect_value(__wrap_sqlite3_column_text, iCol, 1);
+    will_return(__wrap_sqlite3_column_text, "10.10.0");   //start_including
+    expect_value(__wrap_sqlite3_column_text, iCol, 2);
+    will_return(__wrap_sqlite3_column_text, NULL);      //start_excluding
+    expect_value(__wrap_sqlite3_column_text, iCol, 3);
+    will_return(__wrap_sqlite3_column_text, "10.15.1");   //end_including
+    expect_value(__wrap_sqlite3_column_text, iCol, 4);
+    will_return(__wrap_sqlite3_column_text, NULL);      //end_excluding
+    expect_value(__wrap_sqlite3_column_int, iCol, 5);
+    will_return(__wrap_sqlite3_column_int, 0);          //package_id
+    expect_value(__wrap_sqlite3_column_int, iCol, 6);
+    will_return(__wrap_sqlite3_column_int, 0);          //configuration_id
+    expect_value(__wrap_sqlite3_column_int, iCol, 7);
+    will_return(__wrap_sqlite3_column_int, 0);          //package_vulnerable
+    expect_value(__wrap_sqlite3_column_int, iCol, 8);
+    will_return(__wrap_sqlite3_column_int, 1000);       //parent
+    expect_value(__wrap_sqlite3_column_text, iCol, 9);
+    will_return(__wrap_sqlite3_column_text, "OR");      //operator
+    expect_value(__wrap_sqlite3_column_text, iCol, 10);
+    will_return(__wrap_sqlite3_column_text, "vendor");  //vendor
+    expect_value(__wrap_sqlite3_column_text, iCol, 11);
+    will_return(__wrap_sqlite3_column_text, "*");       //target_sw
+
+    will_return(__wrap_wm_checks_package_vulnerability, VU_VULNERABLE);
+
+    will_return(__wrap_wm_checks_package_vulnerability, VU_VULNERABLE);
+
+    //Siblings
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, 1000);
+    will_return(__wrap_sqlite3_bind_int, 0);
+    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    will_return(__wrap_sqlite3_bind_int, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_int, iCol, 0);
+    will_return(__wrap_sqlite3_column_int, 1);
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    will_return(__wrap_wm_vuldet_add_cve_node,0);
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'macos' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'less than or equal' '10.15.1' (feed 'NVD').");
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    int ret = wm_vuldet_check_generic_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    assert_int_equal(ret, 1);
+}
+
 void test_wm_vuldet_check_generic_package_insert_package_mac_no_vendor(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
@@ -3999,6 +4157,154 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_os_x_server(void *
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'mac_os_x_server' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'equal' '10.15.1' (feed 'NVD').");
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    int ret = wm_vuldet_check_specific_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    assert_int_equal(ret, 1);
+}
+
+void test_wm_vuldet_check_specific_package_insert_package_mac_os(void **state)
+{
+    sqlite3 *db = (sqlite3 *)1;
+    sqlite3_stmt *stmt = NULL;
+
+    char *pkg_name = NULL;
+    char *pkg_source = "mac_os";
+    char *pkg_version = "10.15.1";
+    char *pkg_arch = NULL;
+    char *pkg_vendor = NULL;
+    OSHash *cve_table = (OSHash *)1;
+    int8_t name_type = PACKAGE_SOURCE;
+    int i = 1;
+    int *vuln_count = &i;
+
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "mac_os");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "%10.15.1%");
+    will_return(__wrap_sqlite3_bind_text, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "CVE-0000-0000");
+    expect_value(__wrap_sqlite3_column_text, iCol, 1);
+    will_return(__wrap_sqlite3_column_text, "10.15.1");   //version_cmp
+    expect_value(__wrap_sqlite3_column_int, iCol, 2);
+    will_return(__wrap_sqlite3_column_int, 0);          //package_id
+    expect_value(__wrap_sqlite3_column_int, iCol, 3);
+    will_return(__wrap_sqlite3_column_int, 0);          //configuration_id
+    expect_value(__wrap_sqlite3_column_int, iCol, 4);
+    will_return(__wrap_sqlite3_column_int, 0);          //package_vulnerable
+    expect_value(__wrap_sqlite3_column_int, iCol, 5);
+    will_return(__wrap_sqlite3_column_int, 1000);       //parent
+    expect_value(__wrap_sqlite3_column_text, iCol, 6);
+    will_return(__wrap_sqlite3_column_text, "OR");      //operator
+    expect_value(__wrap_sqlite3_column_text, iCol, 7);
+    will_return(__wrap_sqlite3_column_text, "vendor");  //vendor
+    expect_value(__wrap_sqlite3_column_text, iCol, 8);
+    will_return(__wrap_sqlite3_column_text, "*");       //target_sw
+
+    will_return(__wrap_wm_checks_package_vulnerability, VU_VULNERABLE);
+
+    //Siblings
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, 1000);
+    will_return(__wrap_sqlite3_bind_int, 0);
+    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    will_return(__wrap_sqlite3_bind_int, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_int, iCol, 0);
+    will_return(__wrap_sqlite3_column_int, 1);
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    will_return(__wrap_wm_vuldet_add_cve_node,0);
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'mac_os' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'equal' '10.15.1' (feed 'NVD').");
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    int ret = wm_vuldet_check_specific_package(db, FEED_MAC, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    assert_int_equal(ret, 1);
+}
+
+void test_wm_vuldet_check_specific_package_insert_package_macos(void **state)
+{
+    sqlite3 *db = (sqlite3 *)1;
+    sqlite3_stmt *stmt = NULL;
+
+    char *pkg_name = NULL;
+    char *pkg_source = "macos";
+    char *pkg_version = "10.15.1";
+    char *pkg_arch = NULL;
+    char *pkg_vendor = NULL;
+    OSHash *cve_table = (OSHash *)1;
+    int8_t name_type = PACKAGE_SOURCE;
+    int i = 1;
+    int *vuln_count = &i;
+
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "macos");
+    will_return(__wrap_sqlite3_bind_text, 0);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "%10.15.1%");
+    will_return(__wrap_sqlite3_bind_text, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "CVE-0000-0000");
+    expect_value(__wrap_sqlite3_column_text, iCol, 1);
+    will_return(__wrap_sqlite3_column_text, "10.15.1");   //version_cmp
+    expect_value(__wrap_sqlite3_column_int, iCol, 2);
+    will_return(__wrap_sqlite3_column_int, 0);          //package_id
+    expect_value(__wrap_sqlite3_column_int, iCol, 3);
+    will_return(__wrap_sqlite3_column_int, 0);          //configuration_id
+    expect_value(__wrap_sqlite3_column_int, iCol, 4);
+    will_return(__wrap_sqlite3_column_int, 0);          //package_vulnerable
+    expect_value(__wrap_sqlite3_column_int, iCol, 5);
+    will_return(__wrap_sqlite3_column_int, 1000);       //parent
+    expect_value(__wrap_sqlite3_column_text, iCol, 6);
+    will_return(__wrap_sqlite3_column_text, "OR");      //operator
+    expect_value(__wrap_sqlite3_column_text, iCol, 7);
+    will_return(__wrap_sqlite3_column_text, "vendor");  //vendor
+    expect_value(__wrap_sqlite3_column_text, iCol, 8);
+    will_return(__wrap_sqlite3_column_text, "*");       //target_sw
+
+    will_return(__wrap_wm_checks_package_vulnerability, VU_VULNERABLE);
+
+    //Siblings
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, 1000);
+    will_return(__wrap_sqlite3_bind_int, 0);
+    expect_value(__wrap_sqlite3_bind_int, index, 2);
+    expect_value(__wrap_sqlite3_bind_int, value, 0);
+    will_return(__wrap_sqlite3_bind_int, 0);
+
+    will_return(__wrap_sqlite3_step, SQLITE_ROW);
+
+    expect_value(__wrap_sqlite3_column_int, iCol, 0);
+    will_return(__wrap_sqlite3_column_int, 1);
+
+    will_return(__wrap_sqlite3_step, SQLITE_DONE);
+
+    will_return(__wrap_wm_vuldet_add_cve_node,0);
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'macos' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'equal' '10.15.1' (feed 'NVD').");
 
     will_return(__wrap_sqlite3_step, SQLITE_DONE);
 
@@ -5766,6 +6072,8 @@ int main(void) {
         cmocka_unit_test(test_wm_vuldet_check_generic_package_insert_package_linux_kernel),
         cmocka_unit_test(test_wm_vuldet_check_generic_package_insert_package_mac_os_x),
         cmocka_unit_test(test_wm_vuldet_check_generic_package_insert_package_mac_os_x_server),
+        cmocka_unit_test(test_wm_vuldet_check_generic_package_insert_package_mac_os),
+        cmocka_unit_test(test_wm_vuldet_check_generic_package_insert_package_macos),
         cmocka_unit_test(test_wm_vuldet_check_generic_package_insert_package_mac_no_vendor),
         cmocka_unit_test(test_wm_vuldet_check_generic_package_insert_package_mac_with_vendor),
         //Tests wm_vuldet_check_specific_package
@@ -5791,6 +6099,8 @@ int main(void) {
         cmocka_unit_test(test_wm_vuldet_check_specific_package_insert_package_linux_kernel),
         cmocka_unit_test(test_wm_vuldet_check_specific_package_insert_package_mac_os_x),
         cmocka_unit_test(test_wm_vuldet_check_specific_package_insert_package_mac_os_x_server),
+        cmocka_unit_test(test_wm_vuldet_check_specific_package_insert_package_mac_os),
+        cmocka_unit_test(test_wm_vuldet_check_specific_package_insert_package_macos),
         cmocka_unit_test(test_wm_vuldet_check_specific_package_insert_package_mac_no_vendor),
         cmocka_unit_test(test_wm_vuldet_check_specific_package_insert_package_mac_with_vendor),
         //Tests wm_vuldet_linux_nvd_vulnerabilities

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -5333,6 +5333,7 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
             } else {
                 product_name[0] = "mac_os_x";
                 product_name[1] = "mac_os";
+                product_name[2] = "macos";
             }
         break;
         default:

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2292,7 +2292,7 @@ int wm_vuldet_check_generic_package(sqlite3 *dbCVE, vu_feed feed, char *pkg_name
         query = vu_queries[VU_GET_GENERIC_PACKAGE_OS];
         os_package = true;
     } else if (!strcmp(pkg_reference, "mac_os_x") || !strcmp(pkg_reference, "mac_os_x_server") ||
-        !strcmp(pkg_reference, "mac_os")) {
+               !strcmp(pkg_reference, "mac_os") || !strcmp(pkg_reference, "macos")) {
         query = vu_queries[VU_GET_GENERIC_PACKAGE_OS_MAC];
     } else {
         if (feed == FEED_MAC) {
@@ -2531,8 +2531,8 @@ int wm_vuldet_check_specific_package(sqlite3 *dbCVE, vu_feed feed, char *pkg_nam
         !strcmp(pkg_reference, PR_KERNEL)) {
         query = vu_queries[VU_GET_SPECIFIC_PACKAGE_OS];
         os_package = true;
-    } else if (!strcmp(pkg_reference, "mac_os_x") || !strcmp(pkg_reference, "mac_os_x_server") 
-        || !strcmp(pkg_reference, "mac_os")) {
+    } else if (!strcmp(pkg_reference, "mac_os_x") || !strcmp(pkg_reference, "mac_os_x_server") ||
+               !strcmp(pkg_reference, "mac_os") || !strcmp(pkg_reference, "macos")) {
         query = vu_queries[VU_GET_SPECIFIC_PACKAGE_OS_MAC];
         os_package = true;
     } else {


### PR DESCRIPTION
|Related issue|
|---|
|#6869|

## Description

I have added the CPE macOS to get more vulnerabilities for macOS Big Sur.

## Check configuration
```
# sqlite3 /var/ossec/queue/vulnerabilities/cve.db "select * from agents";
```

> 8|||0|apple|mac_os_x||11.0.0||x86_64
> 8|||0|apple|mac_os||11.0.0||x86_64
> 8|||0|apple|macos||11.0.0||x86_64

## Logs/alerts
```
2020/12/11 14:35:17 wazuh-modulesd:vulnerability-detector[208463] wm_vuln_detector.c:1489 at wm_vuldet_send_cve_report(): DEBUG: (5468): The 'mac_os' package (11.0.0) from agent '009' is vulnerable to 'CVE-2020-27894'. Condition: 'Package less than 11.0.1'
2020/12/11 14:33:56 wazuh-modulesd:vulnerability-detector[208463] wm_vuln_detector.c:1489 at wm_vuldet_send_cve_report(): DEBUG: (5468): The 'mac_os_x' package (11.0.0) from agent '009' is vulnerable to 'CVE-2020-27896'. Condition: 'Package less than 11.0.1'
2020/12/11 14:35:17 wazuh-modulesd:vulnerability-detector[208463] wm_vuln_detector.c:1489 at wm_vuldet_send_cve_report(): DEBUG: (5468): The 'macos' package (11.0.0) from agent '009' is vulnerable to 'CVE-2020-27898'. Condition: 'Package less than 11.0.1'
2020/12/11 14:35:21 wazuh-modulesd:vulnerability-detector[208463] wm_vuln_detector.c:1489 at wm_vuldet_send_cve_report(): DEBUG: (5468): The 'macos' package (11.0.0) from agent '009' is vulnerable to 'CVE-2020-27900'. Condition: 'Package less than 11.0.1'
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report

- [x] Added Unit Tests

