### PR TITLE
wazuh-logcollector: add state/statistics generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
   - Added support for bookmarks in Logcollector, allowing to follow the log file at the point where the agent stopped. ([#3368](https://github.com/wazuh/wazuh/issues/3368))
   - Improved support for multi-line logs with a variable number of lines. ([#5652](https://github.com/wazuh/wazuh/issues/5652))
 
+- **API:**
+  - Added new endpoint to get agent stats from different components. ([#7128](https://github.com/wazuh/wazuh/issues/7128))
+  
 - **Ruleset:**
   - Added support for UFW firewall to decoders. ([#7100](https://github.com/wazuh/wazuh/pull/7100))
 

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -7,7 +7,6 @@ import logging
 from aiohttp import web
 from connexion.lifecycle import ConnexionResponse
 
-import wazuh.agent as agent
 from api import configuration
 from api.encoder import dumps, prettify
 from api.models.agent_added_model import AgentAddedModel
@@ -15,10 +14,10 @@ from api.models.agent_inserted_model import AgentInsertedModel
 from api.models.base_model_ import Body
 from api.models.group_added_model import GroupAddedModel
 from api.util import parse_api_param, remove_nones_to_dict, raise_if_exc
+from wazuh import agent, stats
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.common import database_limit
-from wazuh.core.exception import WazuhError
 
 logger = logging.getLogger('wazuh-api')
 
@@ -465,6 +464,39 @@ async def put_upgrade_custom_agents(request, agents_list=None, pretty=False, wai
                 'installer': installer}
 
     dapi = DistributedAPI(f=agent.upgrade_agents,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='distributed_master',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          logger=logger,
+                          rbac_permissions=request['token_info']['rbac_policies']
+                          )
+    data = raise_if_exc(await dapi.distribute_function())
+
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+
+
+async def get_component_stats(request, pretty=False, wait_for_complete=False, agent_id=None, component=None):
+    """Get a specified agent's component stats.
+
+    Parameters
+    ----------
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
+    agent_id : list
+        List of agent IDs. All possible values from 000 onwards.
+
+    Returns
+    -------
+    ApiResponse
+        Module stats.
+    """
+    f_kwargs = {'agent_list': [agent_id],
+                'component': component}
+
+    dapi = DistributedAPI(f=stats.get_agents_component_stats_json,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='distributed_master',
                           is_async=False,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -4277,6 +4277,15 @@ components:
       schema:
         type: string
         format: sort
+    stats_component:
+      in: path
+      name: component
+      description: "Selected stats component"
+      required: true
+      schema:
+        type: string
+        enum:
+          - logcollector
     status:
       in: query
       name: status
@@ -5875,6 +5884,100 @@ paths:
                     total_failed_items: 0
                   message: "Restart command sent to all agents"
                   error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+  /agents/{agent_id}/stats/{component}:
+    get:
+      tags:
+        - Agents
+      summary: "Get agent's component stats"
+      description: "Return Wazuh's {component} statistical information from agent {agent_id}"
+      operationId: api.controllers.agent_controller.get_component_stats
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/agent:read'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/agent_id'
+        - $ref: '#/components/parameters/stats_component'
+      responses:
+        '200':
+          description: "Component stats"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+              example:
+                data:
+                  affected_items:
+                    - global:
+                        start: 'Wed Jan 13 16:08:57 2021'
+                        end: 'Thu Jan 14 12:28:11 2021'
+                        files:
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: df -P
+                            bytes: 51414
+                            events: 570
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: last -n 20
+                            bytes: 3762
+                            events: 57
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: /var/ossec/logs/active-responses.log
+                            bytes: 0
+                            events: 0
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: /var/log/dpkg.log
+                            bytes: 0
+                            events: 0
+                      interval:
+                        start: 'Thu Jan 14 12:28:06 2021'
+                        end: 'Thu Jan 14 12:28:11 2021'
+                        files:
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: df -P
+                            bytes: 0
+                            events: 0
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: last -n 20
+                            bytes: 0
+                            events: 0
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: /var/ossec/logs/active-responses.log
+                            bytes: 0
+                            events: 0
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: /var/log/dpkg.log
+                            bytes: 0
+                            events: 0
+                  total_affected_items: 1
+                  total_failed_items: 0
+                  failed_items: [ ]
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1896,6 +1896,109 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: GET /agents/{agent_id}/stats/{component}
+
+stages:
+
+  - name: Get logcollector stats from agent 000 (manager)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/000/stats/logcollector"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items: &stats_response
+            - global:
+                start: !anystr
+                end: !anystr
+                files: !anything
+              interval:
+                start: !anystr
+                end: !anystr
+                files: !anything
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Get logcollector stats from agent 002
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - <<: *stats_response
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Try to get logcollector stats from agent 007 (incompatible version)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/007/stats/logcollector"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 1
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1735
+              id:
+                - "007"
+          total_affected_items: 0
+          total_failed_items: 1
+
+  - name: Try to get logcollector stats from agent 017 (non-existent)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/017/stats/logcollector"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 1
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1701
+              id:
+                - "017"
+          total_affected_items: 0
+          total_failed_items: 1
+
+  - name: Try to get invalid component stats from agent 000
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/017/stats/invalid_component"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 400
+      json:
+        title: !anystr
+        detail: !anystr
+
+---
 test_name: GET /groups
 
 stages:

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -233,6 +233,46 @@ stages:
          total_failed_items: 0
 
 ---
+test_name: GET /agents/{agent_id}/stats/{component}
+
+stages:
+
+ - name: Try to get logcollector stats from agent 002 (Denied)
+   request:
+     verify: False
+     url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+   response:
+      <<: *permission_denied
+
+ - name: Try to get logcollector stats from agent 003 (Allowed)
+   request:
+     verify: False
+     url: "{protocol:s}://{host:s}:{port:d}/agents/003/stats/logcollector"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+   response:
+     status_code: 200
+     json:
+       error: 0
+       data:
+         affected_items:
+           - global:
+               start: !anystr
+               end: !anystr
+               files: !anything
+             interval:
+               start: !anystr
+               end: !anystr
+               files: !anything
+         failed_items: []
+         total_affected_items: 1
+         total_failed_items: 0
+
+---
 test_name: GET /groups
 
 stages:

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -237,6 +237,46 @@ stages:
          total_failed_items: 0
 
 ---
+test_name: GET /agents/{agent_id}/stats/{component}
+
+stages:
+
+ - name: Try to get logcollector stats from agent 002 (Allowed)
+   request:
+     verify: False
+     url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+   response:
+     status_code: 200
+     json:
+       error: 0
+       data:
+         affected_items:
+           - global:
+               start: !anystr
+               end: !anystr
+               files: !anything
+             interval:
+               start: !anystr
+               end: !anystr
+               files: !anything
+         failed_items: []
+         total_affected_items: 1
+         total_failed_items: 0
+
+ - name: Try to get logcollector stats from agent 003 (Denied)
+   request:
+     verify: False
+     url: "{protocol:s}://{host:s}:{port:d}/agents/003/stats/logcollector"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+   response:
+      <<: *permission_denied
+
+---
 test_name: GET /groups
 
 stages:

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -141,7 +141,7 @@ logcollector.reload_delay=1000
 # Excluded files refresh interval, in seconds [1..172800]
 logcollector.exclude_files_interval=86400
 
-# Statistics generation and file updating interval, in seconds [1..3600]
+# State generation updating interval, in seconds [1..3600]
 logcollector.state_interval=5
 
 # Remoted counter io flush.

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -141,6 +141,9 @@ logcollector.reload_delay=1000
 # Excluded files refresh interval, in seconds [1..172800]
 logcollector.exclude_files_interval=86400
 
+# Statistics generation and file updating interval, in seconds [1..3600]
+logcollector.state_interval=5
+
 # Remoted counter io flush.
 remoted.recv_counter_flush=128
 

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -142,7 +142,7 @@ logcollector.reload_delay=1000
 logcollector.exclude_files_interval=86400
 
 # State generation updating interval, in seconds [0..3600]
-# 0 means disabled
+# 0 means state file creation and updating is disabled
 logcollector.state_interval=5
 
 # Remoted counter io flush.

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -141,7 +141,8 @@ logcollector.reload_delay=1000
 # Excluded files refresh interval, in seconds [1..172800]
 logcollector.exclude_files_interval=86400
 
-# State generation updating interval, in seconds [1..3600]
+# State generation updating interval, in seconds [0..3600]
+# 0 means disabled
 logcollector.state_interval=5
 
 # Remoted counter io flush.

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -15,7 +15,7 @@ from platform import platform
 from shutil import copyfile, rmtree
 from time import time
 
-from wazuh.core import common, configuration
+from wazuh.core import common, configuration, stats
 from wazuh.core.InputValidator import InputValidator
 from wazuh.core.cluster.utils import get_manager_status
 from wazuh.core.exception import WazuhException, WazuhError, WazuhInternalError, WazuhResourceNotFound
@@ -1073,6 +1073,33 @@ class Agent:
             raise WazuhInternalError(1735, extra_message="Minimum required version is " + str(required_version))
 
         return configuration.get_active_configuration(self.id, component, config)
+
+    def get_stats(self, component):
+        """Read the agent's component stats.
+
+        Parameters
+        ----------
+        component : string
+            Name of the component to get stats from.
+
+        Returns
+        -------
+        Dict
+            Object with component's stats.
+        """
+        # Available daemons and the minimum required agent's version.
+        stats_min_ver = {'logcollector': 'v4.2.0'}
+
+        # Check if agent version is compatible with this feature
+        self.load_info_from_db()
+        if self.version is None:
+            raise WazuhInternalError(1015)
+        agent_version = WazuhVersion(self.version.split(" ")[1])
+        required_version = WazuhVersion(stats_min_ver.get(component))
+        if agent_version < required_version:
+            raise WazuhInternalError(1735, extra_message="Minimum required version is " + str(required_version))
+
+        return stats.get_daemons_stats_from_socket(self.id, component)
 
 
 def format_fields(field_name, value):

--- a/framework/wazuh/core/tests/data/test_agent/schema_global_test.sql
+++ b/framework/wazuh/core/tests/data/test_agent/schema_global_test.sql
@@ -66,7 +66,7 @@ INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version,
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Ubuntu','18.04.1 LTS','18','04',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
-                   'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
+                   'Wazuh v4.2.0','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
                     strftime('%s','now','-5 seconds'),'updated', 'active', 'group-2');
 

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1419,6 +1419,27 @@ def test_agent_getconfig_ko(socket_mock, send_mock, mock_ossec_socket):
         agent.getconfig('com', 'active-response')
 
 
+@patch('wazuh.core.stats.OssecSocket')
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_stats(socket_mock, send_mock, mock_ossec_socket):
+    """Test get_stats method returns expected message."""
+    agent = Agent('001')
+    mock_ossec_socket.return_value.receive.return_value = b'{"error":0, "data":{"test":0}}'
+    result = agent.get_stats('logcollector')
+    assert result == {"test": 0}, 'Result message is not as expected.'
+
+
+@patch('wazuh.core.stats.OssecSocket')
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_stats_ko(socket_mock, send_mock, mock_ossec_socket):
+    """Test get_stats method raises expected exception when the agent's version is lower than required."""
+    agent = Agent('002')
+    with pytest.raises(WazuhInternalError, match=r'\b1735\b'):
+        agent.get_stats('logcollector')
+
+
 @pytest.mark.parametrize('last_keep_alive, pending, expected_status', [
     (10, False, 'active'),
     (1900, False, 'disconnected'),

--- a/framework/wazuh/core/tests/test_stats.py
+++ b/framework/wazuh/core/tests/test_stats.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
+        sys.modules['wazuh.rbac.orm'] = MagicMock()
+        import wazuh.rbac.decorators
+
+        del sys.modules['wazuh.rbac.orm']
+        from wazuh.tests.util import RBAC_bypasser
+
+        wazuh.rbac.decorators.expose_resources = RBAC_bypasser
+        from wazuh.core.exception import WazuhError, WazuhInternalError
+        from wazuh.core import stats, common
+
+
+@pytest.mark.parametrize("agent_id, daemon, response", [
+    ('000', 'logcollector', '{"error":0, "data":{"test":0}}'),
+    (3, 'test', '{"error":0, "data":{"test":0}}'),
+])
+def test_get_daemons_stats_from_socket(agent_id, daemon, response):
+    """Check that get_daemons_stats_from_socket function uses the expected params and returns expected result.
+
+    Parameters
+    ----------
+    agent_id : string
+        Id of the agent to get stats from.
+    daemon : string
+        Name of the service to get stats from.
+    response : string
+        Response to be returned by the socket.
+    """
+    with patch('wazuh.core.stats.OssecSocket.__init__', return_value=None) as mock_socket:
+        with patch('wazuh.core.stats.OssecSocket.send', side_effect=None) as mock_send:
+            with patch('wazuh.core.stats.OssecSocket.receive', return_value=response.encode()):
+                with patch('wazuh.core.stats.OssecSocket.close', side_effect=None):
+                    result = stats.get_daemons_stats_from_socket(agent_id, daemon)
+
+        if agent_id == '000':
+            mock_socket.assert_called_once_with(os.path.join(common.ossec_path, "queue", "ossec", "logcollector"))
+            mock_send.assert_called_once_with(b'getstate')
+        else:
+            mock_socket.assert_called_once_with(os.path.join(common.ossec_path, "queue", "ossec", "request"))
+            mock_send.assert_called_once_with(f"{str(agent_id).zfill(3)} {daemon} getstate".encode())
+
+
+def test_get_daemons_stats_from_socket_ko():
+    """Check if get_daemons_stats_from_socket raises expected exceptions."""
+    with pytest.raises(WazuhError, match=r'\b1307\b'):
+        stats.get_daemons_stats_from_socket(None, None)
+
+    with pytest.raises(WazuhInternalError, match=r'\b1121\b'):
+        stats.get_daemons_stats_from_socket('000', 'logcollector')
+
+    with patch('wazuh.core.stats.OssecSocket.__init__', return_value=None):
+        with patch('wazuh.core.stats.OssecSocket.send', side_effect=None):
+            with patch('wazuh.core.configuration.OssecSocket.receive', side_effect=ValueError):
+                with pytest.raises(WazuhInternalError, match=r'\b1118\b'):
+                    stats.get_daemons_stats_from_socket('000', 'logcollector')
+
+            with patch('wazuh.core.configuration.OssecSocket.receive', return_value="err Error message test".encode()):
+                with patch('wazuh.core.stats.OssecSocket.close', side_effect=None):
+                    with pytest.raises(WazuhError, match=r'\b1117\b'):
+                        stats.get_daemons_stats_from_socket('000', 'logcollector')

--- a/framework/wazuh/stats.py
+++ b/framework/wazuh/stats.py
@@ -5,11 +5,12 @@
 import os
 from io import StringIO
 
-from wazuh.core import common
+from wazuh.core import common, stats
+from wazuh.core.agent import Agent, get_agents_info
 from wazuh.core.cluster.cluster import get_node
 from wazuh.core.cluster.utils import read_cluster_config
-from wazuh.core.exception import WazuhError, WazuhInternalError
-from wazuh.core.results import AffectedItemsWazuhResult
+from wazuh.core.exception import WazuhError, WazuhInternalError, WazuhException, WazuhResourceNotFound
+from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.rbac.decorators import expose_resources
 
 try:
@@ -66,7 +67,8 @@ def totals(date):
                 if len(data) in (0, 1):
                     continue
                 else:
-                    result.add_failed_item(id_=node_id, error=WazuhInternalError(1309))
+                    result.add_failed_item(id_=node_id if cluster_enabled else 'manager',
+                                           error=WazuhInternalError(1309))
                     return result
 
             hour = int(data[0])
@@ -191,4 +193,37 @@ def get_daemons_stats(filename):
         raise WazuhError(1308, extra_message=filename)
 
     result.total_affected_items = len(result.affected_items)
+    return result
+
+
+@expose_resources(actions=["agent:read"], resources=["agent:id:{agent_list}"], post_proc_func=None)
+def get_agents_component_stats_json(agent_list=None, component=None):
+    """Get statistics of an agent's component.
+
+    Parameters
+    ----------
+    agent_list : list
+        List of agents ID's.
+    component : string
+        Name of the component to get stats from.
+
+    Returns
+    -------
+    result : AffectedItemsWazuhResult
+        Component stats.
+    """
+    result = AffectedItemsWazuhResult(all_msg=f'Statistical information for each agent was successfully read',
+                                      some_msg=f'Could not read statistical information for some agents',
+                                      none_msg=f'Could not read statistical information for any agent')
+
+    system_agents = get_agents_info()
+    for agent_id in agent_list:
+        try:
+            if agent_id not in system_agents:
+                raise WazuhResourceNotFound(1701)
+            result.affected_items.append(Agent(agent_id).get_stats(component=component))
+        except WazuhException as e:
+            result.add_failed_item(id_=agent_id, error=e)
+    result.total_affected_items = len(result.affected_items)
+
     return result

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -96,6 +96,7 @@ get_rbac_actions:
           - GET /agents/{agent_id}/config/{component}/{configuration}
           - GET /agents/{agent_id}/group/is_sync
           - GET /agents/{agent_id}/key
+          - GET /agents/{agent_id}/stats/{component}
           - GET /groups/{group_id}/agents
           - GET /agents/no_group
           - GET /agents/outdated

--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -56,7 +56,8 @@ int StartMQ(const char *key, short int type, short int n_attempts) __attribute__
  * @return
  * UNIX -> 0 if file descriptor is still available
  * UNIX -> -1 if there is an error in the socket. The socket will be closed before returning (StartMQ should be called to restore queue)
- * WIN32 -> 0
+ * WIN32 -> 0 on success
+ * WIN32 -> -1 on error
  * Notes: (UNIX) If the socket is busy when trying to send a message a DEBUG2 message will be loggeed but the return code will be 0
  */
 
@@ -71,8 +72,9 @@ int SendMSG(int queue, const char *message, const char *locmsg, char loc) __attr
  * @param loc  queue location (WIN32)
  * @param target logtarget ptr with the socket information
  * @return
+ * UNIX ->  1 message was discarded
  * UNIX -> -1 invalid protocol or cannot create socket
- * UNIX ->  0 message was sent or discarded
+ * UNIX ->  0 message was sent
  * WIN32 -> -1 invalid target
  * WIN32 -> 0 valid target
  * Notes: (UNIX) If the message is not sent because the socket is busy, the return code will be 0

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -255,6 +255,7 @@ cJSON *getLogcollectorInternalOptions(void) {
     cJSON_AddNumberToObject(logcollector,"force_reload",force_reload);
     cJSON_AddNumberToObject(logcollector,"reload_interval",reload_interval);
     cJSON_AddNumberToObject(logcollector,"reload_delay",reload_delay);
+    cJSON_AddNumberToObject(logcollector, "exclude_files_interval", free_excluded_files_interval);
     cJSON_AddNumberToObject(logcollector, "state_interval", state_interval);
 
 #ifndef WIN32

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -50,6 +50,7 @@ int LogCollectorConfig(const char *cfgfile)
     reload_interval = getDefine_Int("logcollector", "reload_interval", 1, 86400);
     reload_delay = getDefine_Int("logcollector", "reload_delay", 0, 30000);
     free_excluded_files_interval = getDefine_Int("logcollector", "exclude_files_interval", 1, 172800);
+    state_interval = getDefine_Int("logcollector", "state_interval", 1, 3600);
 
     /* Current and total files counter */
     total_files = 0;
@@ -254,6 +255,7 @@ cJSON *getLogcollectorInternalOptions(void) {
     cJSON_AddNumberToObject(logcollector,"force_reload",force_reload);
     cJSON_AddNumberToObject(logcollector,"reload_interval",reload_interval);
     cJSON_AddNumberToObject(logcollector,"reload_delay",reload_delay);
+    cJSON_AddNumberToObject(logcollector, "state_interval", state_interval);
 
 #ifndef WIN32
     cJSON_AddNumberToObject(logcollector,"rlimit_nofile",nofile);

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -50,7 +50,7 @@ int LogCollectorConfig(const char *cfgfile)
     reload_interval = getDefine_Int("logcollector", "reload_interval", 1, 86400);
     reload_delay = getDefine_Int("logcollector", "reload_delay", 0, 30000);
     free_excluded_files_interval = getDefine_Int("logcollector", "exclude_files_interval", 1, 172800);
-    state_interval = getDefine_Int("logcollector", "state_interval", 1, 3600);
+    state_interval = getDefine_Int("logcollector", "state_interval", 0, 3600);
 
     /* Current and total files counter */
     total_files = 0;

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -12,6 +12,7 @@
 #include "logcollector.h"
 #include "wazuh_modules/wmodules.h"
 #include "os_net/os_net.h"
+#include "state.h"
 
 
 size_t lccom_dispatch(char * command, char ** output){
@@ -33,11 +34,26 @@ size_t lccom_dispatch(char * command, char ** output){
         }
         return lccom_getconfig(rcv_args, output);
 
+    } else if (strcmp(rcv_comm, "getstate") == 0) {
+        return lccom_getstate(output);
     } else {
         mdebug1("LCCOM Unrecognized command '%s'.", rcv_comm);
         os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
+}
+
+size_t lccom_getstate(char ** output) {
+    char * state_str = NULL;
+    if (state_str = w_logcollector_state_get(), state_str == NULL){
+        mdebug1("At LCCOM getstate: Could not process the request");
+        os_strdup("err Could not process the request", *output);
+    } else {
+        os_strdup("ok", *output);
+        wm_strcat(output, state_str, ' ');
+        os_free(state_str);
+    }
+    return strlen(*output);
 }
 
 size_t lccom_getconfig(const char * section, char ** output) {

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -44,15 +44,19 @@ size_t lccom_dispatch(char * command, char ** output){
 }
 
 size_t lccom_getstate(char ** output) {
-    char * state_str = NULL;
-    if (state_str = w_logcollector_state_get(), state_str == NULL){
+    cJSON * state_json = NULL;
+    cJSON * w_packet = cJSON_CreateObject();
+    if (state_json = w_logcollector_state_get(), state_json == NULL){
+        cJSON_AddNumberToObject(w_packet, "error", 1);
+        cJSON_AddObjectToObject(w_packet, "data");
+        cJSON_AddStringToObject(w_packet, "message", "Could not process the request");
         mdebug1("At LCCOM getstate: Could not process the request");
-        os_strdup("err Could not process the request", *output);
     } else {
-        os_strdup("ok", *output);
-        wm_strcat(output, state_str, ' ');
-        os_free(state_str);
+        cJSON_AddNumberToObject(w_packet, "error", 0);
+        cJSON_AddItemToObject(w_packet, "data", state_json);
     }
+    *output = cJSON_PrintUnformatted(w_packet);
+    cJSON_Delete(w_packet);
     return strlen(*output);
 }
 

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -46,7 +46,7 @@ size_t lccom_dispatch(char * command, char ** output){
 size_t lccom_getstate(char ** output) {
     cJSON * state_json = NULL;
     cJSON * w_packet = cJSON_CreateObject();
-    if (state_json = w_logcollector_state_get(), state_json == NULL){
+    if (state_json = w_logcollector_state_get(), state_json == NULL) {
         cJSON_AddNumberToObject(w_packet, "error", 1);
         cJSON_AddObjectToObject(w_packet, "data");
         cJSON_AddStringToObject(w_packet, "message", "Could not process the request");

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -46,12 +46,7 @@ size_t lccom_dispatch(char * command, char ** output){
 size_t lccom_getstate(char ** output) {
     cJSON * state_json = NULL;
     cJSON * w_packet = cJSON_CreateObject();
-    if (state_interval == 0) {
-        cJSON_AddNumberToObject(w_packet, "error", 0);
-        cJSON_AddObjectToObject(w_packet, "data");
-        cJSON_AddStringToObject(w_packet, "message", "Statistics disabled");
-        mdebug1("At LCCOM getstate: Statistics disabled");
-    } else if (state_json = w_logcollector_state_get(), state_json == NULL) {
+    if (state_json = w_logcollector_state_get(), state_json == NULL) {
         cJSON_AddNumberToObject(w_packet, "error", 1);
         cJSON_AddObjectToObject(w_packet, "data");
         cJSON_AddStringToObject(w_packet, "message", "Statistics unavailable");

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -46,11 +46,16 @@ size_t lccom_dispatch(char * command, char ** output){
 size_t lccom_getstate(char ** output) {
     cJSON * state_json = NULL;
     cJSON * w_packet = cJSON_CreateObject();
-    if (state_json = w_logcollector_state_get(), state_json == NULL) {
+    if (state_interval == 0) {
+        cJSON_AddNumberToObject(w_packet, "error", 0);
+        cJSON_AddObjectToObject(w_packet, "data");
+        cJSON_AddStringToObject(w_packet, "message", "Statistics disabled");
+        mdebug1("At LCCOM getstate: Statistics disabled");
+    } else if (state_json = w_logcollector_state_get(), state_json == NULL) {
         cJSON_AddNumberToObject(w_packet, "error", 1);
         cJSON_AddObjectToObject(w_packet, "data");
-        cJSON_AddStringToObject(w_packet, "message", "Could not process the request");
-        mdebug1("At LCCOM getstate: Could not process the request");
+        cJSON_AddStringToObject(w_packet, "message", "Statistics unavailable");
+        mdebug1("At LCCOM getstate: Statistics unavailable");
     } else {
         cJSON_AddNumberToObject(w_packet, "error", 0);
         cJSON_AddItemToObject(w_packet, "data", state_json);

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -157,7 +157,7 @@ void LogCollectorStart()
         merror(ATEXIT_ERROR);
     }
 
-        /* Initialize state component */
+    /* Initialize state component */
     w_logcollector_state_init();
 
     set_sockets();
@@ -1944,7 +1944,7 @@ void * w_output_thread(void * args){
             result = SendMSGtoSCK(logr_queue, message->buffer, message->file,
                                   message->queue_mq, message->log_target);
             if (result != 0) {
-                if (result == 0) {
+                if (result != 1) {
 #ifdef CLIENT
                     merror("Unable to send message to '%s' (wazuh-agentd might be down). Attempting to reconnect.", DEFAULTQPATH);
 #else
@@ -1959,7 +1959,7 @@ void * w_output_thread(void * args){
                 if (result = SendMSGtoSCK(logr_queue, message->buffer, message->file, message->queue_mq, message->log_target),
                     result != 0) {
                     // We reconnected but are still unable to send the message, notify it and go on.
-                    if (result == 0) {
+                    if (result != 1) {
 #ifdef CLIENT
                         merror("Unable to send message to '%s' after a successfull reconnection...", DEFAULTQPATH);
 #else
@@ -1970,7 +1970,7 @@ void * w_output_thread(void * args){
                 }
             }
 
-            w_logcollector_state_update_target(message->file, 
+            w_logcollector_state_update_target(message->file,
                                                message->log_target->log_socket->name,
                                                result == 1);
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1147,7 +1147,7 @@ void set_read(logreader *current, int i, int j) {
     int tg;
     current->command = NULL;
     current->ign = 0;
-
+    w_logcollector_state_update_file(current->file, 0);
     /* Initialize the files */
     if (current->ffile) {
 
@@ -1167,6 +1167,7 @@ void set_read(logreader *current, int i, int j) {
     if (current->target) {
         while (current->target[tg]) {
             mdebug1("Socket target for '%s' -> %s", current->file, current->target[tg]);
+            w_logcollector_state_update_target(current->file, current->target[tg], false);
             tg++;
         }
     }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -96,6 +96,7 @@ int force_reload;
 int reload_interval;
 int reload_delay;
 int free_excluded_files_interval;
+int state_interval;
 OSHash * msg_queues_table;
 
 ///< To asociate the path, the position to read, and the hash key of lines read.
@@ -370,12 +371,12 @@ void LogCollectorStart()
 
     /* Create the state thread */
 #ifndef WIN32
-    w_create_thread(w_logcollector_state_main, NULL);
+    w_create_thread(w_logcollector_state_main, (void *) &state_interval);
 #else
     w_create_thread(NULL,
                      0,
                      w_logcollector_state_main,
-                     NULL,
+                     (void *) &state_interval,
                      0,
                      NULL);
 #endif

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -2600,9 +2600,9 @@ STATIC void w_initialize_file_status() {
     FILE * fd = NULL;
 
     if (fd = fopen(LOCALFILE_STATUS_PATH, "r"), fd != NULL) {
-        char str[OS_MAXSTR];
+        char str[OS_MAXSTR] = {0};
 
-        if (fread(str, 1, OS_MAXSTR, fd) < 1) {
+        if (fread(str, 1, OS_MAXSTR - 1, fd) < 1) {
             merror(FREAD_ERROR, LOCALFILE_STATUS_PATH, errno, strerror(errno));
             clearerr(fd);
         } else {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -158,7 +158,20 @@ void LogCollectorStart()
     }
 
     /* Initialize state component */
-    w_logcollector_state_init();
+    if (state_interval > 0) {
+        w_logcollector_state_init();
+        /* Create the state thread */
+#ifndef WIN32
+        w_create_thread(w_logcollector_state_main, (void *) &state_interval);
+#else
+        w_create_thread(NULL,
+                        0,
+                        w_logcollector_state_main,
+                        (void *) &state_interval,
+                        0,
+                        NULL);
+#endif
+    }
 
     set_sockets();
     files_lock_init();
@@ -368,18 +381,6 @@ void LogCollectorStart()
 
     //Save status localfiles to disk
     w_save_file_status();
-
-    /* Create the state thread */
-#ifndef WIN32
-    w_create_thread(w_logcollector_state_main, (void *) &state_interval);
-#else
-    w_create_thread(NULL,
-                     0,
-                     w_logcollector_state_main,
-                     (void *) &state_interval,
-                     0,
-                     NULL);
-#endif
 
     // Initialize message queue's log builder
     mq_log_builder_init();

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -136,6 +136,7 @@ void * lccom_main(void * arg);
 #endif
 size_t lccom_dispatch(char * command, char ** output);
 size_t lccom_getconfig(const char * section, char ** output);
+size_t lccom_getstate(char ** output);
 
 /*** Global variables ***/
 extern int loop_timeout;

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -152,6 +152,7 @@ extern int force_reload;
 extern int reload_interval;
 extern int reload_delay;
 extern int free_excluded_files_interval;
+extern int state_interval;
 
 typedef enum {
     CONTINUE_IT,

--- a/src/logcollector/read_win_el.c
+++ b/src/logcollector/read_win_el.c
@@ -10,6 +10,7 @@
 
 #include "shared.h"
 #include "logcollector.h"
+#include "state.h"
 
 #ifdef WIN32
 
@@ -465,9 +466,14 @@ void readel(os_el *el, int printit)
                          el_domain,
                          computer_name,
                          descriptive_msg != NULL ? descriptive_msg : el_string);
+                
+                w_logcollector_state_update_file(el->name, strlen(final_msg));
 
                 if (SendMSG(logr_queue, final_msg, "WinEvtLog", LOCALFILE_MQ) < 0) {
                     merror(QUEUE_SEND);
+                    w_logcollector_state_update_target(el->name, "agent", true);
+                } else {
+                    w_logcollector_state_update_target(el->name, "agent", false);
                 }
             }
 

--- a/src/logcollector/read_win_el.c
+++ b/src/logcollector/read_win_el.c
@@ -633,9 +633,9 @@ void win_startel(char *evt_log)
         }
     }
 
-    w_logcollector_state_update_file(channel->evt_log, 0);
-    w_logcollector_state_update_target(channel->evt_log, "agent", false);
-    
+    w_logcollector_state_update_file(evt_log, 0);
+    w_logcollector_state_update_target(evt_log, "agent", false);
+
     /* Start event log -- going to last available record */
     if (entries_count = startEL(evt_log, &el[el_last]), entries_count < 0) {
         merror(INV_EVTLOG, evt_log);

--- a/src/logcollector/read_win_el.c
+++ b/src/logcollector/read_win_el.c
@@ -633,6 +633,9 @@ void win_startel(char *evt_log)
         }
     }
 
+    w_logcollector_state_update_file(channel->evt_log, 0);
+    w_logcollector_state_update_target(channel->evt_log, "agent", false);
+    
     /* Start event log -- going to last available record */
     if (entries_count = startEL(evt_log, &el[el_last]), entries_count < 0) {
         merror(INV_EVTLOG, evt_log);

--- a/src/logcollector/read_win_el.c
+++ b/src/logcollector/read_win_el.c
@@ -466,7 +466,7 @@ void readel(os_el *el, int printit)
                          el_domain,
                          computer_name,
                          descriptive_msg != NULL ? descriptive_msg : el_string);
-                
+
                 w_logcollector_state_update_file(el->name, strlen(final_msg));
 
                 if (SendMSG(logr_queue, final_msg, "WinEvtLog", LOCALFILE_MQ) < 0) {

--- a/src/logcollector/read_win_el.c
+++ b/src/logcollector/read_win_el.c
@@ -633,8 +633,8 @@ void win_startel(char *evt_log)
         }
     }
 
-    w_logcollector_state_update_file(evt_log, 0);
-    w_logcollector_state_update_target(evt_log, "agent", false);
+    w_logcollector_state_add_file(evt_log);
+    w_logcollector_state_add_target(evt_log, "agent");
 
     /* Start event log -- going to last available record */
     if (entries_count = startEL(evt_log, &el[el_last]), entries_count < 0) {

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -638,7 +638,7 @@ int win_start_event_channel(char *evt_log, char future, char *query, int reconne
 
     w_logcollector_state_update_file(channel->evt_log, 0);
     w_logcollector_state_update_target(channel->evt_log, "agent", false);
-    
+
     /* Success */
     status = 1;
 

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -34,6 +34,7 @@
 
 #include "shared.h"
 #include "logcollector.h"
+#include "state.h"
 
 #include <stdint.h>
 #include <winevt.h>
@@ -479,8 +480,13 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
     cJSON_AddStringToObject(event_json, "Event", xml_event);
     msg_sent = cJSON_PrintUnformatted(event_json);
 
+    w_logcollector_state_update_file(channel->evt_log, strlen(msg_sent));
+
     if (SendMSG(logr_queue, msg_sent, "EventChannel", WIN_EVT_MQ) < 0) {
         merror(QUEUE_SEND);
+        w_logcollector_state_update_target(channel->evt_log, "agent", true);
+    } else {
+        w_logcollector_state_update_target(channel->evt_log, "agent", false);
     }
 
     if (channel->bookmark_enabled) {

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -636,6 +636,9 @@ int win_start_event_channel(char *evt_log, char future, char *query, int reconne
         goto cleanup;
     }
 
+    w_logcollector_state_update_file(channel->evt_log, 0);
+    w_logcollector_state_update_target(channel->evt_log, "agent", false);
+    
     /* Success */
     status = 1;
 

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -636,8 +636,8 @@ int win_start_event_channel(char *evt_log, char future, char *query, int reconne
         goto cleanup;
     }
 
-    w_logcollector_state_update_file(channel->evt_log, 0);
-    w_logcollector_state_update_target(channel->evt_log, "agent", false);
+    w_logcollector_state_add_file(channel->evt_log);
+    w_logcollector_state_add_target(channel->evt_log, "agent");
 
     /* Success */
     status = 1;

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -17,11 +17,11 @@
 #endif
 
 /* Global variables */
-cJSON * g_lc_json_stats;           ///< string that store single line formated JSON with states
+cJSON * g_lc_json_stats;           ///< JSON representation of states
 lc_states_t * g_lc_states_global;   ///< global state struct storage
 lc_states_t * g_lc_states_interval; ///< interval state struct storage
-pthread_mutex_t g_lc_raw_stats_mutex = PTHREAD_MUTEX_INITIALIZER; ///< g_lc_json_stats mutual exclusion mechanism
-pthread_mutex_t g_lc_json_stats_mutex = PTHREAD_MUTEX_INITIALIZER; ///< g_lc_states_* structs mutual exclusion mechanism
+pthread_mutex_t g_lc_raw_stats_mutex = PTHREAD_MUTEX_INITIALIZER; ///< g_lc_states_* structs mutual exclusion mechanism
+pthread_mutex_t g_lc_json_stats_mutex = PTHREAD_MUTEX_INITIALIZER; ///< g_lc_json_stats mutual exclusion mechanism
 
 /**
  * @brief Trigger the generation of states
@@ -87,10 +87,16 @@ STATIC void w_logcollector_state_dump() {
     char * lc_state_str = cJSON_Print(lc_state_json);
     cJSON_Delete(lc_state_json);
 
+    // Add trailing newline
+    size_t len = strlen(lc_state_str);
+    os_realloc(lc_state_str, len + 2, lc_state_str);
+    lc_state_str[len] = '\n';
+    lc_state_str[len + 1] = '\0';
+
     FILE * lc_state_file = NULL;
 
     if (lc_state_file = fopen(LOGCOLLECTOR_STATE_PATH, "w"), lc_state_file != NULL) {
-        if (fwrite(lc_state_str, sizeof(char), strlen(lc_state_str), lc_state_file) < 1) {
+        if (fwrite(lc_state_str, sizeof(char), len + 1, lc_state_file) < 1) {
             merror(FWRITE_ERROR, LOGCOLLECTOR_STATE_PATH, errno, strerror(errno));
         }
         fclose(lc_state_file);

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -1,11 +1,10 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
- * Copyright (C) 2009 Trend Micro Inc.
- * All right reserved.
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
- * Foundation
+ * Foundation.
  */
 
 #include "state.h"
@@ -45,13 +44,12 @@ typedef struct {
     lc_state_target_t ** targets; ///< array of poiters to file's different targets
 } lc_state_file_t;
 
+/* Global variables */
 char * g_lc_pritty_stats;           ///< string that store single line formated JSON with states
 lc_states_t * g_lc_states_global;   ///< global state struct storage
 lc_states_t * g_lc_states_interval; ///< interval state struct storage
 pthread_mutex_t g_lc_raw_stats_mutex = PTHREAD_MUTEX_INITIALIZER; ///< g_lc_pritty_stats mutual exclusion mechanism
-pthread_mutex_t g_lc_pritty_stats_mutex =
-    PTHREAD_MUTEX_INITIALIZER; ///< g_lc_states_* structs mutual exclusion mechanism
-
+pthread_mutex_t g_lc_pritty_stats_mutex = PTHREAD_MUTEX_INITIALIZER; ///< g_lc_states_* structs mutual exclusion mechanism
 
 /**
  * @brief Trigger the generation of states
@@ -98,8 +96,8 @@ DWORD WINAPI w_logcollector_state_main(__attribute__((unused)) void * args) {
 #else
 void * w_logcollector_state_main(__attribute__((unused)) void * args) {
 #endif
-    
-    int interval = * (int *) args; 
+
+    int interval = *(int *) args; 
 
     while (FOREVER()) {
         sleep(interval);
@@ -130,7 +128,7 @@ STATIC void w_logcollector_state_dump() {
 }
 
 void w_logcollector_state_init() {
-
+    
     os_calloc(1, sizeof(lc_states_t), g_lc_states_global);
     os_calloc(1, sizeof(lc_states_t), g_lc_states_interval);
 
@@ -282,7 +280,7 @@ char * w_logcollector_state_get() {
 
     w_mutex_lock(&g_lc_pritty_stats_mutex);
 
-    if (g_lc_pritty_stats != NULL){
+    if (g_lc_pritty_stats != NULL) {
         os_strdup(g_lc_pritty_stats, state_str);
     }
 

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -98,8 +98,8 @@ DWORD WINAPI w_logcollector_state_main(__attribute__((unused)) void * args) {
 #else
 void * w_logcollector_state_main(__attribute__((unused)) void * args) {
 #endif
-
-    int interval = getDefine_Int("logcollector", "state_interval", 1, 3600);
+    
+    int interval = * (int *) args; 
 
     while (FOREVER()) {
         sleep(interval);

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -262,7 +262,9 @@ char * w_logcollector_state_get() {
 
     w_mutex_lock(&g_lc_pritty_stats_mutex);
 
-    os_strdup(g_lc_pritty_stats, state_str);
+    if (g_lc_pritty_stats != NULL){
+        os_strdup(g_lc_pritty_stats, state_str);
+    }
 
     w_mutex_unlock(&g_lc_pritty_stats_mutex);
 

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -101,7 +101,7 @@ void * w_logcollector_state_main(__attribute__((unused)) void * args) {
 
     int interval = getDefine_Int("logcollector", "state_interval", 1, 3600);
 
-    while (1) {
+    while (FOREVER()) {
         sleep(interval);
         w_logcollector_generate_state();
         w_logcollector_state_dump();

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -18,8 +18,8 @@
 #endif
 
 /**
- * @brief state key: location option value, value: lc_state_file_t
- * key: location option value, value: lc_state_file_t
+ * @brief state storage structure
+ * key: location option value. value: lc_state_file_t
  */
 typedef struct {
     time_t start;    ///< initial state timestamp
@@ -94,7 +94,11 @@ STATIC void _w_logcollector_state_update_target(lc_states_t * state, char * fpat
  */
 STATIC void w_logcollector_state_dump();
 
-void * w_logcollector_state_main() {
+#ifdef WIN32
+DWORD WINAPI w_logcollector_state_main(__attribute__((unused)) void * args) {
+#else
+void * w_logcollector_state_main(__attribute__((unused)) void * args) {
+#endif
 
     int interval = getDefine_Int("logcollector", "state_interval", 1, 3600);
 
@@ -103,8 +107,9 @@ void * w_logcollector_state_main() {
         w_logcollector_generate_state();
         w_logcollector_state_dump();
     }
-
+#ifndef WIN32
     return NULL;
+#endif
 }
 
 static void w_logcollector_state_dump() {
@@ -297,7 +302,7 @@ cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart) {
         // Files
         cJSON * lc_stats_file = cJSON_CreateObject();
         cJSON_AddItemToObject(lc_stats_file, "targets", lc_stats_targets_array);
-        cJSON_AddStringToObject(lc_stats_file, "path", hash_node->key);
+        cJSON_AddStringToObject(lc_stats_file, "location", hash_node->key);
         cJSON_AddNumberToObject(lc_stats_file, "bytes", data->bytes);
         cJSON_AddNumberToObject(lc_stats_file, "events", data->events);
         if (restart) {

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -1,0 +1,332 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2009 Trend Micro Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "state.h"
+#include "shared.h"
+
+#ifdef WAZUH_UNIT_TESTING
+#define STATIC
+#else
+#define STATIC static
+#endif
+
+/**
+ * @brief state key: location option value, value: lc_state_file_t
+ * key: location option value, value: lc_state_file_t
+ */
+typedef struct {
+    time_t start;    ///< initial state timestamp
+    OSHash * states; ///< state storage
+} lc_states_t;
+
+/**
+ * @brief target state storage
+ *
+ */
+typedef struct {
+    char * name;    ///< target name
+    uint64_t drops; ///< drop count
+} lc_state_target_t;
+
+/**
+ * @brief file state storage
+ *
+ */
+typedef struct {
+    uint64_t bytes;               ///< bytes count
+    uint64_t events;              ///< events count
+    lc_state_target_t ** targets; ///< array of poiters to file's different targets
+} lc_state_file_t;
+
+char * g_lc_pritty_stats;           ///< string that store single line formated JSON with states
+lc_states_t * g_lc_states_global;   ///< global state struct storage
+lc_states_t * g_lc_states_interval; ///< interval state struct storage
+pthread_mutex_t g_lc_raw_stats_mutex = PTHREAD_MUTEX_INITIALIZER; ///< g_lc_pritty_stats mutual exclusion mechanism
+pthread_mutex_t g_lc_pritty_stats_mutex =
+    PTHREAD_MUTEX_INITIALIZER; ///< g_lc_states_* structs mutual exclusion mechanism
+
+const char * LOGCOLLECTOR_STATE_DESCRIPTION = "logcollector_state"; ///< String identifier for errors
+
+/**
+ * @brief Trigger the generation of states
+ *
+ */
+STATIC void w_logcollector_generate_state();
+
+/**
+ * @brief Generate and process the current states information
+ *
+ * @param state state to generate
+ * @param restart restart counters and date after generating
+ * @return cJSON * json decription with state information
+ */
+STATIC cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart);
+
+/**
+ * @brief Update/register current event and byte count for a particular file/location
+ *
+ * @param state state to be used
+ * @param fpath file path or locafile location value
+ * @param bytes amount of bytes
+ */
+STATIC void _w_logcollector_state_update_file(lc_states_t * state, char * fpath, uint64_t bytes);
+
+/**
+ * @brief Update/register current drop count for a target belonging to a particular file
+ *
+ * @param state state to be used
+ * @param fpath file path or locafile location value
+ * @param target target name
+ * @param dropped true if want to register a drop.
+ */
+STATIC void _w_logcollector_state_update_target(lc_states_t * state, char * fpath, char * target, bool dropped);
+
+/**
+ * @brief Dump state information to file
+ *
+ */
+STATIC void w_logcollector_state_dump();
+
+void * w_logcollector_state_main() {
+
+    int interval = getDefine_Int("logcollector", "state_interval", 1, 3600);
+
+    while (1) {
+        sleep(interval);
+        w_logcollector_generate_state();
+        w_logcollector_state_dump();
+    }
+
+    return NULL;
+}
+
+static void w_logcollector_state_dump() {
+
+    char * lc_state_str = w_logcollector_state_get();
+
+    FILE * lc_state_file = NULL;
+
+    if (lc_state_file = fopen(LOGCOLLECTOR_STATE_PATH, "w"), lc_state_file != NULL) {
+        if (fwrite(lc_state_str, sizeof(char), strlen(lc_state_str), lc_state_file) < 1) {
+            merror(FREAD_ERROR, LOGCOLLECTOR_STATE_PATH, errno, strerror(errno));
+        }
+        fclose(lc_state_file);
+    }
+
+    os_free(lc_state_str);
+}
+
+void w_logcollector_state_init() {
+
+    os_calloc(1, sizeof(lc_states_t), g_lc_states_global);
+    os_calloc(1, sizeof(lc_states_t), g_lc_states_interval);
+
+    g_lc_states_global->start = time(NULL);
+    g_lc_states_interval->start = time(NULL);
+
+    if (g_lc_states_global->states = OSHash_Create(), g_lc_states_global->states == NULL) {
+        merror_exit(HCREATE_ERROR, LOGCOLLECTOR_STATE_DESCRIPTION);
+    }
+
+    if (g_lc_states_interval->states = OSHash_Create(), g_lc_states_interval->states == NULL) {
+        merror_exit(HCREATE_ERROR, LOGCOLLECTOR_STATE_DESCRIPTION);
+    }
+
+    if (OSHash_setSize(g_lc_states_global->states, LOGCOLLECTOR_STATE_FILES_MAX) == 0) {
+        merror_exit(HSETSIZE_ERROR, LOGCOLLECTOR_STATE_DESCRIPTION);
+    }
+
+    if (OSHash_setSize(g_lc_states_interval->states, LOGCOLLECTOR_STATE_FILES_MAX) == 0) {
+        merror_exit(HSETSIZE_ERROR, LOGCOLLECTOR_STATE_DESCRIPTION);
+    }
+}
+
+void w_logcollector_state_update_target(char * fpath, char * target, bool dropped) {
+
+    if (fpath == NULL || target == NULL) {
+        return;
+    }
+
+    w_mutex_lock(&g_lc_raw_stats_mutex);
+
+    _w_logcollector_state_update_target(g_lc_states_global, fpath, target, dropped);
+    _w_logcollector_state_update_target(g_lc_states_interval, fpath, target, dropped);
+
+    w_mutex_unlock(&g_lc_raw_stats_mutex);
+}
+
+void w_logcollector_state_update_file(char * fpath, uint64_t bytes) {
+
+    if (fpath == NULL) {
+        return;
+    }
+
+    w_mutex_lock(&g_lc_raw_stats_mutex);
+
+    _w_logcollector_state_update_file(g_lc_states_global, fpath, bytes);
+    _w_logcollector_state_update_file(g_lc_states_interval, fpath, bytes);
+
+    w_mutex_unlock(&g_lc_raw_stats_mutex);
+}
+
+void _w_logcollector_state_update_file(lc_states_t * state, char * fpath, uint64_t bytes) {
+
+    lc_state_file_t * data = NULL;
+
+    // Try to get file stats. Create it if not initialized yet,
+    if (data = (lc_state_file_t *) OSHash_Get(state->states, fpath), data == NULL) {
+        os_calloc(1, sizeof(lc_state_file_t), data);
+        os_calloc(1, sizeof(lc_state_target_t *), data->targets);
+    }
+
+    data->events++;
+    data->bytes += bytes;
+
+    if (OSHash_Update(state->states, fpath, data) != 1) {
+        OSHash_Add(state->states, fpath, data);
+    }
+}
+void _w_logcollector_state_update_target(lc_states_t * state, char * fpath, char * target, bool dropped) {
+
+    lc_state_file_t * data = NULL;
+    lc_state_target_t ** current_target = NULL;
+    int len = 0;
+
+    // Try to get file stats. Create it if not initialized yet,
+    if (data = (lc_state_file_t *) OSHash_Get(state->states, fpath), data == NULL) {
+        os_calloc(1, sizeof(lc_state_file_t), data);
+        os_calloc(1, sizeof(lc_state_target_t *), data->targets);
+    }
+
+    // Try to find target
+    for (len = 0, current_target = data->targets; *current_target != NULL; len++, current_target++) {
+        if (strcmp(target, (*current_target)->name) == 0) {
+            break;
+        }
+    }
+
+    // If target was not found, create it.
+    if (*current_target == NULL) {
+        os_realloc(data->targets, (len + 2) * sizeof(lc_state_target_t *), data->targets);
+        os_calloc(1, sizeof(lc_state_target_t), data->targets[len]);
+        data->targets[len + 1] = NULL;
+        current_target = &data->targets[len];
+        os_strdup(target, (*current_target)->name);
+    }
+
+    if (dropped) {
+        (*current_target)->drops++;
+    }
+
+    if (OSHash_Update(state->states, fpath, data) != 1) {
+        OSHash_Add(state->states, fpath, data);
+    }
+}
+
+void w_logcollector_generate_state() {
+
+    w_mutex_lock(&g_lc_pritty_stats_mutex);
+    w_mutex_lock(&g_lc_raw_stats_mutex);
+
+    os_free(g_lc_pritty_stats);
+
+    cJSON * lc_stats_json = cJSON_CreateObject();
+    cJSON * lc_stats_json_global = _w_logcollector_generate_state(g_lc_states_global, false);
+    cJSON_AddItemToObject(lc_stats_json, "global", lc_stats_json_global);
+    cJSON * lc_stats_json_interval = _w_logcollector_generate_state(g_lc_states_interval, true);
+    cJSON_AddItemToObject(lc_stats_json, "interval", lc_stats_json_interval);
+
+    g_lc_pritty_stats = cJSON_PrintUnformatted(lc_stats_json);
+
+    cJSON_Delete(lc_stats_json);
+
+    w_mutex_unlock(&g_lc_raw_stats_mutex);
+    w_mutex_unlock(&g_lc_pritty_stats_mutex);
+}
+
+char * w_logcollector_state_get() {
+
+    char * state_str = NULL;
+
+    w_mutex_lock(&g_lc_pritty_stats_mutex);
+
+    os_strdup(g_lc_pritty_stats, state_str);
+
+    w_mutex_unlock(&g_lc_pritty_stats_mutex);
+
+    return state_str;
+}
+
+cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart) {
+
+    OSHashNode * hash_node = NULL;
+    unsigned int index = 0;
+
+    if (hash_node = OSHash_Begin(state->states, &index), hash_node == NULL) {
+        return NULL;
+    }
+
+    cJSON * lc_stats_json = cJSON_CreateObject();
+    cJSON * lc_stats_files_array = cJSON_CreateArray();
+
+    // Iterate for each file
+    while (hash_node) {
+        lc_state_file_t * data = hash_node->data;
+
+        // Target logic
+        cJSON * lc_stats_targets_array = cJSON_CreateArray();
+        lc_state_target_t ** target = data->targets;
+        while (*target != NULL) {
+            cJSON * lc_stats_target = cJSON_CreateObject();
+            cJSON_AddStringToObject(lc_stats_target, "name", (*target)->name);
+            cJSON_AddNumberToObject(lc_stats_target, "drops", (*target)->drops);
+            cJSON_AddItemToArray(lc_stats_targets_array, lc_stats_target);
+            if (restart) {
+                (*target)->drops = 0;
+            }
+            target++;
+        }
+
+        // Files
+        cJSON * lc_stats_file = cJSON_CreateObject();
+        cJSON_AddItemToObject(lc_stats_file, "targets", lc_stats_targets_array);
+        cJSON_AddStringToObject(lc_stats_file, "path", hash_node->key);
+        cJSON_AddNumberToObject(lc_stats_file, "bytes", data->bytes);
+        cJSON_AddNumberToObject(lc_stats_file, "events", data->events);
+        if (restart) {
+            data->bytes = 0;
+            data->events = 0;
+        }
+        cJSON_AddItemToArray(lc_stats_files_array, lc_stats_file);
+        hash_node = OSHash_Next(state->states, &index, hash_node);
+    }
+
+    // Convert timestamp to string, removing newline from ctime return
+    time_t now = time(NULL);
+    char * now_str = NULL;
+    char * start_str = NULL;
+    os_strdup(ctime(&now), now_str);
+    os_strdup(ctime(&state->start), start_str);
+
+    now_str[strlen(now_str) - 1] = '\0';
+    start_str[strlen(start_str) - 1] = '\0';
+
+    cJSON_AddStringToObject(lc_stats_json, "start", start_str);
+    cJSON_AddStringToObject(lc_stats_json, "end", now_str);
+    cJSON_AddItemToObject(lc_stats_json, "files", lc_stats_files_array);
+
+    os_free(now_str);
+    os_free(start_str);
+
+    if (restart) {
+        state->start = time(NULL);
+    }
+    return lc_stats_json;
+}

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -69,7 +69,7 @@ DWORD WINAPI w_logcollector_state_main(__attribute__((unused)) void * args) {
 void * w_logcollector_state_main(__attribute__((unused)) void * args) {
 #endif
 
-    int interval = *(int *) args; 
+    int interval = *(int *) args;
 
     while (FOREVER()) {
         sleep(interval);
@@ -82,7 +82,7 @@ void * w_logcollector_state_main(__attribute__((unused)) void * args) {
 }
 
 STATIC void w_logcollector_state_dump() {
-    
+
     cJSON * lc_state_json = w_logcollector_state_get();
     char * lc_state_str = cJSON_Print(lc_state_json);
     cJSON_Delete(lc_state_json);
@@ -108,7 +108,7 @@ STATIC void w_logcollector_state_dump() {
 }
 
 void w_logcollector_state_init() {
-    
+
     os_calloc(1, sizeof(lc_states_t), g_lc_states_global);
     os_calloc(1, sizeof(lc_states_t), g_lc_states_interval);
 
@@ -170,7 +170,7 @@ void _w_logcollector_state_update_file(lc_states_t * state, char * fpath, uint64
         os_calloc(1, sizeof(lc_state_target_t *), data->targets);
     }
 
-    if (bytes > 0){
+    if (bytes > 0) {
         data->events++;
         data->bytes += bytes;
     }
@@ -241,13 +241,13 @@ void w_logcollector_generate_state() {
     w_mutex_lock(&g_lc_raw_stats_mutex);
 
     cJSON_Delete(g_lc_json_stats);
- 
+
     g_lc_json_stats = cJSON_CreateObject();
     cJSON * lc_stats_json_global = _w_logcollector_generate_state(g_lc_states_global, false);
     cJSON_AddItemToObject(g_lc_json_stats, "global", lc_stats_json_global);
     cJSON * lc_stats_json_interval = _w_logcollector_generate_state(g_lc_states_interval, true);
     cJSON_AddItemToObject(g_lc_json_stats, "interval", lc_stats_json_interval);
-    
+
     w_mutex_unlock(&g_lc_raw_stats_mutex);
     w_mutex_unlock(&g_lc_json_stats_mutex);
 }

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -16,34 +16,6 @@
 #define STATIC static
 #endif
 
-/**
- * @brief state storage structure
- * key: location option value. value: lc_state_file_t
- */
-typedef struct {
-    time_t start;    ///< initial state timestamp
-    OSHash * states; ///< state storage
-} lc_states_t;
-
-/**
- * @brief target state storage
- *
- */
-typedef struct {
-    char * name;    ///< target name
-    uint64_t drops; ///< drop count
-} lc_state_target_t;
-
-/**
- * @brief file state storage
- *
- */
-typedef struct {
-    uint64_t bytes;               ///< bytes count
-    uint64_t events;              ///< events count
-    lc_state_target_t ** targets; ///< array of poiters to file's different targets
-} lc_state_file_t;
-
 /* Global variables */
 cJSON * g_lc_json_stats;           ///< string that store single line formated JSON with states
 lc_states_t * g_lc_states_global;   ///< global state struct storage

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -52,7 +52,6 @@ pthread_mutex_t g_lc_raw_stats_mutex = PTHREAD_MUTEX_INITIALIZER; ///< g_lc_prit
 pthread_mutex_t g_lc_pritty_stats_mutex =
     PTHREAD_MUTEX_INITIALIZER; ///< g_lc_states_* structs mutual exclusion mechanism
 
-const char * LOGCOLLECTOR_STATE_DESCRIPTION = "logcollector_state"; ///< String identifier for errors
 
 /**
  * @brief Trigger the generation of states
@@ -112,7 +111,7 @@ void * w_logcollector_state_main(__attribute__((unused)) void * args) {
 #endif
 }
 
-static void w_logcollector_state_dump() {
+STATIC void w_logcollector_state_dump() {
 
     char * lc_state_str = w_logcollector_state_get();
 
@@ -120,7 +119,7 @@ static void w_logcollector_state_dump() {
 
     if (lc_state_file = fopen(LOGCOLLECTOR_STATE_PATH, "w"), lc_state_file != NULL) {
         if (fwrite(lc_state_str, sizeof(char), strlen(lc_state_str), lc_state_file) < 1) {
-            merror(FREAD_ERROR, LOGCOLLECTOR_STATE_PATH, errno, strerror(errno));
+            merror(FWRITE_ERROR, LOGCOLLECTOR_STATE_PATH, errno, strerror(errno));
         }
         fclose(lc_state_file);
     }
@@ -198,6 +197,7 @@ void _w_logcollector_state_update_file(lc_states_t * state, char * fpath, uint64
         OSHash_Add(state->states, fpath, data);
     }
 }
+
 void _w_logcollector_state_update_target(lc_states_t * state, char * fpath, char * target, bool dropped) {
 
     lc_state_file_t * data = NULL;

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -16,11 +16,16 @@
 #define STATIC static
 #endif
 
+#define W_LC_STATE_TIME_FORMAT "%Y-%m-%d %H:%M:%S" ///< Time format for the JSON and the file output
+#define W_LC_STATE_TIME_LENGHT (19 + 1)            ///< Maximum time size
+
 /* Global variables */
-bool g_lc_state_enabled;               ///< state enabled flag
-cJSON *g_lc_json_stats;                ///< JSON representation of states
-lc_states_t *g_lc_states_global;       ///< global state struct storage
-lc_states_t *g_lc_states_interval;     ///< interval state struct storage
+
+w_lc_state_type_t g_lc_state_type;       ///< state enabled flag
+bool g_lc_state_file_enabled;          ///< state file dump enable
+cJSON * g_lc_json_stats;               ///< JSON representation of states
+w_lc_state_storage_t * g_lc_states_global;      ///< global state struct storage
+w_lc_state_storage_t * g_lc_states_interval;    ///< interval state struct storage
 pthread_mutex_t g_lc_raw_stats_mutex;  ///< g_lc_states_* structs mutual exclusion mechanism
 pthread_mutex_t g_lc_json_stats_mutex; ///< g_lc_json_stats mutual exclusion mechanism
 
@@ -28,7 +33,7 @@ pthread_mutex_t g_lc_json_stats_mutex; ///< g_lc_json_stats mutual exclusion mec
  * @brief Trigger the generation of states
  *
  */
-STATIC void w_logcollector_generate_state();
+STATIC void w_logcollector_state_generate();
 
 /**
  * @brief Generate and process the current states information
@@ -37,7 +42,7 @@ STATIC void w_logcollector_generate_state();
  * @param restart restart counters and date after generating
  * @return cJSON * json decription with state information
  */
-STATIC cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart);
+STATIC cJSON * _w_logcollector_generate_state(w_lc_state_storage_t * state, bool restart);
 
 /**
  * @brief Update/register current event and byte count for a particular file/location
@@ -46,7 +51,7 @@ STATIC cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart)
  * @param fpath file path or locafile location value
  * @param bytes amount of bytes
  */
-STATIC void _w_logcollector_state_update_file(lc_states_t * state, char * fpath, uint64_t bytes);
+STATIC void _w_logcollector_state_update_file(w_lc_state_storage_t * state, char * fpath, uint64_t bytes);
 
 /**
  * @brief Update/register current drop count for a target belonging to a particular file
@@ -56,7 +61,7 @@ STATIC void _w_logcollector_state_update_file(lc_states_t * state, char * fpath,
  * @param target target name
  * @param dropped true if want to register a drop.
  */
-STATIC void _w_logcollector_state_update_target(lc_states_t * state, char * fpath, char * target, bool dropped);
+STATIC void _w_logcollector_state_update_target(w_lc_state_storage_t * state, char * fpath, char * target, bool dropped);
 
 /**
  * @brief Dump state information to file
@@ -65,23 +70,27 @@ STATIC void _w_logcollector_state_update_target(lc_states_t * state, char * fpat
 STATIC void w_logcollector_state_dump();
 
 #ifdef WIN32
-DWORD WINAPI w_logcollector_state_main(__attribute__((unused)) void * args) {
+DWORD WINAPI w_logcollector_state_main(void * args) {
 #else
-void * w_logcollector_state_main(__attribute__((unused)) void * args) {
+void * w_logcollector_state_main(void * args) {
 #endif
 
     int interval = *(int *) args;
 
-    if (interval >= 0 && g_lc_state_enabled) {
+    if (interval > 0) {
         while (FOREVER()) {
             sleep(interval);
-            w_logcollector_generate_state();
-            w_logcollector_state_dump();
+            w_logcollector_state_generate();
+            if (g_lc_state_file_enabled) {
+                w_logcollector_state_dump();
+            }
         }
     }
 
 #ifndef WIN32
     return NULL;
+#else
+    return 0;
 #endif
 }
 
@@ -92,7 +101,7 @@ STATIC void w_logcollector_state_dump() {
     cJSON_Delete(lc_state_json);
 
     // Add trailing newline
-    size_t len = strlen(lc_state_str);
+    const size_t len = strlen(lc_state_str);
     os_realloc(lc_state_str, len + 2, lc_state_str);
     lc_state_str[len] = '\n';
     lc_state_str[len + 1] = '\0';
@@ -111,72 +120,88 @@ STATIC void w_logcollector_state_dump() {
     os_free(lc_state_str);
 }
 
-void w_logcollector_state_init() {
+void w_logcollector_state_init(w_lc_state_type_t state_type, bool state_file_enabled) {
 
     pthread_mutex_init(&g_lc_raw_stats_mutex, NULL);
-    pthread_mutex_init(&g_lc_json_stats_mutex, NULL);
 
-    os_calloc(1, sizeof(lc_states_t), g_lc_states_global);
-    os_calloc(1, sizeof(lc_states_t), g_lc_states_interval);
+    if (state_type & LC_STATE_GLOBAL) {
 
-    g_lc_states_global->start = time(NULL);
-    g_lc_states_interval->start = time(NULL);
+        os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_global);
 
-    if (g_lc_states_global->states = OSHash_Create(), g_lc_states_global->states == NULL) {
-        merror_exit(HCREATE_ERROR, LOGCOLLECTOR_STATE_DESCRIPTION);
+        g_lc_states_global->start = time(NULL);
+
+        if (g_lc_states_global->states = OSHash_Create(), g_lc_states_global->states == NULL) {
+            merror_exit(HCREATE_ERROR, LOGCOLLECTOR_STATE_DESCRIPTION);
+        }
+        if (OSHash_setSize(g_lc_states_global->states, LOGCOLLECTOR_STATE_FILES_MAX) == 0) {
+            merror_exit(HSETSIZE_ERROR, LOGCOLLECTOR_STATE_DESCRIPTION);
+        }
     }
 
-    if (g_lc_states_interval->states = OSHash_Create(), g_lc_states_interval->states == NULL) {
-        merror_exit(HCREATE_ERROR, LOGCOLLECTOR_STATE_DESCRIPTION);
+    if (state_type & LC_STATE_INTERVAL) {
+        pthread_mutex_init(&g_lc_json_stats_mutex, NULL);
+
+        os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_interval);
+
+        g_lc_states_interval->start = time(NULL);
+
+        if (g_lc_states_interval->states = OSHash_Create(), g_lc_states_interval->states == NULL) {
+            merror_exit(HCREATE_ERROR, LOGCOLLECTOR_STATE_DESCRIPTION);
+        }
+
+        if (OSHash_setSize(g_lc_states_interval->states, LOGCOLLECTOR_STATE_FILES_MAX) == 0) {
+            merror_exit(HSETSIZE_ERROR, LOGCOLLECTOR_STATE_DESCRIPTION);
+        }
     }
 
-    if (OSHash_setSize(g_lc_states_global->states, LOGCOLLECTOR_STATE_FILES_MAX) == 0) {
-        merror_exit(HSETSIZE_ERROR, LOGCOLLECTOR_STATE_DESCRIPTION);
-    }
-
-    if (OSHash_setSize(g_lc_states_interval->states, LOGCOLLECTOR_STATE_FILES_MAX) == 0) {
-        merror_exit(HSETSIZE_ERROR, LOGCOLLECTOR_STATE_DESCRIPTION);
-    }
-
-    g_lc_state_enabled = true;
+    g_lc_state_type = state_type;
+    g_lc_state_file_enabled = state_file_enabled;
 }
 
 void w_logcollector_state_update_target(char * fpath, char * target, bool dropped) {
 
-    if (fpath == NULL || target == NULL || !g_lc_state_enabled) {
+    if (fpath == NULL || target == NULL) {
         return;
     }
 
     w_mutex_lock(&g_lc_raw_stats_mutex);
 
-    _w_logcollector_state_update_target(g_lc_states_global, fpath, target, dropped);
-    _w_logcollector_state_update_target(g_lc_states_interval, fpath, target, dropped);
+    if (g_lc_state_type & LC_STATE_GLOBAL) {
+        _w_logcollector_state_update_target(g_lc_states_global, fpath, target, dropped);
+    }
 
+    if (g_lc_state_type & LC_STATE_INTERVAL) {
+        _w_logcollector_state_update_target(g_lc_states_interval, fpath, target, dropped);
+    }
     w_mutex_unlock(&g_lc_raw_stats_mutex);
 }
 
 void w_logcollector_state_update_file(char * fpath, uint64_t bytes) {
 
-    if (fpath == NULL || !g_lc_state_enabled) {
+    if (fpath == NULL) {
         return;
     }
 
     w_mutex_lock(&g_lc_raw_stats_mutex);
 
-    _w_logcollector_state_update_file(g_lc_states_global, fpath, bytes);
-    _w_logcollector_state_update_file(g_lc_states_interval, fpath, bytes);
+    if (g_lc_state_type & LC_STATE_GLOBAL) {
+        _w_logcollector_state_update_file(g_lc_states_global, fpath, bytes);
+    }
+    if (g_lc_state_type & LC_STATE_INTERVAL) {
+        _w_logcollector_state_update_file(g_lc_states_interval, fpath, bytes);
+    }
 
     w_mutex_unlock(&g_lc_raw_stats_mutex);
 }
 
-void _w_logcollector_state_update_file(lc_states_t * state, char * fpath, uint64_t bytes) {
+void _w_logcollector_state_update_file(w_lc_state_storage_t * state, char * fpath, uint64_t bytes) {
 
-    lc_state_file_t * data = NULL;
+    w_lc_state_file_t * data = NULL;
 
     // Try to get file stats. Create it if not initialized yet,
-    if (data = (lc_state_file_t *) OSHash_Get(state->states, fpath), data == NULL) {
-        os_calloc(1, sizeof(lc_state_file_t), data);
-        os_calloc(1, sizeof(lc_state_target_t *), data->targets);
+    if (data = (w_lc_state_file_t *) OSHash_Get(state->states, fpath), data == NULL) {
+        os_calloc(1, sizeof(w_lc_state_file_t), data);
+        os_calloc(1, sizeof(w_lc_state_target_t *), data->targets);
     }
 
     if (bytes > 0) {
@@ -186,7 +211,7 @@ void _w_logcollector_state_update_file(lc_states_t * state, char * fpath, uint64
 
     if (OSHash_Update(state->states, fpath, data) != 1) {
         if (OSHash_Add(state->states, fpath, data) != 2) {
-            lc_state_target_t ** target = data->targets;
+            w_lc_state_target_t ** target = data->targets;
             while (*target != NULL) {
                 os_free(*target);
                 target++;
@@ -198,16 +223,16 @@ void _w_logcollector_state_update_file(lc_states_t * state, char * fpath, uint64
     }
 }
 
-void _w_logcollector_state_update_target(lc_states_t * state, char * fpath, char * target, bool dropped) {
+void _w_logcollector_state_update_target(w_lc_state_storage_t * state, char * fpath, char * target, bool dropped) {
 
-    lc_state_file_t * data = NULL;
-    lc_state_target_t ** current_target = NULL;
+    w_lc_state_file_t * data = NULL;
+    w_lc_state_target_t ** current_target = NULL;
     int len = 0;
 
     // Try to get file stats. Create it if not initialized yet,
-    if (data = (lc_state_file_t *) OSHash_Get(state->states, fpath), data == NULL) {
-        os_calloc(1, sizeof(lc_state_file_t), data);
-        os_calloc(1, sizeof(lc_state_target_t *), data->targets);
+    if (data = (w_lc_state_file_t *) OSHash_Get(state->states, fpath), data == NULL) {
+        os_calloc(1, sizeof(w_lc_state_file_t), data);
+        os_calloc(1, sizeof(w_lc_state_target_t *), data->targets);
     }
 
     // Try to find target
@@ -219,8 +244,8 @@ void _w_logcollector_state_update_target(lc_states_t * state, char * fpath, char
 
     // If target was not found, create it.
     if (*current_target == NULL) {
-        os_realloc(data->targets, (len + 2) * sizeof(lc_state_target_t *), data->targets);
-        os_calloc(1, sizeof(lc_state_target_t), data->targets[len]);
+        os_realloc(data->targets, (len + 2) * sizeof(w_lc_state_target_t *), data->targets);
+        os_calloc(1, sizeof(w_lc_state_target_t), data->targets[len]);
         data->targets[len + 1] = NULL;
         current_target = &data->targets[len];
         os_strdup(target, (*current_target)->name);
@@ -232,7 +257,7 @@ void _w_logcollector_state_update_target(lc_states_t * state, char * fpath, char
 
     if (OSHash_Update(state->states, fpath, data) != 1) {
         if (OSHash_Add(state->states, fpath, data) != 2) {
-            lc_state_target_t ** target = data->targets;
+            w_lc_state_target_t ** target = data->targets;
             while (*target != NULL) {
                 os_free(*target);
                 target++;
@@ -244,44 +269,55 @@ void _w_logcollector_state_update_target(lc_states_t * state, char * fpath, char
     }
 }
 
-void w_logcollector_generate_state() {
+void w_logcollector_state_generate() {
 
-    w_mutex_lock(&g_lc_json_stats_mutex);
+    if (g_lc_state_type & LC_STATE_INTERVAL) {
+        w_mutex_lock(&g_lc_json_stats_mutex);
+    }
     w_mutex_lock(&g_lc_raw_stats_mutex);
-
     cJSON_Delete(g_lc_json_stats);
 
     g_lc_json_stats = cJSON_CreateObject();
-    cJSON * lc_stats_json_global = _w_logcollector_generate_state(g_lc_states_global, false);
-    cJSON_AddItemToObject(g_lc_json_stats, "global", lc_stats_json_global);
-    cJSON * lc_stats_json_interval = _w_logcollector_generate_state(g_lc_states_interval, true);
-    cJSON_AddItemToObject(g_lc_json_stats, "interval", lc_stats_json_interval);
+    if (g_lc_state_type & LC_STATE_GLOBAL) {
+        cJSON * lc_stats_json_global = _w_logcollector_generate_state(g_lc_states_global, false);
+        cJSON_AddItemToObject(g_lc_json_stats, "global", lc_stats_json_global);
+    }
+    if (g_lc_state_type & LC_STATE_INTERVAL) {
+        cJSON * lc_stats_json_interval = _w_logcollector_generate_state(g_lc_states_interval, true);
+        cJSON_AddItemToObject(g_lc_json_stats, "interval", lc_stats_json_interval);
+    }
 
     w_mutex_unlock(&g_lc_raw_stats_mutex);
-    w_mutex_unlock(&g_lc_json_stats_mutex);
+    if (g_lc_state_type & LC_STATE_INTERVAL) {
+        w_mutex_unlock(&g_lc_json_stats_mutex);
+    }
 }
 
 cJSON * w_logcollector_state_get() {
 
     cJSON * json_state = NULL;
 
-    if (g_lc_state_enabled) {
+    if (g_lc_state_type & LC_STATE_INTERVAL) {
         w_mutex_lock(&g_lc_json_stats_mutex);
-
         if (g_lc_json_stats != NULL) {
             json_state = cJSON_Duplicate(g_lc_json_stats, true);
         }
-
         w_mutex_unlock(&g_lc_json_stats_mutex);
+    } else if (g_lc_state_type & LC_STATE_GLOBAL) {
+        w_mutex_lock(&g_lc_raw_stats_mutex);
+        json_state = _w_logcollector_generate_state(g_lc_states_global, false);
+        w_mutex_unlock(&g_lc_raw_stats_mutex);
     }
 
     return json_state;
 }
 
-cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart) {
+cJSON * _w_logcollector_generate_state(w_lc_state_storage_t * state, bool restart) {
 
     OSHashNode * hash_node = NULL;
     unsigned int index = 0;
+    struct tm tm = {.tm_sec = 0};
+    char timestamp_tmp[W_LC_STATE_TIME_LENGHT] = {0};
 
     if (hash_node = OSHash_Begin(state->states, &index), hash_node == NULL) {
         return NULL;
@@ -292,11 +328,11 @@ cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart) {
 
     // Iterate for each file
     while (hash_node) {
-        lc_state_file_t * data = hash_node->data;
+        w_lc_state_file_t * data = hash_node->data;
 
         // Target logic
         cJSON * lc_stats_targets_array = cJSON_CreateArray();
-        lc_state_target_t ** target = data->targets;
+        w_lc_state_target_t ** target = data->targets;
         while (*target != NULL) {
             cJSON * lc_stats_target = cJSON_CreateObject();
             cJSON_AddStringToObject(lc_stats_target, "name", (*target)->name);
@@ -310,10 +346,11 @@ cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart) {
 
         // Files
         cJSON * lc_stats_file = cJSON_CreateObject();
-        cJSON_AddItemToObject(lc_stats_file, "targets", lc_stats_targets_array);
         cJSON_AddStringToObject(lc_stats_file, "location", hash_node->key);
-        cJSON_AddNumberToObject(lc_stats_file, "bytes", data->bytes);
         cJSON_AddNumberToObject(lc_stats_file, "events", data->events);
+        cJSON_AddNumberToObject(lc_stats_file, "bytes", data->bytes);
+        cJSON_AddItemToObject(lc_stats_file, "targets", lc_stats_targets_array);
+
         if (restart) {
             data->bytes = 0;
             data->events = 0;
@@ -322,22 +359,17 @@ cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart) {
         hash_node = OSHash_Next(state->states, &index, hash_node);
     }
 
-    // Convert timestamp to string, removing newline from ctime return
+    // Convert timestamp to string
+    localtime_r(&state->start, &tm);
+    strftime(timestamp_tmp, sizeof(timestamp_tmp), W_LC_STATE_TIME_FORMAT, &tm);
+    cJSON_AddStringToObject(lc_stats_json, "start", timestamp_tmp);
+
     time_t now = time(NULL);
-    char * now_str = NULL;
-    char * start_str = NULL;
-    os_strdup(ctime(&now), now_str);
-    os_strdup(ctime(&state->start), start_str);
+    localtime_r(&now, &tm);
+    strftime(timestamp_tmp, sizeof(timestamp_tmp), W_LC_STATE_TIME_FORMAT, &tm);
+    cJSON_AddStringToObject(lc_stats_json, "end", timestamp_tmp);
 
-    now_str[strlen(now_str) - 1] = '\0';
-    start_str[strlen(start_str) - 1] = '\0';
-
-    cJSON_AddStringToObject(lc_stats_json, "start", start_str);
-    cJSON_AddStringToObject(lc_stats_json, "end", now_str);
     cJSON_AddItemToObject(lc_stats_json, "files", lc_stats_files_array);
-
-    os_free(now_str);
-    os_free(start_str);
 
     if (restart) {
         state->start = time(NULL);

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -19,7 +19,9 @@
 #define LOGCOLLECTOR_STATE_PATH DEFAULTDIR LOGCOLLECTOR_STATE
 #endif
 
-#define LOGCOLLECTOR_STATE_FILES_MAX 440000 // Double of max value of logcollector.queue_size
+// Double of max value of logcollector.queue_size
+#define LOGCOLLECTOR_STATE_FILES_MAX   440000               ///< max amount of localfiles location for states
+#define LOGCOLLECTOR_STATE_DESCRIPTION "logcollector_state" ///< String identifier for errors
 
 /**
  * @brief Initialize storing structures

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -19,8 +19,36 @@
 #endif
 
 // Double of max value of logcollector.queue_size
-#define LOGCOLLECTOR_STATE_FILES_MAX   440000               ///< max amount of localfiles location for states
+#define LOGCOLLECTOR_STATE_FILES_MAX   200200               ///< max amount of localfiles location for states
 #define LOGCOLLECTOR_STATE_DESCRIPTION "logcollector_state" ///< String identifier for errors
+
+/**
+ * @brief state storage structure
+ * key: location option value. value: lc_state_file_t
+ */
+typedef struct {
+    time_t start;    ///< initial state timestamp
+    OSHash * states; ///< state storage
+} lc_states_t;
+
+/**
+ * @brief target state storage
+ *
+ */
+typedef struct {
+    char * name;    ///< target name
+    uint64_t drops; ///< drop count
+} lc_state_target_t;
+
+/**
+ * @brief file state storage
+ *
+ */
+typedef struct {
+    uint64_t bytes;               ///< bytes count
+    uint64_t events;              ///< events count
+    lc_state_target_t ** targets; ///< array of poiters to file's different targets
+} lc_state_file_t;
 
 /**
  * @brief Initialize storing structures

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -13,7 +13,7 @@
 #include "shared.h"
 
 #ifdef WIN32
-#define LOGCOLLECTOR_STATE_PATH "var\\run\\wazuh-logcollector.state"
+#define LOGCOLLECTOR_STATE_PATH "wazuh-logcollector.state"
 #else
 #define LOGCOLLECTOR_STATE      "/var/run/wazuh-logcollector.state"
 #define LOGCOLLECTOR_STATE_PATH DEFAULTDIR LOGCOLLECTOR_STATE

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -31,7 +31,7 @@ void w_logcollector_state_init();
 
 /**
  * @brief Logcollector state main thread function
- * @param args optional parameter (unused)
+ * @param args optional parameter. state interval value
  * @return void* default return value for thread function prototype (unused)
  */
 #ifdef WIN32

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -9,6 +9,7 @@
 
 #ifndef LOGCOLLECTOR_STAT_H
 #define LOGCOLLECTOR_STAT_H
+
 #include "shared.h"
 
 #ifdef WIN32
@@ -80,7 +81,7 @@ void w_logcollector_state_update_target(char * fpath, char * target, bool droppe
  * @brief Update/register current event and byte count for a particular file/location
  *
  * @param fpath file path or locafile location value
- * @param bytes amount of bytes
+ * @param bytes amount of bytes. If bigger than zero, event counter will increment.
  */
 void w_logcollector_state_update_file(char * fpath, uint64_t bytes);
 

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -85,10 +85,10 @@ void w_logcollector_state_update_target(char * fpath, char * target, bool droppe
 void w_logcollector_state_update_file(char * fpath, uint64_t bytes);
 
 /**
- * @brief Get a string with current state in JSON format
+ * @brief Get current state in JSON format
  *
  * @return cJSON* allocated object with current state.
- * The string is heap allocated memory that must be freed by the caller.
+ * The cJSON* is heap allocated memory that must be freed by the caller using cJSON_Delete.
  */
 cJSON * w_logcollector_state_get();
 

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -29,10 +29,14 @@ void w_logcollector_state_init();
 
 /**
  * @brief Logcollector state main thread function
- *
- * @return void* default return value for thread function prototype
+ * @param args optional parameter (unused)
+ * @return void* default return value for thread function prototype (unused)
  */
-void * w_logcollector_state_main();
+#ifdef WIN32
+DWORD WINAPI w_logcollector_state_main(__attribute__((unused)) void * args);
+#else
+void * w_logcollector_state_main(__attribute__((unused)) void * args);
+#endif
 
 /**
  * @brief Update/register current drop count for a target belonging to a particular file

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -1,5 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
- * Copyright (C) 2009 Trend Micro Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -59,9 +59,9 @@ void w_logcollector_state_update_file(char * fpath, uint64_t bytes);
 /**
  * @brief Get a string with current state in JSON format
  *
- * @return char* allocated string with current state.
+ * @return cJSON* allocated object with current state.
  * The string is heap allocated memory that must be freed by the caller.
  */
-char * w_logcollector_state_get();
+cJSON * w_logcollector_state_get();
 
 #endif /* LOGCOLLECTOR_STAT_H */

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -1,0 +1,62 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2009 Trend Micro Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef LOGCOLLECTOR_STAT_H
+#define LOGCOLLECTOR_STAT_H
+#include "shared.h"
+
+#ifdef WIN32
+#define LOGCOLLECTOR_STATE_PATH "var\\run\\wazuh-logcollector.state"
+#else
+#define LOGCOLLECTOR_STATE      "/var/run/wazuh-logcollector.state"
+#define LOGCOLLECTOR_STATE_PATH DEFAULTDIR LOGCOLLECTOR_STATE
+#endif
+
+#define LOGCOLLECTOR_STATE_FILES_MAX 440000 // Double of max value of logcollector.queue_size
+
+/**
+ * @brief Initialize storing structures
+ *
+ */
+void w_logcollector_state_init();
+
+/**
+ * @brief Logcollector state main thread function
+ *
+ * @return void* default return value for thread function prototype
+ */
+void * w_logcollector_state_main();
+
+/**
+ * @brief Update/register current drop count for a target belonging to a particular file
+ *
+ * @param fpath file path or locafile location value
+ * @param target target name
+ * @param dropped true if want to register a drop.
+ */
+void w_logcollector_state_update_target(char * fpath, char * target, bool dropped);
+
+/**
+ * @brief Update/register current event and byte count for a particular file/location
+ *
+ * @param fpath file path or locafile location value
+ * @param bytes amount of bytes
+ */
+void w_logcollector_state_update_file(char * fpath, uint64_t bytes);
+
+/**
+ * @brief Get a string with current state in JSON format
+ *
+ * @return char* allocated string with current state.
+ * The string is heap allocated memory that must be freed by the caller.
+ */
+char * w_logcollector_state_get();
+
+#endif /* LOGCOLLECTOR_STAT_H */

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -23,14 +23,18 @@
 #define LOGCOLLECTOR_STATE_FILES_MAX   200200               ///< max amount of localfiles location for states
 #define LOGCOLLECTOR_STATE_DESCRIPTION "logcollector_state" ///< String identifier for errors
 
+// Macros to add files/targets node to states
+#define w_logcollector_state_add_file(x)      w_logcollector_state_update_file(x, 0)
+#define w_logcollector_state_add_target(x, y) w_logcollector_state_update_target(x, y, false)
+
 /**
  * @brief state storage structure
- * key: location option value. value: lc_state_file_t
+ * key: location option value. value: w_lc_state_file_t
  */
 typedef struct {
     time_t start;    ///< initial state timestamp
     OSHash * states; ///< state storage
-} lc_states_t;
+} w_lc_state_storage_t;
 
 /**
  * @brief target state storage
@@ -39,7 +43,7 @@ typedef struct {
 typedef struct {
     char * name;    ///< target name
     uint64_t drops; ///< drop count
-} lc_state_target_t;
+} w_lc_state_target_t;
 
 /**
  * @brief file state storage
@@ -48,14 +52,25 @@ typedef struct {
 typedef struct {
     uint64_t bytes;               ///< bytes count
     uint64_t events;              ///< events count
-    lc_state_target_t ** targets; ///< array of poiters to file's different targets
-} lc_state_file_t;
+    w_lc_state_target_t ** targets; ///< array of poiters to file's different targets
+} w_lc_state_file_t;
+
+/**
+ * @brief statistics types
+ *
+ */
+typedef enum {
+    LC_STATE_GLOBAL = 0x1 << 0,  ///< statistics since the begining of program execution
+    LC_STATE_INTERVAL = 0x1 << 1 ///< periodically calculated statistic
+} w_lc_state_type_t;
 
 /**
  * @brief Initialize storing structures
  *
+ * @param state_type statistics to calculate
+ * @param state_file_enabled enable saving state to file
  */
-void w_logcollector_state_init();
+void w_logcollector_state_init(w_lc_state_type_t state_type, bool state_file_enabled);
 
 /**
  * @brief Logcollector state main thread function
@@ -63,9 +78,9 @@ void w_logcollector_state_init();
  * @return void* default return value for thread function prototype (unused)
  */
 #ifdef WIN32
-DWORD WINAPI w_logcollector_state_main(__attribute__((unused)) void * args);
+DWORD WINAPI w_logcollector_state_main(void * args);
 #else
-void * w_logcollector_state_main(__attribute__((unused)) void * args);
+void * w_logcollector_state_main(void * args);
 #endif
 
 /**

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -113,6 +113,7 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, __attribute
     char tmpstr[OS_MAXSTR + 1];
     time_t mtime;
     char * _message = NULL;
+    int retval = 0;
 
     _message = log_builder_build(mq_log_builder, target->format, message, locmsg);
 
@@ -163,7 +164,7 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, __attribute
             } else {
                 mdebug2("Discarding event from '%s' due to connection issue with '%s'", locmsg, target->log_socket->name);
                 free(_message);
-                return 0;
+                return 1;
             }
         }
 
@@ -192,13 +193,14 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, __attribute
                 merror("Cannot send message to socket '%s'. (Retry)", target->log_socket->name);
                 SendMSG(queue, "Cannot send message to socket.", "logcollector", LOCALFILE_MQ);
             }
+            retval = 1;
         }
 
         free(_message);
-        return (0);
+        return (retval);
     }
     free(_message);
-    return (0);
+    return (retval);
 }
 
 #else

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -195,9 +195,6 @@ int SendMSGtoSCK(int queue, const char *message, const char *locmsg, __attribute
             }
             retval = 1;
         }
-
-        free(_message);
-        return (retval);
     }
     free(_message);
     return (retval);

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -52,8 +52,15 @@ list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,ff
                                 -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddNumberToObject \
                                 -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,ctime \
                                 -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,pthread_mutex_lock \
-                                -Wl,--wrap,cJSON_Delete -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,getDefine_Int \
-                                -Wl,--wrap,FOREVER -Wl,--wrap,sleep -Wl,--wrap,getpid")
+                                -Wl,--wrap,cJSON_Delete -Wl,--wrap,cJSON_Print -Wl,--wrap,getDefine_Int \
+                                -Wl,--wrap,FOREVER -Wl,--wrap,sleep -Wl,--wrap,getpid -Wl,--wrap,cJSON_Duplicate")
+
+list(APPEND logcollector_names "test_lccom")
+list(APPEND logcollector_flags "-Wl,--wrap,w_logcollector_state_get -Wl,--wrap,cJSON_CreateObject \
+                                -Wl,--wrap,_mdebug1 -Wl,--wrap,cJSON_AddNumberToObject \
+                                -Wl,--wrap,cJSON_AddObjectToObject -Wl,--wrap,cJSON_AddStringToObject \
+                                -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,cJSON_PrintUnformatted \
+                                -Wl,--wrap,cJSON_Delete")
 
 list(LENGTH logcollector_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -51,7 +51,9 @@ list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,ff
                                 -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,_merror \
                                 -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddNumberToObject \
                                 -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,ctime \
-                                -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,pthread_mutex_lock")
+                                -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,pthread_mutex_lock \
+                                -Wl,--wrap,cJSON_Delete -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,getDefine_Int \
+                                -Wl,--wrap,FOREVER -Wl,--wrap,sleep -Wl,--wrap,getpid")
 
 list(LENGTH logcollector_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -48,9 +48,10 @@ list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,ff
                                 -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Delete_ex \
                                 -Wl,--wrap,OSHash_Next -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Update \
                                 -Wl,--wrap,OSHash_setSize -Wl,--wrap,OSHash_Begin -Wl,--wrap,_merror_exit \
-                                -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray \
+                                -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,_merror \
                                 -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddNumberToObject \
-                                -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,ctime")
+                                -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,ctime \
+                                -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,pthread_mutex_lock")
 
 list(LENGTH logcollector_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -41,6 +41,16 @@ list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,ff
                                 -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc\
                                 -Wl,--wrap,w_get_attr_val_by_name -Wl,--wrap,_mwarn -Wl,--wrap,fgetpos")
 
+list(APPEND logcollector_names "test_state")
+list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+                                -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc \
+                                -Wl,--wrap,fgetpos -Wl,--wrap,time -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Add \
+                                -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Delete_ex \
+                                -Wl,--wrap,OSHash_Next -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Update \
+                                -Wl,--wrap,OSHash_setSize -Wl,--wrap,OSHash_Begin -Wl,--wrap,_merror_exit \
+                                -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray \
+                                -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddNumberToObject \
+                                -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,ctime")
 
 list(LENGTH logcollector_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -50,10 +50,11 @@ list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,ff
                                 -Wl,--wrap,OSHash_setSize -Wl,--wrap,OSHash_Begin -Wl,--wrap,_merror_exit \
                                 -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,_merror \
                                 -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddNumberToObject \
-                                -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,ctime \
+                                -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddItemToObject \
                                 -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,pthread_mutex_lock \
                                 -Wl,--wrap,cJSON_Delete -Wl,--wrap,cJSON_Print -Wl,--wrap,getDefine_Int \
-                                -Wl,--wrap,FOREVER -Wl,--wrap,sleep -Wl,--wrap,getpid -Wl,--wrap,cJSON_Duplicate")
+                                -Wl,--wrap,FOREVER -Wl,--wrap,sleep -Wl,--wrap,getpid -Wl,--wrap,cJSON_Duplicate \
+                                -Wl,--wrap,strftime")
 
 list(APPEND logcollector_names "test_lccom")
 list(APPEND logcollector_flags "-Wl,--wrap,w_logcollector_state_get -Wl,--wrap,cJSON_CreateObject \

--- a/src/unit_tests/logcollector/test_lccom.c
+++ b/src/unit_tests/logcollector/test_lccom.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../headers/shared.h"
+#include "../../logcollector/state.h"
+#include "../../logcollector/logcollector.h"
+#include "../../wazuh_modules/wmodules.h"
+#include "../../os_net/os_net.h"
+
+#include "../wrappers/common.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../wrappers/externals/cJSON/cJSON_wrappers.h"
+
+size_t lccom_getstate(char ** output);
+
+/* setup/teardown */
+
+static int setup_group(void ** state) {
+    test_mode = 1;
+    return 0;
+}
+
+static int teardown_group(void ** state) {
+    test_mode = 0;
+    return 0;
+}
+
+/* wraps */
+
+cJSON * __wrap_w_logcollector_state_get() {
+    return mock_type(cJSON *);
+}
+
+
+/* tests */
+
+/* lccom_getstate */
+
+void test_lccom_getstate_ok(void ** state) {
+    char * output = NULL;
+    char json[] = "test json";
+
+    will_return(__wrap_cJSON_CreateObject, (cJSON *) 2);
+    will_return(__wrap_w_logcollector_state_get, (cJSON *) 3);
+
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "error");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
+    will_return(__wrap_cJSON_AddNumberToObject, NULL);
+    
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, 0);
+
+    will_return(__wrap_cJSON_PrintUnformatted, json);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    size_t retval = lccom_getstate(&output);
+
+    assert_int_equal(strlen(json), retval);
+    assert_string_equal(json, output);
+
+}
+
+void test_lccom_getstate_null(void ** state) {
+
+    char * output = NULL;
+    char json[] = "test json";
+
+    will_return(__wrap_cJSON_CreateObject, (cJSON *) 2);
+    will_return(__wrap_w_logcollector_state_get, NULL);
+
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "error");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
+    will_return(__wrap_cJSON_AddNumberToObject, NULL);
+
+    expect_string(__wrap_cJSON_AddObjectToObject, name, "data");
+    expect_value(__wrap_cJSON_AddObjectToObject, object, (cJSON *) 2);
+    will_return(__wrap_cJSON_AddObjectToObject, NULL);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "message");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "Could not process the request");
+    will_return(__wrap_cJSON_AddStringToObject, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "At LCCOM getstate: Could not process the request");
+
+    will_return(__wrap_cJSON_PrintUnformatted, json);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    size_t retval = lccom_getstate(&output);
+
+    assert_int_equal(strlen(json), retval);
+    assert_string_equal(json, output);
+
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+
+        // Tests lccom_getstate
+        cmocka_unit_test(test_lccom_getstate_ok),
+        cmocka_unit_test(test_lccom_getstate_null),
+    };
+
+    return cmocka_run_group_tests(tests, setup_group, teardown_group);
+}
+

--- a/src/unit_tests/logcollector/test_lccom.c
+++ b/src/unit_tests/logcollector/test_lccom.c
@@ -43,7 +43,6 @@ cJSON * __wrap_w_logcollector_state_get() {
     return mock_type(cJSON *);
 }
 
-
 /* tests */
 
 /* lccom_getstate */
@@ -58,7 +57,7 @@ void test_lccom_getstate_ok(void ** state) {
     expect_string(__wrap_cJSON_AddNumberToObject, name, "error");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
     will_return(__wrap_cJSON_AddNumberToObject, NULL);
-    
+
     expect_function_call(__wrap_cJSON_AddItemToObject);
     will_return(__wrap_cJSON_AddItemToObject, 0);
 
@@ -69,7 +68,6 @@ void test_lccom_getstate_ok(void ** state) {
 
     assert_int_equal(strlen(json), retval);
     assert_string_equal(json, output);
-
 }
 
 void test_lccom_getstate_null(void ** state) {
@@ -101,7 +99,6 @@ void test_lccom_getstate_null(void ** state) {
 
     assert_int_equal(strlen(json), retval);
     assert_string_equal(json, output);
-
 }
 
 int main(void) {
@@ -114,4 +111,3 @@ int main(void) {
 
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }
-

--- a/src/unit_tests/logcollector/test_lccom.c
+++ b/src/unit_tests/logcollector/test_lccom.c
@@ -104,44 +104,12 @@ void test_lccom_getstate_null(void ** state) {
     assert_string_equal(json, output);
 }
 
-void test_lccom_getstate_disabled(void ** state) {
-
-    char * output = NULL;
-    char json[] = "test json";
-    state_interval = false;
-
-    will_return(__wrap_cJSON_CreateObject, (cJSON *) 2);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "error");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, NULL);
-
-    expect_string(__wrap_cJSON_AddObjectToObject, name, "data");
-    expect_value(__wrap_cJSON_AddObjectToObject, object, (cJSON *) 2);
-    will_return(__wrap_cJSON_AddObjectToObject, NULL);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, "message");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Statistics disabled");
-    will_return(__wrap_cJSON_AddStringToObject, 0);
-
-    expect_string(__wrap__mdebug1, formatted_msg, "At LCCOM getstate: Statistics disabled");
-
-    will_return(__wrap_cJSON_PrintUnformatted, json);
-    expect_function_call(__wrap_cJSON_Delete);
-
-    size_t retval = lccom_getstate(&output);
-
-    assert_int_equal(strlen(json), retval);
-    assert_string_equal(json, output);
-}
-
 int main(void) {
     const struct CMUnitTest tests[] = {
 
         // Tests lccom_getstate
         cmocka_unit_test(test_lccom_getstate_ok),
-        cmocka_unit_test(test_lccom_getstate_null),
-        cmocka_unit_test(test_lccom_getstate_disabled)
+        cmocka_unit_test(test_lccom_getstate_null)
     };
 
     return cmocka_run_group_tests(tests, setup_group, teardown_group);

--- a/src/unit_tests/logcollector/test_state.c
+++ b/src/unit_tests/logcollector/test_state.c
@@ -871,9 +871,9 @@ void test_w_logcollector_state_dump_ok(void ** state) {
 /* w_logcollector_state_main */
 void test_w_logcollector_state_main(void ** state) {
 
-    will_return(__wrap_getDefine_Int, 105);
+    int interval = 105;
     will_return(__wrap_FOREVER, 1);
-    expect_value(__wrap_sleep, seconds, 105);
+    expect_value(__wrap_sleep, seconds, interval);
 
     // w_logcollector_generate_state
     os_calloc(1, sizeof(lc_states_t), g_lc_states_global);
@@ -1001,7 +1001,7 @@ void test_w_logcollector_state_main(void ** state) {
 
     will_return(__wrap_FOREVER, 0);
 
-    w_logcollector_state_main(NULL);
+    w_logcollector_state_main((void *) &interval);
 
     os_free(g_lc_states_global);
     os_free(g_lc_states_interval);

--- a/src/unit_tests/logcollector/test_state.c
+++ b/src/unit_tests/logcollector/test_state.c
@@ -29,6 +29,7 @@ void w_logcollector_state_init();
 char * w_logcollector_state_get();
 cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart);
 void _w_logcollector_state_update_file(lc_states_t * state, char * fpath, uint64_t bytes);
+void w_logcollector_state_update_file(char * fpath, uint64_t bytes);
 
 /* setup/teardown */
 
@@ -351,7 +352,8 @@ void test__w_logcollector_generate_state_one_target_restart(void ** state) {
 // Test _w_logcollector_state_update_file
 void test__w_logcollector_state_update_file_new_data(void ** state) {
 
-    lc_states_t stat;
+    lc_states_t stat = {0};
+    stat.states = (OSHash *) 2;
 
     expect_value(__wrap_OSHash_Get, self, stat.states);
     expect_string(__wrap_OSHash_Get, key, "/test_path");
@@ -367,7 +369,8 @@ void test__w_logcollector_state_update_file_new_data(void ** state) {
 
 void test__w_logcollector_state_update_file_update(void ** state) {
     
-    lc_states_t stat;
+    lc_states_t stat = {0};
+    stat.states = (OSHash *) 2;
     lc_state_file_t data = {0};
 
     expect_value(__wrap_OSHash_Get, self, stat.states);
@@ -380,6 +383,11 @@ void test__w_logcollector_state_update_file_update(void ** state) {
 
     assert_int_equal(data.bytes, 100);
     assert_int_equal(data.events, 1);
+}
+
+// w_logcollector_state_update_file
+void test_w_logcollector_state_update_file_null(void ** state) {
+    w_logcollector_state_update_file(NULL, 500);
 }
 
 int main(void) {
@@ -402,6 +410,10 @@ int main(void) {
         // Tests _w_logcollector_state_update_file
         cmocka_unit_test(test__w_logcollector_state_update_file_new_data),
         cmocka_unit_test(test__w_logcollector_state_update_file_update),
+        
+        // Tests w_logcollector_state_update_file
+        cmocka_unit_test(test_w_logcollector_state_update_file_null),
+        //cmocka_unit_test(test_w_logcollector_state_update_file_ok),
 
     };
 

--- a/src/unit_tests/logcollector/test_state.c
+++ b/src/unit_tests/logcollector/test_state.c
@@ -15,7 +15,7 @@
 #include <time.h>
 
 #include "../../headers/shared.h"
-#include "../../logcollector/state.c"
+#include "../../logcollector/state.h"
 
 #include "../wrappers/common.h"
 #include "../wrappers/wazuh/shared/hash_op_wrappers.h"
@@ -26,7 +26,7 @@
 #include "../wrappers/posix/pthread_wrappers.h"
 
 void w_logcollector_state_init();
-char * w_logcollector_state_get();
+cJSON * w_logcollector_state_get();
 cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart);
 void _w_logcollector_state_update_file(lc_states_t * state, char * fpath, uint64_t bytes);
 void w_logcollector_state_update_file(char * fpath, uint64_t bytes);
@@ -35,7 +35,9 @@ void w_logcollector_state_update_target(char * fpath, char * target, bool droppe
 void w_logcollector_generate_state();
 void w_logcollector_state_dump();
 void * w_logcollector_state_main(__attribute__((unused)) void * args);
-
+extern cJSON * g_lc_json_stats;
+extern lc_states_t * g_lc_states_global;
+extern lc_states_t * g_lc_states_interval;
 /* setup/teardown */
 
 static int setup_group(void ** state) {
@@ -201,7 +203,7 @@ void test_w_logcollector_state_init_ok(void ** state) {
 /* w_logcollector_state_get_null */
 void test_w_logcollector_state_get_null(void ** state) {
 
-    os_free(g_lc_pritty_stats);
+    //os_free(g_lc_pritty_stats);
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
     assert_null(w_logcollector_state_get());
@@ -209,8 +211,8 @@ void test_w_logcollector_state_get_null(void ** state) {
 
 void test_w_logcollector_state_get_non_null(void ** state) {
 
-    os_free(g_lc_pritty_stats);
-    g_lc_pritty_stats = strdup("hi!");
+    //os_free(g_lc_pritty_stats);
+    //g_lc_pritty_stats = strdup("hi!");
 
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
@@ -220,7 +222,7 @@ void test_w_logcollector_state_get_non_null(void ** state) {
     assert_string_equal("hi!", retval);
 
     os_free(retval);
-    os_free(g_lc_pritty_stats);
+    //os_free(g_lc_pritty_stats);
 }
 
 /* Test _w_logcollector_generate_state */
@@ -797,14 +799,14 @@ void test_w_logcollector_generate_state_ok(void ** state) {
     assert_int_equal(g_lc_states_interval->start, 2525);
     os_free(g_lc_states_global);
     os_free(g_lc_states_interval);
-    os_free(g_lc_pritty_stats);
+    //os_free(g_lc_pritty_stats);
 }
 
 /* w_logcollector_state_dump */
 void test_w_logcollector_state_dump_fail_open(void ** state) {
 
-    os_free(g_lc_pritty_stats);
-    g_lc_pritty_stats = strdup("hi!");
+    //os_free(g_lc_pritty_stats);
+    //g_lc_pritty_stats = strdup("hi!");
 
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
@@ -819,13 +821,13 @@ void test_w_logcollector_state_dump_fail_open(void ** state) {
 
     w_logcollector_state_dump();
 
-    os_free(g_lc_pritty_stats);
+    //os_free(g_lc_pritty_stats);
 }
 
 void test_w_logcollector_state_dump_fail_write(void ** state) {
 
-    os_free(g_lc_pritty_stats);
-    g_lc_pritty_stats = strdup("hi!");
+    //os_free(g_lc_pritty_stats);
+    //g_lc_pritty_stats = strdup("hi!");
 
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
@@ -844,13 +846,13 @@ void test_w_logcollector_state_dump_fail_write(void ** state) {
 
     w_logcollector_state_dump();
 
-    os_free(g_lc_pritty_stats);
+    //os_free(g_lc_pritty_stats);
 }
 
 void test_w_logcollector_state_dump_ok(void ** state) {
 
-    os_free(g_lc_pritty_stats);
-    g_lc_pritty_stats = strdup("hi!");
+    //os_free(g_lc_pritty_stats);
+    //g_lc_pritty_stats = strdup("hi!");
 
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
@@ -865,7 +867,7 @@ void test_w_logcollector_state_dump_ok(void ** state) {
 
     w_logcollector_state_dump();
 
-    os_free(g_lc_pritty_stats);
+    //os_free(g_lc_pritty_stats);
 }
 
 /* w_logcollector_state_main */
@@ -1005,7 +1007,7 @@ void test_w_logcollector_state_main(void ** state) {
 
     os_free(g_lc_states_global);
     os_free(g_lc_states_interval);
-    os_free(g_lc_pritty_stats);
+    //os_free(g_lc_pritty_stats);
 }
 
 int main(void) {

--- a/src/unit_tests/logcollector/test_state.c
+++ b/src/unit_tests/logcollector/test_state.c
@@ -223,7 +223,6 @@ void test_w_logcollector_state_get_non_null(void ** state) {
 
     assert_ptr_not_equal(g_lc_json_stats, retval);
     assert_ptr_equal(expect_retval, retval);
-
 }
 
 /* Test _w_logcollector_generate_state */
@@ -805,7 +804,6 @@ void test_w_logcollector_generate_state_ok(void ** state) {
 /* w_logcollector_state_dump */
 void test_w_logcollector_state_dump_fail_open(void ** state) {
 
-
     expect_function_call(__wrap_pthread_mutex_lock);
     will_return(__wrap_cJSON_Duplicate, (cJSON *) 3);
     expect_function_call(__wrap_pthread_mutex_unlock);
@@ -821,7 +819,6 @@ void test_w_logcollector_state_dump_fail_open(void ** state) {
                   "'/var/ossec/var/run/wazuh-logcollector.state' due to [(0)-(Success)].");
 
     w_logcollector_state_dump();
-
 }
 
 void test_w_logcollector_state_dump_fail_write(void ** state) {
@@ -845,8 +842,6 @@ void test_w_logcollector_state_dump_fail_write(void ** state) {
     will_return(__wrap_fclose, 0);
 
     w_logcollector_state_dump();
-
-    //os_free(g_lc_pritty_stats);
 }
 
 void test_w_logcollector_state_dump_ok(void ** state) {
@@ -866,7 +861,6 @@ void test_w_logcollector_state_dump_ok(void ** state) {
     will_return(__wrap_fclose, 0);
 
     w_logcollector_state_dump();
-
 }
 
 /* w_logcollector_state_main */
@@ -1009,7 +1003,6 @@ void test_w_logcollector_state_main(void ** state) {
 
     os_free(g_lc_states_global);
     os_free(g_lc_states_interval);
-    //os_free(g_lc_pritty_stats);
 }
 
 int main(void) {

--- a/src/unit_tests/logcollector/test_state.c
+++ b/src/unit_tests/logcollector/test_state.c
@@ -1,0 +1,409 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <time.h>
+
+
+#include "../../headers/shared.h"
+#include "../../logcollector/state.c"
+
+
+#include "../wrappers/common.h"
+#include "../wrappers/wazuh/shared/hash_op_wrappers.h"
+#include "../wrappers/libc/stdio_wrappers.h"
+#include "../wrappers/externals/cJSON/cJSON_wrappers.h"
+
+// selfcontained
+void w_logcollector_state_init();
+char * w_logcollector_state_get();
+cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart);
+void _w_logcollector_state_update_file(lc_states_t * state, char * fpath, uint64_t bytes);
+
+/* setup/teardown */
+
+static int setup_group(void **state) {
+    test_mode = 1;
+    return 0;
+}
+
+static int teardown_group(void **state) {
+    test_mode = 0;
+    return 0;
+}
+
+/* wraps */
+time_t __wrap_time(time_t * t) {
+    return mock_type(time_t);
+}
+
+char * __wrap_ctime (const time_t *__timer) {
+    return mock_type(char *);
+}
+
+/* tests */
+
+// w_logcollector_state_init
+void test_w_logcollector_state_init_fail_hash_create_global(void ** state) {
+
+    os_free(g_lc_states_global);
+    os_free(g_lc_states_interval);
+
+    will_return(__wrap_time, (time_t) 50);
+    will_return(__wrap_time, (time_t) 51);
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, NULL);
+
+    expect_string(__wrap__merror_exit, formatted_msg, "(1296): Unable to create a 'logcollector_state' hash table");
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, 1);
+    will_return(__wrap_OSHash_setSize, 1);
+    will_return(__wrap_OSHash_setSize, 1);
+
+    w_logcollector_state_init();
+
+    assert_non_null(g_lc_states_global);
+    assert_non_null(g_lc_states_interval);
+
+    os_free(g_lc_states_global);
+    os_free(g_lc_states_interval);
+}
+
+void test_w_logcollector_state_init_fail_hash_create_interval(void ** state) {
+
+    os_free(g_lc_states_global);
+    os_free(g_lc_states_interval);
+
+    will_return(__wrap_time, (time_t) 50);
+    will_return(__wrap_time, (time_t) 51);
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, 2);
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, NULL);
+    expect_string(__wrap__merror_exit, formatted_msg, "(1296): Unable to create a 'logcollector_state' hash table");
+
+    will_return(__wrap_OSHash_setSize, 1);
+    will_return(__wrap_OSHash_setSize, 1);
+
+    w_logcollector_state_init();
+
+    assert_non_null(g_lc_states_global);
+    assert_non_null(g_lc_states_interval);
+
+    os_free(g_lc_states_global);
+    os_free(g_lc_states_interval);
+}
+
+void test_w_logcollector_state_init_fail_hash_setsize_global(void ** state) {
+
+    os_free(g_lc_states_global);
+    os_free(g_lc_states_interval);
+
+    will_return(__wrap_time, (time_t) 50);
+    will_return(__wrap_time, (time_t) 51);
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, 2);
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, 3);
+
+    will_return(__wrap_OSHash_setSize, 0);
+    expect_string(__wrap__merror_exit, formatted_msg, "(1297): Unable to set size of 'logcollector_state' hash table");
+
+    will_return(__wrap_OSHash_setSize, 1);
+
+    w_logcollector_state_init();
+
+    assert_non_null(g_lc_states_global);
+    assert_non_null(g_lc_states_interval);
+
+    os_free(g_lc_states_global);
+    os_free(g_lc_states_interval);
+}
+
+void test_w_logcollector_state_init_fail_hash_setsize_interval(void ** state) {
+
+    os_free(g_lc_states_global);
+    os_free(g_lc_states_interval);
+
+    will_return(__wrap_time, (time_t) 50);
+    will_return(__wrap_time, (time_t) 51);
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, 1);
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, 1);
+
+    will_return(__wrap_OSHash_setSize, 1);
+    will_return(__wrap_OSHash_setSize, 0);
+    expect_string(__wrap__merror_exit, formatted_msg, "(1297): Unable to set size of 'logcollector_state' hash table");
+
+    w_logcollector_state_init();
+
+    assert_non_null(g_lc_states_global);
+    assert_non_null(g_lc_states_interval);
+
+    os_free(g_lc_states_global);
+    os_free(g_lc_states_interval);
+}
+
+void test_w_logcollector_state_init_ok(void ** state) {
+
+    os_free(g_lc_states_global);
+    os_free(g_lc_states_interval);
+
+    will_return(__wrap_time, (time_t) 50);
+    will_return(__wrap_time, (time_t) 51);
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, 2);
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, 3);
+
+    will_return(__wrap_OSHash_setSize, 1);
+    will_return(__wrap_OSHash_setSize, 1);
+
+    w_logcollector_state_init();
+
+    assert_non_null(g_lc_states_global);
+    assert_non_null(g_lc_states_interval);
+
+    assert_ptr_equal(g_lc_states_global->states, 2);
+    assert_int_equal(g_lc_states_global->start, 50);
+    assert_ptr_equal(g_lc_states_interval->states, 3);
+    assert_int_equal(g_lc_states_interval->start, 51);
+
+    os_free(g_lc_states_global);
+    os_free(g_lc_states_interval);
+}
+
+// w_logcollector_state_get_null
+void test_w_logcollector_state_get_null(void ** state) {
+
+    os_free(g_lc_pritty_stats);
+    assert_null(w_logcollector_state_get());
+}
+
+void test_w_logcollector_state_get_non_null(void ** state) {
+
+    os_free(g_lc_pritty_stats);
+    g_lc_pritty_stats = strdup("hi!");
+
+    char * retval = w_logcollector_state_get();
+
+    assert_string_equal("hi!", retval);
+
+    os_free(retval);
+    os_free(g_lc_pritty_stats);
+}
+
+// Test _w_logcollector_generate_state
+void test__w_logcollector_generate_state_fail_get_node(void ** state) {
+
+    lc_states_t stats = {.states = (OSHash *) 2};
+    cJSON * retval;
+    expect_value(__wrap_OSHash_Begin, self, stats.states);
+    will_return(__wrap_OSHash_Begin, NULL);
+
+    retval = _w_logcollector_generate_state(&stats, 0);
+    assert_null(retval);
+}
+
+void test__w_logcollector_generate_state_one_target(void ** state) {
+
+    cJSON * retval;
+    lc_states_t stats = {.states = (OSHash *) 2};
+    lc_state_target_t target = {.drops = 10, .name = "sock1"};
+    lc_state_target_t * target_array[2] = {&target, NULL};
+
+    lc_state_file_t data = {.targets = (lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
+    OSHashNode hash_node = {.data = &data, .key = "key_test"};
+
+    expect_value(__wrap_OSHash_Begin, self, stats.states);
+    will_return(__wrap_OSHash_Begin, &hash_node);
+
+    will_return_always(__wrap_cJSON_AddNumberToObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+    will_return_always(__wrap_cJSON_AddItemToArray, true);
+    will_return_always(__wrap_cJSON_AddItemToObject, true);
+
+    will_return_always(__wrap_cJSON_CreateObject, (cJSON *) 10);
+    will_return_always(__wrap_cJSON_CreateArray, (cJSON *) 1);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "name");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "sock1");
+
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "drops");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 10);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "location");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "key_test");
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "events");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 5);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+
+    expect_value(__wrap_OSHash_Next, self, stats.states);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    will_return(__wrap_time, (time_t) 0);
+    will_return(__wrap_ctime, "Fri Jan  8 04:31:29 AM -03 2021\n");
+    will_return(__wrap_ctime, "Fri Jan  8 03:31:29 AM -03 2021\n");
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "start");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 03:31:29 AM -03 2021");
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "end");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 04:31:29 AM -03 2021");
+
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+
+    retval = _w_logcollector_generate_state(&stats, false);
+    assert_ptr_equal(retval, (cJSON *) 10);
+    assert_int_equal(data.bytes, 100);
+    assert_int_equal(data.events, 5);
+}
+
+void test__w_logcollector_generate_state_one_target_restart(void ** state) {
+
+    cJSON * retval;
+    lc_states_t stats = {.states = (OSHash *) 2, .start = (time_t) 2020};
+    lc_state_target_t target = {.drops = 10, .name = "sock1"};
+    lc_state_target_t * target_array[2] = {&target, NULL};
+
+    lc_state_file_t data = {.targets = (lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
+    OSHashNode hash_node = {.data = &data, .key = "key_test"};
+
+    expect_value(__wrap_OSHash_Begin, self, stats.states);
+    will_return(__wrap_OSHash_Begin, &hash_node);
+
+    will_return_always(__wrap_cJSON_AddNumberToObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+    will_return_always(__wrap_cJSON_AddItemToArray, true);
+    will_return_always(__wrap_cJSON_AddItemToObject, true);
+
+    will_return_always(__wrap_cJSON_CreateObject, (cJSON *) 10);
+    will_return_always(__wrap_cJSON_CreateArray, (cJSON *) 1);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "name");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "sock1");
+
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "drops");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 10);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "location");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "key_test");
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "events");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 5);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+
+    expect_value(__wrap_OSHash_Next, self, stats.states);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    will_return(__wrap_time, (time_t) 0);
+    will_return(__wrap_ctime, "Fri Jan  8 04:31:29 AM -03 2021\n");
+    will_return(__wrap_ctime, "Fri Jan  8 03:31:29 AM -03 2021\n");
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "start");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 03:31:29 AM -03 2021");
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "end");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 04:31:29 AM -03 2021");
+
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_time, (time_t) 2525);
+
+    retval = _w_logcollector_generate_state(&stats, true);
+    assert_ptr_equal(retval, (cJSON *) 10);
+    assert_int_equal(data.bytes, 0);
+    assert_int_equal(data.events, 0);
+    assert_int_equal(stats.start, 2525);
+}
+
+// Test _w_logcollector_state_update_file
+void test__w_logcollector_state_update_file_new_data(void ** state) {
+
+    lc_states_t stat;
+
+    expect_value(__wrap_OSHash_Get, self, stat.states);
+    expect_string(__wrap_OSHash_Get, key, "/test_path");
+    will_return(__wrap_OSHash_Get, NULL);
+
+    will_return(__wrap_OSHash_Update, 0);
+
+    expect_value(__wrap_OSHash_Add, key, "/test_path");
+    will_return(__wrap_OSHash_Add, 0);
+
+    _w_logcollector_state_update_file(&stat, "/test_path", 100);
+}
+
+void test__w_logcollector_state_update_file_update(void ** state) {
+    
+    lc_states_t stat;
+    lc_state_file_t data = {0};
+
+    expect_value(__wrap_OSHash_Get, self, stat.states);
+    expect_string(__wrap_OSHash_Get, key, "/test_path");
+    will_return(__wrap_OSHash_Get, &data);
+
+    will_return(__wrap_OSHash_Update, 1);
+
+    _w_logcollector_state_update_file(&stat, "/test_path", 100);
+
+    assert_int_equal(data.bytes, 100);
+    assert_int_equal(data.events, 1);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        // Tests w_logcollector_state_init
+        cmocka_unit_test(test_w_logcollector_state_init_fail_hash_create_global),
+        cmocka_unit_test(test_w_logcollector_state_init_fail_hash_create_interval),
+        cmocka_unit_test(test_w_logcollector_state_init_fail_hash_setsize_global),
+        cmocka_unit_test(test_w_logcollector_state_init_fail_hash_setsize_interval),
+        cmocka_unit_test(test_w_logcollector_state_init_ok),
+
+        // Tests w_logcollector_state_get
+        cmocka_unit_test(test_w_logcollector_state_get_null), cmocka_unit_test(test_w_logcollector_state_get_non_null),
+
+        // Tests _w_logcollector_generate_state
+        cmocka_unit_test(test__w_logcollector_generate_state_fail_get_node),
+        cmocka_unit_test(test__w_logcollector_generate_state_one_target),
+        cmocka_unit_test(test__w_logcollector_generate_state_one_target_restart),
+
+        // Tests _w_logcollector_state_update_file
+        cmocka_unit_test(test__w_logcollector_state_update_file_new_data),
+        cmocka_unit_test(test__w_logcollector_state_update_file_update),
+
+    };
+
+    return cmocka_run_group_tests(tests, setup_group, teardown_group);
+}

--- a/src/unit_tests/logcollector/test_state.c
+++ b/src/unit_tests/logcollector/test_state.c
@@ -25,20 +25,20 @@
 #include "../wrappers/externals/cJSON/cJSON_wrappers.h"
 #include "../wrappers/posix/pthread_wrappers.h"
 
-void w_logcollector_state_init();
+void w_logcollector_state_init(w_lc_state_type_t state_type, bool state_file_enabled);
 cJSON * w_logcollector_state_get();
-cJSON * _w_logcollector_generate_state(lc_states_t * state, bool restart);
-void _w_logcollector_state_update_file(lc_states_t * state, char * fpath, uint64_t bytes);
+cJSON * _w_logcollector_generate_state(w_lc_state_storage_t * state, bool restart);
+void _w_logcollector_state_update_file(w_lc_state_storage_t * state, char * fpath, uint64_t bytes);
 void w_logcollector_state_update_file(char * fpath, uint64_t bytes);
-void _w_logcollector_state_update_target(lc_states_t * state, char * fpath, char * target, bool dropped);
+void _w_logcollector_state_update_target(w_lc_state_storage_t * state, char * fpath, char * target, bool dropped);
 void w_logcollector_state_update_target(char * fpath, char * target, bool dropped);
-void w_logcollector_generate_state();
+void w_logcollector_state_generate();
 void w_logcollector_state_dump();
 void * w_logcollector_state_main(__attribute__((unused)) void * args);
 extern cJSON * g_lc_json_stats;
-extern lc_states_t * g_lc_states_global;
-extern lc_states_t * g_lc_states_interval;
-extern bool g_lc_state_enabled;
+extern w_lc_state_storage_t * g_lc_states_global;
+extern w_lc_state_storage_t * g_lc_states_interval;
+extern w_lc_state_type_t g_lc_state_type;
 
 /* setup/teardown */
 
@@ -53,12 +53,14 @@ static int teardown_group(void ** state) {
 }
 
 /* wraps */
-time_t __wrap_time(time_t * t) { 
+time_t __wrap_time(time_t * t) {
     return mock_type(time_t);
 }
 
-char * __wrap_ctime(const time_t * __timer) { 
-    return mock_type(char *);
+size_t __wrap_strftime(char *s, size_t max, const char *format,
+                       const struct tm *tm) {
+    strncpy(s, mock_type(char *), max);
+    return mock();
 }
 
 /* tests */
@@ -82,7 +84,7 @@ void test_w_logcollector_state_init_fail_hash_create_global(void ** state) {
     will_return(__wrap_OSHash_setSize, 1);
     will_return(__wrap_OSHash_setSize, 1);
 
-    w_logcollector_state_init();
+    w_logcollector_state_init(LC_STATE_GLOBAL|LC_STATE_INTERVAL, true);
 
     assert_non_null(g_lc_states_global);
     assert_non_null(g_lc_states_interval);
@@ -109,7 +111,7 @@ void test_w_logcollector_state_init_fail_hash_create_interval(void ** state) {
     will_return(__wrap_OSHash_setSize, 1);
     will_return(__wrap_OSHash_setSize, 1);
 
-    w_logcollector_state_init();
+    w_logcollector_state_init(LC_STATE_GLOBAL|LC_STATE_INTERVAL, true);
 
     assert_non_null(g_lc_states_global);
     assert_non_null(g_lc_states_interval);
@@ -137,7 +139,7 @@ void test_w_logcollector_state_init_fail_hash_setsize_global(void ** state) {
 
     will_return(__wrap_OSHash_setSize, 1);
 
-    w_logcollector_state_init();
+    w_logcollector_state_init(LC_STATE_GLOBAL|LC_STATE_INTERVAL, true);
 
     assert_non_null(g_lc_states_global);
     assert_non_null(g_lc_states_interval);
@@ -163,7 +165,7 @@ void test_w_logcollector_state_init_fail_hash_setsize_interval(void ** state) {
     will_return(__wrap_OSHash_setSize, 0);
     expect_string(__wrap__merror_exit, formatted_msg, "(1297): Unable to set size of 'logcollector_state' hash table");
 
-    w_logcollector_state_init();
+    w_logcollector_state_init(LC_STATE_GLOBAL|LC_STATE_INTERVAL, true);
 
     assert_non_null(g_lc_states_global);
     assert_non_null(g_lc_states_interval);
@@ -176,7 +178,7 @@ void test_w_logcollector_state_init_ok(void ** state) {
 
     os_free(g_lc_states_global);
     os_free(g_lc_states_interval);
-    g_lc_state_enabled = 0;
+    g_lc_state_type = 0;
 
     will_return(__wrap_time, (time_t) 50);
     will_return(__wrap_time, (time_t) 51);
@@ -189,7 +191,7 @@ void test_w_logcollector_state_init_ok(void ** state) {
     will_return(__wrap_OSHash_setSize, 1);
     will_return(__wrap_OSHash_setSize, 1);
 
-    w_logcollector_state_init();
+    w_logcollector_state_init(LC_STATE_GLOBAL | LC_STATE_INTERVAL, true);
 
     assert_non_null(g_lc_states_global);
     assert_non_null(g_lc_states_interval);
@@ -198,21 +200,15 @@ void test_w_logcollector_state_init_ok(void ** state) {
     assert_int_equal(g_lc_states_global->start, 50);
     assert_ptr_equal(g_lc_states_interval->states, 3);
     assert_int_equal(g_lc_states_interval->start, 51);
-    assert_int_equal(g_lc_state_enabled, 1);
+    assert_int_equal(g_lc_state_type, LC_STATE_GLOBAL | LC_STATE_INTERVAL);
 
     os_free(g_lc_states_global);
     os_free(g_lc_states_interval);
 }
 
-/* w_logcollector_state_get */
-void test_w_logcollector_state_get_disabled(void ** state) {
-    g_lc_state_enabled = 0;
-    assert_null(w_logcollector_state_get());
-}
 
 void test_w_logcollector_state_get_null(void ** state) {
-
-    g_lc_state_enabled = 1;
+    g_lc_state_type = LC_STATE_INTERVAL;
     g_lc_json_stats = NULL;
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
@@ -222,7 +218,7 @@ void test_w_logcollector_state_get_null(void ** state) {
 void test_w_logcollector_state_get_non_null(void ** state) {
 
     cJSON * expect_retval = (cJSON *) 3;
-    g_lc_state_enabled = 1;
+    g_lc_state_type = LC_STATE_GLOBAL | LC_STATE_INTERVAL;
     g_lc_json_stats = (cJSON *) 5;
 
     expect_function_call(__wrap_pthread_mutex_lock);
@@ -238,7 +234,7 @@ void test_w_logcollector_state_get_non_null(void ** state) {
 /* Test _w_logcollector_generate_state */
 void test__w_logcollector_generate_state_fail_get_node(void ** state) {
 
-    lc_states_t stats = {.states = (OSHash *) 2};
+    w_lc_state_storage_t stats = {.states = (OSHash *) 2};
     cJSON * retval;
     expect_value(__wrap_OSHash_Begin, self, stats.states);
     will_return(__wrap_OSHash_Begin, NULL);
@@ -250,11 +246,11 @@ void test__w_logcollector_generate_state_fail_get_node(void ** state) {
 void test__w_logcollector_generate_state_one_target(void ** state) {
 
     cJSON * retval;
-    lc_states_t stats = {.states = (OSHash *) 2};
-    lc_state_target_t target = {.drops = 10, .name = "sock1"};
-    lc_state_target_t * target_array[2] = {&target, NULL};
+    w_lc_state_storage_t stats = {.states = (OSHash *) 2 , };
+    w_lc_state_target_t target = {.drops = 10, .name = "sock1"};
+    w_lc_state_target_t * target_array[2] = {&target, NULL};
 
-    lc_state_file_t data = {.targets = (lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
+    w_lc_state_file_t data = {.targets = (w_lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
     OSHashNode hash_node = {.data = &data, .key = "key_test"};
 
     expect_value(__wrap_OSHash_Begin, self, stats.states);
@@ -276,29 +272,32 @@ void test__w_logcollector_generate_state_one_target(void ** state) {
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
 
-    expect_function_call(__wrap_cJSON_AddItemToObject);
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "location");
     expect_string(__wrap_cJSON_AddStringToObject, string, "key_test");
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
     expect_string(__wrap_cJSON_AddNumberToObject, name, "events");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 5);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
+
+    expect_function_call(__wrap_cJSON_AddItemToObject);
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
 
     expect_value(__wrap_OSHash_Next, self, stats.states);
     will_return(__wrap_OSHash_Next, NULL);
 
-    will_return(__wrap_time, (time_t) 0);
-    will_return(__wrap_ctime, "Fri Jan  8 04:31:29 AM -03 2021\n");
-    will_return(__wrap_ctime, "Fri Jan  8 03:31:29 AM -03 2021\n");
+    will_return(__wrap_strftime,"2019-02-05 12:18:37");
+    will_return(__wrap_strftime, 20);
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "start");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 03:31:29 AM -03 2021");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2019-02-05 12:18:37");
 
+    will_return(__wrap_time, (time_t) 2525);
+    will_return(__wrap_strftime,"2019-02-05 12:18:42");
+    will_return(__wrap_strftime, 20);
     expect_string(__wrap_cJSON_AddStringToObject, name, "end");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 04:31:29 AM -03 2021");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2019-02-05 12:18:42");
 
     expect_function_call(__wrap_cJSON_AddItemToObject);
 
@@ -311,11 +310,11 @@ void test__w_logcollector_generate_state_one_target(void ** state) {
 void test__w_logcollector_generate_state_one_target_restart(void ** state) {
 
     cJSON * retval;
-    lc_states_t stats = {.states = (OSHash *) 2, .start = (time_t) 2020};
-    lc_state_target_t target = {.drops = 10, .name = "sock1"};
-    lc_state_target_t * target_array[2] = {&target, NULL};
+    w_lc_state_storage_t stats = {.states = (OSHash *) 2, .start = (time_t) 2020};
+    w_lc_state_target_t target = {.drops = 10, .name = "sock1"};
+    w_lc_state_target_t * target_array[2] = {&target, NULL};
 
-    lc_state_file_t data = {.targets = (lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
+    w_lc_state_file_t data = {.targets = (w_lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
     OSHashNode hash_node = {.data = &data, .key = "key_test"};
 
     expect_value(__wrap_OSHash_Begin, self, stats.states);
@@ -337,34 +336,36 @@ void test__w_logcollector_generate_state_one_target_restart(void ** state) {
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
 
-    expect_function_call(__wrap_cJSON_AddItemToObject);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "location");
     expect_string(__wrap_cJSON_AddStringToObject, string, "key_test");
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
     expect_string(__wrap_cJSON_AddNumberToObject, name, "events");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 5);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
+
+    expect_function_call(__wrap_cJSON_AddItemToObject);
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
 
     expect_value(__wrap_OSHash_Next, self, stats.states);
     will_return(__wrap_OSHash_Next, NULL);
 
-    will_return(__wrap_time, (time_t) 0);
-    will_return(__wrap_ctime, "Fri Jan  8 04:31:29 AM -03 2021\n");
-    will_return(__wrap_ctime, "Fri Jan  8 03:31:29 AM -03 2021\n");
-
+    will_return(__wrap_strftime,"2019-02-05 12:18:37");
+    will_return(__wrap_strftime, 20);
     expect_string(__wrap_cJSON_AddStringToObject, name, "start");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 03:31:29 AM -03 2021");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2019-02-05 12:18:37");
 
+    will_return(__wrap_time, (time_t) 2525);
+    will_return(__wrap_strftime,"2019-02-05 12:18:42");
+    will_return(__wrap_strftime, 20);;
     expect_string(__wrap_cJSON_AddStringToObject, name, "end");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 04:31:29 AM -03 2021");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2019-02-05 12:18:42");
 
     expect_function_call(__wrap_cJSON_AddItemToObject);
     will_return(__wrap_time, (time_t) 2525);
 
     retval = _w_logcollector_generate_state(&stats, true);
+
     assert_ptr_equal(retval, (cJSON *) 10);
     assert_int_equal(data.bytes, 0);
     assert_int_equal(data.events, 0);
@@ -374,7 +375,7 @@ void test__w_logcollector_generate_state_one_target_restart(void ** state) {
 /* Test _w_logcollector_state_update_file */
 void test__w_logcollector_state_update_file_new_data(void ** state) {
 
-    lc_states_t stat = {0};
+    w_lc_state_storage_t stat = {0};
     stat.states = (OSHash *) 2;
 
     expect_value(__wrap_OSHash_Get, self, stat.states);
@@ -391,9 +392,9 @@ void test__w_logcollector_state_update_file_new_data(void ** state) {
 
 void test__w_logcollector_state_update_file_update(void ** state) {
 
-    lc_states_t stat = {0};
+    w_lc_state_storage_t stat = {0};
     stat.states = (OSHash *) 2;
-    lc_state_file_t data = {0};
+    w_lc_state_file_t data = {0};
 
     expect_value(__wrap_OSHash_Get, self, stat.states);
     expect_string(__wrap_OSHash_Get, key, "/test_path");
@@ -410,13 +411,13 @@ void test__w_logcollector_state_update_file_update(void ** state) {
 /* w_logcollector_state_update_file */
 void test__w_logcollector_state_update_file_fail_update(void ** state) {
 
-    lc_states_t stat = {0};
+    w_lc_state_storage_t stat = {0};
     stat.states = (OSHash *) 2;
 
-    lc_state_file_t * data = NULL;
-    os_calloc(1, sizeof(lc_state_file_t), data);
-    os_calloc(2, sizeof(lc_state_target_t *), data->targets);
-    os_calloc(1, sizeof(lc_state_target_t), data->targets[0]);
+    w_lc_state_file_t * data = NULL;
+    os_calloc(1, sizeof(w_lc_state_file_t), data);
+    os_calloc(2, sizeof(w_lc_state_target_t *), data->targets);
+    os_calloc(1, sizeof(w_lc_state_target_t), data->targets[0]);
 
     expect_value(__wrap_OSHash_Get, self, stat.states);
     expect_string(__wrap_OSHash_Get, key, "/test_path");
@@ -433,19 +434,16 @@ void test__w_logcollector_state_update_file_fail_update(void ** state) {
 }
 
 /* w_logcollector_state_update_file */
-void test_w_logcollector_state_update_file_null(void ** state) { 
+void test_w_logcollector_state_update_file_null(void ** state) {
     w_logcollector_state_update_file(NULL, 500);
 }
 
-void test_w_logcollector_state_update_file_disabled(void ** state) {
-    g_lc_state_enabled = 0;
-    w_logcollector_state_update_file("filename", 500);
-}
 
 /* _w_logcollector_state_update_target */
 void test__w_logcollector_state_update_target_get_file_stats_fail(void ** state) {
 
-    lc_states_t stats = {0};
+    g_lc_state_type = LC_STATE_GLOBAL | LC_STATE_INTERVAL;
+    w_lc_state_storage_t stats = {0};
 
     char * fpath = "/test_path";
     char * target = "test";
@@ -463,22 +461,23 @@ void test__w_logcollector_state_update_target_get_file_stats_fail(void ** state)
 
 void test__w_logcollector_state_update_target_find_target_fail(void ** state) {
 
-    lc_states_t * stats = NULL;
-    os_calloc(1, sizeof(lc_states_t), stats);
+    g_lc_state_type = LC_STATE_GLOBAL | LC_STATE_INTERVAL;
+    w_lc_state_storage_t * stats = NULL;
+    os_calloc(1, sizeof(w_lc_state_storage_t), stats);
     stats->states = (OSHash *) 2;
     stats->start = (time_t) 2020;
 
-    lc_state_target_t * target;
-    os_calloc(1, sizeof(lc_state_target_t), target);
+    w_lc_state_target_t * target;
+    os_calloc(1, sizeof(w_lc_state_target_t), target);
     target->drops = 10;
     os_strdup("test", target->name);
 
-    lc_state_target_t ** target_array;
-    os_calloc(2, sizeof(lc_state_target_t *), target_array);
+    w_lc_state_target_t ** target_array;
+    os_calloc(2, sizeof(w_lc_state_target_t *), target_array);
     target_array[0] = target;
 
-    lc_state_file_t * data;
-    os_calloc(1, sizeof(lc_state_file_t), data);
+    w_lc_state_file_t * data;
+    os_calloc(1, sizeof(w_lc_state_file_t), data);
     data->targets = target_array;
     data->bytes = 100;
     data->events = 5;
@@ -504,11 +503,12 @@ void test__w_logcollector_state_update_target_find_target_fail(void ** state) {
 
 void test__w_logcollector_state_update_target_find_target_ok(void ** state) {
 
-    lc_states_t stats = {.states = (OSHash *) 2, .start = (time_t) 2020};
-    lc_state_target_t target = {.drops = 10, .name = "test"};
-    lc_state_target_t * target_array[2] = {&target, NULL};
+    g_lc_state_type = LC_STATE_GLOBAL | LC_STATE_INTERVAL;
+    w_lc_state_storage_t stats = {.states = (OSHash *) 2, .start = (time_t) 2020};
+    w_lc_state_target_t target = {.drops = 10, .name = "test"};
+    w_lc_state_target_t * target_array[2] = {&target, NULL};
 
-    lc_state_file_t data = {.targets = (lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
+    w_lc_state_file_t data = {.targets = (w_lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
 
     char * fpath = "/test_path";
     char * target_str = "test";
@@ -526,11 +526,12 @@ void test__w_logcollector_state_update_target_find_target_ok(void ** state) {
 
 void test__w_logcollector_state_update_target_dropped_true(void ** state) {
 
-    lc_states_t stats = {.states = (OSHash *) 2, .start = (time_t) 2020};
-    lc_state_target_t target = {.drops = 10, .name = "test"};
-    lc_state_target_t * target_array[2] = {&target, NULL};
+    g_lc_state_type = LC_STATE_GLOBAL | LC_STATE_INTERVAL;
+    w_lc_state_storage_t stats = {.states = (OSHash *) 2, .start = (time_t) 2020};
+    w_lc_state_target_t target = {.drops = 10, .name = "test"};
+    w_lc_state_target_t * target_array[2] = {&target, NULL};
 
-    lc_state_file_t data = {.targets = (lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
+    w_lc_state_file_t data = {.targets = (w_lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
 
     char * fpath = "/test_path";
     char * target_str = "test";
@@ -548,11 +549,12 @@ void test__w_logcollector_state_update_target_dropped_true(void ** state) {
 
 void test__w_logcollector_state_update_target_OSHash_Update_fail(void ** state) {
 
-    lc_states_t stats = {.states = (OSHash *) 2, .start = (time_t) 2020};
-    lc_state_target_t target = {.drops = 10, .name = "test"};
-    lc_state_target_t * target_array[2] = {&target, NULL};
+    g_lc_state_type = LC_STATE_GLOBAL | LC_STATE_INTERVAL;
+    w_lc_state_storage_t stats = {.states = (OSHash *) 2, .start = (time_t) 2020};
+    w_lc_state_target_t target = {.drops = 10, .name = "test"};
+    w_lc_state_target_t * target_array[2] = {&target, NULL};
 
-    lc_state_file_t data = {.targets = (lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
+    w_lc_state_file_t data = {.targets = (w_lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
 
     char * fpath = "/test_path";
     char * target_str = "test";
@@ -573,18 +575,19 @@ void test__w_logcollector_state_update_target_OSHash_Update_fail(void ** state) 
 
 void test__w_logcollector_state_update_target_OSHash_Add_fail(void ** state) {
 
-    lc_states_t stats = {.states = (OSHash *) 2};
-    lc_state_target_t * target;
-    os_calloc(1, sizeof(lc_state_target_t), target);
+    g_lc_state_type = LC_STATE_GLOBAL | LC_STATE_INTERVAL;
+    w_lc_state_storage_t stats = {.states = (OSHash *) 2};
+    w_lc_state_target_t * target;
+    os_calloc(1, sizeof(w_lc_state_target_t), target);
     target->drops = 10;
     target->name = "test";
 
-    lc_state_target_t ** target_array;
-    os_calloc(2, sizeof(lc_state_target_t *), target_array);
+    w_lc_state_target_t ** target_array;
+    os_calloc(2, sizeof(w_lc_state_target_t *), target_array);
     target_array[0] = target;
 
-    lc_state_file_t * data;
-    os_calloc(1, sizeof(lc_state_file_t), data);
+    w_lc_state_file_t * data;
+    os_calloc(1, sizeof(w_lc_state_file_t), data);
     data->targets = target_array;
     data->bytes = 100;
     data->events = 5;
@@ -611,14 +614,14 @@ void test__w_logcollector_state_update_target_OSHash_Add_fail(void ** state) {
 
 void test_w_logcollector_state_update_file_ok(void ** state) {
 
-    g_lc_state_enabled = 1;
-    os_calloc(1, sizeof(lc_states_t), g_lc_states_global);
+    g_lc_state_type = LC_STATE_GLOBAL | LC_STATE_INTERVAL;
+    os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_global);
     g_lc_states_global->states = (OSHash *) 2;
-    os_calloc(1, sizeof(lc_states_t), g_lc_states_interval);
+    os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_interval);
     g_lc_states_interval->states = (OSHash *) 3;
 
-    lc_state_file_t data = {0};
-    lc_state_file_t data2 = {.bytes = 10, .events = 5};
+    w_lc_state_file_t data = {0};
+    w_lc_state_file_t data2 = {.bytes = 10, .events = 5};
 
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_value(__wrap_OSHash_Get, self, g_lc_states_global->states);
@@ -654,23 +657,17 @@ void test_w_logcollector_state_update_target_null_path(void ** state) {
     w_logcollector_state_update_target(NULL, "test_target", false);
 }
 
-void test_w_logcollector_state_update_target_disabled(void ** state) {
-
-    g_lc_state_enabled = 0;
-    w_logcollector_state_update_target("test path", "test_target", false);
-}
-
 void test_w_logcollector_state_update_target_ok(void ** state) {
 
-    g_lc_state_enabled = 1;
-    os_calloc(1, sizeof(lc_states_t), g_lc_states_global);
+    g_lc_state_type = LC_STATE_GLOBAL | LC_STATE_INTERVAL;
+    os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_global);
     g_lc_states_global->states = (OSHash *) 2;
-    os_calloc(1, sizeof(lc_states_t), g_lc_states_interval);
+    os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_interval);
     g_lc_states_interval->states = (OSHash *) 3;
 
-    lc_state_target_t target = {.drops = 10, .name = "test_target"};
-    lc_state_target_t * target_array[2] = {&target, NULL};
-    lc_state_file_t data = {.targets = (lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
+    w_lc_state_target_t target = {.drops = 10, .name = "test_target"};
+    w_lc_state_target_t * target_array[2] = {&target, NULL};
+    w_lc_state_file_t data = {.targets = (w_lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
 
     expect_function_call(__wrap_pthread_mutex_lock);
 
@@ -680,9 +677,9 @@ void test_w_logcollector_state_update_target_ok(void ** state) {
 
     will_return(__wrap_OSHash_Update, 1);
 
-    lc_state_target_t target2 = {.drops = 10, .name = "test_target"};
-    lc_state_target_t * target_array2[2] = {&target, NULL};
-    lc_state_file_t data2 = {.targets = (lc_state_target_t **) &target_array2, .bytes = 100, .events = 5};
+    w_lc_state_target_t target2 = {.drops = 10, .name = "test_target"};
+    w_lc_state_target_t * target_array2[2] = {&target, NULL};
+    w_lc_state_file_t data2 = {.targets = (w_lc_state_target_t **) &target_array2, .bytes = 100, .events = 5};
 
     expect_value(__wrap_OSHash_Get, self, g_lc_states_interval->states);
     expect_string(__wrap_OSHash_Get, key, "test_path");
@@ -698,17 +695,17 @@ void test_w_logcollector_state_update_target_ok(void ** state) {
     os_free(g_lc_states_interval);
 }
 
-/* w_logcollector_generate_state */
+/* w_logcollector_state_generate */
 void test_w_logcollector_generate_state_ok(void ** state) {
 
-    g_lc_state_enabled = 1;
-    os_calloc(1, sizeof(lc_states_t), g_lc_states_global);
+    g_lc_state_type = LC_STATE_GLOBAL | LC_STATE_INTERVAL;;
+    os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_global);
     g_lc_states_global->states = (OSHash *) 2;
 
-    lc_state_target_t target = {.drops = 10, .name = "sock1"};
-    lc_state_target_t * target_array[2] = {&target, NULL};
+    w_lc_state_target_t target = {.drops = 10, .name = "sock1"};
+    w_lc_state_target_t * target_array[2] = {&target, NULL};
 
-    lc_state_file_t data = {.targets = (lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
+    w_lc_state_file_t data = {.targets = (w_lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
     OSHashNode hash_node = {.data = &data, .key = "key_test"};
 
     expect_function_call(__wrap_pthread_mutex_lock);
@@ -736,39 +733,41 @@ void test_w_logcollector_generate_state_ok(void ** state) {
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
 
-    expect_function_call(__wrap_cJSON_AddItemToObject);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "location");
     expect_string(__wrap_cJSON_AddStringToObject, string, "key_test");
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
     expect_string(__wrap_cJSON_AddNumberToObject, name, "events");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 5);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
 
     expect_value(__wrap_OSHash_Next, self, g_lc_states_global->states);
     will_return(__wrap_OSHash_Next, NULL);
 
-    will_return(__wrap_time, (time_t) 0);
-    will_return(__wrap_ctime, "Fri Jan  8 04:31:29 AM -03 2021\n");
-    will_return(__wrap_ctime, "Fri Jan  8 03:31:29 AM -03 2021\n");
+    will_return(__wrap_strftime,"2019-02-05 12:18:37");
+    will_return(__wrap_strftime, 20);
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "start");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 03:31:29 AM -03 2021");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2019-02-05 12:18:37");
 
+    will_return(__wrap_time, (time_t) 2525);
+    will_return(__wrap_strftime,"2019-02-05 12:18:42");
+    will_return(__wrap_strftime, 20);
     expect_string(__wrap_cJSON_AddStringToObject, name, "end");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 04:31:29 AM -03 2021");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2019-02-05 12:18:42");
 
     expect_function_call(__wrap_cJSON_AddItemToObject);
 
     expect_function_call(__wrap_cJSON_AddItemToObject);
 
-    os_calloc(1, sizeof(lc_states_t), g_lc_states_interval);
+    os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_interval);
     g_lc_states_interval->states = (OSHash *) 4;
     g_lc_states_interval->start = (time_t) 2020;
 
-    lc_state_file_t data2 = {.targets = (lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
+    w_lc_state_file_t data2 = {.targets = (w_lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
     OSHashNode hash_node2 = {.data = &data2, .key = "key_test"};
 
     expect_value(__wrap_OSHash_Begin, self, g_lc_states_interval->states);
@@ -782,29 +781,32 @@ void test_w_logcollector_generate_state_ok(void ** state) {
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
 
-    expect_function_call(__wrap_cJSON_AddItemToObject);
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "location");
     expect_string(__wrap_cJSON_AddStringToObject, string, "key_test");
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
     expect_string(__wrap_cJSON_AddNumberToObject, name, "events");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 5);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
 
     expect_value(__wrap_OSHash_Next, self, g_lc_states_interval->states);
     will_return(__wrap_OSHash_Next, NULL);
 
-    will_return(__wrap_time, (time_t) 0);
-    will_return(__wrap_ctime, "Fri Jan  8 04:31:29 AM -03 2021\n");
-    will_return(__wrap_ctime, "Fri Jan  8 03:31:29 AM -03 2021\n");
+    will_return(__wrap_strftime,"2019-02-05 12:18:37");
+    will_return(__wrap_strftime, 20);
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "start");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 03:31:29 AM -03 2021");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2019-02-05 12:18:37");
 
+    will_return(__wrap_time, (time_t) 2525);
+    will_return(__wrap_strftime,"2019-02-05 12:18:42");
+    will_return(__wrap_strftime, 20);
     expect_string(__wrap_cJSON_AddStringToObject, name, "end");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 04:31:29 AM -03 2021");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2019-02-05 12:18:42");
 
     expect_function_call(__wrap_cJSON_AddItemToObject);
     will_return(__wrap_time, (time_t) 2525);
@@ -814,7 +816,7 @@ void test_w_logcollector_generate_state_ok(void ** state) {
     expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    w_logcollector_generate_state();
+    w_logcollector_state_generate();
 
     assert_int_equal(data.bytes, 100);
     assert_int_equal(data.events, 5);
@@ -887,17 +889,9 @@ void test_w_logcollector_state_dump_ok(void ** state) {
     w_logcollector_state_dump();
 }
 
-/* w_logcollector_state_main */
-void test_w_logcollector_state_main_disabled(void ** state) {
-
-    g_lc_state_enabled = 0;
-    int interval = 105;
-    w_logcollector_state_main((void *) &interval);
-}
-
 void test_w_logcollector_state_main_bad_interval(void ** state) {
 
-    g_lc_state_enabled = 1;
+    g_lc_state_type = LC_STATE_GLOBAL | LC_STATE_INTERVAL;;
     int interval = -1;
     w_logcollector_state_main((void *) &interval);
 }
@@ -908,14 +902,14 @@ void test_w_logcollector_state_main_ok(void ** state) {
     will_return(__wrap_FOREVER, 1);
     expect_value(__wrap_sleep, seconds, interval);
 
-    // w_logcollector_generate_state
-    os_calloc(1, sizeof(lc_states_t), g_lc_states_global);
+    // w_logcollector_state_generate
+    os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_global);
     g_lc_states_global->states = (OSHash *) 2;
 
-    lc_state_target_t target = {.drops = 10, .name = "sock1"};
-    lc_state_target_t * target_array[2] = {&target, NULL};
+    w_lc_state_target_t target = {.drops = 10, .name = "sock1"};
+    w_lc_state_target_t * target_array[2] = {&target, NULL};
 
-    lc_state_file_t data = {.targets = (lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
+    w_lc_state_file_t data = {.targets = (w_lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
     OSHashNode hash_node = {.data = &data, .key = "key_test"};
 
     expect_function_call(__wrap_pthread_mutex_lock);
@@ -943,39 +937,41 @@ void test_w_logcollector_state_main_ok(void ** state) {
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
 
-    expect_function_call(__wrap_cJSON_AddItemToObject);
-
     expect_string(__wrap_cJSON_AddStringToObject, name, "location");
     expect_string(__wrap_cJSON_AddStringToObject, string, "key_test");
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
     expect_string(__wrap_cJSON_AddNumberToObject, name, "events");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 5);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
+
+    expect_function_call(__wrap_cJSON_AddItemToObject);
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
 
     expect_value(__wrap_OSHash_Next, self, g_lc_states_global->states);
     will_return(__wrap_OSHash_Next, NULL);
 
-    will_return(__wrap_time, (time_t) 0);
-    will_return(__wrap_ctime, "Fri Jan  8 04:31:29 AM -03 2021\n");
-    will_return(__wrap_ctime, "Fri Jan  8 03:31:29 AM -03 2021\n");
+    will_return(__wrap_strftime,"2019-02-05 12:18:37");
+    will_return(__wrap_strftime, 20);
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "start");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 03:31:29 AM -03 2021");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2019-02-05 12:18:37");
 
+    will_return(__wrap_time, (time_t) 2525);
+    will_return(__wrap_strftime,"2019-02-05 12:18:42");
+    will_return(__wrap_strftime, 20);
     expect_string(__wrap_cJSON_AddStringToObject, name, "end");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 04:31:29 AM -03 2021");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2019-02-05 12:18:42");
 
     expect_function_call(__wrap_cJSON_AddItemToObject);
 
     expect_function_call(__wrap_cJSON_AddItemToObject);
 
-    os_calloc(1, sizeof(lc_states_t), g_lc_states_interval);
+    os_calloc(1, sizeof(w_lc_state_storage_t), g_lc_states_interval);
     g_lc_states_interval->states = (OSHash *) 4;
     g_lc_states_interval->start = (time_t) 2020;
 
-    lc_state_file_t data2 = {.targets = (lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
+    w_lc_state_file_t data2 = {.targets = (w_lc_state_target_t **) &target_array, .bytes = 100, .events = 5};
     OSHashNode hash_node2 = {.data = &data2, .key = "key_test"};
 
     expect_value(__wrap_OSHash_Begin, self, g_lc_states_interval->states);
@@ -989,29 +985,32 @@ void test_w_logcollector_state_main_ok(void ** state) {
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
 
-    expect_function_call(__wrap_cJSON_AddItemToObject);
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "location");
     expect_string(__wrap_cJSON_AddStringToObject, string, "key_test");
-    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
     expect_string(__wrap_cJSON_AddNumberToObject, name, "events");
     expect_value(__wrap_cJSON_AddNumberToObject, number, 5);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, "bytes");
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 100);
+
+    expect_function_call(__wrap_cJSON_AddItemToObject);
 
     expect_function_call(__wrap_cJSON_AddItemToArray);
 
     expect_value(__wrap_OSHash_Next, self, g_lc_states_interval->states);
     will_return(__wrap_OSHash_Next, NULL);
 
-    will_return(__wrap_time, (time_t) 0);
-    will_return(__wrap_ctime, "Fri Jan  8 04:31:29 AM -03 2021\n");
-    will_return(__wrap_ctime, "Fri Jan  8 03:31:29 AM -03 2021\n");
+    will_return(__wrap_strftime,"2019-02-05 12:18:37");
+    will_return(__wrap_strftime, 20);
 
     expect_string(__wrap_cJSON_AddStringToObject, name, "start");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 03:31:29 AM -03 2021");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2019-02-05 12:18:37");
 
+    will_return(__wrap_time, (time_t) 2525);
+    will_return(__wrap_strftime,"2019-02-05 12:18:42");
+    will_return(__wrap_strftime, 20);
     expect_string(__wrap_cJSON_AddStringToObject, name, "end");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "Fri Jan  8 04:31:29 AM -03 2021");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2019-02-05 12:18:42");
 
     expect_function_call(__wrap_cJSON_AddItemToObject);
     will_return(__wrap_time, (time_t) 2525);
@@ -1053,7 +1052,6 @@ int main(void) {
         cmocka_unit_test(test_w_logcollector_state_init_ok),
 
         // Tests w_logcollector_state_get
-        cmocka_unit_test(test_w_logcollector_state_get_disabled),
         cmocka_unit_test(test_w_logcollector_state_get_null),
         cmocka_unit_test(test_w_logcollector_state_get_non_null),
 
@@ -1068,7 +1066,6 @@ int main(void) {
         cmocka_unit_test(test__w_logcollector_state_update_file_fail_update),
 
         // Tests w_logcollector_state_update_file
-        cmocka_unit_test(test_w_logcollector_state_update_file_disabled),
         cmocka_unit_test(test_w_logcollector_state_update_file_null),
         cmocka_unit_test(test_w_logcollector_state_update_file_ok),
 
@@ -1081,12 +1078,11 @@ int main(void) {
         cmocka_unit_test(test__w_logcollector_state_update_target_OSHash_Add_fail),
 
         // Tests w_logcollector_state_update_target
-        cmocka_unit_test(test_w_logcollector_state_update_target_disabled),
         cmocka_unit_test(test_w_logcollector_state_update_target_null_path),
         cmocka_unit_test(test_w_logcollector_state_update_target_null_target),
         cmocka_unit_test(test_w_logcollector_state_update_target_ok),
 
-        // Tests w_logcollector_generate_state
+        // Tests w_logcollector_state_generate
         cmocka_unit_test(test_w_logcollector_generate_state_ok),
 
         // Tests w_logcollector_state_dump
@@ -1095,7 +1091,6 @@ int main(void) {
         cmocka_unit_test(test_w_logcollector_state_dump_ok),
 
         // Tests w_logcollector_state_main
-        cmocka_unit_test(test_w_logcollector_state_main_disabled),
         cmocka_unit_test(test_w_logcollector_state_main_bad_interval),
         cmocka_unit_test(test_w_logcollector_state_main_ok)
     };

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
@@ -49,6 +49,12 @@ cJSON* __wrap_cJSON_AddNumberToObject(__attribute__ ((__unused__)) cJSON * const
     return mock_type(cJSON *);
 }
 
+cJSON* __wrap_cJSON_AddObjectToObject(cJSON * const object, const char * const name) {
+    if (name) check_expected(name);
+    check_expected(object);
+    return mock_type(cJSON *);
+}
+
 #ifdef WIN32
 cJSON * __stdcall __wrap_cJSON_CreateArray(void) {
     return mock_type(cJSON *);

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
@@ -35,10 +35,10 @@ cJSON* __wrap_cJSON_AddStringToObject(__attribute__ ((__unused__)) cJSON * const
     return mock_type(cJSON *);
 }
 
-cJSON* __wrap_cJSON_AddArrayToObject(__attribute__ ((__unused__)) cJSON * const object, 
+cJSON* __wrap_cJSON_AddArrayToObject(__attribute__ ((__unused__)) cJSON * const object,
                               const char * const name) {
     if (name) check_expected(name);
-    return mock_type(cJSON *);                            
+    return mock_type(cJSON *);
 }
 
 cJSON* __wrap_cJSON_AddNumberToObject(__attribute__ ((__unused__)) cJSON * const object,

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.h
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.h
@@ -23,6 +23,8 @@ extern cJSON_bool __real_cJSON_AddItemToObject(cJSON *object, const char *string
 
 cJSON * __wrap_cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
 
+cJSON* __wrap_cJSON_AddObjectToObject(cJSON * const object, const char * const name);
+
 extern cJSON * __real_cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
 
 cJSON* __wrap_cJSON_AddArrayToObject(cJSON * const object, const char * const name);

--- a/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.c
@@ -114,3 +114,9 @@ int __wrap_OSHash_Update_ex(__attribute__((unused)) OSHash *self,
                             __attribute__((unused)) void *data) {
     return mock();
 }
+
+int __wrap_OSHash_Update(__attribute__((unused)) OSHash *self,
+                            __attribute__((unused)) const char *key,
+                            __attribute__((unused)) void *data) {
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.h
@@ -42,6 +42,8 @@ int __wrap_OSHash_setSize(OSHash *self, unsigned int new_size);
 
 int __wrap_OSHash_Update_ex(OSHash *self, const char *key, void *data);
 
+int __wrap_OSHash_Update(OSHash *self, const char *key, void *data);
+
 extern int OSHash_Add_ex_check_data;
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|#6159|
## Short description

- Active state/statistics generated during `wazuh-logcollector` lifetime
- Information always accesible remotely, and optionally from a file in every agent according to a configurable time
- Historical and last interval state (optional according to a configurable time) generated periodically
- Byte, event and drop count for each active `location` and it's `targets`.

## Description

Hi team!

This PR aims to add state/statistics support for `wazuh-logcollector` during process lifetime, always accesible via remote request from the manager and also persist optionally in a file `WAZUH_DIR/var/run/wazuh-logcollector.state` (UNIX-based) or `WAZUH_DIR\wazuh-logcollector.state`. Both ways (remote request and file) are JSON formatted outputs.

One of the more important aspects of this state/statistics is the `drop` value for the different targets (`sockets`) available for a `location` and `localfile`, giving the possibility to get if the message queue is full or the connection is not successful. 

State/statistics are generated and updated every `logcollector.state_interval` seconds (internal configuration) and accesible any moment. This statistic are are divided in two sections:

- global/historical: since the startup of the process
- interval: since the last generated state info. Only if `logcollector.state_interval` is bigger than zero

If `logcollector.state_interval` is zero, state file will be disabled and remote request will still be accesible but only bringing global stats in realtime.

The state mechanism support following up to 200200 files stats, doubling the max value of `logcollector.max_files`.

### Using `getconfig` as reference for implementation
Currently, the mechanism to [Get active configuration](https://documentation.wazuh.com/4.0/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_agent_config) and it's [low level implementation](https://github.com/wazuh/wazuh/blob/412981d8a0b9e5f11c6d59f3ffef08d73a989211/framework/wazuh/core/configuration.py#L752) is quite similar that the one needed by this implementation
### Data flow proposal
- Manager -> Agent : `API -> /var/ossec/queue/ossec/request -> wazuh-remoted -> wazuh-agentd ->  /var/ossec/queue/ossec/logcollector -> wazuh-logcollector`
- Manager -> Manager: `API -> /var/ossec/queue/ossec/logcollector -> wazuh-logcollector`
### Request proposal
The fact that both `wazuh-remoted` and `wazuh-agentd` need to route request along different components, the request should be the same like used in getconfig:
```
Message format: <agent-id> <module> <command> <configuration>(optional)
```
State information does not have `configuration`, so should be ommited. secure-tcp.py script will be used to exemplify a request

## Examples
[secure-tcp.py](https://github.com/wazuh/wazuh-tools/blob/master/utils/secure-tcp.py) script will be used to get state info independently from API support (#7128).

### Get agents's wazuh-logcollector `state` remotely
```
echo -n "001 logcollector getstate" | ./wazuh-tools/utils/secure-tcp.py /var/ossec/queue/ossec/request
{"error":0,"data":{"global":{"start":"Tue Jan 12 23:48:03 2021","end":"Tue Jan 12 23:48:08 2021","files":[{"targets":[{"name":"agent","drops":0},{"name":"custom_socket","drops":0}],"location":"/var/log/testfile","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/jira-backups.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0},{"name":"custom_socket","drops":0}],"location":"/var/log/syslog","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/vsftpd.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"df -P","bytes":1108,"events":11},{"targets":[{"name":"agent","drops":0}],"location":"last -n 20","bytes":1518,"events":1},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/kern.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/ossec/logs/active-responses.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/audit/audit.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/dpkg.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/auth.log","bytes":0,"events":0}]},"interval":{"start":"Tue Jan 12 23:48:03 2021","end":"Tue Jan 12 23:48:08 2021","files":[{"targets":[{"name":"agent","drops":0},{"name":"custom_socket","drops":0}],"location":"/var/log/testfile","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/jira-backups.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0},{"name":"custom_socket","drops":0}],"location":"/var/log/syslog","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/vsftpd.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"df -P","bytes":1108,"events":11},{"targets":[{"name":"agent","drops":0}],"location":"last -n 20","bytes":1518,"events":1},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/kern.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/ossec/logs/active-responses.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/audit/audit.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/dpkg.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/auth.log","bytes":0,"events":0}]}}}
```
### Get manager's wazuh-logcollector `state`

```
# Message format: <agent-id> <module> <command> <configuration>(optional)
echo -n "getstate" |  ./secure-tcp.py /var/ossec/queue/ossec/logcollector
{"error":0,"data":{"global":{"start":"Tue Jan 12 23:48:03 2021","end":"Tue Jan 12 23:48:08 2021","files":[{"targets":[{"name":"agent","drops":0},{"name":"custom_socket","drops":0}],"location":"/var/log/testfile","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/jira-backups.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0},{"name":"custom_socket","drops":0}],"location":"/var/log/syslog","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/vsftpd.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"df -P","bytes":1108,"events":11},{"targets":[{"name":"agent","drops":0}],"location":"last -n 20","bytes":1518,"events":1},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/kern.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/ossec/logs/active-responses.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/audit/audit.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/dpkg.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/auth.log","bytes":0,"events":0}]},"interval":{"start":"Tue Jan 12 23:48:03 2021","end":"Tue Jan 12 23:48:08 2021","files":[{"targets":[{"name":"agent","drops":0},{"name":"custom_socket","drops":0}],"location":"/var/log/testfile","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/jira-backups.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0},{"name":"custom_socket","drops":0}],"location":"/var/log/syslog","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/vsftpd.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"df -P","bytes":1108,"events":11},{"targets":[{"name":"agent","drops":0}],"location":"last -n 20","bytes":1518,"events":1},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/kern.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/ossec/logs/active-responses.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/audit/audit.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/dpkg.log","bytes":0,"events":0},{"targets":[{"name":"agent","drops":0}],"location":"/var/log/auth.log","bytes":0,"events":0}]}}}
```
### `wazuh-logcollector.state` anatomy

```json
{
        "global":       {
                "start":        "Tue Jan 12 23:48:03 2021",
                "end":  "Wed Jan 13 01:42:22 2021",
                "files":        [{
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }, {
                                                "name": "custom_socket",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/testfile",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/jira-backups.log",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }, {
                                                "name": "custom_socket",
                                                "drops":        76
                                        }],
                                "location":     "/var/log/syslog",
                                "bytes":        55344,
                                "events":       76
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/vsftpd.log",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "wazuh-logcollector",
                                "bytes":        56,
                                "events":       1
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "df -P",
                                "bytes":        7756,
                                "events":       77
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "last -n 20",
                                "bytes":        10626,
                                "events":       7
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/kern.log",
                                "bytes":        660,
                                "events":       4
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/ossec/logs/active-responses.log",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/audit/audit.log",
                                "bytes":        796,
                                "events":       4
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/dpkg.log",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/auth.log",
                                "bytes":        0,
                                "events":       0
                        }]
        },
        "interval":     {
                "start":        "Wed Jan 13 01:42:17 2021",
                "end":  "Wed Jan 13 01:42:22 2021",
                "files":        [{
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }, {
                                                "name": "custom_socket",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/testfile",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/jira-backups.log",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }, {
                                                "name": "custom_socket",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/syslog",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/vsftpd.log",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "wazuh-logcollector",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "df -P",
                                "bytes":        1108,
                                "events":       11
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "last -n 20",
                                "bytes":        1518,
                                "events":       1
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/kern.log",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/ossec/logs/active-responses.log",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/audit/audit.log",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/dpkg.log",
                                "bytes":        0,
                                "events":       0
                        }, {
                                "targets":      [{
                                                "name": "agent",
                                                "drops":        0
                                        }],
                                "location":     "/var/log/auth.log",
                                "bytes":        0,
                                "events":       0
                        }]
        }
}

```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] ~MAC OS X~ (Tested on FreeBSD)
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [x] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [ ] Stress test for affected components

Regards,
Nico