### PR TITLE
Added rule 521 with level 11 and MITRE ID T1014 for rootkit

### DIFF
--- a/ruleset/rules/0015-ossec_rules.xml
+++ b/ruleset/rules/0015-ossec_rules.xml
@@ -154,6 +154,9 @@
     <if_sid>510</if_sid>
     <match>Possible kernel level rootkit</match>
     <description>Possible kernel level rootkit</description>
+    <mitre>
+      <id>T1014</id>
+    </mitre>
     <group>rootcheck,</group>
   </rule>
 

--- a/ruleset/rules/0015-ossec_rules.xml
+++ b/ruleset/rules/0015-ossec_rules.xml
@@ -150,6 +150,12 @@
     <group>pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
+  <rule id="521" level="11">
+    <if_sid>510</if_sid>
+    <match>Possible kernel level rootkit</match>
+    <description>Possible kernel level rootkit</description>
+    <group>rootcheck,</group>
+  </rule>
 
   <!-- Process monitoring rules -->
   <rule id="530" level="0">


### PR DESCRIPTION
|Related issue|
|---|
|7097|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The rule 521 was added to the built-in ruleset for matching logs that include `Possible kernel level rootkit` in their fields. This new rule is a child of the rule 510. It has level 11 which according to our Rules classification (https://documentation.wazuh.com/4.0/user-manual/ruleset/rules-classification.html) indicates the presence of rootkits. For the same reason, the MITRE ID T1014 (https://attack.mitre.org/techniques/T1014/) was also included in the rule.