### PR TITLE
Fix /manager/files endpoints

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5025,7 +5025,7 @@ components:
       required: True
       schema:
         type: string
-        format: path
+        format: wazuh_path
     installer:
       in: query
       name: installer
@@ -8705,7 +8705,7 @@ paths:
               example:
                 data:
                   affected_items:
-                    - "etc/ossec.conf"
+                    - "etc/rules/custom_rules.xml"
                   total_affected_items: 1
                   failed_items: []
                   total_failed_items: 0
@@ -9960,7 +9960,7 @@ paths:
               example:
                 data:
                   affected_items:
-                    - "etc/ossec.conf"
+                    - "etc/rules/custom_rule.xml"
                   total_affected_items: 1
                   failed_items: []
                   total_failed_items: 0

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1214,7 +1214,7 @@ components:
           description: "Name of the file"
         relative_dirname:
           type: string
-          format: etc_path
+          format: paths
           description: "Folder path where the file is located. This path is relative to the Wazuh installation path"
 
     RulesetStatus:
@@ -4444,11 +4444,19 @@ components:
     edit_files_path:
       in: query
       name: path
-      description: "Filepath to upload/delete file. (Relative to wazuh installation folder)"
+      description: "Filepath to upload/edit file. (Relative to wazuh installation folder)"
       required: true
       schema:
         type: string
-        format: etc_file_path
+        format: edit_files_path
+    delete_files_path:
+      in: query
+      name: path
+      description: "Filepath to delete file. (Relative to wazuh installation folder)"
+      required: true
+      schema:
+        type: string
+        format: delete_files_path
     get_files_path:
       in: query
       name: path
@@ -4456,14 +4464,14 @@ components:
       required: true
       schema:
         type: string
-        format: etc_and_ruleset_file_path
-    etc_and_ruleset_path:
+        format: get_files_path
+    get_dirnames_path:
       in: query
       name: relative_dirname
       description: "Filter by relative directory name"
       schema:
         type: string
-        format: etc_and_ruleset_path
+        format: get_dirnames_path
     overwrite:
       in: query
       name: overwrite
@@ -8686,7 +8694,7 @@ paths:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/node_id'
-        - $ref: '#/components/parameters/edit_files_path'
+        - $ref: '#/components/parameters/delete_files_path'
       responses:
         '200':
           description: "Confirmation message"
@@ -8882,7 +8890,7 @@ paths:
         - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
-        - $ref: '#/components/parameters/etc_and_ruleset_path'
+        - $ref: '#/components/parameters/get_dirnames_path'
         - $ref: '#/components/parameters/filename'
       responses:
         '200':
@@ -8970,7 +8978,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
-        - $ref: '#/components/parameters/etc_and_ruleset_path'
+        - $ref: '#/components/parameters/get_dirnames_path'
         - $ref: '#/components/parameters/filename'
       responses:
         '200':
@@ -9939,7 +9947,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/edit_files_path'
+        - $ref: '#/components/parameters/delete_files_path'
       responses:
         '200':
           description: "Confirmation message"
@@ -10360,7 +10368,7 @@ paths:
         - $ref: '#/components/parameters/group'
         - $ref: '#/components/parameters/level'
         - $ref: '#/components/parameters/filename'
-        - $ref: '#/components/parameters/etc_and_ruleset_path'
+        - $ref: '#/components/parameters/get_dirnames_path'
         - $ref: '#/components/parameters/pci_dss'
         - $ref: '#/components/parameters/gdpr'
         - $ref: '#/components/parameters/gpg13'
@@ -10557,7 +10565,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
-        - $ref: '#/components/parameters/etc_and_ruleset_path'
+        - $ref: '#/components/parameters/get_dirnames_path'
         - $ref: '#/components/parameters/filename'
         - $ref: '#/components/parameters/statusRLDParam'
       responses:
@@ -11112,7 +11120,7 @@ paths:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/query'
         - $ref: '#/components/parameters/filename'
-        - $ref: '#/components/parameters/etc_and_ruleset_path'
+        - $ref: '#/components/parameters/get_dirnames_path'
         - $ref: '#/components/parameters/statusRLDParam'
       responses:
         '200':
@@ -11181,7 +11189,7 @@ paths:
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filename'
-        - $ref: '#/components/parameters/etc_and_ruleset_path'
+        - $ref: '#/components/parameters/get_dirnames_path'
         - $ref: '#/components/parameters/statusRLDParam'
       responses:
         '200':

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -6,9 +6,8 @@
 import jsonschema as js
 import os
 import pytest
-from unittest.mock import patch
 
-from api.validator import check_cdb_list, check_exp, check_xml, _alphanumeric_param, \
+from api.validator import check_exp, check_xml, _alphanumeric_param, \
     _array_numbers, _array_names, _boolean, _dates, _empty_boolean, _hashes,\
     _ips, _names, _numbers, _wazuh_key, _paths, _query_param, _ranges, _search_param,\
     _sort_param, _timeframe_type, _type_format, _yes_no_boolean, format_edit_files_path, _edit_files_path, \
@@ -201,25 +200,6 @@ def test_validation_get_paths_ok(relative_path):
 def test_validation_get_paths_ko(relative_path):
     """Verify that format_get_files_path() returns False with incorrect params"""
     assert not format_get_files_path(relative_path)
-
-
-@pytest.mark.parametrize('cdb_list', [
-    ('audit-wazuh-w:write \n audit-wazuh-r:read \n audit-wazuh-a:attribute \n'
-     'audit-wazuh-x:execute \n audit-wazuh-c:command')
-])
-def test_validation_cdb_list_ok(cdb_list):
-    """Verify that check_cdb_list() returns True with correct params"""
-    assert check_cdb_list(cdb_list)
-
-
-@pytest.mark.parametrize('cdb_list', [
-    (':write \n audit-wazuh-r:read \n audit-wazuh-a:attribute'),
-    ('audit-wazuh:write \n $variable:read \n audit-wazuh-a:attribute'),
-    ('import os #:l \n os.system("our custom payload") #:l')
-])
-def test_validation_cdb_list_ko(cdb_list):
-    """Verify that check_cdb_list() returns False with incorrect params"""
-    assert not check_cdb_list(cdb_list)
 
 
 @pytest.mark.parametrize('xml_file', [

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -11,8 +11,8 @@ from unittest.mock import patch
 from api.validator import check_cdb_list, check_exp, check_xml, _alphanumeric_param, \
     _array_numbers, _array_names, _boolean, _dates, _empty_boolean, _hashes,\
     _ips, _names, _numbers, _wazuh_key, _paths, _query_param, _ranges, _search_param,\
-    _sort_param, _timeframe_type, _type_format, _yes_no_boolean, format_etc_file_path, _etc_file_path, \
-    _etc_and_ruleset_file_path, _etc_and_ruleset_path, allowed_fields, is_safe_path
+    _sort_param, _timeframe_type, _type_format, _yes_no_boolean, format_edit_files_path, _edit_files_path, \
+    _delete_files_path, _get_files_path, _get_dirnames_path, allowed_fields, is_safe_path
 
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -60,9 +60,10 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
     ('/var/ossec/etc/internal_options', _paths),
     ('/var/ossec/etc/rules/local_rules.xml', _paths),
     # relative paths
-    ('etc/ossec.conf', _etc_file_path),
-    ('etc/rules/new_rules2.xml', _etc_and_ruleset_file_path),
-    ('etc/lists/new_lists3', _etc_and_ruleset_path),
+    ('etc/ossec.conf', _edit_files_path),
+    ('etc/rules/new_rules2.xml', _get_files_path),
+    ('etc/decoders/new_decoder3.xml', _get_files_path),
+    ('etc/lists/new_lists3', _get_dirnames_path),
 ])
 def test_validation_check_exp_ok(exp, regex_name):
     """Verify that check_exp() returns True with correct params"""
@@ -107,11 +108,17 @@ def test_validation_check_exp_ok(exp, regex_name):
     ('/var/ossec/etc/internal_options$', _paths),
     ('/var/ossec/etc/rules/local_rules.xml()', _paths),
     # relative paths
-    ('etc/internal_options', _etc_and_ruleset_path),
-    ('../../path', _etc_and_ruleset_path),
-    ('/var/ossec/etc/lists/new_lists3', _etc_and_ruleset_path),
-    ('../ossec', _etc_and_ruleset_path),
-    ('etc/rules/../../../dir', _etc_and_ruleset_path)
+    ('etc/internal_options', _get_dirnames_path),
+    ('../../path', _get_dirnames_path),
+    ('/var/ossec/etc/lists/new_lists3', _get_dirnames_path),
+    ('../ossec', _get_dirnames_path),
+    ('etc/rules/../../../dir', _get_dirnames_path),
+    ('ruleset/rules/0010-rules_config.xml', _delete_files_path),
+    ('etc/ossec.conf', _delete_files_path),
+    ('etc/lists/../../../../../../var/ossec/etc/client.keys', _get_files_path),
+    ('ruleset/decoders/../../../../../../var/ossec/ruleset/rules/0016-wazuh_rules.xml', _edit_files_path),
+    ('ruleset/decoders/0040-auditd_decoders.xml', _edit_files_path),
+    ('etc/rules/no_xml.something', _edit_files_path)
 ])
 def test_validation_check_exp_ko(exp, regex_name):
     """Verify that check_exp() returns False with incorrect params"""
@@ -125,8 +132,8 @@ def test_validation_check_exp_ko(exp, regex_name):
     ('etc/ossec.conf')
 ])
 def test_validation_paths_ok(relative_path):
-    """Verify that format_etc_file_path() returns True with correct params"""
-    assert format_etc_file_path(relative_path)
+    """Verify that format_edit_files_path() returns True with correct params"""
+    assert format_edit_files_path(relative_path)
 
 
 @pytest.mark.parametrize('relative_path', [
@@ -136,8 +143,8 @@ def test_validation_paths_ok(relative_path):
     ('etc/internal_options')
 ])
 def test_validation_paths_ko(relative_path):
-    """Verify that format_etc_file_path() returns False with incorrect params"""
-    assert not format_etc_file_path(relative_path)
+    """Verify that format_edit_files_path() returns False with incorrect params"""
+    assert not format_edit_files_path(relative_path)
 
 
 @pytest.mark.parametrize('cdb_list', [
@@ -196,10 +203,10 @@ def test_is_safe_path():
 @pytest.mark.parametrize('value, format', [
     ("test.33alphanumeric:", "alphanumeric"),
     ("cGVwZQ==", "base64"),
-    ("etc/lists/list.csv", "etc_file_path"),
-    ("etc/decoders/dec35.xml", "etc_and_ruleset_file_path"),
-    ("etc/decoders/test/dec35.xml", "etc_and_ruleset_file_path"),
-    ("etc/decoders", "etc_and_ruleset_path"),
+    ("etc/lists/list_me", "delete_files_path"),
+    ("etc/decoders/dec35.xml", "edit_files_path"),
+    ("etc/decoders/test/dec35.xml", "edit_files_path"),
+    ("etc/decoders", "get_dirnames_path"),
     ("AB0264EA00FD9BCDCF1A5B88BC1BDEA4", "hash"),
     ("file_test-33.xml", "names"),
     ("651403650840", "numbers"),
@@ -235,8 +242,13 @@ def test_validation_json_ok(value, format):
 @pytest.mark.parametrize('value, format', [
     ("~test.33alphanumeric:", "alphanumeric"),
     ("cGVwZQ===", "base64"),
-    ("etc/../lists/list.csv", "etc_and_ruleset_file_path"),
-    ("/etc/decoders/dec35.xml", "etc_and_ruleset_file_path"),
+    ("etc/../lists/list.csv", "edit_files_path"),
+    ("/etc/decoders/dec35.xml", "edit_files_path"),
+    ("/etc/decoders/../../dec35.xml", "edit_files_path"),
+    ("/etc/decoders./dec35.xml", "delete_files_path"),
+    ("/etc/ossec.conf", "delete_files_path"),
+    ("/etc/client.keys", "get_files_path"),
+    ("/etc/ossec.conf", "edit_files_path"),
     ("AB0264EA00FD9BCDCF1A5B88BC1BDEA4.", "hash"),
     ("../../file_test-33.xml", "names"),
     ("a651403650840", "numbers"),

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -121,6 +121,20 @@ def is_safe_path(path: str, basedir: str = common.ossec_path, follow_symlinks: b
     return os.path.abspath(path).startswith(basedir)
 
 
+def is_wazuh_path(path: str, basedir: str = common.ossec_path) -> bool:
+    """
+    Check if an absolute path is inside Wazuh installation directory
+    :param path: Path to be checked
+    :param basedir: Wazuh installation directory
+    :return: True if path is correct, False otherwise
+    """
+    # Protect path
+    if './' in path or '../' in path:
+        return False
+
+    return os.path.abspath(path).startswith(basedir)
+
+
 @draft4_format_checker.checks("alphanumeric")
 def format_alphanumeric(value):
     return check_exp(value, _alphanumeric_param)
@@ -210,6 +224,15 @@ def format_numbers_delete(value):
 
 @draft4_format_checker.checks("path")
 def format_path(value):
+    if not is_safe_path(value):
+        return False
+    return check_exp(value, _paths)
+
+
+@draft4_format_checker.checks("wazuh_path")
+def format_wazuh_path(value):
+    if not is_wazuh_path(value):
+        return False
     return check_exp(value, _paths)
 
 

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -36,7 +36,7 @@ _paths = re.compile(r'^[\w\-\.\\\/:]+$')
 _query_param = re.compile(r"^(?:[\w\.\-]+(?:=|!=|<|>|~)[\w\.\- ]+)(?:(?:;|,)[\w\.\-]+(?:=|!=|<|>|~)[\w\.\- ]+)*$")
 _ranges = re.compile(r'[\d]+$|^[\d]{1,2}\-[\d]{1,2}$')
 _edit_files_path = re.compile(r'^etc\/(ossec\.conf|(rules|decoders)\/[\w\-\/]+\.xml|lists\/[\w\-\/]+)$')
-_delete_files_path = re.compile(r'^etc\/((rules|decoders)\/[\w\-\/]+\.xml|lists\/[\w\-\/]+)$')
+_delete_files_path = re.compile(r'^etc\/((rules|decoders)\/[\w\-\/]+\.xml|lists\/[\w\-\/]+(\.cdb|))$')
 _get_files_path = re.compile(
     r'(^etc\/ossec\.conf$)|(^(etc|ruleset)\/(decoders|rules)\/[\w\-]+\.{1}xml$)|(^etc\/lists\/[\w\-\/]+)$')
 _get_dirnames_path = re.compile(r'^(((etc|ruleset)\/(decoders|rules)[\w\-\/]*)|(etc\/lists[\w\-\/]*))$')

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -75,23 +75,6 @@ def check_xml(xml_string: str) -> bool:
     return True
 
 
-def check_cdb_list(cdb_list: str) -> bool:
-    """
-    Function to check if a CDB list is well formed
-    :param cdb_list: CDB list to check
-    :return: True if CDB list is OK, False otherwise
-    """
-    cdb_list_splitted = cdb_list.split('\n')
-    line = 1
-
-    for elem in cdb_list_splitted:
-        if not _cdb_list.match(elem):
-            return False
-        line += 1
-
-    return True
-
-
 def allowed_fields(filters: Dict) -> List:
     """
     Returns a list with allowed fields

--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -45,6 +45,9 @@ variables:
   corrupted_rules_file:
     "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n  <rule id=\"111111\" level=\"XXX\">\n      <if_sid>5716</if_sid>\n      <srcip>1.1.1.1</srcip>\n      <description>sshd: authentication failed from IP 1.1.1.1.</description>\n      <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n    </rule>\n  </group>\n"
 
+  invalid_file:
+    "import os #:l\nos.system('do something bad') #:l"
+
   file_xml:
     <agent_config>
     <labels>

--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -17,7 +17,8 @@ variables:
   login_endpoint: /security/user/authenticate
 
   # delays
-  restart_delay: 40
+  restart_delay: 30
+  restart_delay_cluster: 120
   upgrade_delay: 45
   global_db_delay: 20
   active_reponse_delay: 5

--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -155,7 +155,7 @@ def healthcheck_procedure(module: str):
         os.popen(f'cp -rf {agent_folder} {os.path.join(tmp_content, "agent")}')
 
 
-def change_rbac_mode(rbac_mode: str):
+def change_rbac_mode(rbac_mode: str = 'white'):
     """Modify security.yaml in base folder to change RBAC mode for the current test.
 
     Parameters
@@ -171,13 +171,13 @@ def change_rbac_mode(rbac_mode: str):
 
 
 def clean_tmp_folder():
-    """Remove temporal folder used te configure the environment and set RBAC mode to Black.
+    """Remove temporal folder used te configure the environment and set RBAC mode to White.
     """
     with open(os.path.join(current_path, 'env', 'configurations', 'base', 'manager', 'security.yaml'),
               'r+') as rbac_conf:
         content = rbac_conf.read()
         rbac_conf.seek(0)
-        rbac_conf.write(re.sub(r'rbac_mode: (white|black)', f'rbac_mode: black', content))
+        rbac_conf.write(re.sub(r'rbac_mode: (white|black)', f'rbac_mode: white', content))
 
     shutil.rmtree(os.path.join(current_path, 'env', 'configurations', 'tmp'), ignore_errors=True)
 

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -2396,6 +2396,29 @@ stages:
           total_failed_items: 1
 
   # PUT /cluster/{node_id}/files
+  - name: Try to upload CDB list with a whitespace in the keys (overwrite=true)
+    request:
+      verify: False
+      <<: *upload_cluster_files
+      data: "import os #:l\nos.system('our custom payload') #:l\n"
+      params:
+        path: etc/lists/new-list2
+        overwrite: True
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1800
+              id:
+                - 'etc/lists/new-list2'
+          total_affected_items: 0
+          total_failed_items: 1
+
+  # PUT /cluster/{node_id}/files
   - name: Try to upload valid rule to default ruleset {node_id}
     request:
       verify: False

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -732,6 +732,9 @@ stages:
 ---
 test_name: GET /cluster/configuration/validation
 
+marks:
+  - xfail # Sometimes fails due to https://github.com/wazuh/wazuh/issues/6746
+
 stages:
 
   - name: Request cluster validation
@@ -861,7 +864,7 @@ test_name: GET /cluster/api/config
 stages:
 
   # GET /cluster/api/config
-  - name: Get API configuration
+  - name: Get API configuration for all nodes
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -875,7 +878,7 @@ stages:
         data:
           affected_items:
             - node_name: "master-node"
-              node_api_config: &api_config
+              node_api_config: &default_api_config
                 host: !anystr
                 port: !anyint
                 behind_proxy_server: !anybool
@@ -906,16 +909,16 @@ stages:
                 experimental_features: !anybool
             - node_name: "worker1"
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
             - node_name: "worker2"
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
           total_affected_items: 3
           total_failed_items: 0
           failed_items: []
 
   # GET /cluster/api/config/{node_list}
-  - name: Get API configuration
+  - name: Get API configuration for worker1 and worker2
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -932,10 +935,10 @@ stages:
           affected_items:
             - node_name: 'worker1'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
             - node_name: 'worker2'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
           total_affected_items: 2
           total_failed_items: 0
           failed_items: []
@@ -946,7 +949,7 @@ test_name: PUT /cluster/api/config
 stages:
 
   # PUT /cluster/api/config
-  - name: Modify API configuration (some fields)
+  - name: Modify API configuration (some fields) for all nodes
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -968,7 +971,7 @@ stages:
           failed_items: []
 
   # PUT /cluster/api/config
-  - name: Modify API configuration (all allowed fields)
+  - name: Modify API configuration (all allowed fields) for worker1 and worker2
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1000,7 +1003,7 @@ stages:
           failed_items: []
 
   # PUT /cluster/api/config
-  - name: Modify API configuration (forbidden field)
+  - name: Modify API configuration (forbidden field) for all nodes
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1023,10 +1026,10 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
-    delay_after: !float "{restart_delay}"
+    delay_after: !float "{restart_delay_cluster}"
 
   # GET /cluster/api/config
-  - name: Get API configuration that was set above
+  - name: Get API configuration (default master, modified worker1 and worker2)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1041,7 +1044,7 @@ stages:
           affected_items:
             - node_name: 'master-node'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
             - node_name: 'worker1'
               node_api_config: &modified_api_config
                 logs:
@@ -1064,7 +1067,7 @@ test_name: DELETE /cluster/api/config
 stages:
 
   # DELETE /cluster/api/config (worker1)
-  - name: Restore API configuration
+  - name: Restore default API configuration for worker1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1093,10 +1096,10 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
-    delay_after: !float "{restart_delay}"
+    delay_after: !float "{restart_delay_cluster}"
 
   # GET /cluster/api/config
-  - name: Get API default configuration
+  - name: Get API configuration (default master and worker1, modified worker2)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1111,16 +1114,10 @@ stages:
           affected_items:
             - node_name: 'master-node'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
             - node_name: 'worker1'
               node_api_config:
-                logs:
-                  level: "info"
-                cache:
-                  enabled: true
-                  time: 0.75
-                use_only_authd: false
-                experimental_features: false
+                <<: *default_api_config
             - node_name: 'worker2'
               node_api_config:
                 <<: *modified_api_config
@@ -1129,7 +1126,7 @@ stages:
           failed_items: []
 
   # DELETE /cluster/api/config (all nodes)
-  - name: Restore API configuration
+  - name: Restore default API configuration for all nodes
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1156,10 +1153,10 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
-    delay_after: !float "{restart_delay}"
+    delay_after: !float "{restart_delay_cluster}"
 
   # GET /cluster/api/config
-  - name: Get API default configuration
+  - name: Get API default configuration for all nodes
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
@@ -1174,13 +1171,13 @@ stages:
           affected_items:
             - node_name: 'master-node'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
             - node_name: 'worker1'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
             - node_name: 'worker2'
               node_api_config:
-                <<: *api_config
+                <<: *default_api_config
           total_affected_items: 3
           total_failed_items: 0
           failed_items: []
@@ -1190,7 +1187,7 @@ test_name: GET /cluster/{node_id}/configuration/{component}/{configuration}
 
 stages:
 
-  - name: Try to show the config of analisys/global through a worker
+  - name: Show the config of analisys/global on worker1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/global"
@@ -1223,7 +1220,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of analysis/active_response through a worker
+  - name: Show the config of analysis/active_response on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/analysis/active_response"
@@ -1241,7 +1238,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of analysis/alerts through a worker
+  - name: Show the config of analysis/alerts on worker1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/alerts"
@@ -1259,7 +1256,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show analysis/command through a worker
+  - name: Show analysis/command on master
 
     request:
       verify: False
@@ -1278,7 +1275,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of authd/authd in the manager through a worker
+  - name: Show the config of authd/authd on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/auth/auth"
@@ -1296,7 +1293,6 @@ stages:
                 disabled: !anystr
                 force_insert: !anystr
                 force_time: !anystr
-                limit_maxagents: !anystr
                 port: !anyint
                 purge: !anystr
                 ssl_auto_negotiate: !anystr
@@ -1308,7 +1304,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of com/internal in the manager through a worker
+  - name: Show the config of com/internal on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/com/internal"
@@ -1329,7 +1325,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of analysis/internal through a worker
+  - name: Show the config of analysis/internal on worker1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/internal"
@@ -1361,7 +1357,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of logcollector/localfile in the manager trough a worker
+  - name: Show the config of logcollector/localfile on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/logcollector/localfile"
@@ -1379,7 +1375,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of logcollector/socket in the manager trough a worker
+  - name: Show the config of logcollector/socket on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/logcollector/socket"
@@ -1396,7 +1392,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 0
 
-  - name: Try to show the config of logcollector/internal in the manager trough a worker
+  - name: Show the config of logcollector/internal on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/logcollector/internal"
@@ -1430,7 +1426,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of monitor/internal in the manager trough a worker
+  - name: Show the config of monitor/internal on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/monitor/internal"
@@ -1457,10 +1453,10 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of request/remote in the manager trough a worker
+  - name: Show the config of request/remote on worker2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/request/remote"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/configuration/request/remote"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1480,7 +1476,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of request/internal in the manager trough a worker
+  - name: Show the config of request/internal on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/request/internal"
@@ -1521,7 +1517,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of syscheck/syscheck in the manager trough a worker
+  - name: Show the config of syscheck/syscheck on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/syscheck/syscheck"
@@ -1540,10 +1536,10 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of syscheck/rootcheck in the manager trough a worker
+  - name: Show the config of syscheck/rootcheck on worker1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/syscheck/rootcheck"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/syscheck/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1573,7 +1569,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of syscheck/internal in the manager through a worker
+  - name: Show the config of syscheck/internal on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/syscheck/internal"
@@ -1600,7 +1596,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to show the config of wmodules/wmodules in the manager trough a worker
+  - name: Show the config of wmodules/wmodules on master
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/wmodules/wmodules"
@@ -1700,7 +1696,7 @@ stages:
       json:
         contents: !anything
 
-  - name: Get file with wrong path (master)
+  - name: Try to get file with wrong path {node_id}
     request:
       verify: False
       <<: *get_cluster_files
@@ -1709,7 +1705,7 @@ stages:
     response:
       <<: *connexion_error
 
-  - name: Get file with empty path (master)
+  - name: Try to get file with empty path {node_id}
     request:
       verify: False
       <<: *get_cluster_files
@@ -1718,6 +1714,136 @@ stages:
     response:
       <<: *connexion_error
 
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through lists path {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: etc/lists/../../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through custom decoders path {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: etc/decoders/../../../../../../var/ossec/api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through custom rules path {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: etc/rules/../../../../../var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through ossec.conf path {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: etc/ossec.conf/../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through ruleset rules path {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: ruleset/rules/../../../../../var/ossec/api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through ruleset rules path {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: ruleset/decoders/../../../../../var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through shared groups path {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: etc/shared/../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through relative path (client.keys) {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: etc/client.keys
+    response:
+      status_code: 400
+
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through relative path (jwt_secret) {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through relative path (wazuh-apid script) {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through absolute path (client.keys) {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: /var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through absolute path (jwt_secret) {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: /var/ossec/api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # GET /cluster/{node_id}/files
+  - name: Try to get invalid file through absolute path (wazuh-apid script) {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_files
+      params:
+        path: /var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
 ---
 test_name: DELETE /cluster/{node_id}/files
 
@@ -1725,13 +1851,11 @@ marks:
   - parametrize:
       key: node_id
       vals:
-        - master-node
-        - worker1
-        - worker2
+        - master-node # We only use master-node because the cluster will synchronize the deleted files and may cause errors
 
 stages:
 
-  - name: Delete rules file
+  - name: Delete rules file {node_id}
     request: &delete_cluster_files
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/files"
@@ -1751,7 +1875,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Delete unexisting rules file
+  - name: Delete unexisting rules file {node_id}
     request:
       verify: False
       <<: *delete_cluster_files
@@ -1770,7 +1894,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
-  - name: Delete decoder file
+  - name: Delete decoder file {node_id}
     request:
       verify: False
       <<: *delete_cluster_files
@@ -1787,7 +1911,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Delete unexisting decoder file
+  - name: Delete unexisting decoder file {node_id}
     request:
       verify: False
       <<: *delete_cluster_files
@@ -1796,7 +1920,7 @@ stages:
     response:
       <<: *non_existing_file
 
-  - name: Delete CDB list file
+  - name: Delete CDB list file {node_id}
     request:
       verify: False
       <<: *delete_cluster_files
@@ -1813,7 +1937,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Delete unexisting CDB list file
+  - name: Try to delete unexisting CDB list file {node_id}
     request:
       verify: False
       <<: *delete_cluster_files
@@ -1822,8 +1946,148 @@ stages:
     response:
       <<: *non_existing_file
 
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete ossec.conf {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: etc/ossec.conf
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete ruleset rules file {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: ruleset/rules/0015-ossec_rules.xml
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete ruleset decoders file {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: ruleset/decoders/0006-json_decoders.xml
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete invalid file through custom rules path {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: etc/rules/../../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete invalid file through custom decoders path {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: etc/decoders/../../../../../../var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete invalid file through lists path {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: etc/lists/../../../../../../var/ossec/api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete invalid file through shared groups path {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: etc/shared/../../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete invalid file through ossec.conf path {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: etc/ossec.conf/../../../../../../var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete invalid file using relative path (client.keys) {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: etc/client.keys
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete invalid file using relative path (jwt_secret) {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete invalid file using relative path (wazuh-apid script) {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete invalid file using absolute path (client.keys) {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: /var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete invalid file using absolute path (jwt_secret) {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: /var/ossec/api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # DELETE /cluster/{node_id}/files
+  - name: Try to delete invalid file using absolute path (wazuh-apid script) {node_id}
+    request:
+      verify: False
+      <<: *delete_cluster_files
+      params:
+        path: /var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
 ---
-test_name: PUT /cluster/{node_id}/files
+test_name: PUT /cluster/{node_id}/files (ossec.conf)
 
 marks:
   - parametrize:
@@ -1876,6 +2140,17 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
+
+---
+test_name: PUT /cluster/{node_id}/files (not ossec.conf)
+
+marks:
+  - parametrize:
+      key: node_id
+      vals:
+        - master-node
+
+stages:
 
   - name: Upload new rules {node_id}
     request:
@@ -1936,7 +2211,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Upload rules with XML syntax error (overwrite=true)
+  - name: Try to upload rules with XML syntax error (overwrite=true) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -1958,7 +2233,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
-  - name: Upload new decoder
+  - name: Upload new decoder {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -1976,7 +2251,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Upload decoder (overwrite=false)
+  - name: Upload decoder (overwrite=false) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -1998,7 +2273,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
-  - name: Upload decoder (overwrite=true)
+  - name: Upload decoder (overwrite=true) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -2017,7 +2292,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Upload decoder with XML syntax error (overwrite=true)
+  - name: Try to upload decoder with XML syntax error (overwrite=true) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -2039,7 +2314,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
-  - name: Upload new CDB list
+  - name: Upload new CDB list {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -2057,7 +2332,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Upload CDB list (overwrite=false)
+  - name: Upload CDB list (overwrite=false) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -2079,7 +2354,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
-  - name: Upload CDB list (overwrite=true)
+  - name: Upload CDB list (overwrite=true) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -2098,7 +2373,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Upload CDB list with a syntax error (overwrite=true)
+  - name: Try to upload CDB list with a syntax error (overwrite=true) {node_id}
     request:
       verify: False
       <<: *upload_cluster_files
@@ -2120,12 +2395,120 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
+  # PUT /cluster/{node_id}/files
+  - name: Try to upload valid rule to default ruleset {node_id}
+    request:
+      verify: False
+      <<: *upload_cluster_files
+      data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n <rule id=\"111111\" level=\"5\">\n <if_sid>5716</if_sid>\n <srcip>1.1.1.1</srcip>\n  <description>sshd: authentication failed from IP 1.1.1.1.</description>\n <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n </rule>\n </group>\n"
+      params:
+        path: ruleset/rules/0010-rules_config.xml
+        overwrite: True
+    response:
+      status_code: 400
+
+  # PUT /cluster/{node_id}/files
+  - name: Try to upload valid decoder to default ruleset {node_id}
+    request:
+      verify: False
+      <<: *upload_cluster_files
+      data: "<!-- NEW Local Decoders -->\n <decoder name=\"local_decoder_example\">\n <program_name>NEW DECODER</program_name>\n </decoder>\n"
+      params:
+        path: ruleset/decoders/0005-wazuh_decoders.xml
+        overwrite: True
+    response:
+      status_code: 400
+
+  # PUT /cluster/{node_id}/files
+  - name: Try to upload invalid file to invalid path through ossec.conf path {node_id}
+    request:
+      verify: False
+      <<: *upload_cluster_files
+      data: "{invalid_file}"
+      params:
+        overwrite: True
+        path: etc/ossec.conf/../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # PUT /cluster/{node_id}/files
+  - name: Try to upload invalid file to invalid path through custom rules path {node_id}
+    request:
+      verify: False
+      <<: *upload_cluster_files
+      data: "{invalid_file}"
+      params:
+        overwrite: True
+        path: etc/rules/../../../../../var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # PUT /cluster/{node_id}/files
+  - name: Try to upload invalid file to invalid path through custom decoders path {node_id}
+    request:
+      verify: False
+      <<: *upload_cluster_files
+      data: "{invalid_file}"
+      params:
+        overwrite: True
+        path: etc/decoders/../../../../../var/ossec/api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # PUT /cluster/{node_id}/files
+  - name: Try to upload invalid file to invalid path through lists path {node_id}
+    request:
+      verify: False
+      <<: *upload_cluster_files
+      data: "{invalid_file}"
+      params:
+        overwrite: True
+        path: etc/lists/../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # PUT /cluster/{node_id}/files
+  - name: Try to upload invalid file to invalid path through shared groups path {node_id}
+    request:
+      verify: False
+      <<: *upload_cluster_files
+      data: "{invalid_file}"
+      params:
+        overwrite: True
+        path: etc/shared/../../../../../var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # PUT /cluster/{node_id}/files
+  - name: Try to upload invalid file to ruleset rules {node_id}
+    request:
+      verify: False
+      <<: *upload_cluster_files
+      data: "{invalid_file}"
+      params:
+        overwrite: True
+        path: ruleset/rules/invalid.xml
+    response:
+      status_code: 400
+
+  # PUT /cluster/{node_id}/files
+  - name: Try to upload invalid file to ruleset decoders {node_id}
+    request:
+      verify: False
+      <<: *upload_cluster_files
+      data: "{invalid_file}"
+      params:
+        overwrite: True
+        path: ruleset/decoders/invalid.xml
+    response:
+      status_code: 400
+
 ---
 test_name: PUT /cluster/wrong_node/files
 
 stages:
 
-  - name: Upload rules to unexisting node (overwrite=false) {node_id}
+  - name: Upload rules to unexisting node (overwrite=false)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/unexisting-node/files"
@@ -2194,7 +2577,7 @@ marks:
 
 stages:
 
-  - name: Request {node_id} 0
+  - name: Read info {node_id}
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/info"
@@ -2233,7 +2616,7 @@ marks:
 
 stages:
 
-  - name: Request {node_id} 1
+  - name: Read logs {node_id}
     request: &get_cluster_logs
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs"
@@ -2250,7 +2633,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> limit=3 {node_id}
+  - name: Read logs with filters -> limit=3 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2273,7 +2656,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> limit=4 {node_id}
+  - name: Read logs with filters -> limit=4 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2293,7 +2676,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> limit=2, sort=tag {node_id}
+  - name: Read logs with filters -> limit=2, sort=tag {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2312,7 +2695,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> limit=1, sort=-level {node_id}
+  - name: Read logs with filters -> limit=1, sort=-level {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2330,7 +2713,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> offset=2, limit=3 {node_id}
+  - name: Read logs with filters -> offset=2, limit=3 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2350,7 +2733,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> offset=5, limit=2 {node_id}
+  - name: Read logs with filters -> offset=5, limit=2 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2369,7 +2752,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> tag=ossec-analysisd, limit=1 {node_id}
+  - name: Read logs with filters -> tag=ossec-analysisd, limit=1 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2387,7 +2770,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> tag=ossec-syscheckd, limit=2 {node_id}
+  - name: Read logs with filters -> tag=ossec-syscheckd, limit=2 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2408,7 +2791,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters -> level=info, limit=1 {node_id}
+  - name: Read logs with filters -> level=info, limit=1 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2427,7 +2810,7 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Filters by query (tag=ossec-syscheckd, level=info)
+  - name: Read logs with filters by query (tag=ossec-syscheckd, level=info) {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
@@ -2457,7 +2840,7 @@ marks:
 
 stages:
 
-  - name: Request {node_id} 2
+  - name: Read logs summary {node_id}
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs/summary"
@@ -2528,7 +2911,7 @@ test_name: GET /cluster/wrong_node/stats
 
 stages:
 
-  - name: unexisting_node stats
+  - name: Unexisting_node stats
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/unexisting-node/stats"
@@ -2748,7 +3131,7 @@ marks:
 
 stages:
 
-  - name: Request {node_id} 3
+  - name: Read status {node_id}
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/status"
@@ -2770,7 +3153,7 @@ test_name: PUT /cluster/restart
 
 stages:
 
-  - name: Restart cluster
+  - name: Restart cluster (worker1, worker2)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
@@ -2790,9 +3173,9 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
-    delay_after: !float "{restart_delay}"
+    delay_after: !float "{restart_delay_cluster}"
 
-  - name: Restart cluster
+  - name: Restart cluster all nodes
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1667,6 +1667,33 @@ stages:
           total_failed_items: 1
 
   # PUT /manager/files
+  - name: Try to upload CDB list with a whitespace in the keys (overwrite=true)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: PUT
+      data: "import os #:l\nos.system('our custom payload') #:l\n"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+      params:
+        path: etc/lists/new-list2
+        overwrite: True
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1800
+              id:
+                - 'etc/lists/new-list2'
+          total_affected_items: 0
+          total_failed_items: 1
+
+  # PUT /manager/files
   - name: Try to upload invalid file to invalid path through ossec.conf path
     request:
       verify: False

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1039,7 +1039,7 @@ stages:
         contents: !anystr
 
   # GET /manager/files
-  - name: Get file with wrong path
+  - name: Try to get file with wrong path
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/files"
@@ -1055,7 +1055,7 @@ stages:
         title: !anystr
 
   # GET /manager/files
-  - name: Get file with empty path
+  - name: Try to get file with empty path
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/files"
@@ -1071,7 +1071,7 @@ stages:
         title: !anystr
 
   # GET /manager/files
-  - name: Get unexisting rules file with right path
+  - name: Try to get unexisting rules file with right path
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/files"
@@ -1086,7 +1086,7 @@ stages:
         error: 1906
 
   # GET /manager/files
-  - name: Get unexisting decoder file with right path
+  - name: Try to get unexisting decoders file with right path
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/files"
@@ -1101,7 +1101,7 @@ stages:
         error: 1906
 
   # GET /manager/files
-  - name: Get unexisting list file with right path
+  - name: Try to get unexisting lists file with right path
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/files"
@@ -1114,6 +1114,175 @@ stages:
       status_code: 400
       json:
         error: 1906
+
+  # GET /manager/files
+  - name: Try to get invalid file through lists path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/lists/../../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # GET /manager/files
+  - name: Try to get invalid file through custom decoders path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/decoders/../../../../../../var/ossec/api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # GET /manager/files
+  - name: Try to get invalid file through custom rules path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/rules/../../../../../var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # GET /manager/files
+  - name: Try to get invalid file through ossec.conf path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/ossec.conf/../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # GET /manager/files
+  - name: Try to get invalid file through ruleset rules path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: ruleset/rules/../../../../../var/ossec/api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # GET /manager/files
+  - name: Try to get invalid file through ruleset rules path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: ruleset/decoders/../../../../../var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # GET /manager/files
+  - name: Try to get invalid file through shared groups path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/shared/../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # GET /manager/files
+  - name: Try to get invalid file through relative path (client.keys)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/client.keys
+    response:
+      status_code: 400
+
+  # GET /manager/files
+  - name: Try to get invalid file through relative path (jwt_secret)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # GET /manager/files
+  - name: Try to get invalid file through relative path (wazuh-apid script)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # GET /manager/files
+  - name: Try to get invalid file through absolute path (client.keys)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: /var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # GET /manager/files
+  - name: Try to get invalid file through absolute path (jwt_secret)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: /var/ossec/api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # GET /manager/files
+  - name: Try to get invalid file through absolute path (wazuh-apid script)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: /var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
 
 ---
 test_name: PUT /manager/files
@@ -1237,6 +1406,22 @@ stages:
           total_failed_items: 0
 
   # PUT /manager/files
+  - name: Try to upload valid rule to default ruleset
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: PUT
+      data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n <rule id=\"111111\" level=\"5\">\n <if_sid>5716</if_sid>\n <srcip>1.1.1.1</srcip>\n  <description>sshd: authentication failed from IP 1.1.1.1.</description>\n <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n </rule>\n </group>\n"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+      params:
+        path: ruleset/rules/0010-rules_config.xml
+        overwrite: True
+    response:
+      status_code: 400
+
+  # PUT /manager/files
   - name: Upload rules with XML syntax error (overwrite=true)
     request:
       verify: False
@@ -1336,6 +1521,22 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
+
+  # PUT /manager/files
+  - name: Try to upload valid decoder to default ruleset
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: PUT
+      data: "<!-- NEW Local Decoders -->\n <decoder name=\"local_decoder_example\">\n <program_name>NEW DECODER</program_name>\n </decoder>\n"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+      params:
+        path: ruleset/decoders/0005-wazuh_decoders.xml
+        overwrite: True
+    response:
+      status_code: 400
 
   # PUT /manager/files
   - name: Upload decoder with XML syntax error (overwrite=true)
@@ -1465,6 +1666,118 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
+  # PUT /manager/files
+  - name: Try to upload invalid file to invalid path through ossec.conf path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: PUT
+      data: "{invalid_file}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+      params:
+        overwrite: True
+        path: etc/ossec.conf/../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # PUT /manager/files
+  - name: Try to upload invalid file to invalid path through custom rules path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: PUT
+      data: "{invalid_file}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+      params:
+        overwrite: True
+        path: etc/rules/../../../../../var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # PUT /manager/files
+  - name: Try to upload invalid file to invalid path through custom decoders path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: PUT
+      data: "{invalid_file}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+      params:
+        overwrite: True
+        path: etc/decoders/../../../../../var/ossec/api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # PUT /manager/files
+  - name: Try to upload invalid file to invalid path through lists path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: PUT
+      data: "{invalid_file}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+      params:
+        overwrite: True
+        path: etc/lists/../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # PUT /manager/files
+  - name: Try to upload invalid file to invalid path through shared groups path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: PUT
+      data: "{invalid_file}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+      params:
+        overwrite: True
+        path: etc/shared/../../../../../var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # PUT /manager/files
+  - name: Try to upload invalid file to ruleset rules
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: PUT
+      data: "{invalid_file}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+      params:
+        overwrite: True
+        path: ruleset/rules/invalid.xml
+    response:
+      status_code: 400
+
+  # PUT /manager/files
+  - name: Try to upload invalid file to ruleset decoders
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: PUT
+      data: "{invalid_file}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+      params:
+        overwrite: True
+        path: ruleset/decoders/invalid.xml
+    response:
+      status_code: 400
+
 ---
 test_name: DELETE /manager/files
 
@@ -1492,7 +1805,7 @@ stages:
           total_failed_items: 0
 
   # DELETE /manager/files
-  - name: Delete unexisting rules file
+  - name: Try to delete unexisting rules file
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/files"
@@ -1537,7 +1850,7 @@ stages:
           total_failed_items: 0
 
   # DELETE /manager/files
-  - name: Delete unexisting decoder file
+  - name: Try to delete unexisting decoder file
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/files"
@@ -1582,7 +1895,7 @@ stages:
           total_failed_items: 0
 
   # DELETE /manager/files
-  - name: Delete unexisting CDB list file
+  - name: Try to delete unexisting CDB list file
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/files"
@@ -1604,6 +1917,188 @@ stages:
                 - 'etc/lists/unexisting-list'
           total_affected_items: 0
           total_failed_items: 1
+
+  # DELETE /manager/files
+  - name: Try to delete ossec.conf
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/ossec.conf
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete ruleset rules file
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: ruleset/rules/0015-ossec_rules.xml
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete ruleset decoders file
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: ruleset/decoders/0006-json_decoders.xml
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete invalid file through custom rules path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/rules/../../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete invalid file through custom decoders path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/decoders/../../../../../../var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete invalid file through lists path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/lists/../../../../../../var/ossec/api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete invalid file through shared groups path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/shared/../../../../../../var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete invalid file through ossec.conf path
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/ossec.conf/../../../../../../var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete invalid file using relative path (client.keys)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: etc/client.keys
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete invalid file using relative path (jwt_secret)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete invalid file using relative path (wazuh-apid script)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete invalid file using absolute path (client.keys)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: /var/ossec/etc/client.keys
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete invalid file using absolute path (jwt_secret)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: /var/ossec/api/configuration/security/jwt_secret
+    response:
+      status_code: 400
+
+  # DELETE /manager/files
+  - name: Try to delete invalid file using absolute path (wazuh-apid script)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/files"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        path: /var/ossec/api/scripts/wazuh-apid.py
+    response:
+      status_code: 400
 
 ---
 test_name: GET /manager/configuration/validation (OK)

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -1539,7 +1539,7 @@ stages:
       status_code: 400
 
   # PUT /manager/files
-  - name: Upload decoder with XML syntax error (overwrite=true)
+  - name: Try to upload decoder with XML syntax error (overwrite=true)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/files"
@@ -1640,7 +1640,7 @@ stages:
           total_failed_items: 0
 
   # PUT /manager/files
-  - name: Upload CDB list with a syntax error (overwrite=true)
+  - name: Try to upload CDB list with a syntax error (overwrite=true)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/manager/files"

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -227,7 +227,7 @@ def validate_cdb_list(path):
     :return: True if CDB list is OK, False otherwise
     """
     full_path = join(common.ossec_path, path)
-    regex_cdb = re.compile(r'^[^:]+:[^:]*$')
+    regex_cdb = re.compile(r'^[^:\s]+:[^:]*$')
     try:
         with open(full_path) as f:
             for line in f:


### PR DESCRIPTION
Hello team,

This PR fixes regexes for Wazuh API spec and updates unit and integration tests.


**UNIT TEST RESULTS:**
```
Launching pytest with arguments /wazuh/api/api/test/test_validator.py

============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /venvs/bin/python
cachedir: .pytest_cache
rootdir: /wazuh/api
plugins: asyncio-0.14.0
collecting ... collected 171 items

============================= 171 passed in 0.44s ==============================

Launching pytest with arguments /wazuh/framework/wazuh/tests/test_cdb_list.py

============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /venvs/bin/python
cachedir: .pytest_cache
rootdir: /wazuh/framework
plugins: asyncio-0.14.0
collecting ... collected 47 items

============================== 47 passed in 0.60s ==============================

Launching pytest with arguments /wazuh/framework/wazuh/rbac/tests/test_auth_context.py

============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /venvs/bin/python
cachedir: .pytest_cache
rootdir: /wazuh/framework
plugins: asyncio-0.14.0
collecting ... collected 2 items

========================= 2 passed, 1 warning in 2.43s =========================

Launching pytest with arguments /wazuh/framework/wazuh/rbac/tests/test_decorators.py in /wazuh/framework/wazuh/rbac/tests

============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /venvs/bin/python
cachedir: .pytest_cache
rootdir: /wazuh/framework
plugins: asyncio-0.14.0
collecting ... collected 105 items

======================== 105 passed in 78.31s (0:01:18) ========================

Launching pytest with arguments /wazuh/framework/wazuh/rbac/tests/test_default_configuration.py in /wazuh/framework/wazuh/rbac/tests

============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /venvs/bin/python
cachedir: .pytest_cache
rootdir: /wazuh/framework
plugins: asyncio-0.14.0
collecting ... collected 47 items

============================= 47 passed in 33.99s ==============================

Launching pytest with arguments /wazuh/framework/wazuh/rbac/tests/test_orm.py in /wazuh/framework/wazuh/rbac/tests

============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /venvs/bin/python
cachedir: .pytest_cache
rootdir: /wazuh/framework
plugins: asyncio-0.14.0
collecting ... collected 53 items

============================= 53 passed in 43.33s ==============================

Launching pytest with arguments /wazuh/framework/wazuh/rbac/tests/test_preprocessor.py in /wazuh/framework/wazuh/rbac/tests

============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /venvs/bin/python
cachedir: .pytest_cache
rootdir: /wazuh/framework
plugins: asyncio-0.14.0
collecting ... collected 11 items

============================== 11 passed in 8.51s ==============================

Launching pytest with arguments /wazuh/framework/wazuh/tests/test_security.py in /wazuh/framework/wazuh/tests

============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /home/davidjiglesias/venvs/bin/python
cachedir: .pytest_cache
rootdir: /wazuh/framework
plugins: asyncio-0.14.0
collecting ... collected 69 items

================== 69 passed, 3 warnings in 61.88s (0:01:01) ===================
```

**API INTEGRATION TEST RESULTS:**
```
python3 run_tests.py -l cluster,manager
Collected tests [6]:
test_cluster_endpoints.tavern.yaml, test_manager_endpoints.tavern.yaml, test_rbac_black_cluster_endpoints.tavern.yaml, test_rbac_black_manager_endpoints.tavern.yaml, test_rbac_white_cluster_endpoints.tavern.yaml, test_rbac_white_manager_endpoints.tavern.yaml


test_cluster_endpoints.tavern.yaml 
	 54 passed, 1 xpassed, 72 warnings

test_manager_endpoints.tavern.yaml 
	 35 passed, 38 warnings

test_rbac_black_cluster_endpoints.tavern.yaml 
	 21 passed, 23 warnings

test_rbac_black_manager_endpoints.tavern.yaml 
	 19 passed, 21 warnings

test_rbac_white_cluster_endpoints.tavern.yaml 
	 21 passed, 23 warnings

test_rbac_white_manager_endpoints.tavern.yaml 
	 19 passed, 21 warnings
```