### PR TITLE
Add sys info dependencies

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -744,7 +744,7 @@ endif
 
 #### Sysinfo ##
 
-win32/sysinfo:
+win32/sysinfo: external
 	cd ${SYSINFO} && mkdir -p build && cd build && cmake ${WIN_CMAKE_OPTS} ${SYSINFO_OS} ${SYSINFO_TEST} ${SYSINFO_RELEASE_TYPE} .. && make
 
 #### Syscollector ##

--- a/src/data_provider/CMakeLists.txt
+++ b/src/data_provider/CMakeLists.txt
@@ -36,11 +36,14 @@ include_directories(${SRC_FOLDER}/external/openssl/include/)
 include_directories(${SRC_FOLDER}/shared_modules/utils)
 include_directories(${SRC_FOLDER}/shared_modules/common/)
 include_directories(${SRC_FOLDER}/external/openssl/include/)
+include_directories(${SRC_FOLDER}/external/libplist/bin/include/)
 
 link_directories(${SRC_FOLDER}/external/sqlite/)
 link_directories(${SRC_FOLDER}/external/cJSON/)
 link_directories(${SRC_FOLDER}/external/procps/)
 link_directories(${SRC_FOLDER}/external/bzip2/)
+link_directories(${SRC_FOLDER}/external/libplist/bin/lib/)
+
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   file(GLOB SYSINFO_SRC
@@ -117,8 +120,9 @@ elseif(UNIX AND NOT APPLE)
   set_target_properties(sysinfo PROPERTIES
           LINK_FLAGS "-static-libgcc -static-libstdc++")
   string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath=$ORIGIN")
-else()
-  target_link_libraries(sysinfo proc)
+elseif(APPLE)
+  string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Xlinker -rpath -Xlinker @executable_path") 
+  target_link_libraries(sysinfo proc plist-2.0)
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
 if(UNIT_TEST)

--- a/src/data_provider/CMakeLists.txt
+++ b/src/data_provider/CMakeLists.txt
@@ -42,7 +42,6 @@ link_directories(${SRC_FOLDER}/external/sqlite/)
 link_directories(${SRC_FOLDER}/external/cJSON/)
 link_directories(${SRC_FOLDER}/external/procps/)
 link_directories(${SRC_FOLDER}/external/bzip2/)
-link_directories(${SRC_FOLDER}/external/libplist/bin/lib/)
 
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -121,9 +120,16 @@ elseif(UNIX AND NOT APPLE)
           LINK_FLAGS "-static-libgcc -static-libstdc++")
   string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath=$ORIGIN")
 elseif(APPLE)
-  string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Xlinker -rpath -Xlinker @executable_path") 
-  target_link_libraries(sysinfo proc plist-2.0)
+  target_link_libraries(sysinfo ${SRC_FOLDER}/external/libplist/bin/lib/libplist-2.0.a)
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+
+if(APPLE)
+  set(CMAKE_VERBOSE_MAKEFILE ON)
+  add_custom_command(TARGET sysinfo 
+    POST_BUILD COMMAND 
+    ${CMAKE_INSTALL_NAME_TOOL} -id "@rpath/libsysinfo.dylib"
+    $<TARGET_FILE:sysinfo>)
+endif(APPLE)
 
 if(UNIT_TEST)
 add_subdirectory(tests)

--- a/src/shared_modules/dbsync/CMakeLists.txt
+++ b/src/shared_modules/dbsync/CMakeLists.txt
@@ -58,6 +58,8 @@ elseif(UNIX AND NOT APPLE)
   set_target_properties(dbsync PROPERTIES
         LINK_FLAGS "-static-libgcc -static-libstdc++")
   string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath=$ORIGIN")
+elseif(APPLE)
+  string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Xlinker -rpath -Xlinker @executable_path") 
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/shared_modules/dbsync/CMakeLists.txt
+++ b/src/shared_modules/dbsync/CMakeLists.txt
@@ -24,6 +24,10 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+if(APPLE)
+  set(CMAKE_MACOSX_RPATH 1)
+endif(APPLE)
+
 include_directories(${SRC_FOLDER}/external/sqlite/)
 include_directories(${SRC_FOLDER}/external/nlohmann/)
 include_directories(${SRC_FOLDER}/external/cJSON/)
@@ -58,8 +62,6 @@ elseif(UNIX AND NOT APPLE)
   set_target_properties(dbsync PROPERTIES
         LINK_FLAGS "-static-libgcc -static-libstdc++")
   string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath=$ORIGIN")
-elseif(APPLE)
-  string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Xlinker -rpath -Xlinker @executable_path") 
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/shared_modules/rsync/CMakeLists.txt
+++ b/src/shared_modules/rsync/CMakeLists.txt
@@ -25,6 +25,10 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+if(APPLE)
+  set(CMAKE_MACOSX_RPATH 1)
+endif(APPLE)
+
 include_directories(${SRC_FOLDER}/external/cJSON/)
 include_directories(${SRC_FOLDER}/external/nlohmann/)
 include_directories(${SRC_FOLDER}/external/openssl/include/)
@@ -58,8 +62,6 @@ elseif(UNIX AND NOT APPLE)
   set_target_properties(rsync PROPERTIES
         LINK_FLAGS "-static-libgcc -static-libstdc++")
   string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath=$ORIGIN")
-elseif(APPLE)
-  string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Xlinker -rpath -Xlinker @executable_path") 
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     
 

--- a/src/shared_modules/rsync/CMakeLists.txt
+++ b/src/shared_modules/rsync/CMakeLists.txt
@@ -58,6 +58,8 @@ elseif(UNIX AND NOT APPLE)
   set_target_properties(rsync PROPERTIES
         LINK_FLAGS "-static-libgcc -static-libstdc++")
   string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath=$ORIGIN")
+elseif(APPLE)
+  string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Xlinker -rpath -Xlinker @executable_path") 
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     
 

--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -10,6 +10,8 @@
  */
 
 #include <iostream>
+#include <chrono>
+#include <thread>
 #include "rsync_test.h"
 #include "rsync.h"
 #include "rsync.hpp"
@@ -974,6 +976,6 @@ TEST_F(RSyncTest, RegisterAndPushCPPByInode)
     std::string buffer3{R"(test_id no_data {"begin":1,"end":5,"id":1})"};
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer3.begin(), buffer3.end() }));
 
-    sleep(3);
+    std::this_thread::sleep_for(std::chrono::seconds(3));
     remoteSync.reset();
 }

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -23,6 +23,10 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+if(APPLE)
+  set(CMAKE_MACOSX_RPATH 1)
+endif(APPLE)
+
 include_directories(${SRC_FOLDER}/)
 include_directories(${SRC_FOLDER}/headers/)
 include_directories(${SRC_FOLDER}/external/sqlite/)
@@ -75,8 +79,6 @@ elseif(UNIX AND NOT APPLE)
   set_target_properties(syscollector PROPERTIES
         LINK_FLAGS "-static-libgcc -static-libstdc++")
   string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath=$ORIGIN")
-elseif(APPLE)
-  string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Xlinker -rpath -Xlinker @executable_path") 
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
 target_link_libraries(syscollector crypto dbsync rsync sysinfo cjson pthread)

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -75,6 +75,8 @@ elseif(UNIX AND NOT APPLE)
   set_target_properties(syscollector PROPERTIES
         LINK_FLAGS "-static-libgcc -static-libstdc++")
   string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath=$ORIGIN")
+elseif(APPLE)
+  string(APPEND CMAKE_SHARED_LINKER_FLAGS "-Xlinker -rpath -Xlinker @executable_path") 
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
 target_link_libraries(syscollector crypto dbsync rsync sysinfo cjson pthread)

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -72,7 +72,7 @@ void* wm_sys_main(wm_sys_t *sys)
         syscollector_stop_ptr = so_get_function_sym(syscollector_module, "syscollector_stop");
         syscollector_sync_message_ptr = so_get_function_sym(syscollector_module, "syscollector_sync_message");
     } else {
-        mterror(WM_SYS_LOGTAG, "Can't load syscollector.");
+        mterror(WM_SYS_LOGTAG, "Can't load syscollector");
         pthread_exit(NULL);
     }
 

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -72,7 +72,7 @@ void* wm_sys_main(wm_sys_t *sys)
         syscollector_stop_ptr = so_get_function_sym(syscollector_module, "syscollector_stop");
         syscollector_sync_message_ptr = so_get_function_sym(syscollector_module, "syscollector_sync_message");
     } else {
-        mterror(WM_SYS_LOGTAG, "Can't load syscollector");
+        mterror(WM_SYS_LOGTAG, "Can't load syscollector.");
         pthread_exit(NULL);
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #6777 |

This issue aims to modify the build configuration, to provide functionality to sysinfo and to feed relevant information to the modules that wish to consume the data provider.

The minimum version of CMake 2.6.4 must be respected
This change is only for MacOS configuration.
