### PR TITLE
Add api security headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.0.4] 
 
-### Fixed
-
 ### Added
+- **API:**
+  - Added missing secure headers for API responses. ([#7024](https://github.com/wazuh/wazuh/issues/7024))
 
 ### Changed
+
+### Fixed
 
 ## [v4.0.3] - 2020-11-30
 

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -11,10 +11,14 @@ from aiohttp import web
 from aiohttp.web_exceptions import HTTPException
 from connexion.exceptions import ProblemException, OAuthProblem, Unauthorized
 from connexion.problem import problem as connexion_problem
+from secure import SecureHeaders
 
 from api.configuration import api_conf
 from api.util import raise_if_exc
 from wazuh.core.exception import WazuhTooManyRequests, WazuhPermissionError
+
+# API secure headers
+secure_headers = SecureHeaders(server="Wazuh", csp="none", xfo="DENY")
 
 logger = getLogger('wazuh')
 pool = concurrent.futures.ThreadPoolExecutor()
@@ -25,6 +29,13 @@ async def set_user_name(request, handler):
     if 'token_info' in request:
         request['user'] = request['token_info']['sub']
     return await handler(request)
+
+
+@web.middleware
+async def set_secure_headers(request, handler):
+    resp = await handler(request)
+    secure_headers.aiohttp(resp)
+    return resp
 
 
 ip_stats = dict()

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -41,7 +41,7 @@ def start(foreground, root, config_file):
     from api import validator
     from api.api_exception import APIError
     from api.constants import CONFIG_FILE_PATH
-    from api.middlewares import set_user_name, security_middleware, response_postprocessing
+    from api.middlewares import set_user_name, security_middleware, response_postprocessing, set_secure_headers
     from api.uri_parser import APIUriParser
     from api.util import to_relative_path
     from wazuh.core import pyDaemonModule
@@ -127,7 +127,8 @@ def start(foreground, root, config_file):
                 strict_validation=True,
                 validate_responses=False,
                 pass_context_arg_name='request',
-                options={"middlewares": [response_postprocessing, set_user_name, security_middleware]})
+                options={"middlewares": [response_postprocessing, set_user_name, security_middleware,
+                                         set_secure_headers]})
 
     # Enable CORS
     if api_conf['cors']['enabled']:

--- a/api/test/integration/env/configurations/security/manager/schema_security_test.sql
+++ b/api/test/integration/env/configurations/security/manager/schema_security_test.sql
@@ -71,7 +71,7 @@ INSERT INTO policies VALUES(4,'agents_read_agents','{"actions": ["agent:read"], 
 INSERT INTO policies VALUES(5,'agents_read_groups','{"actions": ["group:read"], "resources": ["group:id:*"], "effect": "allow"}','2020-06-16 14:34:31.668318');
 INSERT INTO policies VALUES(6,'agents_commands_agents','{"actions": ["active-response:command"], "resources": ["agent:id:*"], "effect": "allow"}','2020-06-16 14:34:31.676223');
 INSERT INTO policies VALUES(7,'security_all_resourceless','{"actions": ["security:create", "security:create_user", "security:read_config", "security:update_config", "security:revoke"], "resources": ["*:*:*"], "effect": "allow"}','2020-06-16 14:34:31.684085');
-INSERT INTO policies VALUES(8,'security_all_security','{"actions": ["security:read", "security:update", "security:delete"], "resources": ["role:id:*", "policy:id:*", "user:id:*"], "effect": "allow"}','2020-06-16 14:34:31.691953');
+INSERT INTO policies VALUES(8,'security_all_security','{"actions": ["security:read", "security:update", "security:delete"], "resources": ["role:id:*", "rule:id:*", "policy:id:*", "user:id:*"], "effect": "allow"}','2020-06-16 14:34:31.691953');
 INSERT INTO policies VALUES(9,'users_all_resourceless','{"actions": ["security:create_user", "security:revoke"], "resources": ["*:*:*"], "effect": "allow"}','2020-06-16 14:34:31.699822');
 INSERT INTO policies VALUES(10,'users_all_users','{"actions": ["security:read", "security:update", "security:delete"], "resources": ["user:id:*"], "effect": "allow"}','2020-06-16 14:34:31.707888');
 INSERT INTO policies VALUES(11,'ciscat_read_ciscat','{"actions": ["ciscat:read"], "resources": ["agent:id:*"], "effect": "allow"}','2020-06-16 14:34:31.716023');

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -50,6 +50,7 @@ pytz==2020.1
 requests==2.23.0
 rsa==4.0
 s3transfer==0.3.3
+secure==0.2.1
 setuptools==46.1.3
 six==1.14.0
 SQLAlchemy==1.3.11


### PR DESCRIPTION
|Related issue|
|---|
|#7024|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

As we stated in issue #7024, we did not follow the recommended security standard regarding the headers of the API responses. This PR closes #7024. In this PR he have added missing secure headers for API responses.

```
adriiiprodri@wazuh curl -k -u wazuh:wazuh -D- https://localhost:55040/security/user/authenticate
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Server: Wazuh
Strict-Transport-Security: max-age=63072000; includeSubdomains
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Security-Policy: none
Referrer-Policy: no-referrer, strict-origin-when-cross-origin
Pragma: no-cache
Expires: 0
Cache-control: no-cache, no-store, must-revalidate, max-age=0
Content-Length: 300
Date: Thu, 24 Dec 2020 10:01:02 GMT

{"data": {"token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjA4ODA0MDYyLCJleHAiOjE2MDg4MDc2NjIsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.ffBh2wmdPEIGjNWTxPIRFIJ1gI_zaqgoqffQwjsUH4o"}, "error": 0}
```

## Tests

```
adriiiprodri@wazuh python3 run_tests.py -k security -rbac no
Collected tests [4]:
test_security_DELETE_endpoints.tavern.yaml, test_security_GET_endpoints.tavern.yaml, test_security_POST_endpoints.tavern.yaml, test_security_PUT_endpoints.tavern.yaml


test_security_DELETE_endpoints.tavern.yaml 
         15 passed, 17 warnings

test_security_GET_endpoints.tavern.yaml 
         18 passed, 20 warnings

test_security_POST_endpoints.tavern.yaml 
         6 passed, 8 warnings

test_security_PUT_endpoints.tavern.yaml 
         8 passed, 10 warnings
```
