### PR TITLE
Updated install script to fix error when updating

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -152,6 +152,10 @@ Install()
         WazuhSetup
     fi
 
+    # Calling the init script to start ossec hids during boot
+    runInit $INSTYPE ${update_only}
+    runinit_value=$?
+
     # If update, start OSSEC
     if [ "X${update_only}" = "Xyes" ]; then
         WazuhUpgrade
@@ -161,9 +165,7 @@ Install()
         UpdateStartOSSEC
     fi
 
-    # Calling the init script  to start ossec hids during boot
-    runInit $INSTYPE ${update_only}
-    if [ $? = 1 ]; then
+    if [ $runinit_value = 1 ]; then
         notmodified="yes"
     elif [ "X$START_WAZUH" = "Xyes" ]; then
         echo "Starting Wazuh..."

--- a/install.sh
+++ b/install.sh
@@ -127,7 +127,7 @@ Install()
         fi
     fi
 
-    # If update, stop ossec
+    # If update, stop Wazuh
     if [ "X${update_only}" = "Xyes" ]; then
         echo "Stopping Wazuh..."
         UpdateStopOSSEC
@@ -152,11 +152,11 @@ Install()
         WazuhSetup
     fi
 
-    # Calling the init script to start ossec hids during boot
+    # Calling the init script to start Wazuh during boot
     runInit $INSTYPE ${update_only}
     runinit_value=$?
 
-    # If update, start OSSEC
+    # If update, start Wazuh
     if [ "X${update_only}" = "Xyes" ]; then
         WazuhUpgrade
         # Update versions previous to Wazuh 1.2


### PR DESCRIPTION
|Related issue|
|-----|
|#6889|

## Description

Hi team,

This pull request includes an update of `install.sh` to avoid a starting error when updating Wazuh from certain versions, as described in #6889. This error was being caused by an attempt at starting Wazuh's service before updating its information.

## Modified files

- `install.sh`

## Logs

````
Starting Wazuh...

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/ossec-control start

 - To stop Wazuh:
      /var/ossec/bin/ossec-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---

 - Update completed.
 ````
````
# systemctl status wazuh-manager.service
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/etc/systemd/system/wazuh-manager.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2020-12-15 16:06:48 CET; 4min 48s ago
    Process: 192499 ExecStart=/usr/bin/env ${DIRECTORY}/bin/wazuh-control start (code=exited, statu>
      Tasks: 158 (limit: 19010)
     Memory: 161.8M
     CGroup: /system.slice/wazuh-manager.service
             ├─192578 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─192631 /var/ossec/bin/ossec-authd
             ├─192647 /var/ossec/bin/wazuh-db
             ├─192670 /var/ossec/bin/ossec-execd
             ├─192681 /var/ossec/bin/ossec-analysisd
             ├─192781 /var/ossec/bin/ossec-syscheckd
             ├─192794 /var/ossec/bin/ossec-remoted
             ├─192819 /var/ossec/bin/ossec-logcollector
             ├─192843 /var/ossec/bin/ossec-monitord
             └─192867 /var/ossec/bin/wazuh-modulesd
dic 15 16:06:40 host env[192499]: Started wazuh-db...
dic 15 16:06:40 host env[192499]: Started ossec-execd...
dic 15 16:06:42 host env[192499]: Started ossec-analysisd...
dic 15 16:06:42 host env[192499]: Started ossec-syscheckd...
dic 15 16:06:43 host env[192499]: Started ossec-remoted...
dic 15 16:06:44 host env[192499]: Started ossec-logcollector...
dic 15 16:06:45 host env[192499]: Started ossec-monitord...
dic 15 16:06:46 host env[192499]: Started wazuh-modulesd...
dic 15 16:06:48 host env[192499]: Completed.
dic 15 16:06:48 host systemd[1]: Started Wazuh manager.
 ````


## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation: Linux Manager and agent
- [x] Source upgrade: Linux Manager and agent

