### PR TITLE
Modify analysisd scripts to receive wazuh_home as parameter

### DIFF
--- a/ruleset/testing/runtests.py
+++ b/ruleset/testing/runtests.py
@@ -27,19 +27,23 @@ class MultiOrderedDict(OrderedDict):
             super(MultiOrderedDict, self).__setitem__(key, value)
 
 
-def getOssecConfig(initconf, path):
-    if os.path.isfile(path):
-        with open(path) as f:
-            for line in f.readlines():
-                key, value = line.rstrip("\n").split("=")
-                initconf[key] = value.replace("\"", "")
-        if initconf["NAME"] != "Wazuh" or not os.path.exists(initconf["DIRECTORY"]):
-            print "Seems like there is no correct Wazuh installation "
-            sys.exit(1)
-    else:
-        print "Seems like there is no Wazuh installation or ossec-init.conf is missing."
-        sys.exit(1)
+def getOssecConfig(wazuh_home):   
+    wazuh_control = os.path.join(wazuh_home, "bin/wazuh-control") 
+    wazuh_env_vars = {}
+    try:
+        proc = subprocess.Popen([wazuh_control, "info"], stdout=subprocess.PIPE)
+        (stdout, stderr) = proc.communicate() 
+    except:
+        print "Seems like there is no Wazuh installation."
+        return None
 
+    env_variables=stdout.rsplit("\n")
+    env_variables.remove("")
+    for env_variable in env_variables:
+        key, value = env_variable.split("=")
+        wazuh_env_vars[key] = value.replace("\"", "")
+    
+    return wazuh_env_vars
 
 def provisionDR():
     base_dir = os.path.dirname(os.path.realpath(__file__))
@@ -49,16 +53,16 @@ def provisionDR():
     for file in os.listdir(rules_dir):
         file_fullpath = os.path.join(rules_dir, file)
         if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?)_rules.xml$',file):
-            shutil.copy2(file_fullpath , ossec_init["DIRECTORY"] + "/etc/rules")
+            shutil.copy2(file_fullpath , args.wazuh_home + "/etc/rules")
 
     for file in os.listdir(decoders_dir):
         file_fullpath = os.path.join(decoders_dir, file)
         if os.path.isfile(file_fullpath) and re.match(r'^test_(.*?)_decoders.xml$',file):
-            shutil.copy2(file_fullpath , ossec_init["DIRECTORY"] + "/etc/decoders")
+            shutil.copy2(file_fullpath , args.wazuh_home + "/etc/decoders")
 
 def cleanDR():
-    rules_dir = ossec_init["DIRECTORY"] + "/etc/rules"
-    decoders_dir = ossec_init["DIRECTORY"] + "/etc/decoders"
+    rules_dir = args.wazuh_home + "/etc/rules"
+    decoders_dir = args.wazuh_home + "/etc/decoders"
 
     for file in os.listdir(rules_dir):
         file_fullpath = os.path.join(rules_dir, file)
@@ -155,6 +159,8 @@ def cleanup(*args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='This script tests Wazuh rules.')
+    parser.add_argument('--path', '-p', required=True, dest='wazuh_home',
+                        help='Use -p or --path to specify Wazuh installation path (required)')
     parser.add_argument('--geoip', '-g', action='store_true', dest='geoip',
                         help='Use -g or --geoip to enable geoip tests (default: False)')
     parser.add_argument('--testfile', '-t', action='store', type=str, dest='testfile',
@@ -167,15 +173,17 @@ if __name__ == "__main__":
         selective_test = args.testfile
         if not selective_test.endswith('.ini'):
             selective_test += '.ini'
-    ossec_init = {}
-    initconfigpath = "/etc/ossec-init.conf"
-    getOssecConfig(ossec_init, initconfigpath)
+    
+    wazuh_config = getOssecConfig(args.wazuh_home)
+    if wazuh_config is None:
+        sys.exit(1)
+
     for sig in (signal.SIGABRT, signal.SIGINT, signal.SIGTERM):
         signal.signal(sig, cleanup)
     if args.custom:
         provisionDR()
         restart_analysisd()
-    OT = OssecTester(ossec_init["DIRECTORY"])
+    OT = OssecTester(args.wazuh_home)
     error = OT.run(selective_test, args.geoip, args.custom)
     if args.custom:
         cleanDR()

--- a/src/analysisd/compiled_rules/register_rule.sh
+++ b/src/analysisd/compiled_rules/register_rule.sh
@@ -33,30 +33,32 @@ if [ "x$1" = "xlist" ]; then
     exit 0;
 
 elif [ "x$1" = "xsave" ]; then
-    ls -la /etc/ossec-init.conf > /dev/null 2>&1
-    if [ ! $? = 0 ]; then
-        echo "ERROR: Unable to save rules. You must have OSSEC installed to do so."
+    if [ "X${2}" = "X" ]; then
+        echo "ERROR: You must specify the installation path. i.e.: ${0} $1 WAZUH_HOME"
+        exit 1;
+    fi    
+    WAZUH_HOME=${2}
+
+    eval $(${WAZUH_HOME}/bin/wazuh-control info 2>/dev/null)    
+    if [ "X$WAZUH_TYPE" = "X" ]; then
+        echo "ERROR: Unable to save rules. You must have Wazuh installed to do so."
+        exit 1;
+    fi
+    if [ "$WAZUH_TYPE" = "agent" ]; then
+        echo "ERROR: You must execute this script on Wazuh Manager"
         exit 1;
     fi
 
-    cat /etc/ossec-init.conf > /dev/null 2>&1
+    ls ${WAZUH_HOME}/compiled_rules > /dev/null 2>&1
     if [ ! $? = 0 ]; then
-        echo "ERROR: Unable to save rules. You must be root to do so."
-        exit 1;
-    fi
-
-    . /etc/ossec-init.conf
-
-    ls ${DIRECTORY}/compiled_rules > /dev/null 2>&1
-    if [ ! $? = 0 ]; then
-        mkdir ${DIRECTORY}/compiled_rules > /dev/null 2>&1
+        mkdir ${WAZUH_HOME}/compiled_rules > /dev/null 2>&1
         if [ ! $? = 0 ]; then
             echo "ERROR: Unable to save rules. You must be root to do so."
             exit 1;
         fi
     fi
 
-    cp .function_list ${DIRECTORY}/compiled_rules/function_list > /dev/null 2>&1
+    cp .function_list ${WAZUH_HOME}/compiled_rules/function_list > /dev/null 2>&1
     if [ ! $? = 0 ]; then
         echo "ERROR: Unable to save rules. You must be root to do so."
         exit 1;
@@ -64,46 +66,47 @@ elif [ "x$1" = "xsave" ]; then
 
     for i in `ls *.c`; do
         if [ ! "x$i" = "xgeneric_samples.c" ]; then
-            cp $i ${DIRECTORY}/compiled_rules/ > /dev/null 2>&1
+            cp $i ${WAZUH_HOME}/compiled_rules/ > /dev/null 2>&1
         fi
     done
-    echo "*Save completed at ${DIRECTORY}/compiled_rules/";
+    echo "*Save completed at ${WAZUH_HOME}/compiled_rules/";
     exit 0;
 
 elif [ "x$1" = "xrestore" ]; then
-
-    ls -la /etc/ossec-init.conf > /dev/null 2>&1
-    if [ ! $? = 0 ]; then
-        echo "ERROR: Unable to restore rules. You must have OSSEC installed to do so."
+    if [ "X${2}" = "X" ]; then
+        echo "ERROR: You must specify the installation path. i.e.: ${0} $1 WAZUH_HOME"
+        exit 1;
+    fi    
+    WAZUH_HOME=${2}
+    
+    eval $(${WAZUH_HOME}/bin/wazuh-control info 2>/dev/null)    
+    if [ "X$WAZUH_TYPE" = "X" ]; then
+        echo "ERROR: Unable to save rules. You must have Wazuh installed to do so."
+        exit 1;
+    fi
+    if [ "$WAZUH_TYPE" = "agent" ]; then
+        echo "ERROR: You must execute this script on Wazuh Manager"
         exit 1;
     fi
 
-    cat /etc/ossec-init.conf > /dev/null 2>&1
-    if [ ! $? = 0 ]; then
-        echo "ERROR: Unable to restore rules. You must be root to do so."
-        exit 1;
-    fi
-
-    . /etc/ossec-init.conf
-
-    ls ${DIRECTORY}/compiled_rules/function_list > /dev/null 2>&1
+    ls ${WAZUH_HOME}/compiled_rules/function_list > /dev/null 2>&1
     if [ ! $? = 0 ]; then
         echo "*No local compiled rules available to restore."
         exit 0;
     fi
 
-    cat  ${DIRECTORY}/compiled_rules/function_list >> .function_list
+    cat  ${WAZUH_HOME}/compiled_rules/function_list >> .function_list
     if [ ! $? = 0 ]; then
         echo "ERROR: Unable to restore rules. Function list not present."
         exit 1;
     fi
 
-    for i in `ls ${DIRECTORY}/compiled_rules/*.c`; do
+    for i in `ls ${WAZUH_HOME}/compiled_rules/*.c`; do
         if [ ! "x$i" = "xgeneric_samples.c" ]; then
             cp $i ./ > /dev/null 2>&1
         fi
     done
-    echo "*Restore completed from ${DIRECTORY}/compiled_rules/";
+    echo "*Restore completed from ${WAZUH_HOME}/compiled_rules/";
     exit 0;
 
 elif [ "x$1" = "xbuild" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|7084|

## Description
This PR modifies the analysisd scripts to create environment variables with **wazuh-control** instead of **ossec-init.conf**, and receive **wazuh_home** as a parameter.
To do so:
- **runtests.py** receives the path of Wazuh installation and loads the environment variable from **wazuh-control**
- **runtests.py** parameters parsing is expanded with **-p** (**--path**) option to select Wazuh installation path. **wazuh-control** is executed to check if there is a valid Wazuh installtion. 

<!-- Minimum checks required -->
- Manual test of the scripts with different options
  - [X] **ossec-eps.sh**
  - [X] **util.sh** 