### PR TITLE
Fix delete alerts in whodata when the action is performed by a domain user.

### DIFF
--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -710,7 +710,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
 
                 // In deferred delete events the access mask comes with delete access only,
                 // we need it to scan the directory this file belongs to
-                if (mask == DELETE) {
+                if (mask == DELETE || mask == (DELETE | FILE_READ_ATTRIBUTES)) {
                     w_evt->mask = DELETE;
                 } else {
                     w_evt->mask = 0;


### PR DESCRIPTION
|Related issue|
|---|
|#5797|

## Description
Hi team! 
As explained in #5797, if a domain user deletes a file in a monitored shared folder, whodata is not raising any delete event (creation and modification are working fine).
The cause is that the `AccessMask`  of the event when the domain user deletes a file is `0x10080`.

Closes #5797

## Configuration options
```xml
 <!-- File integrity monitoring -->
  <syscheck>

    <disabled>no</disabled>
    <directories whodata="yes">C:\share</directories>
  <syscheck>
```
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
In my test environment, the user was `vagrant` :
```
** Alert 1611647679.8685: - ossec,syscheck,syscheck_entry_deleted,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2021 Jan 26 07:54:39 (win2016) 10.2.0.14->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File 'c:\share\new rich text document.rtf' deleted
Mode: whodata
Attributes:
 - Size: 7
 - Permissions: Administrator (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Administrators (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, Everyone (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes, SYSTEM (allowed): delete|read_control|write_dac|write_owner|synchronize|read_data|write_data|append_data|read_ea|write_ea|execute|read_attributes|write_attributes
 - Date: Tue Jan 26 07:54:30 2021
 - User: Administrators (S-1-5-32-544)
 - MD5: 8274425de767b30b2fff1124ab54abb5
 - SHA1: 2201589aa3ed709b3665e4ff979e10c6ad5137fc
 - SHA256: 0d6afb7e939f0936f40afdc759b5a354ea5427ec250a47e7b904ab1ea800a01d
 - File attributes: ARCHIVE
 - (Audit) User name: vagrant
 - (Audit) Process id: 4
```
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [X] Windows
- [x] Source installation
- [x] Source upgrade
- Memory tests for Windows
  - [X] Scan-build report
