### PR TITLE
Specify minimum required daemons for each endpoint.

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -49,7 +49,8 @@ async def delete_agents(request, pretty=False, wait_for_complete=False, agents_l
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-modulesd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -112,7 +113,8 @@ async def get_agents(request, pretty=False, wait_for_complete=False, agents_list
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -138,7 +140,8 @@ async def add_agent(request, pretty=False, wait_for_complete=False):
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-modulesd', 'wazuh-db']
                           )
 
     data = raise_if_exc(await dapi.distribute_function())
@@ -163,7 +166,8 @@ async def restart_agents(request, pretty=False, wait_for_complete=False, agents_
                           wait_for_complete=wait_for_complete,
                           rbac_permissions=request['token_info']['rbac_policies'],
                           broadcasting=agents_list == '*',
-                          logger=logger
+                          logger=logger,
+                          basic_services=['wazuh-db', 'wazuh-remoted', 'wazuh-modulesd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -197,7 +201,8 @@ async def restart_agents_by_node(request, node_id, pretty=False, wait_for_comple
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
-                          nodes=nodes
+                          nodes=nodes,
+                          basic_services=['wazuh-clusterd', 'wazuh-db', 'wazuh-remoted', 'wazuh-modulesd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -228,7 +233,8 @@ async def get_agent_config(request, pretty=False, wait_for_complete=False, agent
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-remoted']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -256,7 +262,8 @@ async def delete_single_agent_multiple_groups(request, agent_id, groups_list=Non
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-modulesd']
                           )
 
     data = raise_if_exc(await dapi.distribute_function())
@@ -283,7 +290,8 @@ async def get_sync_agent(request, agent_id, pretty=False, wait_for_complete=Fals
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -311,7 +319,7 @@ async def delete_single_agent_single_group(request, agent_id, group_id, pretty=F
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -362,7 +370,8 @@ async def get_agent_key(request, agent_id, pretty=False, wait_for_complete=False
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db'],
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -385,7 +394,8 @@ async def restart_agent(request, agent_id, pretty=False, wait_for_complete=False
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-remoted']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -430,7 +440,8 @@ async def put_upgrade_agents(request, agents_list=None, pretty=False, wait_for_c
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-remoted', 'wazuh-modulesd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -469,7 +480,8 @@ async def put_upgrade_custom_agents(request, agents_list=None, pretty=False, wai
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-remoted', 'wazuh-modulesd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -502,7 +514,8 @@ async def get_component_stats(request, pretty=False, wait_for_complete=False, ag
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-remoted', 'wazuh-modulesd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -534,7 +547,8 @@ async def get_agent_upgrade(request, agents_list=None, pretty=False, wait_for_co
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-modulesd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -615,7 +629,8 @@ async def put_multiple_agent_single_group(request, group_id, agents_list=None, p
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-modulesd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -640,7 +655,8 @@ async def delete_groups(request, groups_list=None, pretty=False, wait_for_comple
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -718,7 +734,8 @@ async def get_agents_in_group(request, group_id, pretty=False, wait_for_complete
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
 
     data = raise_if_exc(await dapi.distribute_function())
@@ -750,7 +767,8 @@ async def post_group(request, pretty=False, wait_for_complete=False):
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-modulesd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -924,7 +942,8 @@ async def restart_agents_by_group(request, group_id, pretty=False, wait_for_comp
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-remoted', 'wazuh-modulesd']
                           )
 
     data = raise_if_exc(await dapi.distribute_function())
@@ -951,7 +970,8 @@ async def insert_agent(request, pretty=False, wait_for_complete=False):
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-modulesd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -986,7 +1006,8 @@ async def get_agent_no_group(request, pretty=False, wait_for_complete=False, off
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -1019,7 +1040,8 @@ async def get_agent_outdated(request, pretty=False, wait_for_complete=False, off
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -1059,7 +1081,8 @@ async def get_agent_fields(request, pretty=False, wait_for_complete=False, field
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -1088,7 +1111,8 @@ async def get_agent_summary_status(request, pretty=False, wait_for_complete=Fals
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -1117,7 +1141,8 @@ async def get_agent_summary_os(request, pretty=False, wait_for_complete=False):
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/ciscat_controller.py
+++ b/api/api/controllers/ciscat_controller.py
@@ -69,7 +69,8 @@ async def get_agents_ciscat_results(request, agent_id: str, pretty: bool = False
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     response = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -110,7 +110,8 @@ async def get_healthcheck(request, pretty=False, wait_for_complete=False, nodes_
                           logger=logger,
                           local_client_arg='lc',
                           rbac_permissions=request['token_info']['rbac_policies'],
-                          nodes=nodes
+                          nodes=nodes,
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -342,7 +343,8 @@ async def get_stats_analysisd_node(request, node_id, pretty=False, wait_for_comp
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
-                          nodes=nodes
+                          nodes=nodes,
+                          basic_services=['wazuh-analysisd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -367,7 +369,8 @@ async def get_stats_remoted_node(request, node_id, pretty=False, wait_for_comple
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
-                          nodes=nodes
+                          nodes=nodes,
+                          basic_services=['wazuh-remoted']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -572,7 +575,8 @@ async def put_restart(request, pretty=False, wait_for_complete=False, nodes_list
                           logger=logger,
                           broadcasting=nodes_list == '*',
                           rbac_permissions=request['token_info']['rbac_policies'],
-                          nodes=nodes
+                          nodes=nodes,
+                          basic_services=['wazuh-execd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -598,7 +602,8 @@ async def get_conf_validation(request, pretty=False, wait_for_complete=False, no
                           logger=logger,
                           broadcasting=nodes_list == '*',
                           rbac_permissions=request['token_info']['rbac_policies'],
-                          nodes=nodes
+                          nodes=nodes,
+                          basic_services=['wazuh-execd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -626,7 +631,8 @@ async def get_node_config(request, node_id, component, wait_for_complete=False, 
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           rbac_permissions=request['token_info']['rbac_policies'],
-                          nodes=nodes
+                          nodes=nodes,
+                          basic_services=['wazuh-execd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/experimental_controller.py
+++ b/api/api/controllers/experimental_controller.py
@@ -50,7 +50,8 @@ async def clear_syscheck_database(request, pretty=False, wait_for_complete=False
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -106,7 +107,8 @@ async def get_cis_cat_results(request, pretty=False, wait_for_complete=False, ag
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -154,7 +156,8 @@ async def get_hardware_info(request, pretty=False, wait_for_complete=False, agen
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -206,7 +209,8 @@ async def get_network_address_info(request, pretty=False, wait_for_complete=Fals
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -261,7 +265,8 @@ async def get_network_interface_info(request, pretty=False, wait_for_complete=Fa
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -310,7 +315,8 @@ async def get_network_protocol_info(request, pretty=False, wait_for_complete=Fal
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -362,7 +368,8 @@ async def get_os_info(request, pretty=False, wait_for_complete=False, agents_lis
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -413,7 +420,8 @@ async def get_packages_info(request, pretty=False, wait_for_complete=False, agen
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -471,7 +479,8 @@ async def get_ports_info(request, pretty=False, wait_for_complete=False, agents_
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -542,7 +551,8 @@ async def get_processes_info(request, pretty=False, wait_for_complete=False, age
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -584,7 +594,8 @@ async def get_hotfixes_info(request, pretty=False, wait_for_complete=False, agen
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/logtest_controller.py
+++ b/api/api/controllers/logtest_controller.py
@@ -39,7 +39,8 @@ async def run_logtest_tool(request, pretty: bool = False, wait_for_complete: boo
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-analysisd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -70,7 +71,8 @@ async def end_logtest_session(request, pretty: bool = False, wait_for_complete: 
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-analysisd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -374,7 +374,8 @@ async def put_restart(request, pretty=False, wait_for_complete=False):
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-execd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -175,7 +175,8 @@ async def get_stats_analysisd(request, pretty=False, wait_for_complete=False):
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-analysisd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -196,7 +197,8 @@ async def get_stats_remoted(request, pretty=False, wait_for_complete=False):
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-remoted']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -417,7 +419,8 @@ async def get_manager_config_ondemand(request, component, pretty=False, wait_for
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-execd']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/mitre_controller.py
+++ b/api/api/controllers/mitre_controller.py
@@ -48,7 +48,8 @@ async def get_attack(request, pretty=False, wait_for_complete=False, offset=0, l
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/overview_controller.py
+++ b/api/api/controllers/overview_controller.py
@@ -29,7 +29,8 @@ async def get_overview_agents(request, pretty=False, wait_for_complete=False):
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/rootcheck_controller.py
+++ b/api/api/controllers/rootcheck_controller.py
@@ -35,7 +35,8 @@ async def put_rootcheck(request, pretty=False, wait_for_complete=False, agents_l
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-remoted']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -63,7 +64,8 @@ async def delete_rootcheck(request, pretty=False, wait_for_complete=False, agent
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -126,7 +128,8 @@ async def get_rootcheck_agent(request, pretty=False, wait_for_complete=False, ag
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -153,7 +156,8 @@ async def get_last_scan_agent(request, pretty=False, wait_for_complete=False, ag
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/sca_controller.py
+++ b/api/api/controllers/sca_controller.py
@@ -66,7 +66,8 @@ async def get_sca_agent(request, agent_id=None, pretty=False, wait_for_complete=
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -162,7 +163,8 @@ async def get_sca_checks(request, agent_id=None, pretty=False, wait_for_complete
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/syscheck_controller.py
+++ b/api/api/controllers/syscheck_controller.py
@@ -40,7 +40,8 @@ async def put_syscheck(request, agents_list='*', pretty=False, wait_for_complete
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           broadcasting=agents_list == '*',
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db', 'wazuh-remoted']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -111,7 +112,8 @@ async def get_syscheck_agent(request, agent_id, pretty=False, wait_for_complete=
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -143,7 +145,8 @@ async def delete_syscheck_agent(request, agent_id='*', pretty=False, wait_for_co
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -175,7 +178,8 @@ async def get_last_scan_agent(request, agent_id, pretty=False, wait_for_complete
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/syscollector_controller.py
+++ b/api/api/controllers/syscollector_controller.py
@@ -32,7 +32,8 @@ async def get_hardware_info(request, agent_id, pretty=False, wait_for_complete=F
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -75,7 +76,8 @@ async def get_hotfix_info(request, agent_id, pretty=False, wait_for_complete=Fal
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -126,7 +128,8 @@ async def get_network_address_info(request, agent_id, pretty=False, wait_for_com
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -180,7 +183,8 @@ async def get_network_interface_info(request, agent_id, pretty=False, wait_for_c
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -227,7 +231,8 @@ async def get_network_protocol_info(request, agent_id, pretty=False, wait_for_co
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -253,7 +258,8 @@ async def get_os_info(request, agent_id, pretty=False, wait_for_complete=False, 
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -302,7 +308,8 @@ async def get_packages_info(request, agent_id, pretty=False, wait_for_complete=F
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -357,7 +364,8 @@ async def get_ports_info(request, agent_id, pretty=False, wait_for_complete=Fals
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -427,7 +435,8 @@ async def get_processes_info(request, agent_id, pretty=False, wait_for_complete=
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          rbac_permissions=request['token_info']['rbac_policies']
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          basic_services=['wazuh-db']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -36,7 +36,7 @@ class DistributedAPI:
     def __init__(self, f: Callable, logger: logging.getLogger, f_kwargs: Dict = None, node: c_common.Handler = None,
                  debug: bool = False, request_type: str = 'local_master', current_user: str = '',
                  wait_for_complete: bool = False, from_cluster: bool = False, is_async: bool = False,
-                 broadcasting: bool = False, basic_services: tuple = None, local_client_arg: str = None,
+                 broadcasting: bool = False, basic_services = None, local_client_arg: str = None,
                  rbac_permissions: Dict = None, nodes: list = None):
         """Class constructor.
 
@@ -89,13 +89,10 @@ class DistributedAPI:
         self.rbac_permissions = rbac_permissions if rbac_permissions is not None else {'rbac_mode': 'black'}
         self.current_user = current_user
         self.nodes = nodes if nodes is not None else list()
-        if not basic_services:
-            self.basic_services = ('wazuh-modulesd', 'wazuh-analysisd', 'wazuh-execd', 'wazuh-db')
-            if common.install_type != "local":
-                self.basic_services += ('wazuh-remoted',)
+        if basic_services is None:
+            self.basic_services = []
         else:
             self.basic_services = basic_services
-
         self.local_clients = []
         self.local_client_arg = local_client_arg
         self.threadpool = ThreadPoolExecutor(max_workers=1)

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -139,7 +139,7 @@ def test_DistributedAPI_distribute_function_mock_solver(cluster_status_mock, api
 def test_DistributedAPI_distribute_function_exception():
     """Test distribute_function when an exception is raised.
     """
-    dapi_kwargs = {'f': manager.restart, 'logger': logger}
+    dapi_kwargs = {'f': manager.restart, 'logger': logger, 'basic_services': ['wazuh-execd']}
     raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=1017)
 
 


### PR DESCRIPTION
|Related issue|
|---|
|This PR closes #6860 |

## Description

Hello team!

This PR modifies the current restriction whereby the API fails when one of the services specified here is missing:
https://github.com/wazuh/wazuh/blob/1a913d4031345d56d8500202eb7495d0c3182f56/framework/wazuh/core/cluster/dapi/dapi.py#L92-L97

The problem with this very generic list is that many endpoints don't really need all of these services, even none at all. On the other hand, there are endpoints that need some services other than those that appear there.

One solution is to remove the list of essential services, so that it is taken for granted that if an endpoint fails, it is because some necessary service is not running. However, this has some disadvantages:

- The error shown is very generic, and it can lead many users to think that there is a more complex problem than the one that really exists when, for some reason, they do not have any of the necessary services running.
```JSON
{
  "title": "Wazuh Internal Error",
  "detail": "Wazuh Internal Error",
  "remediation": "Please, check `WAZUH_HOME/logs/ossec.log`, `WAZUH_HOME/logs/cluster.log` and `WAZUH_HOME/logs/api.log` to get more information about the error",
  "dapi_errors": {
    "master-node": {
      "error": "Wazuh Internal Error. See log for more detail",
      "logfile": "WAZUH_HOME/logs/api.log"
    }
  },
  "error": 1000
}
```

- In certain cases, if an exception is not generated when the necessary service is not available, long waits and timeouts can occur. An example is the endpoint `GET /cluster/healthcheck`.
- When not all required services are running, the action after running an endpoint seems to be correctly executed. However, in some cases maybe said action is not completed. It could happen for example with the endpoint `POST /agents`. If only the `wazuh-db` service is running when executing the endpoint, no errors will be shown. However, the agent won't be saved into the database since the `wazuh-modulesd` service is required for said action (read the client.keys and update the database accordingly).

## Solution
So the proposed solution has consisted of specifying the necessary services for each endpoint. This way, endpoints that do not require any additional services can be used even with Wazuh turned off, and the errors will be more specific in cases where a key service is missing for a specific endpoint.
```JSON
{
  "title": "Bad Request",
  "detail": "Some Wazuh daemons are not ready yet in node \"master-node\" (wazuh-db->failed)",
  "dapi_errors": {
    "master-node": {
      "error": "Some Wazuh daemons are not ready yet in node \"master-node\" (wazuh-db->failed)"
    }
  },
  "error": 1017
}
```

## Special cases
In those controllers where `distributed_master` is used but wazuh-db is not running, an error explaining that `wdb` socket is not created will show up even if the wazuh-db service is specified as a basic_service.

Best regards,
Selu.