### PR TITLE
[6779] macos pkg decoder

### DIFF
--- a/src/data_provider/src/packages/brewWrapper.h
+++ b/src/data_provider/src/packages/brewWrapper.h
@@ -17,7 +17,7 @@
 
 class BrewWrapper final : public IPackageWrapper
 {
-    public:
+public:
     explicit BrewWrapper(const std::string& /*fileName*/)
     { }
 
@@ -25,31 +25,31 @@ class BrewWrapper final : public IPackageWrapper
 
     std::string name() const override
     {
-        return DEFAULT_STRING_VALUE;
+        return UNKNOWN_VALUE;
     }
     std::string version() const override
     {
-        return DEFAULT_STRING_VALUE;
+        return UNKNOWN_VALUE;
     }
     std::string groups() const override
     {
-        return DEFAULT_STRING_VALUE;
+        return UNKNOWN_VALUE;
     }
     std::string description() const override
     {
-        return DEFAULT_STRING_VALUE;
+        return UNKNOWN_VALUE;
     }
     std::string architecture() const override
     {
-        return DEFAULT_STRING_VALUE;
+        return UNKNOWN_VALUE;
     }
     std::string format() const override
     {
-        return DEFAULT_STRING_VALUE;
+        return UNKNOWN_VALUE;
     }
     std::string osPatch() const override
     {
-        return DEFAULT_STRING_VALUE;
+        return UNKNOWN_VALUE;
     }
 };
 

--- a/src/data_provider/src/packages/packageMac.h
+++ b/src/data_provider/src/packages/packageMac.h
@@ -17,7 +17,7 @@
 
 class FactoryBSDPackage
 {
-    public:
+public:
     static std::shared_ptr<IPackage>create(const std::pair<std::string, int>& ctx);
 };
 

--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -12,45 +12,140 @@
 #ifndef _PKG_WRAPPER_H
 #define _PKG_WRAPPER_H
 
+#include <fstream>
 #include "ipackageWrapper.h"
 #include "sharedDefs.h"
 
 class PKGWrapper final : public IPackageWrapper
 {
-    public:
-    explicit PKGWrapper(const std::string& /*fileName*/)
+public:
+    explicit PKGWrapper(const std::string& filePath)
+      : m_filePath{filePath}
+      , m_name{ DEFAULT_STRING_VALUE }
+      , m_version{ DEFAULT_STRING_VALUE }
+      , m_groups{ DEFAULT_STRING_VALUE }
+      , m_description{ DEFAULT_STRING_VALUE }
+      , m_architecture{ DEFAULT_STRING_VALUE }
+      , m_format{ DEFAULT_STRING_VALUE }
+      , m_osPatch{ DEFAULT_STRING_VALUE }
     { }
 
     ~PKGWrapper() = default;
 
     std::string name() const override
     {
-        return DEFAULT_STRING_VALUE;
+        nlohmann::json jsonData{};
+        getData(jsonData);
+        return jsonData.empty() ? DEFAULT_STRING_VALUE
+                                : jsonData.at("name");
     }
     std::string version() const override
     {
-        return DEFAULT_STRING_VALUE;
+        nlohmann::json jsonData{};
+        getData(jsonData);
+        return jsonData.empty() ? DEFAULT_STRING_VALUE
+                                : jsonData.at("version");
     }
     std::string groups() const override
     {
-        return DEFAULT_STRING_VALUE;
+        nlohmann::json jsonData{};
+        getData(jsonData);
+        return jsonData.empty() ? DEFAULT_STRING_VALUE
+                                : jsonData.at("groups");
     }
     std::string description() const override
     {
-        return DEFAULT_STRING_VALUE;
+        nlohmann::json jsonData{};
+        getData(jsonData);
+        return jsonData.empty() ? DEFAULT_STRING_VALUE
+                                : jsonData.at("description");
     }
     std::string architecture() const override
     {
-        return DEFAULT_STRING_VALUE;
+        nlohmann::json jsonData{};
+        getData(jsonData);
+        return jsonData.empty() ? DEFAULT_STRING_VALUE
+                                : jsonData.at("architecture");
     }
     std::string format() const override
     {
-        return DEFAULT_STRING_VALUE;
+        nlohmann::json jsonData{};
+        getData(jsonData);
+        return jsonData.empty() ? DEFAULT_STRING_VALUE
+                                : jsonData.at("format");
     }
     std::string osPatch() const override
     {
-        return DEFAULT_STRING_VALUE;
+        nlohmann::json jsonData{};
+        getData(jsonData);
+        return jsonData.empty() ? DEFAULT_STRING_VALUE
+                                : jsonData.at("osPatch");
     }
+private:
+    static void getData(nlohmann::json& data)
+    {
+        std::fstream file {m_filePath, std::ios_base::in};
+        static const auto getValueFnc
+        {
+            [](const std::string& val)
+            {
+                const auto start{val.find(">")};
+                const auto end{val.rfind("<")};
+                return val.substr(start+1, end - start -1);
+            }
+        };
+        if (file.is_open())
+        {
+            std::string line;
+            nlohmann::json package;
+            while(std::getline(file, line))
+            {
+                line = Utils::trim(line," \t");
+
+                if (line == "<key>CFBundleName</key>" &&
+                    std::getline(file, line))
+                {
+                    m_name = getValueFnc(line);
+                }
+                else if (line == "<key>CFBundleShortVersionString</key>" &&
+                    std::getline(file, line))
+                {
+                    m_version = getValueFnc(line);
+                }
+                else if (line == "<key>LSApplicationCategoryType</key>" &&
+                    std::getline(file, line))
+                {
+                    m_groups = getValueFnc(line);
+                }
+                else if (line == "<key>CFBundleIdentifier</key>" &&
+                    std::getline(file, line))
+                {
+                    m_description = getValueFnc(line);
+                }
+            }
+
+            if (UNKNOWN_VALUE != m_name)
+            {
+                package["name"]         = m_name;
+                package["version"]      = m_version;
+                package["groups"]       = m_groups;
+                package["description"]  = m_description;
+                package["architecture"] = UNKNOWN_VALUE;
+                package["format"]       = "pkg";
+                package["os_patch"]     = UNKNOWN_VALUE;
+                data.push_back(package);
+            }
+        }
+    }
+
+    std::string m_filePath;
+    std::string m_name;
+    std::string m_version;
+    std::string m_groups;
+    std::string m_description;
+    std::string m_architecture;
+    std::string m_format;
+    std::string m_osPatch;
 };
 
 #endif //_PKG_WRAPPER_H

--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -30,51 +30,52 @@ public:
     {
         nlohmann::json jsonData{};
         getData(jsonData);
-        return jsonData.empty() ? DEFAULT_STRING_VALUE
+        return jsonData.empty() ? UNKNOWN_VALUE
                                 : jsonData.at("name");
     }
     std::string version() const override
     {
         nlohmann::json jsonData{};
         getData(jsonData);
-        return jsonData.empty() ? DEFAULT_STRING_VALUE
+        return jsonData.empty() ? UNKNOWN_VALUE
                                 : jsonData.at("version");
     }
     std::string groups() const override
     {
         nlohmann::json jsonData{};
         getData(jsonData);
-        return jsonData.empty() ? DEFAULT_STRING_VALUE
+        return jsonData.empty() ? UNKNOWN_VALUE
                                 : jsonData.at("groups");
     }
     std::string description() const override
     {
         nlohmann::json jsonData{};
         getData(jsonData);
-        return jsonData.empty() ? DEFAULT_STRING_VALUE
+        return jsonData.empty() ? UNKNOWN_VALUE
                                 : jsonData.at("description");
     }
     std::string architecture() const override
     {
         nlohmann::json jsonData{};
         getData(jsonData);
-        return jsonData.empty() ? DEFAULT_STRING_VALUE
+        return jsonData.empty() ? UNKNOWN_VALUE
                                 : jsonData.at("architecture");
     }
     std::string format() const override
     {
         nlohmann::json jsonData{};
         getData(jsonData);
-        return jsonData.empty() ? DEFAULT_STRING_VALUE
+        return jsonData.empty() ? UNKNOWN_VALUE
                                 : jsonData.at("format");
     }
     std::string osPatch() const override
     {
         nlohmann::json jsonData{};
         getData(jsonData);
-        return jsonData.empty() ? DEFAULT_STRING_VALUE
-                                : jsonData.at("osPatch");
+        return jsonData.empty() ? UNKNOWN_VALUE
+                                : jsonData.at("os_patch");
     }
+
 private:
     void getData(nlohmann::json& data) const
     {
@@ -93,13 +94,13 @@ private:
             std::string line;
             nlohmann::json package;
 
-            std::string name         { DEFAULT_STRING_VALUE };
-            std::string version      { DEFAULT_STRING_VALUE };
-            std::string groups       { DEFAULT_STRING_VALUE };
-            std::string description  { DEFAULT_STRING_VALUE };
-            std::string architecture { DEFAULT_STRING_VALUE };
-            std::string format       { DEFAULT_STRING_VALUE };
-            std::string osPatch      { DEFAULT_STRING_VALUE };
+            std::string name         { UNKNOWN_VALUE };
+            std::string version      { UNKNOWN_VALUE };
+            std::string groups       { UNKNOWN_VALUE };
+            std::string description  { UNKNOWN_VALUE };
+            std::string architecture { UNKNOWN_VALUE };
+            std::string format       { UNKNOWN_VALUE };
+            std::string osPatch      { UNKNOWN_VALUE };
 
             while(std::getline(file, line))
             {

--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -13,6 +13,7 @@
 #define _PKG_WRAPPER_H
 
 #include <fstream>
+#include "stringHelper.h"
 #include "ipackageWrapper.h"
 #include "sharedDefs.h"
 
@@ -21,13 +22,6 @@ class PKGWrapper final : public IPackageWrapper
 public:
     explicit PKGWrapper(const std::string& filePath)
       : m_filePath{filePath}
-      , m_name{ DEFAULT_STRING_VALUE }
-      , m_version{ DEFAULT_STRING_VALUE }
-      , m_groups{ DEFAULT_STRING_VALUE }
-      , m_description{ DEFAULT_STRING_VALUE }
-      , m_architecture{ DEFAULT_STRING_VALUE }
-      , m_format{ DEFAULT_STRING_VALUE }
-      , m_osPatch{ DEFAULT_STRING_VALUE }
     { }
 
     ~PKGWrapper() = default;
@@ -82,7 +76,7 @@ public:
                                 : jsonData.at("osPatch");
     }
 private:
-    static void getData(nlohmann::json& data)
+    void getData(nlohmann::json& data) const
     {
         std::fstream file {m_filePath, std::ios_base::in};
         static const auto getValueFnc
@@ -98,6 +92,15 @@ private:
         {
             std::string line;
             nlohmann::json package;
+
+            std::string name         { DEFAULT_STRING_VALUE };
+            std::string version      { DEFAULT_STRING_VALUE };
+            std::string groups       { DEFAULT_STRING_VALUE };
+            std::string description  { DEFAULT_STRING_VALUE };
+            std::string architecture { DEFAULT_STRING_VALUE };
+            std::string format       { DEFAULT_STRING_VALUE };
+            std::string osPatch      { DEFAULT_STRING_VALUE };
+
             while(std::getline(file, line))
             {
                 line = Utils::trim(line," \t");
@@ -105,31 +108,31 @@ private:
                 if (line == "<key>CFBundleName</key>" &&
                     std::getline(file, line))
                 {
-                    m_name = getValueFnc(line);
+                    name = getValueFnc(line);
                 }
                 else if (line == "<key>CFBundleShortVersionString</key>" &&
                     std::getline(file, line))
                 {
-                    m_version = getValueFnc(line);
+                    version = getValueFnc(line);
                 }
                 else if (line == "<key>LSApplicationCategoryType</key>" &&
                     std::getline(file, line))
                 {
-                    m_groups = getValueFnc(line);
+                    groups = getValueFnc(line);
                 }
                 else if (line == "<key>CFBundleIdentifier</key>" &&
                     std::getline(file, line))
                 {
-                    m_description = getValueFnc(line);
+                    description = getValueFnc(line);
                 }
             }
 
-            if (UNKNOWN_VALUE != m_name)
+            if (UNKNOWN_VALUE != name)
             {
-                package["name"]         = m_name;
-                package["version"]      = m_version;
-                package["groups"]       = m_groups;
-                package["description"]  = m_description;
+                package["name"]         = name;
+                package["version"]      = version;
+                package["groups"]       = groups;
+                package["description"]  = description;
                 package["architecture"] = UNKNOWN_VALUE;
                 package["format"]       = "pkg";
                 package["os_patch"]     = UNKNOWN_VALUE;
@@ -139,13 +142,6 @@ private:
     }
 
     std::string m_filePath;
-    std::string m_name;
-    std::string m_version;
-    std::string m_groups;
-    std::string m_description;
-    std::string m_architecture;
-    std::string m_format;
-    std::string m_osPatch;
 };
 
 #endif //_PKG_WRAPPER_H

--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -22,62 +22,50 @@ class PKGWrapper final : public IPackageWrapper
 public:
     explicit PKGWrapper(const std::string& filePath)
       : m_filePath{filePath}
-    { }
+      , m_name{UNKNOWN_VALUE}
+      , m_version{UNKNOWN_VALUE}
+      , m_groups{UNKNOWN_VALUE}
+      , m_description{UNKNOWN_VALUE}
+      , m_architecture{UNKNOWN_VALUE}
+      , m_format{"pkg"}
+      , m_osPatch{UNKNOWN_VALUE}
+    {
+        getPkgData();
+    }
 
     ~PKGWrapper() = default;
 
     std::string name() const override
     {
-        nlohmann::json jsonData{};
-        getData(jsonData);
-        return jsonData.empty() ? UNKNOWN_VALUE
-                                : jsonData.at("name");
+        return m_name;
     }
     std::string version() const override
     {
-        nlohmann::json jsonData{};
-        getData(jsonData);
-        return jsonData.empty() ? UNKNOWN_VALUE
-                                : jsonData.at("version");
+        return m_version;
     }
     std::string groups() const override
     {
-        nlohmann::json jsonData{};
-        getData(jsonData);
-        return jsonData.empty() ? UNKNOWN_VALUE
-                                : jsonData.at("groups");
+        return m_groups;
     }
     std::string description() const override
     {
-        nlohmann::json jsonData{};
-        getData(jsonData);
-        return jsonData.empty() ? UNKNOWN_VALUE
-                                : jsonData.at("description");
+        return m_description;
     }
     std::string architecture() const override
     {
-        nlohmann::json jsonData{};
-        getData(jsonData);
-        return jsonData.empty() ? UNKNOWN_VALUE
-                                : jsonData.at("architecture");
+        return m_architecture;
     }
     std::string format() const override
     {
-        nlohmann::json jsonData{};
-        getData(jsonData);
-        return jsonData.empty() ? UNKNOWN_VALUE
-                                : jsonData.at("format");
+        return m_format;
     }
     std::string osPatch() const override
     {
-        nlohmann::json jsonData{};
-        getData(jsonData);
-        return jsonData.empty() ? UNKNOWN_VALUE
-                                : jsonData.at("os_patch");
+        return m_osPatch;
     }
 
 private:
-    void getData(nlohmann::json& data) const
+    void getPkgData()
     {
         std::fstream file {m_filePath, std::ios_base::in};
         static const auto getValueFnc
@@ -92,16 +80,6 @@ private:
         if (file.is_open())
         {
             std::string line;
-            nlohmann::json package;
-
-            std::string name         { UNKNOWN_VALUE };
-            std::string version      { UNKNOWN_VALUE };
-            std::string groups       { UNKNOWN_VALUE };
-            std::string description  { UNKNOWN_VALUE };
-            std::string architecture { UNKNOWN_VALUE };
-            std::string format       { UNKNOWN_VALUE };
-            std::string osPatch      { UNKNOWN_VALUE };
-
             while(std::getline(file, line))
             {
                 line = Utils::trim(line," \t");
@@ -109,40 +87,35 @@ private:
                 if (line == "<key>CFBundleName</key>" &&
                     std::getline(file, line))
                 {
-                    name = getValueFnc(line);
+                    m_name = getValueFnc(line);
                 }
                 else if (line == "<key>CFBundleShortVersionString</key>" &&
-                    std::getline(file, line))
+                         std::getline(file, line))
                 {
-                    version = getValueFnc(line);
+                    m_version = getValueFnc(line);
                 }
                 else if (line == "<key>LSApplicationCategoryType</key>" &&
-                    std::getline(file, line))
+                         std::getline(file, line))
                 {
-                    groups = getValueFnc(line);
+                    m_groups = getValueFnc(line);
                 }
                 else if (line == "<key>CFBundleIdentifier</key>" &&
-                    std::getline(file, line))
+                         std::getline(file, line))
                 {
-                    description = getValueFnc(line);
+                    m_description = getValueFnc(line);
                 }
-            }
-
-            if (UNKNOWN_VALUE != name)
-            {
-                package["name"]         = name;
-                package["version"]      = version;
-                package["groups"]       = groups;
-                package["description"]  = description;
-                package["architecture"] = UNKNOWN_VALUE;
-                package["format"]       = "pkg";
-                package["os_patch"]     = UNKNOWN_VALUE;
-                data.push_back(package);
             }
         }
     }
 
     std::string m_filePath;
+    std::string m_name;
+    std::string m_version;
+    std::string m_groups;
+    std::string m_description;
+    std::string m_architecture;
+    std::string m_format;
+    std::string m_osPatch;
 };
 
 #endif //_PKG_WRAPPER_H

--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -21,8 +21,7 @@ class PKGWrapper final : public IPackageWrapper
 {
 public:
     explicit PKGWrapper(const std::string& filePath)
-      : m_filePath{filePath}
-      , m_name{UNKNOWN_VALUE}
+      : m_name{UNKNOWN_VALUE}
       , m_version{UNKNOWN_VALUE}
       , m_groups{UNKNOWN_VALUE}
       , m_description{UNKNOWN_VALUE}
@@ -30,7 +29,7 @@ public:
       , m_format{"pkg"}
       , m_osPatch{UNKNOWN_VALUE}
     {
-        getPkgData();
+        getPkgData(filePath);
     }
 
     ~PKGWrapper() = default;
@@ -65,9 +64,9 @@ public:
     }
 
 private:
-    void getPkgData()
+    void getPkgData(const std::string& filePath)
     {
-        std::fstream file {m_filePath, std::ios_base::in};
+        std::fstream file {filePath, std::ios_base::in};
         static const auto getValueFnc
         {
             [](const std::string& val)
@@ -108,7 +107,6 @@ private:
         }
     }
 
-    std::string m_filePath;
     std::string m_name;
     std::string m_version;
     std::string m_groups;

--- a/src/data_provider/src/sharedDefs.h
+++ b/src/data_provider/src/sharedDefs.h
@@ -24,12 +24,11 @@ constexpr auto WM_SYS_NET_DIR {"/proc/net/" };
 constexpr auto DPKG_PATH {"/var/lib/dpkg/"};
 constexpr auto DPKG_STATUS_PATH {"/var/lib/dpkg/status"};
 
-constexpr auto DEFAULT_STRING_VALUE {"unknown"};
+constexpr auto UNKNOWN_VALUE { "unknown" };
 constexpr auto MAC_ADDRESS_COUNT_SEGMENTS {6ull};
 
 #define ROUNDUP(a) ((a) > 0 ? (1 + (((a)-1) | (sizeof(long) - 1))) : sizeof(long))
 
-constexpr auto UNKNOWN_VALUE { "unknown" };
 
 enum OSType
 {

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -180,7 +180,7 @@ static void getPackagesFromPath(const std::string& pkgDirectory, const int pkgTy
             FactoryPackageFamilyCreator<OSType::BSDBASED>::create(std::make_pair(packagePath, pkgType))->buildPackageData(jsPackage);
             if(UNKNOWN_VALUE != jsPackage.at("name"))
             {
-                // Only return valid packages
+                // Only return valid content packages
                 result.push_back(jsPackage);
             }
         }
@@ -190,26 +190,22 @@ static void getPackagesFromPath(const std::string& pkgDirectory, const int pkgTy
 
 nlohmann::json SysInfo::getPackages() const
 {
-    nlohmann::json ret;
+    nlohmann::json jsPackages;
 
     for(const auto& packageDirectory : s_mapPackagesDirectories)
     {
         const auto pkgDirectory { packageDirectory.first };
         if (Utils::existsDir(pkgDirectory))
         {
-            nlohmann::json package;
             if(std::string::npos != pkgDirectory.find("/Applications") ||
                std::string::npos != pkgDirectory.find("/Library"))
             {
                 // Standard packages location
-                getPackagesFromPath(pkgDirectory, packageDirectory.second, package);
-                ret.push_back(package);
+                getPackagesFromPath(pkgDirectory, packageDirectory.second, jsPackages);
             }
             else
             {
                 // Brew packages location
-                // Once brew packages implementation is done, "ret.push_back(package)" line should be moved
-                // outside the if/else
             }
         }
     }

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -209,7 +209,7 @@ nlohmann::json SysInfo::getPackages() const
             }
         }
     }
-    return ret;
+    return jsPackages;
 }
 
 nlohmann::json SysInfo::getProcessesInfo() const

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -216,11 +216,11 @@ nlohmann::json SysInfo::getPackages() const
     {
         const auto pkgDirectory { packageDirectory.first };
         nlohmann::json package{};
-        if(std::string::npos != pkgDirectory.contains("/Applications"))
+        if(std::string::npos != pkgDirectory.find("/Applications"))
         {
             getPackagesFromApplications(pkgDirectory, packageDirectory.second, package);
         }
-        else if(std::string::npos != pkgDirectory.contains("/Library"))
+        else if(std::string::npos != pkgDirectory.find("/Library"))
         {
             getPackagesFromLibrary(pkgDirectory, packageDirectory.second, package);
         }


### PR DESCRIPTION
|Related issue|
|---|
|[#6779](https://github.com/wazuh/wazuh/issues/6779)|

## Description

This issue aims to implement a decoder of information obtained from raw sources, and to normalize the data provider among all operating systems implemented in sysinfo.

the idea of ​​this is to normalize the data with respect to how the packages are today, and only adding the os_patch field

This change is only for MacOS provider.

## DoD
- [X] Implementation
- [X] UTs execution
![image](https://user-images.githubusercontent.com/22640902/102633704-8bd20f80-412f-11eb-8373-16227f306bd1.png)

- [X] Test tool execution
![image](https://user-images.githubusercontent.com/22640902/102632767-4103c800-412e-11eb-826a-498749b022e7.png)


