### PR TITLE
Fix race condition in syscollector database cleanup

### DIFF
--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -544,7 +544,7 @@ size_t CreateSecMSG(const keystore *keys, const char *msg, size_t msg_length, ch
     if ((msg_length > (OS_MAXSTR - OS_HEADER_SIZE)) || (msg_length < 1)) {
         curr_time = time(0);
         if (curr_time - saved_time > 3600) {
-            merror("Incorrect message size: %lu", (unsigned long)msg_length);
+            merror("Incorrect message size: %s %lu", msg, (unsigned long)msg_length);
             saved_time = curr_time;
         }
         mdebug2(ENCSIZE_ERROR, msg);

--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -544,7 +544,7 @@ size_t CreateSecMSG(const keystore *keys, const char *msg, size_t msg_length, ch
     if ((msg_length > (OS_MAXSTR - OS_HEADER_SIZE)) || (msg_length < 1)) {
         curr_time = time(0);
         if (curr_time - saved_time > 3600) {
-            merror("Incorrect message size: %s %lu", msg, (unsigned long)msg_length);
+            merror("Incorrect message size: %lu", (unsigned long)msg_length);
             saved_time = curr_time;
         }
         mdebug2(ENCSIZE_ERROR, msg);

--- a/src/shared_modules/dbsync/cppcheckSuppress.txt
+++ b/src/shared_modules/dbsync/cppcheckSuppress.txt
@@ -1,2 +1,2 @@
-*:*src/sqlite/sqlite_dbengine.cpp:143
+*:*src/sqlite/sqlite_dbengine.cpp:144
 *:*testtool/action.h:612

--- a/src/shared_modules/dbsync/include/db_exception.h
+++ b/src/shared_modules/dbsync/include/db_exception.h
@@ -29,6 +29,7 @@ constexpr auto INVALID_DATA_BIND          { std::make_pair(12, "Invalid data to 
 constexpr auto INVALID_TABLE              { std::make_pair(13, "Invalid table.") };
 constexpr auto INVALID_DELETE_INFO        { std::make_pair(14, "Invalid information provided for deletion.") };
 constexpr auto BIND_FIELDS_DOES_NOT_MATCH { std::make_pair(15, "Invalid information provided for statement creation.") };
+constexpr auto STEP_ERROR_CREATE_STMT     { std::make_pair(16, "Error when create table.") };
 
 namespace DbSync
 {

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -452,7 +452,10 @@ void SQLiteDBEngine::initialize(const std::string& path,
                     for (const auto& query : createDBQueryList)
                     {
                         const auto& stmt { getStatement(query) };
-                        stmt->step();
+                        if (SQLITE_DONE != stmt->step())
+                        {
+                            throw dbengine_error { STEP_ERROR_CREATE_STMT };
+                        }
                     }
                 }
                 return previousDbRemoved;

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -436,13 +436,13 @@ void SQLiteDBEngine::initialize(const std::string& path,
 {
     if(!path.empty())
     {
-        const auto MAX_RETRY { 10 };
-        const auto SECONDS_TO_RETRY { 10 };
-        auto dbInitialization
+        constexpr auto MAX_RETRY { 10 };
+        constexpr auto SECONDS_TO_RETRY { 10 };
+        const auto dbInitialization
         {
             [this, &tableStmtCreation](const std::string& dbPath) -> bool
             {
-                bool previousDbRemoved { cleanDB(dbPath) };
+                const bool previousDbRemoved { cleanDB(dbPath) };
                 if (previousDbRemoved)
                 {
                     m_sqliteConnection = m_sqliteFactory->createConnection(dbPath);

--- a/src/shared_modules/dbsync/tests/dbengine/dbengine_test.cpp
+++ b/src/shared_modules/dbsync/tests/dbengine/dbengine_test.cpp
@@ -31,7 +31,7 @@ static void initNoMetaDataMocks(std::unique_ptr<SQLiteDBEngine>& spEngine)
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
 
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory,
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
@@ -59,7 +59,7 @@ TEST_F(DBEngineTest, Initialization)
     auto mockStatement { std::make_unique<MockStatement>() };
 
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
-    EXPECT_CALL(*mockStatement, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockStatement, step()).WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory, createStatement(_,_)).WillOnce(Return(ByMove(std::move(mockStatement))));
     EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
     EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
@@ -68,6 +68,24 @@ TEST_F(DBEngineTest, Initialization)
         mockFactory,
         "1", 
         "NNN"));
+}
+
+TEST_F(DBEngineTest, InitializationSQLError)
+{
+    const auto& mockFactory { std::make_shared<MockSQLiteFactory>() };
+    const auto& mockConnection { std::make_shared<MockConnection>() };
+    auto mockStatement { std::make_unique<MockStatement>() };
+
+    EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
+    EXPECT_CALL(*mockStatement, step()).WillOnce(Return(SQLITE_ERROR));
+    EXPECT_CALL(*mockFactory, createStatement(_,_)).WillOnce(Return(ByMove(std::move(mockStatement))));
+    EXPECT_CALL(*mockConnection, execute("PRAGMA temp_store = memory;")).Times(1);
+    EXPECT_CALL(*mockConnection, execute("PRAGMA synchronous = OFF;")).Times(1);
+
+    EXPECT_THROW(std::make_unique<SQLiteDBEngine>(
+        mockFactory,
+        "1",
+        "NNN"), dbengine_error);
 }
 
 TEST_F(DBEngineTest, InitializationEmptyQuery)
@@ -105,7 +123,7 @@ TEST_F(DBEngineTest, InitializeStatusField)
     EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
     
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
@@ -181,7 +199,7 @@ TEST_F(DBEngineTest, InitializeStatusFieldNoMetadata)
     EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
     
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
@@ -218,7 +236,7 @@ TEST_F(DBEngineTest, InitializeStatusFieldPreExistent)
     EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
     
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
@@ -304,7 +322,7 @@ TEST_F(DBEngineTest, DeleteRowsByStatusField)
     EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
     
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
@@ -388,7 +406,7 @@ TEST_F(DBEngineTest, DeleteRowsByStatusFieldNoMetadata)
     EXPECT_CALL(*mockFactory, createTransaction(_)).WillOnce(Return(ByMove(std::move(mockTransaction))));
     
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
@@ -420,7 +438,7 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusFieldNoMetadata)
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
     
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
@@ -452,7 +470,7 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusField)
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
     
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
@@ -603,7 +621,7 @@ TEST_F(DBEngineTest, AddTableRelationship)
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
     
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));
@@ -723,7 +741,7 @@ TEST_F(DBEngineTest, AddTableRelationshipNoMetadata)
     EXPECT_CALL(*mockFactory, createConnection(_)).WillOnce(Return(mockConnection));
     
     auto mockStatement_1 { std::make_unique<MockStatement>() };
-    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(0));
+    EXPECT_CALL(*mockStatement_1, step()).WillOnce(Return(SQLITE_DONE));
     EXPECT_CALL(*mockFactory, 
         createStatement(_,"NNN"))
         .WillOnce(Return(ByMove(std::move(mockStatement_1))));

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -68,7 +68,6 @@ private:
     std::string getCreateStatement() const;
     void registerWithRsync();
 
-    bool sleepFor();
     void scanHardware();
     void scanOs();
     void scanNetwork();

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -90,7 +90,7 @@ private:
     bool                                           m_portsAll;
     bool                                           m_processes;
     bool                                           m_hotfixes;
-    bool                                           m_running;
+    bool                                           m_stopping;
     std::unique_ptr<DBSync>                        m_spDBSync;
     std::unique_ptr<RemoteSync>                    m_spRsync;
     std::condition_variable                        m_cv;

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -60,7 +60,8 @@ public:
     void destroy();
     void push(const std::string& data);
 private:
-    Syscollector() = default;
+    Syscollector()
+    : m_stopping { true } { }
     ~Syscollector() = default;
     Syscollector(const Syscollector&) = delete;
     Syscollector& operator=(const Syscollector&) = delete;
@@ -75,7 +76,7 @@ private:
     void scanPorts();
     void scanProcesses();
     void scan();
-    void syncLoop();
+    void syncLoop(std::unique_lock<std::mutex>& lock);
     std::shared_ptr<ISysInfo>                      m_spInfo;
     std::function<void(const std::string&)>        m_reportDiffFunction;
     std::function<void(const std::string&)>        m_reportSyncFunction;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #6945|

## Description
This issue only occurs in the first post-installation start, since in the agent registration process there is a time in which there are two same wazuh processes at the same time (The unregistered one is shutting down and the registered one is going up), this requires handling the database cleanup race condition.

Actual Result: process crash
Expected result: no process crash 

```
============================= test session starts =============================
platform win32 -- Python 3.7.4, pytest-5.2.0, py-1.8.0, pluggy-0.13.0 -- c:\python37\python.exe
cachedir: .pytest_cache
metadata: {'Python': '3.7.4', 'Platform': 'Windows-10-10.0.14393-SP0', 'Packages': {'pytest': '5.2.0', 'py': '1.8.0', 'pluggy': '0.13.0'}, 'Plugins': {'html': '2.0.1', 'metadata': '1.8.0'}}
rootdir: C:\install_agent
plugins: html-2.0.1, metadata-1.8.0
collecting ... collected 5 items

install_agent_test.py::test_check_version PASSED                         [ 20%]
install_agent_test.py::test_check_process_ossec_agent FAILED             [ 40%]
install_agent_test.py::test_check_log_errors PASSED                      [ 60%]
install_agent_test.py::test_check_ossec_conf PASSED                      [ 80%]
install_agent_test.py::test_connection_agent PASSED                      [100%]

================================== FAILURES ===================================
_______________________ test_check_process_ossec_agent ________________________
install_agent_test.py:45: in test_check_process_ossec_agent
    assert ossec_agent_process_name in process_list, assert_description['process']['ossec-agent']
E   AssertionError: The ossec-agent service is not running
E   assert 'ossec-agent.exe' in ['System Idle Process', 'System', 'smss.exe', 'dwm.exe', 'svchost.exe', 'csrss.exe', ...]
========================= 1 failed, 4 passed in 0.48s =========================
```

## RTR

![image](https://user-images.githubusercontent.com/14300208/102635097-968da400-4131-11eb-9daf-d639b9cd0c56.png)



