### PR TITLE
Fixed a bug when configuring scan_time to 12pm or 12am

### DIFF
--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -532,6 +532,7 @@ static const char *__gethour(const char *str, char *ossec_hour)
     if ((*str == 'a') || (*str == 'A')) {
         str++;
         if ((*str == 'm') || (*str == 'M')) {
+            if (chour == 12) chour = 0;
             snprintf(ossec_hour, 6, "%02d:%02d", chour, cmin);
             str++;
             return (str);
@@ -539,6 +540,7 @@ static const char *__gethour(const char *str, char *ossec_hour)
     } else if ((*str == 'p') || (*str == 'P')) {
         str++;
         if ((*str == 'm') || (*str == 'M')) {
+            if (chour == 12) chour = 0;
             chour += 12;
 
             /* New hour must be valid */


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5610|


## Description

This PR fix a bug found in the syscheck scan configuration <scan_time>, with 12am or 12pm, the function `__gethour` incorrectly reads the values. 

## Errors
Syscheck configuration, scheduled scan, with `<scan_time>12pm</scan_time>`:
```
2020/07/31 12:01:59 ossec-syscheckd: ERROR: (1240): Invalid time format: 'm-12pm'.
2020/07/31 12:04:56 ossec-syscheckd: ERROR: (1235): Invalid value for element 'scan_time': 12pm.
2020/07/31 12:04:56 ossec-syscheckd: ERROR: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
2020/07/31 12:04:56 ossec-syscheckd: ERROR: (1207): syscheck remote configuration in '/var/ossec/etc/ossec.conf' is corrupted.
```

Custom rule using `<time>12pm - 12am</time>`
```
2020/12/17 12:01:53 ossec-analysisd: ERROR: (1240): Invalid time format: 'm - 12am'.
2020/12/17 12:01:53 ossec-analysisd: ERROR: (1274): Invalid configuration. Element 'time': 12pm - 12am.
2020/12/17 12:01:53 ossec-analysisd: CRITICAL: (1220): Error loading the rules: 'etc/rules/local_rules.xml'.
ossec-analysisd: Configuration error. Exiting
```

After the fix, all these issues are solved.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation