### PR TITLE
Fixed process to validate and format a path from the configuration

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1211,7 +1211,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             /* When the maximum number of directories monitored in the same tag is reached,
         the excess are discarded and warned */
         if (j++ >= MAX_DIR_SIZE){
-            mwarn(FIM_WARN_MAX_DIR_REACH, MAX_DIR_SIZE, tmp_dir);
+            mwarn(FIM_WARN_MAX_DIR_REACH, MAX_DIR_SIZE, *dir);
             dir++;
             continue;
         }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -797,12 +797,11 @@ char *format_path(char *dir) {
 }
 
 #ifndef WIN32
-char **expand_wildcards(const char *path){
+char **expand_wildcards(const char *path) {
     /* Check for glob */
     /* The mingw32 builder used by travis.ci can't find glob.h
      * Yet glob must work on actual win32. */
     char **paths;
-    os_calloc(1, sizeof(char **), paths);
 
     if (strchr(path, '*') ||
         strchr(path, '?') ||
@@ -824,6 +823,7 @@ char **expand_wildcards(const char *path){
             return NULL;
         }
 
+        os_calloc(g.gl_pathc + 1, sizeof(char *), paths);
         for (int gindex = 0; g.gl_pathv[gindex]; gindex++) {
             paths[gindex] = realpath(g.gl_pathv[gindex], NULL);
 
@@ -835,6 +835,7 @@ char **expand_wildcards(const char *path){
 
         globfree(&g);
     } else {
+        os_calloc(2, sizeof(char *), paths);
         os_strdup(path, paths[0]);
     }
 
@@ -1215,7 +1216,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                             tmp_diff_size);
 #else
                     char **paths = expand_wildcards(clean_path);
-                    for (int i = 0; paths[i]; i++){
+                    for (int i = 0; paths[i]; i++) {
                         if (paths[i] != NULL && strcmp(paths[i], clean_path) != 0 && (opts & CHECK_FOLLOW)) {
                             dump_syscheck_file(syscheck, paths[i], opts, restrictfile, recursion_limit, clean_tag,
                                                 clean_path, tmp_diff_size);
@@ -2443,7 +2444,7 @@ static char **get_paths_from_env_variable (char *environment_variable) {
 #ifdef WIN32
     char expandedpath[PATH_MAX + 1];
 
-    if (!ExpandEnvironmentStrings(environment_variable, expandedpath, PATH_MAX + 1)){
+    if (!ExpandEnvironmentStrings(environment_variable, expandedpath, PATH_MAX + 1)) {
         merror("Could not expand the environment variable %s (%ld)", expandedpath, GetLastError());
     }
     /* The env. variable may have multiples paths split by ; */
@@ -2451,18 +2452,18 @@ static char **get_paths_from_env_variable (char *environment_variable) {
 #else
     char *expandedpath = NULL;
 
-    if (environment_variable[0] == '$'){
+    if (environment_variable[0] == '$') {
         environment_variable++;
     }
 
-    if (expandedpath = getenv(environment_variable), expandedpath){
+    if (expandedpath = getenv(environment_variable), expandedpath) {
         /* The env. variable may have multiples paths split by : */
         paths = OS_StrBreak(':', expandedpath, MAX_DIR_SIZE);
     }
 
 #endif
 
-    if (paths == NULL){
+    if (paths == NULL) {
         os_calloc(2, sizeof(char *), paths);
         os_strdup(environment_variable, paths[0]);
         paths[1] = NULL;

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1179,6 +1179,13 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             continue;
         }
 
+        // Skip if the content is empty.
+        if (*tmp_dir == '\0') {
+            mdebug2(FIM_EMPTY_DIRECTORIES_CONFIG);
+            dir++;
+            continue;
+        }
+
         /* If it's an environment variable, expand it */
         env_variable = get_paths_from_env_variable(tmp_dir);
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -742,7 +742,7 @@ char *validate_path(char *dir) {
         tmp_str--;
     }
 
-    if (!strcmp(tmp_dir,"")) {
+    if (*tmp_dir == '\0') {
         mdebug2(FIM_EMPTY_DIRECTORIES_CONFIG);
         return NULL;
     }
@@ -753,19 +753,24 @@ char *validate_path(char *dir) {
 char *format_path(char *dir) {
     char *real_path;
     char *tmp_str;
-    char buffer[PATH_MAX];
 
-    if(!strcmp(dir, "") || dir == NULL) {
+    if(dir == NULL || *dir == '\0') {
         return NULL;
     }
 
 #ifdef WIN32
+    char buffer[PATH_MAX];
+
     /* Change forward slashes to backslashes on entry */
     tmp_str = strchr(dir, '/');
     while (tmp_str) {
         *tmp_str = '\\';
         tmp_str++;
         tmp_str = strchr(tmp_str, '/');
+    }
+
+    if (strlen(dir) == 2) {
+        strcat(dir, "\\");
     }
 
     if (!GetFullPathName(dir, PATH_MAX, buffer, NULL)) {
@@ -2518,7 +2523,8 @@ static void process_option(char ***syscheck_option, xml_node *node) {
     char **new_opt = NULL;
 
     tmp_dir = validate_path(dir);
-    if (!tmp_dir) {
+    if (tmp_dir == NULL) {
+        os_free(dir);
         return;
     }
 
@@ -2536,7 +2542,7 @@ static void process_option(char ***syscheck_option, xml_node *node) {
     }
 
     for (int i = 0; new_opt[i]; i++) {
-        if(strcmp(new_opt[i], "")) {
+        if(*new_opt[i] != '\0') {
             real_path = format_path(new_opt[i]);
             if (real_path && !os_IsStrOnArray(dir, syscheck_option[0])) {
                 os_realloc(syscheck_option[0], sizeof(char *) * (counter_opt + 2), syscheck_option[0]);
@@ -2550,6 +2556,7 @@ static void process_option(char ***syscheck_option, xml_node *node) {
         }
         os_free(new_opt[i]);
     }
+    os_free(dir);
     os_free(new_opt);
 }
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -748,7 +748,7 @@ char *format_path(char *dir) {
     }
 
     if (strlen(dir) == 2) {
-        strcat(dir, "\\");
+        wm_strcat(&dir, "\\", '\0');
     }
 
     if (!GetFullPathName(dir, PATH_MAX, buffer, NULL)) {

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -728,26 +728,6 @@ clean_reg:
 }
 #endif /* WIN32 */
 
-char *trim_path(char *dir) {
-    /* Remove spaces at the beginning and the end */
-    while (*dir == ' ') {
-        dir++;
-    }
-
-    char *tail = dir + strlen(dir) - 1;
-    while(*tail == ' ') {
-        *tail = '\0';
-        tail--;
-    }
-
-    if (*dir == '\0') {
-        mdebug2(FIM_EMPTY_DIRECTORIES_CONFIG);
-        return NULL;
-    }
-
-    return dir;
-}
-
 char *format_path(char *dir) {
     char *clean_path;
     char *tmp_str;
@@ -1193,7 +1173,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             continue;
         }
 
-        tmp_dir = trim_path(*dir);
+        tmp_dir = w_strtrim(*dir);
         if (!tmp_dir) {
             dir++;
             continue;
@@ -2520,7 +2500,7 @@ static void process_option(char ***syscheck_option, xml_node *node) {
     char *tmp_dir;
     char **new_opt = NULL;
 
-    tmp_dir = trim_path(dir);
+    tmp_dir = w_strtrim(dir);
     if (tmp_dir == NULL) {
         os_free(dir);
         return;

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -60,7 +60,6 @@
 #define FIM_REGISTRY_FAIL_TO_GET_KEY_ID         "(6945): Unable to get id for registry key '%s %s'"
 #define FIM_AUDIT_DISABLED                      "(6946): Audit is disabled."
 #define FIM_WARN_FORMAT_PATH                    "(6947): Error formatting path: '%s'"
-#define FIM_WARN_ENV_VARIABLES                  "(6948): Error expanding environment variable: '%s'"
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -59,6 +59,8 @@
 #define FIM_REGISTRY_FAIL_TO_INSERT_VALUE       "(6944): Failed to insert value '%s %s\\%s'"
 #define FIM_REGISTRY_FAIL_TO_GET_KEY_ID         "(6945): Unable to get id for registry key '%s %s'"
 #define FIM_AUDIT_DISABLED                      "(6946): Audit is disabled."
+#define FIM_WARN_FORMAT_PATH                    "(6947): Error formatting path: '%s'"
+#define FIM_WARN_ENV_VARIABLES                  "(6948): Error expanding environment variable: '%s'"
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5252|


## Description
This PR solves the problem when we configure to ignore a path of type `c:\.`. It generates an error because the path of the ignore tag is not being treated in the same way as the directories path.
To solve it I have unified all the process:
Whenever a path enters the configuration, we proceed to validate the entry, to check if it is or not an environment variable, and finally, we give it the necessary format.

- validate_path
- get_paths_from_env_variable
- format_path
- check_wildcards_and_sym_links
- if unix os, check_wildcards_and_sym_links
- dump_syscheck_file

## Configuration options
```
  <syscheck>
    <frequency>3600</frequency>
    <disabled>no</disabled>
    <directories realtime="yes" check_all="yes">%TEST_ENV_MULTIPLES_PATH%</directories>
    <directories realtime="yes" check_all="yes">/path/to/testdir</directories>
    <ignore>e:\.</ignore>
  </syscheck>
```
## Logs
```
2020/12/05 12:05:23 wazuh-agent: INFO: (6003): Monitoring path: 'c:\path\to\testdir', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | realtime'.
2020/12/05 12:05:23 wazuh-agent: INFO: (6003): Monitoring path: 'c:\testdir2', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | realtime'.
2020/12/05 12:05:23 wazuh-agent: INFO: (6003): Monitoring path: 'c:\testdir3', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | realtime'.
2020/12/05 12:05:23 wazuh-agent: INFO: (6003): Monitoring path: 'c:\testdir4', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | realtime'.
2020/12/05 12:05:23 wazuh-agent: INFO: (6206): Ignore 'file' entry 'e:\'
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- Memory tests for Windows
  - [x] Scan-build report

