### PR TITLE
Fix cluster integration tests race condition

### DIFF
--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -732,6 +732,9 @@ stages:
 ---
 test_name: GET /cluster/configuration/validation
 
+marks:
+  - xfail # Sometimes fails due to https://github.com/wazuh/wazuh/issues/6746
+
 stages:
 
   - name: Request cluster validation
@@ -861,7 +864,7 @@ test_name: GET /cluster/api/config
 stages:
 
   # GET /cluster/api/config
-  - name: Get API configuration
+  - name: Get API configuration for all nodes
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -875,7 +878,7 @@ stages:
         data:
           affected_items:
             - node_name: "master-node"
-              node_api_config: &api_config
+              node_api_config: &default_api_config
                 host: !anystr
                 port: !anyint
                 behind_proxy_server: !anybool
@@ -906,16 +909,16 @@ stages:
                 experimental_features: !anybool
             - node_name: "worker1"
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
             - node_name: "worker2"
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
           total_affected_items: 3
           total_failed_items: 0
           failed_items: []
 
   # GET /cluster/api/config/{node_list}
-  - name: Get API configuration
+  - name: Get API configuration for worker1 and worker2
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -932,10 +935,10 @@ stages:
           affected_items:
             - node_name: 'worker1'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
             - node_name: 'worker2'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
           total_affected_items: 2
           total_failed_items: 0
           failed_items: []
@@ -946,7 +949,7 @@ test_name: PUT /cluster/api/config
 stages:
 
   # PUT /cluster/api/config
-  - name: Modify API configuration (some fields)
+  - name: Modify API configuration (some fields) for all nodes
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -968,7 +971,7 @@ stages:
           failed_items: []
 
   # PUT /cluster/api/config
-  - name: Modify API configuration (all allowed fields)
+  - name: Modify API configuration (all allowed fields) for worker1 and worker2
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1000,7 +1003,7 @@ stages:
           failed_items: []
 
   # PUT /cluster/api/config
-  - name: Modify API configuration (forbidden field)
+  - name: Modify API configuration (forbidden field) for all nodes
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1026,7 +1029,7 @@ stages:
     delay_after: !float "{restart_delay_cluster}"
 
   # GET /cluster/api/config
-  - name: Get API configuration that was set above
+  - name: Get API configuration (default master, modified worker1 and worker2)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1041,7 +1044,7 @@ stages:
           affected_items:
             - node_name: 'master-node'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
             - node_name: 'worker1'
               node_api_config: &modified_api_config
                 logs:
@@ -1064,7 +1067,7 @@ test_name: DELETE /cluster/api/config
 stages:
 
   # DELETE /cluster/api/config (worker1)
-  - name: Restore API configuration
+  - name: Restore default API configuration for worker1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1096,7 +1099,7 @@ stages:
     delay_after: !float "{restart_delay_cluster}"
 
   # GET /cluster/api/config
-  - name: Get API default configuration
+  - name: Get API configuration (default master and worker1, modified worker2)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1111,16 +1114,10 @@ stages:
           affected_items:
             - node_name: 'master-node'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
             - node_name: 'worker1'
               node_api_config:
-                logs:
-                  level: "info"
-                cache:
-                  enabled: true
-                  time: 0.75
-                use_only_authd: false
-                experimental_features: false
+                <<: *default_api_config
             - node_name: 'worker2'
               node_api_config:
                 <<: *modified_api_config
@@ -1129,7 +1126,7 @@ stages:
           failed_items: []
 
   # DELETE /cluster/api/config (all nodes)
-  - name: Restore API configuration
+  - name: Restore default API configuration for all nodes
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1159,7 +1156,7 @@ stages:
     delay_after: !float "{restart_delay_cluster}"
 
   # GET /cluster/api/config
-  - name: Get API default configuration
+  - name: Get API default configuration for all nodes
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1174,13 +1171,13 @@ stages:
           affected_items:
             - node_name: 'master-node'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
             - node_name: 'worker1'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
             - node_name: 'worker2'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
           total_affected_items: 3
           total_failed_items: 0
           failed_items: []
@@ -1190,7 +1187,7 @@ test_name: GET /cluster/{node_id}/configuration/{component}/{configuration}
 
 stages:
 
-  - name: Try to show the config of analisys/global through a worker
+  - name: Show the config of analisys/global on worker1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/global"
@@ -1223,7 +1220,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of analysis/active_response through a worker
+  - name: Show the config of analysis/active_response on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/analysis/active_response"
@@ -1241,7 +1238,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of analysis/alerts through a worker
+  - name: Show the config of analysis/alerts on worker1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/alerts"
@@ -1259,7 +1256,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show analysis/command through a worker
+  - name: Show analysis/command on master
 
     request:
       verify: False
@@ -1278,7 +1275,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of authd/authd in the manager through a worker
+  - name: Show the config of authd/authd on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/auth/auth"
@@ -1307,7 +1304,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of com/internal in the manager through a worker
+  - name: Show the config of com/internal on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/com/internal"
@@ -1328,7 +1325,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of analysis/internal through a worker
+  - name: Show the config of analysis/internal on worker1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/internal"
@@ -1360,7 +1357,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of logcollector/localfile in the manager trough a worker
+  - name: Show the config of logcollector/localfile on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/logcollector/localfile"
@@ -1378,7 +1375,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of logcollector/socket in the manager trough a worker
+  - name: Show the config of logcollector/socket on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/logcollector/socket"
@@ -1395,7 +1392,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 0
 
-  - name: Try to show the config of logcollector/internal in the manager trough a worker
+  - name: Show the config of logcollector/internal on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/logcollector/internal"
@@ -1429,7 +1426,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of monitor/internal in the manager trough a worker
+  - name: Show the config of monitor/internal on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/monitor/internal"
@@ -1456,10 +1453,10 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of request/remote in the manager trough a worker
+  - name: Show the config of request/remote on worker2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/request/remote"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/configuration/request/remote"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1479,7 +1476,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of request/internal in the manager trough a worker
+  - name: Show the config of request/internal on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/request/internal"
@@ -1520,7 +1517,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of syscheck/syscheck in the manager trough a worker
+  - name: Show the config of syscheck/syscheck on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/syscheck/syscheck"
@@ -1539,10 +1536,10 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of syscheck/rootcheck in the manager trough a worker
+  - name: Show the config of syscheck/rootcheck on worker1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/syscheck/rootcheck"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/syscheck/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1572,7 +1569,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of syscheck/internal in the manager through a worker
+  - name: Show the config of syscheck/internal on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/syscheck/internal"
@@ -1599,7 +1596,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of wmodules/wmodules in the manager trough a worker
+  - name: Show the config of wmodules/wmodules on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/wmodules/wmodules"
@@ -1699,7 +1696,7 @@ stages:
       json:
         contents: !anything
 
-  - name: Get file with wrong path (master)
+  - name: Get file with wrong path {node_id}
     request:
       verify: False
       <<: *get_cluster_files
@@ -1708,7 +1705,7 @@ stages:
     response:
       <<: *connexion_error
 
-  - name: Get file with empty path (master)
+  - name: Get file with empty path {node_id}
     request:
       verify: False
       <<: *get_cluster_files
@@ -1724,13 +1721,11 @@ marks:
   - parametrize:
       key: node_id
       vals:
-        - master-node
-        - worker1
-        - worker2
+        - master-node # We only use master-node because the cluster will synchronize the deleted files and may cause error
 
 stages:
 
-  - name: Delete rules file
+  - name: Delete rules file {node_id}
     request: &delete_cluster_files
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/files"
@@ -1750,7 +1745,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Delete unexisting rules file
+  - name: Delete unexisting rules file {node_id}
     request:
       verify: False
       <<: *delete_cluster_files
@@ -1769,7 +1764,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
-  - name: Delete decoder file
+  - name: Delete decoder file {node_id}
     request:
       verify: False
       <<: *delete_cluster_files
@@ -1786,7 +1781,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Delete unexisting decoder file
+  - name: Delete unexisting decoder file {node_id}
     request:
       verify: False
       <<: *delete_cluster_files
@@ -1795,7 +1790,7 @@ stages:
     response:
       <<: *non_existing_file
 
-  - name: Delete CDB list file
+  - name: Delete CDB list file {node_id}
     request:
       verify: False
       <<: *delete_cluster_files
@@ -1812,7 +1807,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Delete unexisting CDB list file
+  - name: Delete unexisting CDB list file {node_id}
     request:
       verify: False
       <<: *delete_cluster_files
@@ -1822,7 +1817,7 @@ stages:
       <<: *non_existing_file
 
 ---
-test_name: PUT /cluster/{node_id}/files
+test_name: PUT /cluster/{node_id}/files (ossec.conf)
 
 marks:
   - parametrize:
@@ -1876,7 +1871,18 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Upload new rules {node_id}
+---
+test_name: PUT /cluster/{node_id}/files (ruleset)
+
+marks:
+  - parametrize:
+      key: node_id
+      vals:
+        - master-node
+
+stages:
+
+   - name: Upload new rules {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -1935,7 +1941,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Upload rules with XML syntax error (overwrite=true)
+  - name: Upload rules with XML syntax error (overwrite=true) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -1957,7 +1963,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
-  - name: Upload new decoder
+  - name: Upload new decoder {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -1975,7 +1981,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Upload decoder (overwrite=false)
+  - name: Upload decoder (overwrite=false) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -1997,7 +2003,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
-  - name: Upload decoder (overwrite=true)
+  - name: Upload decoder (overwrite=true) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -2016,7 +2022,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Upload decoder with XML syntax error (overwrite=true)
+  - name: Upload decoder with XML syntax error (overwrite=true) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -2038,7 +2044,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
-  - name: Upload new CDB list
+  - name: Upload new CDB list {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -2056,7 +2062,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Upload CDB list (overwrite=false)
+  - name: Upload CDB list (overwrite=false) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -2078,7 +2084,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
-  - name: Upload CDB list (overwrite=true)
+  - name: Upload CDB list (overwrite=true) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -2097,7 +2103,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Upload CDB list with a syntax error (overwrite=true)
+  - name: Upload CDB list with a syntax error (overwrite=true) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -2124,7 +2130,7 @@ test_name: PUT /cluster/wrong_node/files
 
 stages:
 
-  - name: Upload rules to unexisting node (overwrite=false) {node_id}
+  - name: Upload rules to unexisting node (overwrite=false)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/unexisting-node/files"
@@ -2193,7 +2199,7 @@ marks:
 
 stages:
 
-  - name: Request {node_id} 0
+  - name: Read info {node_id}
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/info"
@@ -2232,7 +2238,7 @@ marks:
 
 stages:
 
-  - name: Request {node_id} 1
+  - name: Read logs {node_id}
     request: &get_cluster_logs
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs"
@@ -2249,7 +2255,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> limit=3 {node_id}
+  - name: Read logs with filters -> limit=3 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2272,7 +2278,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> limit=4 {node_id}
+  - name: Read logs with filters -> limit=4 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2292,7 +2298,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> limit=2, sort=tag {node_id}
+  - name: Read logs with filters -> limit=2, sort=tag {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2311,7 +2317,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> limit=1, sort=-level {node_id}
+  - name: Read logs with filters -> limit=1, sort=-level {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2329,7 +2335,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> offset=2, limit=3 {node_id}
+  - name: Read logs with filters -> offset=2, limit=3 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2349,7 +2355,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> offset=5, limit=2 {node_id}
+  - name: Read logs with filters -> offset=5, limit=2 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2368,7 +2374,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> tag=ossec-analysisd, limit=1 {node_id}
+  - name: Read logs with filters -> tag=ossec-analysisd, limit=1 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2386,7 +2392,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> tag=ossec-syscheckd, limit=2 {node_id}
+  - name: Read logs with filters -> tag=ossec-syscheckd, limit=2 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2407,7 +2413,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> level=info, limit=1 {node_id}
+  - name: Read logs with filters -> level=info, limit=1 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2426,7 +2432,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters by query (tag=ossec-syscheckd, level=info)
+  - name: Read logs with filters by query (tag=ossec-syscheckd, level=info) {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2456,7 +2462,7 @@ marks:
 
 stages:
 
-  - name: Request {node_id} 2
+  - name: Read logs summary {node_id}
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs/summary"
@@ -2527,7 +2533,7 @@ test_name: GET /cluster/wrong_node/stats
 
 stages:
 
-  - name: unexisting_node stats
+  - name: Unexisting_node stats
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/unexisting-node/stats"
@@ -2747,7 +2753,7 @@ marks:
 
 stages:
 
-  - name: Request {node_id} 3
+  - name: Read status {node_id}
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/status"
@@ -2769,7 +2775,7 @@ test_name: PUT /cluster/restart
 
 stages:
 
-  - name: Restart cluster
+  - name: Restart cluster (worker1, worker2)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
@@ -2791,7 +2797,7 @@ stages:
           total_failed_items: 0
     delay_after: !float "{restart_delay_cluster}"
 
-  - name: Restart cluster
+  - name: Restart cluster all nodes
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"


### PR DESCRIPTION
Hello team,

This PR fixes a race condition for some test that were updating or deleting files in worker nodes. Those files were also updated or deleted in the master node in a previous stage and the cluster synchronizes them, causing a random error for said calls.

`DELETE /cluster/{node_id}/files` and `PUT /cluster/{node_id}/files` when updating ruleset files in worker nodes.

Regards,
### 
**Integration test run:**
```
Collected tests [1]:
test_cluster_endpoints.tavern.yaml


test_cluster_endpoints.tavern.yaml [1/10]
	 55 passed, 72 warnings

test_cluster_endpoints.tavern.yaml [2/10]
	 55 passed, 72 warnings

test_cluster_endpoints.tavern.yaml [3/10]
	 55 passed, 72 warnings

test_cluster_endpoints.tavern.yaml [4/10]
	 55 passed, 72 warnings

test_cluster_endpoints.tavern.yaml [5/10]
	 55 passed, 72 warnings

test_cluster_endpoints.tavern.yaml [6/10]
	 55 passed, 72 warnings

test_cluster_endpoints.tavern.yaml [7/10]
	 55 passed, 72 warnings

test_cluster_endpoints.tavern.yaml [8/10]
	 55 passed, 72 warnings

test_cluster_endpoints.tavern.yaml [9/10]
	 55 passed, 72 warnings

test_cluster_endpoints.tavern.yaml [10/10]
	 55 passed, 72 warnings
