### PR TITLE
Adding some support for Arch Linux agent

### DIFF
--- a/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
+++ b/etc/templates/config/generic/wodle-vulnerability-detector.manager.template
@@ -32,6 +32,13 @@
       <update_interval>1h</update_interval>
     </provider>
 
+    <!-- Arch OS vulnerabilities -->  
+    <provider name="arch">
+      <enabled>no</enabled>
+      <os>rolling</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
     <!-- Windows OS vulnerabilities -->
     <provider name="msu">
       <enabled>yes</enabled>

--- a/install.sh
+++ b/install.sh
@@ -102,10 +102,6 @@ Install()
         LIB_FLAG="USE_FRAMEWORK_LIB=yes"
     fi
 
-    if [ "X${DIST_NAME}" = "Xarch" ]; then
-        ALPM_FLAG="USE_ALPM=yes"
-    fi
-
     # Makefile
     echo " - ${runningmake}"
     echo ""

--- a/install.sh
+++ b/install.sh
@@ -102,6 +102,10 @@ Install()
         LIB_FLAG="USE_FRAMEWORK_LIB=yes"
     fi
 
+    if [ "X${DIST_NAME}" = "Xarch" ]; then
+        ALPM_FLAG="USE_ALPM=yes"
+    fi
+
     # Makefile
     echo " - ${runningmake}"
     echo ""
@@ -119,7 +123,7 @@ Install()
 
         # Add DATABASE=pgsql or DATABASE=mysql to add support for database
         # alert entry
-        ${MAKEBIN} PREFIX=${INSTALLDIR} TARGET=${INSTYPE} ${SYSC_FLAG} ${MSGPACK_FLAG} ${AUDIT_FLAG} ${LIB_FLAG} ${CPYTHON_FLAGS} -j${THREADS} build
+        ${MAKEBIN} PREFIX=${INSTALLDIR} TARGET=${INSTYPE} ${SYSC_FLAG} ${MSGPACK_FLAG} ${AUDIT_FLAG} ${ALPM_FLAG} ${LIB_FLAG} ${CPYTHON_FLAGS} -j${THREADS} build
 
         if [ $? != 0 ]; then
             cd ../

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,6 +34,8 @@ EXTERNAL_LIBPCRE2=external/libpcre2/
 ifneq (${TARGET},winagent)
 EXTERNAL_PROCPS=external/procps/
 EXTERNAL_LIBDB=external/libdb/build_unix/
+EXTERNAL_PACMAN=external/pacman-5.2.2/
+EXTERNAL_LIBARCHIVE=external/libarchive-3.5.1/
 endif
 # XXX Becareful NO EXTRA Spaces here
 PREFIX?=/var/ossec
@@ -52,7 +54,6 @@ SELINUX_POLICY=selinux/wazuh.pp
 USE_PRELUDE?=no
 USE_ZEROMQ?=no
 USE_GEOIP?=no
-USE_ALPM?=no
 USE_INOTIFY=no
 USE_BIG_ENDIAN=no
 USE_AUDIT=no
@@ -89,7 +90,7 @@ ifneq (${TARGET},winagent)
 ifeq (${uname_S},Linux)
 		DEFINES+=-DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE
 #		DEFINES+=-DUSE_MAGIC
-		OSSEC_CFLAGS+=-pthread -I${EXTERNAL_LIBDB}
+		OSSEC_CFLAGS+=-pthread -I${EXTERNAL_LIBDB} -I${EXTERNAL_PACMAN}lib/libalpm/ -I${EXTERNAL_LIBARCHIVE}
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 		OSSEC_LIBS+=-lrt -ldl -lm
 #		OSSEC_LDFLAGS+=-lmagic
@@ -347,11 +348,6 @@ ifneq (,$(filter ${USE_GEOIP},YES auto yes y Y 1))
 	OSSEC_LIBS+=-lGeoIP
 endif # USE_GEOIP
 
-ifneq (,$(filter ${USE_ALPM},YES auto yes y Y 1))
-	DEFINES+=-DLIBALPM
-	OSSEC_LIBS+=-lalpm
-endif # USE_ALPM
-
 MI :=
 PI :=
 ifdef DATABASE
@@ -499,9 +495,6 @@ help: failtarget
 	@echo "Geoip support: "
 	@echo "   make USE_GEOIP=yes           Build with GeoIP support. Allowed values are auto 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo
-	@echo "Arch Linux support: "
-	@echo "   make USE_ALPM=yes            Build with Arch Linux agent support. Allowed values are auto 1, yes, YES, y and Y, otherwise, the flag is ignored"
-	@echo
 	@echo "User options: "
 	@echo "   make OSSEC_GROUP=ossec       Set ossec group"
 	@echo "   make OSSEC_USER=ossec        Set ossec user"
@@ -533,7 +526,6 @@ settings:
 	@echo "USE settings:"
 	@echo "    USE_ZEROMQ:         ${USE_ZEROMQ}"
 	@echo "    USE_GEOIP:          ${USE_GEOIP}"
-	@echo "    USE_ALPM:           ${USE_ALPM}"
 	@echo "    USE_PRELUDE:        ${USE_PRELUDE}"
 	@echo "    USE_INOTIFY:        ${USE_INOTIFY}"
 	@echo "    USE_BIG_ENDIAN:     ${USE_BIG_ENDIAN}"
@@ -666,6 +658,8 @@ SQLITE_LIB  = $(EXTERNAL_SQLITE)libsqlite3.a
 JSON_LIB    = $(EXTERNAL_JSON)libcjson.a
 PROCPS_LIB  = $(EXTERNAL_PROCPS)/libproc.a
 DB_LIB      = $(EXTERNAL_LIBDB).libs/libdb-6.2.a
+PACMAN_LIB  = $(EXTERNAL_PACMAN)lib/libalpm/.libs/libalpm.a
+LIBARCHIVE_LIB  = $(EXTERNAL_LIBARCHIVE).libs/libarchive.a
 LIBYAML_LIB = $(EXTERNAL_LIBYAML)src/.libs/libyaml.a
 LIBCURL_LIB = $(EXTERNAL_CURL)lib/.libs/libcurl.a
 AUDIT_LIB = $(EXTERNAL_AUDIT)lib/.libs/libaudit.a
@@ -686,7 +680,7 @@ ifneq (,$(filter ${USE_AUDIT},YES yes y Y 1))
 EXTERNAL_LIBS += ${AUDIT_LIB}
 endif
 
-EXTERNAL_LIBS += $(PROCPS_LIB) $(DB_LIB)
+EXTERNAL_LIBS += $(PROCPS_LIB) $(DB_LIB) $(PACMAN_LIB) $(LIBARCHIVE_LIB)
 endif
 endif
 ifeq (${uname_S},Darwin)
@@ -852,6 +846,26 @@ $(EXTERNAL_LIBDB)Makefile:
 	cd ${EXTERNAL_LIBDB} && CPPFLAGS=-fPIC ../dist/configure --with-cryptography=no --disable-queue --disable-heap --disable-partition --disable-mutexsupport --disable-replication --disable-verify --disable-statistics
 endif
 
+#### libarchive ######
+
+ifeq (${uname_S},Linux)
+${LIBARCHIVE_LIB}: $(EXTERNAL_LIBARCHIVE)Makefile
+	 ${MAKE} -C $(EXTERNAL_LIBARCHIVE)
+
+$(EXTERNAL_LIBARCHIVE)Makefile:
+	cd ${EXTERNAL_LIBARCHIVE} && CPPFLAGS=-fPIC ./configure --disable-acl --without-expat --without-iconv --without-xml2 --without-lz4 --without-lzma --without-zstd --without-bz2lib
+endif
+
+#### Pacman ######
+
+ifeq (${uname_S},Linux)
+${PACMAN_LIB}: $(EXTERNAL_PACMAN)Makefile
+	 ${MAKE} -C $(EXTERNAL_PACMAN)/lib/libalpm
+
+$(EXTERNAL_PACMAN)Makefile:
+	cd ${EXTERNAL_PACMAN} && ./autogen.sh && CPPFLAGS=-fPIC ./configure --without-gpgme --without-libcurl
+endif
+
 #### Audit lib ####
 
 ${AUDIT_LIB}: $(EXTERNAL_AUDIT)Makefile
@@ -925,7 +939,7 @@ endif
 endif
 
 
-EXTERNAL_RES := cJSON $(CPYTHON) curl libdb libffi libyaml openssl procps sqlite zlib audit-userspace msgpack bzip2 libpcre2 libplist
+EXTERNAL_RES := cJSON $(CPYTHON) curl libdb libffi libyaml pacman libarchive openssl procps sqlite zlib audit-userspace msgpack bzip2 libpcre2 libplist
 EXTERNAL_DIR :=  $(EXTERNAL_RES:%=external/%)
 EXTERNAL_TAR := $(EXTERNAL_RES:%=external/%.tar.gz)
 
@@ -933,6 +947,18 @@ VULN_DETECTOR_DIR := wazuh_modules/vulnerability_detector
 
 .PHONY: deps
 deps: $(EXTERNAL_TAR)
+
+external/libarchive.tar.gz:
+	$(CURL) $@ https://www.libarchive.org/downloads/libarchive-3.5.1.tar.gz
+	cd external && $(GUNZIP) $(patsubst external/%,%,$@)
+	cd external && $(TAR) $(patsubst external/%.gz,%,$@)
+	rm $(patsubst %.gz,%,$@)
+
+external/pacman.tar.gz:
+	$(CURL) $@ https://git.archlinux.org/pacman.git/snapshot/pacman-5.2.2.tar.gz
+	cd external && $(GUNZIP) $(patsubst external/%,%,$@)
+	cd external && $(TAR) $(patsubst external/%.gz,%,$@)
+	rm $(patsubst %.gz,%,$@)
 
 external/$(CPYTHON).tar.gz:
 ifneq (,$(PRECOMPILED_RES))
@@ -1958,6 +1984,14 @@ ifneq ($(wildcard external/*/*),)
 
 ifneq ($(wildcard external/libdb/build_unix/*),)
 	cd ${EXTERNAL_LIBDB} && ${MAKE} realclean
+endif
+
+ifneq ($(wildcard external/libarchive-3.5.1/*),)
+	cd ${EXTERNAL_LIBARCHIVE} && ${MAKE} clean
+endif
+
+ifneq ($(wildcard external/pacman-5.2.2/*),)
+	cd ${EXTERNAL_PACMAN} && ${MAKE} clean
 endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -90,7 +90,7 @@ ifneq (${TARGET},winagent)
 ifeq (${uname_S},Linux)
 		DEFINES+=-DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE
 #		DEFINES+=-DUSE_MAGIC
-		OSSEC_CFLAGS+=-pthread -I${EXTERNAL_LIBDB} -I${EXTERNAL_PACMAN}lib/libalpm/ -I${EXTERNAL_LIBARCHIVE}
+		OSSEC_CFLAGS+=-pthread -I${EXTERNAL_LIBDB} -I${EXTERNAL_PACMAN}lib/libalpm/ -I${EXTERNAL_LIBARCHIVE}libarchive
 		OSSEC_LDFLAGS+='-Wl,-rpath,$$ORIGIN/../lib'
 		OSSEC_LIBS+=-lrt -ldl -lm
 #		OSSEC_LDFLAGS+=-lmagic
@@ -658,7 +658,7 @@ SQLITE_LIB  = $(EXTERNAL_SQLITE)libsqlite3.a
 JSON_LIB    = $(EXTERNAL_JSON)libcjson.a
 PROCPS_LIB  = $(EXTERNAL_PROCPS)/libproc.a
 DB_LIB      = $(EXTERNAL_LIBDB).libs/libdb-6.2.a
-PACMAN_LIB  = $(EXTERNAL_PACMAN)lib/libalpm/.libs/libalpm.a
+LIBALPM_LIB  = $(EXTERNAL_PACMAN)lib/libalpm/libalpm.a
 LIBARCHIVE_LIB  = $(EXTERNAL_LIBARCHIVE).libs/libarchive.a
 LIBYAML_LIB = $(EXTERNAL_LIBYAML)src/.libs/libyaml.a
 LIBCURL_LIB = $(EXTERNAL_CURL)lib/.libs/libcurl.a
@@ -680,7 +680,7 @@ ifneq (,$(filter ${USE_AUDIT},YES yes y Y 1))
 EXTERNAL_LIBS += ${AUDIT_LIB}
 endif
 
-EXTERNAL_LIBS += $(PROCPS_LIB) $(DB_LIB) $(PACMAN_LIB) $(LIBARCHIVE_LIB)
+EXTERNAL_LIBS += $(PROCPS_LIB) $(DB_LIB) $(LIBALPM_LIB) $(LIBARCHIVE_LIB)
 endif
 endif
 ifeq (${uname_S},Darwin)
@@ -853,17 +853,31 @@ ${LIBARCHIVE_LIB}: $(EXTERNAL_LIBARCHIVE)Makefile
 	 ${MAKE} -C $(EXTERNAL_LIBARCHIVE)
 
 $(EXTERNAL_LIBARCHIVE)Makefile:
-	cd ${EXTERNAL_LIBARCHIVE} && CPPFLAGS=-fPIC ./configure --disable-acl --without-expat --without-iconv --without-xml2 --without-lz4 --without-lzma --without-zstd --without-bz2lib
+	cd ${EXTERNAL_LIBARCHIVE} && CPPFLAGS=-fPIC ./configure --disable-acl --without-expat --without-iconv --without-xml2 --without-lz4 --without-lzma --without-zstd --without-bz2lib --without-openssl
 endif
 
-#### Pacman ######
+#### libalpm ######
 
 ifeq (${uname_S},Linux)
-${PACMAN_LIB}: $(EXTERNAL_PACMAN)Makefile
-	 ${MAKE} -C $(EXTERNAL_PACMAN)/lib/libalpm
 
-$(EXTERNAL_PACMAN)Makefile:
-	cd ${EXTERNAL_PACMAN} && ./autogen.sh && CPPFLAGS=-fPIC ./configure --without-gpgme --without-libcurl
+# we compile libalpm manually because pacman has a lot of dependencies and we only want to compile a few files
+LIBALPM_LDCONFIG=`which ldconfig`
+LIBALPM_CFLAGS=-DSYSHOOKDIR=\"/usr/share/libalpm/hooks\" \
+			    -DLDCONFIG=\"${LIBALPM_LDCONFIG}\" \
+			    -DFSSTATSTYPE="struct statvfs" \
+			    -DSCRIPTLET_SHELL=\"/bin/sh\" \
+			    -DHAVE_SYS_STATVFS_H \
+			    -DLIB_VERSION=\"\" \
+			    -DPATH_MAX=4096 \
+			    -DHAVE_STRNLEN \
+			    -DHAVE_LIBSSL \
+			    -I../../../../${EXTERNAL_LIBARCHIVE}libarchive \
+			    -I. \
+			    -fPIC
+${LIBALPM_LIB}:
+	cd ${EXTERNAL_PACMAN}lib/libalpm && \
+	$(CC) -c *.c ${LIBALPM_CFLAGS} && \
+	ar rcs libalpm.a *.o
 endif
 
 #### Audit lib ####
@@ -955,7 +969,7 @@ external/libarchive.tar.gz:
 	rm $(patsubst %.gz,%,$@)
 
 external/pacman.tar.gz:
-	$(CURL) $@ https://git.archlinux.org/pacman.git/snapshot/pacman-5.2.2.tar.gz
+	$(CURL) $@ https://sources.archlinux.org/other/pacman/pacman-5.2.2.tar.gz
 	cd external && $(GUNZIP) $(patsubst external/%,%,$@)
 	cd external && $(TAR) $(patsubst external/%.gz,%,$@)
 	rm $(patsubst %.gz,%,$@)

--- a/src/Makefile
+++ b/src/Makefile
@@ -2001,12 +2001,12 @@ ifneq ($(wildcard external/libdb/build_unix/*),)
 	cd ${EXTERNAL_LIBDB} && ${MAKE} realclean
 endif
 
-ifneq ($(wildcard external/libarchive-3.5.1/*),)
+ifneq ($(wildcard external/libarchive-3.5.1/Makefile),)
 	cd ${EXTERNAL_LIBARCHIVE} && ${MAKE} clean
 endif
 
-ifneq ($(wildcard external/pacman-5.2.2/*),)
-	cd ${EXTERNAL_PACMAN} && ${MAKE} clean
+ifneq ($(wildcard external/pacman-5.2.2/lib/libalpm/libalpm.a),)
+	rm $(EXTERNAL_PACMAN)lib/libalpm/libalpm.a
 endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -871,7 +871,8 @@ LIBALPM_CFLAGS=-DSYSHOOKDIR=\"/usr/share/libalpm/hooks\" \
 			    -DPATH_MAX=4096 \
 			    -DHAVE_STRNLEN \
 			    -DHAVE_LIBSSL \
-			    -I../../../../${EXTERNAL_LIBARCHIVE}libarchive \
+			    -I${ROUTE_PATH}/${EXTERNAL_LIBARCHIVE}libarchive \
+				-I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include \
 			    -I. \
 			    -fPIC
 ${LIBALPM_LIB}:

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,6 +52,7 @@ SELINUX_POLICY=selinux/wazuh.pp
 USE_PRELUDE?=no
 USE_ZEROMQ?=no
 USE_GEOIP?=no
+USE_ALPM?=no
 USE_INOTIFY=no
 USE_BIG_ENDIAN=no
 USE_AUDIT=no
@@ -346,6 +347,10 @@ ifneq (,$(filter ${USE_GEOIP},YES auto yes y Y 1))
 	OSSEC_LIBS+=-lGeoIP
 endif # USE_GEOIP
 
+ifneq (,$(filter ${USE_ALPM},YES auto yes y Y 1))
+	DEFINES+=-DLIBALPM
+	OSSEC_LIBS+=-lalpm
+endif # USE_ALPM
 
 MI :=
 PI :=
@@ -494,6 +499,9 @@ help: failtarget
 	@echo "Geoip support: "
 	@echo "   make USE_GEOIP=yes           Build with GeoIP support. Allowed values are auto 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo
+	@echo "Arch Linux support: "
+	@echo "   make USE_ALPM=yes            Build with Arch Linux agent support. Allowed values are auto 1, yes, YES, y and Y, otherwise, the flag is ignored"
+	@echo
 	@echo "User options: "
 	@echo "   make OSSEC_GROUP=ossec       Set ossec group"
 	@echo "   make OSSEC_USER=ossec        Set ossec user"
@@ -525,6 +533,7 @@ settings:
 	@echo "USE settings:"
 	@echo "    USE_ZEROMQ:         ${USE_ZEROMQ}"
 	@echo "    USE_GEOIP:          ${USE_GEOIP}"
+	@echo "    USE_ALPM:           ${USE_ALPM}"
 	@echo "    USE_PRELUDE:        ${USE_PRELUDE}"
 	@echo "    USE_INOTIFY:        ${USE_INOTIFY}"
 	@echo "    USE_BIG_ENDIAN:     ${USE_BIG_ENDIAN}"

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -240,7 +240,7 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
             retval = OS_INVALID;
             goto end;
         }
-        if (!strcmp(version, "0")) {
+        if (!strcmp(version, "rolling")) {
             os_index = CVE_ARCH;
             os_strdup(version, upd->version);
             upd->dist_tag_ref = FEED_ARCH;

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -240,11 +240,11 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
             retval = OS_INVALID;
             goto end;
         }
-        if (!strcmp(version, "rolling")) {
+        if (!strcmp(version, "1") || strcasestr(version, vu_feed_tag[FEED_ROLLING])) {
             os_index = CVE_ARCH;
             os_strdup(version, upd->version);
-            upd->dist_tag_ref = FEED_ARCH;
-            upd->dist_ext = vu_feed_ext[FEED_ARCH];
+            upd->dist_tag_ref = FEED_ROLLING;
+            upd->dist_ext = vu_feed_ext[FEED_ROLLING];
             upd->dist_ref = FEED_ARCH;
             upd->json_format = 1;
         } else {

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -235,6 +235,23 @@ int wm_vuldet_set_feed_version(char *feed, char *version, update_node **upd_list
             goto end;
         }
         upd->dist_ref = FEED_REDHAT;
+    } else if (strcasestr(feed, vu_feed_tag[FEED_ARCH])) {
+        if (!version) {
+            retval = OS_INVALID;
+            goto end;
+        }
+        if (!strcmp(version, "0")) {
+            os_index = CVE_ARCH;
+            os_strdup(version, upd->version);
+            upd->dist_tag_ref = FEED_ARCH;
+            upd->dist_ext = vu_feed_ext[FEED_ARCH];
+            upd->dist_ref = FEED_ARCH;
+            upd->json_format = 1;
+        } else {
+            merror("Invalid Arch Linux version '%s'", version);
+            retval = OS_INVALID;
+            goto end;
+        }
     } else if (strcasestr(feed, vu_feed_tag[FEED_MSU])) {
         os_index = CVE_MSU;
         upd->dist_tag_ref = FEED_MSU;
@@ -947,7 +964,8 @@ int wm_vuldet_read_provider_content(xml_node **node, char *name, char multi_prov
 char wm_vuldet_provider_type(char *pr_name) {
     if (strcasestr(pr_name, vu_feed_tag[FEED_CANONICAL]) ||
         strcasestr(pr_name, vu_feed_tag[FEED_DEBIAN]) ||
-        strcasestr(pr_name, vu_feed_tag[FEED_REDHAT])) {
+        strcasestr(pr_name, vu_feed_tag[FEED_REDHAT]) ||
+        strcasestr(pr_name, vu_feed_tag[FEED_ARCH])) {
         return 0;
     } else if (strcasestr(pr_name, vu_feed_tag[FEED_NVD]) ||
         strcasestr(pr_name, vu_feed_tag[FEED_MSU])) {

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -554,6 +554,9 @@ os_info *get_unix_version()
                     break;
                 }
             }
+            if (info->os_version == NULL) {
+                os_strdup("rolling", info->os_version);
+            }
             regfree(&regexCompiled);
             fclose(version_release);
         // Ubuntu

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -538,6 +538,24 @@ os_info *get_unix_version()
             }
             regfree(&regexCompiled);
             fclose(version_release);
+        // Arch
+        } else if (version_release = fopen("/etc/arch-release","r"), version_release){
+            info->os_name = strdup("Arch Linux");
+            info->os_platform = strdup("arch");
+            static const char *pattern = "([0-9][0-9]*\\.?[0-9]*)\\.*";
+            if (regcomp(&regexCompiled, pattern, REG_EXTENDED)) {
+                merror_exit("Cannot compile regular expression.");
+            }
+            while (fgets(buff, sizeof(buff) - 1, version_release)) {
+                if(regexec(&regexCompiled, buff, 2, match, 0) == 0){
+                    match_size = match[1].rm_eo - match[1].rm_so;
+                    os_malloc(match_size + 1, info->os_version);
+                    snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
+                    break;
+                }
+            }
+            regfree(&regexCompiled);
+            fclose(version_release);
         // Ubuntu
         } else if (version_release = fopen("/etc/lsb-release","r"), version_release){
             info->os_name = strdup("Ubuntu");
@@ -574,24 +592,6 @@ os_info *get_unix_version()
             info->os_name = strdup("SuSE Linux");
             info->os_platform = strdup("suse");
             static const char *pattern = ".*VERSION = ([0-9][0-9]*)";
-            if (regcomp(&regexCompiled, pattern, REG_EXTENDED)) {
-                merror_exit("Cannot compile regular expression.");
-            }
-            while (fgets(buff, sizeof(buff) - 1, version_release)) {
-                if(regexec(&regexCompiled, buff, 2, match, 0) == 0){
-                    match_size = match[1].rm_eo - match[1].rm_so;
-                    os_malloc(match_size + 1, info->os_version);
-                    snprintf (info->os_version, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
-                    break;
-                }
-            }
-            regfree(&regexCompiled);
-            fclose(version_release);
-        // Arch
-        } else if (version_release = fopen("/etc/arch-release","r"), version_release){
-            info->os_name = strdup("Arch Linux");
-            info->os_platform = strdup("arch");
-            static const char *pattern = "([0-9][0-9]*\\.?[0-9]*)\\.*";
             if (regcomp(&regexCompiled, pattern, REG_EXTENDED)) {
                 merror_exit("Cannot compile regular expression.");
             }

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -555,7 +555,7 @@ os_info *get_unix_version()
                 }
             }
             if (info->os_version == NULL) {
-                os_strdup("rolling", info->os_version);
+                os_strdup("1.0 (rolling)", info->os_version);
             }
             regfree(&regexCompiled);
             fclose(version_release);

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -147,7 +147,7 @@ CREATE INDEX IF NOT EXISTS ports_id ON sys_ports (scan_id);
 CREATE TABLE IF NOT EXISTS sys_programs (
     scan_id INTEGER,
     scan_time TEXT,
-    format TEXT NOT NULL CHECK (format IN ('deb', 'rpm', 'win', 'pkg')),
+    format TEXT NOT NULL CHECK (format IN ('pacman', 'deb', 'rpm', 'win', 'pkg')),
     name TEXT,
     priority TEXT,
     section TEXT,

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -166,9 +166,7 @@ void sys_ports_windows(const char* LOCATION, int check_all);
 void sys_packages_linux(int queue_fd, const char* WM_SYS_LOCATION);
 char * sys_deb_packages(int queue_fd, const char* WM_SYS_LOCATION, int random_id);
 char * sys_rpm_packages(int queue_fd, const char* WM_SYS_LOCATION, int random_id);
-#ifdef LIBALPM
 char * sys_pacman_packages(int queue_fd, const char* WM_SYS_LOCATION, int random_id);
-#endif
 
 #ifdef WIN32
 // Installed programs inventory for Windows

--- a/src/wazuh_modules/syscollector/syscollector.h
+++ b/src/wazuh_modules/syscollector/syscollector.h
@@ -166,6 +166,9 @@ void sys_ports_windows(const char* LOCATION, int check_all);
 void sys_packages_linux(int queue_fd, const char* WM_SYS_LOCATION);
 char * sys_deb_packages(int queue_fd, const char* WM_SYS_LOCATION, int random_id);
 char * sys_rpm_packages(int queue_fd, const char* WM_SYS_LOCATION, int random_id);
+#ifdef LIBALPM
+char * sys_pacman_packages(int queue_fd, const char* WM_SYS_LOCATION, int random_id);
+#endif
 
 #ifdef WIN32
 // Installed programs inventory for Windows

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -427,6 +427,17 @@ char * sys_pacman_packages(int queue_fd, const char* LOCATION, int random_id){
         cJSON_AddStringToObject(package, "description", alpm_pkg_get_desc(pkg));
         cJSON_AddStringToObject(package, "architecture", alpm_pkg_get_arch(pkg));
         cJSON_AddNumberToObject(package, "size", alpm_pkg_get_isize(pkg) / 1024); // Bytes to KBytes
+        const char *packager = alpm_pkg_get_packager(pkg);
+        if (strcmp(packager, "Unknown Packager")) {
+            /* There isn't a good way to find out what is the vendor.
+             * This way should find out which packages were installed
+             * from a repository as long a the PACKAGER variable hasn't
+             * been set in /etc/makepkg.conf.
+             * If the PACKAGER variable has been set all the packages
+             * on this system will be treated as an os package and will
+             * be compared to the Arch feed only */
+            cJSON_AddStringToObject(package, "vendor", "Arch");
+        }
 
 
         char *installt = w_get_timestamp((time_t)alpm_pkg_get_installdate(pkg));

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -430,7 +430,7 @@ char * sys_pacman_packages(int queue_fd, const char* LOCATION, int random_id){
         cJSON_AddStringToObject(object, "timestamp", timestamp);
         cJSON_AddItemToObject(object, "program", package);
 
-        cJSON_AddStringToObject(package, "format", "pkg"); // FIXME: Using the pkg in order to support older server versions (in the future this should be replaced with the "pacman" format
+        cJSON_AddStringToObject(package, "format", "pacman");
         cJSON_AddStringToObject(package, "name", alpm_pkg_get_name(pkg));
         cJSON_AddStringToObject(package, "version", alpm_pkg_get_version(pkg));
         cJSON_AddStringToObject(package, "description", alpm_pkg_get_desc(pkg));

--- a/src/wazuh_modules/syscollector/syscollector_linux.c
+++ b/src/wazuh_modules/syscollector/syscollector_linux.c
@@ -18,9 +18,7 @@
 
 #if defined(__linux__)
 
-#if defined(LIBALPM)
 #include <alpm.h>
-#endif
 
 #include <stdio.h>
 #include <string.h>
@@ -332,9 +330,7 @@ void sys_packages_linux(int queue_fd, const char* LOCATION) {
     int random_id = os_random();
     char * end_dpkg = NULL;
     char * end_rpm = NULL;
-#if defined(LIBALPM)
     char * end_pacman = NULL;
-#endif
 
     // Define time to sleep between messages sent
     int usec = 1000000 / wm_max_eps;
@@ -358,7 +354,6 @@ void sys_packages_linux(int queue_fd, const char* LOCATION) {
             mterror(WM_SYS_LOGTAG, "Unable to get rpm packages due to: %s", strerror(errno));
         }
     }
-#if defined(LIBALPM)
     if ((dir = opendir("/var/lib/pacman/"))){
         closedir(dir);
         if (end_pacman = sys_pacman_packages(queue_fd, LOCATION, random_id), !end_pacman) {
@@ -377,9 +372,6 @@ void sys_packages_linux(int queue_fd, const char* LOCATION) {
             free(end_dpkg);
         }
     } else if (end_rpm) {
-#else
-    if (end_rpm) {
-#endif
         mtdebug2(WM_SYS_LOGTAG, "sys_packages_linux() sending '%s'", end_rpm);
         wm_sendmsg(usec, queue_fd, end_rpm, LOCATION, SYSCOLLECTOR_MQ);
 
@@ -394,7 +386,6 @@ void sys_packages_linux(int queue_fd, const char* LOCATION) {
     }
 }
 
-#if defined(LIBALPM)
 char * sys_pacman_packages(int queue_fd, const char* LOCATION, int random_id){
     char *timestamp = w_get_timestamp(time(NULL));
     cJSON *object = NULL;
@@ -463,7 +454,6 @@ char * sys_pacman_packages(int queue_fd, const char* LOCATION, int random_id){
 
     return end_msg;
 }
-#endif
 
 char * sys_rpm_packages(int queue_fd, const char* LOCATION, int random_id){
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -362,6 +362,8 @@ const char *vu_feed_tag[] = {
     "RHEL6",
     "RHEL7",
     "RHEL8",
+    // Arch versions
+    "ROLLING",
     // NVD
     "NVD",
     "CPED",
@@ -409,6 +411,8 @@ const char *vu_feed_ext[] = {
     "Red Hat Enterprise Linux 6",
     "Red Hat Enterprise Linux 7",
     "Red Hat Enterprise Linux 8",
+    // Arch versions
+    "Arch Linux",
     // NVD
     "National Vulnerability Database",
     "Common Platform Enumeration Dictionary",
@@ -4941,8 +4945,8 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
             agent_dist = FEED_REDHAT;
             is_centos = TRUE;
         } else if (strcasestr(os_name, vu_feed_ext[FEED_ARCH])) {
-            if (strstr(os_major, "rolling")) {
-                agent_dist_ver = FEED_ARCH;
+            if (strstr(os_major, "1")) {
+                agent_dist_ver = FEED_ROLLING;
             } else {
                 dist_error = FEED_ARCH;
             }
@@ -5480,7 +5484,7 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
             product_name[0] = PR_REDHAT;
             vendor = V_REDHAT;
         break;
-        case FEED_ARCH:
+        case FEED_ROLLING:
             product_name[0] = PR_ARCH;
             vendor = V_ARCH;
         break;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4941,7 +4941,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
             agent_dist = FEED_REDHAT;
             is_centos = TRUE;
         } else if (strcasestr(os_name, vu_feed_ext[FEED_ARCH])) {
-            if (strstr(os_major, "0")) {
+            if (strstr(os_major, "rolling")) {
                 agent_dist_ver = FEED_ARCH;
             } else {
                 dist_error = FEED_ARCH;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -182,6 +182,7 @@ STATIC char *vu_get_version();
 STATIC int wm_vuldet_fetch_oval(update_node *update, char *repo);
 STATIC int wm_vuldet_oval_process(update_node *update, char *path, wm_vuldet_db *parsed_vulnerabilities);
 STATIC int wm_vuldet_json_rh_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilities);
+STATIC int wm_vuldet_json_arch_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilities);
 STATIC int wm_vuldet_db_empty(sqlite3 *db, vu_feed version);
 STATIC int wm_vuldet_nvd_empty();
 STATIC const char *wm_vuldet_get_unified_severity(char *severity);
@@ -240,6 +241,7 @@ STATIC int wm_insert_MSU_metadata(feed_metadata *msu, update_node *update);
 STATIC bool wm_vuldet_check_enabled_msu(sqlite3 *db);
 
 STATIC int wm_vuldet_fetch_redhat(update_node *update);
+STATIC int wm_vuldet_fetch_arch(update_node *update);
 STATIC int wm_vuldet_fetch_wazuh_cpe(update_node *update);
 STATIC int wm_vuldet_json_wcpe_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilities);
 STATIC int wm_vuldet_json_dic_parser(cJSON *json_feed, vu_cpe_dic *wcpes);
@@ -312,10 +314,12 @@ const char *version_null = "0:0";
 static const char *PR_UBUNTU = "ubuntu_linux";
 static const char *PR_DEBIAN = "debian_linux";
 static const char *PR_REDHAT = "enterprise_linux";
+static const char *PR_ARCH = "arch_linux";
 static const char *PR_KERNEL = "linux_kernel";
 static const char *V_UBUNTU = "canonical";
 static const char *V_DEBIAN = "debian";
 static const char *V_REDHAT = "redhat";
+static const char *V_ARCH = "arch";
 static const char *V_KERNEL = "linux";
 
 const char *vu_vendor_list_ubuntu_debian[] = {
@@ -343,6 +347,7 @@ const char *vu_feed_tag[] = {
     "REDHAT",
     "JREDHAT",
     "CENTOS",
+    "ARCH",
     "WIN",
     // Ubuntu versions
     "TRUSTY",
@@ -389,6 +394,7 @@ const char *vu_feed_ext[] = {
     "Red Hat Enterprise Linux",
     "JSON Red Hat Enterprise Linux",
     "CentOS",
+    "Arch Linux",
     "Microsoft Windows",
     // Ubuntu versions
     "Ubuntu Trusty",
@@ -2037,8 +2043,10 @@ int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agent, w
                 goto end;
             }
         }
-        if (wm_vuldet_linux_nvd_vulnerabilities(db, agent, cve_table)) {
-            goto end;
+        if (agent->dist != FEED_ARCH) {
+            if (wm_vuldet_linux_nvd_vulnerabilities(db, agent, cve_table)) {
+                goto end;
+            }
         }
         if (wm_vuldet_linux_rm_false_positivies(db, agent, cve_table)) {
             goto end;
@@ -2456,7 +2464,7 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
                 return OS_INVALID;
             }
         break;
-        case FEED_NVD: case FEED_MSU: case FEED_JREDHAT:
+        case FEED_NVD: case FEED_MSU: case FEED_JREDHAT: case FEED_ARCH:
         break;
         default:
             sqlite3_close_v2(db);
@@ -2524,9 +2532,14 @@ int wm_vuldet_insert(wm_vuldet_db *parsed_oval, update_node *update) {
             sqlite3_bind_text(stmt, 1, vul_it->cve_id, -1, NULL);
             sqlite3_bind_text(stmt, 2, parsed_oval->OS, -1, NULL);
             sqlite3_bind_text(stmt, 3, NULL, -1, NULL);
-            sqlite3_bind_text(stmt, 4, vul_it->package_name ? vul_it->package_name : vul_it->state_id, -1, NULL);
             sqlite3_bind_text(stmt, 5, vul_it->state_id, -1, NULL);
-            sqlite3_bind_text(stmt, 6, NULL, -1, NULL);
+            if (vul_it->package_name && vul_it->package_version) {
+                    sqlite3_bind_text(stmt, 4, vul_it->package_name, -1, NULL);
+                    sqlite3_bind_text(stmt, 6, vul_it->package_version, -1, NULL);
+            } else {
+                sqlite3_bind_text(stmt, 4, vul_it->package_name ? vul_it->package_name : vul_it->state_id, -1, NULL);
+                sqlite3_bind_text(stmt, 6, NULL, -1, NULL);
+            }
             sqlite3_bind_int(stmt, 7, 0);
             sqlite3_bind_int(stmt, 8, vul_it->ignore);
             sqlite3_bind_int(stmt, 9, 0);
@@ -3816,6 +3829,7 @@ bool wm_vuldet_set_feed_update_url(update_node *update) {
         update->dist_ref == FEED_NVD     ||
         update->dist_ref == FEED_CPEW    ||
         update->dist_ref == FEED_JREDHAT ||
+        update->dist_ref == FEED_ARCH    ||
         update->dist_ref == FEED_MSU) {
             return true;
     }
@@ -3961,6 +3975,18 @@ int wm_vuldet_fetch_feed(update_node *update, int8_t *need_update) {
             }
 
             goto end;
+
+        case FEED_ARCH:
+            update->update_state = 0;
+            if (result = wm_vuldet_fetch_arch(update), result != OS_INVALID) {
+                success = 1;
+                if (update->update_state == VU_FINISH_FETCH || update->update_state == VU_TRY_NEXT_PAGE || update->update_state == VU_INV_FEED) {
+                    *need_update = 0;
+                }
+            }
+
+            goto end;
+        break;
 
         case FEED_CPED:
             if (wm_vuldet_fetch_nvd_cpe(update->timeout, repo)) {
@@ -4277,6 +4303,124 @@ int wm_vuldet_json_rh_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilit
     return 0;
 }
 
+int wm_vuldet_json_arch_parser(cJSON *json_feed, wm_vuldet_db *parsed_vulnerabilities) {
+    cJSON *json_it;
+    cJSON *cve_content;
+    cJSON *packages_content;
+    time_t l_time;
+    struct tm *tm_time;
+
+    static char *JSON_NAME = "name";
+    static char *JSON_PACKAGES = "packages";
+    static char *JSON_SEVERITY = "severity";
+    static char *JSON_AFFECTED = "affected";
+    static char *JSON_FIXED = "fixed";
+    static char *JSON_ISSUES = "issues";
+    static char *JSON_ADVISORIES = "advisories";
+
+    // Metadata values
+    STATIC char *arch_product_name = "Arch Linux Security Data";
+    STATIC char *arch_product_version = "1.0";
+    char *m_product_name = NULL;
+    char *m_product_version = NULL;
+    char *m_schema_version = NULL;
+    char m_timestamp[27] = { '\0' };
+
+    for (json_it  = json_feed->child; json_it; json_it = json_it->next) {
+        char *tmp_name = NULL;
+        cJSON *tmp_packages = NULL;
+        char *tmp_severity = NULL;
+        char *tmp_affected = NULL;
+        char *tmp_fixed = NULL;
+        cJSON *tmp_issues = NULL;
+        cJSON *tmp_advisories = NULL;
+
+        time(&l_time);
+        tm_time = localtime(&l_time);
+        strftime(m_timestamp, 26, "%Y-%m-%d %H:%M:%S", tm_time);
+        m_product_name = arch_product_name;
+        m_product_version = arch_product_version;
+
+        for (cve_content = json_it->child; json_tagged_obj(cve_content); cve_content = cve_content->next) {
+            if (!strcmp(cve_content->string, JSON_NAME)) {
+                tmp_name = cve_content->valuestring;
+            } else if (!strcmp(cve_content->string, JSON_PACKAGES)) {
+                tmp_packages = cve_content->child;
+            } else if (!strcmp(cve_content->string, JSON_SEVERITY)) {
+                tmp_severity = cve_content->valuestring;
+            } else if (!strcmp(cve_content->string, JSON_AFFECTED)) {
+                tmp_affected = cve_content->valuestring;
+            } else if (!strcmp(cve_content->string, JSON_FIXED)) {
+                tmp_fixed = cve_content->valuestring;
+            } else if (!strcmp(cve_content->string, JSON_ISSUES)) {
+                tmp_issues = cve_content->child;
+            } else if (!strcmp(cve_content->string, JSON_ADVISORIES)) {
+                tmp_advisories = cve_content->child;
+            }
+        }
+
+        if(!tmp_name || !tmp_severity || !tmp_packages || !tmp_affected) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_FEED_NODE_NULL_ELM);
+            return OS_INVALID;
+        }
+
+        char first_cve = 1;
+        for (cve_content = tmp_issues; first_cve || cve_content; cve_content = cve_content->next) {
+            first_cve = 0;
+
+            for (packages_content = tmp_packages; packages_content; packages_content = packages_content->next) {
+                wm_vuldet_add_vulnerability_info(parsed_vulnerabilities);
+                wm_vuldet_add_oval_vulnerability(parsed_vulnerabilities);
+
+                // Fill in vulnerability information
+                if (cve_content) {
+                    w_strdup(cve_content->valuestring, parsed_vulnerabilities->info_cves->cveid);
+                    w_strdup(cve_content->valuestring, parsed_vulnerabilities->vulnerabilities->cve_id);
+                } else {
+                    w_strdup("Unspecified", parsed_vulnerabilities->info_cves->cveid);
+                    w_strdup("Unspecified", parsed_vulnerabilities->vulnerabilities->cve_id);
+                }
+
+                w_strdup(tmp_severity, parsed_vulnerabilities->info_cves->severity);
+
+                // Setting the reference. In Arch we only have one reference link to save in the array for each CVE
+                if (!parsed_vulnerabilities->info_cves->refs)
+                    os_calloc(1, sizeof(references), parsed_vulnerabilities->info_cves->refs);
+
+                references *refs = parsed_vulnerabilities->info_cves->refs;
+                os_realloc(refs->values, (refs->elements + 2) * sizeof(char *), refs->values);
+                refs->values[refs->elements] = wm_vuldet_build_url(VU_BUILD_REF_CVE_ARCH, tmp_name);
+                refs->values[++refs->elements] = NULL;
+
+                if (!parsed_vulnerabilities->info_cves->bugzilla_references)
+                    os_calloc(1, sizeof(references), parsed_vulnerabilities->info_cves->bugzilla_references);
+
+                parsed_vulnerabilities->info_cves->advisories = wm_vuldet_extract_advisories(tmp_advisories);
+                os_strdup(packages_content->valuestring, parsed_vulnerabilities->vulnerabilities->package_name);
+                if (tmp_fixed) {
+                    os_strdup(tmp_fixed, parsed_vulnerabilities->vulnerabilities->package_version);
+                    os_strdup("less than", parsed_vulnerabilities->vulnerabilities->state_id);
+                } else {
+                    os_strdup(tmp_affected, parsed_vulnerabilities->vulnerabilities->package_version);
+                    os_strdup("less than or equal", parsed_vulnerabilities->vulnerabilities->state_id);
+                }
+            }
+        }
+    }
+
+    // Insert metadata values
+    os_free(parsed_vulnerabilities->metadata.product_name);
+    w_strdup(m_product_name, parsed_vulnerabilities->metadata.product_name);
+    os_free(parsed_vulnerabilities->metadata.product_version);
+    w_strdup(m_product_version, parsed_vulnerabilities->metadata.product_version);
+    os_free(parsed_vulnerabilities->metadata.schema_version);
+    w_strdup(m_schema_version, parsed_vulnerabilities->metadata.schema_version);
+    os_free(parsed_vulnerabilities->metadata.timestamp);
+    os_strdup(m_timestamp, parsed_vulnerabilities->metadata.timestamp);
+
+    return 0;
+}
+
 int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *parsed_vulnerabilities, update_node *update) {
     int retval = OS_INVALID;
     int compress = 0;
@@ -4315,6 +4459,9 @@ int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *parsed_vulnerabilities,
         switch ((int) update->dist_ref) {
             case FEED_JREDHAT:
                 retval = wm_vuldet_json_rh_parser(json_feed, parsed_vulnerabilities);
+                break;
+            case FEED_ARCH:
+                retval = wm_vuldet_json_arch_parser(json_feed, parsed_vulnerabilities);
                 break;
             case FEED_CPEW:
                 retval = wm_vuldet_json_wcpe_parser(json_feed, parsed_vulnerabilities);
@@ -4793,6 +4940,13 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
             }
             agent_dist = FEED_REDHAT;
             is_centos = TRUE;
+        } else if (strcasestr(os_name, vu_feed_ext[FEED_ARCH])) {
+            if (strstr(os_major, "0")) {
+                agent_dist_ver = FEED_ARCH;
+            } else {
+                dist_error = FEED_ARCH;
+            }
+            agent_dist= FEED_ARCH;
         } else if (strcasestr(os_name, vu_feed_ext[FEED_WIN])) {
             agent_dist_ver = wm_vuldet_decode_win_os(os_name);
             agent_dist = FEED_WIN;
@@ -5326,6 +5480,10 @@ int wm_vuldet_generate_os_and_kernel_package(sqlite3 *db, agent_software *agent)
             product_name[0] = PR_REDHAT;
             vendor = V_REDHAT;
         break;
+        case FEED_ARCH:
+            product_name[0] = PR_ARCH;
+            vendor = V_ARCH;
+        break;
         case FEED_MAC:
             vendor = "apple";
             if (!strcmp(agent->os_name, "Mac OS X Server")) {
@@ -5510,6 +5668,55 @@ void wm_vuldet_free_agent_software(agent_software *agent) {
         free(agent->os_name);
         free(agent);
     }
+}
+
+int wm_vuldet_fetch_arch(update_node *update) {
+    int attempt = 1;
+    int retval = VU_TRY_NEXT_PAGE;
+    FILE *fp = NULL;
+    char buffer[OS_SIZE_128 + 1];
+    int res_url_request;
+
+    mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_DOWNLOAD_START, JSON_ARCH_REPO);
+    while (1) {
+        res_url_request = wurl_request_uncompress_bz2_gz(JSON_ARCH_REPO, VU_FIT_TEMP_FILE, NULL, NULL, update->timeout, NULL);
+        if (res_url_request) {
+            if (attempt == ARCH_REPO_MAX_ATTEMPTS) {
+                mtwarn(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV_NEW, JSON_ARCH_REPO, ARCH_REPO_MAX_ATTEMPTS);
+                update->update_state = VU_TRY_NEXT_PAGE;
+                retval = 0;
+                goto end;
+            }
+
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_API_REQ_INV, JSON_ARCH_REPO, attempt);
+            attempt++;
+            sleep(attempt * DOWNLOAD_SLEEP_FACTOR);
+        } else {
+            break;
+        }
+    }
+
+    if (fp = fopen(VU_FIT_TEMP_FILE, "r"), !fp) {
+        mtdebug2(WM_VULNDETECTOR_LOGTAG, "fopen(%s): %s", VU_FIT_TEMP_FILE, strerror(errno));
+        retval = OS_INVALID;
+        update->update_state = VU_INV_FEED;
+        goto end;
+    }
+    if (!fgets(buffer, OS_SIZE_128, fp) || !strncmp(buffer, "[]", 2)) {
+        if (remove(VU_FIT_TEMP_FILE) < 0) {
+            mtdebug2(WM_VULNDETECTOR_LOGTAG, "remove(%s): %s", VU_FIT_TEMP_FILE, strerror(errno));
+        }
+        update->update_state = VU_FINISH_FETCH;
+    } else {
+        update->update_state = VU_SUCC_DOWN_PAGE;
+    }
+
+    retval = 0;
+end:
+    if (fp) {
+        fclose(fp);
+    }
+    return retval;
 }
 
 int wm_vuldet_fetch_MSU(update_node *update, char *repo) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -333,6 +333,10 @@ const char *vu_vendor_list_redhat[] = {
     "CentOS"
 };
 
+const char *vu_vendor_list_arch[] = {
+    "Arch"
+};
+
 const char *vu_package_dist[] = {
     ".el8",
     ".el7",
@@ -1527,12 +1531,23 @@ int wm_vuldet_linux_rm_nvd_not_affected_packages(sqlite3 *db, agent_software *ag
     do {
         next = pkg->next;
 
-        if ((pkg->feed == VU_SRC_NVD) && !pkg->discard && strcmp(pkg->bin_name, PR_KERNEL) && strcmp(pkg->bin_name, PR_UBUNTU) && strcmp(pkg->bin_name, PR_DEBIAN) && strcmp(pkg->bin_name, PR_REDHAT)) {
+        if ((pkg->feed == VU_SRC_NVD) && !pkg->discard && strcmp(pkg->bin_name, PR_KERNEL) && strcmp(pkg->bin_name, PR_UBUNTU) && strcmp(pkg->bin_name, PR_DEBIAN) && strcmp(pkg->bin_name, PR_REDHAT) && strcmp(pkg->bin_name, PR_ARCH)) {
 
             // If it is possible to identify that the package belongs to the lineage
             // of any vendor, it means that it is not affected and we can discard it
             if (pkg->vendor) {
-                if (agent->dist == FEED_REDHAT) {
+                if (agent->dist == FEED_ARCH) {
+                    vendor_len = sizeof(vu_vendor_list_arch) / sizeof(vu_vendor_list_arch[0]);
+                    for(vendor_it = 0; vendor_it < vendor_len; ++vendor_it) {
+                        if(!strcmp(pkg->vendor, vu_vendor_list_arch[vendor_it])) {
+                            // This is an Arch package, so the OVAL said that it is not affected
+                            mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACKAGE_NOT_AFF, pkg->bin_name, cve, "OVAL");
+                            pkg->discard = 1;
+                            (*vuln_discarded)++;
+                            break;
+                        }
+                    }
+                } else if (agent->dist == FEED_REDHAT) {
                     vendor_len = sizeof(vu_vendor_list_redhat) / sizeof(vu_vendor_list_redhat[0]);
                     for(vendor_it = 0; vendor_it < vendor_len; ++vendor_it) {
                         if(!strcmp(pkg->vendor, vu_vendor_list_redhat[vendor_it])) {
@@ -2047,10 +2062,8 @@ int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agent, w
                 goto end;
             }
         }
-        if (agent->dist != FEED_ARCH) {
-            if (wm_vuldet_linux_nvd_vulnerabilities(db, agent, cve_table)) {
-                goto end;
-            }
+        if (wm_vuldet_linux_nvd_vulnerabilities(db, agent, cve_table)) {
+            goto end;
         }
         if (wm_vuldet_linux_rm_false_positivies(db, agent, cve_table)) {
             goto end;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -232,6 +232,8 @@ typedef enum vu_feed {
     FEED_RHEL6,
     FEED_RHEL7,
     FEED_RHEL8,
+    // Arch versions
+    FEED_ROLLING,
     // NVD
     FEED_NVD,
     FEED_CPED,

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -55,6 +55,9 @@
 #define JSON_RED_HAT_REPO  "https://access.redhat.com/labs/securitydataapi/cve.json?after=%d-01-01&per_page=%d&page=%d"
 #define RED_HAT_REPO "https://www.redhat.com/security/data/oval/v2/RHEL%s/rhel-%s-including-unpatched.oval.xml.bz2"
 #define RED_HAT5_REPO "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL5.xml.bz2"
+#define ARCH_REPO_REQ_SIZE 1000
+#define ARCH_REPO_MAX_ATTEMPTS 3
+#define JSON_ARCH_REPO "https://security.archlinux.org/all.json"
 #define NVD_CPE_REPO "https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz"
 #define NVD_CVE_REPO_META "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.meta"
 #define NVD_CVE_REPO "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz"
@@ -107,6 +110,7 @@
 // Patterns for building references
 #define VUL_BUILD_REF_MAX 100
 #define VU_BUILD_REF_CVE_RH "https://access.redhat.com/security/cve/%s"
+#define VU_BUILD_REF_CVE_ARCH "https://security.archlinux.org/%s"
 #define VU_BUILD_REF_BUGZ "https://bugzilla.redhat.com/show_bug.cgi?id=%s"
 #define VU_BUILD_REF_RHSA "https://access.redhat.com/errata/%s"
 
@@ -213,6 +217,7 @@ typedef enum vu_feed {
     FEED_REDHAT,
     FEED_JREDHAT, // JSON RedHat
     FEED_CENTOS,
+    FEED_ARCH,
     FEED_WIN,
     // Ubuntu versions
     FEED_TRUSTY,
@@ -368,6 +373,7 @@ typedef enum cve_db {
     CVE_REDHAT7,
     CVE_REDHAT8,
     CVE_JREDHAT, // JSON RedHat
+    CVE_ARCH,
     CVE_NVD,
     CPE_WDIC,
     CVE_MSU,
@@ -526,6 +532,7 @@ typedef struct vulnerability {
     char *cve_id;
     char *state_id;
     char *package_name;
+    char *package_version;
     int ignore;
     char **rhsa_list; // For CVEs which share a common RHSA - RedHat
     struct vulnerability *prev;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -130,10 +130,12 @@ STATIC char *wm_vuldet_generate_msu_request(cpe *s_cpe, vu_feed dist_ver);
 static const char *PR_UBUNTU = "ubuntu_linux";
 static const char *PR_DEBIAN = "debian_linux";
 static const char *PR_REDHAT = "enterprise_linux";
+static const char *PR_ARCH = "arch_linux";
 static const char *PR_KERNEL = "linux_kernel";
 static const char *V_UBUNTU = "canonical";
 static const char *V_DEBIAN = "debian";
 static const char *V_REDHAT = "redhat";
+static const char *V_ARCH = "arch";
 static const char *V_KERNEL = "linux";
 
 // Common tags
@@ -2244,7 +2246,13 @@ int vw_vuldet_filter_vulnerabilities(vu_feed feed, const char *vendor, const cha
 
     if (vendor) {
         // Check vendor against feed
-        if (feed == FEED_REDHAT) {
+        if (feed == FEED_ARCH) {
+            if (!strcmp(V_UBUNTU, vendor) || !strcmp(V_DEBIAN, vendor) || !strcmp(V_REDHAT, vendor)) {
+                return 1;
+            }
+        } else if (!strcmp(V_ARCH, vendor)) {
+            return 1;
+        } else if (feed == FEED_REDHAT) {
             if (!strcmp(V_UBUNTU, vendor) || !strcmp(V_DEBIAN, vendor)) {
                 return 1;
             }
@@ -2287,6 +2295,7 @@ int wm_vuldet_check_generic_package(sqlite3 *dbCVE, vu_feed feed, char *pkg_name
     if (!strcmp(pkg_reference, PR_UBUNTU) ||
         !strcmp(pkg_reference, PR_DEBIAN) ||
         !strcmp(pkg_reference, PR_REDHAT) ||
+        !strcmp(pkg_reference, PR_ARCH)   ||
         !strcmp(pkg_reference, PR_KERNEL)) {
         query = vu_queries[VU_GET_GENERIC_PACKAGE_OS];
         os_package = true;
@@ -2324,6 +2333,8 @@ int wm_vuldet_check_generic_package(sqlite3 *dbCVE, vu_feed feed, char *pkg_name
             sqlite3_bind_text(stmt, 2, V_DEBIAN, -1, NULL);
         } else if (!strcmp(pkg_reference, PR_REDHAT)) {
             sqlite3_bind_text(stmt, 2, V_REDHAT, -1, NULL);
+        } else if (!strcmp(pkg_reference, PR_ARCH)) {
+            sqlite3_bind_text(stmt, 2, V_ARCH, -1, NULL);
         } else if (!strcmp(pkg_reference, PR_KERNEL)) {
             sqlite3_bind_text(stmt, 2, V_KERNEL, -1, NULL);
         }
@@ -2527,6 +2538,7 @@ int wm_vuldet_check_specific_package(sqlite3 *dbCVE, vu_feed feed, char *pkg_nam
     if (!strcmp(pkg_reference, PR_UBUNTU) ||
         !strcmp(pkg_reference, PR_DEBIAN) ||
         !strcmp(pkg_reference, PR_REDHAT) ||
+        !strcmp(pkg_reference, PR_ARCH)   ||
         !strcmp(pkg_reference, PR_KERNEL)) {
         query = vu_queries[VU_GET_SPECIFIC_PACKAGE_OS];
         os_package = true;
@@ -2568,6 +2580,8 @@ int wm_vuldet_check_specific_package(sqlite3 *dbCVE, vu_feed feed, char *pkg_nam
             sqlite3_bind_text(stmt, 3, V_DEBIAN, -1, NULL);
         } else if (!strcmp(pkg_reference, PR_REDHAT)) {
             sqlite3_bind_text(stmt, 3, V_REDHAT, -1, NULL);
+        } else if (!strcmp(pkg_reference, PR_ARCH)) {
+            sqlite3_bind_text(stmt, 3, V_ARCH, -1, NULL);
         } else if (!strcmp(pkg_reference, PR_KERNEL)) {
             sqlite3_bind_text(stmt, 3, V_KERNEL, -1, NULL);
         }


### PR DESCRIPTION
This commit makes the agent usable on Arch Linux devices.
The agent will get the packages list from the pacman repository as it should.

Also, Arch machines were identified as Ubuntu machines because the file /etc/lsb-release may exists on Arch distributions. It was fixed.