### PR TITLE
Fix segfaults in Windows when FIM operations fail

### DIFF
--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -285,37 +285,43 @@ const char *get_group(int gid);
 
 /**
  * @brief Retrieves the user name of the owner of a registry in Windows.
- * Also sets the user ID associated to that user.
+ * Also sets the ID associated to that user.
+ *
+ * @post *sid is always allocated and must be freed after usage.
  *
  * @param path Registry path to check the owner of.
  * @param sid The user ID associated to the user.
  * @param hndl Handle for the registry to check the owner of.
  *
- * @return The user name on success, NULL on failure.
+ * @return The user name on success, an empty string on failure.
  */
 char *get_registry_user(const char *path, char **sid, HANDLE hndl);
 
 /**
  * @brief Retrieves the user name of the owner of a file in Windows.
- * Also sets the user ID associated to that user.
+ * Also sets the ID associated to that user.
+ *
+ * @post *sid is always allocated and must be freed after usage.
  *
  * @param path File path to check the owner of.
  * @param sid The user ID associated to the user.
  *
- * @return The user name on success, NULL on failure.
+ * @return The user name on success, an empty string on failure.
  */
 char *get_file_user(const char *path, char **sid);
 
 /**
  * @brief Retrieves the user name of the owner of a file or registry in Windows.
- * Also sets the user ID associated to that user.
+ * Also sets the ID associated to that user.
+ *
+ * @post *sid is always allocated and must be freed after usage.
  *
  * @param path File or registry path to check the owner of.
  * @param sid The user ID associated to the user.
- * @param hndl Handle of the file or registry to check the owner of (NULL for files).
+ * @param hndl Handle of the file or registry to check the owner of.
  * @param object_type Type of the object to check the owner of (SE_FILE_OBJECT or SE_REGISTRY_KEY).
  *
- * @return The user name on success, NULL on failure.
+ * @return The user name on success, an empty string on failure.
  */
 char *get_user(const char *path, char **sid, HANDLE hndl, SE_OBJECT_TYPE object_type);
 

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -682,6 +682,7 @@ char *get_user(const char *path, char **sid, HANDLE hndl, SE_OBJECT_TYPE object_
     char *result;
 
     if (hndl == INVALID_HANDLE_VALUE) {
+        os_strdup("", *sid);
         *AcctName = '\0';
         goto end;
     }
@@ -701,7 +702,7 @@ char *get_user(const char *path, char **sid, HANDLE hndl, SE_OBJECT_TYPE object_
     }
 
     if (!ConvertSidToStringSid(pSidOwner, &local_sid)) {
-        *sid = NULL;
+        os_strdup("", *sid);
         mdebug1("The user's SID could not be extracted.");
     } else {
         os_strdup(local_sid, *sid);
@@ -745,7 +746,7 @@ end:
         LocalFree(pSD);
     }
 
-    result = wstr_replace((const char*)&AcctName, " ", "\\ ");
+    result = wstr_replace(AcctName, " ", "\\ ");
 
     return result;
 }
@@ -952,11 +953,12 @@ char *get_registry_group(char **sid, HANDLE hndl) {
         dwSecurityInfoErrorCode = GetLastError();
         merror("GetSecurityInfo error = %lu", dwSecurityInfoErrorCode);
         *GrpName = '\0';
+        os_strdup("", *sid);
         goto end;
     }
 
     if (!ConvertSidToStringSid(pSidGroup, &local_sid)) {
-        *sid = NULL;
+        os_strdup("", *sid);
         mdebug1("The user's SID could not be extracted.");
     } else {
         os_strdup(local_sid, *sid);
@@ -997,7 +999,7 @@ end:
         LocalFree(pSD);
     }
 
-    result = wstr_replace((const char*)&GrpName, " ", "\\ ");
+    result = wstr_replace(GrpName, " ", "\\ ");
 
     return result;
 }

--- a/src/syscheckd/registry/registry.c
+++ b/src/syscheckd/registry/registry.c
@@ -448,6 +448,7 @@ fim_registry_key *fim_registry_get_key_data(HKEY key_handle, const char *path, c
 
         if (retval != ERROR_SUCCESS) {
             mwarn(FIM_EXTRACT_PERM_FAIL, path, retval);
+            os_strdup("", key->perm);
         } else {
             key->perm = decode_win_permissions(permissions);
         }

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -3467,7 +3467,7 @@ void test_get_registry_group_ConvertSidToStringSid_fails(void **state) {
     group = get_registry_group(&group_id, hndl);
 
     assert_string_equal(group, "groupname");
-    assert_null(group_id);
+    assert_string_equal(group_id, "");
 }
 
 void test_get_registry_group_LookupAccountSid_fails(void **state) {


### PR DESCRIPTION
|Related issue|
|---|
|closes #7093 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes possible segfaults in FIM under Windows systems when one of the following operations fails:
- Unable to get registry permissions.
- Fail to retrieve group or user SIDs.

It also fixes a cast operation which was masking a correct but hard to follow `address operator` being used in a buffer tag, this causes no effect on the program (the compiler silently changes `&buffer_label` to `buffer_label`), but was not correct.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source upgrade


- Memory tests for Windows
  - [x] Scan-build report
  - [x] Dr. Memory
