### PR TITLE
[6887] RTR tool fix

### DIFF
--- a/src/data_provider/cppcheckSuppress.txt
+++ b/src/data_provider/cppcheckSuppress.txt
@@ -1,0 +1,1 @@
+*:*src/sysInfoLinux.cpp:423

--- a/src/shared_modules/dbsync/cppcheckSuppress.txt
+++ b/src/shared_modules/dbsync/cppcheckSuppress.txt
@@ -1,1 +1,2 @@
-*:*src/sqlite/sqlite_dbengine.cpp:141
+*:*src/sqlite/sqlite_dbengine.cpp:143
+*:*testtool/action.h:612

--- a/src/shared_modules/rsync/cppcheckSuppress.txt
+++ b/src/shared_modules/rsync/cppcheckSuppress.txt
@@ -1,0 +1,3 @@
+*:*src/rsyncImplementation.cpp:150
+*:*tests/implementation/rsyncImplementationTest.cpp:259
+*:*tests/interface/rsync_test.cpp:246

--- a/src/wazuh_modules/syscollector/cppcheckSuppress.txt
+++ b/src/wazuh_modules/syscollector/cppcheckSuppress.txt
@@ -1,2 +1,3 @@
 *:*.c
 *:*syscollector.h
+*:*src/syscollectorImp.cpp:687


### PR DESCRIPTION
|Related issue|
|---|
|Closes: [6887](https://github.com/wazuh/wazuh/issues/6887)|

## **Description**

It seems that something have been broken in the dev-syscollector-dbsync-rsync branch regarding Ready-To-Review tool. Particularly, during static analysis (cppcheck) execution for each module.
This PR fixes those issues.

## **DoD**

- [X] Data Provider RTR execution
![image](https://user-images.githubusercontent.com/22640902/102087738-be5ece00-3df8-11eb-97fd-c30ccf88d706.png)

- [X] DBSync RTR execution
![image](https://user-images.githubusercontent.com/22640902/102087792-d0d90780-3df8-11eb-9ef5-28dbef78418b.png)

- [X] RSync RTR execution
![image](https://user-images.githubusercontent.com/22640902/102087843-de8e8d00-3df8-11eb-8139-15c69832f7ef.png)

- [X] Syscollector RTR execution
![image](https://user-images.githubusercontent.com/22640902/102087882-eb12e580-3df8-11eb-9806-1555d6057b40.png)
