### PR TITLE
7240 syscollector resync issue

### DIFF
--- a/src/data_provider/cppcheckSuppress.txt
+++ b/src/data_provider/cppcheckSuppress.txt
@@ -1,2 +1,2 @@
-*:*src/sysInfoLinux.cpp:463
-*:*src/packages/pkgWrapper.h:107
+*:*src/sysInfoLinux.cpp:459
+*:*src/packages/pkgWrapper.h:101

--- a/src/data_provider/include/sysInfo.hpp
+++ b/src/data_provider/include/sysInfo.hpp
@@ -25,7 +25,6 @@
 #define EXPORTED
 #endif
 
-#include "timeHelper.h"
 #include "sysInfoInterface.h"
 
 constexpr auto KByte{1024};

--- a/src/data_provider/src/network/inetworkWrapper.h
+++ b/src/data_provider/src/network/inetworkWrapper.h
@@ -21,7 +21,6 @@ public:
     // LCOV_EXCL_STOP
     virtual int family() const = 0;
     virtual std::string name() const = 0;
-    virtual std::string scanTime() const = 0;
     virtual std::string adapter() const = 0;
     virtual std::string address() const = 0;
     virtual std::string netmask() const = 0;

--- a/src/data_provider/src/network/networkBSDWrapper.h
+++ b/src/data_provider/src/network/networkBSDWrapper.h
@@ -27,7 +27,6 @@
 #include "networkHelper.h"
 #include "makeUnique.h"
 #include "sharedDefs.h"
-#include "timeHelper.h"
 
 static const std::map<std::pair<int, int>, std::string> NETWORK_INTERFACE_TYPE =
 {
@@ -47,7 +46,6 @@ class NetworkBSDInterface final : public INetworkInterfaceWrapper
     public:
     explicit NetworkBSDInterface(ifaddrs* addrs)
     : m_interfaceAddress{addrs}
-    , m_scanTime{Utils::getCurrentTimestamp()}
     { 
         if (!addrs)
         {
@@ -58,11 +56,6 @@ class NetworkBSDInterface final : public INetworkInterfaceWrapper
     std::string name() const override
     {
         return m_interfaceAddress->ifa_name ? m_interfaceAddress->ifa_name : UNKNOWN_VALUE;
-    }
-
-    std::string scanTime() const override
-    {
-        return m_scanTime;
     }
 
     std::string adapter() const override

--- a/src/data_provider/src/network/networkInterfaceBSD.cpp
+++ b/src/data_provider/src/network/networkInterfaceBSD.cpp
@@ -85,7 +85,6 @@ void BSDNetworkImpl<AF_LINK>::buildNetworkData(nlohmann::json& network)
     /* Get stats of interface */
 
     network["name"] = m_interfaceAddress->name();
-    network["scan_time"] = m_interfaceAddress->scanTime();
     network["adapter"] = m_interfaceAddress->adapter();
     network["state"] = m_interfaceAddress->state();
     network["type"] = m_interfaceAddress->type();

--- a/src/data_provider/src/network/networkInterfaceLinux.cpp
+++ b/src/data_provider/src/network/networkInterfaceLinux.cpp
@@ -86,7 +86,6 @@ void LinuxNetworkImpl<AF_PACKET>::buildNetworkData(nlohmann::json& network)
 {
     /* Get stats of interface */
     network["name"]    = m_interfaceAddress->name();
-    network["scan_time"] = m_interfaceAddress->scanTime();
     network["adapter"] = m_interfaceAddress->adapter();
     network["type"]    = m_interfaceAddress->type();
     network["state"]   = m_interfaceAddress->state();

--- a/src/data_provider/src/network/networkInterfaceWindows.cpp
+++ b/src/data_provider/src/network/networkInterfaceWindows.cpp
@@ -95,7 +95,6 @@ void WindowsNetworkImpl<Utils::NetworkWindowsHelper::COMMON_DATA>::buildNetworkD
 {
     // Extraction of common adapter data
     networkCommon["name"]       = m_interfaceAddress->name();
-    networkCommon["scan_time"]  = m_interfaceAddress->scanTime();
     networkCommon["adapter"]    = m_interfaceAddress->adapter();
     networkCommon["state"]      = m_interfaceAddress->state();
     networkCommon["type"]       = m_interfaceAddress->type();

--- a/src/data_provider/src/network/networkLinuxWrapper.h
+++ b/src/data_provider/src/network/networkLinuxWrapper.h
@@ -20,7 +20,6 @@
 #include "filesystemHelper.h"
 #include "stringHelper.h"
 #include "sharedDefs.h"
-#include "timeHelper.h"
 
 #ifndef ARPHRD_TUNNEL
 #define ARPHRD_TUNNEL	768		/* IPIP tunnel.  */
@@ -170,7 +169,6 @@ class NetworkLinuxInterface final : public INetworkInterfaceWrapper
     ifaddrs* m_interfaceAddress;
     std::string m_gateway;
     std::string m_metrics;
-    const std::string m_scanTime;
 
     static std::string getNameInfo(const sockaddr* inputData, const socklen_t socketLen)
     {
@@ -230,7 +228,6 @@ public:
     : m_interfaceAddress{ addrs }
     , m_gateway{UNKNOWN_VALUE}
     , m_metrics{UNKNOWN_VALUE}
-    , m_scanTime{Utils::getCurrentTimestamp()}
     { 
         if (!addrs)
         {
@@ -270,11 +267,6 @@ public:
     std::string name() const override
     {
         return m_interfaceAddress->ifa_name ? m_interfaceAddress->ifa_name : "";
-    }
-
-    std::string scanTime() const override
-    {
-        return m_scanTime;
     }
 
     std::string adapter() const override

--- a/src/data_provider/src/network/networkWindowsWrapper.h
+++ b/src/data_provider/src/network/networkWindowsWrapper.h
@@ -21,7 +21,6 @@
 #include "inetworkWrapper.h"
 #include "makeUnique.h"
 #include "sharedDefs.h"
-#include "timeHelper.h"
 
 static const std::map<int, std::string> NETWORK_INTERFACE_TYPES =
 {
@@ -56,7 +55,6 @@ public:
         , m_interfaceAddress(addrs)
         , m_currentUnicastAddress(unicastAddress)
         , m_adapterInfo(adapterInfo)
-        , m_scanTime(Utils::getCurrentTimestamp())
     {
         if (!addrs)
         {
@@ -71,11 +69,6 @@ public:
     std::string name() const override
     {
         return Utils::NetworkWindowsHelper::getAdapterNameStr(m_interfaceAddress->FriendlyName);
-    }
-
-    std::string scanTime() const override
-    {
-        return m_scanTime;
     }
 
     std::string adapter() const override
@@ -461,7 +454,6 @@ private:
     PIP_ADAPTER_ADDRESSES                           m_interfaceAddress;
     PIP_ADAPTER_UNICAST_ADDRESS                     m_currentUnicastAddress;
     PIP_ADAPTER_INFO                                m_adapterInfo;  // XP needed structure
-    const std::string                               m_scanTime;
 };
 
 #endif //_NETWORK_WINDOWS_WRAPPER_H

--- a/src/data_provider/src/osinfo/sysOsInfoInterface.h
+++ b/src/data_provider/src/osinfo/sysOsInfoInterface.h
@@ -29,7 +29,6 @@ public:
     virtual std::string release() const = 0;
     virtual std::string machine() const = 0;
     virtual std::string nodeName() const = 0;
-    virtual std::string scanTime() const = 0;
     // LCOV_EXCL_STOP
 };
 
@@ -50,7 +49,6 @@ public:
         output["hostname"] = osInfoProvider->nodeName();
         output["os_release"] = osInfoProvider->release();
         output["architecture"] = osInfoProvider->machine();
-        output["scan_time"] = osInfoProvider->scanTime();
     }
 };
 

--- a/src/data_provider/src/osinfo/sysOsInfoWin.cpp
+++ b/src/data_provider/src/osinfo/sysOsInfoWin.cpp
@@ -15,7 +15,6 @@
 #include "sysOsInfoWin.h"
 #include "sysOsInfoWin.h"
 #include "stringHelper.h"
-#include "timeHelper.h"
 #include "registryHelper.h"
 
 static std::string getVersion(const bool isMinor = false)
@@ -240,7 +239,6 @@ SysOsInfoProviderWindows::SysOsInfoProviderWindows()
 , m_name{getName()}
 , m_machine{getMachine()}
 , m_nodeName{getNodeName()}
-, m_scanTime{Utils::getCurrentTimestamp()}
 { 
 }
 std::string SysOsInfoProviderWindows::name() const
@@ -274,8 +272,4 @@ std::string SysOsInfoProviderWindows::machine() const
 std::string SysOsInfoProviderWindows::nodeName() const
 {
     return m_nodeName;
-}
-std::string SysOsInfoProviderWindows::scanTime() const
-{
-    return m_scanTime;
 }

--- a/src/data_provider/src/osinfo/sysOsInfoWin.h
+++ b/src/data_provider/src/osinfo/sysOsInfoWin.h
@@ -27,7 +27,6 @@ public:
     std::string release() const override;
     std::string machine() const override;
     std::string nodeName() const override;
-    std::string scanTime() const override;
 private:
     const std::string m_majorVersion;
     const std::string m_minorVersion;
@@ -37,7 +36,6 @@ private:
     const std::string m_name;
     const std::string m_machine;
     const std::string m_nodeName;
-    const std::string m_scanTime;
 };
 
 

--- a/src/data_provider/src/packages/brewWrapper.h
+++ b/src/data_provider/src/packages/brewWrapper.h
@@ -16,7 +16,6 @@
 #include "sharedDefs.h"
 #include "stringHelper.h"
 #include "filesystemHelper.h"
-#include "timeHelper.h"
 
 class BrewWrapper final : public IPackageWrapper
 {
@@ -29,7 +28,6 @@ public:
       , m_architecture{UNKNOWN_VALUE}
       , m_format{"pkg"}
       , m_osPatch{UNKNOWN_VALUE}
-      , m_scanTime{Utils::getCurrentTimestamp()}
     {
         const auto rows { Utils::split(Utils::getFileContent(ctx.filePath + "/" + ctx.package + "/" + ctx.version + "/.brew/" + ctx.package + ".rb"), '\n')};
         for (const auto& row : rows)
@@ -76,10 +74,6 @@ public:
     {
         return m_osPatch;
     }
-    std::string scanTime() const override
-    {
-        return m_scanTime;
-    }
 private:
     std::string m_name;
     std::string m_version;
@@ -88,7 +82,6 @@ private:
     std::string m_architecture;
     const std::string m_format;
     std::string m_osPatch;
-    const std::string m_scanTime;
 };
 
 

--- a/src/data_provider/src/packages/ipackageWrapper.h
+++ b/src/data_provider/src/packages/ipackageWrapper.h
@@ -26,6 +26,5 @@ public:
     virtual std::string architecture() const = 0;
     virtual std::string format() const = 0;
     virtual std::string osPatch() const = 0;
-    virtual std::string scanTime() const = 0;
 };
 #endif // _PACKAGE_INTERFACE_WRAPPER_H

--- a/src/data_provider/src/packages/packageMac.cpp
+++ b/src/data_provider/src/packages/packageMac.cpp
@@ -46,5 +46,4 @@ void BSDPackageImpl::buildPackageData(nlohmann::json& package)
     package["architecture"] = m_packageWrapper->architecture();
     package["format"] = m_packageWrapper->format();
     package["os_patch"] = m_packageWrapper->osPatch();
-    package["scan_time"] = m_packageWrapper->scanTime();
 }

--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -17,7 +17,6 @@
 #include "stringHelper.h"
 #include "ipackageWrapper.h"
 #include "sharedDefs.h"
-#include "timeHelper.h"
 #include "plist/plist.h"
 
 static const std::string APP_INFO_PATH      { "Contents/Info.plist" };
@@ -34,7 +33,6 @@ public:
       , m_architecture{UNKNOWN_VALUE}
       , m_format{"pkg"}
       , m_osPatch{UNKNOWN_VALUE}
-      , m_scanTime{Utils::getCurrentTimestamp()}
     {
         getPkgData(ctx.filePath+ "/" + ctx.package + "/" + APP_INFO_PATH);
     }
@@ -68,10 +66,6 @@ public:
     std::string osPatch() const override
     {
         return m_osPatch;
-    }
-    std::string scanTime() const override
-    {
-        return m_scanTime;
     }
 
 private:
@@ -181,7 +175,6 @@ private:
     std::string m_architecture;
     const std::string m_format;
     std::string m_osPatch;
-    const std::string m_scanTime;
 };
 
 #endif //_PKG_WRAPPER_H

--- a/src/data_provider/src/ports/iportInterface.h
+++ b/src/data_provider/src/ports/iportInterface.h
@@ -13,7 +13,6 @@
 #define _PORT_INTERFACE_H
 
 #include <memory>
-#include "timeHelper.h"
 #include "json.hpp"
 
 class IOSPort

--- a/src/data_provider/src/ports/iportWrapper.h
+++ b/src/data_provider/src/ports/iportWrapper.h
@@ -46,6 +46,5 @@ public:
     virtual std::string state() const = 0;
     virtual int32_t pid() const = 0;
     virtual std::string processName() const = 0;
-    virtual std::string scanTime() const = 0;
 };
 #endif // _PORT_WRAPPER_H

--- a/src/data_provider/src/ports/portBSDWrapper.h
+++ b/src/data_provider/src/ports/portBSDWrapper.h
@@ -159,10 +159,6 @@ class BSDPortWrapper final : public IPortWrapper
         return m_processInformation.processName;
     }
 
-    std::string scanTime() const override
-    {
-        return Utils::getCurrentTimestamp();
-    }
 };
 
 

--- a/src/data_provider/src/ports/portImpl.h
+++ b/src/data_provider/src/ports/portImpl.h
@@ -39,7 +39,6 @@ public:
         port["state"] = m_spPortRawData->state();
         port["pid"] = m_spPortRawData->pid();
         port["process_name"] = m_spPortRawData->processName();
-        port["scan_time"] = m_spPortRawData->scanTime();
     }
 };
 #endif // _PORT_IMPL_H

--- a/src/data_provider/src/ports/portLinuxWrapper.h
+++ b/src/data_provider/src/ports/portLinuxWrapper.h
@@ -244,11 +244,6 @@ class LinuxPortWrapper final : public IPortWrapper
     {
         return {};
     }
-
-    std::string scanTime() const override
-    {
-        return Utils::getCurrentTimestamp();
-    }
 };
 
 

--- a/src/data_provider/src/ports/portWindowsWrapper.h
+++ b/src/data_provider/src/ports/portWindowsWrapper.h
@@ -59,7 +59,6 @@ class WindowsPortWrapper final : public IPortWrapper
     const uint32_t m_state;
     const uint32_t m_pid;
     const std::string m_processName;
-    const std::string m_scanTime;
 
     static std::string getIpAddress(const DWORD addr)
     {
@@ -99,7 +98,6 @@ class WindowsPortWrapper final : public IPortWrapper
     , m_state { data.dwState }
     , m_pid { data.dwOwningPid }
     , m_processName { getProcessName(processDataList, data.dwOwningPid) }
-    , m_scanTime { Utils::getCurrentTimestamp() }
     { }
 
     WindowsPortWrapper(const _MIB_TCP6ROW_OWNER_PID& data, const std::map<pid_t, std::string>& processDataList)
@@ -111,7 +109,6 @@ class WindowsPortWrapper final : public IPortWrapper
     , m_state { data.dwState }
     , m_pid { data.dwOwningPid }
     , m_processName { getProcessName(processDataList, data.dwOwningPid) }
-    , m_scanTime { Utils::getCurrentTimestamp() }
     { }
 
     WindowsPortWrapper(const _MIB_UDPROW_OWNER_PID& data, const std::map<pid_t, std::string>& processDataList)
@@ -122,7 +119,6 @@ class WindowsPortWrapper final : public IPortWrapper
     , m_state { 0 }
     , m_pid { data.dwOwningPid }
     , m_processName { getProcessName(processDataList, data.dwOwningPid) }
-    , m_scanTime { Utils::getCurrentTimestamp() }
     { }
 
     WindowsPortWrapper(const _MIB_UDP6ROW_OWNER_PID& data, const std::map<pid_t, std::string>& processDataList)
@@ -133,7 +129,6 @@ class WindowsPortWrapper final : public IPortWrapper
     , m_state { 0 }
     , m_pid { data.dwOwningPid }
     , m_processName { getProcessName(processDataList, data.dwOwningPid) }
-    , m_scanTime { Utils::getCurrentTimestamp() }
     { }
 
     ~WindowsPortWrapper() = default;
@@ -187,10 +182,6 @@ class WindowsPortWrapper final : public IPortWrapper
     std::string processName() const override
     {
         return m_processName;
-    }
-    std::string scanTime() const override
-    {
-        return m_scanTime;
     }
 };
 

--- a/src/data_provider/src/sysInfo.cpp
+++ b/src/data_provider/src/sysInfo.cpp
@@ -18,7 +18,6 @@ nlohmann::json SysInfo::hardware()
     ret["cpu_name"] = getCpuName();
     ret["cpu_cores"] = getCpuCores();
     ret["cpu_MHz"] = getCpuMHz();
-    ret["scan_time"] = Utils::getCurrentTimestamp();
     getMemory(ret);
     return ret;
 }

--- a/src/data_provider/src/sysInfoFreeBSD.cpp
+++ b/src/data_provider/src/sysInfoFreeBSD.cpp
@@ -11,7 +11,6 @@
 #include "sysInfo.hpp"
 #include "cmdHelper.h"
 #include "stringHelper.h"
-#include "timeHelper.h"
 #include "osinfo/sysOsParsers.h"
 #include <sys/sysctl.h>
 #include <sys/vmmeter.h>
@@ -107,7 +106,6 @@ nlohmann::json SysInfo::getPackages() const
             package["description"] = data[4];
             package["format"] = "pkg";
             package["os_patch"] = UNKNOWN_VALUE;
-            package["scan_time"] = Utils::getCurrentTimestamp();
             ret.push_back(package);
         }
     }
@@ -130,7 +128,6 @@ nlohmann::json SysInfo::getOsInfo() const
         ret["os_name"] = "BSD";
         ret["os_platform"] = "bsd";
         ret["os_version"] = "unknown";
-        ret["scan_time"] = Utils::getCurrentTimestamp();
     }
     if (uname(&uts) >= 0)
     {

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -12,7 +12,6 @@
 #include <iostream>
 #include "sharedDefs.h"
 #include "stringHelper.h"
-#include "timeHelper.h"
 #include "filesystemHelper.h"
 #include "cmdHelper.h"
 #include "osinfo/sysOsParsers.h"
@@ -75,7 +74,6 @@ static nlohmann::json getProcessInfo(const SysInfoProcess& process)
     // Current process information
     jsProcessInfo["pid"]        = std::to_string(process->tid);
     jsProcessInfo["name"]       = process->cmd;
-    jsProcessInfo["scan_time"]  = Utils::getCurrentTimestamp();
     jsProcessInfo["state"]      = &process->state;
     jsProcessInfo["ppid"]       = process->ppid;
     jsProcessInfo["utime"]      = process->utime;
@@ -196,7 +194,6 @@ static nlohmann::json parsePackage(const std::vector<std::string>& entries)
         ret["version"]      = version;
         ret["format"]       = "deb";
         ret["os_patch"]     = UNKNOWN_VALUE;
-        ret["scan_time"]    = Utils::getCurrentTimestamp();
     }
     return ret;
 }
@@ -314,7 +311,6 @@ static nlohmann::json parseRpm(const std::string& packageInfo)
         ret["architecture"] = architecture;
         ret["format"]       = "rpm";
         ret["os_patch"]     = UNKNOWN_VALUE;
-        ret["scan_time"]    = Utils::getCurrentTimestamp();
     }
     return ret;
 }
@@ -495,7 +491,6 @@ nlohmann::json SysInfo::getOsInfo() const
         ret["os_name"] = "Linux";
         ret["os_platform"] = "linux";
         ret["os_version"] = UNKNOWN_VALUE;
-        ret["scan_time"] = Utils::getCurrentTimestamp();
     }
     if (uname(&uts) >= 0)
     {

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -11,7 +11,6 @@
 #include "sysInfo.hpp"
 #include "cmdHelper.h"
 #include "stringHelper.h"
-#include "timeHelper.h"
 #include "filesystemHelper.h"
 #include "osinfo/sysOsParsers.h"
 #include <libproc.h>
@@ -64,7 +63,6 @@ static nlohmann::json getProcessInfo(const ProcessTaskInfo& taskInfo, const pid_
     nlohmann::json jsProcessInfo{};
     jsProcessInfo["pid"]        = std::to_string(pid);
     jsProcessInfo["name"]       = taskInfo.pbsd.pbi_name;
-    jsProcessInfo["scan_time"]  = Utils::getCurrentTimestamp();
 
     const auto procState { s_mapTaskInfoState.find(taskInfo.pbsd.pbi_status) };
     jsProcessInfo["state"]      = (procState != s_mapTaskInfoState.end())
@@ -278,7 +276,6 @@ nlohmann::json SysInfo::getOsInfo() const
         ret["version"] = uts.version;
         ret["architecture"] = uts.machine;
         ret["release"] = uts.release;
-        ret["scan_time"] = Utils::getCurrentTimestamp();
     }
     return ret;
 }

--- a/src/data_provider/src/sysInfoOpenBSD.cpp
+++ b/src/data_provider/src/sysInfoOpenBSD.cpp
@@ -113,7 +113,6 @@ nlohmann::json SysInfo::getOsInfo() const
         ret["os_name"] = "BSD";
         ret["os_platform"] = "bsd";
         ret["os_version"] = UNKNOWN_VALUE;
-        ret["scan_time"] = Utils::getCurrentTimestamp();
     }
     if (uname(&uts) >= 0)
     {

--- a/src/data_provider/src/sysInfoUnix.cpp
+++ b/src/data_provider/src/sysInfoUnix.cpp
@@ -38,7 +38,6 @@ static void getOsInfoFromUname(nlohmann::json& info)
         info["os_name"] = "Unix";
         info["os_platform"] = "Unix";
         info["os_version"] = UNKNOWN_VALUE;
-        info["scan_time"] = Utils::getCurrentTimestamp();
     }
 }
 

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -26,7 +26,6 @@
 #include "sysInfo.hpp"
 #include "cmdHelper.h"
 #include "stringHelper.h"
-#include "timeHelper.h"
 #include "registryHelper.h"
 #include "defs.h"
 #include "debug_op.h"
@@ -320,7 +319,6 @@ static nlohmann::json getProcessInfo(const PROCESSENTRY32& processEntry)
 
     // Current process information
     jsProcessInfo["name"]       = processName(processEntry);
-    jsProcessInfo["scan_time"]  = Utils::getCurrentTimestamp();
     jsProcessInfo["cmd"]        = (isSystemProcess(pId)) ? "none" : process.cmd();
     jsProcessInfo["stime"]      = process.kernelModeTime();
     jsProcessInfo["size"]       = process.pageFileUsage();
@@ -392,7 +390,6 @@ static void getPackagesFromReg(const HKEY key, const std::string& subKey, nlohma
                 packageJson["architecture"] = architecture;
                 packageJson["format"]       = "win";
                 packageJson["os_patch"]     = UNKNOWN_VALUE;
-                packageJson["scan_time"]    = Utils::getCurrentTimestamp();
 
                 data.push_back(packageJson);
             }
@@ -434,7 +431,6 @@ static void getHotFixFromReg(const HKEY key, const std::string& subKey, nlohmann
         {
             nlohmann::json hotfixValue;
             hotfixValue["hotfix"] = hotfix;
-            hotfixValue["scan_time"] = Utils::getCurrentTimestamp();
             data.push_back(hotfixValue);
         }
     }

--- a/src/data_provider/tests/sysInfo/sysOsInfo_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysOsInfo_test.cpp
@@ -32,7 +32,6 @@ public:
     MOCK_METHOD(std::string, release, (), (const override));
     MOCK_METHOD(std::string, machine, (), (const override));
     MOCK_METHOD(std::string, nodeName, (), (const override));
-    MOCK_METHOD(std::string, scanTime, (), (const override));
     MOCK_METHOD(std::string, getSerialNumber, (), (const override));
 };
 
@@ -53,7 +52,6 @@ TEST_F(SysOsInfoTest, setOsInfoSchema)
     EXPECT_CALL(*pOsInfoProvider, release()).WillOnce(Return("1903"));
     EXPECT_CALL(*pOsInfoProvider, machine()).WillOnce(Return("x86_64"));
     EXPECT_CALL(*pOsInfoProvider, nodeName()).WillOnce(Return("DESKTOP-U7Q6UQV"));
-    EXPECT_CALL(*pOsInfoProvider, scanTime()).WillOnce(Return("2020/12/28 19:05:01"));
     SysOsInfo::setOsInfo(spOsInfoProvider, output);
     EXPECT_EQ("x86_64", output.at("architecture"));
     EXPECT_EQ("DESKTOP-U7Q6UQV", output.at("hostname"));
@@ -63,5 +61,4 @@ TEST_F(SysOsInfoTest, setOsInfoSchema)
     EXPECT_EQ("Microsoft Windows 10 Home", output.at("os_name"));
     EXPECT_EQ("1903", output.at("os_release"));
     EXPECT_EQ("10.0.18362", output.at("os_version"));
-    EXPECT_EQ("2020/12/28 19:05:01", output.at("scan_time"));
 }

--- a/src/data_provider/tests/sysInfoNetworkBSD/sysInfoNetworkBSD_test.cpp
+++ b/src/data_provider/tests/sysInfoNetworkBSD/sysInfoNetworkBSD_test.cpp
@@ -29,7 +29,6 @@ public:
     virtual ~SysInfoNetworkBSDWrapperMock() = default;
     MOCK_METHOD(int, family, (), (const override));
     MOCK_METHOD(std::string, name, (), (const override));
-    MOCK_METHOD(std::string, scanTime, (), (const override));
     MOCK_METHOD(std::string, address, (), (const override));
     MOCK_METHOD(std::string, netmask, (), (const override));
     MOCK_METHOD(std::string, broadcast, (), (const override));
@@ -109,7 +108,6 @@ TEST_F(SysInfoNetworkBSDTest, Test_AF_LINK)
     nlohmann::json ifaddr {};
     EXPECT_CALL(*mock, family()).Times(1).WillOnce(Return(AF_LINK));
     EXPECT_CALL(*mock, name()).Times(1).WillOnce(Return("eth01"));
-    EXPECT_CALL(*mock, scanTime()).Times(1).WillOnce(Return("2020/12/2020 19:05:05"));
     EXPECT_CALL(*mock, type()).Times(1).WillOnce(Return("ethernet"));
     EXPECT_CALL(*mock, state()).Times(1).WillOnce(Return("up"));
     EXPECT_CALL(*mock, MAC()).Times(1).WillOnce(Return("00:A0:C9:14:C8:29"));
@@ -121,7 +119,6 @@ TEST_F(SysInfoNetworkBSDTest, Test_AF_LINK)
     EXPECT_NO_THROW(FactoryNetworkFamilyCreator<OSType::BSDBASED>::create(mock)->buildNetworkData(ifaddr));
 
     EXPECT_EQ("eth01",ifaddr.at("name").get_ref<const std::string&>());
-    EXPECT_EQ("2020/12/2020 19:05:05",ifaddr.at("scan_time").get_ref<const std::string&>());
     EXPECT_EQ("ethernet",ifaddr.at("type").get_ref<const std::string&>());
     EXPECT_EQ("up",ifaddr.at("state").get_ref<const std::string&>());
     EXPECT_EQ("00:A0:C9:14:C8:29",ifaddr.at("mac").get_ref<const std::string&>());

--- a/src/data_provider/tests/sysInfoNetworkLinux/sysInfoNetworkLinux_test.cpp
+++ b/src/data_provider/tests/sysInfoNetworkLinux/sysInfoNetworkLinux_test.cpp
@@ -29,7 +29,6 @@ public:
     virtual ~SysInfoNetworkLinuxWrapperMock() = default;
     MOCK_METHOD(int, family, (), (const override));
     MOCK_METHOD(std::string, name, (), (const override));
-    MOCK_METHOD(std::string, scanTime, (), (const override));
     MOCK_METHOD(std::string, address, (), (const override));
     MOCK_METHOD(std::string, netmask, (), (const override));
     MOCK_METHOD(std::string, broadcast, (), (const override));
@@ -110,7 +109,6 @@ TEST_F(SysInfoNetworkLinuxTest, Test_AF_PACKET)
     nlohmann::json ifaddr {};
     EXPECT_CALL(*mock, family()).Times(1).WillOnce(Return(AF_PACKET));
     EXPECT_CALL(*mock, name()).Times(1).WillOnce(Return("eth01"));
-    EXPECT_CALL(*mock, scanTime()).Times(1).WillOnce(Return("2020/12/2020 19:05:05"));
     EXPECT_CALL(*mock, adapter()).Times(1).WillOnce(Return("adapter"));
     EXPECT_CALL(*mock, type()).Times(1).WillOnce(Return("ethernet"));
     EXPECT_CALL(*mock, state()).Times(1).WillOnce(Return("up"));
@@ -122,7 +120,6 @@ TEST_F(SysInfoNetworkLinuxTest, Test_AF_PACKET)
     EXPECT_NO_THROW(FactoryNetworkFamilyCreator<OSType::LINUX>::create(mock)->buildNetworkData(ifaddr));
 
     EXPECT_EQ("eth01",ifaddr.at("name").get_ref<const std::string&>());
-    EXPECT_EQ("2020/12/2020 19:05:05",ifaddr.at("scan_time").get_ref<const std::string&>());
     EXPECT_EQ("adapter",ifaddr.at("adapter").get_ref<const std::string&>());
     EXPECT_EQ("ethernet",ifaddr.at("type").get_ref<const std::string&>());
     EXPECT_EQ("up",ifaddr.at("state").get_ref<const std::string&>());

--- a/src/data_provider/tests/sysInfoNetworkWindows/sysInfoNetworkWindows_test.cpp
+++ b/src/data_provider/tests/sysInfoNetworkWindows/sysInfoNetworkWindows_test.cpp
@@ -28,7 +28,6 @@ public:
     virtual ~SysInfoNetworkWindowsWrapperMock() = default;
     MOCK_METHOD(int, family, (), (const override));
     MOCK_METHOD(std::string, name, (), (const override));
-    MOCK_METHOD(std::string, scanTime, (), (const override));
     MOCK_METHOD(std::string, adapter, (), (const override)); 
     MOCK_METHOD(std::string, address, (), (const override));
     MOCK_METHOD(std::string, netmask, (), (const override));
@@ -130,7 +129,6 @@ TEST_F(SysInfoNetworkWindowsTest, Test_COMMON_DATA)
     auto mock { std::make_shared<SysInfoNetworkWindowsWrapperMock>() };
     nlohmann::json networkInfo {};
     const std::string name      { "eth01" };
-    const std::string timestamp { "2020/12/2020 19:05:05" };
     const std::string type      { "2001:db8:abcd:0012:ffff:ffff:ffff:ffff" };
     const std::string state     { "up" };
     const std::string MAC       { "00:A0:C9:14:C8:29" };
@@ -138,7 +136,6 @@ TEST_F(SysInfoNetworkWindowsTest, Test_COMMON_DATA)
     const std::string gateway   { "10.2.2.50" };
     EXPECT_CALL(*mock, family()).Times(1).WillOnce(Return(Utils::NetworkWindowsHelper::COMMON_DATA));
     EXPECT_CALL(*mock, name()).Times(1).WillOnce(Return(name));
-    EXPECT_CALL(*mock, scanTime()).Times(1).WillOnce(Return(timestamp));
     EXPECT_CALL(*mock, type()).Times(1).WillOnce(Return(type));
     EXPECT_CALL(*mock, state()).Times(1).WillOnce(Return(state));
     EXPECT_CALL(*mock, MAC()).Times(1).WillOnce(Return(MAC));
@@ -149,7 +146,6 @@ TEST_F(SysInfoNetworkWindowsTest, Test_COMMON_DATA)
     EXPECT_NO_THROW(FactoryNetworkFamilyCreator<OSType::WINDOWS>::create(mock)->buildNetworkData(networkInfo));
 
     EXPECT_EQ(name, networkInfo.at("name").get_ref<const std::string&>());
-    EXPECT_EQ(name, networkInfo.at("scan_time").get_ref<const std::string&>());
     EXPECT_EQ(type, networkInfo.at("type").get_ref<const std::string&>());
     EXPECT_EQ(state, networkInfo.at("state").get_ref<const std::string&>());
     EXPECT_EQ(MAC, networkInfo.at("mac").get_ref<const std::string&>());

--- a/src/data_provider/tests/sysInfoPackagesMAC/sysInfoMacPackages_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesMAC/sysInfoMacPackages_test.cpp
@@ -31,7 +31,6 @@ public:
     MOCK_METHOD(std::string, architecture, (), (const override));
     MOCK_METHOD(std::string, format, (), (const override));
     MOCK_METHOD(std::string, osPatch, (), (const override));
-    MOCK_METHOD(std::string, scanTime, (), (const override));
 };
 
 TEST_F(SysInfoMacPackagesTest, Test_SPEC_Data)
@@ -45,7 +44,6 @@ TEST_F(SysInfoMacPackagesTest, Test_SPEC_Data)
     EXPECT_CALL(*mock, architecture()).Times(1).WillOnce(Return("5"));
     EXPECT_CALL(*mock, format()).Times(1).WillOnce(Return("6"));
     EXPECT_CALL(*mock, osPatch()).Times(1).WillOnce(Return("7"));
-    EXPECT_CALL(*mock, scanTime()).Times(1).WillOnce(Return("8"));
    
     EXPECT_NO_THROW(std::make_unique<BSDPackageImpl>(mock)->buildPackageData(packages));
     EXPECT_EQ("1",packages.at("name").get_ref<const std::string&>());
@@ -55,5 +53,4 @@ TEST_F(SysInfoMacPackagesTest, Test_SPEC_Data)
     EXPECT_EQ("5",packages.at("architecture").get_ref<const std::string&>());
     EXPECT_EQ("6",packages.at("format").get_ref<const std::string&>());
     EXPECT_EQ("7",packages.at("os_patch").get_ref<const std::string&>());
-    EXPECT_EQ("8",packages.at("scan_time").get_ref<const std::string&>());
 }

--- a/src/data_provider/tests/sysInfoPorts/sysInfoPort_test.cpp
+++ b/src/data_provider/tests/sysInfoPorts/sysInfoPort_test.cpp
@@ -36,7 +36,6 @@ public:
     MOCK_METHOD(std::string, state, (), (const override));
     MOCK_METHOD(int32_t, pid, (), (const override));
     MOCK_METHOD(std::string, processName, (), (const override));
-    MOCK_METHOD(std::string, scanTime, (), (const override));
 };
 
 TEST_F(SysInfoPortTest, Test_SPEC_Data)
@@ -54,7 +53,6 @@ TEST_F(SysInfoPortTest, Test_SPEC_Data)
     EXPECT_CALL(*mock, state()).Times(1).WillOnce(Return("9"));
     EXPECT_CALL(*mock, pid()).Times(1).WillOnce(Return(10));
     EXPECT_CALL(*mock, processName()).Times(1).WillOnce(Return("11"));
-    EXPECT_CALL(*mock, scanTime()).Times(1).WillOnce(Return("12"));
     
     EXPECT_NO_THROW(std::make_unique<PortImpl>(mock)->buildPortData(port));
     EXPECT_EQ("1",port.at("protocol").get_ref<const std::string&>());
@@ -68,5 +66,4 @@ TEST_F(SysInfoPortTest, Test_SPEC_Data)
     EXPECT_EQ("9",port.at("state").get_ref<const std::string&>());
     EXPECT_EQ(10,port.at("pid").get<int32_t>());
     EXPECT_EQ("11",port.at("process_name").get_ref<const std::string&>());
-    EXPECT_EQ("12",port.at("scan_time").get_ref<const std::string&>());
 }

--- a/src/wazuh_modules/syscollector/cppcheckSuppress.txt
+++ b/src/wazuh_modules/syscollector/cppcheckSuppress.txt
@@ -1,3 +1,3 @@
 *:*.c
 *:*syscollector.h
-*:*src/syscollectorImp.cpp:719
+*:*src/syscollectorImp.cpp:717

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -71,7 +71,7 @@ private:
     
     std::string getCreateStatement() const;
     void registerWithRsync();
-
+    void updateAndNotifyChanges(const std::string& table, const nlohmann::json& values);
     void scanHardware();
     void scanOs();
     void scanNetwork();
@@ -105,6 +105,7 @@ private:
     std::condition_variable                        m_cv;
     std::mutex                                     m_mutex;
     std::unique_ptr<SysNormalizer>                 m_spNormalizer;
+    std::string                                    m_scanTime;
 };
 
 

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include "stringHelper.h"
 #include "hashHelper.h"
+#include "timeHelper.h"
 
 #define TRY_CATCH_TASK(task)                                            \
 do                                                                      \
@@ -694,11 +695,8 @@ static std::string getItemId(const nlohmann::json& item, const std::vector<std::
     return Utils::asciiToHex(hash.hash());
 }
 
-static void updateAndNotifyChanges(const DBSYNC_HANDLE handle,
-                                   const std::string& table,
-                                   const nlohmann::json& values,
-                                   const std::function<void(const std::string&)> reportFunction,
-                                   const std::function<void(const std::string&)> errorFunction)
+void Syscollector::updateAndNotifyChanges(const std::string& table,
+                                          const nlohmann::json& values)
 {
     const std::map<ReturnTypeCallback, std::string> operationsMap
     {
@@ -714,11 +712,11 @@ static void updateAndNotifyChanges(const DBSYNC_HANDLE handle,
     constexpr auto queueSize{4096};
     const auto callback
     {
-        [&table, &operationsMap, reportFunction, errorFunction](ReturnTypeCallback result, const nlohmann::json& data)
+        [this, &table, &operationsMap](ReturnTypeCallback result, const nlohmann::json& data)
         {
             if(result == DB_ERROR)
             {
-                errorFunction(data.dump());
+                m_logErrorFunction(data.dump());
             }
             else if (data.is_array())
             {
@@ -728,7 +726,8 @@ static void updateAndNotifyChanges(const DBSYNC_HANDLE handle,
                     msg["type"] = table;
                     msg["operation"] = operationsMap.at(result);
                     msg["data"] = item;
-                    reportFunction(msg.dump());
+                    msg["data"]["scan_time"] = m_scanTime;
+                    m_reportDiffFunction(msg.dump());
                 }
             }
             else
@@ -738,14 +737,15 @@ static void updateAndNotifyChanges(const DBSYNC_HANDLE handle,
                 msg["type"] = table;
                 msg["operation"] = operationsMap.at(result);
                 msg["data"] = data;
-                reportFunction(msg.dump());
+                msg["data"]["scan_time"] = m_scanTime;
+                m_reportDiffFunction(msg.dump());
                 // LCOV_EXCL_STOP
             }
         }
     };
     DBSyncTxn txn
     {
-        handle,
+        m_spDBSync->handle(),
         nlohmann::json{table},
         0,
         queueSize,
@@ -811,26 +811,43 @@ std::string Syscollector::getCreateStatement() const
 
 void Syscollector::registerWithRsync()
 {
+    const auto reportSyncWrapper
+    {
+        [this](const std::string& data)
+        {
+            auto jsonData{nlohmann::json::parse(data)};
+            const auto it{jsonData.find("data")};
+            if(it != jsonData.end())
+            {
+                (*it)["scan_time"] = Utils::getCurrentTimestamp();
+                m_reportSyncFunction(jsonData.dump());
+            }
+            else
+            {
+                m_reportSyncFunction(data);
+            }
+        }
+    };
 
     if (m_processes)
     {
         m_spRsync->registerSyncID("syscollector_processes", 
                                   m_spDBSync->handle(),
                                   nlohmann::json::parse(PROCESSES_SYNC_CONFIG_STATEMENT),
-                                  m_reportSyncFunction);
+                                  reportSyncWrapper);
     }
     if (m_packages)
     {
         m_spRsync->registerSyncID("syscollector_packages",
                                   m_spDBSync->handle(),
                                   nlohmann::json::parse(PACKAGES_SYNC_CONFIG_STATEMENT),
-                                  m_reportSyncFunction);
+                                  reportSyncWrapper);
         if (m_hotfixes)
         {
             m_spRsync->registerSyncID("syscollector_hotfixes",
                                       m_spDBSync->handle(),
                                       nlohmann::json::parse(HOTFIXES_SYNC_CONFIG_STATEMENT),
-                                      m_reportSyncFunction);
+                                      reportSyncWrapper);
         }
     }
     if (m_ports)
@@ -838,22 +855,22 @@ void Syscollector::registerWithRsync()
         m_spRsync->registerSyncID("syscollector_ports",
                                   m_spDBSync->handle(),
                                   nlohmann::json::parse(PORTS_SYNC_CONFIG_STATEMENT),
-                                  m_reportSyncFunction);
+                                  reportSyncWrapper);
     }
     if (m_network)
     {
         m_spRsync->registerSyncID("syscollector_network_iface",
                                   m_spDBSync->handle(),
                                   nlohmann::json::parse(NETIFACE_SYNC_CONFIG_STATEMENT),
-                                  m_reportSyncFunction);
+                                  reportSyncWrapper);
         m_spRsync->registerSyncID("syscollector_network_protocol",
                                   m_spDBSync->handle(),
                                   nlohmann::json::parse(NETPROTO_SYNC_CONFIG_STATEMENT),
-                                  m_reportSyncFunction);
+                                  reportSyncWrapper);
         m_spRsync->registerSyncID("syscollector_network_address",
                                   m_spDBSync->handle(),
                                   nlohmann::json::parse(NETADDRESS_SYNC_CONFIG_STATEMENT),
-                                  m_reportSyncFunction);
+                                  reportSyncWrapper);
     }
 }
 void Syscollector::init(const std::shared_ptr<ISysInfo>& spInfo,
@@ -966,7 +983,6 @@ void Syscollector::scanNetwork()
                     ifaceTableData["tx_dropped"] = item.at("tx_dropped");
                     ifaceTableData["rx_dropped"] = item.at("rx_dropped");
                     ifaceTableData["item_id"]    = getItemId(ifaceTableData, NETIFACE_ITEM_ID_FIELDS);
-                    ifaceTableData["scan_time"]  = item.at("scan_time");
                     ifaceTableDataList.push_back(ifaceTableData);
 
                     // "dbsync_network_protocol" table data to update and notify
@@ -1004,9 +1020,9 @@ void Syscollector::scanNetwork()
                     protoTableDataList.push_back(protoTableData);
                 }
 
-                updateAndNotifyChanges(m_spDBSync->handle(), netIfaceTable,    ifaceTableDataList, m_reportDiffFunction, m_logErrorFunction);
-                updateAndNotifyChanges(m_spDBSync->handle(), netProtocolTable, protoTableDataList, m_reportDiffFunction, m_logErrorFunction);
-                updateAndNotifyChanges(m_spDBSync->handle(), netAddressTable,  addressTableDataList, m_reportDiffFunction, m_logErrorFunction);
+                updateAndNotifyChanges(netIfaceTable, ifaceTableDataList);
+                updateAndNotifyChanges(netProtocolTable, protoTableDataList);
+                updateAndNotifyChanges(netAddressTable, addressTableDataList);
             }
         }
     }
@@ -1052,11 +1068,11 @@ void Syscollector::scanPackages()
                     packages.push_back(item);
                 }
             }
-            updateAndNotifyChanges(m_spDBSync->handle(), tablePackages, packages, m_reportDiffFunction, m_logErrorFunction);
+            updateAndNotifyChanges(tablePackages, packages);
             if (m_hotfixes)
             {
                 constexpr auto tableHotfixes{"dbsync_hotfixes"};
-                updateAndNotifyChanges(m_spDBSync->handle(), tableHotfixes, hotfixes, m_reportDiffFunction, m_logErrorFunction);
+                updateAndNotifyChanges(tableHotfixes, hotfixes);
             }
         }
     }
@@ -1114,7 +1130,7 @@ void Syscollector::scanPorts()
                         }
                     }
                 }
-                updateAndNotifyChanges(m_spDBSync->handle(), table, portsList, m_reportDiffFunction, m_logErrorFunction);
+                updateAndNotifyChanges(table, portsList);
             }
         }
     }
@@ -1136,7 +1152,7 @@ void Syscollector::scanProcesses()
         const auto& processes{m_spInfo->processes()};
         if (!processes.is_null())
         {
-            updateAndNotifyChanges(m_spDBSync->handle(), table, processes, m_reportDiffFunction, m_logErrorFunction);
+            updateAndNotifyChanges(table, processes);
         }
     }
 }
@@ -1151,6 +1167,7 @@ void Syscollector::syncProcesses()
 
 void Syscollector::scan()
 {
+    m_scanTime = Utils::getCurrentTimestamp();
     TRY_CATCH_TASK(scanHardware);
     TRY_CATCH_TASK(scanOs);
     TRY_CATCH_TASK(scanNetwork);

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -826,10 +826,16 @@ void Syscollector::registerWithRsync()
                     (*it)["scan_time"] = Utils::getCurrentTimestamp();
                     m_reportSyncFunction(jsonData.dump());
                 }
+                else
+                {
+                    m_reportSyncFunction(dataString);
+                }
             }
             else
             {
+                //LCOV_EXCL_START
                 m_reportSyncFunction(dataString);
+                //LCOV_EXCL_STOP
             }
         }
     };

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -436,7 +436,7 @@ TEST_F(SyscollectorImpTest, scanOnInverval)
 
 TEST_F(SyscollectorImpTest, pushMessageOk)
 {
-    constexpr auto messageToPush{R"(syscollector_network_iface dbsync checksum_fail {"begin":"Ethernet (Kernel Debugger) ","end":"Loopback Pseudo-Interface 1","id":1606851004})"};
+    constexpr auto messageToPush{R"(syscollector_network_iface dbsync checksum_fail {"begin":"8026abed91dee13057cbbafaa98918d827fc5698","end":"8026abed91dee13057cbbafaa98918d827fc5698","id":1606851004})"};
     const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
     EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14", "os_patch":""}])")));
@@ -470,6 +470,44 @@ TEST_F(SyscollectorImpTest, pushMessageOk)
         t.join();
     }
 }
+
+TEST_F(SyscollectorImpTest, pushMessageOk1)
+{
+    constexpr auto messageToPush{R"(syscollector_processes dbsync checksum_fail {"begin":"1","end":"99","id":1})"};
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(R"({"board_serial":"Intel Corporation","scan_time":"2020/12/28 21:49:50", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
+    EXPECT_CALL(*spInfoWrapper, packages()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":"411","source":"xorg","version":"1:7.7+19ubuntu14", "os_patch":""}])")));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(R"({"iface":[{"address":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "mac":"d4:5d:64:51:07:5d", "gateway":"192.168.0.1|600","broadcast":"127.255.255.255", "name":"ens1", "mtu":"1500", "name":"enp4s0", "adapter":"unknown", "type":"ethernet", "state":"up", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":"unknown","netmask":"255.255.255.0"}, "IPv6":{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":"unknown","netmask":"ffff:ffff:ffff:ffff::"}}]})")));
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(R"({"architecture":"x86_64","scan_time":"2020/12/28 21:49:50", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_release":"sp1","os_version":"6.1.7601"})")));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":431625,"ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0}])")));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"argvs":"--use-gnome-session","cmd":"/usr/libexec/at-spi2-registryd","egroup":"fedegc","euser":"fedegc","fgroup":"fedegc","name":"at-spi2-registr","nice":0,"nlwp":3,"pgrp":2102,"pid":"2223","ppid":1912,"priority":20,"processor":0,"resident":1427,"rgroup":"fedegc","ruser":"fedegc","session":2102,"sgroup":"fedegc","share":1344,"size":40726,"start_time":13687,"state":"S","stime":128,"suser":"fedegc","tgid":2223,"tty":0,"utime":105,"vm_size":162904},{"argvs":"","cmd":"/usr/libexec/xdg-permission-store","egroup":"fedegc","euser":"fedegc","fgroup":"fedegc","name":"xdg-permission-","nice":0,"nlwp":3,"pgrp":2227,"pid":"2227","ppid":1912,"priority":20,"processor":1,"resident":761,"rgroup":"fedegc","ruser":"fedegc","session":2227,"sgroup":"fedegc","share":713,"size":58897,"start_time":13733,"state":"S","stime":0,"suser":"fedegc","tgid":2227,"tty":0,"utime":0,"vm_size":235588}])")));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"argvs":"--use-gnome-session","cmd":"/usr/libexec/at-spi2-registryd","egroup":"fedegc","euser":"fedegc","fgroup":"fedegc","name":"at-spi2-registr","nice":0,"nlwp":3,"pgrp":2102,"pid":"2223","ppid":1912,"priority":20,"processor":0,"resident":1427,"rgroup":"fedegc","ruser":"fedegc","session":2102,"sgroup":"fedegc","share":1344,"size":40726,"start_time":13687,"state":"S","stime":128,"suser":"fedegc","tgid":2223,"tty":0,"utime":105,"vm_size":162904},{"argvs":"","cmd":"/usr/libexec/xdg-permission-store","egroup":"fedegc","euser":"fedegc","fgroup":"fedegc","name":"xdg-permission-","nice":0,"nlwp":3,"pgrp":2227,"pid":"2227","ppid":1912,"priority":20,"processor":1,"resident":761,"rgroup":"fedegc","ruser":"fedegc","session":2227,"sgroup":"fedegc","share":713,"size":58897,"start_time":13733,"state":"S","stime":0,"suser":"fedegc","tgid":2227,"tty":0,"utime":0,"vm_size":235588}])")));
+    EXPECT_CALL(*spInfoWrapper, processes()).WillRepeatedly(Return(nlohmann::json::parse(R"([{"argvs":"--use-gnome-session","cmd":"/usr/libexec/at-spi2-registryd","egroup":"fedegc","euser":"fedegc","fgroup":"fedegc","name":"at-spi2-registr","nice":0,"nlwp":3,"pgrp":2102,"pid":"2223","ppid":1912,"priority":20,"processor":0,"resident":1427,"rgroup":"fedegc","ruser":"fedegc","session":2102,"sgroup":"fedegc","share":1344,"size":40726,"start_time":13687,"state":"S","stime":128,"suser":"fedegc","tgid":2223,"tty":0,"utime":105,"vm_size":162904},{"argvs":"","cmd":"/usr/libexec/xdg-permission-store","egroup":"fedegc","euser":"fedegc","fgroup":"fedegc","name":"xdg-permission-","nice":0,"nlwp":3,"pgrp":2227,"pid":"2227","ppid":1912,"priority":20,"processor":1,"resident":761,"rgroup":"fedegc","ruser":"fedegc","session":2227,"sgroup":"fedegc","share":713,"size":58897,"start_time":13733,"state":"S","stime":0,"suser":"fedegc","tgid":2227,"tty":0,"utime":0,"vm_size":235588}])")));
+    EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(R"({"ports":[{"inode":0,"local_ip":"127.0.0.1","scan_time":"2020/12/28 21:49:50", "local_port":631,"pid":0,"process_name":"System Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}]})")));
+    std::thread t
+    {
+        [&spInfoWrapper]()
+        {
+            Syscollector::instance().init(spInfoWrapper,
+                                          reportFunction,
+                                          reportFunction,
+                                          reportFunction,
+                                          SYSCOLLECTOR_DB_PATH,
+                                          "",
+                                          "",
+                                          1);
+        }
+    };
+    std::this_thread::sleep_for(std::chrono::seconds{1});
+    Syscollector::instance().push(messageToPush);
+    std::this_thread::sleep_for(std::chrono::seconds{1});
+    Syscollector::instance().destroy();
+    if (t.joinable())
+    {
+        t.join();
+    }
+}
+
 
 TEST_F(SyscollectorImpTest, pushMessageInvalid)
 {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7240  |

## Description
This issue aims to fix the wrong resynchronization of syscollector tables.
RCA: this issue was due to the scan_time field that was added as part of the data gathered from data providers. As every regular timestamp it changed changing the computed checksum in every syscollector scanning.
scan time was moved from data providers to delta and sync report functions within syscollector imp.

## DoD
- [X] RCA
- [X] Development
- [X] Testing
- [X] Syscollector RTR
![image](https://user-images.githubusercontent.com/54002291/105441606-aecc7380-5c47-11eb-855e-54bf7a09012e.png)

- [X] Sysinfo RTR
![image](https://user-images.githubusercontent.com/54002291/105441408-4bdadc80-5c47-11eb-8761-242b446fca29.png)

