### PR TITLE
Fix logtest: avoid register rules in AR

### DIFF
--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1789,7 +1789,9 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
             } /* end of elements block */
 
             /* Assign an active response to the rule */
-            Rule_AddAR(config_ruleinfo);
+            if (os_analysisd_rulelist == *r_node) {
+                Rule_AddAR(config_ruleinfo);
+            }
 
             j++; /* next rule */
 


### PR DESCRIPTION
|Related issue|
|---|
| Close #7204 |

## Description
Hi Team,

This PR aims to solve `ossec-analysisd` crash when Active Response was triggered after using `wazuh-logtest`.

The cause of the problem was that AR information was shared between analysisd scope and it inner component dedicate to test rules (wazuh-logtest backend), and when testing session was deleted AR information was also released.

Fix proposal consist in not associate the logtest rules to AR information at all.
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] ~~Windows~~
  - [x] ~~MAC OS X~~
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] ~~Scan-build report~~
  - [x] ~~Coverity~~
  - [x] ~~Dr. Memory~~
- Memory tests for macOS
  - [x] ~~Scan-build report~~
  - [x] ~~Leaks~~
  - [x] ~~AddressSanitizer~~

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [x] ~~Configuration on demand reports new parameters~~
- [x] The data flow works as expected (agent-manager-api-app)
- [x] ~~Added unit tests (for new features)~~
- [ ] Stress test for affected components
