### PR TITLE
Fix of installation problems during exploratory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -589,6 +589,7 @@ setEnv()
 {
     CEXTRA="$CEXTRA -DDEFAULTDIR=\\\"${INSTALLDIR}\\\""
 
+    echo ""
     echo "    - ${installat} ${INSTALLDIR} ."
 
     if [ "X$INSTYPE" = "Xagent" ]; then
@@ -621,31 +622,6 @@ askForDelete()
                     echo "Error deleting ${INSTALLDIR}"
                     exit 2;
                 fi
-                ;;
-            $nomatch)
-                if [ "X$PREINSTALLEDDIR" != "X" ]; then
-                    echo "WARNING! The installation can't proceed without removing already installed versions. Exiting."
-                    exit 2;
-                fi
-                ;;
-        esac
-    elif [ -d "$PREINSTALLEDDIR" ]; then
-        $ECHO "    - WARNING! The installation can't proceed without removing already installed versions. Should I delete it? ($yes/$no) [$no]: "
-        read ANSWER
-
-        case $ANSWER in
-            $yesmatch)
-                echo "      Stopping Wazuh..."
-                UpdateStopOSSEC
-                rm -rf $PREINSTALLEDDIR
-                if [ ! $? = 0 ]; then
-                    echo "Error deleting ${PREINSTALLEDDIR}"
-                    exit 2;
-                fi
-                ;;
-            $nomatch)
-                echo "Exiting."
-                exit 2;
                 ;;
         esac
     fi

--- a/install.sh
+++ b/install.sh
@@ -562,9 +562,9 @@ ConfigureServer()
 ##########
 setInstallDir()
 {
-    echo ""
     if [ "X${USER_DIR}" = "X" ]; then
         while [ 1 ]; do
+            echo ""
             $ECHO "2- ${wheretoinstall} [$INSTALLDIR]: "
             read ANSWER
             if [ ! "X$ANSWER" = "X" ]; then
@@ -885,6 +885,7 @@ main()
                     break;
                     ;;
                 $no)
+                    echo ""
                     echo "${mustuninstall}"
                     exit 0;
                     ;;
@@ -922,7 +923,6 @@ main()
             fi
 
         fi
-        echo ""
     fi
 
     # Setting up the installation type

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -273,7 +273,7 @@ getPreinstalledType()
             getPreinstalledDir
         fi
 
-        TYPE=`$PREINSTALLEDDIR/bin/wazuh-control -t`
+        TYPE=`$PREINSTALLEDDIR/bin/wazuh-control info -t`
     fi
 
     echo $TYPE
@@ -290,7 +290,7 @@ getPreinstalledVersion()
             getPreinstalledDir
         fi
 
-        VERSION=`$PREINSTALLEDDIR/bin/wazuh-control -v`
+        VERSION=`$PREINSTALLEDDIR/bin/wazuh-control info -v`
     fi
 
     echo $VERSION

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -336,7 +336,7 @@ UpdateStopOSSEC()
 {
     MAJOR_VERSION=`echo ${VERSION} | cut -f1 -d'.' | cut -f2 -d'v'`
 
-    if [ "X$TYPE" != "X" ]; then
+    if [ "X$TYPE" = "X" ]; then
         getPreinstalledType
     fi
 


### PR DESCRIPTION
|Related issue|
|---|
|7090|

## Description
This PR fixes three issues found during exploratory testing on installation steps:
 - Fixes an error during a merge that generates the installation to continue even after the user selects to not update Wazuh.
 - Fixes a bad usage of **wazuh-control** when finding Wazuh installed type that unchains an error on building steps.
 - FIxes a comparison that unchains a bad service usage to stop Wazuh  

Manual test of the scripts with different options
  - [X] Source install of Wazuh
  - [X] Source update of Wazuh from v4.1
  - [X] Source update of Wazuh from v4.2

  