### PR TITLE
Migrate README file from the ruleset repository to the ruleset folder.

### DIFF
--- a/ruleset/README.md
+++ b/ruleset/README.md
@@ -1,0 +1,48 @@
+# Wazuh Ruleset
+
+[![Slack](https://img.shields.io/badge/slack-join-blue.svg)](https://goo.gl/forms/M2AoZC4b2R9A9Zy12)
+[![Email](https://img.shields.io/badge/email-join-blue.svg)](https://groups.google.com/forum/#!forum/wazuh)
+[![Documentation](https://img.shields.io/badge/docs-view-green.svg)](https://documentation.wazuh.com)
+[![Documentation](https://img.shields.io/badge/web-view-green.svg)](https://wazuh.com)
+
+Wazuh ruleset is used to detect attacks, intrusions, software misuse, configuration problems, application errors, malware, rootkits, system anomalies or security policy violations.
+
+The ruleset includes compliance mapping with PCI DSS v3.1 and CIS.
+
+## Installation
+
+* [Installation instructions](https://documentation.wazuh.com/current/user-manual/ruleset/update.html)
+
+## Directory structure
+
+    ├── wazuh/ruleset
+    │ ├── decoders            # Wazuh decoders created/updated by Wazuh
+    │ ├── rules               # Wazuh rules created/updated by Wazuh
+    │ ├── rootcheck           # Wazuh rootchecks created/updated by Wazuh
+    │ ├── sca                 # Security Configuration Assessment created/updated by Wazuh
+    │ ├── lists               # CDB lists created/updated by Wazuh
+    |
+    │ ├── testing             # Ruleset test scripts
+    |
+    │ ├── README.md
+
+## Full documentation
+
+Full documentation at [documentation.wazuh.com](https://documentation.wazuh.com/current/user-manual/ruleset/index.html)
+
+## Contribute
+
+If you have created new rules, decoders or rootchecks and you would like to contribute to our repository, please fork our Github repository and submit a pull request. To make a pull request for new rules and decoders, follow these instructions:
+
+1. If your rules and decoders are related to existent ones in the ruleset, you should add them at the end of the corresponding file. If they are made for a new application or device that Wazuh does not currently support, you should create a new `XML` following the title format. For example, if the last `XML` file is `0620-last-xml_rules.xml`, the next one should be named `0625-new_integration.xml`. Please, make sure your rules do not use an existent `rule id`.
+
+2. Make sure to create your `test.ini` file. You may find examples under the `wazuh/wazuh-ruleset/tools/rules-testing/tests` folder. Then add it to the repository along with the rest of the tests.
+
+3. Create the pull request
+
+If you are not familiar with Github, you can also share them through [our users mailing list](https://groups.google.com/d/forum/wazuh), to which you can subscribe by sending an email to `wazuh+subscribe@googlegroups.com`. As well do not hesitate to request new rules or rootchecks that you would like to see running in Wazuh and our team will do our best to make it happen.
+
+## Web references
+
+* [Wazuh website](http://wazuh.com)
+* [OSSEC project website](http://ossec.github.io)

--- a/ruleset/README.md
+++ b/ruleset/README.md
@@ -9,10 +9,6 @@ Wazuh ruleset is used to detect attacks, intrusions, software misuse, configurat
 
 The ruleset includes compliance mapping with PCI DSS v3.1 and CIS.
 
-## Installation
-
-* [Installation instructions](https://documentation.wazuh.com/current/user-manual/ruleset/update.html)
-
 ## Directory structure
 
     ├── wazuh/ruleset
@@ -36,7 +32,7 @@ If you have created new rules, decoders or rootchecks and you would like to cont
 
 1. If your rules and decoders are related to existent ones in the ruleset, you should add them at the end of the corresponding file. If they are made for a new application or device that Wazuh does not currently support, you should create a new `XML` following the title format. For example, if the last `XML` file is `0620-last-xml_rules.xml`, the next one should be named `0625-new_integration.xml`. Please, make sure your rules do not use an existent `rule id`.
 
-2. Make sure to create your `test.ini` file. You may find examples under the `wazuh/wazuh-ruleset/tools/rules-testing/tests` folder. Then add it to the repository along with the rest of the tests.
+2. Make sure to create your `test.ini` file. You may find examples under the `wazuh/ruleset/testing/tests` folder. Then add it to the repository along with the rest of the tests.
 
 3. Create the pull request
 


### PR DESCRIPTION
|Related issue|
|---|
|6939|

This PR migrates the original README file from the **Ruleset** repository to the new ruleset folder and adapts its content with new descriptions.