### PR TITLE
Making wazuh-control capable of returning installation data

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -1,5 +1,5 @@
 WAZUH
-Copyright (C) 2015-2020, Wazuh Inc.
+Copyright (C) 2015-2021, Wazuh Inc.
 
 Based on OSSEC
 Copyright (C) 2014 Trend Micro Inc.
@@ -11,8 +11,7 @@ Bugs should be sent to the Wazuh mailling list
 (https://groups.google.com/forum/#!forum/wazuh). Please, make sure to include
 the following information:
 
--Wazuh version number.
--Content of /etc/ossec-init.conf
+-Output of WAZUH_HOME/bin/wazuh-control info
 -Content of /var/ossec/etc/ossec.conf
 -Content of /var/ossec/logs/ossec.log
 -Operating system name/version (uname -a if Unix)

--- a/BUGS
+++ b/BUGS
@@ -11,7 +11,7 @@ Bugs should be sent to the Wazuh mailling list
 (https://groups.google.com/forum/#!forum/wazuh). Please, make sure to include
 the following information:
 
--Output of WAZUH_HOME/bin/wazuh-control info
+-Output of "WAZUH_HOME/bin/wazuh-control info"
 -Content of /var/ossec/etc/ossec.conf
 -Content of /var/ossec/logs/ossec.log
 -Operating system name/version (uname -a if Unix)

--- a/contrib/bump_version.sh
+++ b/contrib/bump_version.sh
@@ -59,6 +59,9 @@ cd $(dirname $0)
 VERSION_FILE="../src/VERSION"
 REVISION_FILE="../src/REVISION"
 DEFS_FILE="../src/headers/defs.h"
+WAZUH_SERVER="../src/init/wazuh-server.sh"
+WAZUH_AGENT="../src/init/wazuh-client.sh"
+WAZUH_LOCAL="../src/init/wazuh-local.sh"
 NSIS_FILE="../src/win32/wazuh-installer.nsi"
 MSI_FILE="../src/win32/wazuh-installer.wxs"
 FW_SETUP="../framework/setup.py"
@@ -86,6 +89,12 @@ then
     fi
 
     sed -E -i'' -e "s/^(#define __ossec_version +)\"v.*\"/\1\"$version\"/" $DEFS_FILE
+
+    # wazuh-control
+
+    sed -E -i'' -e "s/^(VERSION=+)\"v.*\"/\1\"$version\"/" $WAZUH_SERVER
+    sed -E -i'' -e "s/^(VERSION=+)\"v.*\"/\1\"$version\"/" $WAZUH_AGENT
+    sed -E -i'' -e "s/^(VERSION=+)\"v.*\"/\1\"$version\"/" $WAZUH_LOCAL
 
     # File wazuh-installer.nsi
 
@@ -121,6 +130,7 @@ then
     sed -E -i'' -e "s/__version__ = '.+'/__version__ = '${version:1}'/g" $CLUSTER_INIT
 
     # API
+
     sed -E -i'' -e "s/version='.+',/version='${version:1}',/g" $API_SETUP
     sed -E -i'' -e "s/version: '.+'/version: '${version:1}'/g" $API_SPEC
 
@@ -136,6 +146,12 @@ then
     # File REVISION
 
     echo $revision > $REVISION_FILE
+
+    # wazuh-control
+
+    sed -E -i'' -e "s/^(REVISION=+)\".*\"/\1\"$revision\"/" $WAZUH_SERVER
+    sed -E -i'' -e "s/^(REVISION=+)\".*\"/\1\"$revision\"/" $WAZUH_AGENT
+    sed -E -i'' -e "s/^(REVISION=+)\".*\"/\1\"$revision\"/" $WAZUH_LOCAL
 
     # File wazuh-installer.nsi
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -689,20 +689,15 @@ InstallCommon()
     INSTALL="install"
 
     if [ ${INSTYPE} = 'server' ]; then
-        OSSEC_CONTROL_SRC_TEMPLATE='./init/wazuh-server.sh'
+        OSSEC_CONTROL_SRC='./init/wazuh-server.sh'
         OSSEC_CONF_SRC='../etc/ossec-server.conf'
     elif [ ${INSTYPE} = 'agent' ]; then
-        OSSEC_CONTROL_SRC_TEMPLATE='./init/wazuh-client.sh'
+        OSSEC_CONTROL_SRC='./init/wazuh-client.sh'
         OSSEC_CONF_SRC='../etc/ossec-agent.conf'
     elif [ ${INSTYPE} = 'local' ]; then
-        OSSEC_CONTROL_SRC_TEMPLATE='./init/wazuh-local.sh'
+        OSSEC_CONTROL_SRC='./init/wazuh-local.sh'
         OSSEC_CONF_SRC='../etc/ossec-local.conf'
     fi
-
-    sed "s/TEMP_DATE/`date`/
-         s/TEMP_INSTYPE/${INSTYPE}/" ${OSSEC_CONTROL_SRC_TEMPLATE} > ./init/wazuh-control.sh.tmp
-
-    OSSEC_CONTROL_SRC='./init/wazuh-control.sh.tmp'
 
     if [ ! ${PREFIX} = ${INSTALLDIR} ]; then
         PREFIX=${INSTALLDIR}
@@ -754,9 +749,6 @@ InstallCommon()
   ${INSTALL} -m 0750 -o root -g 0 manage_agents ${PREFIX}/bin
   ${INSTALL} -m 0750 -o root -g 0 ${OSSEC_CONTROL_SRC} ${PREFIX}/bin/wazuh-control
   ${INSTALL} -m 0750 -o root -g 0 wazuh-modulesd ${PREFIX}/bin/
-
-  # Removing the wazuh-control.sh.tmp file
-  rm ${OSSEC_CONTROL_SRC}
 
   ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue
   ${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/alerts

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -699,15 +699,8 @@ InstallCommon()
         OSSEC_CONF_SRC='../etc/ossec-local.conf'
     fi
 
-    # Reading from files again to prevent an error during upgrade
-    VERSION_FROM_FILE=`cat ../${VERSION_FILE}`
-    REVISION_FROM_FILE=`cat ../${REVISION_FILE}`
-
-    sed "s/TEMP_VERSION/${VERSION_FROM_FILE}/
-         s/TEMP_REVISION/${REVISION_FROM_FILE}/
-         s/TEMP_DATE/`date`/
-         s/TEMP_INSTYPE/${INSTYPE}/"\
-        ${OSSEC_CONTROL_SRC_TEMPLATE} > ./init/wazuh-control.sh.tmp
+    sed "s/TEMP_DATE/`date`/
+         s/TEMP_INSTYPE/${INSTYPE}/" ${OSSEC_CONTROL_SRC_TEMPLATE} > ./init/wazuh-control.sh.tmp
 
     OSSEC_CONTROL_SRC='./init/wazuh-control.sh.tmp'
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Wazuh Installer Functions
-# Copyright (C) 2015-2020, Wazuh Inc.
+# Copyright (C) 2015-2021, Wazuh Inc.
 # November 18, 2016.
 #
 # This program is free software; you can redistribute it
@@ -699,11 +699,10 @@ InstallCommon()
         OSSEC_CONF_SRC='../etc/ossec-local.conf'
     fi
 
-    sed "s/TEMP_NAME/${NAME}/
-         s/TEMP_VERSION/${VERSION}/
+    sed "s/TEMP_VERSION/${VERSION}/
          s/TEMP_REVISION/${REVISION}/
-         s/TEMP_DATE/${DATE}/
-         s/TEMP_TYPE/${TYPE}/"\
+         s/TEMP_DATE/`date`/
+         s/TEMP_INSTYPE/${INSTYPE}/"\
         ${OSSEC_CONTROL_SRC_TEMPLATE} > ./init/wazuh-control.sh.tmp
 
     OSSEC_CONTROL_SRC='./init/wazuh-control.sh.tmp'

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -689,15 +689,24 @@ InstallCommon()
     INSTALL="install"
 
     if [ ${INSTYPE} = 'server' ]; then
-        OSSEC_CONTROL_SRC='./init/wazuh-server.sh'
+        OSSEC_CONTROL_SRC_TEMPLATE='./init/wazuh-server.sh'
         OSSEC_CONF_SRC='../etc/ossec-server.conf'
     elif [ ${INSTYPE} = 'agent' ]; then
-        OSSEC_CONTROL_SRC='./init/wazuh-client.sh'
+        OSSEC_CONTROL_SRC_TEMPLATE='./init/wazuh-client.sh'
         OSSEC_CONF_SRC='../etc/ossec-agent.conf'
     elif [ ${INSTYPE} = 'local' ]; then
-        OSSEC_CONTROL_SRC='./init/wazuh-local.sh'
+        OSSEC_CONTROL_SRC_TEMPLATE='./init/wazuh-local.sh'
         OSSEC_CONF_SRC='../etc/ossec-local.conf'
     fi
+
+    sed "s/TEMP_NAME/${NAME}/
+         s/TEMP_VERSION/${VERSION}/
+         s/TEMP_REVISION/${REVISION}/
+         s/TEMP_DATE/${DATE}/
+         s/TEMP_TYPE/${TYPE}/"\
+        ${OSSEC_CONTROL_SRC_TEMPLATE} > ./init/wazuh-control.sh.tmp
+
+    OSSEC_CONTROL_SRC='./init/wazuh-control.sh.tmp'
 
     if [ ! ${PREFIX} = ${INSTALLDIR} ]; then
         PREFIX=${INSTALLDIR}
@@ -749,6 +758,9 @@ InstallCommon()
   ${INSTALL} -m 0750 -o root -g 0 manage_agents ${PREFIX}/bin
   ${INSTALL} -m 0750 -o root -g 0 ${OSSEC_CONTROL_SRC} ${PREFIX}/bin/wazuh-control
   ${INSTALL} -m 0750 -o root -g 0 wazuh-modulesd ${PREFIX}/bin/
+
+  # Removing the wazuh-control.sh.tmp file
+  rm ${OSSEC_CONTROL_SRC}
 
   ${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/queue
   ${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/alerts

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -699,8 +699,12 @@ InstallCommon()
         OSSEC_CONF_SRC='../etc/ossec-local.conf'
     fi
 
-    sed "s/TEMP_VERSION/${VERSION}/
-         s/TEMP_REVISION/${REVISION}/
+    # Reading from files again to prevent an error during upgrade
+    VERSION_FROM_FILE=`cat ../${VERSION_FILE}`
+    REVISION_FROM_FILE=`cat ../${REVISION_FILE}`
+
+    sed "s/TEMP_VERSION/${VERSION_FROM_FILE}/
+         s/TEMP_REVISION/${REVISION_FROM_FILE}/
          s/TEMP_DATE/`date`/
          s/TEMP_INSTYPE/${INSTYPE}/"\
         ${OSSEC_CONTROL_SRC_TEMPLATE} > ./init/wazuh-control.sh.tmp

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -223,7 +223,7 @@ wait_pid() {
     return 0
 }
 
-stopa()
+stop()
 {
     checkpid;
     for i in ${DAEMONS}; do
@@ -249,6 +249,30 @@ stopa()
     echo "$NAME $VERSION Stopped"
 }
 
+info()
+{
+    if [ "X${1}" = "X" ]; then
+        if [ $USE_JSON = true ]; then
+            echo -n '{"error":0,"data":['
+            echo -n '{"WAZUH_VERSION":"'${VERSION}'"},'
+            echo -n '{"WAZUH_REVISION":"'${REVISION}'"},'
+            echo -n '{"WAZUH_TYPE":"'${TYPE}'"}'
+            echo -n ']}'
+        else
+            echo "WAZUH_VERSION=\"${VERSION}\""
+            echo "WAZUH_REVISION=\"${REVISION}\""
+            echo "WAZUH_TYPE=\"${TYPE}\""
+        fi
+    else
+        case "${1}" in
+            -v) echo "${VERSION}" ;;
+            -r) echo "${REVISION}" ;;
+            -t) echo "${TYPE}" ;;
+             *) echo "Invalid flag: ${1}" && help ;;
+        esac
+    fi
+}
+
 ### MAIN HERE ###
 
 case "$1" in
@@ -260,13 +284,13 @@ start)
     ;;
 stop)
     lock
-    stopa
+    stop
     unlock
     ;;
 restart)
     testconfig
     lock
-    stopa
+    stop
     sleep 1
     start
     unlock
@@ -274,7 +298,7 @@ restart)
 reload)
     DAEMONS=$(echo $DAEMONS | sed 's/wazuh-execd//')
     lock
-    stopa
+    stop
     sleep 1
     start
     unlock
@@ -285,18 +309,7 @@ status)
     unlock
     ;;
 info)
-    if [ "X$2" = "X" ]; then
-        echo "VERSION=\"${VERSION}\""
-        echo "REVISION=\"${REVISION}\""
-        echo "TYPE=\"${TYPE}\""
-    else
-        case "$2" in
-            -v) echo "${VERSION}" ;;
-            -r) echo "${REVISION}" ;;
-            -t) echo "${TYPE}" ;;
-             *) echo "Invalid flag: $2" && help ;;
-        esac
-    fi
+    info $arg
     ;;
 help)
     help

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -10,16 +10,19 @@ cd ${LOCAL}
 PWD=`pwd`
 DIR=`dirname $PWD`;
 
+# These variables will be replaced during the installation process
+NAME="TEMP_NAME"
+VERSION="TEMP_VERSION"
+REVISION="TEMP_REVISION"
+DATE="TEMP_DATE"
+TYPE="TEMP_TYPE"
+
 ###  Do not modify bellow here ###
 AUTHOR="Wazuh Inc."
 DAEMONS="wazuh-modulesd wazuh-logcollector wazuh-syscheckd wazuh-agentd wazuh-execd"
 
 # Reverse order of daemons
 SDAEMONS=$(echo $DAEMONS | awk '{ for (i=NF; i>1; i--) printf("%s ",$i); print $1; }')
-
-INITCONF="/etc/ossec-init.conf"
-
-[ -f ${INITCONF} ] && . ${INITCONF}  || echo "ERROR: No such file ${INITCONF}"
 
 ## Locking for the start/stop
 LOCK="${DIR}/var/start-script-lock"

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -10,11 +10,11 @@ cd ${LOCAL}
 PWD=`pwd`
 DIR=`dirname $PWD`;
 
-# These variables will be replaced during the installation process
-VERSION="TEMP_VERSION"
-REVISION="TEMP_REVISION"
+# Installation info
+VERSION="v4.2.0"
+REVISION="40200"
+TYPE="agent"
 DATE="TEMP_DATE"
-TYPE="TEMP_INSTYPE"
 
 ###  Do not modify bellow here ###
 AUTHOR="Wazuh Inc."

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (C) 2015-2020, Wazuh Inc.
+# Copyright (C) 2015-2021, Wazuh Inc.
 # wazuh-control        This shell script takes care of starting
 #                      or stopping ossec-hids
 # Author: Daniel B. Cid <daniel.cid@gmail.com>
@@ -11,11 +11,10 @@ PWD=`pwd`
 DIR=`dirname $PWD`;
 
 # These variables will be replaced during the installation process
-NAME="TEMP_NAME"
 VERSION="TEMP_VERSION"
 REVISION="TEMP_REVISION"
 DATE="TEMP_DATE"
-TYPE="TEMP_TYPE"
+TYPE="TEMP_INSTYPE"
 
 ###  Do not modify bellow here ###
 AUTHOR="Wazuh Inc."
@@ -97,7 +96,7 @@ unlock()
 help()
 {
     # Help message
-    echo "Usage: $0 {start|stop|restart|status}";
+    echo "Usage: $0 {start|stop|restart|status|info [-v -r -d -t]}";
     exit 1;
 }
 
@@ -285,6 +284,22 @@ status)
     lock
     status
     unlock
+    ;;
+info)
+    if [ "X$2" = "X" ]; then
+        echo "VERSION=\"${VERSION}\""
+        echo "REVISION=\"${REVISION}\""
+        echo "DATE=\"${DATE}\""
+        echo "TYPE=\"${TYPE}\""
+    else
+        case "$2" in
+            -v) echo "${VERSION}" ;;
+            -r) echo "${REVISION}" ;;
+            -d) echo "${DATE}" ;;
+            -t) echo "${TYPE}" ;;
+             *) echo "Invalid flag: $2" && help ;;
+        esac
+    fi
     ;;
 help)
     help

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -95,7 +95,7 @@ unlock()
 help()
 {
     # Help message
-    echo "Usage: $0 {start|stop|restart|status|info [-v -r -d -t]}";
+    echo "Usage: $0 {start|stop|restart|status|info [-v -r -t]}";
     exit 1;
 }
 
@@ -251,18 +251,10 @@ stop()
 
 info()
 {
-    if [ "X${1}" = "X" ]; then
-        if [ $USE_JSON = true ]; then
-            echo -n '{"error":0,"data":['
-            echo -n '{"WAZUH_VERSION":"'${VERSION}'"},'
-            echo -n '{"WAZUH_REVISION":"'${REVISION}'"},'
-            echo -n '{"WAZUH_TYPE":"'${TYPE}'"}'
-            echo -n ']}'
-        else
-            echo "WAZUH_VERSION=\"${VERSION}\""
-            echo "WAZUH_REVISION=\"${REVISION}\""
-            echo "WAZUH_TYPE=\"${TYPE}\""
-        fi
+     if [ "X${1}" = "X" ]; then
+        echo "VERSION=\"${VERSION}\""
+        echo "REVISION=\"${REVISION}\""
+        echo "TYPE=\"${TYPE}\""
     else
         case "${1}" in
             -v) echo "${VERSION}" ;;
@@ -274,6 +266,8 @@ info()
 }
 
 ### MAIN HERE ###
+
+arg=$2
 
 case "$1" in
 start)

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -14,9 +14,8 @@ DIR=`dirname $PWD`;
 VERSION="v4.2.0"
 REVISION="40200"
 TYPE="agent"
-DATE="TEMP_DATE"
 
-###  Do not modify bellow here ###
+###  Do not modify below here ###
 AUTHOR="Wazuh Inc."
 DAEMONS="wazuh-modulesd wazuh-logcollector wazuh-syscheckd wazuh-agentd wazuh-execd"
 
@@ -289,13 +288,11 @@ info)
     if [ "X$2" = "X" ]; then
         echo "VERSION=\"${VERSION}\""
         echo "REVISION=\"${REVISION}\""
-        echo "DATE=\"${DATE}\""
         echo "TYPE=\"${TYPE}\""
     else
         case "$2" in
             -v) echo "${VERSION}" ;;
             -r) echo "${REVISION}" ;;
-            -d) echo "${DATE}" ;;
             -t) echo "${TYPE}" ;;
              *) echo "Invalid flag: $2" && help ;;
         esac

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -318,7 +318,7 @@ wait_pid() {
     return 0
 }
 
-stopa()
+stop()
 {
     checkpid;
     for i in ${DAEMONS}; do
@@ -349,6 +349,30 @@ stopa()
     echo "$NAME $VERSION Stopped"
 }
 
+info()
+{
+    if [ "X${1}" = "X" ]; then
+        if [ $USE_JSON = true ]; then
+            echo -n '{"error":0,"data":['
+            echo -n '{"WAZUH_VERSION":"'${VERSION}'"},'
+            echo -n '{"WAZUH_REVISION":"'${REVISION}'"},'
+            echo -n '{"WAZUH_TYPE":"'${TYPE}'"}'
+            echo -n ']}'
+        else
+            echo "WAZUH_VERSION=\"${VERSION}\""
+            echo "WAZUH_REVISION=\"${REVISION}\""
+            echo "WAZUH_TYPE=\"${TYPE}\""
+        fi
+    else
+        case "${1}" in
+            -v) echo "${VERSION}" ;;
+            -r) echo "${REVISION}" ;;
+            -t) echo "${TYPE}" ;;
+             *) echo "Invalid flag: ${1}" && help ;;
+        esac
+    fi
+}
+
 ### MAIN HERE ###
 
 case "$1" in
@@ -360,20 +384,20 @@ start)
     ;;
 stop)
     lock
-    stopa
+    stop
     unlock
     ;;
 restart)
     testconfig
     lock
-    stopa
+    stop
     start
     unlock
     ;;
 reload)
     DAEMONS=$(echo $DAEMONS | sed 's/wazuh-execd//')
     lock
-    stopa
+    stop
     start
     unlock
     ;;
@@ -393,18 +417,7 @@ disable)
     unlock
     ;;
 info)
-    if [ "X$2" = "X" ]; then
-        echo "VERSION=\"${VERSION}\""
-        echo "REVISION=\"${REVISION}\""
-        echo "TYPE=\"${TYPE}\""
-    else
-        case $2 in
-            -v) echo "${VERSION}" ;;
-            -r) echo "${REVISION}" ;;
-            -t) echo "${TYPE}" ;;
-             *) echo "Invalid flag: $2" && help ;;
-        esac
-    fi
+    info $arg
     ;;
 help)
     help

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -12,6 +12,13 @@ PWD=`pwd`
 DIR=`dirname $PWD`;
 PLIST=${DIR}/bin/.process_list;
 
+# These variables will be replaced during the installation process
+NAME="TEMP_NAME"
+VERSION="TEMP_VERSION"
+REVISION="TEMP_REVISION"
+DATE="TEMP_DATE"
+TYPE="TEMP_TYPE"
+
 ###  Do not modify bellow here ###
 
 # Getting additional processes
@@ -26,8 +33,6 @@ INITCONF="/etc/ossec-init.conf"
 
 # Reverse order of daemons
 SDAEMONS=$(echo $DAEMONS | awk '{ for (i=NF; i>1; i--) printf("%s ",$i); print $1; }')
-
-[ -f ${INITCONF} ] && . ${INITCONF}  || echo "ERROR: No such file ${INITCONF}"
 
 ## Locking for the start/stop
 LOCK="${DIR}/var/start-script-lock"

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -12,11 +12,11 @@ PWD=`pwd`
 DIR=`dirname $PWD`;
 PLIST=${DIR}/bin/.process_list;
 
-# These variables will be replaced during the installation process
-VERSION="TEMP_VERSION"
-REVISION="TEMP_REVISION"
+# Installation info
+VERSION="v4.2.0"
+REVISION="40200"
+TYPE="local"
 DATE="TEMP_DATE"
-TYPE="TEMP_INSTYPE"
 
 ###  Do not modify bellow here ###
 
@@ -28,7 +28,6 @@ fi
 
 AUTHOR="Wazuh Inc."
 DAEMONS="wazuh-modulesd wazuh-monitord wazuh-logcollector wazuh-syscheckd wazuh-analysisd wazuh-maild wazuh-execd wazuh-db wazuh-agentlessd wazuh-integratord wazuh-dbd wazuh-csyslogd"
-INITCONF="/etc/ossec-init.conf"
 
 # Reverse order of daemons
 SDAEMONS=$(echo $DAEMONS | awk '{ for (i=NF; i>1; i--) printf("%s ",$i); print $1; }')

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -103,7 +103,7 @@ help()
 {
     # Help message
     echo ""
-    echo "Usage: $0 {start|stop|restart|status|enable|disable|info [-v -r -d -t]}";
+    echo "Usage: $0 {start|stop|restart|status|enable|disable|info [-v -r -t]}";
     exit 1;
 }
 
@@ -352,19 +352,11 @@ stop()
 info()
 {
     if [ "X${1}" = "X" ]; then
-        if [ $USE_JSON = true ]; then
-            echo -n '{"error":0,"data":['
-            echo -n '{"WAZUH_VERSION":"'${VERSION}'"},'
-            echo -n '{"WAZUH_REVISION":"'${REVISION}'"},'
-            echo -n '{"WAZUH_TYPE":"'${TYPE}'"}'
-            echo -n ']}'
-        else
-            echo "WAZUH_VERSION=\"${VERSION}\""
-            echo "WAZUH_REVISION=\"${REVISION}\""
-            echo "WAZUH_TYPE=\"${TYPE}\""
-        fi
+        echo "VERSION=\"${VERSION}\""
+        echo "REVISION=\"${REVISION}\""
+        echo "TYPE=\"${TYPE}\""
     else
-        case "${1}" in
+        case ${1} in
             -v) echo "${VERSION}" ;;
             -r) echo "${REVISION}" ;;
             -t) echo "${TYPE}" ;;
@@ -374,6 +366,8 @@ info()
 }
 
 ### MAIN HERE ###
+
+arg=$2
 
 case "$1" in
 start)

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -16,9 +16,8 @@ PLIST=${DIR}/bin/.process_list;
 VERSION="v4.2.0"
 REVISION="40200"
 TYPE="local"
-DATE="TEMP_DATE"
 
-###  Do not modify bellow here ###
+###  Do not modify below here ###
 
 # Getting additional processes
 ls -la ${PLIST} > /dev/null 2>&1
@@ -397,13 +396,11 @@ info)
     if [ "X$2" = "X" ]; then
         echo "VERSION=\"${VERSION}\""
         echo "REVISION=\"${REVISION}\""
-        echo "DATE=\"${DATE}\""
         echo "TYPE=\"${TYPE}\""
     else
         case $2 in
             -v) echo "${VERSION}" ;;
             -r) echo "${REVISION}" ;;
-            -d) echo "${DATE}" ;;
             -t) echo "${TYPE}" ;;
              *) echo "Invalid flag: $2" && help ;;
         esac

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (C) 2015-2020, Wazuh Inc.
+# Copyright (C) 2015-2021, Wazuh Inc.
 # wazuh-control        This shell script takes care of starting
 #                      or stopping ossec-hids
 # Author: Daniel B. Cid <daniel.cid@gmail.com>
@@ -13,11 +13,10 @@ DIR=`dirname $PWD`;
 PLIST=${DIR}/bin/.process_list;
 
 # These variables will be replaced during the installation process
-NAME="TEMP_NAME"
 VERSION="TEMP_VERSION"
 REVISION="TEMP_REVISION"
 DATE="TEMP_DATE"
-TYPE="TEMP_TYPE"
+TYPE="TEMP_INSTYPE"
 
 ###  Do not modify bellow here ###
 
@@ -106,7 +105,7 @@ help()
 {
     # Help message
     echo ""
-    echo "Usage: $0 {start|stop|restart|status|enable|disable}";
+    echo "Usage: $0 {start|stop|restart|status|enable|disable|info [-v -r -d -t]}";
     exit 1;
 }
 
@@ -385,9 +384,6 @@ status)
     status
     unlock
     ;;
-help)
-    help
-    ;;
 enable)
     lock
     enable $1 $2;
@@ -397,6 +393,25 @@ disable)
     lock
     disable $1 $2;
     unlock
+    ;;
+info)
+    if [ "X$2" = "X" ]; then
+        echo "VERSION=\"${VERSION}\""
+        echo "REVISION=\"${REVISION}\""
+        echo "DATE=\"${DATE}\""
+        echo "TYPE=\"${TYPE}\""
+    else
+        case $2 in
+            -v) echo "${VERSION}" ;;
+            -r) echo "${REVISION}" ;;
+            -d) echo "${DATE}" ;;
+            -t) echo "${TYPE}" ;;
+             *) echo "Invalid flag: $2" && help ;;
+        esac
+    fi
+    ;;
+help)
+    help
     ;;
 *)
     help

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (C) 2015-2020, Wazuh Inc.
+# Copyright (C) 2015-2021, Wazuh Inc.
 # wazuh-control        This shell script takes care of starting
 #                      or stopping ossec-hids
 # Author: Daniel B. Cid <daniel.cid@gmail.com>
@@ -13,11 +13,10 @@ DIR=`dirname $PWD`;
 PLIST=${DIR}/bin/.process_list;
 
 # These variables will be replaced during the installation process
-NAME="TEMP_NAME"
 VERSION="TEMP_VERSION"
 REVISION="TEMP_REVISION"
 DATE="TEMP_DATE"
-TYPE="TEMP_TYPE"
+TYPE="TEMP_INSTYPE"
 
 ###  Do not modify bellow here ###
 
@@ -114,7 +113,7 @@ help()
 {
     # Help message
     echo ""
-    echo "Usage: $0 [-j] {start|stop|restart|status|enable|disable}";
+    echo "Usage: $0 [-j] {start|stop|restart|status|enable|disable|info [-v -r -d -t]}";
     echo ""
     echo "    -j    Use JSON output."
     exit 1;
@@ -560,9 +559,6 @@ status)
     status
     unlock
     ;;
-help)
-    help
-    ;;
 enable)
     lock
     enable $action $arg;
@@ -572,6 +568,34 @@ disable)
     lock
     disable $action $arg;
     unlock
+    ;;
+info)
+    if [ "X${arg}" = "X" ]; then
+        if [ $USE_JSON = true ]; then
+            echo -n '{"error":0,"data":['
+            echo -n '{"VERSION":"'${VERSION}'"},'
+            echo -n '{"REVISION":"'${REVISION}'"},'
+            echo -n '{"DATE":"'${DATE}'"},'
+            echo -n '{"TYPE":"'${TYPE}'"}'
+            echo -n ']}'
+        else
+            echo "VERSION=\"${VERSION}\""
+            echo "REVISION=\"${REVISION}\""
+            echo "DATE=\"${DATE}\""
+            echo "TYPE=\"${TYPE}\""
+        fi
+    else
+        case "${arg}" in
+            -v) echo "${VERSION}" ;;
+            -r) echo "${REVISION}" ;;
+            -d) echo "${DATE}" ;;
+            -t) echo "${TYPE}" ;;
+             *) echo "Invalid flag: ${arg}" && help ;;
+        esac
+    fi
+    ;;
+help)
+    help
     ;;
 *)
     help

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -12,6 +12,13 @@ PWD=`pwd`
 DIR=`dirname $PWD`;
 PLIST=${DIR}/bin/.process_list;
 
+# These variables will be replaced during the installation process
+NAME="TEMP_NAME"
+VERSION="TEMP_VERSION"
+REVISION="TEMP_REVISION"
+DATE="TEMP_DATE"
+TYPE="TEMP_TYPE"
+
 ###  Do not modify bellow here ###
 
 # Getting additional processes
@@ -29,8 +36,6 @@ OP_DAEMONS="wazuh-clusterd wazuh-maild wazuh-agentlessd wazuh-integratord wazuh-
 # Reverse order of daemons
 SDAEMONS=$(echo $DAEMONS | awk '{ for (i=NF; i>1; i--) printf("%s ",$i); print $1; }')
 OP_SDAEMONS=$(echo $OP_DAEMONS | awk '{ for (i=NF; i>1; i--) printf("%s ",$i); print $1; }')
-
-[ -f ${INITCONF} ] && . ${INITCONF}  || echo "ERROR: No such file ${INITCONF}"
 
 ## Locking for the start/stop
 LOCK="${DIR}/var/start-script-lock"

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -454,7 +454,7 @@ wait_pid() {
     return 0
 }
 
-stopa()
+stop()
 {
     checkpid;
     first=true
@@ -509,6 +509,30 @@ stopa()
     fi
 }
 
+info()
+{
+    if [ "X${1}" = "X" ]; then
+        if [ $USE_JSON = true ]; then
+            echo -n '{"error":0,"data":['
+            echo -n '{"WAZUH_VERSION":"'${VERSION}'"},'
+            echo -n '{"WAZUH_REVISION":"'${REVISION}'"},'
+            echo -n '{"WAZUH_TYPE":"'${TYPE}'"}'
+            echo -n ']}'
+        else
+            echo "WAZUH_VERSION=\"${VERSION}\""
+            echo "WAZUH_REVISION=\"${REVISION}\""
+            echo "WAZUH_TYPE=\"${TYPE}\""
+        fi
+    else
+        case "${1}" in
+            -v) echo "${VERSION}" ;;
+            -r) echo "${REVISION}" ;;
+            -t) echo "${TYPE}" ;;
+             *) echo "Invalid flag: ${1}" && help ;;
+        esac
+    fi
+}
+
 ### MAIN HERE ###
 
 if [ "$1" = "-j" ]; then
@@ -529,7 +553,7 @@ start)
     ;;
 stop)
     lock
-    stopa
+    stop
     unlock
     ;;
 restart)
@@ -537,9 +561,9 @@ restart)
     testconfig
     lock
     if [ $USE_JSON = true ]; then
-        stopa > /dev/null 2>&1
+        stop > /dev/null 2>&1
     else
-        stopa
+        stop
     fi
     start
     rm -f ${DIR}/var/run/.restart
@@ -548,7 +572,7 @@ restart)
 reload)
     DAEMONS=$(echo $DAEMONS | sed 's/wazuh-execd//')
     lock
-    stopa
+    stop
     start
     unlock
     ;;
@@ -568,26 +592,7 @@ disable)
     unlock
     ;;
 info)
-    if [ "X${arg}" = "X" ]; then
-        if [ $USE_JSON = true ]; then
-            echo -n '{"error":0,"data":['
-            echo -n '{"VERSION":"'${VERSION}'"},'
-            echo -n '{"REVISION":"'${REVISION}'"},'
-            echo -n '{"TYPE":"'${TYPE}'"}'
-            echo -n ']}'
-        else
-            echo "VERSION=\"${VERSION}\""
-            echo "REVISION=\"${REVISION}\""
-            echo "TYPE=\"${TYPE}\""
-        fi
-    else
-        case "${arg}" in
-            -v) echo "${VERSION}" ;;
-            -r) echo "${REVISION}" ;;
-            -t) echo "${TYPE}" ;;
-             *) echo "Invalid flag: ${arg}" && help ;;
-        esac
-    fi
+    info $arg
     ;;
 help)
     help

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -111,7 +111,7 @@ help()
 {
     # Help message
     echo ""
-    echo "Usage: $0 [-j] {start|stop|restart|status|enable|disable|info [-v -r -d -t]}";
+    echo "Usage: $0 [-j] {start|stop|restart|status|enable|disable|info [-v -r -t]}";
     echo ""
     echo "    -j    Use JSON output."
     exit 1;

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -12,11 +12,11 @@ PWD=`pwd`
 DIR=`dirname $PWD`;
 PLIST=${DIR}/bin/.process_list;
 
-# These variables will be replaced during the installation process
-VERSION="TEMP_VERSION"
-REVISION="TEMP_REVISION"
+# Installation info
+VERSION="v4.2.0"
+REVISION="40200"
+TYPE="server"
 DATE="TEMP_DATE"
-TYPE="TEMP_INSTYPE"
 
 ###  Do not modify bellow here ###
 
@@ -28,7 +28,6 @@ fi
 
 AUTHOR="Wazuh Inc."
 USE_JSON=false
-INITCONF="/etc/ossec-init.conf"
 DAEMONS="wazuh-clusterd wazuh-modulesd wazuh-monitord wazuh-logcollector wazuh-remoted wazuh-syscheckd wazuh-analysisd wazuh-maild wazuh-execd wazuh-db wazuh-authd wazuh-agentlessd wazuh-integratord wazuh-dbd wazuh-csyslogd wazuh-apid"
 OP_DAEMONS="wazuh-clusterd wazuh-maild wazuh-agentlessd wazuh-integratord wazuh-dbd wazuh-csyslogd"
 

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -16,9 +16,8 @@ PLIST=${DIR}/bin/.process_list;
 VERSION="v4.2.0"
 REVISION="40200"
 TYPE="server"
-DATE="TEMP_DATE"
 
-###  Do not modify bellow here ###
+###  Do not modify below here ###
 
 # Getting additional processes
 ls -la ${PLIST} > /dev/null 2>&1
@@ -574,20 +573,17 @@ info)
             echo -n '{"error":0,"data":['
             echo -n '{"VERSION":"'${VERSION}'"},'
             echo -n '{"REVISION":"'${REVISION}'"},'
-            echo -n '{"DATE":"'${DATE}'"},'
             echo -n '{"TYPE":"'${TYPE}'"}'
             echo -n ']}'
         else
             echo "VERSION=\"${VERSION}\""
             echo "REVISION=\"${REVISION}\""
-            echo "DATE=\"${DATE}\""
             echo "TYPE=\"${TYPE}\""
         fi
     else
         case "${arg}" in
             -v) echo "${VERSION}" ;;
             -r) echo "${REVISION}" ;;
-            -d) echo "${DATE}" ;;
             -t) echo "${TYPE}" ;;
              *) echo "Invalid flag: ${arg}" && help ;;
         esac


### PR DESCRIPTION
|Related issue|
|---|
|7081|

## Description

This PR adds to` ossec-control ` the capability of returning the following fields related to the installation:
- VERSION
- REVISION
- TYPE

They may be extracted one by one, or printed all together for debugging purposes.
The JSON output in the server case was also considered.
The BUGS file was updated with the new instructions to get the installation information. 

Closes #7081 .
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
