### PR TITLE
Add new component and remove unused log.

### DIFF
--- a/src/analysisd/decoders/dbsync.c
+++ b/src/analysisd/decoders/dbsync.c
@@ -31,7 +31,7 @@ extern void mock_assert(const int result, const char* const expression,
 static void dispatch_send_local(dbsync_context_t * ctx, const char * query) {
     int sock;
 
-    if (strcmp(ctx->component, "syscheck") == 0 || strncmp(ctx->component, "syscollector", 12) == 0) {
+    if (strncmp(ctx->component, "syscheck", 8) == 0 || strncmp(ctx->component, "syscollector", 12) == 0) {
         sock = OS_ConnectUnixDomain(SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR);
     } else {
         merror("dbsync: unknown location '%s'", ctx->component);

--- a/src/analysisd/decoders/dbsync.c
+++ b/src/analysisd/decoders/dbsync.c
@@ -31,7 +31,7 @@ extern void mock_assert(const int result, const char* const expression,
 static void dispatch_send_local(dbsync_context_t * ctx, const char * query) {
     int sock;
 
-    if (strcmp(ctx->component, "syscheck") == 0) {
+    if (strcmp(ctx->component, "syscheck") == 0 || strcmp(ctx->component, "syscollector") == 0) {
         sock = OS_ConnectUnixDomain(SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR);
     } else {
         merror("dbsync: unknown location '%s'", ctx->component);

--- a/src/analysisd/decoders/dbsync.c
+++ b/src/analysisd/decoders/dbsync.c
@@ -31,7 +31,7 @@ extern void mock_assert(const int result, const char* const expression,
 static void dispatch_send_local(dbsync_context_t * ctx, const char * query) {
     int sock;
 
-    if (strcmp(ctx->component, "syscheck") == 0 || strcmp(ctx->component, "syscollector") == 0) {
+    if (strcmp(ctx->component, "syscheck") == 0 || strncmp(ctx->component, "syscollector", 12) == 0) {
         sock = OS_ConnectUnixDomain(SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR);
     } else {
         merror("dbsync: unknown location '%s'", ctx->component);

--- a/src/headers/sym_load.h
+++ b/src/headers/sym_load.h
@@ -17,6 +17,7 @@
 #include <windows.h>
 #endif
 
+void* so_get_module_handle_on_path(const char *path, const char *so);
 void* so_get_module_handle(const char *so);
 void* so_get_function_sym(void *handle, const char *function_name);
 int so_free_library(void *handle);

--- a/src/shared/sym_load.c
+++ b/src/shared/sym_load.c
@@ -1,6 +1,21 @@
 #include <stdio.h>
 #include "sym_load.h"
 
+void* so_get_module_handle_on_path(const char *path, const char *so){
+#ifdef WIN32
+    char file_name[MAX_PATH] = { 0 };
+    snprintf(file_name, MAX_PATH-1, "%s%s.dll", path, so);
+    return LoadLibrary(file_name);
+#else
+    char file_name[4096] = { 0 };
+#if defined(__MACH__)
+    snprintf(file_name, 4096-1, "%slib%s.dylib", path, so);
+#else
+    snprintf(file_name, 4096-1, "%slib%s.so", path, so);
+#endif
+    return dlopen(file_name, RTLD_LAZY);
+#endif
+}
 
 void* so_get_module_handle(const char *so){
 #ifdef WIN32

--- a/src/tests/tap_os_net.c
+++ b/src/tests/tap_os_net.c
@@ -7,6 +7,8 @@
 #include "shared.h"
 #include "os_net/os_net.h"
 #include "os_err.h"
+#include "sym_load.h"
+#include "sysInfo.h"
 
 #include "tap.h"
 
@@ -15,6 +17,10 @@
 #define PORT 4321
 #define SENDSTRING "Hello World!\n"
 #define BUFFERSIZE 1024
+
+extern sysinfo_networks_func sysinfo_network_ptr;
+extern sysinfo_free_result_func sysinfo_free_result_ptr;
+void *test_sysinfo_module = NULL;
 
 char * getPrimaryIP();
 
@@ -292,6 +298,11 @@ int test_get_ip() {
 int main(void) {
     printf("\n\n    STARTING TEST - OS_NET   \n\n");
 
+    if (test_sysinfo_module = so_get_module_handle_on_path("data_provider/build/lib/", "sysinfo"), test_sysinfo_module) {
+        sysinfo_free_result_ptr = so_get_function_sym(test_sysinfo_module, "sysinfo_free_result");
+        sysinfo_network_ptr = so_get_function_sym(test_sysinfo_module, "sysinfo_networks");
+    }
+
     // Send and receive string using TCP IPV4 socket on localhost
     TAP_TEST_MSG(test_tcpv4_local(), "TCP IPV4 send an receive: localhost test.");
 
@@ -330,6 +341,10 @@ int main(void) {
 
     // Get IP address
     TAP_TEST_MSG(test_get_ip(), "Get primary IP address collection.");
+
+    if (test_sysinfo_module){
+        so_free_library(test_sysinfo_module);
+    }
 
     TAP_PLAN;
     int r = tap_summary();

--- a/src/wazuh_db/wdb_integrity.c
+++ b/src/wazuh_db/wdb_integrity.c
@@ -78,7 +78,6 @@ int wdbi_checksum_range(wdb_t * wdb, wdb_component_t component, const char * beg
     int step = sqlite3_step(stmt);
 
     if (step != SQLITE_ROW) {
-        merror("Can't query %s, query:%s database: %s", COMPONENT_NAMES[component], sqlite3_sql(stmt), sqlite3_errmsg(wdb->db));
         return 0;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #6876 |

It was detected during automation that it was failing due to an incorrectly added log. To do this, this log must be eliminated, and also another error log was detected in which the new components for local delivery are not included.

![image](https://user-images.githubusercontent.com/14300208/101952844-136fc980-3bd8-11eb-814b-4389bc4c8622.png)
Actual result: Mindless error log
Expected result: No error logs.
Discovered in: CI
