### PR TITLE
Brew implementation to get packages

### DIFF
--- a/src/data_provider/src/packages/brewWrapper.h
+++ b/src/data_provider/src/packages/brewWrapper.h
@@ -14,43 +14,74 @@
 
 #include "ipackageWrapper.h"
 #include "sharedDefs.h"
+#include "stringHelper.h"
+#include "filesystemHelper.h"
 
 class BrewWrapper final : public IPackageWrapper
 {
 public:
-    explicit BrewWrapper(const std::string& /*fileName*/)
-    { }
+    explicit BrewWrapper(const PackageContext& ctx)
+      : m_name{ctx.package}
+      , m_version{Utils::splitIndex(ctx.version, '_', 0)}
+      , m_groups{UNKNOWN_VALUE}
+      , m_description{UNKNOWN_VALUE}
+      , m_architecture{UNKNOWN_VALUE}
+      , m_format{"pkg"}
+      , m_osPatch{UNKNOWN_VALUE}
+    {
+        const auto rows { Utils::split(Utils::getFileContent(ctx.filePath + "/" + ctx.package + "/" + ctx.version + "/.brew/" + ctx.package + ".rb"), '\n')};
+        for (const auto& row : rows)
+        {
+            auto rowParsed { Utils::trim(row) };
+
+            if (Utils::startsWith(rowParsed, "desc "))
+            {
+                Utils::replaceFirst(rowParsed, "desc ", "");
+                Utils::replaceAll(rowParsed, "\"","");
+                m_description = rowParsed;
+                break;
+            }
+        }
+    }
 
     ~BrewWrapper() = default;
 
     std::string name() const override
     {
-        return UNKNOWN_VALUE;
+        return m_name;
     }
     std::string version() const override
     {
-        return UNKNOWN_VALUE;
+        return m_version;
     }
     std::string groups() const override
     {
-        return UNKNOWN_VALUE;
+        return m_groups;
     }
     std::string description() const override
     {
-        return UNKNOWN_VALUE;
+        return m_description;
     }
     std::string architecture() const override
     {
-        return UNKNOWN_VALUE;
+        return m_architecture;
     }
     std::string format() const override
     {
-        return UNKNOWN_VALUE;
+        return m_format;
     }
     std::string osPatch() const override
     {
-        return UNKNOWN_VALUE;
+        return m_osPatch;
     }
+private:
+    std::string m_name;
+    std::string m_version;
+    std::string m_groups;
+    std::string m_description;
+    std::string m_architecture;
+    std::string m_format;
+    std::string m_osPatch;
 };
 
 

--- a/src/data_provider/src/packages/packageFamilyDataAFactory.h
+++ b/src/data_provider/src/packages/packageFamilyDataAFactory.h
@@ -21,7 +21,7 @@ template <OSType osType>
 class FactoryPackageFamilyCreator final
 {
 public:
-    static std::shared_ptr<IPackage> create(const std::pair<std::string, int>& /*ctx*/)
+    static std::shared_ptr<IPackage> create(const std::pair<PackageContext, int>& /*ctx*/)
     {
         throw std::runtime_error
         {
@@ -34,7 +34,7 @@ template <>
 class FactoryPackageFamilyCreator<OSType::BSDBASED> final
 {
 public:
-    static std::shared_ptr<IPackage> create(const std::pair<std::string, int>& ctx)
+    static std::shared_ptr<IPackage> create(const std::pair<PackageContext, int>& ctx)
     {
         return FactoryBSDPackage::create(ctx);
     }

--- a/src/data_provider/src/packages/packageMac.cpp
+++ b/src/data_provider/src/packages/packageMac.cpp
@@ -14,7 +14,7 @@
 #include "brewWrapper.h"
 #include "pkgWrapper.h"
 
-std::shared_ptr<IPackage> FactoryBSDPackage::create(const std::pair<std::string, int>& ctx)
+std::shared_ptr<IPackage> FactoryBSDPackage::create(const std::pair<PackageContext, int>& ctx)
 {
     std::shared_ptr<IPackage> ret;
 

--- a/src/data_provider/src/packages/packageMac.h
+++ b/src/data_provider/src/packages/packageMac.h
@@ -15,10 +15,17 @@
 #include "ipackageInterface.h"
 #include "ipackageWrapper.h"
 
+struct PackageContext
+{
+    std::string filePath;
+    std::string package;
+    std::string version;
+};
+
 class FactoryBSDPackage
 {
 public:
-    static std::shared_ptr<IPackage>create(const std::pair<std::string, int>& ctx);
+    static std::shared_ptr<IPackage>create(const std::pair<PackageContext, int>& ctx);
 };
 
 class BSDPackageImpl final : public IPackage

--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -17,10 +17,12 @@
 #include "ipackageWrapper.h"
 #include "sharedDefs.h"
 
+const std::string APP_INFO_PATH{"Contents/Info.plist"};
+
 class PKGWrapper final : public IPackageWrapper
 {
 public:
-    explicit PKGWrapper(const std::string& filePath)
+    explicit PKGWrapper(const PackageContext& ctx)
       : m_name{UNKNOWN_VALUE}
       , m_version{UNKNOWN_VALUE}
       , m_groups{UNKNOWN_VALUE}
@@ -29,7 +31,7 @@ public:
       , m_format{"pkg"}
       , m_osPatch{UNKNOWN_VALUE}
     {
-        getPkgData(filePath);
+        getPkgData(ctx.filePath+ "/" + ctx.package + "/" + APP_INFO_PATH);
     }
 
     ~PKGWrapper() = default;

--- a/src/data_provider/testtool/CMakeLists.txt
+++ b/src/data_provider/testtool/CMakeLists.txt
@@ -9,6 +9,10 @@ include_directories(${SRC_FOLDER}/external/nlohmann/)
 
 link_directories(${SRC_FOLDER}/external/procps/)
 
+if(APPLE)
+  set(CMAKE_MACOSX_RPATH OFF)
+endif(APPLE)
+
 if(COVERITY)
   add_definitions(-D__GNUC__=8)
 endif(COVERITY)
@@ -50,3 +54,10 @@ else()
         )
     endif(SOLARIS)
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+
+if(APPLE)
+  add_custom_command(TARGET sysinfo_test_tool
+    POST_BUILD COMMAND
+    ${CMAKE_INSTALL_NAME_TOOL} -change "@rpath/libsysinfo.dylib" "@executable_path/../lib/libsysinfo.dylib"
+    $<TARGET_FILE:sysinfo_test_tool>)
+endif(APPLE)

--- a/src/data_provider/testtool/CMakeLists.txt
+++ b/src/data_provider/testtool/CMakeLists.txt
@@ -9,10 +9,6 @@ include_directories(${SRC_FOLDER}/external/nlohmann/)
 
 link_directories(${SRC_FOLDER}/external/procps/)
 
-if(APPLE)
-  set(CMAKE_MACOSX_RPATH OFF)
-endif(APPLE)
-
 if(COVERITY)
   add_definitions(-D__GNUC__=8)
 endif(COVERITY)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #6780|

This issue aims to implement a decoder of information obtained from raw sources, and to normalize the data provider among all operating systems implemented in sysinfo.

the idea of ​​this is to normalize the data with respect to how the packages are today, and only adding the os_patch field

This change is only for MacOS provider.
