### PR TITLE
[6926] Coverity fixes for the assigned CIDs

### DIFF
--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -414,9 +414,10 @@ void SysInfo::getMemory(nlohmann::json& info) const
         memFree = std::stoi(itFree->second);
     }
 
-    info["ram_total"] = memTotal == 0 ? 1 : memTotal;
+    const auto ramTotal { memTotal == 0 ? 1 : memTotal };
+    info["ram_total"] = ramTotal;
     info["ram_free"] = memFree;
-    info["ram_usage"] = 100 - (100*memFree/memTotal);
+    info["ram_usage"] = 100 - (100*memFree/ramTotal);
 }
 
 nlohmann::json SysInfo::getPackages() const

--- a/src/data_provider/testtool/main.cpp
+++ b/src/data_provider/testtool/main.cpp
@@ -23,6 +23,6 @@ int main()
     }
     catch(const std::exception& e)
     {
-        std::cerr << "Error getting system information: " << e.what() << '\n';
+        std::cerr << "Error getting system information: " << e.what() << std::endl;
     }
 }

--- a/src/data_provider/testtool/main.cpp
+++ b/src/data_provider/testtool/main.cpp
@@ -4,18 +4,25 @@
 
 int main()
 {
-    SysInfo info;
-    const auto& hw          {info.hardware()};
-    const auto& packages    {info.packages()};
-    const auto& processes   {info.processes()};
-    const auto& networks    {info.networks()};
-    const auto& os          {info.os()};
-    const auto& ports       {info.ports()};
-    
-    std::cout << hw.dump() << std::endl;
-    std::cout << packages.dump() << std::endl;
-    std::cout << processes.dump() << std::endl;
-    std::cout << networks.dump() << std::endl;
-    std::cout << os.dump() << std::endl;
-    std::cout << ports.dump() << std::endl;
+    try
+    {
+        SysInfo info;
+        const auto& hw        {info.hardware()};
+        const auto& packages  {info.packages()};
+        const auto& processes {info.processes()};
+        const auto& networks  {info.networks()};
+        const auto& os        {info.os()};
+        const auto& ports     {info.ports()};
+
+        std::cout << hw.dump() << std::endl;
+        std::cout << packages.dump() << std::endl;
+        std::cout << processes.dump() << std::endl;
+        std::cout << networks.dump() << std::endl;
+        std::cout << os.dump() << std::endl;
+        std::cout << ports.dump() << std::endl;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Error getting system information: " << e.what() << '\n';
+    }
 }

--- a/src/shared_modules/rsync/cppcheckSuppress.txt
+++ b/src/shared_modules/rsync/cppcheckSuppress.txt
@@ -1,3 +1,3 @@
-*:*src/rsyncImplementation.cpp:150
+*:*src/rsyncImplementation.cpp:151
 *:*tests/implementation/rsyncImplementationTest.cpp:259
 *:*tests/interface/rsync_test.cpp:248

--- a/src/shared_modules/rsync/src/rsyncImplementation.cpp
+++ b/src/shared_modules/rsync/src/rsyncImplementation.cpp
@@ -66,6 +66,7 @@ void RSyncImplementation::startRSync(const RSYNC_HANDLE handle,
         auto messageCreator { FactoryMessageCreator<SplitContext, MessageType::CHECKSUM>::create() };
 
         ChecksumContext checksumCtx;
+        checksumCtx.size = 1;
         checksumCtx.rightCtx.id = std::time(nullptr);
 
         if(!jsonFirstQueryResult.empty() && !jsonLastQueryResult.empty())

--- a/src/shared_modules/rsync/src/rsyncImplementation.cpp
+++ b/src/shared_modules/rsync/src/rsyncImplementation.cpp
@@ -66,7 +66,8 @@ void RSyncImplementation::startRSync(const RSYNC_HANDLE handle,
         auto messageCreator { FactoryMessageCreator<SplitContext, MessageType::CHECKSUM>::create() };
 
         ChecksumContext checksumCtx;
-        checksumCtx.size = 1;
+        // In this case, 'size' field will not be used because of the checksum type (CHECKSUM_COMPLETE).
+        checksumCtx.size = 0;
         checksumCtx.rightCtx.id = std::time(nullptr);
 
         if(!jsonFirstQueryResult.empty() && !jsonLastQueryResult.empty())


### PR DESCRIPTION
|Related issue|
|---|
|[#6926](https://github.com/wazuh/wazuh/issues/6926)|

## Description

Fixes for the following Coverity ID issues:
- 215814-> ctx.size not initialized.
- 215813-> add sanity to avoid memtotal=0
- 215809-> Add try-catch
- 215808-> Add try-catch

## **DoD:**

- [X] Development
- [X] RTR
![image](https://user-images.githubusercontent.com/22640902/102658410-46750880-4156-11eb-8edb-6bb067588fdd.png)


- [X] CI/CD checks are part of this PR