### PR TITLE
Fix API integration tests healthcheck.

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -18,7 +18,7 @@ variables:
 
   # delays
   restart_delay: 30
-  restart_delay_cluster: 60
+  restart_delay_cluster: 120
   upgrade_delay: 45
   global_db_delay: 20
   active_reponse_delay: 5

--- a/api/test/integration/env/configurations/base/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/base/manager/healthcheck/healthcheck.py
@@ -12,13 +12,17 @@ def check(result):
 def get_master_health():
     os.system("/var/ossec/bin/agent_control -ls > /tmp/output.txt")
     os.system("/var/ossec/bin/ossec-control status > /tmp/daemons.txt")
-    return check(os.popen("diff -q /tmp/output.txt /configuration_files/healthcheck/agent_control_check.txt").read()) or \
-           check(os.popen("diff -q /tmp/daemons.txt /configuration_files/healthcheck/master_daemons_check.txt").read())
+    check1 = check(os.popen("diff -q /tmp/output.txt /configuration_files/healthcheck/agent_control_check.txt").read())
+    check2 = check(os.popen("diff -q /tmp/daemons.txt /configuration_files/healthcheck/master_daemons_check.txt").read())
+    check3 = 0 if os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log") == 0 else 1
+    return check1 or check2 or check3
 
 
 def get_manager_health():
     os.system("/var/ossec/bin/ossec-control status > /tmp/daemons.txt")
-    return check(os.popen("diff -q /tmp/daemons.txt /configuration_files/healthcheck/master_daemons_check.txt").read())
+    check1 = check(os.popen("diff -q /tmp/daemons.txt /configuration_files/healthcheck/master_daemons_check.txt").read())
+    check2 = 0 if os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log") == 0 else 1
+    return check1 or check2
 
 
 if __name__ == "__main__":

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -12,7 +12,7 @@
 import os
 
 def get_health():
-    output = os.system("grep -q 'wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
+    output = os.system("grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
     output_syscollector = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
 
     if output == 0 and output_syscollector == 0:

--- a/api/test/integration/env/configurations/experimental/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/manager/healthcheck/healthcheck.py
@@ -19,10 +19,11 @@ def create_connection(agent_id):
 
 def get_health():
     os.system("/var/ossec/bin/agent_control -ls > /tmp/output.txt")
-    check = os.popen("diff -q /tmp/output.txt /configuration_files/healthcheck/agent_control_check.txt").read()
-    output = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+    check0 = os.popen("diff -q /tmp/output.txt /configuration_files/healthcheck/agent_control_check.txt").read()
+    check1 = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+    check2 = 0 if os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log") == 0 else 1
 
-    if "differ" not in check and output == 0:
+    if "differ" not in check0 and check1 == 0 and check2 == 0:
         return 0
     else:
         return 1

--- a/api/test/integration/env/configurations/manager/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/manager/manager/healthcheck/healthcheck.py
@@ -11,12 +11,16 @@ def check(result):
 
 def get_master_health():
     os.system("/var/ossec/bin/ossec-control status > /tmp/daemons.txt")
-    return check(os.popen("diff -q /tmp/daemons.txt /configuration_files/healthcheck/master_daemons_check.txt").read())
+    check0 = check(os.popen("diff -q /tmp/daemons.txt /configuration_files/healthcheck/master_daemons_check.txt").read())
+    check1 = 0 if os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log") == 0 else 1
+    return check0 or check1
 
 
 def get_worker_health():
     os.system("/var/ossec/bin/ossec-control status > /tmp/daemons.txt")
-    return check(os.popen("diff -q /tmp/daemons.txt /configuration_files/healthcheck/worker_daemons_check.txt").read())
+    check0 = check(os.popen("diff -q /tmp/daemons.txt /configuration_files/healthcheck/worker_daemons_check.txt").read())
+    check1 = 0 if os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log") == 0 else 1
+    return check0 or check1
 
 
 if __name__ == "__main__":

--- a/api/test/integration/env/configurations/syscheck/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscheck/agent/healthcheck/healthcheck.py
@@ -2,7 +2,7 @@ import os
 
 
 def get_health():
-    output = os.system("grep -q 'wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
+    output = os.system("grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
 
     if output == 0:
         return 0

--- a/api/test/integration/env/configurations/syscheck/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscheck/manager/healthcheck/healthcheck.py
@@ -3,10 +3,11 @@ import os
 
 def get_health():
     os.system("/var/ossec/bin/agent_control -ls > /tmp/output.txt")
-    check = os.popen("diff -q /tmp/output.txt /configuration_files/healthcheck/agent_control_check.txt").read()
-    output = os.system("grep -q 'wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
+    check0 = os.popen("diff -q /tmp/output.txt /configuration_files/healthcheck/agent_control_check.txt").read()
+    check1 = os.system("grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
+    check2 = 0 if os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log") == 0 else 1
 
-    if "differ" not in check and output == 0:
+    if "differ" not in check0 and check1 == 0 and check2 == 0:
         return 0
     else:
         return 1

--- a/api/test/integration/env/configurations/syscollector/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscollector/manager/healthcheck/healthcheck.py
@@ -18,10 +18,11 @@ def create_connection(agent_id):
 
 def get_health():
     os.system("/var/ossec/bin/agent_control -ls > /tmp/output.txt")
-    check = os.popen("diff -q /tmp/output.txt /configuration_files/healthcheck/agent_control_check.txt").read()
-    output = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+    check0 = os.popen("diff -q /tmp/output.txt /configuration_files/healthcheck/agent_control_check.txt").read()
+    check1 = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+    check2 = 0 if os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log") == 0 else 1
 
-    if "differ" not in check and output == 0:
+    if "differ" not in check0 and check1 == 0 and check2 == 0:
         return 0
     else:
         return 1


### PR DESCRIPTION
|Related issue|
|---|
|#6950|

## Description

Hello team!

Some tests, especially in slow environments, were failing due to making requests while the API was still not ready and running. This PR changes the healthcheck so that the state of the API is checked before performing the testing. 

The delay after restart has also been changed since sometimes, not all worker nodes were reconnected to the master node on time after restarting wazuh.

## Tests

### Unittests
```
python3 -m pytest framework
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: trio-0.6.0, asyncio-0.14.0
collected 1607 items                                                                                                                                                                                         

framework/wazuh/core/cluster/dapi/tests/test_dapi.py ......................                                                                                                                            [  1%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................                                                                                                                                 [  2%]
framework/wazuh/core/cluster/tests/test_common.py .......                                                                                                                                              [  2%]
framework/wazuh/core/cluster/tests/test_control.py .....                                                                                                                                               [  3%]
framework/wazuh/core/cluster/tests/test_local_client.py .                                                                                                                                              [  3%]
framework/wazuh/core/cluster/tests/test_utils.py .......                                                                                                                                               [  3%]
framework/wazuh/core/cluster/tests/test_worker.py ................                                                                                                                                     [  4%]
framework/wazuh/core/tests/test_active_response.py ............                                                                                                                                        [  5%]
framework/wazuh/core/tests/test_agent.py .......................................................................................................................................................       [ 14%]
framework/wazuh/core/tests/test_cdb_list.py .................................                                                                                                                          [ 16%]
framework/wazuh/core/tests/test_common.py .......                                                                                                                                                      [ 17%]
framework/wazuh/core/tests/test_configuration.py ..................................                                                                                                                    [ 19%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                            [ 20%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                 [ 20%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                          [ 20%]
framework/wazuh/core/tests/test_manager.py ................................                                                                                                                            [ 22%]
framework/wazuh/core/tests/test_ossec_queue.py ...................                                                                                                                                     [ 24%]
framework/wazuh/core/tests/test_pyDaemonModule.py ......                                                                                                                                               [ 24%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                    [ 26%]
framework/wazuh/core/tests/test_rootcheck.py ..........                                                                                                                                                [ 27%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                         [ 28%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                    [ 29%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................. [ 38%]
.....................................................                                                                                                                                                  [ 42%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                   [ 43%]
framework/wazuh/core/tests/test_wdb.py .....................                                                                                                                                           [ 44%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                     [ 44%]
framework/wazuh/rbac/tests/test_decorators.py .........................................................................................................                                                [ 51%]
framework/wazuh/rbac/tests/test_default_configuration.py ...................................................                                                                                           [ 54%]
framework/wazuh/rbac/tests/test_orm.py .....................................................                                                                                                           [ 57%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                            [ 58%]
framework/wazuh/tests/test_active_response.py .........                                                                                                                                                [ 59%]
framework/wazuh/tests/test_agent.py ....................................................................................                                                                               [ 64%]
framework/wazuh/tests/test_cdb_list.py ...............................................                                                                                                                 [ 67%]
framework/wazuh/tests/test_ciscat.py ..                                                                                                                                                                [ 67%]
framework/wazuh/tests/test_cluster.py .......                                                                                                                                                          [ 67%]
framework/wazuh/tests/test_decoders.py ...............................                                                                                                                                 [ 69%]
framework/wazuh/tests/test_group.py ........                                                                                                                                                           [ 70%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                           [ 70%]
framework/wazuh/tests/test_manager.py ........................................                                                                                                                         [ 73%]
framework/wazuh/tests/test_mitre.py .................................................................................................................................................................. [ 83%]
..................                                                                                                                                                                                     [ 84%]
framework/wazuh/tests/test_rootcheck.py .................................................                                                                                                              [ 87%]
framework/wazuh/tests/test_rule.py ....................................................                                                                                                                [ 90%]
framework/wazuh/tests/test_sca.py .......                                                                                                                                                              [ 90%]
framework/wazuh/tests/test_security.py .....................................................................                                                                                           [ 95%]
framework/wazuh/tests/test_stats.py .............                                                                                                                                                      [ 96%]
framework/wazuh/tests/test_syscheck.py .......................                                                                                                                                         [ 97%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                                [ 98%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                        [100%]

=============================================================================== 1607 passed, 15 warnings in 236.80s (0:03:56) ================================================================================
```

```
python3 -m pytest api/api/test/ --disable-warnings
============================================================ test session starts =============================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/api
plugins: trio-0.6.0, asyncio-0.14.0
collected 195 items                                                                                                                          

api/api/test/test_alogging.py ........                                                                                                 [  4%]
api/api/test/test_authentication.py ..........                                                                                         [  9%]
api/api/test/test_configuration.py .......                                                                                             [ 12%]
api/api/test/test_util.py ...................................                                                                          [ 30%]
api/api/test/test_validator.py ....................................................................................................... [ 83%]
................................                                                                                                       [100%]

====================================================== 195 passed, 16 warnings in 1.05s ======================================================
```


### Integration tests
```
pytest -vv test_manager_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-1029-aws-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'metadata': '1.10.0', 'html': '2.0.1'}}
rootdir: /tmp/B42_test_files/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, metadata-1.10.0, html-2.0.1
collected 35 items                                                                                                                                                                                           

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                                         [  2%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                           [  5%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                                                                                                                [  8%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                                                                                                  [ 11%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                                                                                               [ 14%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                                                                                               [ 17%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                                                                                               [ 20%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                                                                                                [ 22%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                                                                                             [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                                                                                               [ 28%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                                                                                                [ 31%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                                                                                             [ 34%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                                                                                               [ 37%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                                                                                                   [ 40%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                                                                                              [ 42%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                                                                                                          [ 45%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detector] PASSED                                                                                                [ 48%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                                  [ 51%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                                          [ 54%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                                   [ 57%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                                   [ 60%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                                [ 62%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                                  [ 65%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                           [ 68%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                                   [ 71%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                                                     [ 74%]
test_manager_endpoints.tavern.yaml::PUT /manager/api/config PASSED                                                                                                                                     [ 77%]
test_manager_endpoints.tavern.yaml::DELETE /manager/api/config PASSED                                                                                                                                  [ 80%]
test_manager_endpoints.tavern.yaml::GET /manager/files PASSED                                                                                                                                          [ 82%]
test_manager_endpoints.tavern.yaml::PUT /manager/files PASSED                                                                                                                                          [ 85%]
test_manager_endpoints.tavern.yaml::DELETE /manager/files PASSED                                                                                                                                       [ 88%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                                                                                                  [ 91%]
test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED                                                                                                                                [ 94%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                                      [ 97%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                                        [100%]

================================================================================ 35 passed, 38 warnings in 192.62s (0:03:12) =================================================================================
```

```
pytest -vv test_cluster_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-1029-aws-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'metadata': '1.10.0', 'html': '2.0.1'}}
rootdir: /tmp/B42_test_files/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, metadata-1.10.0, html-2.0.1
collected 56 items                                                                                                                                                                                           

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                                                                   [  1%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                                                    [  3%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                                                     [  5%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                                                          [  7%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                                                                                             [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                                                                                                 [ 10%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                                                                                                 [ 12%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                                                                                               [ 14%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                                                                                             [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                                                                                             [ 17%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                                                                                                          [ 19%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                                                         [ 21%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                                                        [ 23%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                                                       [ 25%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                                                     [ 26%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/api/config PASSED                                                                                                                                     [ 28%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/api/config PASSED                                                                                                                                  [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                                                            [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[master-node] PASSED                                                                                                                   [ 33%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[worker1] PASSED                                                                                                                       [ 35%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/files[worker2] PASSED                                                                                                                       [ 37%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[master-node] PASSED                                                                                                                [ 39%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[worker1] PASSED                                                                                                                    [ 41%]
test_cluster_endpoints.tavern.yaml::DELETE /cluster/{node_id}/files[worker2] PASSED                                                                                                                    [ 42%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[master-node] PASSED                                                                                                                   [ 44%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[worker1] PASSED                                                                                                                       [ 46%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/files[worker2] PASSED                                                                                                                       [ 48%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/wrong_node/files PASSED                                                                                                                               [ 50%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                                                                                                    [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                                                                                                        [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                                                                                                        [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                                                                                                    [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                                                                                                        [ 58%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                                                                                                        [ 60%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                                                                                                [ 62%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                                                                                                [ 64%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                                                                                                   [ 66%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                                                                                                       [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                                                                                                       [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                                                                                               [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                                                                                                         [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                                                                                                             [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                                                                                                             [ 76%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                                                                                            [ 78%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                                                                                                [ 80%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                                                                                                [ 82%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                                                                                                           [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                                                                                               [ 85%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                                                                                               [ 87%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                                                                                            [ 89%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                                                                                                [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                                                                                                [ 92%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                                                                                                  [ 94%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                                                                                                      [ 96%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                                                                                                      [ 98%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                                                        [100%]

================================================================================ 56 passed, 72 warnings in 808.23s (0:13:28) =================================================================================
```

```
pytest -vv test_syscollector_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-1029-aws-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'metadata': '1.10.0', 'html': '2.0.1'}}
rootdir: /tmp/B42_test_files/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, metadata-1.10.0, html-2.0.1
collected 161 items                                                                                                                                                                                          

test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os PASSED                                                                                                                        [  0%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[architecture] PASSED                                                                                                 [  1%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[hostname] PASSED                                                                                                     [  1%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.codename] PASSED                                                                                                  [  2%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.major] PASSED                                                                                                     [  3%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.minor] PASSED                                                                                                     [  3%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.name] PASSED                                                                                                      [  4%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.platform] PASSED                                                                                                  [  4%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.version] PASSED                                                                                                   [  5%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[release] PASSED                                                                                                      [  6%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.id] PASSED                                                                                                      [  6%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.time] PASSED                                                                                                    [  7%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[sysname] PASSED                                                                                                      [  8%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[version] PASSED                                                                                                      [  8%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware PASSED                                                                                                                  [  9%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[board_serial] PASSED                                                                                           [  9%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.cores] PASSED                                                                                              [ 10%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.mhz] PASSED                                                                                                [ 11%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.name] PASSED                                                                                               [ 11%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.free] PASSED                                                                                               [ 12%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.total] PASSED                                                                                              [ 13%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.usage] PASSED                                                                                              [ 13%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.id] PASSED                                                                                                [ 14%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.time] PASSED                                                                                              [ 14%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages PASSED                                                                                                                  [ 15%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[architecture] PASSED                                                                                           [ 16%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[description] PASSED                                                                                            [ 16%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[format] PASSED                                                                                                 [ 17%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[name] PASSED                                                                                                   [ 18%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[priority] PASSED                                                                                               [ 18%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[scan.id] PASSED                                                                                                [ 19%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[scan.time] PASSED                                                                                              [ 19%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[section] PASSED                                                                                                [ 20%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[size] PASSED                                                                                                   [ 21%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[vendor] PASSED                                                                                                 [ 21%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/packages?{select}[version] PASSED                                                                                                [ 22%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes PASSED                                                                                                                 [ 22%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[argvs] PASSED                                                                                            [ 23%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[cmd] PASSED                                                                                              [ 24%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[egroup] PASSED                                                                                           [ 24%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[euser] PASSED                                                                                            [ 25%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[fgroup] PASSED                                                                                           [ 26%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[name] PASSED                                                                                             [ 26%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[nice] PASSED                                                                                             [ 27%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[nlwp] PASSED                                                                                             [ 27%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[pgrp] PASSED                                                                                             [ 28%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[pid] PASSED                                                                                              [ 29%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[ppid] PASSED                                                                                             [ 29%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[priority] PASSED                                                                                         [ 30%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[processor] PASSED                                                                                        [ 31%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[resident] PASSED                                                                                         [ 31%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[rgroup] PASSED                                                                                           [ 32%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[ruser] PASSED                                                                                            [ 32%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[scan.id] PASSED                                                                                          [ 33%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[session] PASSED                                                                                          [ 34%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[sgroup] PASSED                                                                                           [ 34%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[share] PASSED                                                                                            [ 35%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[size] PASSED                                                                                             [ 36%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[start_time] PASSED                                                                                       [ 36%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[state] PASSED                                                                                            [ 37%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[stime] PASSED                                                                                            [ 37%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[suser] PASSED                                                                                            [ 38%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[tgid] PASSED                                                                                             [ 39%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[tty] PASSED                                                                                              [ 39%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[utime] PASSED                                                                                            [ 40%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/processes?{sort,select}[vm_size] PASSED                                                                                          [ 40%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/ports PASSED                                                                                                                     [ 41%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[inode] PASSED                                                                                                 [ 42%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[local.ip] PASSED                                                                                              [ 42%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[local.port] PASSED                                                                                            [ 43%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[protocol] PASSED                                                                                              [ 44%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[remote.ip] PASSED                                                                                             [ 44%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[remote.port] PASSED                                                                                           [ 45%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[rx_queue] PASSED                                                                                              [ 45%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[scan.id] PASSED                                                                                               [ 46%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[scan.time] PASSED                                                                                             [ 47%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[state] PASSED                                                                                                 [ 47%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/port?{sort,select}[tx_queue] PASSED                                                                                              [ 48%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr PASSED                                                                                                                   [ 49%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[address] PASSED                                                                                            [ 49%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[broadcast] PASSED                                                                                          [ 50%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[iface] PASSED                                                                                              [ 50%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[netmask] PASSED                                                                                            [ 51%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[proto] PASSED                                                                                              [ 52%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[scan.id] PASSED                                                                                            [ 52%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto PASSED                                                                                                                  [ 53%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[dhcp] PASSED                                                                                              [ 54%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[gateway] PASSED                                                                                           [ 54%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[iface] PASSED                                                                                             [ 55%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[scan.id] PASSED                                                                                           [ 55%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[type] PASSED                                                                                              [ 56%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface PASSED                                                                                                                  [ 57%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mac] PASSED                                                                                               [ 57%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mtu] PASSED                                                                                               [ 58%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[name] PASSED                                                                                              [ 59%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.bytes] PASSED                                                                                          [ 59%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.dropped] PASSED                                                                                        [ 60%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.errors] PASSED                                                                                         [ 60%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.packets] PASSED                                                                                        [ 61%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.id] PASSED                                                                                           [ 62%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.time] PASSED                                                                                         [ 62%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[state] PASSED                                                                                             [ 63%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.bytes] PASSED                                                                                          [ 63%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.dropped] PASSED                                                                                        [ 64%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.errors] PASSED                                                                                         [ 65%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.packets] PASSED                                                                                        [ 65%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[type] PASSED                                                                                              [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os PASSED                                                                                                                        [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[architecture] PASSED                                                                                                 [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[hostname] PASSED                                                                                                     [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.codename] PASSED                                                                                                  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.major] PASSED                                                                                                     [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.minor] PASSED                                                                                                     [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.name] PASSED                                                                                                      [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.platform] PASSED                                                                                                  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[os.version] PASSED                                                                                                   [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[release] PASSED                                                                                                      [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.id] PASSED                                                                                                      [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[scan.time] PASSED                                                                                                    [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[sysname] PASSED                                                                                                      [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/os?{select}[version] PASSED                                                                                                      [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware PASSED                                                                                                                  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[board_serial] PASSED                                                                                           [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.cores] PASSED                                                                                              [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.mhz] PASSED                                                                                                [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[cpu.name] PASSED                                                                                               [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.free] PASSED                                                                                               [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.total] PASSED                                                                                              [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[ram.usage] PASSED                                                                                              [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.id] PASSED                                                                                                [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hardware?{select}[scan.time] PASSED                                                                                              [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr PASSED                                                                                                                   [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[address] PASSED                                                                                            [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[broadcast] PASSED                                                                                          [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[iface] PASSED                                                                                              [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[netmask] PASSED                                                                                            [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[proto] PASSED                                                                                              [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netaddr?{sort,select}[scan.id] PASSED                                                                                            [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto PASSED                                                                                                                  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[dhcp] PASSED                                                                                              [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[gateway] PASSED                                                                                           [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[iface] PASSED                                                                                             [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[scan.id] PASSED                                                                                           [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netproto?{sort,select}[type] PASSED                                                                                              [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface PASSED                                                                                                                  [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mac] PASSED                                                                                               [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[mtu] PASSED                                                                                               [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[name] PASSED                                                                                              [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.bytes] PASSED                                                                                          [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.dropped] PASSED                                                                                        [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.errors] PASSED                                                                                         [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[rx.packets] PASSED                                                                                        [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.id] PASSED                                                                                           [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[scan.time] PASSED                                                                                         [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[state] PASSED                                                                                             [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.bytes] PASSED                                                                                          [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.dropped] PASSED                                                                                        [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.errors] PASSED                                                                                         [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[tx.packets] PASSED                                                                                        [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/netiface?{sort,select}[type] PASSED                                                                                              [ 66%]
test_syscollector_endpoints.tavern.yaml::GET /syscollector/{agent_id}/hotfixes PASSED                                                                                                                  [ 67%]

=============================================================================== 161 passed, 176 warnings in 258.90s (0:04:18) ================================================================================
```

```
pytest -vv test_syscheck_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-1029-aws-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'metadata': '1.10.0', 'html': '2.0.1'}}
rootdir: /tmp/B42_test_files/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, metadata-1.10.0, html-2.0.1
collected 35 items                                                                                                                                                                                           

test_syscheck_endpoints.tavern.yaml::GET /syscheck/000 PASSED                                                                                                                                          [  2%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[date] PASSED                                                                                                                                    [  5%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[mtime] PASSED                                                                                                                                   [  8%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[file] PASSED                                                                                                                                    [ 11%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[size] PASSED                                                                                                                                    [ 14%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[perm] PASSED                                                                                                                                    [ 17%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[uname] PASSED                                                                                                                                   [ 20%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[gname] PASSED                                                                                                                                   [ 22%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[md5] PASSED                                                                                                                                     [ 25%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[sha1] PASSED                                                                                                                                    [ 28%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[sha256] PASSED                                                                                                                                  [ 31%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[inode] PASSED                                                                                                                                   [ 34%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[gid] PASSED                                                                                                                                     [ 37%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[uid] PASSED                                                                                                                                     [ 40%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[type] PASSED                                                                                                                                    [ 42%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000/last_scan PASSED                                                                                                                                [ 45%]
test_syscheck_endpoints.tavern.yaml::PUT /syscheck/000 PASSED                                                                                                                                          [ 48%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002 PASSED                                                                                                                                          [ 51%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[date] PASSED                                                                                                                                    [ 54%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[mtime] PASSED                                                                                                                                   [ 57%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[file] PASSED                                                                                                                                    [ 60%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[size] PASSED                                                                                                                                    [ 62%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[perm] PASSED                                                                                                                                    [ 65%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[uname] PASSED                                                                                                                                   [ 68%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[gname] PASSED                                                                                                                                   [ 71%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[md5] PASSED                                                                                                                                     [ 74%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[sha1] PASSED                                                                                                                                    [ 77%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[sha256] PASSED                                                                                                                                  [ 80%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[inode] PASSED                                                                                                                                   [ 82%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[gid] PASSED                                                                                                                                     [ 85%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[uid] PASSED                                                                                                                                     [ 88%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[type] PASSED                                                                                                                                    [ 91%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002/last_scan PASSED                                                                                                                                [ 94%]
test_syscheck_endpoints.tavern.yaml::DELETE /syscheck PASSED                                                                                                                                           [ 97%]
test_syscheck_endpoints.tavern.yaml::PUT /syscheck PASSED                                                                                                                                              [100%]

================================================================================ 35 passed, 39 warnings in 191.38s (0:03:11) =================================================================================
```

```
pytest -vv test_experimental_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-1029-aws-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'metadata': '1.10.0', 'html': '2.0.1'}}
rootdir: /tmp/B42_test_files/api/test/integration, inifile: pytest.ini
plugins: tavern-1.0.0, metadata-1.10.0, html-2.0.1
collected 11 items                                                                                                                                                                                           

test_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck PASSED                                                                                                                          [  9%]
test_experimental_endpoints.tavern.yaml::GET /experimental/ciscat/results PASSED                                                                                                                       [ 18%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hardware PASSED                                                                                                                [ 27%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netaddr PASSED                                                                                                                 [ 36%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netiface PASSED                                                                                                                [ 45%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netproto PASSED                                                                                                                [ 54%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/os PASSED                                                                                                                      [ 63%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/packages PASSED                                                                                                                [ 72%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/ports PASSED                                                                                                                   [ 81%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/processes PASSED                                                                                                               [ 90%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hotfixes PASSED                                                                                                                [100%]

================================================================================ 11 passed, 13 warnings in 302.82s (0:05:02) =================================================================================
```

Best regards,
Selu.