### PR TITLE
Changed -- for - - in line 23 and 34 example logs for compliance with…

### DIFF
--- a/ruleset/rules/0500-owncloud_rules.xml
+++ b/ruleset/rules/0500-owncloud_rules.xml
@@ -20,7 +20,7 @@
 
 <!-- EXAMPLE LOGS
 
-  - {"reqId":"wlioIFa6pOvt6DIAoeHE","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1')","level":2,"time":"2016-04-12T22:28:20+02:00","method":"POST","url":"\/","user":"--","@source":"ownCloud"}
+  - {"reqId":"wlioIFa6pOvt6DIAoeHE","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1')","level":2,"time":"2016-04-12T22:28:20+02:00","method":"POST","url":"\/","user":"- -","@source":"ownCloud"}
   - {"reqId":"prLlx9+QIfl1jHtz9C5o","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1')","level":2,"time":"2015-07-08T12:12:41+02:00","@source":"ownCloud"}
   - {"reqId":"wLP7a3MdzTo8wgCWret9","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1')","level":2,"time":"2015-07-15T09:40:35+02:00","method":"POST","url":"\/","@source":"ownCloud"}
   - {"reqId":"prLlx9+QIfl1jHtz9C5o","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1)","level":2,"time":"2015-07-08T12:12:41+02:00","@source":"ownCloud"}
@@ -31,7 +31,7 @@
   - {"reqId":"5576a04643d8e","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1', X-Forwarded-For: '')","level":2,"time":"2015-06-09T08:13:58+00:00","method":"POST","url":"\/owncloud\/index.php","@source":"ownCloud"}
   - {"app":"core","message":"Login failed: user 'admin' , wrong password, IP:127.0.0.1","level":2,"time":"2015-06-09T08:10:29+00:00","@source":"ownCloud"}
   - {"reqId":"55769fcacd1e0","app":"core","message":"Login failed: user 'admin' , wrong password, IP:127.0.0.1","level":2,"time":"2015-06-09T08:11:54+00:00","method":"POST","url":"\/owncloud\/index.php","@source":"ownCloud"}
-  - {"reqId":"BaW6nfA5rHBoihjDtQVm","remoteAddr":"127.0.0.1","app":"core-preview","message":"Passed filename is not valid, might be malicious (file:\"test\";ip:\"127.0.0.1\")","level":2,"time":"2017-09-01T22:11:25+02:00","method":"POST","url":"\/login","user":"--","@source":"ownCloud"}
+  - {"reqId":"BaW6nfA5rHBoihjDtQVm","remoteAddr":"127.0.0.1","app":"core-preview","message":"Passed filename is not valid, might be malicious (file:\"test\";ip:\"127.0.0.1\")","level":2,"time":"2017-09-01T22:11:25+02:00","method":"POST","url":"\/login","user":"- -","@source":"ownCloud"}
   - {"reqId":"4ETnKW0UyDBNmL4z\/umV","remoteAddr":"127.0.0.1","app":"PHP","message":"Redis::connect(): connect() failed: No such file or directory at \/var\/www\/owncloud\/lib\/private\/RedisFactory.php#60","level":3,"time":"2017-08-21T16:00:34+02:00","method":"PROPFIND","url":"\/remote.php\/dav\/addressbooks\/users\/admin\/example\/","user":"admin","@source":"ownCloud"}
   - {"reqId":"4j2DKpvOh0OezXVwfuLO","remoteAddr":"127.0.0.1","app":"PHP","message":"fopen(\/var\/www\/owncloud\/data\/user 1\/thumbnails\/1234\/32-32.png): failed to open stream: No such file or directory at \/var\/www\/owncloud\/lib\/private\/Files\/Storage\/Local.php#278","level":3,"time":"2017-07-15T23:59:20+02:00","method":"GET","url":"\/core\/preview.png?file=%2Fexample.txt&c=123&x=32&y=32&forceIcon=0","user":"user 1","@source":"ownCloud"}
 


### PR DESCRIPTION
… XML standard

|Related issue|
|---|
|7113|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
XML standard does not allow `--` in comments. As the rule file `0500-owncloud_rules.xml` has 2 example logs in comments that include `--` in their fields (line 23 and line 34), they cause issues when parsing the file during analysis procedures. The `--` in both examples was changed by `- -`, allowing the file to be parsed properly.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
