### PR TITLE
Modify DockerListener to find wazuh installation path relative to its own path

### DIFF
--- a/wodles/docker-listener/DockerListener.py
+++ b/wodles/docker-listener/DockerListener.py
@@ -7,6 +7,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+import os
 import threading
 import json
 import socket
@@ -31,11 +32,11 @@ class DockerListener:
         """
         # socket variables
         if sys.platform == "win32":
-            self.wazuh_path = 'C:\Program Files (x86)\ossec-agent'
             sys.stderr.write("This wodle does not work on Windows.\n")
             sys.exit(1)
         else:
-            self.wazuh_path = open('/etc/ossec-init.conf').readline().split('"')[1]
+            # Get Wazuh installation path, obtained relative to the path of this file
+            self.wazuh_path = os.path.abspath(os.path.join(__file__, "../../.."))
         self.wazuh_queue = '{0}/queue/ossec/queue'.format(self.wazuh_path)
         self.msg_header = "1:Wazuh-Docker:"
         # docker variables


### PR DESCRIPTION
|Related issue|
|---|
|7088|

## Description
This PR modifies the **DockerListener** to find Wazuh installation using its relative path (keep in mind that these scripts are installed into the installation directory). 
- **DockerListener.py** now checks its own location to obtain the installation path by reference.

<!-- Minimum checks required -->
- Manual test of the scripts with different options
  - [X] **DockerListener.py**