### PR TITLE
Improve add agent manual functions and input validators

### DIFF
--- a/api/api/controllers/agents_controller.py
+++ b/api/api/controllers/agents_controller.py
@@ -870,17 +870,6 @@ async def insert_agent(request, pretty=False, wait_for_complete=False):
     Body.validate_content_type(request, expected_content_type='application/json')
     f_kwargs = await AgentInsertedModel.get_kwargs(request)
 
-    # Get IP if not given
-    if not f_kwargs['ip']:
-        if configuration.api_conf['behind_proxy_server']:
-            try:
-                f_kwargs['ip'] = request.headers['X-Forwarded-For']
-            except KeyError:
-                raise_if_exc(WazuhError(1120))
-        else:
-            peername = request.transport.get_extra_info('peername')
-            if peername is not None:
-                f_kwargs['ip'], _ = peername
     f_kwargs['use_only_authd'] = configuration.api_conf['use_only_authd']
 
     dapi = DistributedAPI(f=agent.add_agent,

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -26,8 +26,8 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
     (100, _alphanumeric_param),
     # names
     ('alphanumeric1_param2', _alphanumeric_param),
-    ('file_1,file_2,file-3', _array_names),
-    ('file-test_name1', _names),
+    ('file_%1,file_2,file-3', _array_names),
+    ('file%1-test_name1', _names),
     # IPs
     ('192.168.122.255', _ips),
     ('any', _ips),

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -14,7 +14,7 @@ from wazuh.core import common
 _alphanumeric_param = re.compile(r'^[\w,\-\.\+\s\:]+$')
 _symbols_alphanumeric_param = re.compile(r'^[a-zA-Z0-9_,<>!\-.+\s:/()\'"|=]+$')
 _array_numbers = re.compile(r'^\d+(,\d+)*$')
-_array_names = re.compile(r'^[\w\-\.]+(,[\w\-\.]+)*$')
+_array_names = re.compile(r'^[\w\-\.%]+(,[\w\-\.%]+)*$')
 _base64 = re.compile(r'^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$')
 _boolean = re.compile(r'^true$|^false$')
 _cdb_list = re.compile(r'^#?[\w\s-]+:{1}(#?[\w\s-]+|)$')
@@ -28,7 +28,7 @@ _ips = re.compile(
 _iso8601_date = (r'^([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])$')
 _iso8601_date_time = (
     r'^([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])[tT](2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?([zZ]|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])$')
-_names = re.compile(r'^[\w\-\.]+$')
+_names = re.compile(r'^[\w\-\.%]+$')
 _numbers = re.compile(r'^\d+$')
 _numbers_delete = re.compile(r'^\d+|all$')
 _wazuh_key = re.compile(r'[a-zA-Z0-9]+$')

--- a/api/test/integration/test_agents_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_GET_endpoints.tavern.yaml
@@ -490,7 +490,7 @@ stages:
       verify: False
       <<: *get_agents
       params:
-        node_name: test_node_name
+        node_name: test_node_name%
     response:
       status_code: 200
       json:
@@ -503,7 +503,7 @@ stages:
       verify: False
       <<: *get_agents
       params:
-        node_name: test_node_name_%
+        node_name: test_node_name_*
     response:
       status_code: 400
       json:

--- a/api/test/integration/test_agents_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_agents_POST_endpoints.tavern.yaml
@@ -472,7 +472,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        agent_name: 'wrong%name'
+        agent_name: 'wrong*name'
     response:
       status_code: 400
       json:

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -393,8 +393,10 @@ class Agent:
         self.manager = None
         self.node_name = None
         self.registerIP = ip
+        self.lock_file = None
+        self.lock_acquired = False
 
-        # if the method has only been called with an ID parameter, no new agent should be added.
+        # If the method has only been called with an ID parameter, no new agent should be added.
         # Otherwise, a new agent must be added
         if name is not None and ip is not None:
             self._add(name=name, ip=ip, id=id, key=key, force=force, use_only_authd=use_only_authd)
@@ -410,6 +412,17 @@ class Agent:
 
         return dictionary
 
+    def _acquire_client_keys_lock(self):
+        self.lock_file = open("{}/var/run/.api_lock".format(common.ossec_path), 'a+')
+        fcntl.lockf(self.lock_file, fcntl.LOCK_EX)
+        self.lock_acquired = True
+
+    def _release_client_keys_lock(self):
+        fcntl.lockf(self.lock_file, fcntl.LOCK_UN)
+        self.lock_file.close()
+        self.lock_file = None
+        self.lock_acquired = False
+
     def load_info_from_db(self, select=None):
         """Gets attributes of existing agent.
         """
@@ -419,7 +432,7 @@ class Agent:
         try:
             data = db_query.run()['items'][0]
         except IndexError:
-            raise WazuhResourceNotFound(1701)
+            raise WazuhResourceNotFound(1701, extra_message=self.id)
 
         list(map(lambda x: setattr(self, x[0], x[1]), data.items()))
 
@@ -513,46 +526,58 @@ class Agent:
         # Check if agent exists
         self.load_info_from_db()
 
-        f_keys_temp = '{0}.tmp'.format(common.client_keys)
+        client_keys_entries = []
+        # Check if id exists in client.keys
+        if self.lock_acquired:
+            # If the lock is already acquired there is a client.keys file change in progress as part of a registration
+            # and the void entry will be written there instead of here.
+            pending_client_keys_update = True
+        else:
+            pending_client_keys_update = False
+            self._acquire_client_keys_lock()
 
         try:
             agent_found = False
-            with open(common.client_keys) as client_keys, open(f_keys_temp, 'w') as client_keys_tmp:
-                try:
-                    for line in client_keys.readlines():
-                        id, name, ip, key = line.strip().split(' ')  # 0 -> id, 1 -> name, 2 -> ip, 3 -> key
-                        if self.id == id and name[0] not in '#!':
-                            if not purge:
-                                client_keys_tmp.write('{0} !{1} {2} {3}\n'.format(id, name, ip, key))
-
-                            agent_found = True
+            with open(common.client_keys) as f_k:
+                for line in f_k.readlines():
+                    line = line.rstrip()
+                    if line:
+                        if not line.startswith('#') and not line.startswith(' '):
+                            try:
+                                entry_id, entry_name, entry_ip, entry_key = line.split(' ')
+                            except ValueError:
+                                # Bad entries will be ignored and not rewritten to the new file
+                                continue
                         else:
-                            client_keys_tmp.write(line)
-                except Exception as e:
-                    remove(f_keys_temp)
-                    raise e
-
-            if not agent_found:
-                remove(f_keys_temp)
-                raise WazuhError(1701, extra_message=str(self.id))
-            else:
-                f_keys_st = stat(common.client_keys)
-                chown(f_keys_temp, common.ossec_uid(), common.ossec_gid())
-                chmod(f_keys_temp, f_keys_st.st_mode)
+                            # Ignore void entries, but preserve them
+                            client_keys_entries.append(line)
+                            continue
+                        if self.id == entry_id and not (entry_name.startswith('#') or entry_name.startswith('!')):
+                            # If not purging then create a void entry
+                            agent_found = True
+                            if not purge:
+                                client_keys_entries.append(
+                                    '{0} !{1} {2} {3}'.format(entry_id, entry_name, entry_ip, entry_key))
+                        else:
+                            client_keys_entries.append(line)
         except Exception as e:
             raise WazuhInternalError(1746, extra_message=str(e))
 
-        # Tell wazuhbd to delete agent database
+        if not agent_found:
+            raise WazuhResourceNotFound(1701, extra_message=self.id)
+
+        # Tell wazuh-db to delete agent database
         wdb_backend_conn = WazuhDBBackend(self.id).connect_to_db()
         wdb_backend_conn.delete_agents_db([self.id])
 
+        # Remove agent from groups
         try:
-            # remove agent from groups
             wdb_conn = WazuhDBConnection()
             wdb_conn.run_wdb_command(f'global sql DELETE FROM belongs WHERE id_agent = {self.id}')
         except Exception as e:
             raise WazuhInternalError(1747, extra_message=str(e))
 
+        # Clean up agent files
         try:
             # Remove rid file
             rids_file = path.join(common.ossec_path, 'queue/rids', self.id)
@@ -602,11 +627,22 @@ class Agent:
                             remove(agent_file)
                     elif not path.exists(backup_file):
                         safe_move(agent_file, backup_file, permissions=0o660)
-
-            # Overwrite client.keys
-            safe_move(f_keys_temp, common.client_keys, permissions=0o640)
         except Exception as e:
             raise WazuhInternalError(1748, extra_message=str(e))
+
+        # Update client.keys file and release the lock only if there are no other pending changes
+        if not pending_client_keys_update:
+            # Write temporary client.keys file
+            f_keys_temp = '{0}.tmp'.format(common.client_keys)
+            with open(f_keys_temp, 'a') as f_kt:
+                client_keys_entries.append('')
+                f_kt.writelines('\n'.join(client_keys_entries))
+
+            # Overwrite client.keys
+            f_keys_st = stat(common.client_keys)
+            safe_move(f_keys_temp, common.client_keys, permissions=f_keys_st.st_mode)
+
+            self._release_client_keys_lock()
 
         return 'Agent was successfully deleted'
 
@@ -644,12 +680,18 @@ class Agent:
             if not is_authd_running:
                 raise WazuhInternalError(1726)
 
-        if not is_authd_running:
-            data = self._add_manual(name, ip, id, key, force)
-        else:
-            data = self._add_authd(name, ip, id, key, force)
-
-        return data
+        try:
+            if not is_authd_running:
+                self._add_manual(name, ip, id, key, force)
+            else:
+                self._add_authd(name, ip, id, key, force)
+        except WazuhException as e:
+            raise e
+        except Exception as e:
+            raise WazuhError(1725, extra_message=str(e))
+        finally:
+            if self.lock_acquired:
+                self._release_client_keys_lock()
 
     def _add_authd(self, name, ip, id=None, key=None, force=-1):
         """Adds an agent to OSSEC using authd.
@@ -713,12 +755,26 @@ class Agent:
         """
         # Check arguments
         if id:
-            id = id.zfill(3)
+            agent_id = id.zfill(3)
+        else:
+            agent_id = None
 
-        if key and len(key) < 64:
-            raise WazuhError(1709)
+        if key:
+            if len(key) < 64:
+                raise WazuhError(1709)
+            else:
+                agent_key = key
+        else:
+            epoch_time = int(time())
+            str1 = "{0}{1}{2}".format(epoch_time, name, platform())
+            str2 = "{0}{1}".format(ip, agent_id)
+            hash1 = hashlib.md5(str1.encode())
+            hash1.update(urandom(64))
+            hash2 = hashlib.md5(str2.encode())
+            hash1.update(urandom(64))
+            agent_key = hash1.hexdigest() + hash2.hexdigest()
 
-        force = force if type(force) == int else int(force)
+        force = int(force)
 
         # Check manager name
         wdb_conn = WazuhDBConnection()
@@ -727,96 +783,77 @@ class Agent:
         if name == manager_name:
             raise WazuhError(1705, extra_message=name)
 
-        # Check if ip, name or id exist in client.keys
+        # Never allow duplication or replacement of an agent id. Check before running through the client.keys to avoid
+        # deleting an entry with duplicate name or ip and then find out that the id was already present
+        if agent_id in get_agents_info():
+            raise WazuhError(1708, agent_id)
+
+        client_keys_entries = []
+        # Check if ip or name exist in client.keys
         last_id = 0
-        lock_file = open("{}/var/run/.api_lock".format(common.ossec_path), 'a+')
-        fcntl.lockf(lock_file, fcntl.LOCK_EX)
+        self._acquire_client_keys_lock()
         with open(common.client_keys) as f_k:
-            try:
-                for line in f_k.readlines():
-                    if not line.strip():  # ignore empty lines
+            for line in f_k.readlines():
+                line = line.rstrip()
+                if line:
+                    if not line.startswith('#') and not line.startswith(' '):
+                        try:
+                            entry_id, entry_name, entry_ip, entry_key = line.split(' ')
+                        except ValueError:
+                            # Bad entries will be ignored and not rewritten to the new file
+                            continue
+                    else:
+                        # Ignore void entries, but preserve them
+                        client_keys_entries.append(line)
                         continue
 
-                    if line[0] in '# ':  # starts with # or ' '
+                    # Update last_id with highest seen value
+                    if int(entry_id) > last_id:
+                        last_id = int(entry_id)
+
+                    # Ignore void entries, but preserve them
+                    if entry_name.startswith('#') or entry_name.startswith('!'):
+                        client_keys_entries.append(line)
                         continue
 
-                    line_data = line.strip().split(' ')  # 0 -> id, 1 -> name, 2 -> ip, 3 -> key
-
-                    line_id = int(line_data[0])
-                    if last_id < line_id:
-                        last_id = line_id
-
-                    if line_data[1][0] in '#!':  # name starts with # or !
-                        continue
-
-                    check_remove = 0
-                    if id and id == line_data[0]:
-                        raise WazuhError(1708, extra_message=id)
-                    if name == line_data[1]:
-                        if force < 0:
-                            raise WazuhError(1705, extra_message=name)
+                    # Detect entries with duplicate name or ip
+                    if name == entry_name or (ip != 'any' and ip == entry_ip):
+                        # If force is non-negative then we check to remove the agent using value of force as the max age
+                        # in seconds
+                        if force >= 0 and Agent.check_if_delete_agent(entry_id, force):
+                            # Call _remove_manual directly since we are already in _add_manual and will handle releasing
+                            # the lock properly when complete.
+                            Agent(entry_id)._remove_manual(backup=True)
+                            # We add a void entry since remove_agent will not update client.keys with a change in
+                            # progress
+                            client_keys_entries.append(
+                                '{0} !{1} {2} {3}'.format(entry_id, entry_name, entry_ip, entry_key))
                         else:
-                            check_remove = 1
-                    if ip != 'any' and ip == line_data[2]:
-                        if force < 0:
-                            raise WazuhError(1706, extra_message=ip)
-                        else:
-                            check_remove = 2
-
-                    if check_remove:
-                        if force == 0 or Agent.check_if_delete_agent(line_data[0], force):
-                            Agent(line_data[0]).remove(backup=True)
-                        else:
-                            if check_remove == 1:
+                            # If force is negative or the agent is not older than the max age we raise an error based
+                            # on the duplicate field.
+                            if name == entry_name:
                                 raise WazuhError(1705, extra_message=name)
                             else:
                                 raise WazuhError(1706, extra_message=ip)
+                    else:
+                        # Preserve the entry if it is not a duplicate
+                        client_keys_entries.append(line)
 
-                if not id:
-                    agent_id = str(last_id + 1).zfill(3)
-                else:
-                    agent_id = id
+        # If id not specified then create a new id 1 greater than the last id created.
+        if not agent_id:
+            agent_id = str(last_id + 1).zfill(3)
 
-                if not key:
-                    # Generate key
-                    epoch_time = int(time())
-                    str1 = "{0}{1}{2}".format(epoch_time, name, platform())
-                    str2 = "{0}{1}".format(ip, agent_id)
-                    hash1 = hashlib.md5(str1.encode())
-                    hash1.update(urandom(64))
-                    hash2 = hashlib.md5(str2.encode())
-                    hash1.update(urandom(64))
-                    agent_key = hash1.hexdigest() + hash2.hexdigest()
-                else:
-                    agent_key = key
+        # Write temporary client.keys file
+        f_keys_temp = '{0}.tmp'.format(common.client_keys)
+        with open(f_keys_temp, 'a') as f_kt:
+            client_keys_entries.append('')
+            f_kt.writelines('\n'.join(client_keys_entries))
+            f_kt.write('{0} {1} {2} {3}\n'.format(agent_id, name, ip, agent_key))
 
-                # Tmp file
-                f_keys_temp = '{0}.tmp'.format(common.client_keys)
-                open(f_keys_temp, 'a').close()
-
-                f_keys_st = stat(common.client_keys)
-                chown(f_keys_temp, common.ossec_uid(), common.ossec_gid())
-                chmod(f_keys_temp, f_keys_st.st_mode)
-
-                copyfile(common.client_keys, f_keys_temp)
-
-                # Write key
-                with open(f_keys_temp, 'a') as f_kt:
-                    f_kt.write('{0} {1} {2} {3}\n'.format(agent_id, name, ip, agent_key))
-
-                # Overwrite client.keys
-                safe_move(f_keys_temp, common.client_keys, permissions=f_keys_st.st_mode)
-            except WazuhException as ex:
-                fcntl.lockf(lock_file, fcntl.LOCK_UN)
-                lock_file.close()
-                raise ex
-            except Exception as e:
-                fcntl.lockf(lock_file, fcntl.LOCK_UN)
-                lock_file.close()
-                raise WazuhError(1725, extra_message=str(e))
-
-            fcntl.lockf(lock_file, fcntl.LOCK_UN)
-            lock_file.close()
+        # Overwrite client.keys
+        f_keys_st = stat(common.client_keys)
+        safe_move(f_keys_temp, common.client_keys, permissions=f_keys_st.st_mode)
+        self._release_client_keys_lock()
 
         self.id = agent_id
         self.internal_key = agent_key
@@ -937,19 +974,23 @@ class Agent:
         :return: True if time from last connection is greater thant <seconds>.
         """
         remove_agent = False
-        agent_info = Agent(id=id).get_basic_information()
 
-        if 'lastKeepAlive' in agent_info:
-            if agent_info['lastKeepAlive'] == 0:
-                remove_agent = True
-            else:
-                if isinstance(agent_info['lastKeepAlive'], datetime):
-                    last_date = agent_info['lastKeepAlive']
-                else:
-                    last_date = datetime.strptime(agent_info['lastKeepAlive'], '%Y-%m-%d %H:%M:%S')
-                difference = (datetime.utcnow() - last_date).total_seconds()
-                if difference >= seconds:
+        # Always return true for 0 seconds to prevent any possible races
+        if seconds == 0:
+            remove_agent = True
+        else:
+            agent_info = Agent(id=id).get_basic_information()
+            if 'lastKeepAlive' in agent_info:
+                if agent_info['lastKeepAlive'] == 0:
                     remove_agent = True
+                else:
+                    if isinstance(agent_info['lastKeepAlive'], datetime):
+                        last_date = agent_info['lastKeepAlive']
+                    else:
+                        last_date = datetime.strptime(agent_info['lastKeepAlive'], '%Y-%m-%d %H:%M:%S')
+                    difference = (datetime.utcnow() - last_date).total_seconds()
+                    if difference >= seconds:
+                        remove_agent = True
 
         return remove_agent
 

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -690,10 +690,10 @@ def test_agent_remove_authd(mock_ossec_socket):
     (True, False),
     (True, True),
 ])
+@patch('wazuh.core.agent.fcntl.lockf')
 @patch('wazuh.core.wdb.WazuhDBConnection.delete_agents_db')
 @patch('wazuh.core.agent.remove')
 @patch('wazuh.core.agent.rmtree')
-@patch('wazuh.core.agent.chown')
 @patch('wazuh.core.agent.chmod')
 @patch('wazuh.core.agent.stat')
 @patch("wazuh.common.ossec_path", new=test_data_path)
@@ -711,7 +711,7 @@ def test_agent_remove_authd(mock_ossec_socket):
 @patch('socket.socket.connect')
 def test_agent_remove_manual(socket_mock, run_wdb_mock, send_mock, grp_mock, pwd_mock, chmod_r_mock, makedirs_mock,
                              safe_move_mock, isdir_mock, isfile_mock, exists_mock, stat_mock, chmod_mock,
-                             chown_mock, rmtree_mock, remove_mock, mock_delete_agents, backup, exists_backup_dir):
+                             rmtree_mock, remove_mock, mock_delete_agents, lockf_mock, backup, exists_backup_dir):
     """Test the _remove_manual function
 
     Parameters
@@ -731,16 +731,15 @@ def test_agent_remove_manual(socket_mock, run_wdb_mock, send_mock, grp_mock, pwd
         Agent('001')._remove_manual(backup=backup)
 
         m.assert_any_call(common.client_keys)
-        m.assert_any_call(common.client_keys + '.tmp', 'w')
+        m.assert_any_call(common.client_keys + '.tmp', 'a')
         stat_mock.assert_called_once_with(common.client_keys)
-        chown_mock.assert_called_once_with(common.client_keys + '.tmp', common.ossec_uid(), common.ossec_gid())
         mock_delete_agents.assert_called_once_with(['001'])
         run_wdb_mock.assert_called_once_with('global sql DELETE FROM belongs WHERE id_agent = 001')
         remove_mock.assert_any_call(os.path.join(common.ossec_path, 'queue/rids/001'))
 
         # make sure the mock is called with a string according to a non-backup path
         exists_mock.assert_any_call('{0}/queue/agent-info/agent-1-any'.format(test_data_path))
-        safe_move_mock.assert_called_with(common.client_keys + '.tmp', common.client_keys, permissions=0o640)
+        safe_move_mock.assert_called_with(common.client_keys + '.tmp', common.client_keys, permissions=stat_mock().st_mode)
         if backup:
             if exists_backup_dir:
                 backup_path = os.path.join(common.backup_path, f'agents/1975/Jan/01/001-agent-1-any-002')
@@ -859,23 +858,20 @@ def test_agent_add_authd_ko(mock_ossec_socket, mocked_exception, expected_except
 
 
 @pytest.mark.parametrize("ip, id, key, force", [
-    ('192.168.0.0', '002', None, -1),
-    ('192.168.0.0/28', '002', None, -1),
-    ('any', '002', 'WMPlw93l2PnwQMN', -1),
+    ('192.168.0.0', '003', None, -1),
+    ('192.168.0.0/28', '004', None, -1),
+    ('any', None, 'WMPlw93l2PnwQMN', -1),
     ('any', '003', 'WMPlw93l2PnwQMN', 1),
 ])
 @patch('wazuh.core.agent.safe_move')
-@patch('wazuh.core.agent.copyfile')
 @patch('wazuh.common.ossec_uid')
 @patch('wazuh.common.ossec_gid')
-@patch('wazuh.core.agent.chown')
-@patch('wazuh.core.agent.chmod')
 @patch('wazuh.core.agent.stat')
 @patch('wazuh.core.agent.fcntl.lockf')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_agent_add_manual(socket_mock, mock_send, mock_lockf, mock_stat, mock_chmod, mock_chown, mock_ossec_gid,
-                          mosck_ossec_uid, mock_copyfile, mock_safe_move, ip, id, key, force):
+def test_agent_add_manual(socket_mock, mock_send, mock_lockf, mock_stat, mock_ossec_gid,
+                          mosck_ossec_uid, mock_safe_move, ip, id, key, force):
     """Tests if method _add_manual() works as expected"""
     key = 'MDAyIHdpbmRvd3MtYWdlbnQyIGFueSAzNDA2MjgyMjEwYmUwOWVlMWViNDAyZTYyODZmNWQ2OTE5' \
           'MjBkODNjNTVjZDE5N2YyMzk3NzA0YWRhNjg1YzQz'
@@ -886,14 +882,11 @@ def test_agent_add_manual(socket_mock, mock_send, mock_lockf, mock_stat, mock_ch
 
         agent._add_manual('test_agent', ip=ip, id=id, key=key, force=force)
 
-        assert agent.id == id, 'ID should has been updated.'
+        assert agent.id == id if id is not None else agent.id == '002', 'ID should has been updated.'
         calls = [call('global sql select count(*) from agent where (id = 0)'),
                  call('global sql select name from agent where (id = 0) limit 1 offset 0')]
 
         mock_send.assert_has_calls(calls)
-        mock_chown.assert_called_once_with('{0}.tmp'.format(common.client_keys), ANY, ANY)
-        mock_chmod.assert_called_once_with('{0}.tmp'.format(common.client_keys), ANY)
-        mock_copyfile.assert_called_once_with(common.client_keys, '{0}.tmp'.format(common.client_keys))
         mock_safe_move.assert_called_once_with('{0}.tmp'.format(common.client_keys), common.client_keys,
                                                permissions=ANY)
 
@@ -940,12 +933,14 @@ def test_agent_add_manual_ko(mock_lockf, mock_stat, mock_chmod, mock_chown, mock
                         agent = Agent(1)
                         agent._add_manual('test_agent', '192.168.0.1')
 
-                    with pytest.raises(WazuhError, match=".* 1725 .*"):
+                    # It used to raise 1725, now FileNotFoundError is captured at a higher level and then raises 1725
+                    with pytest.raises(FileNotFoundError):
                         agent._add_manual('test_agent', '172.19.0.100')
 
-                    with patch('wazuh.core.agent.Agent.remove') as mock_remove:
+                    # It used to raise 1725, now FileNotFoundError is captured at a higher level and then raises 1725
+                    with patch('wazuh.core.agent.Agent._remove_manual') as mock_remove:
                         # IP already exists and force
-                        with pytest.raises(WazuhError, match=".* 1725 .*"):
+                        with pytest.raises(FileNotFoundError):
                             agent = Agent(1)
                             agent._add_manual('test_agent', '192.168.0.1', force=0)
                         mock_remove.assert_called_once_with(backup=True)
@@ -2127,6 +2122,7 @@ def test_send_restart_command(mock_ossec_queue):
 
 def test_get_agents_info():
     """Test that get_agents_info() returns expected agent IDs"""
+    reset_context_cache()
     with open(os.path.join(test_data_path, 'client.keys')) as f:
         client_keys = ''.join(f.readlines())
 
@@ -2196,6 +2192,9 @@ def test_expand_group(group, expected_agents):
     ('001', 1747),
     ('001', 1748),
 ])
+@patch('wazuh.core.agent.Agent._acquire_client_keys_lock')
+@patch('wazuh.core.agent.safe_move')
+@patch('wazuh.core.agent.fcntl.lockf')
 @patch('wazuh.core.wdb.WazuhDBConnection.delete_agents_db')
 @patch('wazuh.core.agent.remove')
 @patch('wazuh.core.agent.rmtree')
@@ -2213,7 +2212,7 @@ def test_expand_group(group, expected_agents):
 @patch('socket.socket.connect')
 def test_agent_remove_manual_ko(socket_mock, send_mock, grp_mock, pwd_mock, chmod_r_mock, makedirs_mock,
                                 isdir_mock, stat_mock, chmod_mock, chown_mock, rmtree_mock, remove_mock, delete_mock,
-                                 agent_id, expected_exception):
+                                lockf_mock, mock_safe_move, acquire_mock, agent_id, expected_exception):
     """Test the _remove_manual function error cases.
 
     Parameters
@@ -2224,7 +2223,8 @@ def test_agent_remove_manual_ko(socket_mock, send_mock, grp_mock, pwd_mock, chmo
         Error code that is expected.
     """
     def check_exception(client_keys):
-        with patch('wazuh.core.agent.open', mock_open(read_data=client_keys)) as m:
+        with patch('wazuh.core.agent.open',
+                   mock_open(read_data=client_keys) if not isinstance(client_keys, Exception) else client_keys) as m:
             with pytest.raises(WazuhException, match=f".* {expected_exception} .*"):
                 Agent(agent_id)._remove_manual()
 
@@ -2240,12 +2240,14 @@ def test_agent_remove_manual_ko(socket_mock, send_mock, grp_mock, pwd_mock, chmo
 
     if expected_exception == 1747:
         check_exception(client_keys_text)
-    else:
+
+    if expected_exception == 1701:
         with patch('wazuh.core.wdb.WazuhDBConnection.run_wdb_command'):
             check_exception(client_keys_text)
 
     if expected_exception == 1746:
-        remove_mock.assert_any_call('{0}/etc/client.keys.tmp'.format(test_data_path))
+        with patch('wazuh.core.wdb.WazuhDBConnection.run_wdb_command'):
+            check_exception(Exception("Boom!"))
 
 
 @pytest.mark.parametrize('system_resources, permitted_resources, filters, expected_result', [

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -14,6 +14,7 @@ import pytest
 
 from api.util import remove_nones_to_dict
 from wazuh.core.exception import WazuhResourceNotFound
+from wazuh.core.common import reset_context_cache
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../..'))
 
@@ -309,7 +310,7 @@ def test_agent_delete_agents_different_status(socket_mock, send_mock):
 
 
 @pytest.mark.parametrize('name, agent_id, key', [
-    ('agent-1', '001', 'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f'),
+    ('agent-1', '011', 'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f'),
     ('a' * 129, '002', 'f304f582f2417a3fddad69d9ae2b4f3b6e6fda788229668af9a6934d454ef44d')
 ])
 @patch('wazuh.core.agent.fcntl.lockf')


### PR DESCRIPTION
Hello team,

We are adding the requested changes from the issue https://github.com/wazuh/wazuh/issues/6849 for `v4.0.4`. This mainly consists in a rebase/cherry pick from the development branch.

## Tests results
### Unit tests
#### Framework
```
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 22 items

wazuh/core/cluster/dapi/tests/test_dapi.py ......................        [100%]

======================= 22 passed, 11 warnings in 0.40s ========================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 19 items

wazuh/core/cluster/tests/test_cluster.py ...................             [100%]

============================== 19 passed in 0.10s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 7 items

wazuh/core/cluster/tests/test_common.py .......                          [100%]

============================== 7 passed in 0.10s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 5 items

wazuh/core/cluster/tests/test_control.py .....                           [100%]

============================== 5 passed in 0.10s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 1 item

wazuh/core/cluster/tests/test_local_client.py .                          [100%]

============================== 1 passed in 0.03s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 7 items

wazuh/core/cluster/tests/test_utils.py .......                           [100%]

============================== 7 passed in 0.04s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 16 items

wazuh/core/cluster/tests/test_worker.py ................                 [100%]

======================== 16 passed, 2 warnings in 0.29s ========================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 12 items

wazuh/core/tests/test_active_response.py ............                    [100%]

============================== 12 passed in 0.08s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 187 items

wazuh/core/tests/test_agent.py ......................................... [ 21%]
........................................................................ [ 60%]
........................................................................ [ 98%]
..                                                                       [100%]

======================= 187 passed, 11 warnings in 1.44s =======================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 33 items

wazuh/core/tests/test_cdb_list.py .................................      [100%]

============================== 33 passed in 0.07s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 7 items

wazuh/core/tests/test_common.py .......                                  [100%]

============================== 7 passed in 0.02s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 34 items

wazuh/core/tests/test_configuration.py ................................. [ 97%]
.                                                                        [100%]

============================== 34 passed in 0.14s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 15 items

wazuh/core/tests/test_decoder.py ...............                         [100%]

============================== 15 passed in 0.03s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 3 items

wazuh/core/tests/test_input_validator.py ...                             [100%]

============================== 3 passed in 0.02s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 30 items

wazuh/core/tests/test_manager.py ..............................          [100%]

============================== 30 passed in 0.15s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 19 items

wazuh/core/tests/test_ossec_queue.py ...................                 [100%]

============================== 19 passed in 0.05s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 6 items

wazuh/core/tests/test_pyDaemonModule.py ......                           [100%]

============================== 6 passed in 0.03s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 40 items

wazuh/core/tests/test_results.py ....................................... [ 97%]
.                                                                        [100%]

============================== 40 passed in 0.07s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 21 items

wazuh/core/tests/test_rule.py .....................                      [100%]

============================== 21 passed in 0.11s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 3 items

wazuh/core/tests/test_syscollector.py ...                                [100%]

============================== 3 passed in 0.08s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 204 items

wazuh/core/tests/test_utils.py ......................................... [ 20%]
........................................................................ [ 55%]
........................................................................ [ 90%]
...................                                                      [100%]

============================= 204 passed in 0.67s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 15 items

wazuh/core/tests/test_wazuh_socket.py ...............                    [100%]

============================== 15 passed in 0.05s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 21 items

wazuh/core/tests/test_wdb.py .....................                       [100%]

============================== 21 passed in 0.06s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 2 items

wazuh/rbac/tests/test_auth_context.py ..                                 [100%]

========================= 2 passed, 1 warning in 2.68s =========================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 105 items

wazuh/rbac/tests/test_decorators.py .................................... [ 34%]
.....................................................................    [100%]

======================== 105 passed in 77.57s (0:01:17) ========================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 47 items

wazuh/rbac/tests/test_default_configuration.py ......................... [ 53%]
......................                                                   [100%]

============================= 47 passed in 37.44s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 53 items

wazuh/rbac/tests/test_orm.py ........................................... [ 81%]
..........                                                               [100%]

============================= 53 passed in 41.90s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 11 items

wazuh/rbac/tests/test_preprocessor.py ...........                        [100%]

============================== 11 passed in 8.07s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 9 items

wazuh/tests/test_active_response.py .........                            [100%]

============================== 9 passed in 0.10s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 90 items

wazuh/tests/test_agent.py .............................................. [ 51%]
............................................                             [100%]

======================= 90 passed, 11 warnings in 2.95s ========================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 47 items

wazuh/tests/test_cdb_list.py ........................................... [ 91%]
....                                                                     [100%]

============================== 47 passed in 0.12s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 2 items

wazuh/tests/test_ciscat.py ..                                            [100%]

============================== 2 passed in 0.07s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 7 items

wazuh/tests/test_cluster.py .......                                      [100%]

============================== 7 passed in 0.09s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 31 items

wazuh/tests/test_decoders.py ...............................             [100%]

============================== 31 passed in 0.14s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 8 items

wazuh/tests/test_group.py ........                                       [100%]

============================== 8 passed in 0.09s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 38 items

wazuh/tests/test_manager.py ......................................       [100%]

============================== 38 passed in 0.32s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 180 items

wazuh/tests/test_mitre.py .............................................. [ 25%]
........................................................................ [ 65%]
..............................................................           [100%]

============================= 180 passed in 0.42s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 52 items

wazuh/tests/test_rule.py ............................................... [ 90%]
.....                                                                    [100%]

============================== 52 passed in 0.26s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 7 items

wazuh/tests/test_sca.py .......                                          [100%]

============================== 7 passed in 0.10s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 69 items

wazuh/tests/test_security.py ........................................... [ 62%]
..........................                                               [100%]

======================= 69 passed, 12 warnings in 49.22s =======================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 13 items

wazuh/tests/test_stats.py .............                                  [100%]

============================== 13 passed in 0.11s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 18 items

wazuh/tests/test_syscheck.py ..................                          [100%]

============================== 18 passed in 0.11s ==============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/framework
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 12 items

wazuh/tests/test_syscollector.py ............                            [100%]

============================== 12 passed in 0.11s ==============================
```

#### API
```
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 8 items

test/test_alogging.py ........                                           [100%]

========================= 8 passed, 1 warning in 0.09s =========================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 10 items

test/test_authentication.py ..........                                   [100%]

======================= 10 passed, 14 warnings in 0.40s ========================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 7 items

test/test_configuration.py .......                                       [100%]

============================== 7 passed in 0.23s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 35 items

test/test_util.py ...................................                    [100%]

======================= 35 passed, 12 warnings in 0.38s ========================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 171 items

test/test_validator.py ................................................. [ 28%]
........................................................................ [ 70%]
..................................................                       [100%]

======================= 171 passed, 2 warnings in 0.25s ========================

```

### Integration tests
```
test_agents_DELETE_endpoints.tavern.yaml 
	 7 passed, 9 warnings

test_agents_GET_endpoints.tavern.yaml 
	 90 passed, 97 warnings

test_agents_POST_endpoints.tavern.yaml 
	 5 passed, 7 warnings

test_agents_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings

test_rbac_black_agents_endpoints.tavern.yaml 
	 39 passed, 41 warnings

test_rbac_white_agents_endpoints.tavern.yaml 
	 39 passed, 41 warnings

```

Regards,
Víctor.