### PR TITLE
[API] Add new remote commands configuration

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -57,7 +57,17 @@ default_api_configuration = {
     },
     "use_only_authd": False,
     "drop_privileges": True,
-    "experimental_features": False
+    "experimental_features": False,
+    "remote_commands": {
+        "localfile": {
+            "enabled": True,
+            "exceptions": []
+        },
+        "wodle_command": {
+            "enabled": True,
+            "exceptions": []
+        }
+    }
 }
 
 
@@ -191,6 +201,24 @@ def read_yaml_config(config_file=common.api_config_path, default_conf=None) -> D
 
     :return: API configuration
     """
+    def replace_bools(conf):
+        """Replace 'yes' and 'no' strings in configuration for actual booleans.
+
+        Parameters
+        ----------
+        conf : dict
+            Current API configuration.
+        """
+        for k in conf.keys():
+            if isinstance(conf[k], dict):
+                replace_bools(conf[k])
+            else:
+                if isinstance(conf[k], str):
+                    if conf[k].lower() == 'yes':
+                        conf[k] = True
+                    elif conf[k].lower() == 'no':
+                        conf[k] = False
+
     if default_conf is None:
         default_conf = default_api_configuration
 
@@ -198,6 +226,8 @@ def read_yaml_config(config_file=common.api_config_path, default_conf=None) -> D
         try:
             with open(config_file) as f:
                 configuration = yaml.safe_load(f)
+            # Replace strings for booleans
+            configuration and replace_bools(configuration)
         except IOError as e:
             raise APIError(2004, details=e.strerror)
     else:

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -49,3 +49,12 @@
 # Enable features under development
 # experimental_features: no
 
+# Enable remote commands
+# remote_commands:
+#   localfile:
+#     enabled: yes
+#     exceptions: []
+#
+#   wodle_command:
+#     enabled: yes
+#     exceptions: []

--- a/api/api/models/configuration_model.py
+++ b/api/api/models/configuration_model.py
@@ -98,7 +98,7 @@ class CORSModel(Model):
             'source_route': str,
             'expose_headers': str,
             'allow_headers': bool,
-            'allow_credentials': str
+            'allow_credentials': bool
         }
 
         self.attribute_map = {

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2523,6 +2523,7 @@ components:
     APIconfiguration:
       type: object
       minProperties: 1
+      additionalProperties: false
       properties:
         access:
           description: API Security Options

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -820,6 +820,20 @@ stages:
     response:
       status_code: 400
 
+  # PUT /manager/api/config
+  - name: Modify API configuration (unknown field)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        unknown:
+          path: "test"
+    response:
+      status_code: 400
+
   # Restart manager to apply changes
   - name: Restart manager
     request:

--- a/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
@@ -124,7 +124,7 @@ stages:
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
-      data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n <rule id=\"111111\" level=\"5\">\n <if_sid>5716\n <srcip>1.1.1.1</srcip>\n  <description>sshd: authentication failed from IP 1.1.1.1.</description>\n <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n </rule>\n </group>\n"
+      data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n <rule id=\"111111\" level=\"5\">\n <if_sid>5716</if_sid>\n <srcip>1.1.1.1</srcip>\n  <description>sshd: authentication failed from IP 1.1.1.1.</description>\n <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n </rule>\n </group>\n"
       params:
         path: 'etc/rules/local_rules.xml'
         overwrite: True

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -93,6 +93,8 @@ class WazuhException(Exception):
                               'using API endpoint https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.put_api_config or '
                               'https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.put_api_config'},
         1123: {'message': f"Error communicating with socket. Query too long, maximum allowed size for queries is {MAX_SOCKET_BUFFER_SIZE // 1024} KB"},
+        1124: {'message': 'Remote command detected',
+               'remediation': f'To solve this issue please enable the remote commands in the API settings or add an exception: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/configuration.html#remote-commands-configuration'},
 
         # Rule: 1200 - 1299
         1200: {'message': 'Error reading rules from `WAZUH_HOME/etc/ossec.conf`',

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -26,7 +26,7 @@ from wazuh import WazuhInternalError, WazuhError
 from wazuh.core import common
 from wazuh.core.cluster.utils import get_manager_status
 from wazuh.core.results import WazuhResult
-from wazuh.core.utils import load_wazuh_xml, safe_move, tail
+from wazuh.core.utils import load_wazuh_xml, safe_move, tail, check_remote_commands
 
 _re_logtest = re.compile(r"^.*(?:ERROR: |CRITICAL: )(?:\[.*\] )?(.*)$")
 execq_lockfile = join(common.ossec_path, "var", "run", ".api_execq_lock")
@@ -108,61 +108,75 @@ def get_logs_summary(limit=2000):
     return tags
 
 
-def upload_xml(xml_file, path):
-    """
-    Upload XML files (rules and decoders)
-    :param xml_file: content of the XML file
-    :param path: Destination of the new XML file
-    :return: Confirmation message
+def prettify_xml(xml_file):
+    """Prettify XML files (rules, decoders and ossec.conf)
+
+    Parameters
+    ----------
+    xml_file : str
+        Content of the XML file
+
+    Returns
+    -------
+    Checked XML content
     """
     # -- characters are not allowed in XML comments
     xml_file = replace_in_comments(xml_file, '--', '%wildcard%')
 
-    # path of temporary files for parsing xml input
-    tmp_file_path = '{}/tmp/api_tmp_file_{}_{}.xml'.format(common.ossec_path, time.time(), random.randint(0, 1000))
-
     # create temporary file for parsing xml input
     try:
+        # beauty xml file
+        xml = parseString('<root>' + xml_file + '</root>')
+        # remove first line (XML specification: <? xmlversion="1.0" ?>), <root> and </root> tags, and empty lines
+        indent = '  '  # indent parameter for toprettyxml function
+        pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent=indent).split('\n')[2:-2])) + '\n'
+        # revert xml.dom replacings
+        # (https://github.com/python/cpython/blob/8e0418688906206fe59bd26344320c0fc026849e/Lib/xml/dom/minidom.py#L305)
+        pretty_xml = pretty_xml.replace("&amp;", "&").replace("&lt;", "<").replace("&quot;", "\"", ) \
+            .replace("&gt;", ">").replace('&apos;', "'")
+        # delete two first spaces of each line
+        final_xml = re.sub(fr'^{indent}', '', pretty_xml, flags=re.MULTILINE)
+        final_xml = replace_in_comments(final_xml, '%wildcard%', '--')
+
+        # Check if remote commands are allowed
+        check_remote_commands(final_xml)
+        # Check xml format
+        load_wazuh_xml(xml_path='', data=final_xml)
+
+        return final_xml
+    except ExpatError:
+        raise WazuhError(1113)
+    except WazuhError as e:
+        raise e
+    except Exception as e:
+        raise WazuhError(1113, str(e))
+
+
+def upload_xml(xml_file, path):
+    """
+    Upload XML files (rules, decoders and ossec.conf)
+    :param xml_file: content of the XML file
+    :param path: Destination of the new XML file
+    :return: Confirmation message
+    """
+    # Path of temporary files for parsing xml input
+    tmp_file_path = '{}/tmp/api_tmp_file_{}_{}.xml'.format(common.ossec_path, time.time(), random.randint(0, 1000))
+    try:
         with open(tmp_file_path, 'w') as tmp_file:
-            # beauty xml file
-            xml = parseString('<root>' + xml_file + '</root>')
-            # remove first line (XML specification: <? xmlversion="1.0" ?>), <root> and </root> tags, and empty lines
-            indent = '  '  # indent parameter for toprettyxml function
-            pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent=indent).split('\n')[2:-2])) + '\n'
-            # revert xml.dom replacings
-            # (https://github.com/python/cpython/blob/8e0418688906206fe59bd26344320c0fc026849e/Lib/xml/dom/minidom.py#L305)
-            pretty_xml = pretty_xml.replace("&amp;", "&").replace("&lt;", "<").replace("&quot;", "\"", ) \
-                .replace("&gt;", ">").replace('&apos;', "'")
-            # delete two first spaces of each line
-            final_xml = re.sub(fr'^{indent}', '', pretty_xml, flags=re.MULTILINE)
-            final_xml = replace_in_comments(final_xml, '%wildcard%', '--')
+            final_xml = prettify_xml(xml_file)
             tmp_file.write(final_xml)
         chmod(tmp_file_path, 0o660)
     except IOError:
         raise WazuhInternalError(1005)
-    except ExpatError:
-        raise WazuhError(1113)
 
+    # Move temporary file to group folder
     try:
-        # check xml format
-        try:
-            load_wazuh_xml(tmp_file_path)
-        except Exception as e:
-            raise WazuhError(1113, str(e))
+        new_conf_path = join(common.ossec_path, path)
+        safe_move(tmp_file_path, new_conf_path, permissions=0o660)
+    except Error:
+        raise WazuhInternalError(1016)
 
-        # move temporary file to group folder
-        try:
-            new_conf_path = join(common.ossec_path, path)
-            safe_move(tmp_file_path, new_conf_path, permissions=0o660)
-        except Error:
-            raise WazuhInternalError(1016)
-
-        return WazuhResult({'message': 'File was successfully updated'})
-
-    except Exception as e:
-        # remove created temporary file if an exception happens
-        remove(tmp_file_path)
-        raise e
+    return WazuhResult({'message': 'File was successfully updated'})
 
 
 def upload_list(list_file, path):
@@ -369,7 +383,13 @@ def update_api_conf(new_config):
         Dictionary with the new configuration.
     """
     if new_config:
+        'remote_commands' in new_config.keys() and new_config.pop('remote_commands')
         try:
+            with open(common.api_config_path, 'r') as f:
+                # Avoid changing the "remote_commands" option through the Framework
+                previous_config = yaml.safe_load(f)
+                if previous_config and 'remote_commands' in previous_config.keys():
+                    new_config['remote_commands'] = previous_config['remote_commands']
             with open(common.api_config_path, 'w+') as f:
                 yaml.dump(new_config, f)
         except IOError:

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -125,13 +125,29 @@ def test_get_logs_summary():
                                                      'debug': 2}
 
 
+@patch('wazuh.core.manager.check_remote_commands')
+@patch('wazuh.core.manager.common.ossec_path', new=test_data_path)
+def test_prettify_xml(mock_remote_commands, test_manager):
+    """Tests prettify_xml method works and methods inside are called with expected parameters"""
+    input_file, _ = getattr(test_manager, 'input_rules_file'), getattr(test_manager, 'output_rules_file')
+
+    with open(os.path.join(test_data_path, input_file)) as f:
+        xml_file = f.read()
+    m = mock_open(read_data=xml_file)
+    with patch('builtins.open', m):
+        result = prettify_xml(xml_file)
+
+    assert isinstance(result, str)
+    mock_remote_commands.assert_called_once_with(result)
+
+
 @patch('time.time', return_value=0)
 @patch('random.randint', return_value=0)
 @patch('wazuh.core.manager.chmod')
-@patch('wazuh.core.manager.load_wazuh_xml')
+@patch('wazuh.core.manager.check_remote_commands')
 @patch('wazuh.core.manager.safe_move')
 @patch('wazuh.core.manager.common.ossec_path', new=test_data_path)
-def test_upload_xml(mock_safe, mock_load_wazuh, mock_chmod, mock_random, mock_time, test_manager):
+def test_upload_xml(mock_safe, mock_check_remote_commands, mock_chmod, mock_random, mock_time, test_manager):
     """Tests upload_xml method works and methods inside are called with expected parameters"""
     input_file, output_file = getattr(test_manager, 'input_rules_file'), getattr(test_manager, 'output_rules_file')
 
@@ -146,15 +162,33 @@ def test_upload_xml(mock_safe, mock_load_wazuh, mock_chmod, mock_random, mock_ti
     mock_random.assert_called_once_with(0, 1000)
     m.assert_any_call(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'), 'w')
     mock_chmod.assert_called_once_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'), 0o660)
-    mock_load_wazuh.assert_called_once_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'))
     mock_safe.assert_called_once_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'),
                                       os.path.join(test_data_path, output_file),
                                       permissions=0o660)
 
 
 @pytest.mark.parametrize('effect, expected_exception', [
-    (IOError, 1005),
     (ExpatError, 1113)
+])
+def test_prettify_xml_open_ko(effect, expected_exception, test_manager):
+    """Tests prettify_xml function works when open function raise an exception
+
+    Parameters
+    ----------
+    effect : Exception
+        Exception to be triggered.
+    expected_exception
+        Expected code when triggering the exception.
+    """
+    input_file, _ = getattr(test_manager, 'input_rules_file'), getattr(test_manager, 'output_rules_file')
+
+    with patch('wazuh.core.manager.load_wazuh_xml', side_effect=effect):
+        with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
+            prettify_xml(input_file)
+
+
+@pytest.mark.parametrize('effect, expected_exception', [
+    (IOError, 1005)
 ])
 def test_upload_xml_open_ko(effect, expected_exception, test_manager):
     """Tests upload_xml function works when open function raise an exception
@@ -175,10 +209,10 @@ def test_upload_xml_open_ko(effect, expected_exception, test_manager):
 
 @patch('time.time', return_value=0)
 @patch('random.randint', return_value=0)
+@patch('wazuh.core.manager.check_remote_commands')
 @patch('wazuh.core.manager.chmod')
-@patch('wazuh.core.manager.remove')
 @patch('wazuh.core.manager.common.ossec_path', new=test_data_path)
-def test_upload_xml_ko(mock_remove, mock_chmod, mock_random, mock_time, test_manager):
+def test_upload_xml_ko(mock_chmod, mock_remote_commands, mock_random, mock_time, test_manager):
     """Tests upload_xml function exception works and methods inside are called with expected parameters"""
     input_file, output_file = getattr(test_manager, 'input_rules_file'), getattr(test_manager, 'output_rules_file')
 
@@ -198,7 +232,6 @@ def test_upload_xml_ko(mock_remove, mock_chmod, mock_random, mock_time, test_man
     mock_time.assert_called_with()
     mock_random.assert_called_with(0, 1000)
     mock_chmod.assert_called_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'), 0o660)
-    mock_remove.assert_called_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'))
 
 
 @patch('wazuh.core.manager.validate_cdb_list', return_value=True)
@@ -444,9 +477,10 @@ def test_get_api_config():
     assert result == {'experimental_features': True}
 
 
+@patch('wazuh.core.manager.yaml.safe_load')
 @patch('wazuh.core.manager.yaml.dump')
 @patch('wazuh.core.manager.open')
-def test_update_api_conf(mock_open, mock_yaml):
+def test_update_api_conf(mock_open, mock_yaml, mock_safe_load):
     """Verify whether update_api_conf correctly updates shared api_conf dict.
 
     It also checks that the configuration is updated in the api.yaml file
@@ -458,7 +492,6 @@ def test_update_api_conf(mock_open, mock_yaml):
     with patch('wazuh.core.manager.configuration.api_conf', new=old_config):
         update_api_conf(new_config=new_config)
 
-        mock_open.assert_called_once(), '"Open" should be called, but it was not.'
         mock_yaml.assert_called_once_with(new_config, ANY), '"Yaml.dump" should be called with updated config.'
 
 

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -13,7 +13,7 @@ from wazuh.core.cluster.utils import manager_restart, read_cluster_config
 from wazuh.core.configuration import get_ossec_conf
 from wazuh.core.exception import WazuhError, WazuhInternalError
 from wazuh.core.manager import status, upload_xml, upload_list, validate_xml, validate_cdb_list, \
-    get_api_conf, update_api_conf, get_ossec_logs, get_logs_summary, validate_ossec_conf
+    get_api_conf, update_api_conf, get_ossec_logs, get_logs_summary, validate_ossec_conf, prettify_xml
 from wazuh.core.results import WazuhResult, AffectedItemsWazuhResult
 from wazuh.core.utils import process_array
 from wazuh.rbac.decorators import expose_resources
@@ -131,6 +131,8 @@ def upload_file(path=None, content=None, overwrite=False):
         if not overwrite and exists(join(common.ossec_path, path)):
             raise WazuhError(1905)
         elif overwrite and exists(join(common.ossec_path, path)):
+            # Check if the content is valid
+            not re.match(r'^etc/lists', path) and prettify_xml(content)
             delete_file(path=path)
 
         # For CDB lists

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -150,8 +150,9 @@ def test_ossec_log_summary():
 ])
 @patch('wazuh.manager.delete_file')
 @patch('wazuh.manager.upload_xml')
+@patch('wazuh.core.manager.check_remote_commands')
 @patch('wazuh.manager.upload_list')
-def test_upload_file(mock_list, mock_xml, mock_delete, path, overwrite):
+def test_upload_file(mock_list, mock_remote_commands, mock_xml, mock_delete, path, overwrite):
     """Tests uploading a file to the manager
 
     Parameters
@@ -261,9 +262,10 @@ def test_get_api_config():
     assert result['data']['affected_items'][0]['node_name'] == 'manager', 'Not expected node name'
 
 
+@patch('wazuh.core.manager.yaml.safe_load')
 @patch('wazuh.core.manager.yaml.dump')
 @patch('wazuh.core.manager.open')
-def test_update_api_config(mock_open, mock_yaml):
+def test_update_api_config(mock_open, mock_yaml, mock_safe_load):
     """Checks that update_api_config method is updating current api_conf dict and returning expected result."""
     old_config = {'experimental_features': True}
     new_config = {'experimental_features': False}


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

In this PR we have added a new configuration that allows blocking the upload of files with remote commands inside them. It is possible to add the necessary commands for the user using the exceptions parameter. By default all remote commands are allowed.

```yaml
# Enable remote commands
 remote_commands:
   localfile:
     enabled: yes
     exceptions: []

   wodle_command:
     enabled: yes
     exceptions: []
```

More information: https://documentation.wazuh.com/4.0/user-manual/reference/ossec-conf/localfile.html and https://documentation.wazuh.com/4.0/user-manual/reference/ossec-conf/wodle-command.html

Documentation: https://github.com/wazuh/wazuh-documentation/pull/3248

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

## Test results
### Integration tests
```
adriiiprodri@wazuh python3 run_tests.py -rbac both -k cluster              
Collected tests [3]:
test_cluster_endpoints.tavern.yaml, test_rbac_black_cluster_endpoints.tavern.yaml, test_rbac_white_cluster_endpoints.tavern.yaml


test_cluster_endpoints.tavern.yaml 
	 56 passed, 57 warnings

test_rbac_black_cluster_endpoints.tavern.yaml 
	 21 passed, 22 warnings

test_rbac_white_cluster_endpoints.tavern.yaml 
	 21 passed, 22 warnings

 adriiiprodri@wazuh python3 run_tests.py -rbac both -k manager 
Collected tests [3]:
test_manager_endpoints.tavern.yaml, test_rbac_black_manager_endpoints.tavern.yaml, test_rbac_white_manager_endpoints.tavern.yaml


test_manager_endpoints.tavern.yaml 
	 35 passed, 36 warnings

test_rbac_black_manager_endpoints.tavern.yaml 
	 19 passed, 20 warnings

test_rbac_white_manager_endpoints.tavern.yaml 
	 19 passed, 20 warnings
```

### Unittests
```
adriiiprodri@wazuh python3 -m pytest -x wazuh/tests
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/framework
plugins: metadata-1.10.0, html-2.1.1, tavern-1.7.0
collected 667 items                                                                                                                                                       

wazuh/tests/test_active_response.py .........                                                                                                                       [  1%]
wazuh/tests/test_agent.py ....................................................................................                                                      [ 13%]
wazuh/tests/test_cdb_list.py ...............................................                                                                                        [ 20%]
wazuh/tests/test_ciscat.py ..                                                                                                                                       [ 21%]
wazuh/tests/test_cluster.py .....ss                                                                                                                                 [ 22%]
wazuh/tests/test_decoders.py ...............................                                                                                                        [ 26%]
wazuh/tests/test_group.py ........                                                                                                                                  [ 28%]
wazuh/tests/test_logtest.py ......                                                                                                                                  [ 29%]
wazuh/tests/test_manager.py ........................................                                                                                                [ 35%]
wazuh/tests/test_mitre.py ......................................................................................................................................... [ 55%]
...........................................                                                                                                                         [ 62%]
wazuh/tests/test_rootcheck.py .................................................                                                                                     [ 69%]
wazuh/tests/test_rule.py ....................................................                                                                                       [ 77%]
wazuh/tests/test_sca.py .......                                                                                                                                     [ 78%]
wazuh/tests/test_security.py .....................................................................                                                                  [ 88%]
wazuh/tests/test_stats.py .............                                                                                                                             [ 90%]
wazuh/tests/test_syscheck.py .......................                                                                                                                [ 94%]
wazuh/tests/test_syscollector.py ............                                                                                                                       [ 95%]
wazuh/tests/test_task.py ............................                                                                                                               [100%]

========================================================== 665 passed, 2 skipped, 4 warnings in 66.79s (0:01:06) ==========================================================


adriiiprodri@wazuh python3 -m pytest -x wazuh/core/tests/
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/framework
plugins: metadata-1.10.0, html-2.1.1, tavern-1.7.0
collected 642 items                                                                                                                                                       

wazuh/core/tests/test_active_response.py ............                                                                                                               [  1%]
wazuh/core/tests/test_agent.py .................................................................................................................................... [ 22%]
...................                                                                                                                                                 [ 25%]
wazuh/core/tests/test_cdb_list.py .................................                                                                                                 [ 30%]
wazuh/core/tests/test_common.py .......                                                                                                                             [ 31%]
wazuh/core/tests/test_configuration.py ..................................                                                                                           [ 36%]
wazuh/core/tests/test_decoder.py ................                                                                                                                   [ 39%]
wazuh/core/tests/test_input_validator.py ...                                                                                                                        [ 39%]
wazuh/core/tests/test_logtest.py ..                                                                                                                                 [ 40%]
wazuh/core/tests/test_manager.py .................................                                                                                                  [ 45%]
wazuh/core/tests/test_ossec_queue.py ...................                                                                                                            [ 48%]
wazuh/core/tests/test_pyDaemonModule.py ......                                                                                                                      [ 49%]
wazuh/core/tests/test_results.py ........................................                                                                                           [ 55%]
wazuh/core/tests/test_rootcheck.py ..........                                                                                                                       [ 57%]
wazuh/core/tests/test_rule.py ......................                                                                                                                [ 60%]
wazuh/core/tests/test_syscollector.py ...                                                                                                                           [ 60%]
wazuh/core/tests/test_utils.py .................................................................................................................................... [ 81%]
..............................................................................                                                                                      [ 93%]
wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                          [ 96%]
wazuh/core/tests/test_wdb.py .....................                                                                                                                  [100%]

=========================================================================== 642 passed in 2.49s ===========================================================================
```

![Screenshot from 2020-12-23 09-29-05](https://user-images.githubusercontent.com/15522808/102986510-3b80f600-4511-11eb-8260-e442e228016e.png)
