### PR TITLE
[6992] Fixed coverity issues based on last run

### DIFF
--- a/src/shared_modules/dbsync/include/db_exception.h
+++ b/src/shared_modules/dbsync/include/db_exception.h
@@ -14,22 +14,25 @@
 #include <stdexcept>
 #include <string>
 
-constexpr auto FACTORY_INSTANTATION       { std::make_pair(1, "Unspecified type during factory instantiation") };
-constexpr auto INVALID_HANDLE             { std::make_pair(2, "Invalid handle value.") };
-constexpr auto INVALID_TRANSACTION        { std::make_pair(3, "Invalid transaction value.") };
-constexpr auto SQLITE_CONNECTION_ERROR    { std::make_pair(4, "No connection available for executions.") };
-constexpr auto EMPTY_DATABASE_PATH        { std::make_pair(5, "Empty database store path.") };
-constexpr auto EMPTY_TABLE_METADATA       { std::make_pair(6, "Empty table metadata.") };
-constexpr auto INVALID_PARAMETERS         { std::make_pair(7, "Invalid parameters.") };
-constexpr auto DATATYPE_NOT_IMPLEMENTED   { std::make_pair(8, "Datatype not implemented.") };
-constexpr auto SQL_STMT_ERROR             { std::make_pair(9, "Invalid SQL statement.") };
-constexpr auto INVALID_PK_DATA            { std::make_pair(10, "Primary key not found.") };
-constexpr auto INVALID_COLUMN_TYPE        { std::make_pair(11, "Invalid column field type.") };
-constexpr auto INVALID_DATA_BIND          { std::make_pair(12, "Invalid data to bind.") };
-constexpr auto INVALID_TABLE              { std::make_pair(13, "Invalid table.") };
-constexpr auto INVALID_DELETE_INFO        { std::make_pair(14, "Invalid information provided for deletion.") };
-constexpr auto BIND_FIELDS_DOES_NOT_MATCH { std::make_pair(15, "Invalid information provided for statement creation.") };
-constexpr auto STEP_ERROR_CREATE_STMT     { std::make_pair(16, "Error when create table.") };
+constexpr auto FACTORY_INSTANTATION           { std::make_pair(1, "Unspecified type during factory instantiation") };
+constexpr auto INVALID_HANDLE                 { std::make_pair(2, "Invalid handle value.") };
+constexpr auto INVALID_TRANSACTION            { std::make_pair(3, "Invalid transaction value.") };
+constexpr auto SQLITE_CONNECTION_ERROR        { std::make_pair(4, "No connection available for executions.") };
+constexpr auto EMPTY_DATABASE_PATH            { std::make_pair(5, "Empty database store path.") };
+constexpr auto EMPTY_TABLE_METADATA           { std::make_pair(6, "Empty table metadata.") };
+constexpr auto INVALID_PARAMETERS             { std::make_pair(7, "Invalid parameters.") };
+constexpr auto DATATYPE_NOT_IMPLEMENTED       { std::make_pair(8, "Datatype not implemented.") };
+constexpr auto SQL_STMT_ERROR                 { std::make_pair(9, "Invalid SQL statement.") };
+constexpr auto INVALID_PK_DATA                { std::make_pair(10, "Primary key not found.") };
+constexpr auto INVALID_COLUMN_TYPE            { std::make_pair(11, "Invalid column field type.") };
+constexpr auto INVALID_DATA_BIND              { std::make_pair(12, "Invalid data to bind.") };
+constexpr auto INVALID_TABLE                  { std::make_pair(13, "Invalid table.") };
+constexpr auto INVALID_DELETE_INFO            { std::make_pair(14, "Invalid information provided for deletion.") };
+constexpr auto BIND_FIELDS_DOES_NOT_MATCH     { std::make_pair(15, "Invalid information provided for statement creation.") };
+constexpr auto STEP_ERROR_CREATE_STMT         { std::make_pair(16, "Error creating table.") };
+constexpr auto STEP_ERROR_ADD_STATUS_FIELD    { std::make_pair(17, "Error adding status field.") };
+constexpr auto STEP_ERROR_UPDATE_STATUS_FIELD { std::make_pair(18, "Error updating status field.") };
+constexpr auto STEP_ERROR_DELETE_STATUS_FIELD { std::make_pair(19, "Error deleting status field.") };
 
 namespace DbSync
 {

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -248,14 +248,25 @@ void SQLiteDBEngine::initializeStatusField(const nlohmann::json& tableNames)
                                                    " " +
                                                    STATUS_FIELD_TYPE +
                                                    " DEFAULT 1;")};
-                stmtAdd->step();
+                // LCOV_EXCL_START
+                if (SQLITE_ERROR == stmtAdd->step())
+                {
+                    throw dbengine_error{ STEP_ERROR_UPDATE_STATUS_FIELD };
+                }
+                // LCOV_EXCL_STOP
             }
             const auto& stmtInit { getStatement("UPDATE " +
                                                 table +
                                                 " SET " +
                                                 STATUS_FIELD_NAME +
                                                 "=0;")};
-            stmtInit->step();
+
+            // LCOV_EXCL_START
+            if (SQLITE_ERROR == stmtInit->step())
+            {
+                throw dbengine_error{ STEP_ERROR_ADD_STATUS_FIELD };
+            }
+            // LCOV_EXCL_STOP
         } 
         else
         {
@@ -280,7 +291,12 @@ void SQLiteDBEngine::deleteRowsByStatusField(const nlohmann::json& tableNames)
                                             " WHERE " +
                                             STATUS_FIELD_NAME +
                                             "=0;")};
-            stmt->step();
+            // LCOV_EXCL_START
+            if (SQLITE_ERROR == stmt->step())
+            {
+                throw dbengine_error{ STEP_ERROR_DELETE_STATUS_FIELD };
+            }
+            // LCOV_EXCL_STOP
         }
         else
         {

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1510,20 +1510,22 @@ bool wdb_delete_dbsync(wdb_t * wdb, struct kv const *kv_value, char *data)
             int index = 1;
             for (column = kv_value->column_list; column ; column=column->next) {
                 if (!column->value.is_old_implementation) {
-                    if (column->value.is_pk) {
-                        if (FIELD_TEXT == column->value.type) {
-                            if (SQLITE_OK != sqlite3_bind_text(stmt, index, strcmp(field_value, "NULL") == 0 ? "" : field_value, -1, NULL)) {
-                                merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+                    if (NULL != field_value) {
+                        if (column->value.is_pk) {
+                            if (FIELD_TEXT == column->value.type) {
+                                if (SQLITE_OK != sqlite3_bind_text(stmt, index, strcmp(field_value, "NULL") == 0 ? "" : field_value, -1, NULL)) {
+                                    merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+                                }
+                            } else {
+                                if (SQLITE_OK != sqlite3_bind_int(stmt, index, strcmp(field_value, "NULL") == 0 ? 0 : atoi(field_value))) {
+                                    merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+                                }
                             }
-                        } else {
-                            if (SQLITE_OK != sqlite3_bind_int(stmt, index, strcmp(field_value, "NULL") == 0 ? 0 : atoi(field_value))) {
-                                merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-                            }
+                            ++index;
                         }
-                        ++index;
-                    }
-                    if (column->next && NULL != field_value) {
-                        field_value = strtok(NULL, FIELD_SEPARATOR_DBSYNC);
+                        if (column->next) {
+                            field_value = strtok(NULL, FIELD_SEPARATOR_DBSYNC);
+                        }
                     }
                 }
             }

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -61,7 +61,18 @@ public:
     void push(const std::string& data);
 private:
     Syscollector()
-    : m_stopping { true } { }
+    : m_intervalValue { 0 }
+    , m_scanOnStart { false }
+    , m_hardware { false }
+    , m_os { false }
+    , m_network { false }
+    , m_packages { false }
+    , m_ports { false }
+    , m_portsAll { false }
+    , m_processes { false }
+    , m_hotfixes { false }
+    , m_stopping { true }
+    {}
     ~Syscollector() = default;
     Syscollector(const Syscollector&) = delete;
     Syscollector& operator=(const Syscollector&) = delete;


### PR DESCRIPTION
|Related issue|
|---|
|[#6992](https://github.com/wazuh/wazuh/issues/6992)|

## Description

Fixes for the following Coverity ID issues:
- 215843-> Unchecked return value
- 215844-> Uninitialized scalar field
- 215845-> Unchecked return value
- 215816 -> Dereference after null check (this was not fixed previously)

## **DoD:**

- [X] Development
- [X] RTR

**DBSync**
![image](https://user-images.githubusercontent.com/22640902/102688851-5af9e500-41d8-11eb-8f77-913f030d7fc9.png)

**Syscollector**
![image](https://user-images.githubusercontent.com/22640902/102688856-6816d400-41d8-11eb-8a40-824476bd442e.png)


- [X] CI/CD checks are part of this PR