### PR TITLE
Move syshcheck internal options to regular config.

### DIFF
--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -61,7 +61,7 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.key_ignore_regex = NULL;
     syscheck.value_ignore = NULL;
     syscheck.value_ignore_regex = NULL;
-    syscheck.max_fd_win_rt  = 0;
+    syscheck.max_fd_win_rt  = 256;
     syscheck.registry_nodiff = NULL;
     syscheck.registry_nodiff_regex = NULL;
     syscheck.enable_registry_synchronization = 1;
@@ -82,6 +82,11 @@ int Read_Syscheck_Config(const char *cfgfile)
     syscheck.comp_estimation_perc = 0.9;    // 90%
     syscheck.disk_quota_full_msg = true;
     syscheck.audit_key = NULL;
+    syscheck.rt_delay = 5;
+    syscheck.max_depth = 256;
+    syscheck.file_max_size = 0;
+    syscheck.sym_checker_interval = 600;
+    syscheck.max_audit_entries = 256;
 
     mdebug1(FIM_CONFIGURATION_FILE, cfgfile);
 

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -96,7 +96,6 @@ int main(int argc, char **argv)
 
     /* Read internal options */
     read_internal(debug_level);
-
     mdebug1(STARTED_MSG);
 
     /* Check if the configuration is present */

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -50,16 +50,8 @@ void init_magic(magic_t *cookie_ptr)
 #endif /* USE_MAGIC */
 
 /* Read syscheck internal options */
-void read_internal(int debug_level)
-{
-    syscheck.rt_delay = getDefine_Int("syscheck", "rt_delay", 0, 1000);
-    syscheck.max_depth = getDefine_Int("syscheck", "default_max_depth", 1, 320);
-    syscheck.file_max_size = (size_t)getDefine_Int("syscheck", "file_max_size", 0, 4095) * 1024 * 1024;
-    syscheck.sym_checker_interval = getDefine_Int("syscheck", "symlink_scan_interval", 1, 2592000);
+void read_internal(int debug_level) {
 
-#ifndef WIN32
-    syscheck.max_audit_entries = getDefine_Int("syscheck", "max_audit_entries", 1, 4096);
-#endif
     sys_debug_level = getDefine_Int("syscheck", "debug", 0, 2);
 
     /* Check current debug_level
@@ -102,7 +94,6 @@ int Start_win32_Syscheck()
     read_internal(debug_level);
 
     mdebug1(STARTED_MSG);
-
     /* Check if the configuration is present */
     if (File_DateofChange(cfg) < 0) {
         merror_exit(NO_CONFIG, cfg);


### PR DESCRIPTION
|Related issue|
|---|
|#5648|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to move all the FIM options (except for the `debug` option) from the internal options file to the regular configuration. 

## Configuration options

The options that have been moved are: 

| Options                       | Default value | Range  |
|------------------------------|------------------|-------------| 
| rt_delay                       | 5                  | 0...1000 |
| default_max_depth     | 256              | 1....320  |
| file_max_size              | 0 (disabled) | 0...1000000 |
| symlink_scan_interval | 600              | 1...25292000|
| max_audit_entries       | 256              | 1...256 |

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [X] Source installation
- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
