### PR TITLE
Fix ciscat and experimental API integration tests healtheck

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -22,7 +22,6 @@ variables:
   upgrade_delay: 45
   global_db_delay: 20
   active_reponse_delay: 5
-  get_experimental_ciscat_results_delay: 60
 
   custom_wpk_path: "/var/ossec/test_custom_upgrade_3.12.2.wpk"
 

--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -22,6 +22,7 @@ variables:
   upgrade_delay: 45
   global_db_delay: 20
   active_reponse_delay: 5
+  get_experimental_ciscat_results_delay: 60
 
   custom_wpk_path: "/var/ossec/test_custom_upgrade_3.12.2.wpk"
 

--- a/api/test/integration/env/configurations/ciscat/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/ciscat/agent/healthcheck/healthcheck.py
@@ -1,6 +1,6 @@
 import os
 
-output = os.system("grep -q 'wazuh-modulesd:ciscat: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+output = os.system("grep -q 'wazuh-modulesd:ciscat: INFO: Scan finished successfully.' /var/ossec/logs/ossec.log")
 
 if output == 0:
     exit(0)

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -1,36 +1,25 @@
+# import os
+#
+# output_ciscat = os.system("grep -q 'wazuh-modulesd:ciscat: INFO: Scan finished successfully.' /var/ossec/logs/ossec.log")
+# output_sysc = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+#
+# if output_ciscat == 0 and output_sysc == 0:
+#     exit(0)
+# else:
+#     exit(1)
+
+# Provisionally
 import os
-import re
-from datetime import datetime, timedelta
 
-output_code_ciscat_scan = os.system(
-    "grep -q 'wazuh-modulesd:ciscat: INFO: Scan finished successfully.' /var/ossec/logs/ossec.log")
-output_code_ciscat_evaluation = os.system(
-    "grep -q 'wazuh-modulesd:ciscat: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
-output_code_sysc = os.system(
-    "grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+def get_health():
+    output = os.system("grep -q 'ossec-syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
+    output_syscollector = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
 
-if output_code_ciscat_scan == 0 and output_code_ciscat_evaluation == 0 and output_code_sysc == 0:
-    exit(0)
-else:
-    # Check if the last ciscat evaluation started and did not finish
-    output_ciscat_start = os.popen(
-        "grep 'wazuh-modulesd:ciscat: INFO: Starting evaluation.' /var/ossec/logs/ossec.log").read().splitlines()
-    last_ciscat_start = output_ciscat_start[len(output_ciscat_start) - 1]
+    if output == 0 and output_syscollector == 0:
+        return 0
+    else:
+        return 1
 
-    timestamp_last_ciscat_start = datetime.strptime(last_ciscat_start[:19], '%Y/%m/%d %H:%M:%S')
 
-    # If the last ciscat evaluation is taking more than 150 seconds,
-    # restart the daemon so a new ciscat evaluation starts
-    if (datetime.now() - timestamp_last_ciscat_start) >= timedelta(seconds=150):
-        # Kill the old wazuh-modulesd daemon
-        old_modulesd_pidfile = os.popen(
-            "ls /var/ossec/var/run/ | grep wazuh-modulesd-").read()
-        old_modulesd_pid = re.search(r'(\d+).pid$', old_modulesd_pidfile).group(1)
-        output_code_kill_modulesd = os.system(
-            "kill {}".format(old_modulesd_pid))
-
-        if output_code_kill_modulesd == 0:
-            # Start wazuh-modulesd daemon
-            os.system("/var/ossec/bin/wazuh-modulesd")
-
-    exit(1)
+if __name__ == "__main__":
+    exit(get_health())

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -1,25 +1,9 @@
-# import os
-#
-# output_ciscat = os.system("grep -q 'wazuh-modulesd:ciscat: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
-# output_sysc = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
-#
-# if output_ciscat == 0 and output_sysc == 0:
-#     exit(0)
-# else:
-#     exit(1)
-
-# Provisionally
 import os
 
-def get_health():
-    output = os.system("grep -q 'ossec-syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
-    output_syscollector = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+output_ciscat = os.system("grep -q 'wazuh-modulesd:ciscat: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+output_sysc = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
 
-    if output == 0 and output_syscollector == 0:
-        return 0
-    else:
-        return 1
-
-
-if __name__ == "__main__":
-    exit(get_health())
+if output_ciscat == 0 and output_sysc == 0:
+    exit(0)
+else:
+    exit(1)

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -1,9 +1,10 @@
 import os
 
-output_ciscat = os.system("grep -q 'wazuh-modulesd:ciscat: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+output_ciscat_scan = os.system("grep -q 'wazuh-modulesd:ciscat: INFO: Scan finished successfully.' /var/ossec/logs/ossec.log")
+output_ciscat_evaluation = os.system("grep -q 'wazuh-modulesd:ciscat: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
 output_sysc = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
 
-if output_ciscat == 0 and output_sysc == 0:
+if output_ciscat_scan == 0 and output_ciscat_evaluation == 0 and output_sysc == 0:
     exit(0)
 else:
     exit(1)

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -20,7 +20,7 @@ else:
 
     # If the last ciscat evaluation is taking more than 90 seconds,
     # restart the daemon so a new ciscat evaluation starts
-    if (datetime.now() - timestamp_last_ciscat_start) >= timedelta(seconds=90):
+    if (datetime.now() - timedelta(hours=1) - timestamp_last_ciscat_start) >= timedelta(seconds=90):
         os.system("/var/ossec/bin/wazuh-modulesd")
 
     exit(1)

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -1,4 +1,5 @@
 import os
+import re
 from datetime import datetime, timedelta
 
 output_code_ciscat_scan = os.system(
@@ -21,6 +22,15 @@ else:
     # If the last ciscat evaluation is taking more than 150 seconds,
     # restart the daemon so a new ciscat evaluation starts
     if (datetime.now() - timestamp_last_ciscat_start) >= timedelta(seconds=150):
-        os.system("/var/ossec/bin/wazuh-modulesd")
+        # Kill the old wazuh-modulesd daemon
+        old_modulesd_pidfile = os.popen(
+            "ls /var/ossec/var/run/ | grep wazuh-modulesd-").read()
+        old_modulesd_pid = re.search(r'(\d+).pid$', old_modulesd_pidfile).group(1)
+        output_code_kill_modulesd = os.system(
+            "kill {}".format(old_modulesd_pid))
+
+        if output_code_kill_modulesd == 0:
+            # Start wazuh-modulesd daemon
+            os.system("/var/ossec/bin/wazuh-modulesd")
 
     exit(1)

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -18,9 +18,9 @@ else:
 
     timestamp_last_ciscat_start = datetime.strptime(last_ciscat_start[:19], '%Y/%m/%d %H:%M:%S')
 
-    # If the last ciscat evaluation is taking more than 90 seconds,
+    # If the last ciscat evaluation is taking more than 150 seconds,
     # restart the daemon so a new ciscat evaluation starts
-    if (datetime.now() - timedelta(hours=1) - timestamp_last_ciscat_start) >= timedelta(seconds=90):
+    if (datetime.now() - timestamp_last_ciscat_start) >= timedelta(seconds=150):
         os.system("/var/ossec/bin/wazuh-modulesd")
 
     exit(1)

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -1,9 +1,10 @@
 # import os
 #
 # output_ciscat = os.system("grep -q 'wazuh-modulesd:ciscat: INFO: Scan finished successfully.' /var/ossec/logs/ossec.log")
-# output_sysc = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+# output_syscollector = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+# output_syscheck = os.system("grep -q 'ossec-syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
 #
-# if output_ciscat == 0 and output_sysc == 0:
+# if output_ciscat == 0 and output_syscollector == 0 and output_syscheck == 0:
 #     exit(0)
 # else:
 #     exit(1)

--- a/api/test/integration/env/configurations/experimental/agent/syscollector.sh
+++ b/api/test/integration/env/configurations/experimental/agent/syscollector.sh
@@ -1,2 +1,0 @@
-sed -i '/name="syscollector"/,/\/wodle/s/<interval>.*/<interval>10s<\/interval>/' /var/ossec/etc/ossec.conf
-sed -i '/name="syscollector"/,/\/wodle/s/<scan_on_start>.*/<scan_on_start>no<\/scan_on_start>/' /var/ossec/etc/ossec.conf

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -64,10 +64,12 @@ stages:
 ---
 test_name: GET /experimental/ciscat/results
 
+marks:
+  - xfail
+
 stages:
 
   - name: Request
-    skip: True
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
@@ -105,7 +107,6 @@ stages:
           total_failed_items: 0
 
   - name: Request
-    skip: True
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -62,73 +62,6 @@ stages:
           total_failed_items: 0
 
 ---
-test_name: GET /experimental/ciscat/results
-
-stages:
-
-  - name: Request
-    skip: True
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - &ciscat_response
-              agent_id: !anystr
-              benchmark: !anystr
-              error: !anyint
-              fail: !anyint
-              notchecked: !anyint
-              pass: !anyint
-              profile: !anystr
-              scan:
-                id: !anyint
-                time: !anystr
-              score: !anyint
-              unknown: !anyint
-            - <<: *ciscat_response
-            - <<: *ciscat_response
-            - <<: *ciscat_response
-            - <<: *ciscat_response
-            - <<: *ciscat_response
-            - <<: *ciscat_response
-            - <<: *ciscat_response
-          failed_items: []
-          total_affected_items: 8
-          total_failed_items: 0
-
-  - name: Request
-    skip: True
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        agents_list: '001,003'
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *ciscat_response
-              agent_id: '001'
-            - <<: *ciscat_response
-              agent_id: '003'
-          failed_items: []
-          total_affected_items: 2
-          total_failed_items: 0
-
----
 test_name: GET /experimental/syscollector/hardware
 
 stages:
@@ -502,7 +435,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages?wait_for_complete=true"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -688,4 +621,70 @@ stages:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
+          total_failed_items: 0
+
+---
+test_name: GET /experimental/ciscat/results
+
+stages:
+
+  - name: Request
+    delay_before: !float "{get_experimental_ciscat_results_delay}"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - &ciscat_response
+              agent_id: !anystr
+              benchmark: !anystr
+              error: !anyint
+              fail: !anyint
+              notchecked: !anyint
+              pass: !anyint
+              profile: !anystr
+              scan:
+                id: !anyint
+                time: !anystr
+              score: !anyint
+              unknown: !anyint
+            - <<: *ciscat_response
+            - <<: *ciscat_response
+            - <<: *ciscat_response
+            - <<: *ciscat_response
+            - <<: *ciscat_response
+            - <<: *ciscat_response
+            - <<: *ciscat_response
+          failed_items: []
+          total_affected_items: 8
+          total_failed_items: 0
+
+  - name: Request
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '001,003'
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - <<: *ciscat_response
+              agent_id: '001'
+            - <<: *ciscat_response
+              agent_id: '003'
+          failed_items: []
+          total_affected_items: 2
           total_failed_items: 0

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -62,6 +62,73 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: GET /experimental/ciscat/results
+
+stages:
+
+  - name: Request
+    skip: True
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - &ciscat_response
+              agent_id: !anystr
+              benchmark: !anystr
+              error: !anyint
+              fail: !anyint
+              notchecked: !anyint
+              pass: !anyint
+              profile: !anystr
+              scan:
+                id: !anyint
+                time: !anystr
+              score: !anyint
+              unknown: !anyint
+            - <<: *ciscat_response
+            - <<: *ciscat_response
+            - <<: *ciscat_response
+            - <<: *ciscat_response
+            - <<: *ciscat_response
+            - <<: *ciscat_response
+            - <<: *ciscat_response
+          failed_items: []
+          total_affected_items: 8
+          total_failed_items: 0
+
+  - name: Request
+    skip: True
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '001,003'
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - <<: *ciscat_response
+              agent_id: '001'
+            - <<: *ciscat_response
+              agent_id: '003'
+          failed_items: []
+          total_affected_items: 2
+          total_failed_items: 0
+
+---
 test_name: GET /experimental/syscollector/hardware
 
 stages:
@@ -621,70 +688,4 @@ stages:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: 0
-
----
-test_name: GET /experimental/ciscat/results
-
-stages:
-
-  - name: Request
-    delay_before: !float "{get_experimental_ciscat_results_delay}"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - &ciscat_response
-              agent_id: !anystr
-              benchmark: !anystr
-              error: !anyint
-              fail: !anyint
-              notchecked: !anyint
-              pass: !anyint
-              profile: !anystr
-              scan:
-                id: !anyint
-                time: !anystr
-              score: !anyint
-              unknown: !anyint
-            - <<: *ciscat_response
-            - <<: *ciscat_response
-            - <<: *ciscat_response
-            - <<: *ciscat_response
-            - <<: *ciscat_response
-            - <<: *ciscat_response
-            - <<: *ciscat_response
-          failed_items: []
-          total_affected_items: 8
-          total_failed_items: 0
-
-  - name: Request
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        agents_list: '001,003'
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - <<: *ciscat_response
-              agent_id: '001'
-            - <<: *ciscat_response
-              agent_id: '003'
-          failed_items: []
-          total_affected_items: 2
           total_failed_items: 0

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -57,60 +57,6 @@ stages:
           total_failed_items: 2
 
 ---
-test_name: GET /experimental/ciscat/results
-
-stages:
-
-  - name: Request all agents (Partially allowed, user agnostic)
-    skip: True
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - agent_id: '002'
-            - agent_id: '004'
-            - agent_id: '006'
-            - agent_id: '008'
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
-
-  - name: Request a list of agents (Partially allowed, user aware)
-    skip: True
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        agents_list: '002,003,007,008'
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - agent_id: '002'
-            - agent_id: '008'
-          failed_items:
-            - error:
-                code: 4000
-              id:
-                - '003'
-                - '007'
-          total_affected_items: 2
-          total_failed_items: 2
-
----
 test_name: GET /experimental/syscollector/hardware
 
 stages:
@@ -526,3 +472,56 @@ stages:
                 - '005'
           total_affected_items: !anyint
           total_failed_items: 1
+
+---
+test_name: GET /experimental/ciscat/results
+
+stages:
+
+  - name: Request all agents (Partially allowed, user agnostic)
+    delay_before: !float "{get_experimental_ciscat_results_delay}"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - agent_id: '002'
+            - agent_id: '004'
+            - agent_id: '006'
+            - agent_id: '008'
+          failed_items: []
+          total_affected_items: 4
+          total_failed_items: 0
+
+  - name: Request a list of agents (Partially allowed, user aware)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '002,003,007,008'
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - agent_id: '002'
+            - agent_id: '008'
+          failed_items:
+            - error:
+                code: 4000
+              id:
+                - '003'
+                - '007'
+          total_affected_items: 2
+          total_failed_items: 2

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -57,6 +57,60 @@ stages:
           total_failed_items: 2
 
 ---
+test_name: GET /experimental/ciscat/results
+
+stages:
+
+  - name: Request all agents (Partially allowed, user agnostic)
+    skip: True
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - agent_id: '002'
+            - agent_id: '004'
+            - agent_id: '006'
+            - agent_id: '008'
+          failed_items: []
+          total_affected_items: 4
+          total_failed_items: 0
+
+  - name: Request a list of agents (Partially allowed, user aware)
+    skip: True
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '002,003,007,008'
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - agent_id: '002'
+            - agent_id: '008'
+          failed_items:
+            - error:
+                code: 4000
+              id:
+                - '003'
+                - '007'
+          total_affected_items: 2
+          total_failed_items: 2
+
+---
 test_name: GET /experimental/syscollector/hardware
 
 stages:
@@ -472,56 +526,3 @@ stages:
                 - '005'
           total_affected_items: !anyint
           total_failed_items: 1
-
----
-test_name: GET /experimental/ciscat/results
-
-stages:
-
-  - name: Request all agents (Partially allowed, user agnostic)
-    delay_before: !float "{get_experimental_ciscat_results_delay}"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - agent_id: '002'
-            - agent_id: '004'
-            - agent_id: '006'
-            - agent_id: '008'
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
-
-  - name: Request a list of agents (Partially allowed, user aware)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        agents_list: '002,003,007,008'
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - agent_id: '002'
-            - agent_id: '008'
-          failed_items:
-            - error:
-                code: 4000
-              id:
-                - '003'
-                - '007'
-          total_affected_items: 2
-          total_failed_items: 2

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -59,10 +59,12 @@ stages:
 ---
 test_name: GET /experimental/ciscat/results
 
+marks:
+  - xfail
+
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
-    skip: True
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
@@ -84,7 +86,6 @@ stages:
           total_failed_items: 0
 
   - name: Request a list of agents (Partially allowed, user aware)
-    skip: True
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -297,7 +297,7 @@ stages:
   - name:  Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages?wait_for_complete=true"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -56,6 +56,60 @@ stages:
           total_failed_items: 2
 
 ---
+test_name: GET /experimental/ciscat/results
+
+stages:
+
+  - name: Request all agents (Partially allowed, user agnostic)
+    skip: True
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - agent_id: '001'
+            - agent_id: '003'
+            - agent_id: '005'
+            - agent_id: '007'
+          failed_items: []
+          total_affected_items: 4
+          total_failed_items: 0
+
+  - name: Request a list of agents (Partially allowed, user aware)
+    skip: True
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '003,004,007,008'
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - agent_id: '003'
+            - agent_id: '007'
+          failed_items:
+            - error:
+                code: 4000
+              id:
+                - '004'
+                - '008'
+          total_affected_items: 2
+          total_failed_items: 2
+
+---
 test_name: GET /experimental/syscollector/hardware
 
 stages:
@@ -496,56 +550,3 @@ stages:
                 - '006'
           total_affected_items: 0
           total_failed_items: 3
-
----
-test_name: GET /experimental/ciscat/results
-
-stages:
-
-  - name: Request all agents (Partially allowed, user agnostic)
-    delay_before: !float "{get_experimental_ciscat_results_delay}"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - agent_id: '001'
-            - agent_id: '003'
-            - agent_id: '005'
-            - agent_id: '007'
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
-
-  - name: Request a list of agents (Partially allowed, user aware)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        agents_list: '003,004,007,008'
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - agent_id: '003'
-            - agent_id: '007'
-          failed_items:
-            - error:
-                code: 4000
-              id:
-                - '004'
-                - '008'
-          total_affected_items: 2
-          total_failed_items: 2

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -58,10 +58,12 @@ stages:
 ---
 test_name: GET /experimental/ciscat/results
 
+marks:
+  - xfail
+
 stages:
 
   - name: Request all agents (Partially allowed, user agnostic)
-    skip: True
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
@@ -83,7 +85,6 @@ stages:
           total_failed_items: 0
 
   - name: Request a list of agents (Partially allowed, user aware)
-    skip: True
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -28,7 +28,7 @@ stages:
           failed_items: []
           total_affected_items: 4
           total_failed_items: 0
-        
+
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
@@ -54,61 +54,7 @@ stages:
                 - '006'
           total_affected_items: 2
           total_failed_items: 2
-        
----
-test_name: GET /experimental/ciscat/results
 
-stages:
-
-  - name: Request all agents (Partially allowed, user agnostic)
-    skip: True
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - agent_id: '001'
-            - agent_id: '003'
-            - agent_id: '005'
-            - agent_id: '007'
-          failed_items: []
-          total_affected_items: 4
-          total_failed_items: 0
-        
-  - name: Request a list of agents (Partially allowed, user aware)
-    skip: True
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        agents_list: '003,004,007,008'
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - agent_id: '003'
-            - agent_id: '007'
-          failed_items:
-            - error:
-                code: 4000
-              id:
-                - '004'
-                - '008'
-          total_affected_items: 2
-          total_failed_items: 2
-        
 ---
 test_name: GET /experimental/syscollector/hardware
 
@@ -160,7 +106,7 @@ stages:
                 - '006'
           total_affected_items: 2
           total_failed_items: 2
-        
+
 ---
 test_name: GET /experimental/syscollector/netaddr
 
@@ -212,7 +158,7 @@ stages:
                 - '008'
           total_affected_items: 2
           total_failed_items: 2
-        
+
 ---
 test_name: GET /experimental/syscollector/netiface
 
@@ -264,7 +210,7 @@ stages:
                 - '008'
           total_affected_items: 3
           total_failed_items: 1
-        
+
 ---
 test_name: GET /experimental/syscollector/netproto
 
@@ -316,7 +262,7 @@ stages:
                 - '008'
           total_affected_items: 1
           total_failed_items: 3
-        
+
 ---
 test_name: GET /experimental/syscollector/os
 
@@ -368,7 +314,7 @@ stages:
                 - '004'
           total_affected_items: 2
           total_failed_items: 2
-        
+
 ---
 test_name: GET /experimental/syscollector/packages
 
@@ -390,7 +336,7 @@ stages:
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
-        
+
   - name:  Request all agents (Denied)
     request:
       verify: False
@@ -478,7 +424,7 @@ stages:
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
-        
+
   - name: Request
     request:
       verify: False
@@ -502,7 +448,7 @@ stages:
                 - '008'
           total_affected_items: !anyint
           total_failed_items: 2
-        
+
 ---
 test_name: GET /experimental/syscollector/hotfixes
 
@@ -524,7 +470,7 @@ stages:
           failed_items: []
           total_affected_items: 0  # Only the agent 000 will have results but we don't have permissions
           total_failed_items: 0
-        
+
   - name: Request
     request:
       verify: False
@@ -550,3 +496,56 @@ stages:
                 - '006'
           total_affected_items: 0
           total_failed_items: 3
+
+---
+test_name: GET /experimental/ciscat/results
+
+stages:
+
+  - name: Request all agents (Partially allowed, user agnostic)
+    delay_before: !float "{get_experimental_ciscat_results_delay}"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - agent_id: '001'
+            - agent_id: '003'
+            - agent_id: '005'
+            - agent_id: '007'
+          failed_items: []
+          total_affected_items: 4
+          total_failed_items: 0
+
+  - name: Request a list of agents (Partially allowed, user aware)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        agents_list: '003,004,007,008'
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - agent_id: '003'
+            - agent_id: '007'
+          failed_items:
+            - error:
+                code: 4000
+              id:
+                - '004'
+                - '008'
+          total_affected_items: 2
+          total_failed_items: 2

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -323,7 +323,7 @@ stages:
   - name:  Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages"
+      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages?wait_for_complete=true"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"


### PR DESCRIPTION
Hi team,

_There is extra information about this PR here https://github.com/wazuh/wazuh/issues/6868, I have used this PR to add a provisional fix to the errors happening when the agents don't go healthy (known error that happens ocassionally). This fix will not be merged as a deeper investigation about `ciscat`/`wazuh-modulesd` is needed._

In this PR, I have fixed the ciscat healthcheck for the `ciscat` and `experimental` endpoint tests. The healthcheck was waiting for the message `wazuh-modulesd:ciscat: INFO: Evaluation finished.` while the important log message is `wazuh-modulesd:ciscat: INFO: Scan finished successfully.` I have changed this in both the provisional and the old healthcheck.

It was also necessary to add `wait_for_complete=true` to the `GET /experimental/syscollector/packages` endpoint tests in order to avoid failed tests due to API timeouts.

The following tests are passing locally (the issue #6868 may need to be solved to pass them in jenkins). The experimental tests must pass in jenkins as the ciscat part is skipped.

```
test_ciscat_endpoints.tavern.yaml 
	 11 passed, 14 warnings

test_rbac_black_ciscat_endpoints.tavern.yaml 
	 1 passed, 3 warnings

test_rbac_white_ciscat_endpoints.tavern.yaml 
	 1 passed, 3 warnings


test_experimental_endpoints.tavern.yaml 
	 10 passed, 1 xfailed, 13 warnings

test_rbac_black_experimental_endpoints.tavern.yaml 
	 10 passed, 1 xfailed, 13 warnings

test_rbac_white_experimental_endpoints.tavern.yaml 
	 10 passed, 1 xfailed, 13 warnings

```



Regards,
Manuel.

