### PR TITLE
Modify wazuh-logtest to use wazuh-control instead of ossec-init.conf

### DIFF
--- a/ruleset/testing/runtests.py
+++ b/ruleset/testing/runtests.py
@@ -27,7 +27,7 @@ class MultiOrderedDict(OrderedDict):
             super(MultiOrderedDict, self).__setitem__(key, value)
 
 
-def getOssecConfig(wazuh_home):   
+def getWazuhInfo(wazuh_home):   
     wazuh_control = os.path.join(wazuh_home, "bin/wazuh-control") 
     wazuh_env_vars = {}
     try:
@@ -37,7 +37,7 @@ def getOssecConfig(wazuh_home):
         print "Seems like there is no Wazuh installation."
         return None
 
-    env_variables=stdout.rsplit("\n")
+    env_variables = stdout.rsplit("\n")
     env_variables.remove("")
     for env_variable in env_variables:
         key, value = env_variable.split("=")
@@ -174,8 +174,8 @@ if __name__ == "__main__":
         if not selective_test.endswith('.ini'):
             selective_test += '.ini'
     
-    wazuh_config = getOssecConfig(args.wazuh_home)
-    if wazuh_config is None:
+    wazuh_info = getWazuhInfo(args.wazuh_home)
+    if wazuh_info is None:
         sys.exit(1)
 
     for sig in (signal.SIGABRT, signal.SIGINT, signal.SIGTERM):


### PR DESCRIPTION
|Related issue|
|---|
|7153|

## Description
This PR modifies the **wazuh-logtest** to find Wazuh installation using its relative path (keep in mind that these scripts are installed into the installation directory). And uses wazuh-control to obtain Wazuh info.
- **wazuh-logtest.py** now checks its own location to obtain the installation path by reference. Also, it calls **wazuh-control** with **info** option and parses its output to obtain information like **WAZUH_VERSION**. 

<!-- Minimum checks required -->
- Manual test of the scripts with different options
  - [X] **wazuh-logtest.py**