### PR TITLE
SCA - CIS checks for apple macOS 10.14 Mojave

### DIFF
--- a/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
+++ b/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
@@ -56,7 +56,6 @@ checks:
     condition: all
     rules:
       - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -> 1'
-# bool or int? there is some incongruence between audit and remediation steps on benchmark doc.
 
 # jal - UPDATED
 # 1.3 Enable app update installs (Automated)
@@ -70,7 +69,6 @@ checks:
     condition: all
     rules:
       - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -> 1'
-# bool or int? there is some incongruence between audit and remediation steps on benchmark doc.
 
 # jal - UPDATED
 # 1.4 Enable app update installs (Automated)
@@ -84,7 +82,6 @@ checks:
     condition: all
     rules:
       - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> 1'
-# bool or int? there is some incongruence between audit and remediation steps on benchmark doc.
 
 # jal - 
 # 1.5 Enable system data files and security update installs (Automated)
@@ -136,7 +133,7 @@ checks:
     title: "Show Bluetooth status in menu bar"
     description: "By showing the Bluetooth status in the menu bar, a small Bluetooth icon is placed in the menu bar. This icon quickly shows the status of Bluetooth, and can allow the user to quickly turn Bluetooth on or off."
     rationale: "Enabling \"Show Bluetooth status in menu bar\" is a security awareness method that helps understand the current state of Bluetooth, including whether it is enabled, Discoverable, what paired devices exist and are currently active."
-    remediation: "Open a terminal session and enter the following command to enable Bluetooth status in the menu bar. sudo -u <username> defaults write /Users/<username>/Library/Preferences/com.apple.systemuiserver menuExtras - array-add "/System/Library/CoreServices/Menu Extras/Bluetooth.menu""
+    remediation: "Open a terminal session and enter the following command to enable Bluetooth status in the menu bar. sudo -u <username> defaults write /Users/<username>/Library/Preferences/com.apple.systemuiserver menuExtras - array-add \"/System/Library/CoreServices/Menu Extras/Bluetooth.menu\""
     compliance:
       - cis: ["2.1.2"]
     condition: any
@@ -182,7 +179,6 @@ checks:
     condition: all
     rules:
       - 'c:defaults -currentHost read com.apple.screensaver idleTime -> !r:does not exist'
-
 
 # jal 
 # 2.3.2 Secure screen saver corners (Automated) 
@@ -324,7 +320,7 @@ checks:
     rules:
       - 'not p:ARDAgent'
 
-# jal ***
+# jal
 # 2.4.10 Disable Content Caching (Automated)
   - id: 17021
     title: "Disable Content Caching"
@@ -336,19 +332,6 @@ checks:
     condition: all
     rules:
       - 'c:defaults read /Library/Preferences/com.apple.AssetCache.plist Activated -> 0'
-
-# jal - doesn't exists 
-# 2.5.1 Disable "Wake for network access" (Scored)
-  # - id: 9510 
-  #   title: "Disable \"Wake for network access\""
-  #   description: "This feature allows other users to be able to access your computer's shared resources, such as shared printers or iTunes playlists, even when your computer is in sleep mode. In a closed network when only authorized devices could wake a computer it could be valuable to wake computers in order to do management push activity. Where mobile workstations and agents exist the device will more likely check in to receive updates when already awake. Mobile devices should not be listening for signals on unmanaged network where untrusted devices could send wake signals."
-  #   rationale: "Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access."
-  #   remediation: "Run the following command in Terminal: sudo pmset -a womp 0"
-  #   compliance:
-  #     - cis: ["2.5.1"]
-  #   condition: none
-  #   rules:
-  #     - 'c:pmset -g -> r:womp && !r:\s0$'
 
 # jal 
 # 2.5.1.1 Enable FileVault (Automated)
@@ -444,15 +427,12 @@ checks:
     rules:
       - 'c:defaults read /Library/Application\ Support/CrashReporter/DiagnosticMessagesHistory.plist AutoSubmit -> 0'
 
-
 # jal 
 # not implemented - SCA Limit -> 2.5.9 Review Advertising settings (Manual)
 # jal not implemented -> 2.6.1 iCloud configuration (Manual)
 # jal not implemented -> 2.6.2 iCloud keychain (Manual)
 # jal not implemented -> 2.6.3 iCloud Drive (Manual)
 # jal not implemented -> 2.6.4 iCloud Drive Document and Desktop sync (Manual)
-
-
 
 # jal 
 # 2.7.1 Time Machine Auto-Backup (Automated) 
@@ -511,19 +491,6 @@ checks:
       - 'c:defaults read -app Terminal SecureKeyboardEntry -> 1'
       # - 'c:sudo -u <username> defaults read -app Terminal SecureKeyboardEntry -> 1'
 
-# jal -> doesn't exists
-# 2.11 Java 6 is not the default Java runtime (Scored)
-  # - id: 9516 
-  #   title: "Java 6 is not the default Java runtime"
-  #   description: "Apple had made Java part of the core Operating System for macOS. Apple is no longer providing Java updates for macOS and updated JREs and JDK are made available by Oracle.  The latest version of Java 6 made available by Apple has many unpatched vulnerabilities and should not be the default runtime for Java applets that request one from the Operating System"
-  #   rationale: "Java has been one of the most exploited environments and Java 6, which was provided as an OS component by Apple, is no longer maintained by Apple or Oracle. The old versions provided by Apple are both unsupported and missing the more modern security controls that have limited current exploits. The EOL version may still be installed and should be removed from the computer or not be in the default path."
-  #   remediation: "Java 6 can be removed completely or, if required Java applications will only work with Java 6, a custom path can be used. Apple is likely to finally pull the plug on Java 6 in upcoming macOS versions so any applications that still require Java 6 will likely soon be unavailable."
-  #   compliance:
-  #     - cis: ["2.11"]
-  #   condition: none
-  #   rules:
-  #     - 'c:/usr/libexec/java_home -> r:1.6.0'
-
 # jal
 # jal not implemented -> 2.11 Securely delete files as needed (Manual)
 
@@ -555,17 +522,6 @@ checks:
       - 'c:launchctl list -> r:com.apple.auditd'
 
 # jal not implemented -> 3.2 Configure Security Auditing Flags per local organizational requirements (Manual)
-# 3.2 Configure Security Auditing Flags (Scored)
-  # - id: 17035 
-  #   title: "Configure Security Auditing Flags"
-  #   description: "Auditing is the capture and maintenance of information about security-related events."
-  #   rationale: "Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises or attacks that have occurred, have begun, or are about to begin. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised."
-  #   remediation: "1. Open a terminal session and edit the /etc/security/audit_control file  2. Find the line beginning with \"flags\"  3. Add the following flags: lo, ad, fd, fm, -all.  4. Save the file."
-  #   compliance:
-  #     - cis: ["3.2"]
-  #   condition: all
-  #   rules:
-  #     - 'f:/etc/security/audit_control -> r:^flags && r:lo && r:ad && r:fd && r:fm && r:-all'
 
 # jal 
 # 3.3 Retain install.log for 365 or more days with no maximum size (Automated)
@@ -581,7 +537,7 @@ checks:
       - 'c:grep -i ttl /etc/asl/com.apple.install -> n:ttl\w+(\d+) compare > 365'
 
 # jal 
-# jal not implemented sca limit-> 3.4 Ensure security auditing retention (Automated) 17036
+# jal not implemented sca limit-> 3.4 Ensure security auditing retention (Automated) 
 
 # jal  
 # 3.5 Control access to audit records (Automated) 
@@ -657,7 +613,7 @@ checks:
       - 'f:/etc/exports'
 
 # jal 
-# jal not implemented - Users -> 5.1.1 Secure Home Folders (Automated) 17043
+# jal not implemented - Users -> 5.1.1 Secure Home Folders (Automated) 
 
 # jal 
 # 5.1.2 Check System Wide Applications for appropriate permissions (Automated) 
@@ -677,7 +633,7 @@ checks:
   - id: 17045 
     title: "Check System folder for world writable files"
     description: "Software sometimes insists on being installed in the /System Directory and have inappropriate world writable permissions."
-    rationale: "Folders in /System should not be world writable. The audit check excludes the "Drop Box" folder that is part of Apple's default user template."
+    rationale: "Folders in /System should not be world writable. The audit check excludes the \"Drop Box\" folder that is part of Apple's default user template."
     remediation: "Run the following command to set permissions so that folders are not world writable in the /System folder: sudo chmod -R o-w /Path/<baddirectory>"
     compliance:
       - cis: ["5.1.3"]
@@ -699,13 +655,13 @@ checks:
       - 'c:find /Library -type d -perm -2 -ls -> r:^$|Caches'
 
 # jal 
-# jal not implemented - SCA limit -> 5.2.1 Configure account lockout threshold (Automated) 17047
-# jal not implemented - SCA limit -> 5.2.2 Set a minimum password length (Automated) 17048
+# jal not implemented - SCA limit -> 5.2.1 Configure account lockout threshold (Automated) 
+# jal not implemented - SCA limit -> 5.2.2 Set a minimum password length (Automated) 
 # jal not implemented - SCA limit -> 5.2.4 Complex passwords must contain a Numeric Character (Manual)
 # jal not implemented - SCA limit -> 5.2.5 Complex passwords must contain a Special Character (Manual)
 # jal not implemented - SCA limit -> 5.2.6 Complex passwords must uppercase and lowercase letters (Manual)
-# jal not implemented - SCA limit -> 5.2.7 Password Age (Automated) 17049
-# jal not implemented - SCA limit -> 5.2.8 Password History (Automated) 17050
+# jal not implemented - SCA limit -> 5.2.7 Password Age (Automated) 
+# jal not implemented - SCA limit -> 5.2.8 Password History (Automated) 
 
 # jal 
 # 5.3 Reduce the sudo timeout period (Automated) 17051
@@ -724,7 +680,7 @@ checks:
 # jal not implemented - SCA Limit -> 5.4 Automatically lock the login keychain for inactivity (Manual) 
 
 # jal 
-# 5.5 Use a separate timestamp for each user/tty combo (Automated) 17052
+# 5.5 Use a separate timestamp for each user/tty combo (Automated) 
   - id: 17052
     title: "Use a separate timestamp for each user/tty combo"
     description: "Using tty tickets ensures that a user must enter the sudo password in each Terminal session. With sudo versions 1.8 and higher, introduced in 10.12, the default value is to have tty tickets for each interface so that root access is limited to a specific terminal. The default configuration can be overwritten or not configured correctly on earlier versions of macOS."
@@ -770,9 +726,9 @@ checks:
 # jal not implemented - Not a command - 5.9 Require a password to wake the computer from sleep or screen saver (Manual)
 
 # jal
-# jal not implemented - SCA Limit -> 5.10 Ensure system is set to hibernate (Automated) 17055
-# jal not implemented - SCA Limit -> 5.11 Require an administrator password to access system-wide preferences (Automated) 17056
-# jal not implemented - SCA Limit -> 5.12 Disable ability to login to another user's active and locked session (Automated) 17057 
+# jal not implemented - SCA Limit -> 5.10 Ensure system is set to hibernate (Automated) 
+# jal not implemented - SCA Limit -> 5.11 Require an administrator password to access system-wide preferences (Automated) 
+# jal not implemented - SCA Limit -> 5.12 Disable ability to login to another user's active and locked session (Automated)  
 
 # 5.13 Create a custom message for the Login Screen (Automated) 17058
   - id: 17058
@@ -798,7 +754,10 @@ checks:
     rules:
       - 'c:cat /Library/Security/PolicyBanner.* -> !r:^$'
 
-# jal not implemented - SCA Limit -> 5.15 Do not enter a password-related hint (Automated) 17060
+# jal 
+# not implemented - SCA Limit -> 5.15 Do not enter a password-related hint (Automated) 
+
+# jal
 # 5.16 Disable Fast User Switching (Manual)
   - id: 17070
     title: "Disable Fast User Switching" 
@@ -812,8 +771,9 @@ checks:
       - 'c:defaults read /Library/Preferences/.GlobalPreferences.plist MultipleSessionEnabled -> r:does not exist'
       - 'c:defaults read /Library/Preferences/.GlobalPreferences.plist MultipleSessionEnabled -> 0'
 
-# jal not implemented - process - 5.17 Secure individual keychains and items (Manual)
-# jal not implemented - process - 5.18 Create specialized keychains for different purposes (Manual)
+# jal 
+# not implemented - process - 5.17 Secure individual keychains and items (Manual)
+# not implemented - process - 5.18 Create specialized keychains for different purposes (Manual)
 
 # jal
 # 5.19 System Integrity Protection status (Automated)
@@ -827,7 +787,6 @@ checks:
     condition: all
     rules:
       - 'c:/usr/bin/csrutil status -> r:^System Integrity Protection status: enabled'
-
 
 # jal 
 # 6.1.1 Display login window as name and password (Automated) 17062

--- a/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
+++ b/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
@@ -829,9 +829,9 @@ checks:
     condition: any
     rules:
       - 'c:defaults read /Library/Preferences/com.apple.AppleFileServer guestAccess -> 0'
-      - 'defaults read /Library/Preferences/SystemConfiguration/com.apple.smb.server AllowGuestAccess -> 0'
+      - 'c:defaults read /Library/Preferences/SystemConfiguration/com.apple.smb.server AllowGuestAccess -> 0'
       - 'c:defaults read /Library/Preferences/com.apple.AppleFileServer guestAccess -> r:does not exist'
-      - 'defaults read /Library/Preferences/SystemConfiguration/com.apple.smb.server AllowGuestAccess -> r:does not exist'
+      - 'c:defaults read /Library/Preferences/SystemConfiguration/com.apple.smb.server AllowGuestAccess -> r:does not exist'
 
 # jal
 # 6.1.5 Remove Guest home folder (Automated)

--- a/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
+++ b/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
@@ -141,8 +141,7 @@ checks:
       - cis: ["2.1.2"]
     condition: any
     rules:
-      #- 'c:defaults read /Users/<username>/Library/Preferences/com.apple.systemuiserver menuExtras -> r:Bluetooth.menu'
-      - 'c:for d in /Users/*/ ; do (defaults read $d/Library/Preferences/com.apple.systemuiserver menuExtras); done -> r:Bluetooth.menu'
+      - 'c:defaults read /Users/<username>/Library/Preferences/com.apple.systemuiserver menuExtras -> r:Bluetooth.menu'
 
 
 # jal 
@@ -447,19 +446,7 @@ checks:
 
 
 # jal 
-# 2.5.9 Review Advertising settings (Manual)
-  - id: 17069 
-    title: "Review Advertising settings"
-    description: "Apple provides a framework that allows advertisers to target Apple users and end users to tailor their tolerance for what is shared with advertisers and what amount of targeting they will accept. While many people prefer that when they see advertising it is relevant to them and their interests the detailed information that is available with data mining collected information available in repositories to advertisers is often disconcerting."
-    rationale: "Organizations should manage user provacy settings on managed devices to align with organizational policies and user data protection requirements."
-    remediation: "For each needed user, run the following command to enable limited ad tracking: sudo -u <username> defaults -currentHost write /Users/<username>/Library/Preferences/com.apple.Adlib.plist forceLimitAdTracking -bool true"
-    compliance:
-      - cis: ["2.5.9"]
-    condition: all
-    rules:
-      - 'c:for d in /Users/*/ ; do (defaults read $d/Library/Preferences/com.apple.AdLib.plist forceLimitAdTracking); done -> n:(\d) compare != 1'
-
-
+# not implemented - SCA Limit -> 2.5.9 Review Advertising settings (Manual)
 # jal not implemented -> 2.6.1 iCloud configuration (Manual)
 # jal not implemented -> 2.6.2 iCloud keychain (Manual)
 # jal not implemented -> 2.6.3 iCloud Drive (Manual)
@@ -482,17 +469,6 @@ checks:
 
 # jal 
 # jal not implemented SCA limit -> 2.7.2 Time Machine Volumes Are Encrypted (Automated) 
-  # - id: 17029 
-  #   title: "Time Machine Volumes Are Encryptedp"
-  #   description: "One of the most important security tools for data protection on macOS is FileVault. With encryption in place it makes it difficult for an outside party to access your data if they get physical possession of the computer. One very large weakness in data protection with FileVault is the level of protection on backup volumes. If the internal drive is encrypted but the external backup volume that goes home in the same laptop bag is not it is self-defeating. Apple tries to make this mistake easily avoided by providing a checkbox to enable encryption when setting-up a time machine backup. Using this option does require some password management, particularly if a large drive is used with multiple computers. A unique complex password to unlock the drive can be stored in keychains on multiple systems for ease of use. While some portable drives may contain non-sensitive data and encryption may make interoperability with other systems difficult backup volumes should be protected just like boot volumes."
-  #   rationale: "Backup volumes need to be encrypted."
-  #   remediation: "You can set encryption through Disk Utility or diskutil in terminal."
-  #   compliance:
-  #     - cis: ["2.7.2"]
-  #   condition: all
-  #   rules:
-  #     - 'c:defaults read /Library/Preferences/com.apple.TimeMachine.plist AutoBackup -> 1'
-
 
 # jal 
 # 2.8 Disable Wake for network access (Automated) 

--- a/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
+++ b/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
@@ -128,18 +128,7 @@ checks:
       - 'c:system_profiler SPBluetoothDataType -> r:Connectable: Yes'
 
 # jal
-# 2.1.2 Show Bluetooth status in menu bar (Automated) 
-  - id: 17007
-    title: "Show Bluetooth status in menu bar"
-    description: "By showing the Bluetooth status in the menu bar, a small Bluetooth icon is placed in the menu bar. This icon quickly shows the status of Bluetooth, and can allow the user to quickly turn Bluetooth on or off."
-    rationale: "Enabling \"Show Bluetooth status in menu bar\" is a security awareness method that helps understand the current state of Bluetooth, including whether it is enabled, Discoverable, what paired devices exist and are currently active."
-    remediation: "Open a terminal session and enter the following command to enable Bluetooth status in the menu bar. sudo -u <username> defaults write /Users/<username>/Library/Preferences/com.apple.systemuiserver menuExtras - array-add \"/System/Library/CoreServices/Menu Extras/Bluetooth.menu\""
-    compliance:
-      - cis: ["2.1.2"]
-    condition: any
-    rules:
-      - 'c:defaults read /Users/<username>/Library/Preferences/com.apple.systemuiserver menuExtras -> r:Bluetooth.menu'
-
+# not implemented SCA Limit -> 2.1.2 Show Bluetooth status in menu bar (Automated) 
 
 # jal 
 # 2.2.1 Enable "Set time and date automatically" (Automated)
@@ -248,7 +237,7 @@ checks:
     compliance:
       - cis: ["2.4.4"]
     references:
-      - http://support.apple.com/kb/PH11450
+      - https://support.apple.com/kb/PH11450
     condition: all
     rules:
       - 'c:sudo system_profiler SPPrintersDataType | grep -e Sharing -> r:System Printer Sharing:\s*\t*Yes'
@@ -752,7 +741,7 @@ checks:
       - cis: ["5.14"]
     condition: all
     rules:
-      - 'c:cat /Library/Security/PolicyBanner.* -> !r:^$'
+      - 'd:/Library/Security -> r:^PolicyBanner'
 
 # jal 
 # not implemented - SCA Limit -> 5.15 Do not enter a password-related hint (Automated) 

--- a/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
+++ b/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
@@ -1,0 +1,950 @@
+# Security Configuration Assessment
+# CIS Checks for macOS 10.14
+# Copyright (C) 2015-2020, Wazuh Inc.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation
+#
+# Based on:
+# Center for Internet Security Apple macOS 10.14 Benchmark v1.0.0 - 11-09-2020
+
+policy:
+  id: "cis_apple_macos_10_14"
+  file: "cis_apple_macOS_10.14.yml"
+  name: "CIS Apple macOS 10.14 Benchmark"
+  description: "This document, CIS Apple macOS 10.14 Benchmark, provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 10.14. This guide was tested against Apple macOS 10.14."
+  references:
+    - https://www.cisecurity.org/cis-benchmarks/
+
+requirements:
+  title: "Check macOS version"
+  description: "Requirements for running the SCA scan against macOS 10.14 (Mojave)."
+  condition: any
+  rules:
+    - 'c:sw_vers -> r:^ProductVersion:\t*\s*10\p14'
+    - 'c:system_profiler SPSoftwareDataType -> r:System Version:\.*10\p14'
+    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\t*\s*10\p14'
+
+checks:
+# jal
+# 1.1 Verify all Apple provided software is current (Automated)
+  - id: 17000 
+    title: "Verify all Apple provided software is current"
+    description: "Software vendors release security patches and software updates for their products when security vulnerabilities are discovered. There is no simple way to complete this action without a network connection to an Apple software repository. Please ensure appropriate access for this control. This check is only for what Apple provides through software update."
+    rationale: "It is important that these updates be applied in a timely manner to prevent unauthorized persons from exploiting the identified vulnerabilities."
+    remediation: "1. In Terminal, run the following: softwareupdate -l    2. In Terminal, run the following for any packages that show up in step 1: sudo softwareupdate -i packagename"
+    compliance:
+      - cis: ["1.1"]
+    condition: all
+    rules:
+      - 'c:softwareupdate -l -> r:No new software available'
+
+# jal
+# 1.2 Enable Auto Update (Automated)
+  - id: 17001 
+    title: "Enable Auto Update"
+    description: "Auto Update verifies that your system has the newest security patches and software updates. If \"Automatically check for updates\" is not selected background updates for new malware definition files from Apple for XProtect and Gatekeeper will not occur."
+    rationale: "It is important that a system has the newest updates applied so as to prevent unauthorized persons from exploiting identified vulnerabilities."
+    remediation: "Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -bool true"
+    compliance:
+      - cis: ["1.2"]
+    references:
+      - https://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/
+      - https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -> 1'
+# bool or int? there is some incongruence between audit and remediation steps on benchmark doc.
+
+# jal - UPDATED
+# 1.3 Enable app update installs (Automated)
+  - id: 17002 
+    title: "Enable Download new updates when available"
+    description: "In the GUI both \"Install macOS updates\" and \"Install app updates from the App Store\" are dependent on whether \"Download new updates when available\" is selected"
+    rationale: "It is important that a system has the newest updates downloaded so that they can be applied."
+    remediation: "Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool true"
+    compliance:
+      - cis: ["1.3"]
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -> 1'
+# bool or int? there is some incongruence between audit and remediation steps on benchmark doc.
+
+# jal - UPDATED
+# 1.4 Enable app update installs (Automated)
+  - id: 17003
+    title: "Enable app update installs"
+    description: "Ensure that application updates are installed after they are available from Apple. These updates do not require reboots or admin privileges for end users."
+    rationale: "Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited."
+    remediation: "Open a terminal session and enter the following command to enable the auto update feature: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate - bool TRUE"
+    compliance:
+      - cis: ["1.4"]
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> 1'
+# bool or int? there is some incongruence between audit and remediation steps on benchmark doc.
+
+# jal - 
+# 1.5 Enable system data files and security update installs (Automated)
+  - id: 17004 
+    title: "Enable system data files and security update installs"
+    description: "Ensure that system and security updates are installed after they are available from Apple.  This setting enables definition updates for XProtect and Gatekeeper, with this setting in place new malware and adware that Apple has added to the list of malware or untrusted software will not execute. These updates do not require reboots or end user admin rights."
+    rationale: "Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited"
+    remediation: "Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true && sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true"
+    compliance:
+      - cis: ["1.5"]
+    references:
+      - https://www.thesafemac.com/tag/xprotect/
+      - https://support.apple.com/en-us/HT202491
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -> 1'
+      - 'c:defaults read /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -> 1'
+
+# jal - 
+# 1.6 Enable macOS update installs (Automated)
+  - id: 17005 
+    title: "Enable macOS update installs"
+    description: "Ensure that macOS updates are installed after they are available from Apple. This setting enables macOS updates to be automatically installed. Some environments will want to approve and test updates before they are delivered. It is best practice to test first where updates can and have caused disruptions to operations. Automatic updates should be turned off where changes are tightly controlled and there are mature testing and approval processes. Automatic updates should not be turned off so the admin can call the users first to let them know it's ok to install. A dependable repeatable process involving a patch agent or remote management tool should be in place before auto-updates are turned off."
+    rationale: "Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited"
+    remediation: "Open a terminal session and enter the following command to enable install system data files and security updates: sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate - bool TRUE"
+    compliance:
+      - cis: ["1.6"]
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> 1'
+
+# jal 
+# 2.1.1 Turn off Bluetooth, if no paired devices exist (Automated) 
+  - id: 17006
+    title: "Turn off Bluetooth, if no paired devices exist"
+    description: "Bluetooth devices use a wireless communications system that replaces the cables used by other peripherals to connect to a system. It is by design a peer-to-peer network technology and typically lacks centralized administration and security enforcement infrastructure."
+    rationale: "Bluetooth is particularly susceptible to a diverse set of security vulnerabilities involving identity detection, location tracking, denial of service, unintended control and access of data and voice channels, and unauthorized device control and data access."
+    remediation: "Open a terminal session and enter the following command to disable bluetooth: sudo defaults write /Library/Preferences/com.apple.Bluetooth ControllerPowerState -int 0 && sudo killall -HUP blued"
+    compliance:
+      - cis: ["2.1.1"]
+    condition: any
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.Bluetooth ControllerPowerState -> 0'
+      - 'c:system_profiler SPBluetoothDataType -> r:Connectable: Yes'
+
+# jal
+# 2.1.2 Show Bluetooth status in menu bar (Automated) 
+  - id: 17007
+    title: "Show Bluetooth status in menu bar"
+    description: "By showing the Bluetooth status in the menu bar, a small Bluetooth icon is placed in the menu bar. This icon quickly shows the status of Bluetooth, and can allow the user to quickly turn Bluetooth on or off."
+    rationale: "Enabling \"Show Bluetooth status in menu bar\" is a security awareness method that helps understand the current state of Bluetooth, including whether it is enabled, Discoverable, what paired devices exist and are currently active."
+    remediation: "Open a terminal session and enter the following command to enable Bluetooth status in the menu bar. sudo -u <username> defaults write /Users/<username>/Library/Preferences/com.apple.systemuiserver menuExtras - array-add "/System/Library/CoreServices/Menu Extras/Bluetooth.menu""
+    compliance:
+      - cis: ["2.1.2"]
+    condition: any
+    rules:
+      #- 'c:defaults read /Users/<username>/Library/Preferences/com.apple.systemuiserver menuExtras -> r:Bluetooth.menu'
+      - 'c:for d in /Users/*/ ; do (defaults read $d/Library/Preferences/com.apple.systemuiserver menuExtras); done -> r:Bluetooth.menu'
+
+
+# jal 
+# 2.2.1 Enable "Set time and date automatically" (Automated)
+  - id: 17008 
+    title: "Enable \"Set time and date automatically\""
+    description: "Correct date and time settings are required for authentication protocols, file creation, modification dates and log entries."
+    rationale: "Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes.  This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features."
+    remediation: "Run the following commands: sudo systemsetup -setnetworktimeserver <timeserver>    sudo systemsetup -setusingnetworktime on"
+    compliance:
+      - cis: ["2.2.1"]
+    condition: all
+    rules:
+      - 'c:systemsetup -getusingnetworktime -> r:Network Time:\s*\t*On'
+
+# jal
+# 2.2.2 Ensure time set is within appropriate limits (Automated)
+  - id: 17009 
+    title: "Ensure time set is within appropriate limits"
+    description: "Correct date and time settings are required for authentication protocols, file creation, modification dates and log entries. Ensure that time on the computer is within acceptable limits. Truly accurate time is measured within milliseconds, for this audit a drift under four and a half minutes passes the control check. Since Kerberos is one of the important features of macOS integration into Directory systems the guidance here is to warn you before there could be an impact to operations. From the perspective of accurate time this check is not strict, it may be too great for your organization, adjust to a smaller offset value as needed. Note: ntpdate has been deprecated with 10.14. sntp replaces that command."
+    rationale: "Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes. This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features. Audit check is for more than 4 minutes and 30 seconds ahead or behind."
+    remediation: "Run the following commands to ensure your time is set within an appropriate limit: sudo systemsetup -getnetworktimeserver -> Get the time server name and then run: sudo touch /var/db/ntp-kod && sudo chown root:wheel /var/db/ntp-kod && sudo sntp -sS <YOUR-TIME-SERVER> "
+    compliance:
+      - cis: ["2.2.2"]
+    condition: all
+    rules:
+      - 'c:systemsetup -getnetworktimeserver -> r:Network Time Server:'
+
+# jal
+# 2.3.1 Set an inactivity interval of 20 minutes or less for the screen saver (Automated) 
+  - id: 17010 
+    title: "Set an inactivity interval of 20 minutes or less for the screen saver"
+    description: "A locking screensaver is one of the standard security controls to limit access to a computer and the current user's session when the computer is temporarily unused or unattended. In macOS the screensaver starts after a value selected in a drop down menu, 10 minutes and 20 minutes are both options and either is acceptable. Any value can be selected through the command line or script but a number that is not reflected in the GUI can be problematic. 20 minutes is the default for new accounts."
+    rationale: "Setting an inactivity interval for the screensaver prevents unauthorized persons from viewing a system left unattended for an extensive period of time."
+    remediation: "Run the following command to verify that the idle time of the screen saver to 20 minutes or less (≤1200): sudo defaults -currentHost write com.apple.screensaver idleTime -int 600 "
+    compliance:
+      - cis: ["2.3.1"]
+    condition: all
+    rules:
+      - 'c:defaults -currentHost read com.apple.screensaver idleTime -> !r:does not exist'
+
+
+# jal 
+# 2.3.2 Secure screen saver corners (Automated) 
+  - id: 17011
+    title: "Secure screen saver corners" 
+    description: "Hot Corners can be configured to disable the screen saver by moving the mouse cursor to a corner of the screen."
+    rationale: "Setting a hot corner to disable the screen saver poses a potential security risk since an unauthorized person could use this to bypass the login screen and gain access to the system."
+    remediation: "Run the following command to turn off Disable Screen Saver for a Hot Corner: sudo -u <username> defaults write com.apple.dock <corner that is set to '6'> -int 0 "
+    compliance:
+      - cis: ["2.3.2"]
+    condition: all
+    rules:
+      - 'c:defaults read com.apple.dock wvous-tl-corner -> !r:^6$'
+      - 'c:defaults read com.apple.dock wvous-nl-corner -> !r:^6$'
+      - 'c:defaults read com.apple.dock wvous-tr-corner -> !r:^6$'
+      - 'c:defaults read com.apple.dock wvous-br-corner -> !r:^6$'
+
+# jal
+# jal not implemented -> 2.3.3 Familiarize users with screen lock tools or corner to Start Screen Saver (Manual)
+
+# jal 
+# 2.4.1 Disable Remote Apple Events (Automated)
+  - id: 17012
+    title: "Disable Remote Apple Events"
+    description: "Apple Events is a technology that allows one program to communicate with other programs. Remote Apple Events allows a program on one computer to communicate with a program on a different computer."
+    rationale: "Disabling Remote Apple Events mitigates the risk of an unauthorized program gaining access to the system."
+    remediation: "Run the following command in Terminal: sudo systemsetup -setremoteappleevents off"
+    compliance:
+      - cis: ["2.4.1"]
+    condition: all
+    rules:
+      - 'c:systemsetup -getremoteappleevents -> r:Remote Apple Events:\s*\t*Off'
+
+# jal 
+# 2.4.2 Disable Internet Sharing (Automated) 
+  - id: 17013
+    title: "Disable Internet Sharing"
+    description: "Internet Sharing uses the open source natd process to share an internet connection with other computers and devices on a local network. This allows the Mac to function as a router and share the connection to other, possibly unauthorized, devices."
+    rationale: "Disabling Internet Sharing reduces the remote attack surface of the system."
+    remediation: "Run the following command to turn off Internet Sharing: sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict Enabled -int 0"
+    compliance:
+      - cis: ["2.4.2"]
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/SystemConfiguration/com.apple.nat -> r:Enabled\s*\t*=\s*\t*1'
+
+# jal 
+# 2.4.3 Disable Screen Sharing (Automated) 
+  - id: 17014
+    title: "Disable Screen Sharing"
+    description: "Screen sharing allows a computer to connect to another computer on a network and display the computer’s screen. While sharing the computer’s screen, the user can control what happens on that computer, such as opening documents or applications, opening, moving, or closing windows, and even shutting down the computer."
+    rationale: "Disabling screen sharing mitigates the risk of remote connections being made without the user of the console knowing that they are sharing the computer."
+    remediation: "Run the following command to turn off Screen Sharing: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.screensharing.plist"
+    compliance:
+      - cis: ["2.4.3"]
+    condition: all
+    rules:
+      - 'c:launchctl load /System/Library/LaunchDaemons/com.apple.screensharing.plist -> r:Service is disabled'
+
+# jal 
+# 2.4.4 Disable Printer Sharing (Automated)
+  - id: 17015 
+    title: "Disable Printer Sharing"
+    description: "By enabling Printer sharing the computer is set up as a print server to accept print jobs from other computers. Dedicated print servers or direct IP printing should be used instead."
+    rationale: "Disabling Printer Sharing mitigates the risk of attackers attempting to exploit the print server to gain access to the system."
+    remediation: "Run the following command in Terminal: sudo cupsctl --no-share-printers"
+    compliance:
+      - cis: ["2.4.4"]
+    references:
+      - http://support.apple.com/kb/PH11450
+    condition: all
+    rules:
+      - 'c:sudo system_profiler SPPrintersDataType | grep -e Sharing -> r:System Printer Sharing:\s*\t*Yes'
+
+# jal
+# 2.4.5 Disable Remote Login (Automated)
+  - id: 17016 
+    title: "Disable Remote Login"
+    description: "Remote Login allows an interactive terminal connection to a computer."
+    rationale: "Disabling Remote Login mitigates the risk of an unauthorized person gaining access to the system via Secure Shell (SSH). While SSH is an industry standard to connect to posix servers, the scope of the benchmark is for Apple macOS clients, not servers. macOS does have an IP based firewall available (pf, ipfw has been deprecated) that is not enabled or configured. There are more details and links in section 7.5. macOS no longer has TCP Wrappers support built-in and does not have strong Brute-Force password guessing mitigations, or frequent patching of openssh by Apple. Most macOS computers are mobile workstations, managing IP based firewall rules on mobile devices can be very resource intensive. All of these factors can be parts of running a hardened SSH server."
+    remediation: "Run the following command in Terminal: sudo systemsetup -setremotelogin off"
+    compliance:
+      - cis: ["2.4.5"]
+    condition: all
+    rules:
+      - 'c:systemsetup -getremotelogin -> r:Remote Login:\s*\t*Off'
+
+# jal 
+# 2.4.6 Disable DVD or CD Sharing (Automated) 
+  - id: 17017 
+    title: "Disable DVD or CD Sharing"
+    description: "DVD or CD Sharing allows users to remotely access the system's optical drive."
+    rationale: "Disabling DVD or CD Sharing minimizes the risk of an attacker using the optical drive as a vector for attack and exposure of sensitive data."
+    remediation: "Run the following command to disable DVD or CD sharing: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.ODSAgent.plist"
+    compliance:
+      - cis: ["2.4.6"]
+    condition: all
+    rules:
+      - 'c:launchctl list -> r:ODSAgent'
+
+# jal
+# 2.4.7 Disable Bluetooth Sharing (Automated) 
+  - id: 17018 
+    title: "Disable Bluetooth Sharing "
+    description: "Bluetooth Sharing allows files to be exchanged with Bluetooth enabled devices."
+    rationale: "Disabling Bluetooth Sharing minimizes the risk of an attacker using Bluetooth to remotely attack the system."
+    remediation: "Perform the following to disable Bluetooth Sharing: Graphical Method: 1. Open System Preferences 2. Select Sharing 3. Uncheck Bluetooth Sharing"
+    compliance:
+      - cis: ["2.4.7"]
+    condition: all
+    rules:
+      - 'c:system_profiler SPBluetoothDataType -> !r:State:\s*\t*Enabled'
+
+# jal
+# 2.4.8 Disable File Sharing (Automated)
+  - id: 17019 
+    title: "Disable File Sharing"
+    description: "Apple's File Sharing uses a combination of SMB (Windows sharing) and AFP (Mac sharing)"
+    rationale: "By disabling file sharing, the remote attack surface and risk of unauthorized access to files stored on the system is reduced."
+    remediation: "Run the following command in Terminal to turn off AFP and SMB file sharing from the command line: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist && sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist"
+    compliance:
+      - cis: ["2.4.8"]
+    condition: none
+    rules:
+      - 'c:launchctl list -> r:AppleFileServer'
+      - 'f:/Library/Preferences/SystemConfiguration/com.apple.smb.server.plist -> r:\<array|\<Array|\<ARRAY'
+#      - 'c:sudo launchctl print-disabled system | grep com.apple.smbd -> r:\s*\t*com.apple.smbd'
+
+# jal 
+# 2.4.9 Disable Remote Management (Automated)
+  - id: 17020 
+    title: "Disable Remote Management"
+    description: "Remote Management is the client portion of Apple Remote Desktop (ARD). Remote Management can be used by remote administrators to view the current Screen, install software, report on, and generally manage client Macs. The screen sharing options in Remote Management are identical to those in the Screen Sharing section. In fact, only one of the two can be configured. If Remote Management is used, refer to the Screen Sharing section above on issues regard screen sharing. Remote Management should only be enabled when a Directory is in place to manage the accounts with access. Computers will be available on port 5900 on a macOS System and could accept connections from untrusted hosts depending on the configuration, definitely a concern for mobile systems."
+    rationale: "Remote management should only be enabled on trusted networks with strong user controls present in a Directory system. Mobile devices without strict controls are vulnerable to exploit and monitoring."
+    remediation: "Run the following command to disable remote management: sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources /kickstart -deactivate -stop"
+    compliance:
+      - cis: ["2.4.9"]
+    condition: all
+    rules:
+      - 'not p:ARDAgent'
+
+# jal ***
+# 2.4.10 Disable Content Caching (Automated)
+  - id: 17021
+    title: "Disable Content Caching"
+    description: "Starting with 10.13 (macOS High Sierra) Apple introduced a service to make it easier deploy data from Apple, including software updates, where there are bandwidth constraints to the Internet and fewer constraints and greater bandwidth on the local subnet. This capability can be very valuable for organizations that have throttled and possibly metered Internet connections. In heterogeneous enterprise networks with multiple subnets the effectiveness of this capability would be determined on how many Macs were on each subnet at the time new large updates were made available upstream. This capability requires the use of mac OS clients as P2P nodes for updated Apple content. Unless there is a business requirement to manage operational Internet connectivity bandwidth user endpoints should not store content and act as a cluster to provision data."
+    rationale: "The main use case for Mac computers is as mobile user endpoints. P2P sharing services should not be enabled on laptops that are using untrusted networks. Content Caching can allow a computer to be a server for local nodes on an untrusted network. While there are certainly logical controls that could be used to mitigate risk they add to the management complexity, since the value of the service is in specific use cases organizations with the use case described above can accept risk as necessary."
+    remediation: "Run the following command in to disable content caching: sudo AssetCacheManagerUtil deactivate"
+    compliance:
+      - cis: ["2.4.10"]
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.AssetCache.plist Activated -> 0'
+
+# jal - doesn't exists 
+# 2.5.1 Disable "Wake for network access" (Scored)
+  # - id: 9510 
+  #   title: "Disable \"Wake for network access\""
+  #   description: "This feature allows other users to be able to access your computer's shared resources, such as shared printers or iTunes playlists, even when your computer is in sleep mode. In a closed network when only authorized devices could wake a computer it could be valuable to wake computers in order to do management push activity. Where mobile workstations and agents exist the device will more likely check in to receive updates when already awake. Mobile devices should not be listening for signals on unmanaged network where untrusted devices could send wake signals."
+  #   rationale: "Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access."
+  #   remediation: "Run the following command in Terminal: sudo pmset -a womp 0"
+  #   compliance:
+  #     - cis: ["2.5.1"]
+  #   condition: none
+  #   rules:
+  #     - 'c:pmset -g -> r:womp && !r:\s0$'
+
+# jal 
+# 2.5.1.1 Enable FileVault (Automated)
+  - id: 17022 
+    title: "Enable FileVault"
+    description: "FileVault secures a system's data by automatically encrypting its boot volume and requiring a password or recovery key to access it. Filevault may also be enabled using command line using the fdesetup command. To use this functionality, consult the Der Flounder blog for more details: https://derflounder.wordpress.com/2015/02/02/managing-yosemites-filevault-2-with-fdesetup/ https://derflounder.wordpress.com/2019/01/15/unlock-or-decrypt-your-filevault-encrypted-boot-drive-from-the-command-line-on-macos-mojave/ "
+    rationale: "Encrypting sensitive data minimizes the likelihood of unauthorized users gaining access to it."
+    remediation: "1. Open System Preferences 2. Select Security & Privacy 3. Select FileVault 4. Select Turn on FileVault"
+    compliance:
+      - cis: ["2.5.1.1"]
+    condition: all
+    rules:
+      - 'c:fdesetup status -> r:^FileVault\s*\t*is\s*\t*On$'
+
+# jal 
+# jal not implemented SCA Limit -> 2.5.1.2 Ensure all user storage APFS volumes are encrypted (Manual)
+# jal not implemented SCA Limit -> 2.5.1.3 Ensure all user storage CoreStorage volumes are encrypted (Manual)
+
+# jal 
+# 2.5.2 Enable Gatekeeper (Automated)
+  - id: 17023 
+    title: "Enable Gatekeeper"
+    description: "Gatekeeper is Apple's application white-listing control that restricts downloaded applications from launching. It functions as a control to limit applications from unverified sources from running without authorization."
+    rationale: "Disallowing unsigned software will reduce the risk of unauthorized or malicious applications from running on the system."
+    remediation: "Run the following command in Terminal: sudo spctl --master-enable"
+    compliance:
+      - cis: ["2.5.2"]
+    condition: all
+    rules:
+      - 'c:spctl --status -> r:^assessments\s*\t*enabled$'
+
+# jal 
+# 2.5.3 Enable Firewall (Automated)
+  - id: 17024 
+    title: "Enable Firewall"
+    description: "A firewall is a piece of software that blocks unwanted incoming connections to a system.  Apple has posted general documentation about the application firewall."
+    rationale: "A firewall minimizes the threat of unauthorized users from gaining access to your system while connected to a network or the Internet."
+    remediation: "Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.alf globalstate - int <value>    Where <value> is: - 1 = on for specific services - 2 = on for essential services "
+    compliance:
+      - cis: ["2.5.3"]
+    references:
+      - https://support.apple.com/en-us/HT201642
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.alf globalstate -> r:^1$|^2$'
+
+# jal 
+# 2.5.4 Enable Firewall Stealth Mode (Automated)
+  - id: 17025 
+    title: "Enable Firewall Stealth Mode"
+    description: "While in Stealth mode the computer will not respond to unsolicited probes, dropping that traffic."
+    rationale: "Stealth mode on the firewall minimizes the threat of system discovery tools while connected to a network or the Internet."
+    remediation: "Run the following command in Terminal: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on"
+    compliance:
+      - cis: ["2.5.4"]
+    references:
+      - https://support.apple.com/en-us/HT201642
+    condition: all
+    rules:
+      - 'c:/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode -> r:^Stealth mode enabled'
+
+# jal 
+# jal not implemented N/A -> 2.5.5 Review Application Firewall Rules (Manual)
+
+# jal 
+# 2.5.6 Enable Location Services (Automated)
+  - id: 17026 
+    title: "Enable Location Services"
+    description: "macOS uses location information gathered through local Wi-Fi networks to enable applications to supply relevant information to users. Users do not need to change the time or the time zone, the computer will do it for them. They do not need to specify their location for weather or travel times and even get alerts on travel times to meetings and appointment where location information is supplied. For the purpose of asset management and time and log management with mobile computers location services simplify some processes.There are some use cases where it is important that the computer not be able to report it's exact location. While the general use case is to enable Location Services, it should not be allowed if the physical location of the computer and the user should not be public knowledge."
+    rationale: "Location services are helpful in most use cases and can simplify log and time management where computers change time zones."
+    remediation: "Run the following command to enable location services: sudo launchctl load /System/Library/LaunchDaemons/com.apple.locationd.plist"
+    compliance:
+      - cis: ["2.5.6"]
+    references:
+      - https://support.apple.com/en-us/HT204690
+    condition: all
+    rules:
+      - 'c:launchctl load /System/Library/LaunchDaemons/com.apple.locationd.plist -> r:service already loaded'
+
+# jal 
+# jal not implemented N/A -> 2.5.7 Monitor Location Services Access (Manual)
+
+# jal 
+# 2.5.8 Disable sending diagnostic and usage data to Apple (Automated) 17027
+  - id: 17027 
+    title: "Disable sending diagnostic and usage data to Apple"
+    description: "Apple provides a mechanism to send diagnostic and analytics data back to Apple to help them improve the platform. Information sent to Apple may contain internal organizational information that should be controlled and not available for processing by Apple. Turn off all Analytics and Improvements sharing."
+    rationale: "Organizations should have knowledge of what is shared with the vendor and the setting automatically forwards information to Apple."
+    remediation: "Run the following command in Terminal: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist"
+    compliance:
+      - cis: ["2.5.8"]
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Application\ Support/CrashReporter/DiagnosticMessagesHistory.plist AutoSubmit -> 0'
+
+
+# jal 
+# 2.5.9 Review Advertising settings (Manual)
+  - id: 17069 
+    title: "Review Advertising settings"
+    description: "Apple provides a framework that allows advertisers to target Apple users and end users to tailor their tolerance for what is shared with advertisers and what amount of targeting they will accept. While many people prefer that when they see advertising it is relevant to them and their interests the detailed information that is available with data mining collected information available in repositories to advertisers is often disconcerting."
+    rationale: "Organizations should manage user provacy settings on managed devices to align with organizational policies and user data protection requirements."
+    remediation: "For each needed user, run the following command to enable limited ad tracking: sudo -u <username> defaults -currentHost write /Users/<username>/Library/Preferences/com.apple.Adlib.plist forceLimitAdTracking -bool true"
+    compliance:
+      - cis: ["2.5.9"]
+    condition: all
+    rules:
+      - 'c:for d in /Users/*/ ; do (defaults read $d/Library/Preferences/com.apple.AdLib.plist forceLimitAdTracking); done -> n:(\d) compare != 1'
+
+
+# jal not implemented -> 2.6.1 iCloud configuration (Manual)
+# jal not implemented -> 2.6.2 iCloud keychain (Manual)
+# jal not implemented -> 2.6.3 iCloud Drive (Manual)
+# jal not implemented -> 2.6.4 iCloud Drive Document and Desktop sync (Manual)
+
+
+
+# jal 
+# 2.7.1 Time Machine Auto-Backup (Automated) 
+  - id: 17028 
+    title: "Time Machine Auto-Backup"
+    description: "Backup solutions are only effective if the backups run on a regular basis. The time to check for backups is before the hard drive fails or the computer goes missing. In order to simplify the user experience so that backups are more likely to occur Time Machine should be on and set to Back Up Automatically whenever the target volume is available. Operational staff should ensure that backups complete on a regular basis and the backups are tested to ensure that file restoration from backup is possible when needed. Backup dates are available even when the target volume is not available in the Time Machine plist. When the backup volume is connected to the computer more extensive information is available through tmutil. See man tmutil"
+    rationale: "Backups should automatically run whenever the backup drive is available."
+    remediation: "Run the following enable TimeMachine: sudo sudo tmutil setdestination -a /Volumes/<volumename> && sudo tmutil enable"
+    compliance:
+      - cis: ["2.7.1"]
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.TimeMachine.plist AutoBackup -> 1'
+
+# jal 
+# jal not implemented SCA limit -> 2.7.2 Time Machine Volumes Are Encrypted (Automated) 
+  # - id: 17029 
+  #   title: "Time Machine Volumes Are Encryptedp"
+  #   description: "One of the most important security tools for data protection on macOS is FileVault. With encryption in place it makes it difficult for an outside party to access your data if they get physical possession of the computer. One very large weakness in data protection with FileVault is the level of protection on backup volumes. If the internal drive is encrypted but the external backup volume that goes home in the same laptop bag is not it is self-defeating. Apple tries to make this mistake easily avoided by providing a checkbox to enable encryption when setting-up a time machine backup. Using this option does require some password management, particularly if a large drive is used with multiple computers. A unique complex password to unlock the drive can be stored in keychains on multiple systems for ease of use. While some portable drives may contain non-sensitive data and encryption may make interoperability with other systems difficult backup volumes should be protected just like boot volumes."
+  #   rationale: "Backup volumes need to be encrypted."
+  #   remediation: "You can set encryption through Disk Utility or diskutil in terminal."
+  #   compliance:
+  #     - cis: ["2.7.2"]
+  #   condition: all
+  #   rules:
+  #     - 'c:defaults read /Library/Preferences/com.apple.TimeMachine.plist AutoBackup -> 1'
+
+
+# jal 
+# 2.8 Disable Wake for network access (Automated) 
+  - id: 17030 
+    title: "Disable Wake for network access"
+    description: "This feature allows the computer to take action when the user is not present and the computer is in energy saving mode. These tools require FileVault to remain unlocked and fully rejoin known networks. Theie macOS feature is meant to allow the computer to resume activity as needed regardless of physical security controls. This feature allows other users to be able to access your computer’s shared resources, such as shared printers or iTunes playlists, even when your computer is in sleep mode. In a closed network when only authorized devices could wake a computer it could be valuable to wake computers in order to do management push activity. Where mobile workstations and agents exist the device will more likely check in to receive updates when already awake. Mobile devices should not be listening for signals on unmanaged network where untrusted devices could send wake signals."
+    rationale: "Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access."
+    remediation: "Run the following command to disable Wake for network access: sudo pmset -a womp 0 "
+    compliance:
+      - cis: ["2.8"]
+    condition: all
+    rules:
+      - 'c:pmset -g -> n:womp\s*\t*(\d) compare == 0'
+
+# jal 
+# 2.9 Disable Power Nap (Automated) 
+  - id: 17031 
+    title: "Disable Power Nap"
+    description: "This features allows the computer to take action when the user is not present and the computer is in energy saving mode. These tools require FileVault to remain unlocked and fully rejoin known networks. This macOS features are meant to allow the computer to resume activity as needed regardless of physical security controls. Power Nap allows the system to stay in low power mode, especially while on battery power and periodically connect to previously named networks with stored credentials for user applications to phone home and get updates. This capability requires FileVault to remain unlocked and the use of previously joined networks to be risk accepted based on the SSID without user input."
+    rationale: "Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access."
+    remediation: "Run the following command to disable Power Nap: sudo pmset -a powernap 0"
+    compliance:
+      - cis: ["2.9"]
+    condition: all
+    rules:
+      - 'c:pmset -g -> n:pwernap\s*\t*(\d) compare == 0'
+
+
+# jal - users
+# 2.10 Enable Secure Keyboard Entry in terminal.app (Automated)
+  - id: 17032 
+    title: "Enable Secure Keyboard Entry in terminal.app"
+    description: "Secure Keyboard Entry prevents other applications on the system and/or network from detecting and recording what is typed into Terminal."
+    rationale: "Enabling Secure Keyboard Entry minimizes the risk of a key logger from detecting what is entered in Terminal."
+    remediation: "Perform the following to implement the prescribed state: 1. Open Terminal 2. Select Terminal 3. Select Secure Keyboard Entry"
+    compliance:
+      - cis: ["2.10"]
+    condition: all
+    rules:
+      - 'c:defaults read -app Terminal SecureKeyboardEntry -> 1'
+      # - 'c:sudo -u <username> defaults read -app Terminal SecureKeyboardEntry -> 1'
+
+# jal -> doesn't exists
+# 2.11 Java 6 is not the default Java runtime (Scored)
+  # - id: 9516 
+  #   title: "Java 6 is not the default Java runtime"
+  #   description: "Apple had made Java part of the core Operating System for macOS. Apple is no longer providing Java updates for macOS and updated JREs and JDK are made available by Oracle.  The latest version of Java 6 made available by Apple has many unpatched vulnerabilities and should not be the default runtime for Java applets that request one from the Operating System"
+  #   rationale: "Java has been one of the most exploited environments and Java 6, which was provided as an OS component by Apple, is no longer maintained by Apple or Oracle. The old versions provided by Apple are both unsupported and missing the more modern security controls that have limited current exploits. The EOL version may still be installed and should be removed from the computer or not be in the default path."
+  #   remediation: "Java 6 can be removed completely or, if required Java applications will only work with Java 6, a custom path can be used. Apple is likely to finally pull the plug on Java 6 in upcoming macOS versions so any applications that still require Java 6 will likely soon be unavailable."
+  #   compliance:
+  #     - cis: ["2.11"]
+  #   condition: none
+  #   rules:
+  #     - 'c:/usr/libexec/java_home -> r:1.6.0'
+
+# jal
+# jal not implemented -> 2.11 Securely delete files as needed (Manual)
+
+# jal
+# 2.12 Ensure EFI version is valid and being regularly checked (Automated)
+  - id: 17033 
+    title: "Ensure EFI version is valid and being regularly checked"
+    description: "In order to mitigate firmware attacks Apple has created a automated Firmware check to ensure that the EFI version running is a known good version from Apple. There is also an automated process to check it every seven days."
+    rationale: "If the Firmware of a computer has been compromised the Operating System that the Firmware loads cannot be trusted either."
+    remediation: "If EFI does not pass the integrity check you may send a report to Apple. Backing up files and clean installing a known good Operating System and Firmware is recommended."
+    compliance:
+      - cis: ["2.12"]
+    condition: all
+    rules:
+      - 'c:/usr/libexec/firmwarecheckers/eficheck/eficheck --integrity-check -> r:Primary allowlist version match found. No changes detected in primary hashes'
+      - 'c:launchctl list -> r:^-\s*\t*0\s*\t*com.apple.driver.eficheck$'
+
+# jal
+# 3.1 Enable security auditing (Automated)
+  - id: 17034 
+    title: "Enable security auditing"
+    description: "macOS's audit facility, auditd, receives notifications from the kernel when certain system calls, such as open, fork, and exit, are made. These notifications are captured and written to an audit log."
+    rationale: "Logs generated by auditd may be useful when investigating a security incident as they may help reveal the vulnerable application and the actions taken by a malicious actor."
+    remediation: "Run the following command in Terminal: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist"
+    compliance:
+      - cis: ["3.1"]
+    condition: all
+    rules:
+      - 'c:launchctl list -> r:com.apple.auditd'
+
+# jal not implemented -> 3.2 Configure Security Auditing Flags per local organizational requirements (Manual)
+# 3.2 Configure Security Auditing Flags (Scored)
+  # - id: 17035 
+  #   title: "Configure Security Auditing Flags"
+  #   description: "Auditing is the capture and maintenance of information about security-related events."
+  #   rationale: "Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises or attacks that have occurred, have begun, or are about to begin. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised."
+  #   remediation: "1. Open a terminal session and edit the /etc/security/audit_control file  2. Find the line beginning with \"flags\"  3. Add the following flags: lo, ad, fd, fm, -all.  4. Save the file."
+  #   compliance:
+  #     - cis: ["3.2"]
+  #   condition: all
+  #   rules:
+  #     - 'f:/etc/security/audit_control -> r:^flags && r:lo && r:ad && r:fd && r:fm && r:-all'
+
+# jal 
+# 3.3 Retain install.log for 365 or more days with no maximum size (Automated)
+  - id: 17035
+    title: "Retain install.log for 365 or more days with no maximum size"
+    description: "macOS writes information pertaining to system-related events to the file /var/log/install.log and has a configurable retention policy for this file. The default logging setting limits the file size of the logs and the maximum size for all logs. The default allows for an errant application to fill the log files and does not enforce sufficient log retention. The Benchmark recommends a value based on standard use cases. The value should align with local requirements within the organization."
+    rationale: "Archiving and retaining install.log for at least a year is beneficial in the event of an incident as it will allow the user to view the various changes to the system along with the date and time they occurred."
+    remediation: "Perform the following to ensure that install logs are retained for at least 365 days:Edit the /etc/asl/com.apple.install file and add or modify the ttl value to 365 or greater on the file line. Also, remove the all_max= setting and value from the file line."
+    compliance:
+      - cis: ["3.3"]
+    condition: all
+    rules:
+      - 'c:grep -i ttl /etc/asl/com.apple.install -> n:ttl\w+(\d+) compare > 365'
+
+# jal 
+# jal not implemented sca limit-> 3.4 Ensure security auditing retention (Automated) 17036
+
+# jal  
+# 3.5 Control access to audit records (Automated) 
+  - id: 17037
+    title: "Control access to audit records"
+    description: "The audit system on macOS writes important operational and security information that can be both useful for an attacker and a place for an attacker to attempt to obfuscate unwanted changes that were recorded. As part of defense-in-depth the /etc/security/audit_control configuration and the files in /var/audit should be owned only by root with group wheel with read only rights and no other access allowed. macOS ACLs should not be used for these files."
+    rationale: "Audit records should never be changed except by the system daemon posting events. Records may be viewed or extracts manipulated but the authoritative files should be protected from unauthorized changes."
+    remediation: "Run the following to commands to set the audit records to the root user and wheel group:  sudo chown -R root:wheel /etc/security/audit_control && sudo chown -R root:wheel /var/audit/"
+    compliance:
+      - cis: ["3.5"]
+    condition: all
+    rules:
+      - 'c:ls -le /etc/security/audit_control -> r:root\s*\t*wheel|total'
+      - 'c:ls -le /var/audit/ -> r:root\s*\t*wheel|total'
+
+# jal 
+# 3.6 Ensure Firewall is configured to log (Automated) 
+  - id: 17038
+    title: "Ensure Firewall is configured to log"
+    description: "The socketfilter firewall is what is used when the firewall is turned on in the Security PreferencePane. In order to appropriately monitor what access is allowed and denied logging must be enabled."
+    rationale: "In order to troubleshoot the successes and failures of a firewall logging should be enabled."
+    remediation: "Run the following command to enable logging of the firewall: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setloggingmode on"
+    compliance:
+      - cis: ["3.6"]
+    condition: all
+    rules:
+      - 'c:/usr/libexec/ApplicationFirewall/socketfilterfw --getloggingmode -> r:Log mode is on'
+
+# jal 
+# 4.1 Disable Bonjour advertising service (Automated)
+  - id: 17039
+    title: "Disable Bonjour advertising service"
+    description: "Bonjour is an auto-discovery mechanism for TCP/IP devices which enumerate devices and services within a local subnet. DNS on macOS is integrated with Bonjour and should not be turned off, but the Bonjour advertising service can be disabled."
+    rationale: "Bonjour can simplify device discovery from an internal rogue or compromised host. An attacker could use Bonjour's multicast DNS feature to discover a vulnerable or poorly- configured service or additional information to aid a targeted attack. Implementing this control disables the continuous broadcasting of \"I'm here!\" messages. Typical end-user endpoints should not have to advertise services to other computers.. This setting does not stop the computer from sending out service discovery messages when looking for services on an internal subnet, if the computer is looking for a printer or server and using service discovery. To block all Bonjour traffic except to approved devices the pf or other firewall would be needed."
+    remediation: "Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -bool true"
+    compliance:
+      - cis: ["4.1"]
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -> 1'
+
+# jal 
+# jal not implemented -> 4.2 Enable "Show Wi-Fi status in menu bar" (Automated) 17040
+# jal not implemented -> 4.3 Create network specific locations (Manual)
+
+# jal 
+# 4.4 Ensure http server is not running (Automated)
+  - id: 17041 
+    title: "Ensure http server is not running"
+    description: "macOS used to have a graphical front-end to the embedded Apache web server in the Operating System. Personal web sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Personal web sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. Apache however is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end user computer.  Web sharing should only be done through hardened web servers and appropriate cloud services."
+    rationale: "Web serving should not be done from a user desktop. Dedicated webservers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer."
+    remediation: "Ensure that the Web Server is not running and is not set to start at boot Stop the Web Server: sudo apachectl stop    Ensure that the web server will not auto-start at boot sudo: defaults write /System/Library/LaunchDaemons/org.apache.httpd Disabled - bool true"
+    compliance:
+      - cis: ["4.4"]
+    condition: none
+    rules:
+      - 'p:httpd'
+      - 'p:/usr/sbin/httpd'
+
+# jal 
+# 4.5 Ensure nfs server is not running (Scored)
+  - id: 17042 
+    title: "Ensure nfs server is not running"
+    description: "macOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount shares and gain access to information from the user's computer. File sharing from a user endpoint has long been considered questionable and Apple has removed that capability from the GUI. NFSD is still part of the Operating System and can be easily turned on to export shares and provide remote connectivity to an end user computer."
+    rationale: "File serving should not be done from a user desktop, dedicated servers should be used.  Open ports make it easier to exploit the computer."
+    remediation: "Ensure that the NFS Server is not running and is not set to start at boot Stop the NFS Server: sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.nfsd.plist   Remove the exported Directory listing: sudo rm /etc/export"
+    compliance:
+      - cis: ["4.5"]
+    condition: none
+    rules:
+      - 'p:nfsd'
+      - 'p:/sbin/nfsd'
+      - 'f:/etc/exports'
+
+# jal 
+# jal not implemented - Users -> 5.1.1 Secure Home Folders (Automated) 17043
+
+# jal 
+# 5.1.2 Check System Wide Applications for appropriate permissions (Automated) 
+  - id: 17044 
+    title: "Check System Wide Applications for appropriate permissions"
+    description: "Applications in the System Applications Directory (/Applications) should be world executable since that is their reason to be on the system. They should not be world writable and allow any process or user to alter them for other processes or users to then execute modified versions"
+    rationale: "Unauthorized modifications of applications could lead to the execution of malicious code."
+    remediation: "Run the following command to change the permissions for each application that does not meet the requirements: sudo chmod -R o-w /Applications/<applicationname>"
+    compliance:
+      - cis: ["5.1.2"]
+    condition: all
+    rules:
+      - 'c:find /Applications -iname "*.app" -type d -perm -2 -ls -> r:^$'
+
+# jal  
+# 5.1.3 Check System folder for world writable files (Automated)
+  - id: 17045 
+    title: "Check System folder for world writable files"
+    description: "Software sometimes insists on being installed in the /System Directory and have inappropriate world writable permissions."
+    rationale: "Folders in /System should not be world writable. The audit check excludes the "Drop Box" folder that is part of Apple's default user template."
+    remediation: "Run the following command to set permissions so that folders are not world writable in the /System folder: sudo chmod -R o-w /Path/<baddirectory>"
+    compliance:
+      - cis: ["5.1.3"]
+    condition: all
+    rules:
+      - 'c:find /System -type d -perm -2 -ls -> r:^$|Public/Drop Box'
+
+# jal 
+# 5.1.4 Check Library folder for world writable files (Automated) 
+  - id: 17046 
+    title: "Check Library folder for world writable files"
+    description: "Software sometimes insists on being installed in the /Library Directory and have inappropriate world writable permissions."
+    rationale: "Folders in /Library should not be world writable. The audit check excludes the /Library/Caches folder where the sticky bit is set."
+    remediation: "Run the following command to set permissions so that folders are not world writable in the /Library folder: sudo chmod -R o-w /Library/<baddirectory>"
+    compliance:
+      - cis: ["5.1.4"]
+    condition: all
+    rules:
+      - 'c:find /Library -type d -perm -2 -ls -> r:^$|Caches'
+
+# jal 
+# jal not implemented - SCA limit -> 5.2.1 Configure account lockout threshold (Automated) 17047
+# jal not implemented - SCA limit -> 5.2.2 Set a minimum password length (Automated) 17048
+# jal not implemented - SCA limit -> 5.2.4 Complex passwords must contain a Numeric Character (Manual)
+# jal not implemented - SCA limit -> 5.2.5 Complex passwords must contain a Special Character (Manual)
+# jal not implemented - SCA limit -> 5.2.6 Complex passwords must uppercase and lowercase letters (Manual)
+# jal not implemented - SCA limit -> 5.2.7 Password Age (Automated) 17049
+# jal not implemented - SCA limit -> 5.2.8 Password History (Automated) 17050
+
+# jal 
+# 5.3 Reduce the sudo timeout period (Automated) 17051
+  - id: 17051 
+    title: "Reduce the sudo timeout period"
+    description: "The sudo command allows the user to run programs as the root user. Working as the root user allows the user an extremely high level of configurability within the system."
+    rationale: "The sudo command stays logged in as the root user for five minutes before timing out and re-requesting a password. This five minute window should be eliminated since it leaves the system extremely vulnerable. This is especially true if an exploit were to gain access to the system, since they would be able to make changes as a root user."
+    remediation: "Run the following command to edit the sudo settings: sudo visudo -> Add the line Defaults timestamp_timeout=0 in the Override built-in defaults section. "
+    compliance:
+      - cis: ["5.3"]
+    condition: all
+    rules:
+      - 'c:grep -e "timestamp" /etc/sudoers -> r:Defaults timestamp_timeout=0'
+
+# jal 
+# jal not implemented - SCA Limit -> 5.4 Automatically lock the login keychain for inactivity (Manual) 
+
+# jal 
+# 5.5 Use a separate timestamp for each user/tty combo (Automated) 17052
+  - id: 17052
+    title: "Use a separate timestamp for each user/tty combo"
+    description: "Using tty tickets ensures that a user must enter the sudo password in each Terminal session. With sudo versions 1.8 and higher, introduced in 10.12, the default value is to have tty tickets for each interface so that root access is limited to a specific terminal. The default configuration can be overwritten or not configured correctly on earlier versions of macOS."
+    rationale: "In combination with removing the sudo timeout grace period a further mitigation should be in place to reduce the possibility of a background process using elevated rights when a user elevates to root in an explicit context or tty. Additional mitigation should be in place to reduce the risk of privilege escalation of background processes."
+    remediation: "Run the following command to edit the sudo settings: sudo visudo -> Add the line Defaults timestamp_timeout=0 in the Override built-in defaults section. "
+    compliance:
+      - cis: ["5.3"]
+    condition: all
+    rules:
+      - 'c:grep -E -s "!tty_tickets" /etc/sudoers /etc/sudoers.d/* -> r:^$'
+      - 'c:grep -E -s "timestamp_type" /etc/sudoers /etc/sudoers.d/* -> r:^$|!timestamp_type=ppid|!timestamp_type=global'
+
+# jal 
+# jal not implemented - SCA Limit -> 5.6 Ensure login keychain is locked when the computer sleeps (Manual)
+
+# jal 
+# 5.7 Do not enable the "root" account (Automated)
+  - id: 17053 
+    title: "Do not enable the \"root\" account"
+    description: "The root account is a superuser account that has access privileges to perform any actions and read/write to any file on the computer. With some Linux distros the system administrator may commonly uses the root account to perform administrative functions."
+    rationale: "Enabling and using the root account puts the system at risk since any successful exploit or mistake while the root account is in use could have unlimited access privileges within the system. Using the sudo command allows users to perform functions as a root user while limiting and password protecting the access privileges. By default the root account is not enabled on a macOS computer. An administrator can escalate privileges using the sudo command (use -s or -i to get a root shell)."
+    remediation: "Open System Preferences, Uses & Groups. Click the lock icon to unlock it. In the Network Account Server section, click Join or Edit. Click Open Directory Utility. Click the lock icon to unlock it. Select the Edit menu > Disable Root User."
+    compliance:
+      - cis: ["5.7"]
+    condition: all
+    rules:
+      - 'c:dscl . -read /Users/root AuthenticationAuthority -> r:^No such key: AuthenticationAuthority'
+
+# jal 
+# 5.8 Disable automatic login (Automated)
+  - id: 17054 
+    title: "Disable automatic login"
+    description: "The automatic login feature saves a user's system access credentials and bypasses the login screen, instead the system automatically loads to the user's desktop screen."
+    rationale: "Disabling automatic login decreases the likelihood of an unauthorized person gaining access to a system."
+    remediation: "Run the following command in Terminal: sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser"
+    compliance:
+      - cis: ["5.8"]
+    condition: none
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.loginwindow -> r:autoLoginUser'
+
+# jal 
+# jal not implemented - Not a command - 5.9 Require a password to wake the computer from sleep or screen saver (Manual)
+
+# jal
+# jal not implemented - SCA Limit -> 5.10 Ensure system is set to hibernate (Automated) 17055
+# jal not implemented - SCA Limit -> 5.11 Require an administrator password to access system-wide preferences (Automated) 17056
+# jal not implemented - SCA Limit -> 5.12 Disable ability to login to another user's active and locked session (Automated) 17057 
+
+# 5.13 Create a custom message for the Login Screen (Automated) 17058
+  - id: 17058
+    title: "Create a custom message for the Login Screen" 
+    description: "An access warning informs the user that the system is reserved for authorized use only, and that the use of the system may be monitored."
+    rationale: "An access warning may reduce a casual attacker's tendency to target the system. Access warnings may also aid in the prosecution of an attacker by evincing the attacker's knowledge of the system's private status, acceptable use policy, and authorization requirements."
+    remediation: "Run the following command to enable a custom login screen message: sudo defaults write /Library/Preferences/com.apple.loginwindow LoginwindowText \"<custom.message>\""
+    compliance:
+      - cis: ["5.13"]
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.loginwindow.plist LoginwindowText -> !r:does not exist'
+
+# 5.14 Create a Login window banner (Automated) 17059
+  - id: 17059
+    title: "Create a Login window banner" 
+    description: "A Login window banner warning informs the user that the system is reserved for authorized use only. It enforces an acknowledgment by the user that they have been informed of the use policy in the banner if required. The system recognizes either the .txt and the .rtf formats."
+    rationale: "An access warning may reduce a casual attacker's tendency to target the system. Access warnings may also aid in the prosecution of an attacker by evincing the attacker's knowledge of the system's private status, acceptable use policy, and authorization requirements."
+    remediation: "Edit (or create) a PolicyBanner.txt or PolicyBanner.rtf file, in the /Library/Security/ folder, to include the required login window banner text."
+    compliance:
+      - cis: ["5.14"]
+    condition: all
+    rules:
+      - 'c:cat /Library/Security/PolicyBanner.* -> !r:^$'
+
+# jal not implemented - SCA Limit -> 5.15 Do not enter a password-related hint (Automated) 17060
+# 5.16 Disable Fast User Switching (Manual)
+  - id: 17070
+    title: "Disable Fast User Switching" 
+    description: "Fast user switching allows a person to quickly log in to the computer with a different account. While only a minimal security risk, when a second user is logged in, that user might be able to see what processes the first user is using, or possibly gain other information about the first user. In a large directory environment where it is difficult to limit login access many valid users can login to other user's assigned computers."
+    rationale: "Fast user switching allows multiple users to run applications simultaneously at console. There can be information disclosed about processes running under a different user. Without a specific configuration to save data and log out users can have unsaved data running in a background session that is not obvious."
+    remediation: "Run the following command to turn fast user switching off:  sudo defaults write /Library/Preferences/.GlobalPreferences MultipleSessionEnabled -bool false"
+    compliance:
+      - cis: ["5.16"]
+    condition: any
+    rules:
+      - 'c:defaults read /Library/Preferences/.GlobalPreferences.plist MultipleSessionEnabled -> r:does not exist'
+      - 'c:defaults read /Library/Preferences/.GlobalPreferences.plist MultipleSessionEnabled -> 0'
+
+# jal not implemented - process - 5.17 Secure individual keychains and items (Manual)
+# jal not implemented - process - 5.18 Create specialized keychains for different purposes (Manual)
+
+# jal
+# 5.19 System Integrity Protection status (Automated)
+  - id: 17061 
+    title: "System Integrity Protection status"
+    description: "System Integrity Protection is a security feature introduced in OS X 10.11 El Capitan. System Integrity Protection restricts access to System domain locations and restricts runtime attachment to system processes. Any attempt to attempt to inspect or attach to a system process will fail. Kernel Extensions are now restricted to /Library/Extensions and are required to be signed with a Developer ID."
+    rationale: "Running without System Integrity Protection on a production system runs the risk of the modification of system binaries or code injection of system processes that would otherwise be protected by SIP."
+    remediation: "Perform the following while booted in macOS Recovery Partition.  1. Select Terminal from the Utilities menu    2. Run the following command in Terminal: /usr/bin/csrutil enable    3. The output should be: Successfully enabled System Integrity Protection. Please restart the machine for the changes to take effect.    4. Reboot."
+    compliance:
+      - cis: ["5.19"]
+    condition: all
+    rules:
+      - 'c:/usr/bin/csrutil status -> r:^System Integrity Protection status: enabled'
+
+
+# jal 
+# 6.1.1 Display login window as name and password (Automated) 17062
+  - id: 17062
+    title: "Display login window as name and password"
+    description: "The login window prompts a user for his/her credentials, verifies their authorization level and then allows or denies the user access to the system."
+    rationale: "Prompting the user to enter both their username and password makes it twice as hard for unauthorized users to gain access to the system since they must discover two attributes."
+    remediation: "Run the following command to enable the login window to display name and password: sudo defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true"
+    compliance:
+      - cis: ["6.1.1"]
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -> 1'
+
+# jal 
+# 6.1.2 Disable "Show password hints" (Automated) 17063
+  - id: 17063
+    title: "Disable \"Show password hints\""
+    description: "Password hints are user created text displayed when an incorrect password is used for an account."
+    rationale: "Password hints make it easier for unauthorized persons to gain access to systems by providing information to anyone that the user provided to assist remembering the password. This info could include the password itself or other information that might be readily discerned with basic knowledge of the end user."
+    remediation: "Run the following command to disable password hints: sudo defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 0"
+    compliance:
+      - cis: ["6.1.2"]
+    condition: any
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.loginwindow RetriesUntilHint -> 0'
+      - 'c:defaults read /Library/Preferences/com.apple.loginwindow RetriesUntilHint -> r:does not exist'
+
+# jal 
+# 6.1.3 Disable guest account login (Automated)
+  - id: 17064 
+    title: "Disable guest account login"
+    description: "The guest account allows users access to the system without having to create an account or password. Guest users are unable to make setting changes, cannot remotely login to the system and all created files, caches, and passwords are deleted upon logging out."
+    rationale: "Disabling the guest account mitigates the risk of an untrusted user doing basic reconnaissance and possibly using privilege escalation attacks to take control of the system."
+    remediation: "Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled - bool false"
+    compliance:
+      - cis: ["6.1.3"]
+    condition: all
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -> 0'
+
+# jal 
+# 6.1.4 Disable "Allow guests to connect to shared folders" (Automated) 17065
+  - id: 17065 
+    title: "Disable \"Allow guests to connect to shared folders\""
+    description: "Allowing guests to connect to shared folders enables users to access selected shared folders and their contents from different computers on a network."
+    rationale: "Not allowing guests to connect to shared folders mitigates the risk of an untrusted user doing basic reconnaissance and possibly use privilege escalation attacks to take control of the system."
+    remediation: "Run the following command in Terminal: sudo defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled - bool false"
+    compliance:
+      - cis: ["6.1.4"]
+    condition: any
+    rules:
+      - 'c:defaults read /Library/Preferences/com.apple.AppleFileServer guestAccess -> 0'
+      - 'defaults read /Library/Preferences/SystemConfiguration/com.apple.smb.server AllowGuestAccess -> 0'
+      - 'c:defaults read /Library/Preferences/com.apple.AppleFileServer guestAccess -> r:does not exist'
+      - 'defaults read /Library/Preferences/SystemConfiguration/com.apple.smb.server AllowGuestAccess -> r:does not exist'
+
+# jal
+# 6.1.5 Remove Guest home folder (Automated)
+  - id: 17066 
+    title: "Remove Guest home folder"
+    description: "In the previous two controls the guest account login has been disabled and sharing to guests has been disabled as well. There is no need for the legacy Guest home folder to remain in the file system. When normal user accounts are removed you have the option to archive it, leave it in place or delete. In the case of the guest folder the folder remains in place without a GUI option to remove it. If at some point in the future a Guest account is needed it will be re-created. The presence of the Guest home folder can cause automated audits to fail when looking for compliant settings within all User folders as well. Rather than ignoring the folders continued existence it is best removed."
+    rationale: "The Guest home folders are unneeded after the Guest account is disabled and could be used inappropriately."
+    remediation: "1. Run the following command in Terminal: sudo rm -R /Users/Guest  2. Make sure there is no output"
+    compliance:
+      - cis: ["6.1.5"]
+    condition: none
+    rules:
+      - 'd:/Users/Guest'
+
+# jal 
+# 6.2 Turn on filename extensions (Automated)
+  - id: 17067 
+    title: "Turn on filename extensions"
+    description: "A filename extension is a suffix added to a base filename that indicates the base filename's file format."
+    rationale: "Visible filename extensions allows the user to identify the file type and the application it is associated with which leads to quick identification of misrepresented malicious files."
+    remediation: "Perform the following to implement the prescribed state: 1. Select Finder 2. Select Preferences 3. Check Show all filename extensions    Alternatively, use the following command: defaults write NSGlobalDomain AppleShowAllExtensions -bool true"
+    compliance:
+      - cis: ["6.2"]
+    condition: all
+    rules:
+      - 'c:defaults read NSGlobalDomain AppleShowAllExtensions -> 1'
+      # - 'c:defaults read /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -> 1'
+
+# jal 
+# 6.3 Disable the automatic run of safe files in Safari (Automated)
+  - id: 17068 
+    title: "Disable the automatic run of safe files in Safari"
+    description: "Safari will automatically run or execute what it considers safe files. This can include installers and other files that execute on the operating system. Safari bases file safety by using a list of filetypes maintained by Apple. The list of files include text, image, video and archive formats that would be run in the context of the OS rather than the browser."
+    rationale: "Hackers have taken advantage of this setting via drive-by attacks. These attacks occur when a user visits a legitimate website that has been corrupted. The user unknowingly downloads a malicious file either by closing an infected pop-up or hovering over a malicious banner. An attacker can create a malicious file that will fall within Safari's safe file list that will download and execute without user input."
+    remediation: "Perform the following to implement the prescribed state: 1. Open Safari 2. Select Safari from the menu bar 3. Select Preferences 4. Select General 5. Uncheck Open \"safe\" files after downloading    Alternatively run the following command in Terminal: defaults write com.apple.Safari AutoOpenSafeDownloads -boolean no"
+    compliance:
+      - cis: ["6.3"]
+    condition: all
+    rules:
+      - 'c:defaults read com.apple.Safari AutoOpenSafeDownloads -> 0'


### PR DESCRIPTION
|Related issue|
|---|
|#7013|

## Description

Added yml file with CIS checks for Apple macOS 10.14 

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
