### PR TITLE
Make Wazuh installation check for control binary to check if it is already installed

### DIFF
--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -222,6 +222,17 @@ getPreinstalledDirByType()
     return 1;
 }
 
+isWazuhInstalled()
+{
+    if [ -f "${1}/bin/wazuh-control" ]; then
+        return 0;
+    elif [ -f "${1}/bin/ossec-control" ]; then
+        return 0;
+    else
+        return 1;
+    fi
+}
+
 ##########
 # Checks if Wazuh is installed by trying with each installation type. If it finds
 # an installation, it sets the PREINSTALLEDDIR variable.
@@ -233,31 +244,30 @@ getPreinstalledDir()
     # Checking ossec-init.conf for old wazuh versions
     if [ -f "${OSSEC_INIT}" ]; then
         . ${OSSEC_INIT}
-        if [ "X$DIRECTORY" = "X" ]; then
-            return 1;
-        fi
         if [ -d "$DIRECTORY" ]; then
             PREINSTALLEDDIR="$DIRECTORY"
-            return 0;
+            if isWazuhInstalled $PREINSTALLEDDIR; then
+                return 0;
+            fi
         fi
-    else
-        # Getting preinstalled dir for Wazuh manager and hibrid installations
-        pidir_service_name="wazuh-manager"
-        if getPreinstalledDirByType; then
-            return 0;
-        fi
+    fi
+    
+    # Getting preinstalled dir for Wazuh manager and hibrid installations
+    pidir_service_name="wazuh-manager"
+    if getPreinstalledDirByType && isWazuhInstalled $PREINSTALLEDDIR; then
+        return 0;
+    fi
 
-        # Getting preinstalled dir for Wazuh agent installations
-        pidir_service_name="wazuh-agent"
-        if getPreinstalledDirByType; then
-            return 0;
-        fi
+    # Getting preinstalled dir for Wazuh agent installations
+    pidir_service_name="wazuh-agent"
+    if getPreinstalledDirByType && isWazuhInstalled $PREINSTALLEDDIR; then
+        return 0;
+    fi
 
-        # Getting preinstalled dir for Wazuh local installations
-        pidir_service_name="wazuh-local"
-        if getPreinstalledDirByType; then
-            return 0;
-        fi
+    # Getting preinstalled dir for Wazuh local installations
+    pidir_service_name="wazuh-local"
+    if getPreinstalledDirByType && isWazuhInstalled $PREINSTALLEDDIR; then
+        return 0;
     fi
 
     return 1;

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -222,6 +222,11 @@ getPreinstalledDirByType()
     return 1;
 }
 
+##########
+# Checks if Wazuh is installed in the specified path by searching for the control binary.
+#
+# isWazuhInstalled()
+##########
 isWazuhInstalled()
 {
     if [ -f "${1}/bin/wazuh-control" ]; then
@@ -234,8 +239,11 @@ isWazuhInstalled()
 }
 
 ##########
-# Checks if Wazuh is installed by trying with each installation type. If it finds
-# an installation, it sets the PREINSTALLEDDIR variable.
+# Checks if Wazuh is installed by trying with each installation type. 
+# If it finds an installation, it sets the PREINSTALLEDDIR variable.
+# After that it checks if Wazuh is truly installed there, if it is installed it returns TRUE.
+# If it isn't installed continue searching in other installation types and replacing PREINSTALLEDDIR variable. 
+# It returns FALSE if Wazuh isn't installed in any of this.
 #
 # getPreinstalledDir()
 ##########


### PR DESCRIPTION
|Related issue|
|---|
|7090|

## Description
This PR refactor some installation functionalities:
 - The upgrade only occur if Wazuh control binary is also ound.

Manual test of the scripts with different options
  - [X] Source install of Wazuh
  - [X] Source update of Wazuh from v4.1
  - [X] Source update of Wazuh from v4.2