### PR TITLE
Update syscheck and experimental API tests.

### DIFF
--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -13,8 +13,8 @@
 import os
 
 def get_health():
-    output_syscheck = os.system("grep -q 'wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
-    output_syscollector = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+    output_syscheck = os.system("grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
+    output_syscollector = os.system("grep -q 'modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
 
     if output_syscheck == 0 and output_syscollector == 0:
         return 0

--- a/api/test/integration/env/configurations/syscheck/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscheck/agent/healthcheck/healthcheck.py
@@ -2,7 +2,7 @@ import os
 
 
 def get_health():
-    output = os.system("grep -q 'wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
+    output = os.system("grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
 
     if output == 0:
         return 0


### PR DESCRIPTION
|Related issue|
|---|
| Closes #7198 |

## Description

Hi team!

This PR updates some agents healthchecks so they fail neither for agents v3.x/v4.0.x nor v4.2, where some services are renamed.  

## Tests
### Unittests
#### Framework
```
python3 -m pytest framework --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: trio-0.6.0, asyncio-0.14.0
collected 1604 items                                                                                                                                                                                         

framework/wazuh/core/cluster/dapi/tests/test_dapi.py ......................                                                                                                                            [  1%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................                                                                                                                                 [  2%]
framework/wazuh/core/cluster/tests/test_common.py .......                                                                                                                                              [  2%]
framework/wazuh/core/cluster/tests/test_control.py .....                                                                                                                                               [  3%]
framework/wazuh/core/cluster/tests/test_local_client.py .                                                                                                                                              [  3%]
framework/wazuh/core/cluster/tests/test_utils.py .......                                                                                                                                               [  3%]
framework/wazuh/core/cluster/tests/test_worker.py ................                                                                                                                                     [  4%]
framework/wazuh/core/tests/test_active_response.py ............                                                                                                                                        [  5%]
framework/wazuh/core/tests/test_agent.py .......................................................................................................................................................       [ 14%]
framework/wazuh/core/tests/test_cdb_list.py .................................                                                                                                                          [ 17%]
framework/wazuh/core/tests/test_common.py .......                                                                                                                                                      [ 17%]
framework/wazuh/core/tests/test_configuration.py ..................................                                                                                                                    [ 19%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                            [ 20%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                 [ 20%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                          [ 20%]
framework/wazuh/core/tests/test_manager.py ...............................                                                                                                                             [ 22%]
framework/wazuh/core/tests/test_ossec_queue.py ...................                                                                                                                                     [ 24%]
framework/wazuh/core/tests/test_pyDaemonModule.py ......                                                                                                                                               [ 24%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                    [ 26%]
framework/wazuh/core/tests/test_rootcheck.py ..........                                                                                                                                                [ 27%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                         [ 28%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                    [ 29%]
framework/wazuh/core/tests/test_utils.py ............................................................................................................................................................. [ 38%]
.....................................................                                                                                                                                                  [ 42%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                   [ 43%]
framework/wazuh/core/tests/test_wdb.py .....................                                                                                                                                           [ 44%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                     [ 44%]
framework/wazuh/rbac/tests/test_decorators.py .........................................................................................................                                                [ 51%]
framework/wazuh/rbac/tests/test_default_configuration.py ...................................................                                                                                           [ 54%]
framework/wazuh/rbac/tests/test_orm.py .....................................................                                                                                                           [ 57%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                            [ 58%]
framework/wazuh/tests/test_active_response.py .........                                                                                                                                                [ 59%]
framework/wazuh/tests/test_agent.py ....................................................................................                                                                               [ 64%]
framework/wazuh/tests/test_cdb_list.py ...............................................                                                                                                                 [ 67%]
framework/wazuh/tests/test_ciscat.py ..                                                                                                                                                                [ 67%]
framework/wazuh/tests/test_cluster.py .......                                                                                                                                                          [ 67%]
framework/wazuh/tests/test_decoders.py ...............................                                                                                                                                 [ 69%]
framework/wazuh/tests/test_group.py ........                                                                                                                                                           [ 70%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                           [ 70%]
framework/wazuh/tests/test_manager.py ......................................                                                                                                                           [ 73%]
framework/wazuh/tests/test_mitre.py .................................................................................................................................................................. [ 83%]
..................                                                                                                                                                                                     [ 84%]
framework/wazuh/tests/test_rootcheck.py .................................................                                                                                                              [ 87%]
framework/wazuh/tests/test_rule.py ....................................................                                                                                                                [ 90%]
framework/wazuh/tests/test_sca.py .......                                                                                                                                                              [ 90%]
framework/wazuh/tests/test_security.py .....................................................................                                                                                           [ 95%]
framework/wazuh/tests/test_stats.py .............                                                                                                                                                      [ 96%]
framework/wazuh/tests/test_syscheck.py .......................                                                                                                                                         [ 97%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                                [ 98%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                        [100%]

=============================================================================== 1604 passed, 15 warnings in 250.25s (0:04:10) ================================================================================
```
#### Api
```
python3 -m pytest api/api/test/ --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/api
plugins: trio-0.6.0, asyncio-0.14.0
collected 231 items                                                                                                                                                                                          

api/api/test/test_alogging.py ........                                                                                                                                                                 [  3%]
api/api/test/test_authentication.py ..........                                                                                                                                                         [  7%]
api/api/test/test_configuration.py .......                                                                                                                                                             [ 10%]
api/api/test/test_util.py ...................................                                                                                                                                          [ 25%]
api/api/test/test_validator.py ....................................................................................................................................................................... [ 98%]
....                                                                                                                                                                                                   [100%]

====================================================================================== 231 passed, 16 warnings in 1.05s ======================================================================================
```

### Integration
All tests failing in https://github.com/wazuh/wazuh/pull/7194/checks?check_run_id=1707349967 are passing, although some of them needed no fix (active-response, tasks), so it seems those are random failures and will need further investigation.

#### Active response
```
pytest -vv test_active_response_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-58-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 2 items                                                                                                                                                                                            

test_active_response_endpoints.tavern.yaml::PUT /active-response/{:agent_id} PASSED                                                                                                                    [ 50%]
test_active_response_endpoints.tavern.yaml::PUT /active-response PASSED                                                                                                                                [100%]

================================================================================= 2 passed, 4 warnings in 167.65s (0:02:47) ==================================================================================
```

#### Syscheck 
```
pytest -vv test_syscheck_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-58-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 35 items                                                                                                                                                                                           

test_syscheck_endpoints.tavern.yaml::GET /syscheck/000 PASSED                                                                                                                                          [  2%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[date] PASSED                                                                                                                                    [  5%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[mtime] PASSED                                                                                                                                   [  8%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[file] PASSED                                                                                                                                    [ 11%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[size] PASSED                                                                                                                                    [ 14%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[perm] PASSED                                                                                                                                    [ 17%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[uname] PASSED                                                                                                                                   [ 20%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[gname] PASSED                                                                                                                                   [ 22%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[md5] PASSED                                                                                                                                     [ 25%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[sha1] PASSED                                                                                                                                    [ 28%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[sha256] PASSED                                                                                                                                  [ 31%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[inode] PASSED                                                                                                                                   [ 34%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[gid] PASSED                                                                                                                                     [ 37%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[uid] PASSED                                                                                                                                     [ 40%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000[type] PASSED                                                                                                                                    [ 42%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/000/last_scan PASSED                                                                                                                                [ 45%]
test_syscheck_endpoints.tavern.yaml::PUT /syscheck/000 PASSED                                                                                                                                          [ 48%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002 PASSED                                                                                                                                          [ 51%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[date] PASSED                                                                                                                                    [ 54%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[mtime] PASSED                                                                                                                                   [ 57%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[file] PASSED                                                                                                                                    [ 60%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[size] PASSED                                                                                                                                    [ 62%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[perm] PASSED                                                                                                                                    [ 65%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[uname] PASSED                                                                                                                                   [ 68%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[gname] PASSED                                                                                                                                   [ 71%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[md5] PASSED                                                                                                                                     [ 74%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[sha1] PASSED                                                                                                                                    [ 77%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[sha256] PASSED                                                                                                                                  [ 80%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[inode] PASSED                                                                                                                                   [ 82%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[gid] PASSED                                                                                                                                     [ 85%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[uid] PASSED                                                                                                                                     [ 88%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002[type] PASSED                                                                                                                                    [ 91%]
test_syscheck_endpoints.tavern.yaml::GET /syscheck/002/last_scan PASSED                                                                                                                                [ 94%]
test_syscheck_endpoints.tavern.yaml::DELETE /syscheck PASSED                                                                                                                                           [ 97%]
test_syscheck_endpoints.tavern.yaml::PUT /syscheck PASSED                                                                                                                                              [100%]

================================================================================ 35 passed, 39 warnings in 118.76s (0:01:58) =================================================================================
```

```
pytest -vv test_rbac_white_syscheck_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-58-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 4 items                                                                                                                                                                                            

test_rbac_white_syscheck_endpoints.tavern.yaml::GET /syscheck PASSED                                                                                                                                   [ 25%]
test_rbac_white_syscheck_endpoints.tavern.yaml::GET /syscheck/000/last_scan PASSED                                                                                                                     [ 50%]
test_rbac_white_syscheck_endpoints.tavern.yaml::PUT /syscheck PASSED                                                                                                                                   [ 75%]
test_rbac_white_syscheck_endpoints.tavern.yaml::DELETE /syscheck PASSED                                                                                                                                [100%]

================================================================================= 4 passed, 6 warnings in 103.20s (0:01:43) ==================================================================================
```

```
pytest -vv test_rbac_black_syscheck_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-58-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 4 items                                                                                                                                                                                            

test_rbac_black_syscheck_endpoints.tavern.yaml::GET /syscheck PASSED                                                                                                                                   [ 25%]
test_rbac_black_syscheck_endpoints.tavern.yaml::GET /syscheck/000/last_scan PASSED                                                                                                                     [ 50%]
test_rbac_black_syscheck_endpoints.tavern.yaml::PUT /syscheck PASSED                                                                                                                                   [ 75%]
test_rbac_black_syscheck_endpoints.tavern.yaml::DELETE /syscheck PASSED                                                                                                                                [100%]

================================================================================== 4 passed, 6 warnings in 82.94s (0:01:22) ==================================================================================
```

#### Experimental
```
pytest -vv test_experimental_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-58-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 11 items                                                                                                                                                                                           

test_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck PASSED                                                                                                                          [  9%]
test_experimental_endpoints.tavern.yaml::GET /experimental/ciscat/results XFAIL                                                                                                                        [ 18%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hardware PASSED                                                                                                                [ 27%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netaddr PASSED                                                                                                                 [ 36%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netiface PASSED                                                                                                                [ 45%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netproto PASSED                                                                                                                [ 54%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/os PASSED                                                                                                                      [ 63%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/packages PASSED                                                                                                                [ 72%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/ports PASSED                                                                                                                   [ 81%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/processes PASSED                                                                                                               [ 90%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hotfixes PASSED                                                                                                                [100%]

=========================================================================== 10 passed, 1 xfailed, 13 warnings in 121.23s (0:02:01) ===========================================================================
```

```
pytest -vv test_rbac_black_experimental_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-58-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 11 items                                                                                                                                                                                           

test_rbac_black_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck PASSED                                                                                                               [  9%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/ciscat/results XFAIL                                                                                                             [ 18%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hardware PASSED                                                                                                     [ 27%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netaddr PASSED                                                                                                      [ 36%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netiface PASSED                                                                                                     [ 45%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netproto PASSED                                                                                                     [ 54%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/os PASSED                                                                                                           [ 63%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/packages PASSED                                                                                                     [ 72%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/ports PASSED                                                                                                        [ 81%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/processes PASSED                                                                                                    [ 90%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hotfixes PASSED                                                                                                     [100%]

=========================================================================== 10 passed, 1 xfailed, 13 warnings in 113.28s (0:01:53) ===========================================================================
```

#### Tasks
```
pytest -vv test_task_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-58-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 3 items                                                                                                                                                                                            

test_task_endpoints.tavern.yaml::GET /tasks/status PASSED                                                                                                                                              [ 33%]
test_task_endpoints.tavern.yaml::GET /tasks/status PASSED                                                                                                                                              [ 33%]
test_task_endpoints.tavern.yaml::GET /tasks/status (Filters) PASSED                                                                                                                                    [ 66%]

================================================================================= 3 passed, 5 warnings in 147.28s (0:02:27) ==================================================================================
```

Regards,
Selu.