### PR TITLE
Wazuh-Logtest: expand nested JSON objects in decode and match output

### DIFF
--- a/framework/scripts/wazuh-logtest.py
+++ b/framework/scripts/wazuh-logtest.py
@@ -354,12 +354,13 @@ class WazuhLogtest:
         if output['alert']:
             logging.info('**Alert to be generated.')
 
-    def show_phase_info(phase_data, show_first=[]):
+    def show_phase_info(phase_data, show_first=[], prefix=""):
         """Show wazuh-logtest processing phase information
 
         Args:
             phase_data (dict): phase info to display
-            show_first (list, optional): fields to be shown first. Defaults to [].
+            show_first (list, optional): fields to be shown first. Defaults to []
+            prefix (str, optional): add prefix to the name of the field to print. Default empty string
         """
         # Ordered fields first
         for field in show_first:
@@ -367,7 +368,10 @@ class WazuhLogtest:
                 logging.info("\t%s: '%s'", field, phase_data.pop(field))
         # Remaining fields then
         for field in sorted(phase_data.keys()):
-                logging.info("\t%s: '%s'", field, phase_data.pop(field))
+            if isinstance(phase_data.get(field), dict):
+                WazuhLogtest.show_phase_info(phase_data.pop(field), [], prefix + field + '.')
+            else:
+                logging.info("\t%s: '%s'", prefix + field, phase_data.pop(field))
 
     def show_last_ut_result(self, ut):
         """Display unit test result


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/7103|

Hi team!

This PR fixes the expansion of json objects in Wazuh-Logtest, I attach some outputs from the master and this PR

## Decoding Phase 

**JSON input**

```json
{
    "url": "test.com",
    "test_obj": {
        "field1": "yes",
        "field2": "no"
    },
    "test_array": [
        "str1",
        "str2"
    ],
    "test_obj2": {
        "array_2": [
            1,
            2,
            3
        ],
        "bool": true,
        "emmbebed_objt": {
            "eo1": "hi",
            "eo2": "bye"
        }
    },
    "empty": {}
}
```

### Master output

`test_obj` and `test_obj2` should be expanded into dynamic subfields

```
Starting wazuh-logtest v4.2.0
Type one log per line
{"url": "test.com", "test_obj": {"field1" : "yes", "field2" : "no"}, "test_array": ["str1", "str2"], "test_obj2" : {"array_2" : [1,2,3], "bool": true, "emmbebed_objt": {"eo1": "hi", "eo2": "bye"}}, "empty":{}}
**Phase 1: Completed pre-decoding.
        full event: '{"url": "test.com", "test_obj": {"field1" : "yes", "field2" : "no"}, "test_array": ["str1", "str2"], "test_obj2" : {"array_2" : [1,2,3], "bool": true, "emmbebed_objt": {"eo1": "hi", "eo2": "bye"}}, "empty":{}}'
**Phase 2: Completed decoding.
        name: 'json'
        test_array: '['str1', 'str2']'
        test_obj: '{'field1': 'yes', 'field2': 'no'}'
        test_obj2: '{'array_2': [1, 2, 3], 'bool': 'true', 'emmbebed_objt': {'eo1': 'hi', 'eo2': 'bye'}}'
        url: 'test.com'
```
### PR output

```
Starting wazuh-logtest v4.2.0
Type one log per line

{"url": "test.com", "test_obj": {"field1" : "yes", "field2" : "no"}, "test_array": ["str1", "str2"], "test_obj2" : {"array_2" : [1,2,3], "bool": true, "emmbebed_objt": {"eo1": "hi", "eo2": "bye"}}, "empty":{}}

**Phase 1: Completed pre-decoding.
        full event: '{"url": "test.com", "test_obj": {"field1" : "yes", "field2" : "no"}, "test_array": ["str1", "str2"], "test_obj2" : {"array_2" : [1,2,3], "bool": true, "emmbebed_objt": {"eo1": "hi", "eo2": "bye"}}, "empty":{}}'

**Phase 2: Completed decoding.
        name: 'json'
        test_array: '['str1', 'str2']'
        test_obj.field1: 'yes'
        test_obj.field2: 'no'
        test_obj2.array_2: '[1, 2, 3]'
        test_obj2.bool: 'true'
        test_obj2.emmbebed_objt.eo1: 'hi'
        test_obj2.emmbebed_objt.eo2: 'bye'
        url: 'test.com'
```
## Filter Phase  (rules match)

**input**

```
Oct 15 21:07:56 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928
```

### Master output

`mitre` object should be expanded into dynamic subfields

```
Starting wazuh-logtest v4.2.0
Type one log per line
Oct 15 21:07:56 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928
**Phase 1: Completed pre-decoding.
        full event: 'Oct 15 21:07:56 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928'
        timestamp: 'Oct 15 21:07:56'
        hostname: 'linux-agent'
        program_name: 'sshd'
**Phase 2: Completed decoding.
        name: 'sshd'
        parent: 'sshd'
        srcip: '18.18.18.18'
        srcport: '48928'
        srcuser: 'blimey'
**Phase 3: Completed filtering (rules).
        id: '5710'
        level: '5'
        description: 'sshd: Attempt to login using a non-existent user'
        groups: '['syslog', 'sshd', 'invalid_login', 'authentication_failed']'
        firedtimes: '1'
        gdpr: '['IV_35.7.d', 'IV_32.2']'
        gpg13: '['7.1']'
        hipaa: '['164.312.b']'
        mail: 'False'
        mitre: '{'id': ['T1110'], 'tactic': ['Credential Access'], 'technique': ['Brute Force']}'
        nist_800_53: '['AU.14', 'AC.7', 'AU.6']'
        pci_dss: '['10.2.4', '10.2.5', '10.6.1']'
        tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']'
**Alert to be generated.
```

### PR Output
```
Starting wazuh-logtest v4.2.0
Type one log per line

Oct 15 21:07:56 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928

**Phase 1: Completed pre-decoding.
        full event: 'Oct 15 21:07:56 linux-agent sshd[29205]: Invalid user blimey from 18.18.18.18 port 48928'
        timestamp: 'Oct 15 21:07:56'
        hostname: 'linux-agent'
        program_name: 'sshd'

**Phase 2: Completed decoding.
        name: 'sshd'
        parent: 'sshd'
        srcip: '18.18.18.18'
        srcport: '48928'
        srcuser: 'blimey'

**Phase 3: Completed filtering (rules).
        id: '5710'
        level: '5'
        description: 'sshd: Attempt to login using a non-existent user'
        groups: '['syslog', 'sshd', 'invalid_login', 'authentication_failed']'
        firedtimes: '1'
        gdpr: '['IV_35.7.d', 'IV_32.2']'
        gpg13: '['7.1']'
        hipaa: '['164.312.b']'
        mail: 'False'
        mitre.id: '['T1110']'
        mitre.tactic: '['Credential Access']'
        mitre.technique: '['Brute Force']'
        nist_800_53: '['AU.14', 'AC.7', 'AU.6']'
        pci_dss: '['10.2.4', '10.2.5', '10.6.1']'
        tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']'
**Alert to be generated.
```

## Tests
- [X] runtest.py -c -g
- [X] Install/update from source
- [X]  Retrocompatibility with `ossec-logtest`