### PR TITLE
Add minor fixes for 4.1.0 in Wazuh modules daemon

### DIFF
--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -27,7 +27,6 @@ int main(int argc, char **argv)
     int test_config = 0;
     wmodule *cur_module;
     gid_t gid;
-    const char *group = GROUPGLOBAL;
     wm_debug_level = getDefine_Int("wazuh_modules", "debug", 0, 2);
 
     /* Set the name */
@@ -66,17 +65,6 @@ int main(int argc, char **argv)
             nowDebug();
             wm_debug--;
         }
-    }
-
-    /* Check if the group given is valid */
-    gid = Privsep_GetGroup(group);
-    if (gid == (gid_t) - 1) {
-        merror_exit(USER_ERROR, "", group, strerror(errno), errno);
-    }
-
-    /* Privilege separation */
-    if (Privsep_SetGroup(gid) < 0) {
-        merror_exit(SETGID_ERROR, group, errno, strerror(errno));
     }
 
     // Setup daemon

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
     if (test_config)
         exit(EXIT_SUCCESS);
 
-    minfo("Process started.");
+    minfo(STARTUP_MSG, (int)getpid());
 
     // Run modules
 

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -26,7 +26,6 @@ int main(int argc, char **argv)
     int wm_debug = 0;
     int test_config = 0;
     wmodule *cur_module;
-    gid_t gid;
     wm_debug_level = getDefine_Int("wazuh_modules", "debug", 0, 2);
 
     /* Set the name */

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -38,7 +38,7 @@ void * wm_command_main(wm_command_t * command) {
     char * timestamp = NULL;
 
     if (!command->enabled) {
-        mtwarn(WM_COMMAND_LOGTAG, "Module command:%s is disabled. Exiting.", command->tag);
+        mtinfo(WM_COMMAND_LOGTAG, "Module command:%s is disabled. Exiting.", command->tag);
         pthread_exit(0);
     }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2966,7 +2966,7 @@ static void * wm_sca_request_thread(wm_sca_t * data) {
 
         But rest assured, if the fork dies the memory is recalled by the OS.
     */
-    os_calloc(OS_MAXSTR + 1,sizeof(char),buffer);
+    os_calloc(OS_MAXSTR + 1, sizeof(char), buffer);
 
     while (1) {
         if (recv = OS_RecvUnix(cfga_queue, OS_MAXSTR, buffer),recv) {
@@ -3023,6 +3023,7 @@ static void * wm_sca_request_thread(wm_sca_t * data) {
         }
     }
 
+    os_free(buffer);
     return NULL;
 }
 #endif

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2957,10 +2957,19 @@ static void * wm_sca_request_thread(wm_sca_t * data) {
     }
 
     int recv = 0;
-    char buffer[OS_MAXSTR + 1] = { '\0' };
+    char *buffer = NULL;
+
+    /* For he who seeks The Leak in here:
+        This buffer is going to report a leak whenever the process dies, as this function never returns
+        and its buffer is never released. Also, any forks() comming from the process that's started this
+        thread will report a leak here, as the leak has been inherited from the parent.
+
+        But rest assured, if the fork dies the memory is recalled by the OS.
+    */
+    os_calloc(OS_MAXSTR + 1,sizeof(char),buffer);
 
     while (1) {
-        if (recv = OS_RecvUnix(cfga_queue, OS_MAXSTR, buffer), recv) {
+        if (recv = OS_RecvUnix(cfga_queue, OS_MAXSTR, buffer),recv) {
             buffer[recv] = '\0';
 
             char *db = strchr(buffer,':');

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2957,19 +2957,10 @@ static void * wm_sca_request_thread(wm_sca_t * data) {
     }
 
     int recv = 0;
-    char *buffer = NULL;
-
-    /* For he who seeks The Leak in here:
-        This buffer is going to report a leak whenever the process dies, as this function never returns
-        and its buffer is never released. Also, any forks() comming from the process that's started this
-        thread will report a leak here, as the leak has been inherited from the parent.
-
-        But rest assured, if the fork dies the memory is recalled by the OS.
-    */
-    os_calloc(OS_MAXSTR + 1,sizeof(char),buffer);
+    char buffer[OS_MAXSTR + 1] = { '\0' };
 
     while (1) {
-        if (recv = OS_RecvUnix(cfga_queue, OS_MAXSTR, buffer),recv) {
+        if (recv = OS_RecvUnix(cfga_queue, OS_MAXSTR, buffer), recv) {
             buffer[recv] = '\0';
 
             char *db = strchr(buffer,':');

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -299,7 +299,7 @@ static int wm_sca_start(wm_sca_t * data) {
     char * timestamp = NULL;
 
     do {
-        const time_t time_sleep = sched_scan_get_time_until_next_scan(&(data->scan_config), WM_GCP_LOGTAG, data->scan_on_start);
+        const time_t time_sleep = sched_scan_get_time_until_next_scan(&(data->scan_config), WM_SCA_LOGTAG, data->scan_on_start);
 
         if (time_sleep) {
             const int next_scan_time = sched_get_next_scan_time(data->scan_config);

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -297,6 +297,8 @@ static void wm_sca_send_policies_scanned(wm_sca_t * data) {
 
 static int wm_sca_start(wm_sca_t * data) {
     char * timestamp = NULL;
+    time_t time_start = 0;
+    time_t duration = 0;
 
     do {
         const time_t time_sleep = sched_scan_get_time_until_next_scan(&(data->scan_config), WM_SCA_LOGTAG, data->scan_on_start);
@@ -309,6 +311,7 @@ static int wm_sca_start(wm_sca_t * data) {
             w_sleep_until(next_scan_time);
         }
         mtinfo(WM_SCA_LOGTAG,"Starting Security Configuration Assessment scan.");
+        time_start = time(NULL);
 
         /* Do scan for every policy file */
         wm_sca_read_files(data);
@@ -316,7 +319,8 @@ static int wm_sca_start(wm_sca_t * data) {
         /* Send policies scanned for database purge on manager side */
         wm_sca_send_policies_scanned(data);
 
-        mtinfo(WM_SCA_LOGTAG, "Security Configuration Assessment scan finished. Duration: %d seconds.", (int)time_sleep);
+        duration = time(NULL) - time_start;
+        mtinfo(WM_SCA_LOGTAG, "Security Configuration Assessment scan finished. Duration: %d seconds.", (int)duration);
 
     } while(FOREVER());
 


### PR DESCRIPTION
## Description

This pull request includes several minor fixes:

- Switch a warning to info message when the command module is disabled by configuration. To be consistent with the rest of the components. https://github.com/wazuh/wazuh/pull/7028/commits/8c8b1ec9d366524a33e662527ea740b26e8c8c67
- Fix a typo in the SCA tag when an interval overtaken happens. https://github.com/wazuh/wazuh/pull/7028/commits/be4428b35db954184d0b0d91830e933ce9a0bc71
- Freeing a buffer in SCA even it will never be freed since it is after a forever loop (just a visual change). https://github.com/wazuh/wazuh/pull/7028/commits/e8d9567da8fd6140263e201516065e234587a080
- Add PID to the starting log for Wazuh modules daemon. https://github.com/wazuh/wazuh/pull/7028/commits/e4529841875775827ae91f09f9bcb2a57696e171
```
2020/12/30 15:59:10 wazuh-modulesd: INFO: Started (pid: 81197).
```
- Remove duplicated group assignment when starting the Wazuh modules daemon. https://github.com/wazuh/wazuh/pull/7028/commits/33435c957bae47db81427de5c95b7b525a7e9187
- The SCA scan duration was not measured correctly, it always counted 0 seconds on the first scan. https://github.com/wazuh/wazuh/pull/7028/commits/d93a7bf169070efde863f0484abd94bba960564e
```
2020/12/30 15:59:18 sca: INFO: Security Configuration Assessment scan finished. Duration: 8 seconds.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- [x] Compilation in Linux
- [x] Source installation
- [x] Running an SCA scan to check everything work fine
- [x] Scan-build report
