### PR TITLE
Import wazuh-logtest socket name

### DIFF
--- a/framework/scripts/wazuh-logtest.py
+++ b/framework/scripts/wazuh-logtest.py
@@ -13,6 +13,7 @@ import argparse
 import atexit
 import struct
 import textwrap
+from wazuh.core.common import LOGTEST_SOCKET
 
 
 def init_argparse():
@@ -218,7 +219,7 @@ class WazuhLogtest:
             log_format (str, optional): type of log. Defaults to "syslog".
         """
         self.protocol = WazuhDeamonProtocol()
-        self.socket = WazuhSocket('/var/ossec/queue/ossec/logtest')
+        self.socket = WazuhSocket(LOGTEST_SOCKET)
         self.fixed_fields = dict()
         self.fixed_fields['location'] = location
         self.fixed_fields['log_format'] = log_format


### PR DESCRIPTION
|Related issue|
|---|
|[7216](https://github.com/wazuh/wazuh/issues/7216)|

## Description

Importing the socket name from Wazuh library, we should obtain the correct socket path.

## Tests

- [x] Installation in default path
- [x] Installation in different path