### PR TITLE
Update of the gen_ossec.sh script to stop using ossec-init.conf

### DIFF
--- a/gen_ossec.sh
+++ b/gen_ossec.sh
@@ -14,7 +14,7 @@ cd `dirname $0`
 
 Use()
 {
-  echo " USE: ./gen_ossec.sh install_type distribution version [installation_path]"
+  echo " USE: ./gen_ossec.sh conf install_type distribution version [installation_path]"
   echo "   - install_type: manager, agent, local"
   echo "   - distribution: rhel, debian, ubuntu, ..."
   echo "   - version: 6, 7, 16.04, ..."
@@ -22,25 +22,25 @@ Use()
 }
 
 # Read script values
-if [ "$#" -ge "3" ]; then
+if [ "$1" = "conf" ] && [ "$#" -ge "4" ]; then
 
   . ./src/init/shared.sh
   . ./src/init/inst-functions.sh
 
-  INSTYPE=$(echo $1 | tr '[:upper:]' '[:lower:]')
+  INSTYPE=$(echo $2 | tr '[:upper:]' '[:lower:]')
   if [ "$INSTYPE" = "manager" ]; then
       INSTYPE="server"
   fi
-  DIST_NAME=$(echo $2 | tr '[:upper:]' '[:lower:]')
-  if [ $(echo $3 | grep "\.") ]; then
-    DIST_VER=$(echo $3 | cut -d\. -f1)
-    DIST_SUBVER=$(echo $3 | cut -d\. -f2)
+  DIST_NAME=$(echo $3 | tr '[:upper:]' '[:lower:]')
+  if [ $(echo $4 | grep "\.") ]; then
+    DIST_VER=$(echo $4 | cut -d\. -f1)
+    DIST_SUBVER=$(echo $4 | cut -d\. -f2)
   else
-    DIST_VER="$3"
+    DIST_VER="$4"
     DIST_SUBVER="0"
   fi
-  if [ "$#" = "4" ]; then
-    INSTALLDIR="$4"
+  if [ "$#" = "5" ]; then
+    INSTALLDIR="$5"
   fi
 
   # Default values definition

--- a/gen_ossec.sh
+++ b/gen_ossec.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Wazuh Configuration & Init Files Generator
-# Copyright (C) 2015-2020, Wazuh Inc.
+# Copyright (C) 2015-2021, Wazuh Inc.
 # November 24, 2016.
 #
 # This program is free software; you can redistribute it
@@ -9,60 +9,38 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-# File dependencies:
-# ./src/init/shared.sh
-# ./src/init/inst-functions.sh
-# ./src/init/template-select.sh
-# ./src/init/dist-detect.sh
-# ./src/VERSION
-# ./src/LOCATION
-# ./etc/templates/config
-
-
 # Looking up for the execution directory
 cd `dirname $0`
 
-Conf_Use()
+Use()
 {
-  echo " USE: ./gen_ossec.sh conf install_type distribution version [installation_path]"
+  echo " USE: ./gen_ossec.sh install_type distribution version [installation_path]"
   echo "   - install_type: manager, agent, local"
   echo "   - distribution: rhel, debian, ubuntu, ..."
   echo "   - version: 6, 7, 16.04, ..."
   echo "   - installation_path (optional): changes the default path '/var/ossec' "
 }
 
-Init_Use()
-{
-  echo " USE: ./gen_ossec.sh init install_type [installation_path]"
-  echo "   - install_type: manager, agent, local"
-  echo "   - installation_path (optional): changes the default path '/var/ossec' "
-}
-
 # Read script values
-if [ "$1" = "conf" ]; then
+if [ "$#" -ge "3" ]; then
 
   . ./src/init/shared.sh
   . ./src/init/inst-functions.sh
 
-  if [ "$#" -ge "4" ]; then
-    INSTYPE=$(echo $2 | tr '[:upper:]' '[:lower:]')
-    if [ "$INSTYPE" = "manager" ]; then
-        INSTYPE="server"
-    fi
-    DIST_NAME=$(echo $3 | tr '[:upper:]' '[:lower:]')
-    if [ $(echo $4 | grep "\.") ]; then
-      DIST_VER=$(echo $4 | cut -d\. -f1)
-      DIST_SUBVER=$(echo $4 | cut -d\. -f2)
-    else
-      DIST_VER="$4"
-      DIST_SUBVER="0"
-    fi
-    if [ "$#" = "5" ]; then
-      INSTALLDIR="$5"
-    fi
+  INSTYPE=$(echo $1 | tr '[:upper:]' '[:lower:]')
+  if [ "$INSTYPE" = "manager" ]; then
+      INSTYPE="server"
+  fi
+  DIST_NAME=$(echo $2 | tr '[:upper:]' '[:lower:]')
+  if [ $(echo $3 | grep "\.") ]; then
+    DIST_VER=$(echo $3 | cut -d\. -f1)
+    DIST_SUBVER=$(echo $3 | cut -d\. -f2)
   else
-    Conf_Use
-    exit 1
+    DIST_VER="$3"
+    DIST_SUBVER="0"
+  fi
+  if [ "$#" = "4" ]; then
+    INSTALLDIR="$4"
   fi
 
   # Default values definition
@@ -86,10 +64,10 @@ if [ "$1" = "conf" ]; then
     WriteManager "no_localfiles"
   elif [ "$INSTYPE" = "agent" ]; then
     WriteAgent "no_localfiles"
-elif [ "$INSTYPE" = "local" ]; then
+  elif [ "$INSTYPE" = "local" ]; then
     WriteLocal "no_localfiles"
   else
-    Conf_Use
+    Use
     exit 1
   fi
 
@@ -97,39 +75,11 @@ elif [ "$INSTYPE" = "local" ]; then
   rm "$NEWCONFIG"
 
   exit 0
-
-elif [ "$1" = "init" ]; then
-
-  . ./src/init/inst-functions.sh
-  . ./src/init/shared.sh
-
-  # Read script values
-  if [ "$#" -ge "2" ]; then
-    INSTYPE=$(echo $2 | tr '[:upper:]' '[:lower:]')
-    if [ "$INSTYPE" = "manager" ]; then
-        INSTYPE="server"
-    fi
-    if [ "$#" = "3" ]; then
-      INSTALLDIR="$3"
-    fi
-  else
-    Init_Use
-    exit 1
-  fi
-
-  GenerateInitConf
-
-  exit 0
-
 else
   echo ""
-  echo "Wazuh Configuration & Init Files Generator"
+  echo "Wazuh Configuration Generator"
   echo ""
-  echo " Generate a default ossec.conf file."
-  Conf_Use
-  echo ""
-  echo " Generate a default ossec-init.conf file."
-  Init_Use
+  Use
   echo ""
   exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -589,7 +589,6 @@ setEnv()
 {
     CEXTRA="$CEXTRA -DDEFAULTDIR=\\\"${INSTALLDIR}\\\""
 
-    echo ""
     echo "    - ${installat} ${INSTALLDIR} ."
 
     if [ "X$INSTYPE" = "Xagent" ]; then
@@ -622,6 +621,31 @@ askForDelete()
                     echo "Error deleting ${INSTALLDIR}"
                     exit 2;
                 fi
+                ;;
+            $nomatch)
+                if [ "X$PREINSTALLEDDIR" != "X" ]; then
+                    echo "WARNING! The installation can't proceed without removing already installed versions. Exiting."
+                    exit 2;
+                fi
+                ;;
+        esac
+    elif [ -d "$PREINSTALLEDDIR" ]; then
+        $ECHO "    - WARNING! The installation can't proceed without removing already installed versions. Should I delete it? ($yes/$no) [$no]: "
+        read ANSWER
+
+        case $ANSWER in
+            $yesmatch)
+                echo "      Stopping Wazuh..."
+                UpdateStopOSSEC
+                rm -rf $PREINSTALLEDDIR
+                if [ ! $? = 0 ]; then
+                    echo "Error deleting ${PREINSTALLEDDIR}"
+                    exit 2;
+                fi
+                ;;
+            $nomatch)
+                echo "Exiting."
+                exit 2;
                 ;;
         esac
     fi

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -308,22 +308,6 @@ SetHeaders()
 }
 
 ##########
-# Generate the ossec-init.conf
-##########
-GenerateInitConf()
-{
-    NEWINIT="./ossec-init.conf.temp"
-    echo "DIRECTORY=\"${INSTALLDIR}\"" > ${NEWINIT}
-    echo "NAME=\"${NAME}\"" >> ${NEWINIT}
-    echo "VERSION=\"${VERSION}\"" >> ${NEWINIT}
-    echo "REVISION=\"${REVISION}\"" >> ${NEWINIT}
-    echo "DATE=\"`date`\"" >> ${NEWINIT}
-    echo "TYPE=\"${INSTYPE}\"" >> ${NEWINIT}
-    cat "$NEWINIT"
-    rm "$NEWINIT"
-}
-
-##########
 # GenerateService() $1=template
 ##########
 GenerateService()

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -35,7 +35,7 @@ getPreinstalledDirByType()
 {
     # Checking for Systemd
     if hash ps 2>&1 > /dev/null && hash grep 2>&1 > /dev/null && [ -n "$(ps -e | egrep ^\ *1\ .*systemd$)" ]; then
-        if [ "X$service" = "Xwazuh-manager" ] || [ "X$service" = "Xwazuh-local" ]; then #manager, hibrid or local
+        if [ "X$pidir_service_name" = "Xwazuh-manager" ] || [ "X$pidir_service_name" = "Xwazuh-local" ]; then #manager, hibrid or local
             type="manager"
         else
             type="agent"
@@ -61,8 +61,8 @@ getPreinstalledDirByType()
     # Checking for Redhat system.
     if [ -r "/etc/redhat-release" ]; then
         if [ -d /etc/rc.d/init.d ]; then
-            if [ -f /etc/rc.d/init.d/${service} ]; then
-                PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/rc.d/init.d/${service}`
+            if [ -f /etc/rc.d/init.d/${pidir_service_name} ]; then
+                PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/rc.d/init.d/${pidir_service_name}`
                 if [ -d "$PREINSTALLEDDIR" ]; then
                     return 0;
                 else
@@ -75,8 +75,8 @@ getPreinstalledDirByType()
     fi
     # Checking for Gentoo
     if [ -r "/etc/gentoo-release" ]; then
-        if [ -f /etc/init.d/${service} ]; then
-            PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/init.d/${service}`
+        if [ -f /etc/init.d/${pidir_service_name} ]; then
+            PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/init.d/${pidir_service_name}`
             if [ -d "$PREINSTALLEDDIR" ]; then
                 return 0;
             else
@@ -88,8 +88,8 @@ getPreinstalledDirByType()
     fi
     # Checking for Suse
     if [ -r "/etc/SuSE-release" ]; then
-        if [ -f /etc/init.d/${service} ]; then
-            PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/init.d/${service}`
+        if [ -f /etc/init.d/${pidir_service_name} ]; then
+            PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/init.d/${pidir_service_name}`
             if [ -d "$PREINSTALLEDDIR" ]; then
                 return 0;
             else
@@ -101,8 +101,8 @@ getPreinstalledDirByType()
     fi
     # Checking for Slackware
     if [ -r "/etc/slackware-version" ]; then
-        if [ -f /etc/rc.d/rc.${service} ]; then
-            PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/rc.d/rc.${service}`
+        if [ -f /etc/rc.d/rc.${pidir_service_name} ]; then
+            PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/rc.d/rc.${pidir_service_name}`
             if [ -d "$PREINSTALLEDDIR" ]; then
                 return 0;
             else
@@ -127,8 +127,8 @@ getPreinstalledDirByType()
     fi
     # Checking for SunOS
     if [ "X${UN}" = "XSunOS" ]; then
-        if [ -f /etc/init.d/${service} ]; then
-            PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/init.d/${service}`
+        if [ -f /etc/init.d/${pidir_service_name} ]; then
+            PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/init.d/${pidir_service_name}`
             if [ -d "$PREINSTALLEDDIR" ]; then
                 return 0;
             else
@@ -140,8 +140,8 @@ getPreinstalledDirByType()
     fi
     # Checking for HP-UX
     if [ "X${UN}" = "XHP-UX" ]; then
-        if [ -f /sbin/init.d/${service} ]; then
-            PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /sbin/init.d/${service}`
+        if [ -f /sbin/init.d/${pidir_service_name} ]; then
+            PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /sbin/init.d/${pidir_service_name}`
             if [ -d "$PREINSTALLEDDIR" ]; then
                 return 0;
             else
@@ -153,8 +153,8 @@ getPreinstalledDirByType()
     fi
     # Checking for AIX
     if [ "X${UN}" = "XAIX" ]; then
-        if [ -f /etc/rc.d/init.d/${service} ]; then
-            PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/rc.d/init.d/${service}`
+        if [ -f /etc/rc.d/init.d/${pidir_service_name} ]; then
+            PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/rc.d/init.d/${pidir_service_name}`
             if [ -d "$PREINSTALLEDDIR" ]; then
                 return 0;
             else
@@ -194,8 +194,8 @@ getPreinstalledDirByType()
             fi
         # Checking for Linux (SysV)
         elif [ -d "/etc/rc.d/init.d" ]; then
-            if [ -f /etc/rc.d/init.d/${service} ]; then
-                PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/rc.d/init.d/${service}`
+            if [ -f /etc/rc.d/init.d/${pidir_service_name} ]; then
+                PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/rc.d/init.d/${pidir_service_name}`
                 if [ -d "$PREINSTALLEDDIR" ]; then
                     return 0;
                 else
@@ -206,8 +206,8 @@ getPreinstalledDirByType()
             fi
         # Checking for Debian (Ubuntu or derivative)
         elif [ -d "/etc/init.d" -a -f "/usr/sbin/update-rc.d" ]; then
-            if [ -f /etc/init.d/${service} ]; then
-                PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/init.d/${service}`
+            if [ -f /etc/init.d/${pidir_service_name} ]; then
+                PREINSTALLEDDIR=`sed -n 's/^WAZUH_HOME=\(.*\)$/\1/p' /etc/init.d/${pidir_service_name}`
                 if [ -d "$PREINSTALLEDDIR" ]; then
                     return 0;
                 else
@@ -241,20 +241,20 @@ getPreinstalledDir()
             return 0;
         fi
     else
-        # Getting preinstalled dir for Wazuh manager and Hibrid installations
-        service="wazuh-manager"
+        # Getting preinstalled dir for Wazuh manager and hibrid installations
+        pidir_service_name="wazuh-manager"
         if getPreinstalledDirByType; then
             return 0;
         fi
 
         # Getting preinstalled dir for Wazuh agent installations
-        service="wazuh-agent"
+        pidir_service_name="wazuh-agent"
         if getPreinstalledDirByType; then
             return 0;
         fi
 
-        # Getting preinstalled dir for Wazuh agent installations
-        service="wazuh-local"
+        # Getting preinstalled dir for Wazuh local installations
+        pidir_service_name="wazuh-local"
         if getPreinstalledDirByType; then
             return 0;
         fi

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -127,7 +127,7 @@ testconfig()
 }
 
 # Start function
-start()
+start_service()
 {
     echo "Starting $NAME $VERSION..."
     checkpid;
@@ -223,7 +223,7 @@ wait_pid() {
     return 0
 }
 
-stop()
+stop_service()
 {
     checkpid;
     for i in ${DAEMONS}; do
@@ -273,28 +273,28 @@ case "$1" in
 start)
     testconfig
     lock
-    start
+    start_service
     unlock
     ;;
 stop)
     lock
-    stop
+    stop_service
     unlock
     ;;
 restart)
     testconfig
     lock
-    stop
+    stop_service
     sleep 1
-    start
+    start_service
     unlock
     ;;
 reload)
     DAEMONS=$(echo $DAEMONS | sed 's/wazuh-execd//')
     lock
-    stop
+    stop_service
     sleep 1
-    start
+    start_service
     unlock
     ;;
 status)

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -215,7 +215,7 @@ testconfig()
     done
 }
 
-start()
+start_service()
 {
     echo "Starting $NAME $VERSION..."
     TEST=$(${DIR}/bin/wazuh-analysisd -t  2>&1)
@@ -318,7 +318,7 @@ wait_pid() {
     return 0
 }
 
-stop()
+stop_service()
 {
     checkpid;
     for i in ${DAEMONS}; do
@@ -373,26 +373,26 @@ case "$1" in
 start)
     testconfig
     lock
-    start
+    start_service
     unlock
     ;;
 stop)
     lock
-    stop
+    stop_service
     unlock
     ;;
 restart)
     testconfig
     lock
-    stop
-    start
+    stop_service
+    start_service
     unlock
     ;;
 reload)
     DAEMONS=$(echo $DAEMONS | sed 's/wazuh-execd//')
     lock
-    stop
-    start
+    stop_service
+    start_service
     unlock
     ;;
 status)

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -255,7 +255,7 @@ testconfig()
 }
 
 # Start function
-start()
+start_service()
 {
 
     if [ $USE_JSON = false ]; then
@@ -454,7 +454,7 @@ wait_pid() {
     return 0
 }
 
-stop()
+stop_service()
 {
     checkpid;
     first=true
@@ -548,12 +548,12 @@ case "$action" in
 start)
     testconfig
     lock
-    start
+    start_service
     unlock
     ;;
 stop)
     lock
-    stop
+    stop_service
     unlock
     ;;
 restart)
@@ -561,19 +561,19 @@ restart)
     testconfig
     lock
     if [ $USE_JSON = true ]; then
-        stop > /dev/null 2>&1
+        stop_service > /dev/null 2>&1
     else
-        stop
+        stop_service
     fi
-    start
+    start_service
     rm -f ${DIR}/var/run/.restart
     unlock
     ;;
 reload)
     DAEMONS=$(echo $DAEMONS | sed 's/wazuh-execd//')
     lock
-    stop
-    start
+    stop_service
+    start_service
     unlock
     ;;
 status)


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7089 |

## Description

This pull request includes all the necessary changes to remove the `init` option from the `gen_ossec.sh` script. This option was used by the installation scripts and the packages to generate the `ossec-init.conf` file during the installation and the upgrades.

After this change, the `ossec-init.conf` file will no longer be part of the Wazuh installations so, as part of this issue all the Wazuh packages were modified to stop making use of this file. The changes were implemented in the pull https://github.com/wazuh/wazuh-packages/pull/603.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade