### PR TITLE
Fix gcc 4.4.7 warning + old logcollector coverity

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -2253,7 +2253,10 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
                         mdebug1(OPEN_UNABLE, current->file);
                     }
 
-                    clearerr(current->fp);
+                    if (current->fp) {
+                        clearerr(current->fp);
+                    }
+
                     w_mutex_unlock(&current->mutex);
                 }
             }

--- a/src/shared/labels_op.c
+++ b/src/shared/labels_op.c
@@ -98,7 +98,7 @@ wlabel_t* labels_parse(cJSON *json_labels) {
     cJSON *json_key = NULL;
     cJSON *json_value = NULL;
     wlabel_t *labels = NULL;
-    label_flags_t flags = {0};
+    label_flags_t flags = {.hidden = 0};
     size_t size = 0;
 
     if (json_labels && json_labels->child) {

--- a/src/shared/remoted_op.c
+++ b/src/shared/remoted_op.c
@@ -47,7 +47,7 @@ void parse_uname_string (char *uname,
                          os_data *osd)
 {
     char *str_tmp = NULL;
-    regmatch_t match[2] = { 0 };
+    regmatch_t match[2] = {{.rm_so = 0}};
     int match_size = 0;
 
     if (!osd)

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.c
@@ -238,7 +238,10 @@ STATIC bool wm_upgrade_agent_search_upgrade_result(int *queue_fd) {
 
     FILE *result_file = fopen(PATH, "r");
     if (result_file) {
-        fgets(buffer, 20, result_file);
+        if (fgets(buffer, 20, result_file) == NULL) {
+            fclose(result_file);
+            return true;
+        }
         fclose(result_file);
 
         wm_upgrade_agent_state state;

--- a/src/wazuh_modules/wm_gcp.c
+++ b/src/wazuh_modules/wm_gcp.c
@@ -159,7 +159,7 @@ void wm_gcp_run(const wm_gcp *data) {
     }
 
     char *line;
-    char *save_ptr;
+    char *save_ptr = NULL;
 
     for (line = strtok_r(output, "\n", &save_ptr); line; line = strtok_r(NULL, "\n", &save_ptr)) {
         switch (data->logging) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/7140|

Hi Team,

This PR fixes the following 2 warnings that occur when compiling with gcc 4.4.7. They could be easily checked when building the rpm with Wazuh-Package.
Also fixes a null reference error discovered in logcollector by coverity.

```
    CC shared/pthreads_op.o
shared/labels_op.c: In function 'labels_parse':
shared/labels_op.c:101: warning: missing initializer
shared/labels_op.c:101: warning: (near initialization for 'flags.system')
    CC shared/queue_linked_op.o
```
```
    CC shared/utf8_op.o
    CC shared/validate_op.o
    CC shared/vector_op.o
shared/remoted_op.c: In function 'parse_uname_string':
shared/remoted_op.c:50: warning: missing braces around initializer
shared/remoted_op.c:50: warning: (near initialization for 'match[0]')
shared/remoted_op.c:50: warning: missing initializer
shared/remoted_op.c:50: warning: (near initialization for 'match[0].rm_eo')
    CC shared/version_op.o
    CC shared/wait_op.o
    CC shared/wazuhdb_op.o
```

## Update
This PR also fixes the following warnings in ubuntu 16 (gcc 5.4.0) on agent build in release mode

```
    CC wazuh_modules/wmodules.o
In file included from ./headers/shared.h:220:0,
                 from wazuh_modules/wmodules.h:19,
                 from wazuh_modules/wm_gcp.c:12:
wazuh_modules/wm_gcp.c: In function ‘wm_gcp_main’:
./headers/debug_op.h:41:33: warning: ‘save_ptr’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 #define mtdebug1(tag, msg, ...) _mtdebug1(tag, __FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
                                 ^
wazuh_modules/wm_gcp.c:162:11: note: ‘save_ptr’ was declared here
     char *save_ptr;
           ^
```

```
    CC wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.o
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.c: In function ‘wm_upgrade_agent_search_upgrade_result’:
wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.c:241:9: warning: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Wunused-result]
         fgets(buffer, 20, result_file);
         ^

```

Regards,
Julian

## Tests


- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [ ] MAC OS X
- [X] Source installation
- [x] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] ~Review logs syntax and correct language~
- [x] ~QA templates contemplate the added capabilities~

- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] ~Dr. Memory~
  - [x] ~AddressSanitizer~
- Memory tests for Windows
  - [x] ~Scan-build report~
  - [ ] Coverity
  - [x] ~Dr. Memory~
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer
