### PR TITLE
Add new endpoint to get logcollector stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
   - Improved support for multi-line logs with a variable number of lines. ([#5652](https://github.com/wazuh/wazuh/issues/5652))
 
 - **API:**
-  - Added new endpoint to get logcollector stats from an agent. ([#7128](https://github.com/wazuh/wazuh/issues/7128))
+  - Added new endpoint to get agent stats from different components. ([#7128](https://github.com/wazuh/wazuh/issues/7128))
   
 - **Ruleset:**
   - Added support for UFW firewall to decoders. ([#7100](https://github.com/wazuh/wazuh/pull/7100))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
   - Added support for bookmarks in Logcollector, allowing to follow the log file at the point where the agent stopped. ([#3368](https://github.com/wazuh/wazuh/issues/3368))
   - Improved support for multi-line logs with a variable number of lines. ([#5652](https://github.com/wazuh/wazuh/issues/5652))
 
+- **API:**
+  - Added new endpoint to get logcollector stats from an agent. ([#7128](https://github.com/wazuh/wazuh/issues/7128))
+  
 - **Ruleset:**
   - Added support for UFW firewall to decoders. ([#7100](https://github.com/wazuh/wazuh/pull/7100))
 

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -7,7 +7,6 @@ import logging
 from aiohttp import web
 from connexion.lifecycle import ConnexionResponse
 
-from wazuh import agent, stats
 from api import configuration
 from api.encoder import dumps, prettify
 from api.models.agent_added_model import AgentAddedModel
@@ -15,10 +14,10 @@ from api.models.agent_inserted_model import AgentInsertedModel
 from api.models.base_model_ import Body
 from api.models.group_added_model import GroupAddedModel
 from api.util import parse_api_param, remove_nones_to_dict, raise_if_exc
+from wazuh import agent, stats
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.common import database_limit
-from wazuh.core.exception import WazuhError
 
 logger = logging.getLogger('wazuh-api')
 
@@ -478,7 +477,7 @@ async def put_upgrade_custom_agents(request, agents_list=None, pretty=False, wai
 
 
 async def get_component_stats(request, pretty=False, wait_for_complete=False, agent_id=None, component=None):
-    """Get a specified agent's logcollector stats.
+    """Get a specified agent's component stats.
 
     Parameters
     ----------
@@ -492,12 +491,12 @@ async def get_component_stats(request, pretty=False, wait_for_complete=False, ag
     Returns
     -------
     ApiResponse
-        Logcollector stats.
+        Module stats.
     """
     f_kwargs = {'agent_list': [agent_id],
-                'daemon': component}
+                'component': component}
 
-    dapi = DistributedAPI(f=stats.get_daemon_stats_json,
+    dapi = DistributedAPI(f=stats.get_agents_component_stats_json,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='distributed_master',
                           is_async=False,

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -477,7 +477,7 @@ async def put_upgrade_custom_agents(request, agents_list=None, pretty=False, wai
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def get_stats_logcollector(request, pretty=False, wait_for_complete=False, agent_id=None):
+async def get_component_stats(request, pretty=False, wait_for_complete=False, agent_id=None, component=None):
     """Get a specified agent's logcollector stats.
 
     Parameters
@@ -495,7 +495,7 @@ async def get_stats_logcollector(request, pretty=False, wait_for_complete=False,
         Logcollector stats.
     """
     f_kwargs = {'agent_list': [agent_id],
-                'daemon': 'logcollector'}
+                'daemon': component}
 
     dapi = DistributedAPI(f=stats.get_daemon_stats_json,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -4277,6 +4277,15 @@ components:
       schema:
         type: string
         format: sort
+    stats_component:
+      in: path
+      name: component
+      description: "Selected stats component"
+      required: true
+      schema:
+        type: string
+        enum:
+          - logcollector
     status:
       in: query
       name: status
@@ -5886,22 +5895,23 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
-  /agents/{agent_id}/stats/logcollector:
+  /agents/{agent_id}/stats/{component}:
     get:
       tags:
         - Agents
-      summary: "Get stats logcollector"
-      description: "Return Wazuh logcollector statistical information in agent {agent_id}"
-      operationId: api.controllers.agent_controller.get_stats_logcollector
+      summary: "Get agent's component stats"
+      description: "Return Wazuh's {component} statistical information in agent {agent_id}"
+      operationId: api.controllers.agent_controller.get_component_stats
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/agent:read'
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/agent_id'
+        - $ref: '#/components/parameters/stats_component'
       responses:
         '200':
-          description: "Get agent logcollector stats"
+          description: "Component stats"
           content:
             application/json:
               schema:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5886,6 +5886,99 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
+  /agents/{agent_id}/stats/logcollector:
+    get:
+      tags:
+        - Agents
+      summary: "Get stats logcollector"
+      description: "Return Wazuh logcollector statistical information in agent {agent_id}"
+      operationId: api.controllers.agent_controller.get_stats_logcollector
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/agent:read'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/agent_id'
+      responses:
+        '200':
+          description: "Get agent logcollector stats"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+              example:
+                data:
+                  affected_items:
+                    - global:
+                        start: 'Wed Jan 13 16:08:57 2021'
+                        end: 'Thu Jan 14 12:28:11 2021'
+                        files:
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: df -P
+                            bytes: 51414
+                            events: 570
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: last -n 20
+                            bytes: 3762
+                            events: 57
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: /var/ossec/logs/active-responses.log
+                            bytes: 0
+                            events: 0
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: /var/log/dpkg.log
+                            bytes: 0
+                            events: 0
+                      interval:
+                        start: 'Thu Jan 14 12:28:06 2021'
+                        end: 'Thu Jan 14 12:28:11 2021'
+                        files:
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: df -P
+                            bytes: 0
+                            events: 0
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: last -n 20
+                            bytes: 0
+                            events: 0
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: /var/ossec/logs/active-responses.log
+                            bytes: 0
+                            events: 0
+                          - targets:
+                              - name: agent
+                                drops: 0
+                            location: /var/log/dpkg.log
+                            bytes: 0
+                            events: 0
+                  total_affected_items: 1
+                  total_failed_items: 0
+                  failed_items: [ ]
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
   /agents/upgrade:
     put:
       tags:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5900,7 +5900,7 @@ paths:
       tags:
         - Agents
       summary: "Get agent's component stats"
-      description: "Return Wazuh's {component} statistical information in agent {agent_id}"
+      description: "Return Wazuh's {component} statistical information from agent {agent_id}"
       operationId: api.controllers.agent_controller.get_component_stats
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/agent:read'

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1896,6 +1896,96 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: GET /agents/{agent_id}/stats/logcollector
+
+stages:
+
+  - name: Try get logcollector stats from agent 000 (manager)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/000/stats/logcollector"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items: &stats_response
+            - global:
+                start: !anystr
+                end: !anystr
+                files: !anything
+              interval:
+                start: !anystr
+                end: !anystr
+                files: !anything
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Try get logcollector stats from agent 002
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - <<: *stats_response
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Try get logcollector stats from agent 007 (incompatible version)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/007/stats/logcollector"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 1
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1735
+              id:
+                - "007"
+          total_affected_items: 0
+          total_failed_items: 1
+
+  - name: Try get logcollector stats from agent 017 (non-existent)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/017/stats/logcollector"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 1
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1701
+              id:
+                - "017"
+          total_affected_items: 0
+          total_failed_items: 1
+
+---
 test_name: GET /groups
 
 stages:

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1896,11 +1896,11 @@ stages:
           total_failed_items: 0
 
 ---
-test_name: GET /agents/{agent_id}/stats/logcollector
+test_name: GET /agents/{agent_id}/stats/{component}
 
 stages:
 
-  - name: Try get logcollector stats from agent 000 (manager)
+  - name: Try to get logcollector stats from agent 000 (manager)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/stats/logcollector"
@@ -1925,7 +1925,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try get logcollector stats from agent 002
+  - name: Try to get logcollector stats from agent 002
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"
@@ -1943,7 +1943,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try get logcollector stats from agent 007 (incompatible version)
+  - name: Try to get logcollector stats from agent 007 (incompatible version)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/007/stats/logcollector"
@@ -1964,7 +1964,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
-  - name: Try get logcollector stats from agent 017 (non-existent)
+  - name: Try to get logcollector stats from agent 017 (non-existent)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/017/stats/logcollector"
@@ -1984,6 +1984,19 @@ stages:
                 - "017"
           total_affected_items: 0
           total_failed_items: 1
+
+  - name: Try to get invalid component stats from agent 000
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/017/stats/invalid_component"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 400
+      json:
+        title: !anystr
+        detail: !anystr
 
 ---
 test_name: GET /groups

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1900,7 +1900,7 @@ test_name: GET /agents/{agent_id}/stats/{component}
 
 stages:
 
-  - name: Try to get logcollector stats from agent 000 (manager)
+  - name: Get logcollector stats from agent 000 (manager)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/000/stats/logcollector"
@@ -1925,7 +1925,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to get logcollector stats from agent 002
+  - name: Get logcollector stats from agent 002
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -233,6 +233,46 @@ stages:
          total_failed_items: 0
 
 ---
+test_name: GET /agents/{agent_id}/stats/logcollector
+
+stages:
+
+ - name: Try get logcollector stats from agent 002 (Denied)
+   request:
+     verify: False
+     url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+   response:
+      <<: *permission_denied
+
+ - name: Try get logcollector stats from agent 003 (Allowed)
+   request:
+     verify: False
+     url: "{protocol:s}://{host:s}:{port:d}/agents/003/stats/logcollector"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+   response:
+     status_code: 200
+     json:
+       error: 0
+       data:
+         affected_items:
+           - global:
+               start: !anystr
+               end: !anystr
+               files: !anything
+             interval:
+               start: !anystr
+               end: !anystr
+               files: !anything
+         failed_items: []
+         total_affected_items: 1
+         total_failed_items: 0
+
+---
 test_name: GET /groups
 
 stages:

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -233,11 +233,11 @@ stages:
          total_failed_items: 0
 
 ---
-test_name: GET /agents/{agent_id}/stats/logcollector
+test_name: GET /agents/{agent_id}/stats/{component}
 
 stages:
 
- - name: Try get logcollector stats from agent 002 (Denied)
+ - name: Try to get logcollector stats from agent 002 (Denied)
    request:
      verify: False
      url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"
@@ -247,7 +247,7 @@ stages:
    response:
       <<: *permission_denied
 
- - name: Try get logcollector stats from agent 003 (Allowed)
+ - name: Try to get logcollector stats from agent 003 (Allowed)
    request:
      verify: False
      url: "{protocol:s}://{host:s}:{port:d}/agents/003/stats/logcollector"

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -237,6 +237,46 @@ stages:
          total_failed_items: 0
 
 ---
+test_name: GET /agents/{agent_id}/stats/logcollector
+
+stages:
+
+ - name: Try get logcollector stats from agent 002 (Allowed)
+   request:
+     verify: False
+     url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+   response:
+     status_code: 200
+     json:
+       error: 0
+       data:
+         affected_items:
+           - global:
+               start: !anystr
+               end: !anystr
+               files: !anything
+             interval:
+               start: !anystr
+               end: !anystr
+               files: !anything
+         failed_items: []
+         total_affected_items: 1
+         total_failed_items: 0
+
+ - name: Try get logcollector stats from agent 003 (Denied)
+   request:
+     verify: False
+     url: "{protocol:s}://{host:s}:{port:d}/agents/003/stats/logcollector"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+   response:
+      <<: *permission_denied
+
+---
 test_name: GET /groups
 
 stages:

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -237,11 +237,11 @@ stages:
          total_failed_items: 0
 
 ---
-test_name: GET /agents/{agent_id}/stats/logcollector
+test_name: GET /agents/{agent_id}/stats/{component}
 
 stages:
 
- - name: Try get logcollector stats from agent 002 (Allowed)
+ - name: Try to get logcollector stats from agent 002 (Allowed)
    request:
      verify: False
      url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"
@@ -266,7 +266,7 @@ stages:
          total_affected_items: 1
          total_failed_items: 0
 
- - name: Try get logcollector stats from agent 003 (Denied)
+ - name: Try to get logcollector stats from agent 003 (Denied)
    request:
      verify: False
      url: "{protocol:s}://{host:s}:{port:d}/agents/003/stats/logcollector"

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1074,18 +1074,18 @@ class Agent:
 
         return configuration.get_active_configuration(self.id, component, config)
 
-    def getstats(self, daemon):
-        """Read the agent's daemon stats.
+    def get_stats(self, component):
+        """Read the agent's component stats.
 
         Parameters
         ----------
-        daemon : string
-            Name of the service to get stats from.
+        component : string
+            Name of the component to get stats from.
 
         Returns
         -------
         Dict
-            Object with daemon's stats.
+            Object with component's stats.
         """
         # Available daemons and the minimum required agent's version.
         stats_min_ver = {'logcollector': 'v4.2.0'}
@@ -1095,11 +1095,11 @@ class Agent:
         if self.version is None:
             raise WazuhInternalError(1015)
         agent_version = WazuhVersion(self.version.split(" ")[1])
-        required_version = WazuhVersion(stats_min_ver.get(daemon))
+        required_version = WazuhVersion(stats_min_ver.get(component))
         if agent_version < required_version:
             raise WazuhInternalError(1735, extra_message="Minimum required version is " + str(required_version))
 
-        return stats.get_daemons_stats_from_socket(self.id, daemon)
+        return stats.get_daemons_stats_from_socket(self.id, component)
 
 
 def format_fields(field_name, value):

--- a/framework/wazuh/core/tests/data/test_agent/schema_global_test.sql
+++ b/framework/wazuh/core/tests/data/test_agent/schema_global_test.sql
@@ -66,7 +66,7 @@ INSERT INTO agent (id, name, ip, register_ip, internal_key, os_name, os_version,
                    'b3650e11eba2f27er4d160c69de533ee7eed601636a85ba2455d53a90927747f', 'Ubuntu','18.04.1 LTS','18','04',
                    'Bionic Beaver','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
-                   'Wazuh v3.8.2','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
+                   'Wazuh v4.2.0','ab73af41699f13fdd81903b5f23d8d00','f8d49771911ed9d5c45b03a40babd065','master',
                    'node01',strftime('%s','now','-4 days'),
                     strftime('%s','now','-5 seconds'),'updated', 'active', 'group-2');
 

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1419,6 +1419,27 @@ def test_agent_getconfig_ko(socket_mock, send_mock, mock_ossec_socket):
         agent.getconfig('com', 'active-response')
 
 
+@patch('wazuh.core.stats.OssecSocket')
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_getstats(socket_mock, send_mock, mock_ossec_socket):
+    """Test getstats method returns expected message."""
+    agent = Agent('001')
+    mock_ossec_socket.return_value.receive.return_value = b'{"error":0, "data":{"test":0}}'
+    result = agent.getstats('logcollector')
+    assert result == {"test": 0}, 'Result message is not as expected.'
+
+
+@patch('wazuh.core.stats.OssecSocket')
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_getstats_ko(socket_mock, send_mock, mock_ossec_socket):
+    """Test getstats method raises expected exception when the agent's version is lower than required."""
+    agent = Agent('002')
+    with pytest.raises(WazuhInternalError, match=r'\b1735\b'):
+        agent.getstats('logcollector')
+
+
 @pytest.mark.parametrize('last_keep_alive, pending, expected_status', [
     (10, False, 'active'),
     (1900, False, 'disconnected'),

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1422,22 +1422,22 @@ def test_agent_getconfig_ko(socket_mock, send_mock, mock_ossec_socket):
 @patch('wazuh.core.stats.OssecSocket')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_agent_getstats(socket_mock, send_mock, mock_ossec_socket):
-    """Test getstats method returns expected message."""
+def test_agent_get_stats(socket_mock, send_mock, mock_ossec_socket):
+    """Test get_stats method returns expected message."""
     agent = Agent('001')
     mock_ossec_socket.return_value.receive.return_value = b'{"error":0, "data":{"test":0}}'
-    result = agent.getstats('logcollector')
+    result = agent.get_stats('logcollector')
     assert result == {"test": 0}, 'Result message is not as expected.'
 
 
 @patch('wazuh.core.stats.OssecSocket')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_agent_getstats_ko(socket_mock, send_mock, mock_ossec_socket):
-    """Test getstats method raises expected exception when the agent's version is lower than required."""
+def test_agent_get_stats_ko(socket_mock, send_mock, mock_ossec_socket):
+    """Test get_stats method raises expected exception when the agent's version is lower than required."""
     agent = Agent('002')
     with pytest.raises(WazuhInternalError, match=r'\b1735\b'):
-        agent.getstats('logcollector')
+        agent.get_stats('logcollector')
 
 
 @pytest.mark.parametrize('last_keep_alive, pending, expected_status', [

--- a/framework/wazuh/core/tests/test_stats.py
+++ b/framework/wazuh/core/tests/test_stats.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2015-2020, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
+        sys.modules['wazuh.rbac.orm'] = MagicMock()
+        import wazuh.rbac.decorators
+
+        del sys.modules['wazuh.rbac.orm']
+        from wazuh.tests.util import RBAC_bypasser
+
+        wazuh.rbac.decorators.expose_resources = RBAC_bypasser
+        from wazuh.core.exception import WazuhError, WazuhInternalError
+        from wazuh.core import stats, common
+
+
+@pytest.mark.parametrize("agent_id, daemon, response", [
+    ('000', 'logcollector', '{"error":0, "data":{"test":0}}'),
+    (3, 'test', '{"error":0, "data":{"test":0}}'),
+])
+def test_get_daemons_stats_from_socket(agent_id, daemon, response):
+    """Check that get_daemons_stats_from_socket function uses the expected params and returns expected result.
+
+    Parameters
+    ----------
+    agent_id : string
+        Id of the agent to get stats from.
+    daemon : string
+        Name of the service to get stats from.
+    response : string
+        Response to be returned by the socket.
+    """
+    with patch('wazuh.core.stats.OssecSocket.__init__', return_value=None) as mock_socket:
+        with patch('wazuh.core.stats.OssecSocket.send', side_effect=None) as mock_send:
+            with patch('wazuh.core.stats.OssecSocket.receive', return_value=response.encode()):
+                with patch('wazuh.core.stats.OssecSocket.close', side_effect=None):
+                    result = stats.get_daemons_stats_from_socket(agent_id, daemon)
+
+        if agent_id == '000':
+            mock_socket.assert_called_once_with(os.path.join(common.ossec_path, "queue", "ossec", "logcollector"))
+            mock_send.assert_called_once_with(b'getstate')
+        else:
+            mock_socket.assert_called_once_with(os.path.join(common.ossec_path, "queue", "ossec", "request"))
+            mock_send.assert_called_once_with(f"{str(agent_id).zfill(3)} {daemon} getstate".encode())
+
+
+def test_get_daemons_stats_from_socket_ko():
+    """Check if get_daemons_stats_from_socket raises expected exceptions."""
+    with pytest.raises(WazuhError, match=r'\b1307\b'):
+        stats.get_daemons_stats_from_socket(None, None)
+
+    with pytest.raises(WazuhInternalError, match=r'\b1121\b'):
+        stats.get_daemons_stats_from_socket('000', 'logcollector')
+
+    with patch('wazuh.core.stats.OssecSocket.__init__', return_value=None):
+        with patch('wazuh.core.stats.OssecSocket.send', side_effect=None):
+            with patch('wazuh.core.configuration.OssecSocket.receive', side_effect=ValueError):
+                with pytest.raises(WazuhInternalError, match=r'\b1118\b'):
+                    stats.get_daemons_stats_from_socket('000', 'logcollector')
+
+            with patch('wazuh.core.configuration.OssecSocket.receive', return_value="err Error message test".encode()):
+                with patch('wazuh.core.stats.OssecSocket.close', side_effect=None):
+                    with pytest.raises(WazuhError, match=r'\b1117\b'):
+                        stats.get_daemons_stats_from_socket('000', 'logcollector')

--- a/framework/wazuh/stats.py
+++ b/framework/wazuh/stats.py
@@ -211,9 +211,9 @@ def get_daemon_stats_json(agent_list=None, daemon=None):
     result : AffectedItemsWazuhResult
         Stats of daemon.
     """
-    result = AffectedItemsWazuhResult(all_msg=f'Obtained {daemon} stats from all selected agents',
-                                      some_msg=f'Some {daemon} stats were not obtained',
-                                      none_msg=f'No {daemon} stats were obtained')
+    result = AffectedItemsWazuhResult(all_msg=f'Statistical information for each agent was successfully read',
+                                      some_msg=f'Could not read statistical information for some agents',
+                                      none_msg=f'Could not read statistical information for any agent')
 
     system_agents = get_agents_info()
     for agent_id in agent_list:

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -96,6 +96,7 @@ get_rbac_actions:
           - GET /agents/{agent_id}/config/{component}/{configuration}
           - GET /agents/{agent_id}/group/is_sync
           - GET /agents/{agent_id}/key
+          - GET /agents/{agent_id}/stats/logcollector
           - GET /groups/{group_id}/agents
           - GET /agents/no_group
           - GET /agents/outdated

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -96,7 +96,7 @@ get_rbac_actions:
           - GET /agents/{agent_id}/config/{component}/{configuration}
           - GET /agents/{agent_id}/group/is_sync
           - GET /agents/{agent_id}/key
-          - GET /agents/{agent_id}/stats/logcollector
+          - GET /agents/{agent_id}/stats/{component}
           - GET /groups/{group_id}/agents
           - GET /agents/no_group
           - GET /agents/outdated

--- a/framework/wazuh/tests/test_stats.py
+++ b/framework/wazuh/tests/test_stats.py
@@ -5,6 +5,7 @@
 import sys
 from datetime import date
 from unittest.mock import patch, MagicMock
+from wazuh.tests.test_agent import send_msg_to_wdb
 
 import pytest
 
@@ -159,3 +160,30 @@ def test_get_daemons_stats_ko(mock_readfp):
 
             assert isinstance(response, WazuhException), f'The result is not WazuhResult type'
             assert response.code == 1104, f'Response code is not the same'
+
+
+@pytest.mark.parametrize('daemon', [
+    'logcollector', 'test'
+])
+@patch('wazuh.core.agent.Agent.getstats')
+@patch('wazuh.stats.get_agents_info', return_value=['000', '001'])
+def test_get_daemon_stats_json(mock_agents_info, mock_getstats, daemon):
+    """Test `get_daemon_stats_json` function from agent module.
+
+    Parameters
+    ----------
+    daemon : string
+        Name of the daemon to get stats from.
+    """
+    response = get_daemon_stats_json(agent_list=['001'], daemon=daemon)
+    assert isinstance(response, AffectedItemsWazuhResult), f'The result is not AffectedItemsWazuhResult type'
+    mock_getstats.assert_called_once_with(daemon=daemon)
+
+
+@patch('wazuh.core.agent.Agent.getstats')
+@patch('wazuh.stats.get_agents_info', return_value=['000', '001'])
+def test_get_daemon_stats_json_ko(mock_agents_info, mock_getstats):
+    """Test `get_daemon_stats_json` function from agent module."""
+    response = get_daemon_stats_json(agent_list=['003'], daemon='logcollector')
+    assert isinstance(response, AffectedItemsWazuhResult), f'The result is not AffectedItemsWazuhResult type'
+    assert response.render()['data']['failed_items'][0]['error']['code'] == 1701, 'Expected error code was not returned'

--- a/framework/wazuh/tests/test_stats.py
+++ b/framework/wazuh/tests/test_stats.py
@@ -162,28 +162,28 @@ def test_get_daemons_stats_ko(mock_readfp):
             assert response.code == 1104, f'Response code is not the same'
 
 
-@pytest.mark.parametrize('daemon', [
+@pytest.mark.parametrize('component', [
     'logcollector', 'test'
 ])
-@patch('wazuh.core.agent.Agent.getstats')
+@patch('wazuh.core.agent.Agent.get_stats')
 @patch('wazuh.stats.get_agents_info', return_value=['000', '001'])
-def test_get_daemon_stats_json(mock_agents_info, mock_getstats, daemon):
-    """Test `get_daemon_stats_json` function from agent module.
+def test_get_agents_component_stats_json(mock_agents_info, mock_getstats, component):
+    """Test `get_agents_component_stats_json` function from agent module.
 
     Parameters
     ----------
     daemon : string
         Name of the daemon to get stats from.
     """
-    response = get_daemon_stats_json(agent_list=['001'], daemon=daemon)
+    response = get_agents_component_stats_json(agent_list=['001'], component=component)
     assert isinstance(response, AffectedItemsWazuhResult), f'The result is not AffectedItemsWazuhResult type'
-    mock_getstats.assert_called_once_with(daemon=daemon)
+    mock_getstats.assert_called_once_with(component=component)
 
 
-@patch('wazuh.core.agent.Agent.getstats')
+@patch('wazuh.core.agent.Agent.get_stats')
 @patch('wazuh.stats.get_agents_info', return_value=['000', '001'])
-def test_get_daemon_stats_json_ko(mock_agents_info, mock_getstats):
-    """Test `get_daemon_stats_json` function from agent module."""
-    response = get_daemon_stats_json(agent_list=['003'], daemon='logcollector')
+def test_get_agents_component_stats_json_ko(mock_agents_info, mock_getstats):
+    """Test `get_agents_component_stats_json` function from agent module."""
+    response = get_agents_component_stats_json(agent_list=['003'], component='logcollector')
     assert isinstance(response, AffectedItemsWazuhResult), f'The result is not AffectedItemsWazuhResult type'
     assert response.render()['data']['failed_items'][0]['error']['code'] == 1701, 'Expected error code was not returned'


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7128|

## Description

Hello team!

A new endpoint is developed in this PR as requested in #7128:
```
GET /agents/{agent_id}/stats/logcollector
```

It can retrieve information from both, managers (000) and agents (!=000). Example output from the agent `003` is:
```Python
{
  "data": {
    "affected_items": [
      {
        "global": {
          "start": "Fri Jan 15 13:55:56 2021",
          "end": "Fri Jan 15 15:49:18 2021",
          "files": [
            {
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ],
              "location": "df -P",
              "bytes": 9020,
              "events": 100
            },
            {
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ],
              "location": "/var/log/dpkg.log",
              "bytes": 0,
              "events": 0
            },
            {
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ],
              "location": "/var/ossec/logs/active-responses.log",
              "bytes": 0,
              "events": 0
            },
            {
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ],
              "location": "last -n 20",
              "bytes": 660,
              "events": 10
            }
          ]
        },
        "interval": {
          "start": "Fri Jan 15 15:49:13 2021",
          "end": "Fri Jan 15 15:49:18 2021",
          "files": [
            {
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ],
              "location": "df -P",
              "bytes": 0,
              "events": 0
            },
            {
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ],
              "location": "/var/log/dpkg.log",
              "bytes": 0,
              "events": 0
            },
            {
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ],
              "location": "/var/ossec/logs/active-responses.log",
              "bytes": 0,
              "events": 0
            },
            {
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ],
              "location": "last -n 20",
              "bytes": 0,
              "events": 0
            }
          ]
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Obtained logcollector stats from all selected agents",
  "error": 0
}
```

## Tests output
### Integration tests
New integration tests have been added inside `test_agent_GET_endpoints`, `test_rbac_white_agent_endpoints` and `test_rbac_black_agent_endpoints`:

```
pytest -vv test_agent_GET_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-58-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 91 items                                                                                                                                                                                           

test_agent_GET_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                               [  1%]
test_agent_GET_endpoints.tavern.yaml::GET /agents with single agent id PASSED                                                                                                                          [  2%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                                 [  3%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                                      [  4%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                                [  5%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/logcollector PASSED                                                                                                                 [  6%]
test_agent_GET_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                               [  7%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[md5] PASSED                                                                                                                              [  8%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha1] PASSED                                                                                                                             [  9%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha224] PASSED                                                                                                                           [ 10%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha256] PASSED                                                                                                                           [ 12%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha384] PASSED                                                                                                                           [ 13%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha512] PASSED                                                                                                                           [ 14%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2b] PASSED                                                                                                                          [ 15%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2s] PASSED                                                                                                                          [ 16%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_224] PASSED                                                                                                                         [ 17%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_256] PASSED                                                                                                                         [ 18%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_384] PASSED                                                                                                                         [ 19%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_512] PASSED                                                                                                                         [ 20%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                             [ 21%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[configSum] PASSED                                                                                                    [ 23%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[dateAdd] PASSED                                                                                                      [ 24%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[group] PASSED                                                                                                        [ 25%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[id] PASSED                                                                                                           [ 26%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[ip] PASSED                                                                                                           [ 27%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[lastKeepAlive] PASSED                                                                                                [ 28%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[manager] PASSED                                                                                                      [ 29%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[mergedSum] PASSED                                                                                                    [ 30%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[name] PASSED                                                                                                         [ 31%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[node_name] PASSED                                                                                                    [ 32%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.arch] PASSED                                                                                                      [ 34%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.build] PASSED                                                                                                     [ 35%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.codename] PASSED                                                                                                  [ 36%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.major] PASSED                                                                                                     [ 37%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.minor] PASSED                                                                                                     [ 38%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.name] PASSED                                                                                                      [ 39%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.platform] PASSED                                                                                                  [ 40%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.uname] PASSED                                                                                                     [ 41%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.version] PASSED                                                                                                   [ 42%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[registerIP] PASSED                                                                                                   [ 43%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status] PASSED                                                                                                       [ 45%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[version] PASSED                                                                                                      [ 46%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                                      [ 47%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                              [ 48%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[md5] PASSED                                                                                                             [ 49%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha1] PASSED                                                                                                            [ 50%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha224] PASSED                                                                                                          [ 51%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha256] PASSED                                                                                                          [ 52%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha384] PASSED                                                                                                          [ 53%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha512] PASSED                                                                                                          [ 54%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2b] PASSED                                                                                                         [ 56%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2s] PASSED                                                                                                         [ 57%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_224] PASSED                                                                                                        [ 58%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_256] PASSED                                                                                                        [ 59%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_384] PASSED                                                                                                        [ 60%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_512] PASSED                                                                                                        [ 61%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                                              [ 62%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                                               [ 63%]
test_agent_GET_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                               [ 64%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                                      [ 65%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED                                                                                                               [ 67%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED                                                                                                                    [ 68%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED                                                                                                                    [ 69%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED                                                                                                                  [ 70%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED                                                                                                             [ 71%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED                                                                                                            [ 72%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED                                                                                                                [ 73%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                                      [ 74%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                                [ 75%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[dateAdd] PASSED                                                                                                              [ 76%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[id] PASSED                                                                                                                   [ 78%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[ip] PASSED                                                                                                                   [ 79%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[lastKeepAlive] PASSED                                                                                                        [ 80%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[manager] PASSED                                                                                                              [ 81%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[name] PASSED                                                                                                                 [ 82%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[node_name] PASSED                                                                                                            [ 83%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.arch] PASSED                                                                                                              [ 84%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.build] PASSED                                                                                                             [ 85%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.codename] PASSED                                                                                                          [ 86%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.major] PASSED                                                                                                             [ 87%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.minor] PASSED                                                                                                             [ 89%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.name] PASSED                                                                                                              [ 90%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.platform] PASSED                                                                                                          [ 91%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.uname] PASSED                                                                                                             [ 92%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.version] PASSED                                                                                                           [ 93%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[registerIP] PASSED                                                                                                           [ 94%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status] PASSED                                                                                                               [ 95%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[version] PASSED                                                                                                              [ 96%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                                [ 97%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                                    [ 98%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                                                [100%]

================================================================================ 91 passed, 98 warnings in 143.51s (0:02:23) =================================================================================
```


```
pytest -vv test_rbac_white_agent_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-58-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 40 items                                                                                                                                                                                           

test_rbac_white_agent_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                        [  2%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents?agents_list=agent_id PASSED                                                                                                                   [  5%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                          [  7%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                               [ 10%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                         [ 12%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/logcollector PASSED                                                                                                          [ 15%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                        [ 17%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                      [ 20%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                               [ 22%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                       [ 25%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                                       [ 27%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                                        [ 30%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                        [ 32%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                               [ 35%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                               [ 37%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                         [ 40%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                         [ 42%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                             [ 45%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                                         [ 47%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                                                    [ 50%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/group?group_id={group_id} PASSED                                                                                                           [ 52%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /groups?groups_list={group_id} PASSED                                                                                                              [ 55%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                                                     [ 57%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents?agents_list=agent_id&status=all PASSED                                                                                                     [ 60%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                                     [ 62%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                                       [ 65%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                                [ 67%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                                          [ 70%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                                       [ 72%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/group PASSED                                                                                                                                  [ 75%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                                               [ 77%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                                               [ 80%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                                [ 82%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                                            [ 85%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                                     [ 87%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                                                [ 90%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                                                                                                                         [ 92%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                                         [ 95%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents (deny cluster:read) PASSED                                                                                                                    [ 97%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                                                                 [100%]

================================================================================ 40 passed, 42 warnings in 582.65s (0:09:42) =================================================================================
```

```
pytest -vv test_rbac_black_agent_endpoints.tavern.yaml --disable-warnings
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-58-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 40 items                                                                                                                                                                                           

test_rbac_black_agent_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                        [  2%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents?agents_list=agent_id PASSED                                                                                                                   [  5%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                          [  7%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                               [ 10%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                         [ 12%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/logcollector PASSED                                                                                                          [ 15%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                        [ 17%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                      [ 20%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                               [ 22%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                       [ 25%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/json PASSED                                                                                                       [ 27%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename}/xml PASSED                                                                                                        [ 30%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                        [ 32%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                               [ 35%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                               [ 37%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                         [ 40%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                         [ 42%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                             [ 45%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                                         [ 47%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                                         [ 50%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                                                    [ 52%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/group?group_id=group_id PASSED                                                                                                             [ 55%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE groups?groups_list=group_id PASSED                                                                                                                 [ 57%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                                                     [ 60%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents?agents_list=agent_id PASSED                                                                                                                [ 62%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                                     [ 65%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                                       [ 67%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                                [ 70%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                                          [ 72%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                                       [ 75%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/group?group_id={group_id} PASSED                                                                                                              [ 77%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                                               [ 80%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                                               [ 82%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                                [ 85%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                                            [ 87%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                                     [ 90%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                                                [ 92%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                                                                                                                         [ 95%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents (allow cluster:read) PASSED                                                                                                                   [ 97%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                                                                 [100%]

================================================================================ 40 passed, 42 warnings in 590.51s (0:09:50) =================================================================================
```    

### Unittests
New unittests have been developed for stats, core/stats and core/agent modules:
```
python3 -m pytest framework/wazuh/core/tests/test_stats.py framework/wazuh/core/tests/test_agent.py framework/wazuh/tests/test_stats.py --disable-warnings
============================================================ test session starts =============================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/framework
plugins: trio-0.6.0, asyncio-0.14.0
collected 172 items                                                                                                                          

framework/wazuh/core/tests/test_stats.py ...                                                                                           [  1%]
framework/wazuh/core/tests/test_agent.py ............................................................................................. [ 55%]
............................................................                                                                           [ 90%]
framework/wazuh/tests/test_stats.py ................                                                                                   [100%]

====================================================== 172 passed, 11 warnings in 1.20s ======================================================
```


Regards,
Selu.