### PR TITLE
Analysisd: Remove deprecate command static field (fix JSON Decoder)

### DIFF
--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -83,11 +83,6 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
         return;
     }
 
-    if (strcmp(key, "command") == 0){
-        os_strdup(value, lf->command);
-        return;
-    }
-
     if (strcmp(key, "url") == 0){
         os_strdup(value, lf->url);
         return;

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -638,7 +638,6 @@ void Zero_Eventinfo(Eventinfo *lf)
     lf->dstuser = NULL;
     lf->id = NULL;
     lf->status = NULL;
-    lf->command = NULL;
     lf->url = NULL;
     lf->data = NULL;
     lf->extra_data = NULL;
@@ -840,9 +839,6 @@ void Free_Eventinfo(Eventinfo *lf)
     }
     if (lf->id) {
         free(lf->id);
-    }
-    if (lf->command) {
-        free(lf->command);
     }
     if (lf->url) {
         free(lf->url);
@@ -1161,10 +1157,6 @@ void w_copy_event_for_log(Eventinfo *lf,Eventinfo *lf_cpy){
 
     if(lf->status){
         os_strdup(lf->status,lf_cpy->status);
-    }
-
-    if(lf->command){
-        os_strdup(lf->command,lf_cpy->command);
     }
 
     if(lf->url){

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -50,7 +50,6 @@ typedef struct _Eventinfo {
     char *dstuser;
     char *id;
     char *status;
-    char *command;
     char *url;
     char *data;
     char *extra_data;

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -418,9 +418,6 @@ char* Eventinfo_to_jsonstr(const Eventinfo* lf, bool force_full_log)
     if(lf->status)
         cJSON_AddStringToObject(data, "status", lf->status);
 
-    if(lf->command)
-        cJSON_AddStringToObject(root, "command", lf->command);
-
     if(lf->url)
         cJSON_AddStringToObject(data, "url", lf->url);
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/7102|


## Description

Command is a static field that was neither implemented nor documented. There is no `command` tag in decoders, and when command is loaded in order, this is a dynamic field.
When implementing the json decoder, unlike an xml decoder, the command is stored in the command field of the event, but in the rule evaluation it is never evaluated.
There is also no command tag in the rules.

This PR removes the incomplete implementation of the command field so that it is always treated as a dynamic field.

### Test log

```
{ "url" : "test.com", "command" : "logged" }

```

### Test rules

```xml

  <rule id="100011" level="4">
    <url>test.com</url>
    <description>command: $(command)</description>
  </rule>

  <rule id="100012" level="4">
    <if_sid>100011</if_sid>
    <field name="command">logged</field>
    <description>command: '$(command)'</description>
  </rule>

```

## 4.0 Output (ossec-Logtest)
Trigger rule 100011 when it should trigger 100012

```
2021/01/06 18:50:45 ossec-testrule: INFO: Started (pid: 4190).
ossec-testrule: Type one log per line.

{ "url" : "test.com", "command" : "logged" }


**Phase 1: Completed pre-decoding.
       full event: '{ "url" : "test.com", "command" : "logged" }'
       timestamp: '(null)'
       hostname: '30-u20-manager'
       program_name: '(null)'
       log: '{ "url" : "test.com", "command" : "logged" }'

**Phase 2: Completed decoding.
       decoder: 'json'
       url: 'test.com'
       command: 'logged'

**Phase 3: Completed filtering (rules).
       Rule id: '100011'
       Level: '4'
       Description: 'command: '
**Alert to be generated.

```

## Master Output (Wazuh-logtest)
Trigger rule 100011 when it should trigger 100012
```
Starting wazuh-logtest v4.2.0
Type one log per line

{ "url" : "test.com", "command" : "logged" }

**Phase 1: Completed pre-decoding.
        full event: '{ "url" : "test.com", "command" : "logged" }'

**Phase 2: Completed decoding.
        name: 'json'
        url: 'test.com'

**Phase 3: Completed filtering (rules).
        id: '100011'
        level: '4'
        description: 'command: '
        groups: '['local', 'syslog', 'sshd']'
        firedtimes: '1'
        mail: 'False'
**Alert to be generated.
```

## PR Output (Wazuh Logtest)

```
Starting wazuh-logtest v4.2.0
Type one log per line

{ "url" : "test.com", "command" : "logged" }

**Phase 1: Completed pre-decoding.
        full event: '{ "url" : "test.com", "command" : "logged" }'

**Phase 2: Completed decoding.
        name: 'json'
        command: 'logged'
        url: 'test.com'

**Phase 3: Completed filtering (rules).
        id: '100012'
        level: '4'
        description: 'command: 'logged''
        groups: '['local', 'syslog', 'sshd']'
        firedtimes: '1'
        mail: 'False'
**Alert to be generated.
```

## Tests

- [x] ./runtests.py -g -c

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] ~Review logs syntax and correct language~
- [x] ~QA templates contemplate the added capabilities~

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] ~Dr. Memory~
  - [x] ~AddressSanitizer~
- Memory tests for Windows
  - [x] ~Scan-build report~
  - [x] ~Coverity~
  - [x] ~Dr. Memory~
- Memory tests for macOS
  - [x] ~Scan-build report~
  - [x] ~Leaks~
  - [x] ~AddressSanitizer~

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [x] ~Working on cluster environments~
- [x] ~Configuration on demand reports new parameters~
- [ ] The data flow works as expected (agent-manager-api-app)
- [x] ~Added unit tests (for new features)~
- [x] ~Stress test for affected components~
