### PR TITLE
Update default auth_token_exp_timeout to 15 minutes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - **API:**
   - Deprecated endpoints to restore and update API configuration file. ([#7132](https://github.com/wazuh/wazuh/issues/7132))
+  - Default expiration time of the JWT token set to 15 minutes. ([#7167](https://github.com/wazuh/wazuh/pull/7167)) 
 
 ### Fixed
 

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -20,7 +20,7 @@ from api.constants import SECURITY_CONFIG_PATH
 from wazuh.core import common
 
 default_security_configuration = {
-    "auth_token_exp_timeout": 3600,
+    "auth_token_exp_timeout": 900,
     "rbac_mode": "white"
 }
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2610,7 +2610,7 @@ components:
           type: integer
           format: int32
           minimum: 30
-          example: 3600
+          example: 900
         rbac_mode:
           description: "RBAC mode (white/black)"
           type: string
@@ -12876,7 +12876,7 @@ paths:
         - Security
       summary: "Login"
       description: "This method should be called to get an API token. This token will expire after
-      auth_token_exp_timeout seconds (default: 3600). This value can be changed using PUT /security/config"
+      auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config"
       operationId: api.controllers.security_controller.login_user
       parameters:
         - $ref: '#/components/parameters/raw'
@@ -12944,7 +12944,7 @@ paths:
       - Security
       summary: "Login auth_context"
       description: "This method should be called to get an API token using an authorization context body. This token
-      will expire after auth_token_exp_timeout seconds (default: 3600). This value can be changed using PUT
+      will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT
       /security/config"
       operationId: api.controllers.security_controller.login_user
       parameters:
@@ -14625,7 +14625,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ApiResponse"
               example:
-                auth_token_exp_timeout: 3600
+                auth_token_exp_timeout: 900
                 rbac_mode: white
         '400':
           $ref: '#/components/responses/ResponseError'

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -25,7 +25,7 @@ test_path = os.path.dirname(os.path.realpath(__file__))
 test_data_path = os.path.join(test_path, 'data')
 
 security_conf = WazuhResult({
-    'auth_token_exp_timeout': 3600,
+    'auth_token_exp_timeout': 900,
     'rbac_mode': 'black'
 })
 decoded_payload = {
@@ -196,6 +196,6 @@ def test_decode_token_ko(mock_generate_secret, mock_raise_if_exc, mock_submit, m
 
                         with pytest.raises(Unauthorized):
                             mock_raise_if_exc.side_effect = [WazuhResult({'valid': True, 'policies': {'value': 'test'}}),
-                                                             WazuhResult({'auth_token_exp_timeout': 3600,
+                                                             WazuhResult({'auth_token_exp_timeout': 900,
                                                                           'rbac_mode': 'white'})]
                             authentication.decode_token(token='test_token')

--- a/api/test/integration/env/configurations/base/manager/security.yaml
+++ b/api/test/integration/env/configurations/base/manager/security.yaml
@@ -1,3 +1,3 @@
 # WAZUH SYSTEM FILE, PLEASE DO NOT MODIFY
-auth_token_exp_timeout: 3600
+auth_token_exp_timeout: 900
 rbac_mode: white


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7163|

## Description
Hi team!

This PR updates the default expiration timeout of the API JWT tokens. 

## Tests results
### QA exp_timeout
```
python3 -m pytest integration/test_api/test_config/test_jwt_token_exp_timeout/
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.2, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-1.11.0, tavern-1.12.2, cov-2.10.1
collected 4 items                                                                                                                                                                                            

integration/test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py .ss.                                                                                                         [100%]

================================================================================= 2 passed, 2 skipped, 3 warnings in 47.60s ==================================================================================
```

### Unittests
#### API
```
python3 -m pytest api/api/test/ --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/api
plugins: trio-0.6.0, asyncio-0.14.0
collected 231 items                                                                                                                                                                                          

api/api/test/test_alogging.py ........                                                                                                                                                                 [  3%]
api/api/test/test_authentication.py ..........                                                                                                                                                         [  7%]
api/api/test/test_configuration.py .......                                                                                                                                                             [ 10%]
api/api/test/test_util.py ...................................                                                                                                                                          [ 25%]
api/api/test/test_validator.py ....................................................................................................................................................................... [ 98%]
....                                                                                                                                                                                                   [100%]

====================================================================================== 231 passed, 14 warnings in 0.98s ======================================================================================
```

Regards,
Selu.