### PR TITLE
Change references to the product name in logs

### DIFF
--- a/src/analysisd/active-response.c
+++ b/src/analysisd/active-response.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
@@ -54,12 +54,12 @@ int AR_ReadConfig(const char *cfgfile)
 #ifndef WIN32
     gid_t gr_gid;
     if (gr_gid = Privsep_GetGroup(USER), gr_gid == (uid_t) -1) {
-        merror("Could not get ossec gid.");
+        merror("Could not get '%s' gid.", USER);
         return (OS_INVALID);
     }
 
     if ((chown(DEFAULTARPATH, (uid_t) - 1, gr_gid)) == -1) {
-        merror("Could not change the group to ossec: %d", errno);
+        merror("Could not change the group to '%s': %d", GROUPGLOBAL, errno);
         return (OS_INVALID);
     }
 #endif

--- a/src/analysisd/output/prelude.c
+++ b/src/analysisd/output/prelude.c
@@ -9,7 +9,7 @@
  */
 
 /*
- * OSSEC to Prelude
+ * Wazuh to Prelude
  */
 
 #ifdef PRELUDE_OUTPUT_ENABLED
@@ -30,8 +30,8 @@
 #define ANALYZER_MANUFACTURER __site
 #define ANALYZER_VERSION __ossec_version
 
-/** OSSEC to prelude severity mapping. **/
-static const char *(ossec2prelude_sev[]) = {"info", "info", "info", "info",
+/** Wazuh to prelude severity mapping. **/
+static const char *(wazuh2prelude_sev[]) = {"info", "info", "info", "info",
                                "low", "low", "low", "low",
                                "medium", "medium", "medium", "medium",
                                "high", "high", "high", "high", "high"
@@ -312,7 +312,7 @@ void OS_PreludeLog(const Eventinfo *lf)
 
     add_idmef_object(idmef, "alert.assessment.impact.severity",
                      (lf->generated_rule->level > 15) ? "high" :
-                     ossec2prelude_sev[lf->generated_rule->level]);
+                     wazuh2prelude_sev[lf->generated_rule->level]);
 
     add_idmef_object(idmef, "alert.assessment.impact.completion", "succeeded");
 

--- a/src/analysisd/output/prelude.c
+++ b/src/analysisd/output/prelude.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
@@ -75,7 +75,7 @@ add_idmef_object(idmef_message_t *msg, const char *object, const char *value)
 
     ret = idmef_path_set(path, msg, val);
     if (ret < 0) {
-        merror("OSSEC2Prelude: IDMEF: Cannot add object '%s': %s.",
+        merror("Wazuh2Prelude: IDMEF: Cannot add object '%s': %s.",
                object, prelude_strerror(ret));
     }
 
@@ -118,7 +118,7 @@ setup_analyzer(idmef_analyzer_t *analyzer)
     return 0;
 
 err:
-    merror("OSSEC2Prelude: %s: IDMEF error: %s.",
+    merror("Wazuh2Prelude: %s: IDMEF error: %s.",
            prelude_strsource(ret), prelude_strerror(ret));
 
     return -1;
@@ -303,7 +303,7 @@ void OS_PreludeLog(const Eventinfo *lf)
     /* Generate prelude alert */
     ret = idmef_message_new(&idmef);
     if ( ret < 0 ) {
-        merror("OSSEC2Prelude: Cannot create IDMEF message");
+        merror("Wazuh2Prelude: Cannot create IDMEF message");
         return;
     }
 
@@ -362,7 +362,7 @@ void OS_PreludeLog(const Eventinfo *lf)
                          lf->generated_rule->comment);
 
         /* The Common Vulnerabilities and Exposures (CVE) (http://www.cve.mitre.org/)
-         * infomation if present in the triggering rule
+         * information if present in the triggering rule
          */
         if (lf->generated_rule->cve) {
             add_idmef_object(idmef, "alert.classification.reference(>>).origin", "cve");
@@ -372,16 +372,15 @@ void OS_PreludeLog(const Eventinfo *lf)
             add_idmef_object(idmef, "alert.classification.reference(-1).meaning", _prelude_data);
         }
 
-        /* Rule sid is used to create a link to the rule on the OSSEC wiki */
+        /* Check Wazuh rules for reference */
         if (lf->generated_rule->sigid) {
             add_idmef_object(idmef, "alert.classification.reference(>>).origin", "vendor-specific");
 
             snprintf(_prelude_data, 256, "Rule:%d", lf->generated_rule->sigid);
             add_idmef_object(idmef, "alert.classification.reference(-1).name", _prelude_data);
-            add_idmef_object(idmef, "alert.classification.reference(-1).meaning", "OSSEC Rule Wiki Documentation");
+            add_idmef_object(idmef, "alert.classification.reference(-1).meaning", "Wazuh Ruleset");
 
-            snprintf(_prelude_data, 256, "http://www.ossec.net/wiki/Rule:%d",
-                     lf->generated_rule->sigid);
+            snprintf(_prelude_data, 256, "https://github.com/wazuh/wazuh/tree/master/ruleset");
             add_idmef_object(idmef, "alert.classification.reference(-1).url", _prelude_data);
         }
 
@@ -426,7 +425,7 @@ void OS_PreludeLog(const Eventinfo *lf)
 
         /* Break up the list of groups on the "," boundary
          * For each section create a prelude reference classification
-         * that points back to the the OSSEC wiki for more infomation.
+         * that points back to Wazuh ruleset for more infomation.
          */
         if (lf->generated_rule->group) {
             char *copy_group;
@@ -440,10 +439,9 @@ void OS_PreludeLog(const Eventinfo *lf)
                 snprintf(_prelude_data, 256, "Group:%s", copy_group);
                 add_idmef_object(idmef, "alert.classification.reference(-1).name", _prelude_data);
 
-                add_idmef_object(idmef, "alert.classification.reference(-1).meaning", "OSSEC Group Wiki Documentation");
+                add_idmef_object(idmef, "alert.classification.reference(-1).meaning", "Wazuh Ruleset");
 
-                snprintf(_prelude_data, 256, "http://www.ossec.net/wiki/Group:%s",
-                         copy_group);
+                snprintf(_prelude_data, 256, "https://github.com/wazuh/wazuh/tree/master/ruleset");
                 add_idmef_object(idmef, "alert.classification.reference(-1).url", _prelude_data);
 
                 copy_group = strtok_r(NULL, ",", &saveptr);

--- a/src/config/active-response.c
+++ b/src/config/active-response.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
@@ -68,7 +68,7 @@ int ReadActiveResponses(XML_NODE node, void *d1, void *d2)
     }
 
     if ((chown(DEFAULTARPATH, (uid_t) - 1, gid)) == -1) {
-        merror("Could not change the group to ossec: %d.", errno);
+        merror("Could not change the group to '%s': %d.", GROUPGLOBAL, errno);
         fclose(fp);
         return OS_INVALID;
     }

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
@@ -299,7 +299,7 @@
 #define DB_MISS_CONFIG        "(5205): Missing database configuration. "\
                               "It requires host, user, pass and database."
 #define DB_CONFIGERR          "(5206): Database configuration error."
-#define DB_COMPILED           "(5207): OSSEC not compiled with support for '%s'."
+#define DB_COMPILED           "(5207): Wazuh not compiled with support for '%s'."
 #define DB_MAINERROR          "(5208): Multiple database errors. Exiting."
 #define DB_CLOSING            "(5209): Closing connection to database."
 #define DB_ATTEMPT            "(5210): Attempting to reconnect to database."

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * June 12, 2017.
  *
  * This program is free software; you can redistribute it
@@ -54,9 +54,9 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
         minfo("Running daily rotation of log files.");
     else {
         if (rotate_json)
-            minfo("Rotating 'ossec.json' file: Maximum size reached.");
+            minfo("Rotating '%s' file: Maximum size reached.", LOGJSONFILE);
         else
-            minfo("Rotating 'ossec.log' file: Maximum size reached.");
+            minfo("Rotating '%s' file: Maximum size reached.", LOGFILE);
     }
 
     if (new_day)

--- a/src/unit_tests/analysisd/test_rules.c
+++ b/src/unit_tests/analysisd/test_rules.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -1,6 +1,6 @@
 /*
  * Wazuh Module for custom command execution
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * October 26, 2017.
  *
  * This program is free software; you can redistribute it
@@ -192,7 +192,7 @@ void * wm_command_main(wm_command_t * command) {
             }
             break;
         case WM_ERROR_TIMEOUT:
-            mterror(WM_COMMAND_LOGTAG, "%s: Timeout overtaken. You can modify your command timeout at ossec.conf. Exiting...", command->tag);
+            mterror(WM_COMMAND_LOGTAG, "%s: Timeout overtaken. You can modify your command timeout at '%s'. Exiting...", command->tag, OSSECCONF);
             break;
 
         default:


### PR DESCRIPTION
|Related issue|
|---|
|7258|

## Description

This PR replaces all OSSEC references in the logs for Wazuh.
There are still some files, paths and user/group names that contain the OSSEC word and they will remain in the logs until they get updated. In those cases, the corresponding variables were used. 

The following files were checked:

- **error_messages.h**
- **warning_messages.h** 
- **debuh_messages.h** 
- **information_messages.h** 
- **defs.h** 

The following log functions were analyzed:

- `mdebug`
- `merror`	 
- `minfo`
- `mwarn`
- `merror_critical`
- `mterror`
- `mtdebug`
- `mtwarn` 
- `mtinfo` 
- `print_out` 	
- `mferror` 
- `mtferror`

Closes  #7258 .

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Review logs syntax and correct language
