### PR TITLE
Make API SSL cipher configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - **API:**
   - Added missing secure headers for API responses. ([#7138](https://github.com/wazuh/wazuh/issues/7138))
   - Added new config option to disable uploading configurations containing remote commands. ([#7134](https://github.com/wazuh/wazuh/issues/7134))
+  - Added new config option to choose the TLS protocol. Default value `TLSv1.2`. ([#7164](https://github.com/wazuh/wazuh/issues/7164))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - **API:**
   - Added missing secure headers for API responses. ([#7138](https://github.com/wazuh/wazuh/issues/7138))
   - Added new config option to disable uploading configurations containing remote commands. ([#7134](https://github.com/wazuh/wazuh/issues/7134))
-  - Added new config option to choose the TLS protocol. Default value `TLSv1.2`. ([#7164](https://github.com/wazuh/wazuh/issues/7164))
+  - Added new config option to choose the SSL ciphers. Default value `TLSv1.2`. ([#7164](https://github.com/wazuh/wazuh/issues/7164))
 
 ### Changed
 

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -34,7 +34,7 @@ default_api_configuration = {
         "cert": "api/configuration/ssl/server.crt",
         "use_ca": False,
         "ca": "api/configuration/ssl/ca.crt",
-        "tls_protocol": "TLSv1.2"
+        "ssl_cipher": "TLSv1.2"
     },
     "logs": {
         "level": "info",

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -33,7 +33,8 @@ default_api_configuration = {
         "key": "api/configuration/ssl/server.key",
         "cert": "api/configuration/ssl/server.crt",
         "use_ca": False,
-        "ca": "api/configuration/ssl/ca.crt"
+        "ca": "api/configuration/ssl/ca.crt",
+        "tls_protocol": "TLSv1.2"
     },
     "logs": {
         "level": "info",

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -14,6 +14,7 @@
 #  cert: "api/configuration/ssl/server.crt"
 #  use_ca: False
 #  ca: "api/configuration/ssl/ca.crt"
+# tls_protocol: "TLSv1.2"
 
 # Logging configuration
 # Values for API log level: disabled, info, warning, error, debug, debug2 (each level includes the previous level).

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -14,7 +14,7 @@
 #  cert: "api/configuration/ssl/server.crt"
 #  use_ca: False
 #  ca: "api/configuration/ssl/ca.crt"
-# tls_protocol: "TLSv1.2"
+#  ssl_cipher: "TLSv1.2"
 
 # Logging configuration
 # Values for API log level: disabled, info, warning, error, debug, debug2 (each level includes the previous level).

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -9902,6 +9902,7 @@ paths:
                           cert: "/var/ossec/api/configuration/ssl/server.crt"
                           use_ca: false
                           ca: "/var/ossec/api/configuration/ssl/ca.crt"
+                          ssl_cipher: "TLSv1.2"
                         access:
                           max_login_attempts: 50
                           block_time: 300

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -20,7 +20,7 @@ custom_api_configuration = {
         "cert": "api/configuration/ssl/server.crt",
         "use_ca": False,
         "ca": "api/configuration/ssl/ca.crt",
-        "tls_protocol": "TLSv1.1"
+        "ssl_cipher": "TLSv1.1"
     },
     "logs": {
         "level": "DEBUG",

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -19,7 +19,8 @@ custom_api_configuration = {
         "key": "api/configuration/ssl/server.key",
         "cert": "api/configuration/ssl/server.crt",
         "use_ca": False,
-        "ca": "api/configuration/ssl/ca.crt"
+        "ca": "api/configuration/ssl/ca.crt",
+        "tls_protocol": "TLSv1.1"
     },
     "logs": {
         "level": "DEBUG",
@@ -52,7 +53,7 @@ custom_incomplete_configuration = {
 def check_config_values(config, read_config, default_config):
     for k in default_config.keys() - read_config.keys():
         if isinstance(default_config[k], str):
-            assert config[k] == default_config[k].lower()
+            assert config[k].lower() == default_config[k].lower()
         elif isinstance(default_config[k], dict):
             check_config_values(config[k], read_config.get(k, {}), default_config[k])
         else:

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -73,21 +73,21 @@ def start(foreground, root, config_file):
                 logger.info(f"Generated certificate file in WAZUH_PATH/{to_relative_path(api_conf['https']['cert'])}")
 
             # Load SSL context
-            allowed_tls_protocols = {
+            allowed_ssl_ciphers = {
                 'tls': ssl.PROTOCOL_TLS,
                 'tlsv1': ssl.PROTOCOL_TLSv1,
                 'tlsv1.1': ssl.PROTOCOL_TLSv1_1,
                 'tlsv1.2': ssl.PROTOCOL_TLSv1_2
             }
             try:
-                tls_protocol = allowed_tls_protocols[api_conf['https']['tls_protocol'].lower()]
+                ssl_cipher = allowed_ssl_ciphers[api_conf['https']['ssl_cipher'].lower()]
             except (KeyError, AttributeError):
                 # KeyError: invalid string value
                 # AttributeError: invalid boolean value
-                logger.error(str(APIError(2003, details='TLS protocol is not valid. Allowed values: '
+                logger.error(str(APIError(2003, details='SSL cipher is not valid. Allowed values: '
                                                         'TLS, TLSv1, TLSv1.1, TLSv1.2')))
                 sys.exit(1)
-            ssl_context = ssl.SSLContext(protocol=tls_protocol)
+            ssl_context = ssl.SSLContext(protocol=ssl_cipher)
             if api_conf['https']['use_ca']:
                 ssl_context.verify_mode = ssl.CERT_REQUIRED
                 ssl_context.load_verify_locations(api_conf['https']['ca'])

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -73,7 +73,21 @@ def start(foreground, root, config_file):
                 logger.info(f"Generated certificate file in WAZUH_PATH/{to_relative_path(api_conf['https']['cert'])}")
 
             # Load SSL context
-            ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS)
+            allowed_tls_protocols = {
+                'tls': ssl.PROTOCOL_TLS,
+                'tlsv1': ssl.PROTOCOL_TLSv1,
+                'tlsv1.1': ssl.PROTOCOL_TLSv1_1,
+                'tlsv1.2': ssl.PROTOCOL_TLSv1_2
+            }
+            try:
+                tls_protocol = allowed_tls_protocols[api_conf['https']['tls_protocol'].lower()]
+            except (KeyError, AttributeError):
+                # KeyError: invalid string value
+                # AttributeError: invalid boolean value
+                logger.error(str(APIError(2003, details='TLS protocol is not valid. Allowed values: '
+                                                        'TLS, TLSv1, TLSv1.1, TLSv1.2')))
+                sys.exit(1)
+            ssl_context = ssl.SSLContext(protocol=tls_protocol)
             if api_conf['https']['use_ca']:
                 ssl_context.verify_mode = ssl.CERT_REQUIRED
                 ssl_context.load_verify_locations(api_conf['https']['ca'])

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -888,6 +888,7 @@ stages:
                   cert: !anystr
                   use_ca: !anybool
                   ca: !anystr
+                  ssl_cipher: !anystr
                 logs:
                   level: !anystr
                   path: !anystr

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -728,6 +728,7 @@ stages:
                   cert: !anystr
                   use_ca: !anybool
                   ca: !anystr
+                  ssl_cipher: !anystr
                 logs:
                   level: !anystr
                   path: !anystr


### PR DESCRIPTION
Hello team, 
this closes #7164 .

The default SSL cipher used by the API will be `TLSv1.2` from now on. In addition, this protocol can be changed through the API configuration file using the `https` section:

```yaml
https:
  ssl_cipher: "<VALUE>"
```

The allowed protocols are:
- `TLS`
- `TLSv1`
- `TLSv1.1`
- `TLSv1.2`

> **NOTE**: These values are not case sensitive

### Tests performed
#### Manual testing
- Default configuration
```
root@wazuh-master:/# curl --tlsv1.1 -u wazuh:wazuh -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to localhost:55000 

root@wazuh-master:/# curl --tlsv1.0 -u wazuh:wazuh -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to localhost:55000 

root@wazuh-master:/# curl --tlsv1.2 -u wazuh:wazuh -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjEwNTM0MjU5LCJleHAiOjE2MTA1Mzc4NTksInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.L39ztMBfYCWT_3oYIXC-2Aeyg0E7p7epFGcB2pvze3Mroot@wazuh-master
```

- Using `TLSv1.1`
```
root@wazuh-master:/# curl --tlsv1.0 -u wazuh:wazuh -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to localhost:55000 

root@wazuh-master:/# curl --tlsv1.1 -u wazuh:wazuh -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjEwNTM0MzI2LCJleHAiOjE2MTA1Mzc5MjYsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZ
SwicmJhY19yb2xlcyI

root@wazuh-master:/# curl --tlsv1.2 -u wazuh:wazuh -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
curl: (35) error:1425F102:SSL routines:ssl_choose_client_version:unsupported protocol
```

- Using `TLS` (all versions allowed)
```
root@wazuh-master:/# curl --tlsv1.0 -u wazuh:wazuh -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjEwNTM0NDI5LCJleHAiOjE2MTA1MzgwMjksInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI

root@wazuh-master:/# curl --tlsv1.1 -u wazuh:wazuh -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjEwNTM0NDM0LCJleHAiOjE2MTA1MzgwMzQsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI

root@wazuh-master:/# curl --tlsv1.2 -u wazuh:wazuh -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjEwNTM0NDM4LCJleHAiOjE2MTA1MzgwMzgsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.IHsnjzHhDqwXXy4m6b0Rv1z8jPtvg42V7o56z_rAdjM
```

- Using an invalid value (API log)
```
2021/01/13 10:31:35 ERROR: 2003 - Error loading SSL/TLS certificates: SSL cipher is not valid. Allowed values: TLS, TLSv1, TLSv1.1, TLSv1.2.
```

#### Unit tests
```
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /home/vicferpoy/Desktop/Git/wazuh/api
plugins: metadata-1.10.0, asyncio-0.12.0, cov-2.10.1, html-2.0.1
collected 231 items                                                                                                                                                                         

test/test_alogging.py ........                                                                                                                                                        [  3%]
test/test_authentication.py ..........                                                                                                                                                [  7%]
test/test_configuration.py .......                                                                                                                                                    [ 10%]
test/test_util.py ...................................                                                                                                                                 [ 25%]
test/test_validator.py .............................................................................................................................................................. [ 94%]
.............                                                                                                                                                                         [100%]

============================================================================= 231 passed, 16 warnings in 0.78s ==============================================================================

```

Regards,
Víctor Fernández.