### PR TITLE
6872 compile time error in winagent target

### DIFF
--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -156,7 +156,7 @@ void *receiver_thread(__attribute__((unused)) void *none)
 
                 /* syscollector */
                 else if (strncmp(tmp_msg, HC_SYSCOLLECTOR, strlen(HC_SYSCOLLECTOR)) == 0) {
-                    wmcom_sync(tmp_msg);
+                    wmcom_send(tmp_msg);
                     continue;
                 }
 

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -133,7 +133,7 @@ int receive_msg()
 
             /* syscollector */
             else if (strncmp(tmp_msg, HC_SYSCOLLECTOR, strlen(HC_SYSCOLLECTOR)) == 0) {
-                wcom_send(tmp_msg);
+                wmcom_send(tmp_msg);
                 continue;
             }
 

--- a/src/wazuh_modules/wmcom.c
+++ b/src/wazuh_modules/wmcom.c
@@ -84,19 +84,24 @@ int wmcom_sync(char * buffer) {
     return ret;
 }
 
-#ifndef WIN32
+#ifdef WIN32
+void wmcom_send(char * message)
+{
+    wmcom_sync(message);
+}
+#else
 
-void wcom_send(char * message)
+void wmcom_send(char * message)
 {
     int sock;
     if (sock = OS_ConnectUnixDomain(DEFAULTDIR WM_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
         switch (errno) {
             case ECONNREFUSED:
-                merror("At wcom_send(): Target wmodules refused connection. The component might be disabled");
+                merror("At wmcom_send(): Target wmodules refused connection. The component might be disabled");
                 break;
 
             default:
-                merror("At wcom_send(): Could not connect to socket wmodules: %s (%d).", strerror(errno), errno);
+                merror("At wmcom_send(): Could not connect to socket wmodules: %s (%d).", strerror(errno), errno);
         }
     }
     else

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -177,8 +177,8 @@ void * wmcom_main(void * arg);
  *
  * @param message Payload.
  */
-void wcom_send(char * message);
 #endif
+void wmcom_send(char * message);
 size_t wmcom_dispatch(char * command, char ** output);
 size_t wmcom_getconfig(const char * section, char ** output);
 int wmcom_sync(char * buffer);


### PR DESCRIPTION
|Related issue|
|---|
|#6872|
Closes #6872 
## Description
This PR aims to fix the compile time error in winagent target compilation.
<!-- Minimum checks required -->
- Compilation
  - [X] Linux
![image](https://user-images.githubusercontent.com/54002291/101906843-645fcd80-3b98-11eb-9bb6-7ebc13046763.png)
  - [X] Windows
![image](https://user-images.githubusercontent.com/54002291/101906876-72ade980-3b98-11eb-8625-70757b611724.png)
