### PR TITLE
[API] Add integration test mapping script and file

### DIFF
--- a/api/test/integration/mapping/README.md
+++ b/api/test/integration/mapping/README.md
@@ -1,0 +1,29 @@
+## API Integration Test Mapping Script
+### What is it
+This is a script to generate a JSON file with all the API integration test mapping. This JSON file will be used to run the assigned test whenever a file is modified in a PR.
+
+### How to use it
+This script has two modes:
+- Generate the JSON file
+    Run the script without any argument.
+    ```
+    python3 _test_mapping.py
+    ```
+    The JSON file will be generated within the same directory as the script as `integration_test_api_endpoints.json`.
+    
+- Test the mapping
+    Run the script with a relative path from the `wazuh` folder to check if a file is mapped.
+    ```
+    python3 _test_mapping.py framework/wazuh/agent.py
+    ```
+    If the file is mapped, this will be the output (for `agent.py`):
+    ```
+    test_agent_GET_endpoints.tavern.yaml
+    test_agent_DELETE_endpoints.tavern.yaml
+    test_agent_PUT_endpoints.tavern.yaml
+    test_agent_POST_endpoints.tavern.yaml
+    test_rbac_black_agent_endpoints.tavern.yaml
+    test_rbac_white_agent_endpoints.tavern.yaml
+    ```
+  
+    > **NOTE:** Please use a relative path when trying the testing mode. For instance: `/home/wazuh/Desktop/git/wazuh/framework/wazuh/agent.py` -> `framework/wazuh/agent.py`

--- a/api/test/integration/mapping/_test_mapping.py
+++ b/api/test/integration/mapping/_test_mapping.py
@@ -1,0 +1,123 @@
+import glob
+import json
+import re
+import sys
+from collections import defaultdict
+from copy import copy
+from os import path, chdir, walk
+
+base = path.dirname(path.dirname(path.dirname(path.dirname(path.dirname(path.abspath(__file__))))))
+framework = path.join(base, 'framework', 'wazuh')
+api = path.join(base, 'api', 'api')
+integration_tests = path.join(base, 'api', 'test', 'integration')
+
+# Mapping file
+file_path = path.join(integration_tests, 'mapping', 'integration_test_api_endpoints.json')
+
+# Wazuh modules
+wazuh_modules = [
+    api,                             # API
+    framework,                       # SDK
+    path.join(framework, 'core'),    # CORE
+    path.join(framework, 'rbac'),    # RBAC
+    integration_tests                # Integration tests
+]
+
+file_tag_regex = re.compile(r'([^_]+).*\.[a-z]{2,4}')
+test_tag_regex = re.compile(r'test_([^_]+).*.yaml')
+allowed_extensions = ('.py', '.yaml', '.sql', '.yml', '.sh')
+
+
+def calculate_test_mappings():
+    chdir(integration_tests)
+    test_mapping = defaultdict(list)
+
+    for test in glob.glob('test_*.yaml'):
+        test_tag = re.match(test_tag_regex, test).group(1)
+        if test_tag.startswith('rbac'):
+            # Add RBAC tests
+            test_mapping['rbac'].append(test.lower())
+        else:
+            # Add every other test
+            test_mapping[test_tag.lower()].append(test)
+
+    # Create custom tag for basic tests
+    for test in [tests for tests in map(lambda x: test_mapping[x], ['agent', 'security', 'cluster', 'experimental'])]:
+        test_mapping['basic'].extend(test)
+
+    return test_mapping
+
+
+def get_file_and_test_info(test_name, test_mapping, module_name):
+    try:
+        # Get file tag, i.e.: agent.py -> agent
+        test_tag = re.match(file_tag_regex, test_name).group(1)
+    except AttributeError:
+        return None
+
+    if test_tag == 'test':
+        # Integration tests themselves must be added. Unit tests must not
+        related_tests = [] if not test_name.endswith('.yaml') else [test_name]
+    elif path.basename(module_name) == 'rbac':
+        # Every file within the RBAC directory must be tagged as RBAC
+        related_tests = test_mapping['rbac']
+    elif test_mapping[test_tag]:
+        # If a tag matches, both their normal and RBAC tests will be assigned
+        related_tests = test_mapping[test_tag] + [test for test in test_mapping['rbac'] if test_tag in test]
+    else:
+        # If no tag is matched, basic tests will be assigned
+        related_tests = test_mapping['basic']
+
+    return [test_name, test_tag, related_tests]
+
+
+if __name__ == '__main__':
+    # Generate mapping file
+    if len(sys.argv) == 1:
+        test_tags = calculate_test_mappings()
+
+        mapping_list = list()
+        for module in wazuh_modules:
+            chdir(module)
+            for root, dirs, files in walk('.'):
+                mappings = dict()
+                mappings['path'] = path.join(path.relpath(module, base), root.lstrip('./')).strip('/')
+                mappings['files'] = list()
+                for file in files:
+                    if file.endswith(allowed_extensions):
+                        test_info = get_file_and_test_info(file.lower(), test_tags, module)
+                        if test_info and test_info[2]:
+                            mappings['files'].append({'name': test_info[0], 'tag': test_info[1], 'tests': test_info[2]})
+
+                mappings['files'] and mapping_list.append(copy(mappings))
+
+        with open(file_path, 'w') as f:
+            f.write(json.dumps(mapping_list, indent=4))
+
+        print(f'Test mappings file generated at {file_path}')
+    # Calculate mappings for a given file
+    elif len(sys.argv) == 2:
+        if not path.exists(file_path):
+            print('Test mapping file does not exist. Run this script without any argument to generate it.')
+            exit(0)
+        file_rel_path = sys.argv[1]
+
+        if not path.exists(path.join(base, file_rel_path)):
+            print('The relative path does not exist. Example: "framework/wazuh/agent.py"')
+            exit(0)
+
+        with open(file_path) as f:
+            mappings = json.loads(f.read())
+        file_path = path.dirname(file_rel_path)
+        file_name = path.basename(file_rel_path)
+
+        match = next((item for item in mappings if item['path'] == file_path), None)
+        if not match:
+            print('That file is not mapped.')
+            exit(0)
+
+        files = next((item['tests'] for item in match['files'] if item['name'] == file_name), [])
+        print('No tests assigned to that file' if not files else '\n'.join(files))
+    else:
+        print('Invalid number of arguments.\n\t- No arguments: generate test mapping file.\n\t- One argument: '
+              'Show assigned integration tests to that file.')

--- a/api/test/integration/mapping/integration_test_api_endpoints.json
+++ b/api/test/integration/mapping/integration_test_api_endpoints.json
@@ -1,0 +1,4537 @@
+[
+    {
+        "path": "api/api",
+        "files": [
+            {
+                "name": "alogging.py",
+                "tag": "alogging",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "configuration.py",
+                "tag": "configuration",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "constants.py",
+                "tag": "constants",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "uri_parser.py",
+                "tag": "uri",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "util.py",
+                "tag": "util",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "middlewares.py",
+                "tag": "middlewares",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "encoder.py",
+                "tag": "encoder",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "authentication.py",
+                "tag": "authentication",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "api_exception.py",
+                "tag": "api",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "validator.py",
+                "tag": "validator",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/api/controllers",
+        "files": [
+            {
+                "name": "syscheck_controller.py",
+                "tag": "syscheck",
+                "tests": [
+                    "test_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "agent_controller.py",
+                "tag": "agent",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "mitre_controller.py",
+                "tag": "mitre",
+                "tests": [
+                    "test_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "overview_controller.py",
+                "tag": "overview",
+                "tests": [
+                    "test_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "active_response_controller.py",
+                "tag": "active",
+                "tests": [
+                    "test_active_response_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "security_controller.py",
+                "tag": "security",
+                "tests": [
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "cluster_controller.py",
+                "tag": "cluster",
+                "tests": [
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "syscollector_controller.py",
+                "tag": "syscollector",
+                "tests": [
+                    "test_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "logtest_controller.py",
+                "tag": "logtest",
+                "tests": [
+                    "test_logtest_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "rootcheck_controller.py",
+                "tag": "rootcheck",
+                "tests": [
+                    "test_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "task_controller.py",
+                "tag": "task",
+                "tests": [
+                    "test_task_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "experimental_controller.py",
+                "tag": "experimental",
+                "tests": [
+                    "test_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "default_controller.py",
+                "tag": "default",
+                "tests": [
+                    "test_default_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "rule_controller.py",
+                "tag": "rule",
+                "tests": [
+                    "test_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "cdb_list_controller.py",
+                "tag": "cdb",
+                "tests": [
+                    "test_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "manager_controller.py",
+                "tag": "manager",
+                "tests": [
+                    "test_manager_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "ciscat_controller.py",
+                "tag": "ciscat",
+                "tests": [
+                    "test_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "decoder_controller.py",
+                "tag": "decoder",
+                "tests": [
+                    "test_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "sca_controller.py",
+                "tag": "sca",
+                "tests": [
+                    "test_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/api/spec",
+        "files": [
+            {
+                "name": "spec.yaml",
+                "tag": "spec",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/api/configuration",
+        "files": [
+            {
+                "name": "api.yaml",
+                "tag": "api",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/api/models",
+        "files": [
+            {
+                "name": "security_model.py",
+                "tag": "security",
+                "tests": [
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "configuration_model.py",
+                "tag": "configuration",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "agent_added_model.py",
+                "tag": "agent",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "logtest_model.py",
+                "tag": "logtest",
+                "tests": [
+                    "test_logtest_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "agent_inserted_model.py",
+                "tag": "agent",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "security_token_response_model.py",
+                "tag": "security",
+                "tests": [
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "basic_info_model.py",
+                "tag": "basic",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "active_response_model.py",
+                "tag": "active",
+                "tests": [
+                    "test_active_response_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "base_model_.py",
+                "tag": "base",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh",
+        "files": [
+            {
+                "name": "logtest.py",
+                "tag": "logtest",
+                "tests": [
+                    "test_logtest_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "cdb_list.py",
+                "tag": "cdb",
+                "tests": [
+                    "test_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "cluster.py",
+                "tag": "cluster",
+                "tests": [
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "agent.py",
+                "tag": "agent",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "rule.py",
+                "tag": "rule",
+                "tests": [
+                    "test_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "sca.py",
+                "tag": "sca",
+                "tests": [
+                    "test_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "manager.py",
+                "tag": "manager",
+                "tests": [
+                    "test_manager_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "stats.py",
+                "tag": "stats",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "mitre.py",
+                "tag": "mitre",
+                "tests": [
+                    "test_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "ciscat.py",
+                "tag": "ciscat",
+                "tests": [
+                    "test_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "syscheck.py",
+                "tag": "syscheck",
+                "tests": [
+                    "test_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "task.py",
+                "tag": "task",
+                "tests": [
+                    "test_task_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "active_response.py",
+                "tag": "active",
+                "tests": [
+                    "test_active_response_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "rootcheck.py",
+                "tag": "rootcheck",
+                "tests": [
+                    "test_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "decoder.py",
+                "tag": "decoder",
+                "tests": [
+                    "test_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "security.py",
+                "tag": "security",
+                "tests": [
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "syscollector.py",
+                "tag": "syscollector",
+                "tests": [
+                    "test_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/tests",
+        "files": [
+            {
+                "name": "util.py",
+                "tag": "util",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/tests/data",
+        "files": [
+            {
+                "name": "schema_ciscat_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "schema_sca_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "schema_global_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "schema_syscheck_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "schema_syscollector_000.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "schema_mitre_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "schema_tasks_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/tests/data/security",
+        "files": [
+            {
+                "name": "roles_test_cases.yml",
+                "tag": "roles",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "users_roles_test_cases.yml",
+                "tag": "users",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "policies_test_cases.yml",
+                "tag": "policies",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "schema_security_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "rbac_catalog.yml",
+                "tag": "rbac",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "role_policies_test_cases.yml",
+                "tag": "role",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/core",
+        "files": [
+            {
+                "name": "logtest.py",
+                "tag": "logtest",
+                "tests": [
+                    "test_logtest_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "cdb_list.py",
+                "tag": "cdb",
+                "tests": [
+                    "test_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "utils.py",
+                "tag": "utils",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "agent.py",
+                "tag": "agent",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "configuration.py",
+                "tag": "configuration",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "rule.py",
+                "tag": "rule",
+                "tests": [
+                    "test_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "pydaemonmodule.py",
+                "tag": "pydaemonmodule",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "wlogging.py",
+                "tag": "wlogging",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "sca.py",
+                "tag": "sca",
+                "tests": [
+                    "test_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "results.py",
+                "tag": "results",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "manager.py",
+                "tag": "manager",
+                "tests": [
+                    "test_manager_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "common.py",
+                "tag": "common",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "wdb.py",
+                "tag": "wdb",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "inputvalidator.py",
+                "tag": "inputvalidator",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "ossec_queue.py",
+                "tag": "ossec",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "wazuh_socket.py",
+                "tag": "wazuh",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "syscheck.py",
+                "tag": "syscheck",
+                "tests": [
+                    "test_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "task.py",
+                "tag": "task",
+                "tests": [
+                    "test_task_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "active_response.py",
+                "tag": "active",
+                "tests": [
+                    "test_active_response_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "database.py",
+                "tag": "database",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "rootcheck.py",
+                "tag": "rootcheck",
+                "tests": [
+                    "test_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "decoder.py",
+                "tag": "decoder",
+                "tests": [
+                    "test_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "security.py",
+                "tag": "security",
+                "tests": [
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "syscollector.py",
+                "tag": "syscollector",
+                "tests": [
+                    "test_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "exception.py",
+                "tag": "exception",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/core/tests/data/test_rootcheck",
+        "files": [
+            {
+                "name": "schema_rootcheck_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/core/tests/data/test_agent",
+        "files": [
+            {
+                "name": "schema_global_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/core/cluster",
+        "files": [
+            {
+                "name": "utils.py",
+                "tag": "utils",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "cluster.py",
+                "tag": "cluster",
+                "tests": [
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "client.py",
+                "tag": "client",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "worker.py",
+                "tag": "worker",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "local_server.py",
+                "tag": "local",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "master.py",
+                "tag": "master",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "common.py",
+                "tag": "common",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "local_client.py",
+                "tag": "local",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "server.py",
+                "tag": "server",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "control.py",
+                "tag": "control",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/core/cluster/dapi",
+        "files": [
+            {
+                "name": "dapi.py",
+                "tag": "dapi",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/rbac",
+        "files": [
+            {
+                "name": "decorators.py",
+                "tag": "decorators",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "auth_context.py",
+                "tag": "auth",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "orm.py",
+                "tag": "orm",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "preprocessor.py",
+                "tag": "preprocessor",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/rbac/tests",
+        "files": [
+            {
+                "name": "utils.py",
+                "tag": "utils",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/rbac/tests/data",
+        "files": [
+            {
+                "name": "schema_security_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/rbac/migrations",
+        "files": [
+            {
+                "name": "env.py",
+                "tag": "env",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/rbac/default",
+        "files": [
+            {
+                "name": "rules.yaml",
+                "tag": "rules",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "policies.yaml",
+                "tag": "policies",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "users.yaml",
+                "tag": "users",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "relationships.yaml",
+                "tag": "relationships",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "roles.yaml",
+                "tag": "roles",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/core",
+        "files": [
+            {
+                "name": "logtest.py",
+                "tag": "logtest",
+                "tests": [
+                    "test_logtest_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "cdb_list.py",
+                "tag": "cdb",
+                "tests": [
+                    "test_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "utils.py",
+                "tag": "utils",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "agent.py",
+                "tag": "agent",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "configuration.py",
+                "tag": "configuration",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "rule.py",
+                "tag": "rule",
+                "tests": [
+                    "test_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "pydaemonmodule.py",
+                "tag": "pydaemonmodule",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "wlogging.py",
+                "tag": "wlogging",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "sca.py",
+                "tag": "sca",
+                "tests": [
+                    "test_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "results.py",
+                "tag": "results",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "manager.py",
+                "tag": "manager",
+                "tests": [
+                    "test_manager_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "common.py",
+                "tag": "common",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "wdb.py",
+                "tag": "wdb",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "inputvalidator.py",
+                "tag": "inputvalidator",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "ossec_queue.py",
+                "tag": "ossec",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "wazuh_socket.py",
+                "tag": "wazuh",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "syscheck.py",
+                "tag": "syscheck",
+                "tests": [
+                    "test_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "task.py",
+                "tag": "task",
+                "tests": [
+                    "test_task_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "active_response.py",
+                "tag": "active",
+                "tests": [
+                    "test_active_response_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "database.py",
+                "tag": "database",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "rootcheck.py",
+                "tag": "rootcheck",
+                "tests": [
+                    "test_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "decoder.py",
+                "tag": "decoder",
+                "tests": [
+                    "test_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "security.py",
+                "tag": "security",
+                "tests": [
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "syscollector.py",
+                "tag": "syscollector",
+                "tests": [
+                    "test_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "exception.py",
+                "tag": "exception",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/core/tests/data/test_rootcheck",
+        "files": [
+            {
+                "name": "schema_rootcheck_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/core/tests/data/test_agent",
+        "files": [
+            {
+                "name": "schema_global_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/core/cluster",
+        "files": [
+            {
+                "name": "utils.py",
+                "tag": "utils",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "cluster.py",
+                "tag": "cluster",
+                "tests": [
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "client.py",
+                "tag": "client",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "worker.py",
+                "tag": "worker",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "local_server.py",
+                "tag": "local",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "master.py",
+                "tag": "master",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "common.py",
+                "tag": "common",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "local_client.py",
+                "tag": "local",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "server.py",
+                "tag": "server",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "control.py",
+                "tag": "control",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/core/cluster/dapi",
+        "files": [
+            {
+                "name": "dapi.py",
+                "tag": "dapi",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/rbac",
+        "files": [
+            {
+                "name": "decorators.py",
+                "tag": "decorators",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "auth_context.py",
+                "tag": "auth",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "orm.py",
+                "tag": "orm",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "preprocessor.py",
+                "tag": "preprocessor",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/rbac/tests",
+        "files": [
+            {
+                "name": "utils.py",
+                "tag": "utils",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/rbac/tests/data",
+        "files": [
+            {
+                "name": "schema_security_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/rbac/migrations",
+        "files": [
+            {
+                "name": "env.py",
+                "tag": "env",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "framework/wazuh/rbac/default",
+        "files": [
+            {
+                "name": "rules.yaml",
+                "tag": "rules",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "policies.yaml",
+                "tag": "policies",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "users.yaml",
+                "tag": "users",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "relationships.yaml",
+                "tag": "relationships",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "roles.yaml",
+                "tag": "roles",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml",
+                    "test_rbac_white_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_rule_endpoints.tavern.yaml",
+                    "test_rbac_black_experimental_endpoints.tavern.yaml",
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_active_response_endpoints.tavern.yaml",
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                    "test_rbac_black_sca_endpoints.tavern.yaml",
+                    "test_rbac_white_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_logtest_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_rule_endpoints.tavern.yaml",
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_decoder_endpoints.tavern.yaml",
+                    "test_rbac_white_sca_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration",
+        "files": [
+            {
+                "name": "test_rbac_white_experimental_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_logtest_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_logtest_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_logtest_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_logtest_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_agent_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_agent_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_active_response_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_active_response_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_rule_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_rule_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_experimental_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_syscheck_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_syscheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_agent_get_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_agent_get_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_sca_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_sca_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_rootcheck_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_rootcheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_task_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_task_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_security_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_security_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_manager_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_manager_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_cluster_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_cdb_list_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_cdb_list_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_ciscat_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_ciscat_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_mitre_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_mitre_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_overview_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_overview_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_security_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_security_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rule_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rule_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_cluster_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_syscheck_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_syscheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_rootcheck_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_rootcheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_task_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_task_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_experimental_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_active_response_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_active_response_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_cdb_list_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_cdb_list_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_sca_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_sca_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_decoder_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_decoder_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_security_post_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_security_post_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_agent_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_agent_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_agent_delete_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_agent_delete_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "run_tests.py",
+                "tag": "run",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_logtest_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_logtest_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_overview_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_overview_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_agent_put_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_agent_put_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_manager_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_manager_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_manager_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_manager_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_rule_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_rule_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_syscheck_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_syscheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_syscollector_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_decoder_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_decoder_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_mitre_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_mitre_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_overview_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_overview_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_sca_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_sca_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_black_task_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_black_task_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_security_put_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_security_put_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_agent_post_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_agent_post_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_syscollector_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_syscollector_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_mitre_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_mitre_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "tavern_utils.py",
+                "tag": "tavern",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_default_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_default_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_ciscat_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_security_delete_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_security_delete_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "conftest.py",
+                "tag": "conftest",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "common.yaml",
+                "tag": "common",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_security_get_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_security_get_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rootcheck_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rootcheck_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_cdb_list_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_cdb_list_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_rbac_white_cluster_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_rbac_white_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_decoder_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_decoder_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "test_active_response_endpoints.tavern.yaml",
+                "tag": "test",
+                "tests": [
+                    "test_active_response_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env",
+        "files": [
+            {
+                "name": "docker-compose.yml",
+                "tag": "docker-compose",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/scripts",
+        "files": [
+            {
+                "name": "xml_parser.py",
+                "tag": "xml",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/security/manager",
+        "files": [
+            {
+                "name": "schema_security_test.sql",
+                "tag": "schema",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "security_config.sh",
+                "tag": "security",
+                "tests": [
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/syscheck/agent/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/syscheck/manager/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/agent/manager",
+        "files": [
+            {
+                "name": "agents_config.sh",
+                "tag": "agents",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/ciscat/agent",
+        "files": [
+            {
+                "name": "ciscat.sh",
+                "tag": "ciscat",
+                "tests": [
+                    "test_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/ciscat/agent/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/experimental/agent",
+        "files": [
+            {
+                "name": "syscollector.sh",
+                "tag": "syscollector",
+                "tests": [
+                    "test_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_black_syscollector_endpoints.tavern.yaml",
+                    "test_rbac_white_syscollector_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "ciscat.sh",
+                "tag": "ciscat",
+                "tests": [
+                    "test_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_black_ciscat_endpoints.tavern.yaml",
+                    "test_rbac_white_ciscat_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/experimental/agent/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/experimental/manager/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/cluster/manager",
+        "files": [
+            {
+                "name": "entrypoint.sh",
+                "tag": "entrypoint",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/active/agent",
+        "files": [
+            {
+                "name": "agent3_config.sh",
+                "tag": "agent3",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/sca/agent/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/manager/agent/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/manager/manager",
+        "files": [
+            {
+                "name": "manager.sh",
+                "tag": "manager",
+                "tests": [
+                    "test_manager_endpoints.tavern.yaml",
+                    "test_rbac_white_manager_endpoints.tavern.yaml",
+                    "test_rbac_black_manager_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/manager/manager/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/base/agent/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/base/manager",
+        "files": [
+            {
+                "name": "api.yaml",
+                "tag": "api",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "security.yaml",
+                "tag": "security",
+                "tests": [
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/base/manager/security",
+        "files": [
+            {
+                "name": "base_security_test.sql",
+                "tag": "base",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/base/manager/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/base/manager/master_only",
+        "files": [
+            {
+                "name": "agent_info.yaml",
+                "tag": "agent",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "update_agent_info.py",
+                "tag": "update",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/security",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/syscheck",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/agent",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/rootcheck",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/mitre",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/ciscat",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/experimental",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/decoder",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/rule",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/overview",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/cluster",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/active",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/cdb",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/logtest",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/task",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/sca",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/manager",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/rbac/syscollector",
+        "files": [
+            {
+                "name": "black_config.yaml",
+                "tag": "black",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "white_config.yaml",
+                "tag": "white",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/syscollector/agent/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/configurations/syscollector/manager/healthcheck",
+        "files": [
+            {
+                "name": "healthcheck.py",
+                "tag": "healthcheck",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/base/agent",
+        "files": [
+            {
+                "name": "entrypoint.sh",
+                "tag": "entrypoint",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/base/nginx-lb",
+        "files": [
+            {
+                "name": "entrypoint.sh",
+                "tag": "entrypoint",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "api/test/integration/env/base/manager",
+        "files": [
+            {
+                "name": "entrypoint.sh",
+                "tag": "entrypoint",
+                "tests": [
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_security_POST_endpoints.tavern.yaml",
+                    "test_security_PUT_endpoints.tavern.yaml",
+                    "test_security_DELETE_endpoints.tavern.yaml",
+                    "test_security_GET_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml",
+                    "test_experimental_endpoints.tavern.yaml"
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Hello team,
this closes #7000 .

In order to maintain the test mapping file according to our changes, we made a python script to generate it and uploaded an improved version including mappings to the testing environment files.

This script allows testing for a given file to see what mappings it will have. More information and examples can be found in the `README`.

Regards,
Víctor.