### PR TITLE
Add remote commands option to API config

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -57,7 +57,17 @@ default_api_configuration = {
     },
     "use_only_authd": False,
     "drop_privileges": True,
-    "experimental_features": False
+    "experimental_features": False,
+    "remote_commands": {
+        "localfile": {
+            "enabled": True,
+            "exceptions": []
+        },
+        "wodle_command": {
+            "enabled": True,
+            "exceptions": []
+        }
+    }
 }
 
 
@@ -191,6 +201,23 @@ def read_yaml_config(config_file=common.api_config_path, default_conf=None) -> D
 
     :return: API configuration
     """
+    def replace_bools(conf):
+        """Replace 'yes' and 'no' strings in configuration for actual booleans.
+        Parameters
+        ----------
+        conf : dict
+            Current API configuration.
+        """
+        for k in conf.keys():
+            if isinstance(conf[k], dict):
+                replace_bools(conf[k])
+            else:
+                if isinstance(conf[k], str):
+                    if conf[k].lower() == 'yes':
+                        conf[k] = True
+                    elif conf[k].lower() == 'no':
+                        conf[k] = False
+
     if default_conf is None:
         default_conf = default_api_configuration
 
@@ -198,6 +225,8 @@ def read_yaml_config(config_file=common.api_config_path, default_conf=None) -> D
         try:
             with open(config_file) as f:
                 configuration = yaml.safe_load(f)
+            # Replace strings for booleans
+            configuration and replace_bools(configuration)
         except IOError as e:
             raise APIError(2004, details=e.strerror)
     else:

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -49,3 +49,12 @@
 # Enable features under development
 # experimental_features: no
 
+# Enable remote commands
+# remote_commands:
+#   localfile:
+#     enabled: yes
+#     exceptions: []
+#
+#   wodle_command:
+#     enabled: yes
+#     exceptions: []

--- a/api/api/models/configuration.py
+++ b/api/api/models/configuration.py
@@ -98,7 +98,7 @@ class CORSModel(Model):
             'source_route': str,
             'expose_headers': str,
             'allow_headers': bool,
-            'allow_credentials': str
+            'allow_credentials': bool
         }
 
         self.attribute_map = {

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2437,6 +2437,7 @@ components:
     APIconfiguration:
       type: object
       minProperties: 1
+      additionalProperties: false
       properties:
         access:
           description: API Security Options

--- a/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
@@ -124,7 +124,7 @@ stages:
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
-      data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n <rule id=\"111111\" level=\"5\">\n <if_sid>5716\n <srcip>1.1.1.1</srcip>\n  <description>sshd: authentication failed from IP 1.1.1.1.</description>\n <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n </rule>\n </group>\n"
+      data: "<!-- Local rules -->\n <group name=\"local,\">\n <!--   NEW RULE    -->\n <rule id=\"111111\" level=\"5\">\n <if_sid>5716</if_sid>\n <srcip>1.1.1.1</srcip>\n  <description>sshd: authentication failed from IP 1.1.1.1.</description>\n <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>\n </rule>\n </group>\n"
       params:
         path: 'etc/rules/local_rules.xml'
         overwrite: True

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -93,6 +93,8 @@ class WazuhException(Exception):
                               'using API endpoint https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.put_api_config or '
                               'https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.put_api_config'},
         1123: {'message': f"Error communicating with socket. Query too long, maximum allowed size for queries is {MAX_SOCKET_BUFFER_SIZE // 1024} KB"},
+        1124: {'message': 'Remote command detected',
+               'remediation': f'To solve this issue please enable the remote commands in the API settings or add an exception: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/configuration.html#remote-commands-configuration'},
 
         # Rule: 1200 - 1299
         1200: {'message': 'Error reading rules from `WAZUH_HOME/etc/ossec.conf`',

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -26,7 +26,7 @@ from wazuh import WazuhInternalError, WazuhError
 from wazuh.core import common
 from wazuh.core.cluster.utils import get_manager_status
 from wazuh.core.results import WazuhResult
-from wazuh.core.utils import load_wazuh_xml, safe_move, tail
+from wazuh.core.utils import load_wazuh_xml, safe_move, tail, check_remote_commands
 
 _re_logtest = re.compile(r"^.*(?:ERROR: |CRITICAL: )(?:\[.*\] )?(.*)$")
 execq_lockfile = join(common.ossec_path, "var", "run", ".api_execq_lock")
@@ -108,61 +108,75 @@ def get_logs_summary(limit=2000):
     return tags
 
 
-def upload_xml(xml_file, path):
-    """
-    Upload XML files (rules and decoders)
-    :param xml_file: content of the XML file
-    :param path: Destination of the new XML file
-    :return: Confirmation message
+def prettify_xml(xml_file):
+    """Prettify XML files (rules, decoders and ossec.conf)
+
+    Parameters
+    ----------
+    xml_file : str
+        Content of the XML file
+
+    Returns
+    -------
+    Checked XML content
     """
     # -- characters are not allowed in XML comments
     xml_file = replace_in_comments(xml_file, '--', '%wildcard%')
 
-    # path of temporary files for parsing xml input
-    tmp_file_path = '{}/tmp/api_tmp_file_{}_{}.xml'.format(common.ossec_path, time.time(), random.randint(0, 1000))
-
     # create temporary file for parsing xml input
     try:
+        # beauty xml file
+        xml = parseString('<root>' + xml_file + '</root>')
+        # remove first line (XML specification: <? xmlversion="1.0" ?>), <root> and </root> tags, and empty lines
+        indent = '  '  # indent parameter for toprettyxml function
+        pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent=indent).split('\n')[2:-2])) + '\n'
+        # revert xml.dom replacings
+        # (https://github.com/python/cpython/blob/8e0418688906206fe59bd26344320c0fc026849e/Lib/xml/dom/minidom.py#L305)
+        pretty_xml = pretty_xml.replace("&amp;", "&").replace("&lt;", "<").replace("&quot;", "\"", ) \
+            .replace("&gt;", ">").replace('&apos;', "'")
+        # delete two first spaces of each line
+        final_xml = re.sub(fr'^{indent}', '', pretty_xml, flags=re.MULTILINE)
+        final_xml = replace_in_comments(final_xml, '%wildcard%', '--')
+
+        # Check if remote commands are allowed
+        check_remote_commands(final_xml)
+        # Check xml format
+        load_wazuh_xml(xml_path='', data=final_xml)
+
+        return final_xml
+    except ExpatError:
+        raise WazuhError(1113)
+    except WazuhError as e:
+        raise e
+    except Exception as e:
+        raise WazuhError(1113, str(e))
+
+
+def upload_xml(xml_file, path):
+    """
+    Upload XML files (rules, decoders and ossec.conf)
+    :param xml_file: content of the XML file
+    :param path: Destination of the new XML file
+    :return: Confirmation message
+    """
+    # Path of temporary files for parsing xml input
+    tmp_file_path = '{}/tmp/api_tmp_file_{}_{}.xml'.format(common.ossec_path, time.time(), random.randint(0, 1000))
+    try:
         with open(tmp_file_path, 'w') as tmp_file:
-            # beauty xml file
-            xml = parseString('<root>' + xml_file + '</root>')
-            # remove first line (XML specification: <? xmlversion="1.0" ?>), <root> and </root> tags, and empty lines
-            indent = '  '  # indent parameter for toprettyxml function
-            pretty_xml = '\n'.join(filter(lambda x: x.strip(), xml.toprettyxml(indent=indent).split('\n')[2:-2])) + '\n'
-            # revert xml.dom replacings
-            # (https://github.com/python/cpython/blob/8e0418688906206fe59bd26344320c0fc026849e/Lib/xml/dom/minidom.py#L305)
-            pretty_xml = pretty_xml.replace("&amp;", "&").replace("&lt;", "<").replace("&quot;", "\"", ) \
-                .replace("&gt;", ">").replace('&apos;', "'")
-            # delete two first spaces of each line
-            final_xml = re.sub(fr'^{indent}', '', pretty_xml, flags=re.MULTILINE)
-            final_xml = replace_in_comments(final_xml, '%wildcard%', '--')
+            final_xml = prettify_xml(xml_file)
             tmp_file.write(final_xml)
         chmod(tmp_file_path, 0o660)
     except IOError:
         raise WazuhInternalError(1005)
-    except ExpatError:
-        raise WazuhError(1113)
 
+    # Move temporary file to group folder
     try:
-        # check xml format
-        try:
-            load_wazuh_xml(tmp_file_path)
-        except Exception as e:
-            raise WazuhError(1113, str(e))
+        new_conf_path = join(common.ossec_path, path)
+        safe_move(tmp_file_path, new_conf_path, permissions=0o660)
+    except Error:
+        raise WazuhInternalError(1016)
 
-        # move temporary file to group folder
-        try:
-            new_conf_path = join(common.ossec_path, path)
-            safe_move(tmp_file_path, new_conf_path, permissions=0o660)
-        except Error:
-            raise WazuhInternalError(1016)
-
-        return WazuhResult({'message': 'File was successfully updated'})
-
-    except Exception as e:
-        # remove created temporary file if an exception happens
-        remove(tmp_file_path)
-        raise e
+    return WazuhResult({'message': 'File was successfully updated'})
 
 
 def upload_list(list_file, path):

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -125,9 +125,9 @@ def test_get_logs_summary():
                                                      'debug': 2}
 
 
-@patch('wazuh.core.manager.load_wazuh_xml')
+@patch('wazuh.core.manager.check_remote_commands')
 @patch('wazuh.core.manager.common.ossec_path', new=test_data_path)
-def test_prettify_xml(mock_load_wazuh, test_manager):
+def test_prettify_xml(mock_remote_commands, test_manager):
     """Tests prettify_xml method works and methods inside are called with expected parameters"""
     input_file, _ = getattr(test_manager, 'input_rules_file'), getattr(test_manager, 'output_rules_file')
 
@@ -138,15 +138,16 @@ def test_prettify_xml(mock_load_wazuh, test_manager):
         result = prettify_xml(xml_file)
 
     assert isinstance(result, str)
-    mock_load_wazuh.assert_called_once_with(xml_path='', data=result)
+    mock_remote_commands.assert_called_once_with(result)
 
 
 @patch('time.time', return_value=0)
 @patch('random.randint', return_value=0)
 @patch('wazuh.core.manager.chmod')
+@patch('wazuh.core.manager.check_remote_commands')
 @patch('wazuh.core.manager.safe_move')
 @patch('wazuh.core.manager.common.ossec_path', new=test_data_path)
-def test_upload_xml(mock_safe, mock_chmod, mock_random, mock_time, test_manager):
+def test_upload_xml(mock_safe, mock_check_remote_commands, mock_chmod, mock_random, mock_time, test_manager):
     """Tests upload_xml method works and methods inside are called with expected parameters"""
     input_file, output_file = getattr(test_manager, 'input_rules_file'), getattr(test_manager, 'output_rules_file')
 
@@ -206,30 +207,23 @@ def test_upload_xml_open_ko(effect, expected_exception, test_manager):
             upload_xml(input_file, output_file)
 
 
-@patch('time.time', return_value=0)
-@patch('random.randint', return_value=0)
-@patch('wazuh.core.manager.chmod')
-@patch('wazuh.core.manager.common.ossec_path', new=test_data_path)
-def test_upload_xml_ko(mock_chmod, mock_random, mock_time, test_manager):
-    """Tests upload_xml function exception works and methods inside are called with expected parameters"""
+@pytest.mark.parametrize('effect, expected_exception', [
+    (IOError, 1005)
+])
+def test_upload_xml_open_ko(effect, expected_exception, test_manager):
+    """Tests upload_xml function works when open function raise an exception
+    Parameters
+    ----------
+    effect : Exception
+        Exception to be triggered.
+    expected_exception
+        Expected code when triggering the exception.
+    """
     input_file, output_file = getattr(test_manager, 'input_rules_file'), getattr(test_manager, 'output_rules_file')
 
-    with open(os.path.join(test_data_path, input_file)) as f:
-        xml_file = f.read()
-    m = mock_open(read_data=xml_file)
-    with patch('builtins.open', m):
-        with patch('wazuh.core.manager.load_wazuh_xml', side_effect=Exception):
-            with pytest.raises(WazuhException, match=f'.* 1113 .*'):
-                upload_xml(xml_file, output_file)
-
-        with patch('wazuh.core.manager.load_wazuh_xml'):
-            with patch('wazuh.core.manager.safe_move', side_effect=Error):
-                with pytest.raises(WazuhException, match=f'.* 1016 .*'):
-                    upload_xml(xml_file, output_file)
-
-    mock_time.assert_called_with()
-    mock_random.assert_called_with(0, 1000)
-    mock_chmod.assert_called_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'), 0o660)
+    with patch('wazuh.core.manager.open', side_effect=effect):
+        with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
+            upload_xml(input_file, output_file)
 
 
 @patch('wazuh.core.manager.validate_cdb_list', return_value=True)

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -4,17 +4,14 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-import sys
-from unittest.mock import patch, mock_open, MagicMock, ANY
+from unittest.mock import patch, mock_open, ANY
 
 import pytest
 
-with patch('wazuh.common.ossec_uid'):
-    with patch('wazuh.common.ossec_gid'):
-        sys.modules['api'] = MagicMock()
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
         from wazuh.core.manager import *
         from wazuh.core.exception import WazuhException
-        del sys.modules['api']
 
 ossec_cdb_list = "172.16.19.:\n172.16.19.:\n192.168.:"
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'manager')
@@ -128,13 +125,28 @@ def test_get_logs_summary():
                                                      'debug': 2}
 
 
+@patch('wazuh.core.manager.load_wazuh_xml')
+@patch('wazuh.core.manager.common.ossec_path', new=test_data_path)
+def test_prettify_xml(mock_load_wazuh, test_manager):
+    """Tests prettify_xml method works and methods inside are called with expected parameters"""
+    input_file, _ = getattr(test_manager, 'input_rules_file'), getattr(test_manager, 'output_rules_file')
+
+    with open(os.path.join(test_data_path, input_file)) as f:
+        xml_file = f.read()
+    m = mock_open(read_data=xml_file)
+    with patch('builtins.open', m):
+        result = prettify_xml(xml_file)
+
+    assert isinstance(result, str)
+    mock_load_wazuh.assert_called_once_with(xml_path='', data=result)
+
+
 @patch('time.time', return_value=0)
 @patch('random.randint', return_value=0)
 @patch('wazuh.core.manager.chmod')
-@patch('wazuh.core.manager.load_wazuh_xml')
 @patch('wazuh.core.manager.safe_move')
 @patch('wazuh.core.manager.common.ossec_path', new=test_data_path)
-def test_upload_xml(mock_safe, mock_load_wazuh, mock_chmod, mock_random, mock_time, test_manager):
+def test_upload_xml(mock_safe, mock_chmod, mock_random, mock_time, test_manager):
     """Tests upload_xml method works and methods inside are called with expected parameters"""
     input_file, output_file = getattr(test_manager, 'input_rules_file'), getattr(test_manager, 'output_rules_file')
 
@@ -149,15 +161,33 @@ def test_upload_xml(mock_safe, mock_load_wazuh, mock_chmod, mock_random, mock_ti
     mock_random.assert_called_once_with(0, 1000)
     m.assert_any_call(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'), 'w')
     mock_chmod.assert_called_once_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'), 0o660)
-    mock_load_wazuh.assert_called_once_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'))
     mock_safe.assert_called_once_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'),
                                       os.path.join(test_data_path, output_file),
                                       permissions=0o660)
 
 
 @pytest.mark.parametrize('effect, expected_exception', [
-    (IOError, 1005),
     (ExpatError, 1113)
+])
+def test_prettify_xml_open_ko(effect, expected_exception, test_manager):
+    """Tests prettify_xml function works when open function raise an exception
+
+    Parameters
+    ----------
+    effect : Exception
+        Exception to be triggered.
+    expected_exception
+        Expected code when triggering the exception.
+    """
+    input_file, _ = getattr(test_manager, 'input_rules_file'), getattr(test_manager, 'output_rules_file')
+
+    with patch('wazuh.core.manager.load_wazuh_xml', side_effect=effect):
+        with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
+            prettify_xml(input_file)
+
+
+@pytest.mark.parametrize('effect, expected_exception', [
+    (IOError, 1005)
 ])
 def test_upload_xml_open_ko(effect, expected_exception, test_manager):
     """Tests upload_xml function works when open function raise an exception
@@ -179,9 +209,8 @@ def test_upload_xml_open_ko(effect, expected_exception, test_manager):
 @patch('time.time', return_value=0)
 @patch('random.randint', return_value=0)
 @patch('wazuh.core.manager.chmod')
-@patch('wazuh.core.manager.remove')
 @patch('wazuh.core.manager.common.ossec_path', new=test_data_path)
-def test_upload_xml_ko(mock_remove, mock_chmod, mock_random, mock_time, test_manager):
+def test_upload_xml_ko(mock_chmod, mock_random, mock_time, test_manager):
     """Tests upload_xml function exception works and methods inside are called with expected parameters"""
     input_file, output_file = getattr(test_manager, 'input_rules_file'), getattr(test_manager, 'output_rules_file')
 
@@ -201,7 +230,6 @@ def test_upload_xml_ko(mock_remove, mock_chmod, mock_random, mock_time, test_man
     mock_time.assert_called_with()
     mock_random.assert_called_with(0, 1000)
     mock_chmod.assert_called_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'), 0o660)
-    mock_remove.assert_called_with(os.path.join(test_manager.api_tmp_path, 'api_tmp_file_0_0.xml'))
 
 
 @patch('wazuh.core.manager.validate_cdb_list', return_value=True)

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -17,6 +17,7 @@ from itertools import groupby, chain
 from os import chmod, chown, path, listdir, mkdir, curdir, rename, utime
 from subprocess import CalledProcessError, check_output
 from xml.etree.ElementTree import fromstring
+from api import configuration
 
 from wazuh.core import common
 from wazuh.core.database import Connection
@@ -627,9 +628,42 @@ def plain_dict_to_nested_dict(data, nested=None, non_nested=None, force_fields=[
     return nested_dict
 
 
-def load_wazuh_xml(xml_path):
-    with open(xml_path) as f:
-        data = f.read()
+def check_remote_commands(data):
+    """Check if remote commands are allowed.
+    If not, it will check if the found command is in the list of exceptions.
+    Parameters
+    ----------
+    data : str
+        Configuration file
+    """
+    def check_section(command_regex, section, split_section):
+        try:
+            for line in command_regex.findall(data)[0].split(split_section):
+                command_matches = re.match(r".*<(command|full_command)>(.*)</(command|full_command)>.*",
+                                           line, flags=re.MULTILINE | re.DOTALL)
+                if command_matches and \
+                        (line.count('<command>') > 1 or
+                         command_matches.group(2) not in
+                         configuration.api_conf['remote_commands'][section]['exceptions']):
+                    raise WazuhError(1124)
+        except IndexError:
+            pass
+
+    if configuration.api_conf['remote_commands']['localfile']['enabled'] is not None and \
+            not configuration.api_conf['remote_commands']['localfile']['enabled']:
+        command_section = re.compile(r"<localfile>(.*)</localfile>", flags=re.MULTILINE | re.DOTALL)
+        check_section(command_section, section='localfile', split_section='</localfile>')
+
+    if configuration.api_conf['remote_commands']['wodle_command']['enabled'] is not None and not \
+            configuration.api_conf['remote_commands']['wodle_command']['enabled']:
+        command_section = re.compile(r"<wodle name=\"command\">(.*)</wodle>", flags=re.MULTILINE | re.DOTALL)
+        check_section(command_section, section='wodle_command', split_section='<wodle name=\"command\">')
+
+
+def load_wazuh_xml(xml_path, data=None):
+    if not data:
+        with open(xml_path) as f:
+            data = f.read()
 
     # -- characters are not allowed in XML comments
     xml_comment = re.compile(r"(<!--(.*?)-->)", flags=re.MULTILINE | re.DOTALL)

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -13,7 +13,8 @@ from wazuh.core.cluster.utils import manager_restart, read_cluster_config
 from wazuh.core.configuration import get_ossec_conf
 from wazuh.core.exception import WazuhError, WazuhInternalError
 from wazuh.core.manager import status, upload_xml, upload_list, validate_xml, validate_cdb_list, \
-    get_api_conf, get_ossec_logs, get_logs_summary, validate_ossec_conf
+    get_api_conf, get_ossec_logs, get_logs_summary, validate_ossec_conf, prettify_xml
+
 from wazuh.core.results import WazuhResult, AffectedItemsWazuhResult
 from wazuh.core.utils import process_array
 from wazuh.rbac.decorators import expose_resources
@@ -131,6 +132,8 @@ def upload_file(path=None, content=None, overwrite=False):
         if not overwrite and exists(join(common.ossec_path, path)):
             raise WazuhError(1905)
         elif overwrite and exists(join(common.ossec_path, path)):
+            # Check if the content is valid
+            not re.match(r'^etc/lists', path) and prettify_xml(content)
             delete_file(path=path)
 
         # For CDB lists

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -152,8 +152,9 @@ def test_ossec_log_summary():
 ])
 @patch('wazuh.manager.delete_file')
 @patch('wazuh.manager.upload_xml')
+@patch('wazuh.core.manager.check_remote_commands')
 @patch('wazuh.manager.upload_list')
-def test_upload_file(mock_list, mock_xml, mock_delete, path, overwrite):
+def test_upload_file(mock_list, mock_remote_commands, mock_xml, mock_delete, path, overwrite):
     """Tests uploading a file to the manager
 
     Parameters


### PR DESCRIPTION
Hello team, 

This PR add the option to block remote commands to the API configuration.

### **UNIT TEST RESULTS:**
```
Launching pytest with arguments /wazuh/framework/wazuh/tests/test_manager.py in /wazuh/framework/wazuh/tests

============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3.8
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.8.0-36-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'metadata': '1.11.0', 'html': '3.1.1', 'testinfra': '5.0.0'}}
rootdir: /wazuh/framework
plugins: tavern-1.0.0, metadata-1.11.0, html-3.1.1, testinfra-5.0.0
collecting ... collected 38 items

============================== 38 passed in 0.40s ==============================

Launching pytest with arguments /wazuh/framework/wazuh/core/tests/test_manager.py in /wazuh/framework/wazuh/core/tests

============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3.8
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.8.0-36-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.9.0', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.0.0', 'metadata': '1.11.0', 'html': '3.1.1', 'testinfra': '5.0.0'}}
rootdir: /wazuh/framework
plugins: tavern-1.0.0, metadata-1.11.0, html-3.1.1, testinfra-5.0.0
collecting ... collected 30 items

============================== 30 passed in 0.21s ==============================
```

### **INTEGRATION TEST RESULTS:**
```
python3 run_tests.py -l manager,cluster -rbac no
Collected tests [2]:
test_cluster_endpoints.tavern.yaml, test_manager_endpoints.tavern.yaml


test_cluster_endpoints.tavern.yaml 
	 52 passed, 1 xpassed, 70 warnings

test_manager_endpoints.tavern.yaml 
	 33 passed, 36 warnings

python3 run_tests.py -l manager,cluster -rbac yes
Collected tests [4]:
test_rbac_black_cluster_endpoints.tavern.yaml, test_rbac_black_manager_endpoints.tavern.yaml, test_rbac_white_cluster_endpoints.tavern.yaml, test_rbac_white_manager_endpoints.tavern.yaml


test_rbac_black_cluster_endpoints.tavern.yaml 
	 19 passed, 21 warnings

test_rbac_black_manager_endpoints.tavern.yaml 
	 17 passed, 19 warnings

test_rbac_white_cluster_endpoints.tavern.yaml 
	 19 passed, 21 warnings

test_rbac_white_manager_endpoints.tavern.yaml 
	 17 passed, 19 warnings
```