### PR TITLE
Modify kaspersky scripts to use its relative path to find Wazuh installation path

### DIFF
--- a/active-response/kaspersky.py
+++ b/active-response/kaspersky.py
@@ -24,8 +24,7 @@ from socket import socket, AF_UNIX, SOCK_DGRAM
 ##################################################################################################################
 # Sets the file paths
 ##################################################################################################################
-
-wazuh_path = open('/etc/ossec-init.conf').readline().split('"')[1]
+wazuh_path = os.path.abspath(os.path.join(__file__, "../../.."))
 wazuh_queue = '{0}/queue/ossec/queue'.format(wazuh_path)
 now = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 ar_log_file = '{0}/logs/active-responses.log'.format(wazuh_path)

--- a/active-response/kaspersky.sh
+++ b/active-response/kaspersky.sh
@@ -11,18 +11,17 @@
 #
 ##
 
-
-. /etc/ossec-init.conf 2> /dev/null || exit 1
-
+SCRIPT=$(readlink -f "$0")
+S_PATH=$(dirname "$SCRIPT")
 python2="/usr/bin/python"
 python3="/usr/bin/python3"
 
 if [ -f "$python2" ]
 then
-        python $DIRECTORY/active-response/bin/kaspersky.py "$@"
+        python ${S_PATH}/kaspersky.py "$@"
 elif [ -f "$python3" ]
 then
-        python3 $DIRECTORY/active-response/bin/kaspersky.py "$@"
+        python3 ${S_PATH}/kaspersky.py "$@"
 else
         echo "Python binary not found"
 fi


### PR DESCRIPTION
|Related issue|
|---|
|7085|

## Description
This PR modifies the active response scripts to find Wazuh installation using its relative path (keep in mind that these scripts are installed into the installation directory).
To do so:
- **kaspersky.py** and **kaspersky.sh** now checks its own location to obtain the installation path by reference.

<!-- Minimum checks required -->
- Manual test of the scripts with different options
  - [X] **kaspersky.sh**
  - [X] **kaspersky.py** 