### PR TITLE
Change the POST /groups endpoint to specify the group name in a JSON body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 - **API:**
   - Removed ruleset version from `GET /cluster/{node_id}/info` and `GET /manager/info` as it was deprecated. ([#6904](https://github.com/wazuh/wazuh/issues/6904))
+  - Changed the `POST /groups` endpoint to specify the group name in a JSON body instead of in a query parameter. ([#6909](https://github.com/wazuh/wazuh/pull/6909))
 
 - **Framework:**
   - Deprecated `update_ruleset` script. ([#6904](https://github.com/wazuh/wazuh/issues/6904))

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -13,6 +13,7 @@ from api.encoder import dumps, prettify
 from api.models.agent_added_model import AgentAddedModel
 from api.models.agent_inserted_model import AgentInsertedModel
 from api.models.base_model_ import Body
+from api.models.group_added_model import GroupAddedModel
 from api.util import parse_api_param, remove_nones_to_dict, raise_if_exc
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
@@ -693,15 +694,23 @@ async def get_agents_in_group(request, group_id, pretty=False, wait_for_complete
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def post_group(request, group_id, pretty=False, wait_for_complete=False):
+async def post_group(request, pretty=False, wait_for_complete=False):
     """Create a new group.
+    
+    Parameters
+    ----------
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
 
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
-    :param group_id: Group ID.
-    :return: ApiResponse
+    Returns
+    -------
+    ApiResponse
     """
-    f_kwargs = {'group_id': group_id}
+    # Get body parameters
+    Body.validate_content_type(request, expected_content_type='application/json')
+    f_kwargs = await GroupAddedModel.get_kwargs(request)
 
     dapi = DistributedAPI(f=agent.create_group,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/models/group_added_model.py
+++ b/api/api/models/group_added_model.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+
+from __future__ import absolute_import
+
+from datetime import date, datetime  # noqa: F401
+from typing import List, Dict  # noqa: F401
+
+from api.models.base_model_ import Body
+
+
+class GroupAddedModel(Body):
+
+    def __init__(self, group_id: str = None):
+        """GroupAddedModel body model.
+
+        Parameters
+        ----------
+        group_id : str
+            Group name.
+        """
+        self.swagger_types = {
+            'group_id': str,
+        }
+
+        self.attribute_map = {
+            'group_id': 'group_id',
+        }
+
+        self._group_id = group_id
+
+    @property
+    def group_id(self) -> str:
+        """Group name getter.
+        Returns
+        -------
+        group_id : str
+            Group name.
+        """
+        return self._group_id
+
+    @group_id.setter
+    def group_id(self, group_id):
+        """Group name setter.
+        Parameters
+        ----------
+        group_id : str
+            Group name.
+        """
+        self._group_id = group_id

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6316,7 +6316,19 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/group_id_query'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                group_id:
+                  description: "Group name"
+                  type: string
+                  format: names
+              required:
+                - group_id
+            example:
+              name: NewGroup_1
       responses:
         '200':
           description: "Add new agent"

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6324,7 +6324,7 @@ paths:
                 group_id:
                   description: "Group name"
                   type: string
-                  format: names
+                  format: group_names
               required:
                 - group_id
             example:

--- a/api/test/integration/test_agent_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_POST_endpoints.tavern.yaml
@@ -206,7 +206,7 @@ test_name: POST /groups/{group_id}
 
 stages:
 
-    # POST /groups?group_id=group4
+    # POST /groups
   - name: Create a group called group4
     request:
       verify: False
@@ -214,15 +214,15 @@ stages:
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
-      params:
-        group_id: group4
+      json:
+        group_id: "group4"
     response:
       status_code: 200
       json:
         message: !anystr
     delay_after: !float "{global_db_delay}"
 
-    # POST /groups?group_id=group1
+    # POST /groups
   - name: Try to create a group that already exists
     request:
       verify: False
@@ -230,14 +230,14 @@ stages:
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
-      params:
-        group_id: group1
+      json:
+        group_id: "group1"
     response:
       status_code: 400
       json:
         error: 1711
 
-    # POST /groups?group_id=;wrong_name
+    # POST /groups
   - name: Try to create a group with an invalid name
     request:
       verify: False
@@ -245,8 +245,8 @@ stages:
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
-      params:
-        group_id: ';wrong_name'
+      json:
+        group_id: ";wrong_name"
     response:
       status_code: 400
       json:

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -1168,7 +1168,7 @@ stages:
       <<: *permission_denied
 
 ---
-test_name: POST /groups?group_id={group_id}
+test_name: POST /groups
 
 stages:
 
@@ -1179,8 +1179,8 @@ stages:
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
-      params:
-        group_id: group4
+      json:
+        group_id: "group4"
     response:
       <<: *permission_denied
 

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -1250,8 +1250,8 @@ stages:
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
-      params:
-        group_id: 'group4'
+      json:
+        group_id: "group4"
     response:
       <<: *permission_denied
 


### PR DESCRIPTION
|Related issue|
|---|
| #6886 |

Hi team,

This PR closes #6886. I have deleted the `agent_id` query parameter of the `POST /groups` endpoint. Instead of a parameter, the group name is now defined by the key `group_id` of the JSON body that has been added to the endpoint.

I have added the` added group model` and updated the spec and the controller. I have also updated the API integration tests.

**- Test results:**

```
test_agent_DELETE_endpoints.tavern.yaml 
	 6 passed, 8 warnings

test_agent_GET_endpoints.tavern.yaml 
	 90 passed, 97 warnings

test_agent_POST_endpoints.tavern.yaml 
	 5 passed, 7 warnings

test_agent_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings

test_rbac_black_agent_endpoints.tavern.yaml 
	 39 passed, 41 warnings

test_rbac_white_agent_endpoints.tavern.yaml 
	 39 passed, 41 warnings
```

Regards,
Manuel.
