### PR TITLE
analysisd: Fix Missing fields in rules description evaluation

### DIFF
--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -1033,11 +1033,13 @@ char* ParseRuleComment(Eventinfo *lf) {
 #ifdef LIBGEOIP_ENABLED
         } else if (strcmp(var, "srcgeoip") == 0) {
             field = lf->srcgeoip;
-        } else if (strcmp(var, "dstuser") == 0) {
+        } else if (strcmp(var, "dstgeoip") == 0) {
             field = lf->dstgeoip;
 #endif
         } else if (strcmp(var, "srcport") == 0) {
             field = lf->srcport;
+        } else if (strcmp(var, "dstport") == 0) {
+            field = lf->dstport;
         } else if (strcmp(var, "protocol") == 0) {
             field = lf->protocol;
         } else if (strcmp(var, "action") == 0) {

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -1058,6 +1058,13 @@ char* ParseRuleComment(Eventinfo *lf) {
             field = lf->systemname;
         }
 
+        // Find pre-decoding fields
+        else if (strcmp(var, "program_name") == 0) {
+            field = lf->program_name;
+        } else if (strcmp(var, "hostname") == 0) {
+            field = lf->hostname;
+        }
+
         // Find dynamic fields
 
         else {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/7044|

Hi team!,

This PR fix the `description` output in rules evaluation.

## Description

When variables are used in the `description` option, the `dstgeoip` and `dstport` variables are never filled. This does not affect the evaluation of the rule but the output of the alert.

## Wazuh-Logtest Output

simple example for test

**decoders**
```xml
<decoder name="example">
  <program_name>^example</program_name>
</decoder>

<decoder name="example">
  <parent>example</parent>
  <regex>User '(\w+)' logged from '(\d+.\d+.\d+.\d+):(\d+)' to '(\d+.\d+.\d+.\d+):(\d+)'</regex>
  <order>user, srcip, srcport, dstip, dstport</order>
</decoder>
```

**rules**
```xml
  <rule id="100010" level="0">
  <program_name>example</program_name>
  <description>User logged from $(srcip):$(srcport) to $(dstip):$(dstport)[$(dstgeoip)] </description>
</rule>
```

**test log**
```console
Dec 25 20:45:02 MyHost example[12345]: User 'admin' logged from '8.8.8.8:55000' to '200.16.19.1:22'
```
### Current output

missing `dstgeoip` and `dstport` in description (Phase 3)
```
Starting wazuh-logtest v4.2.0
Type one log per line
Dec 25 20:45:02 MyHost example[12345]: User 'admin' logged from '8.8.8.8:55000' to '200.16.19.1:22'
**Phase 1: Completed pre-decoding.
        full event: 'Dec 25 20:45:02 MyHost example[12345]: User 'admin' logged from '8.8.8.8:55000' to '200.16.19.1:22''
        timestamp: 'Dec 25 20:45:02'
        hostname: 'MyHost'
        program_name: 'example'
**Phase 2: Completed decoding.
        name: 'example'
        dstip: '200.16.19.1'
        dstport: '22'
        dstuser: 'admin'
        srcip: '8.8.8.8'
        srcport: '55000'
**Phase 3: Completed filtering (rules).
        id: '100010'
        level: '0'
        description: 'User logged from 8.8.8.8:55000 to 200.16.19.1:[] '
        groups: '['local', 'syslog', 'sshd']'
        firedtimes: '1'
        mail: 'False'
```

### PR output

```
Starting wazuh-logtest v4.2.0
Type one log per line

Dec 25 20:45:02 MyHost example[12345]: User 'admin' logged from '8.8.8.8:55000' to '200.16.19.1:22'

**Phase 1: Completed pre-decoding.
        full event: 'Dec 25 20:45:02 MyHost example[12345]: User 'admin' logged from '8.8.8.8:55000' to '200.16.19.1:22''
        timestamp: 'Dec 25 20:45:02'
        hostname: 'MyHost'
        program_name: 'example'

**Phase 2: Completed decoding.
        name: 'example'
        dstip: '200.16.19.1'
        dstport: '22'
        dstuser: 'admin'
        srcip: '8.8.8.8'
        srcport: '55000'

**Phase 3: Completed filtering (rules).
        id: '100010'
        level: '0'
        description: 'User logged from 8.8.8.8:55000 to 200.16.19.1:22[AR / Cordoba] '
        groups: '['local', 'syslog', 'sshd']'
        firedtimes: '1'
        mail: 'False'
```

## Tests

- [X] `runtest.py -c -g`
- Compilation without warnings in every supported platform
  - [X] Linux
  - [x] ~~Windows~~
  - [x] ~~MAC OS X~~
- [X] Source installation
- [X] Package installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [x] ~~Coverity~~
  - [X] Valgrind (memcheck and descriptor leaks check)
  - [x] ~~Dr. Memory~~
  - [x] ~~AddressSanitizer~~
 - ~~Memory tests for Windows~~
- ~~Memory tests for macOS~~

- [X] Retrocompatibility with older Wazuh versions
- [X] Working on cluster environments
- [x] ~~Configuration on demand reports new parameters~~
- [X] The data flow works as expected (agent-manager-api-app)