### PR TITLE
Commit, close and free memory associated to FIM DB

### DIFF
--- a/src/syscheckd/db/fim_db.c
+++ b/src/syscheckd/db/fim_db.c
@@ -124,6 +124,9 @@ fdb_t *fim_db_init(int storage) {
         goto free_fim;
     }
 
+    // Close the DB when ending execution.
+    atexit(fim_db_close);
+
     return fim;
 
 free_fim:
@@ -134,11 +137,19 @@ free_fim:
     return NULL;
 }
 
-void fim_db_close(fdb_t *fim_sql) {
-    fim_db_force_commit(fim_sql);
-    fim_db_finalize_stmt(fim_sql);
-    sqlite3_close_v2(fim_sql->db);
+// LCOV_EXCL_START
+void fim_db_close() {
+    if (syscheck.database == NULL) {
+        return;
+    }
+
+    fim_db_force_commit(syscheck.database);
+    fim_db_finalize_stmt(syscheck.database);
+    sqlite3_close_v2(syscheck.database->db);
+
+    os_free(syscheck.database);
 }
+// LCOV_EXCL_STOP
 
 
 void fim_db_clean(void) {

--- a/src/syscheckd/db/fim_db.h
+++ b/src/syscheckd/db/fim_db.h
@@ -231,13 +231,9 @@ int fim_db_get_path_range(fdb_t *fim_sql, fim_type type, const char *start, cons
 fdb_t *fim_db_init(int storage);
 
 /**
- * @brief Finalize stmt and close DB.
- *
- * @param fim_sql FIM database struct.
- *
- * @return FIMDB_OK on success, FIMDB_ERR otherwise.
+ * @brief Finalize stmt and close the global FIM DB.
  */
-void fim_db_close(fdb_t *fim_sql);
+void fim_db_close();
 
 /**
  * @brief Clean the FIM databases.

--- a/src/unit_tests/syscheckd/db/test_fim_db.c
+++ b/src/unit_tests/syscheckd/db/test_fim_db.c
@@ -810,41 +810,6 @@ void test_fim_db_cache_success(void **state) {
 }
 
 /**********************************************************************************************************************\
- * fim_db_close() tests
-\**********************************************************************************************************************/
-void test_fim_db_close_failed(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-    expect_fim_db_check_transaction();
-    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return(__wrap_sqlite3_finalize, SQLITE_ERROR);
-    will_return(__wrap_sqlite3_errmsg, "REASON GOES HERE");
-#ifndef TEST_WINAGENT
-    expect_string(__wrap__merror, formatted_msg,
-                  "Error finalizing statement 'INSERT INTO file_data (dev, inode, size, perm, attributes, uid, gid, "
-                  "user_name, group_name, hash_md5, hash_sha1, hash_sha256, mtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, "
-                  "?, ?, ?, ?);': REASON GOES HERE");
-#else
-    expect_string(__wrap__merror, formatted_msg,
-                  "Error finalizing statement 'INSERT INTO file_data (dev, inode, size, perm, attributes, uid, gid, "
-                  "user_name, group_name, hash_md5, hash_sha1, hash_sha256, mtime) VALUES (NULL, NULL, ?, ?, ?, ?, ?, "
-                  "?, ?, ?, ?, ?, ?);': REASON GOES HERE");
-#endif
-    will_return(__wrap_sqlite3_close_v2, SQLITE_BUSY);
-    fim_db_close(test_data->fim_sql);
-}
-
-void test_fim_db_close_success(void **state) {
-    test_fim_db_insert_data *test_data = *state;
-    expect_fim_db_check_transaction();
-    will_return_always(__wrap_sqlite3_reset, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_clear_bindings, SQLITE_OK);
-    will_return_always(__wrap_sqlite3_finalize, SQLITE_OK);
-    will_return(__wrap_sqlite3_close_v2, SQLITE_OK);
-    fim_db_close(test_data->fim_sql);
-}
-
-/**********************************************************************************************************************\
  * fim_db_finalize_stmt() tests
 \**********************************************************************************************************************/
 void test_fim_db_finalize_stmt_failed(void **state) {
@@ -2265,9 +2230,6 @@ int main(void) {
         // fim_db_cache
         cmocka_unit_test_setup_teardown(test_fim_db_cache_failed, test_fim_db_setup, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_cache_success, test_fim_db_setup, test_fim_db_teardown),
-        // fim_db_close
-        cmocka_unit_test_setup_teardown(test_fim_db_close_failed, test_fim_db_setup, test_fim_db_teardown),
-        cmocka_unit_test_setup_teardown(test_fim_db_close_success, test_fim_db_setup, test_fim_db_teardown),
         // fim_db_finalize_stmt
         cmocka_unit_test_setup_teardown(test_fim_db_finalize_stmt_failed, test_fim_db_setup, test_fim_db_teardown),
         cmocka_unit_test_setup_teardown(test_fim_db_finalize_stmt_success, test_fim_db_setup, test_fim_db_teardown),

--- a/src/unit_tests/syscheckd/test_fim_sync.c
+++ b/src/unit_tests/syscheckd/test_fim_sync.c
@@ -129,7 +129,8 @@ static int setup_group(void **state) {
 }
 
 static int teardown_group(void **state) {
-    fim_db_close(syscheck.database);
+    expect_any(__wrap__mdebug1, formatted_msg);
+    fim_db_close();
     return 0;
 }
 
@@ -864,5 +865,5 @@ int main(void) {
         cmocka_unit_test(test_fim_entry_json_null_data),
     };
 
-    return cmocka_run_group_tests(tests, setup_group, NULL);
+    return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }


### PR DESCRIPTION
## Description

This is a simple PR that repurpuoses a previously unused function from `fim_db` and marks it to be used when the process exits in order to close the DB and clean all memory associated with it.

The main benefit from this PR is cleaning up valgrind reports, since the "still reachable" messages associated with sqlite no longer show up.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Dr. Memory
