### PR TITLE
Add API integration test mapping check to API/framework issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-framework.md
+++ b/.github/ISSUE_TEMPLATE/api-framework.md
@@ -32,7 +32,9 @@ Please fill the table above. Feel free to extend it at your convenience.
 - API tavern integration tests without failures. Updated and/or expanded if needed (`api/test/integration/`):
   - [ ] Affected tests 
   - [ ] Affected RBAC (black and white) tests
+- [ ] Review integration test mapping using the script (`api/test/integration/mapping/integration_test_api_endpoints.json`)
 - [ ] Review of spec.yaml examples and schemas (`api/api/spec/spec.yaml`)
+- [ ] Review exceptions remediation when any endpoint path changes or is removed (`framework/wazuh/core/exception.py`)
 - [ ] Changelog (`CHANGELOG.md`)
 <!-- If changes are made to any of the following components, uncomment the corresponding line 
 - [ ] **Integration tests** without failures for API configuration (`/wazuh-qa/tests/integration/test_api/test_config/`)


### PR DESCRIPTION
Hello team,
this closes #7144 .

As requested, the API/framework issue template has been updated to include a check for the API integration mapping file. It should be reviewed when adding, renaming or deleting framework and API files or tests.

This will be the new template:

![image](https://user-images.githubusercontent.com/37274979/104345695-eed07f80-54fe-11eb-9f30-9f3ec4e0db86.png)

Regards,
Víctor.