### PR TITLE
Add Maltrail ruleset/decoder

### DIFF
--- a/ruleset/decoders/0510-maltrail_decoders.xml
+++ b/ruleset/decoders/0510-maltrail_decoders.xml
@@ -1,0 +1,24 @@
+<!--
+  -  Maltrail decoder
+  -  Author: Michael Muenz, Julián Morales
+  -  Updated by Wazuh, Inc.
+  -  Copyright (C) 2015-2020, Wazuh Inc.
+  -  Copyright (C) 2009 Trend Micro Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+<!--
+  - Will extract the srcip, srcport, dstip and dstport and also trail and category.
+  - Examples: Dec 23 14:55:34 OPNsense.localdomain CEF: 0|Maltrail|sensor|0.26.1|2020-12-23|long domain (suspicious)
+    |0|src=172.24.68.133 spt=55989 dst=8.8.8.8 dpt=53 trail=(q6pmisvlqpgxptq1s6psghvyoqali.uribl).rspamd.com ref=(heuristic)
+-->
+
+<decoder name="CEF">
+      <program_name>^CEF$</program_name>
+</decoder>
+
+<decoder name="CEF">
+      <parent>CEF</parent>
+      <regex>(\w+)\|(\w+)\|(\w+)\|(\.+)\|(\d+-\d+-\d+)\|(\.+)\|(\d+)\|src=(\d+.\d+.\d+.\d+) spt=(\.+) dst=(\d+.\d+.\d+.\d+) dpt=(\.+) trail=(\.+) ref=(\.+)</regex>
+      <order>code, application, type, version, date, category, severity, srcip, srcport, dstip, dstport, trail, ref</order>
+</decoder>

--- a/ruleset/rules/0705-maltrail_rules.xml
+++ b/ruleset/rules/0705-maltrail_rules.xml
@@ -1,0 +1,35 @@
+<!--
+  -  Maltrail rules
+  -  ID range: 64520 - 64530
+  -  Created by Michael Muenz
+  -  Copyright (C) 2015-2020, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
+
+</group>
+
+<group name="Maltrail,connection_attempt,">
+    <rule id="64520" level="0">
+        <decoded_as>CEF</decoded_as>
+        <description>Maltrail messages grouped.</description>
+    </rule>
+
+    <rule id="64521" level="3">
+        <if_sid>64520</if_sid>
+        <field name="severity">0</field>
+        <description>Low critical Maltrail event triggered</description>
+    </rule>
+
+    <rule id="64522" level="7">
+        <if_sid>64520</if_sid>
+        <field name="severity">1</field>
+        <description>Medium critical Maltrail event triggered</description>
+    </rule>
+
+    <rule id="64523" level="10">
+        <if_sid>64520</if_sid>
+        <field name="severity">2</field>
+        <description>High critical Maltrail event triggered</description>
+    </rule>
+
+</group>

--- a/ruleset/rules/0705-maltrail_rules.xml
+++ b/ruleset/rules/0705-maltrail_rules.xml
@@ -32,4 +32,13 @@
         <description>High critical Maltrail event triggered</description>
     </rule>
 
+    <rule id="64524" level="12" frequency="10" timeframe="120">
+        <if_matched_sid>64523</if_matched_sid>
+        <field name="severity">2</field>
+        <description>Too many critical Maltrail events triggered, possible infection detected.</description>
+        <mitre>
+            <id>T1584</id>
+        </mitre>
+    </rule>
+
 </group>


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

As already proposed here https://github.com/wazuh/wazuh-ruleset/pull/816 this is a new ruleset and decoder for open source software maltrail https://github.com/stamparm/maltrail

This decoder was done with help of Julián Morales here:
https://wazuh.slack.com/archives/C0A933R8E/p1608733841319200

I added 3 rules for different severities discussed with maltrail author here 

https://github.com/stamparm/maltrail/issues/13251

Would be nice for wazuh and maltrail community to have this native included :)
## Configuration options

## Logs/Alerts example

```
** Alert 1608899641.11816: - Maltrail,connection_attempt,
2020 Dec 25 13:34:01 OPNsense.localdomain->10.24.80.101
Rule: 64522 (level 7) -> 'Medium critical Maltrail event triggered'
Src IP: 172.24.68.133
Src Port: 52753
Dst IP: 8.8.8.8
Dst Port: 53
Dec 25 14:35:26 OPNsense.localdomain CEF:0|Maltrail|sensor|0.27.71|2020-12-25|long domain (suspicious)|1|src=172.24.68.133 spt=52753 dst=8.8.8.8 dpt=53 trail=(sdbsxsrbdbtxsdbsxdxdsffsxds).test.de ref=(heuristic)
code: 0
application: Maltrail
type: sensor
version: 0.27.71
date: 2020-12-25
category: long domain (suspicious)
severity: 1
trail: (sdbsxsrbdbtxsdbsxdxdsffsxds).test.de
ref: (heuristic)

```

```
** Alert 1608899654.12483: - Maltrail,connection_attempt,
2020 Dec 25 13:34:14 OPNsense.localdomain->10.24.80.101
Rule: 64523 (level 10) -> 'High critical Maltrail event triggered'
Src IP: 172.24.68.133
Src Port: -
Dst IP: 136.161.101.53
Dst Port: -
Dec 25 14:35:38 OPNsense.localdomain CEF:0|Maltrail|sensor|0.27.71|2020-12-25|sinkhole conficker (malware)|2|src=172.24.68.133 spt=- dst=136.161.101.53 dpt=- trail=136.161.101.53 ref=(static)
code: 0
application: Maltrail
type: sensor
version: 0.27.71
date: 2020-12-25
category: sinkhole conficker (malware)
severity: 2
trail: 136.161.101.53
ref: (static)
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [x] MAC OS X
- [X] Source installation
- [X] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
