### PR TITLE
Modify WPK upgrade scripts to use relative path and wazuh-control

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -2,52 +2,53 @@
 
 # Copyright (C) 2015-2020, Wazuh Inc.
 
-. /etc/ossec-init.conf
+WAZUH_HOME=${1}
+WAZUH_VERSION=${2} 
 
 # Generating Backup
 BDATE=$(date +"%m-%d-%Y_%H-%M-%S")
 
-echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." > ${DIRECTORY}/logs/upgrade.log
-mkdir -p ${DIRECTORY}/tmp_bkp/${DIRECTORY}/bin
-mkdir -p ${DIRECTORY}/tmp_bkp/${DIRECTORY}/etc
-mkdir -p ${DIRECTORY}/tmp_bkp/etc
+echo "$(date +"%Y/%m/%d %H:%M:%S") - Generating Backup." > ${WAZUH_HOME}/logs/upgrade.log
+mkdir -p ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}/bin
+mkdir -p ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}/etc
+mkdir -p ${WAZUH_HOME}/tmp_bkp/etc
 
-cp -rp ${DIRECTORY}/bin ${DIRECTORY}/tmp_bkp/${DIRECTORY}
-cp -rp ${DIRECTORY}/etc ${DIRECTORY}/tmp_bkp/${DIRECTORY}
-cp -p /etc/ossec-init.conf ${DIRECTORY}/tmp_bkp/etc
+cp -rp ${WAZUH_HOME}/bin ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}
+cp -rp ${WAZUH_HOME}/etc ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}
+cp -p /etc/ossec-init.conf ${WAZUH_HOME}/tmp_bkp/etc
 
-tar czf ${DIRECTORY}/backup/backup_${VERSION}_[${BDATE}].tar.gz -C ${DIRECTORY}/tmp_bkp . >> ${DIRECTORY}/logs/upgrade.log 2>&1
-rm -rf ${DIRECTORY}/tmp_bkp
+tar czf ${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz -C ${WAZUH_HOME}/tmp_bkp . >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+rm -rf ${WAZUH_HOME}/tmp_bkp
 
 # Installing upgrade
-echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade started." >> ${DIRECTORY}/logs/upgrade.log
-chmod +x ${DIRECTORY}/var/upgrade/install.sh
-${DIRECTORY}/var/upgrade/install.sh >> ${DIRECTORY}/logs/upgrade.log 2>&1
+echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade started." >> ${WAZUH_HOME}/logs/upgrade.log
+chmod +x ${WAZUH_HOME}/var/upgrade/install.sh
+${WAZUH_HOME}/var/upgrade/install.sh >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
 
 # Check installation result
 RESULT=$?
-echo "$(date +"%Y/%m/%d %H:%M:%S") - Installation result = ${RESULT}" >> ${DIRECTORY}/logs/upgrade.log
+echo "$(date +"%Y/%m/%d %H:%M:%S") - Installation result = ${RESULT}" >> ${WAZUH_HOME}/logs/upgrade.log
 
 # Wait connection
 status="pending"
 COUNTER=30
 while [ "$status" != "connected" -a $COUNTER -gt 0  ]; do
-    . ${DIRECTORY}/var/run/wazuh-agentd.state >> ${DIRECTORY}/logs/upgrade.log 2>&1
+    . ${WAZUH_HOME}/var/run/wazuh-agentd.state >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
     sleep 1
     COUNTER=$[COUNTER - 1]
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Waiting connection... Status = "${status}". Remaining attempts: ${COUNTER}." >> ${DIRECTORY}/logs/upgrade.log
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Waiting connection... Status = "${status}". Remaining attempts: ${COUNTER}." >> ${WAZUH_HOME}/logs/upgrade.log
 done
 
 # Check connection
 if [ "$status" = "connected" -a $RESULT -eq 0  ]; then
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Connected to manager." >> ${DIRECTORY}/logs/upgrade.log
-    echo -ne "0" > ${DIRECTORY}/var/upgrade/upgrade_result
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade finished successfully." >> ${DIRECTORY}/logs/upgrade.log
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Connected to manager." >> ${WAZUH_HOME}/logs/upgrade.log
+    echo -ne "0" > ${WAZUH_HOME}/var/upgrade/upgrade_result
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade finished successfully." >> ${WAZUH_HOME}/logs/upgrade.log
 else
     # Restoring backup
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Restoring..." >> ${DIRECTORY}/logs/upgrade.log
-    ${DIRECTORY}/bin/wazuh-control stop >> ${DIRECTORY}/logs/upgrade.log 2>&1
-    tar xzf ${DIRECTORY}/backup/backup_${VERSION}_[${BDATE}].tar.gz -C / >> ${DIRECTORY}/logs/upgrade.log 2>&1
-    echo -ne "2" > ${DIRECTORY}/var/upgrade/upgrade_result
-    ${DIRECTORY}/bin/wazuh-control start >> ${DIRECTORY}/logs/upgrade.log 2>&1
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Restoring..." >> ${WAZUH_HOME}/logs/upgrade.log
+    ${WAZUH_HOME}/bin/ossec-control stop >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+    tar xzf ${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz -C / >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+    echo -ne "2" > ${WAZUH_HOME}/var/upgrade/upgrade_result
+    ${WAZUH_HOME}/bin/ossec-control start >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
 fi

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2015-2020, Wazuh Inc.
+# Copyright (C) 2015-2021, Wazuh Inc.
 
 WAZUH_HOME=${1}
 WAZUH_VERSION=${2} 
@@ -15,7 +15,9 @@ mkdir -p ${WAZUH_HOME}/tmp_bkp/etc
 
 cp -rp ${WAZUH_HOME}/bin ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}
 cp -rp ${WAZUH_HOME}/etc ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}
-cp -p /etc/ossec-init.conf ${WAZUH_HOME}/tmp_bkp/etc
+if [ -f /etc/ossec-init.conf ]; then
+    cp -p /etc/ossec-init.conf ${WAZUH_HOME}/tmp_bkp/etc
+fi
 
 tar czf ${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz -C ${WAZUH_HOME}/tmp_bkp . >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
 rm -rf ${WAZUH_HOME}/tmp_bkp

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -47,8 +47,8 @@ if [ "$status" = "connected" -a $RESULT -eq 0  ]; then
 else
     # Restoring backup
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Restoring..." >> ${WAZUH_HOME}/logs/upgrade.log
-    ${WAZUH_HOME}/bin/ossec-control stop >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+    ${WAZUH_HOME}/bin/wazuh-control stop >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
     tar xzf ${WAZUH_HOME}/backup/backup_${WAZUH_VERSION}_[${BDATE}].tar.gz -C / >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
     echo -ne "2" > ${WAZUH_HOME}/var/upgrade/upgrade_result
-    ${WAZUH_HOME}/bin/ossec-control start >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
+    ${WAZUH_HOME}/bin/wazuh-control start >> ${WAZUH_HOME}/logs/upgrade.log 2>&1
 fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
 # Copyright (C) 2015-2020, Wazuh Inc.
-. /etc/ossec-init.conf 2> /dev/null || exit 1
-(sleep 5 && chmod +x $DIRECTORY/var/upgrade/src/init/*.sh && $DIRECTORY/var/upgrade/src/init/pkg_installer.sh) >/dev/null 2>&1 &
+
+# Get Wazuh installation path
+SCRIPT=$(readlink -f "$0")
+WAZUH_HOME=$(dirname $(dirname $(dirname "$SCRIPT")))
+
+# Get Wazuh Info
+eval $(${WAZUH_HOME}/bin/wazuh-control info 2>/dev/null)
+if [ "X${WAZUH_VERSION}" = "X" ] ; then
+    . /etc/ossec-init.conf 2> /dev/null
+    if [ "X${VERSION}" = "X" ] ; then
+        exit 1
+    else
+        WAZUH_VERSION=${VERSION}
+    fi
+fi
+
+(sleep 5 && chmod +x ${WAZUH_HOME}/var/upgrade/src/init/*.sh && ${WAZUH_HOME}/var/upgrade/src/init/pkg_installer.sh ${WAZUH_HOME} ${WAZUH_VERSION}) >/dev/null 2>&1 &

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2015-2020, Wazuh Inc.
+# Copyright (C) 2015-2021, Wazuh Inc.
 
 # Get Wazuh installation path
 SCRIPT=$(readlink -f "$0")


### PR DESCRIPTION
|Related issue|
|---|
|7112|

## Description
This PR modifies the **WPK** default upgrade scripts to find Wazuh installation path using its relative path (keep in mind that these scripts are deployed into the installation directory). And uses **wazuh-control** to obtain Wazuh Version.
As these scripts are in charge of performing an update, **upgrade.sh** search for Wazuh info by both methods: calling **wazuh-control info** and sourcing **ossec-init.conf**.
- **upgrade.sh** now finds Wazuh installation path using its own relative path. It also searches for WAZUH_VERSION by **wazuh-control** or **ossec-init.conf** and hands both variables to **pkg_installer.sh**. 
If Wazuh info isn't found (Wazuh isn't installed properly), the scripts returns with 1. 
This script continues forking to return immediately as WPK requirements.
- **pkg_installer.sh** now receives WAZUH_HOME and WAZUH_VERSION as parameters to perform the upgrade.

Manual test of the scripts with different options
  - [X] **Use the scripts to generate an update from 4.1 (without **wazuh-control info**)
  - [X] **Use the scripts to generate an update from 4.2 (without **ossec-init.con**)
  - [X] **Try to use the scripts to generate an updatewithout installed Wazuh (must fail and return 1)
  