### PR TITLE
FIM nodes_count database variable is not checking correctly

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1825,7 +1825,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 
                     syscheck->file_limit = atoi(children[j]->content);
 
-                    if (syscheck->file_limit > MAX_FILE_LIMIT) {
+                    if (syscheck->file_limit < 0) {
                         mdebug2("Maximum value allowed for file_limit is '%d'", MAX_FILE_LIMIT);
                         syscheck->file_limit = MAX_FILE_LIMIT;
                     }

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -88,7 +88,7 @@ typedef enum fdb_stmt {
 #define MAX_DIR_SIZE    64
 #define MAX_DIR_ENTRY   128
 #define SYSCHECK_WAIT   1
-#define MAX_FILE_LIMIT  2147483647
+#define MAX_FILE_LIMIT  INT_MAX
 #define MIN_COMP_ESTIM  0.4         // Minimum value to be taken by syscheck.comp_estimation_perc
 
 /* Checking options */
@@ -356,7 +356,7 @@ typedef struct _config {
     char *scan_day;                 /* run syscheck on this day */
     char *scan_time;                /* run syscheck at this time */
 
-    unsigned int file_limit;        /* maximum number of files to monitor */
+    int file_limit;        /* maximum number of files to monitor */
     unsigned int file_limit_enabled;    /* Enable file_limit option */
 
     char **ignore;                  /* list of files/dirs to ignore */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -60,6 +60,7 @@
 #define FIM_REGISTRY_FAIL_TO_GET_KEY_ID         "(6945): Unable to get id for registry key '%s %s'"
 #define FIM_AUDIT_DISABLED                      "(6946): Audit is disabled."
 #define FIM_WARN_FORMAT_PATH                    "(6947): Error formatting path: '%s'"
+#define FIM_DATABASE_NODES_COUNT_FAIL           "(6948): Unable to get the number of entries in database."
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -57,7 +57,7 @@ void fim_scan() {
     struct timespec start;
     struct timespec end;
     clock_t cputime_start;
-    unsigned int nodes_count = 0;
+    int nodes_count = 0;
     struct fim_element item;
 
     cputime_start = clock();
@@ -480,7 +480,7 @@ void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt
 
 // Checks the DB state, sends a message alert if necessary
 void fim_check_db_state() {
-    unsigned int nodes_count = 0;
+    int nodes_count = 0;
     cJSON *json_event = NULL;
     char *json_plain = NULL;
     char alert_msg[OS_SIZE_256] = {'\0'};

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -489,6 +489,11 @@ void fim_check_db_state() {
     nodes_count = fim_db_get_count_entries(syscheck.database);
     w_mutex_unlock(&syscheck.fim_entry_mutex);
 
+    if (nodes_count < 0) {
+        mwarn(FIM_DATABASE_NODES_COUNT_FAIL);
+        return;
+    }
+
     switch (_db_state) {
     case FIM_STATE_DB_FULL:
         if (nodes_count >= syscheck.file_limit) {

--- a/src/syscheckd/db/fim_db_files.c
+++ b/src/syscheckd/db/fim_db_files.c
@@ -390,6 +390,10 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_file_data *new, fim
     if (!saved) {
         if (syscheck.file_limit_enabled) {
             nodes_count = fim_db_get_count_entries(syscheck.database);
+            if (nodes_count < 0) {
+                mwarn(FIM_DATABASE_NODES_COUNT_FAIL);
+                return FIMDB_ERR;
+            }
             if (nodes_count >= syscheck.file_limit) {
                 fim_sql->full = true;
                 mdebug1("Couldn't insert '%s' entry into DB. The DB is full, please check your configuration.",

--- a/src/syscheckd/db/fim_db_files.c
+++ b/src/syscheckd/db/fim_db_files.c
@@ -384,7 +384,7 @@ int fim_db_insert_path(fdb_t *fim_sql, const char *file_path, fim_file_data *ent
 int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_file_data *new, fim_file_data *saved) {
     int inode_id;
     int res, res_data, res_path;
-    unsigned int nodes_count;
+    int nodes_count;
 
     // Add event
     if (!saved) {

--- a/src/syscheckd/db/fim_db_registries.c
+++ b/src/syscheckd/db/fim_db_registries.c
@@ -458,7 +458,7 @@ int fim_db_insert_registry_data(fdb_t *fim_sql,
             return FIMDB_ERR;
         }
 
-        if ((unsigned int)count >= syscheck.file_limit) {
+        if (count >= syscheck.file_limit) {
             mdebug1("Couldn't insert '%s' value entry into DB. The DB is full, please check your configuration.",
                     data->name);
             return FIMDB_FULL;
@@ -488,7 +488,7 @@ int fim_db_insert_registry_key(fdb_t *fim_sql, fim_registry_key *entry, unsigned
             return FIMDB_ERR;
         }
 
-        if ((unsigned int)count >= syscheck.file_limit) {
+        if (count >= syscheck.file_limit) {
             mdebug1("Couldn't insert '%s %s' entry into DB. The DB is full, please check your configuration.",
                     registry_arch[entry->arch], entry->path);
             return FIMDB_FULL;

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -3510,6 +3510,24 @@ static void test_fim_check_db_state_80_percentage_to_normal(void **state) {
     assert_int_equal(_db_state, FIM_STATE_DB_NORMAL);
 }
 
+static void test_fim_check_db_state_nodes_count_database_error(void **state) {
+    (void) state;
+#ifdef TEST_WINAGENT
+    expect_function_call(__wrap_pthread_mutex_lock);
+#endif
+    expect_wrapper_fim_db_get_count_entries(syscheck.database, -1);
+#ifdef TEST_WINAGENT
+    expect_function_call(__wrap_pthread_mutex_unlock);
+#endif
+    expect_string(__wrap__mwarn, formatted_msg, "(6947): Unable to get the number of entries in database.");
+
+    assert_int_equal(_db_state, FIM_STATE_DB_NORMAL);
+
+    fim_check_db_state();
+
+    assert_int_equal(_db_state, FIM_STATE_DB_NORMAL);
+}
+
 /* fim_directory */
 static void test_fim_directory(void **state) {
     fim_data_t *fim_data = *state;
@@ -4163,6 +4181,7 @@ int main(void) {
         cmocka_unit_test(test_fim_check_db_state_full_to_90_percentage),
         cmocka_unit_test(test_fim_check_db_state_90_percentage_to_80_percentage),
         cmocka_unit_test(test_fim_check_db_state_80_percentage_to_normal),
+        cmocka_unit_test(test_fim_check_db_state_nodes_count_database_error),
 #ifndef TEST_WINAGENT
         cmocka_unit_test_setup_teardown(test_fim_scan_no_realtime, setup_fim_scan_realtime, teardown_fim_scan_realtime),
         cmocka_unit_test_setup_teardown(test_fim_scan_realtime_enabled, setup_fim_scan_realtime, teardown_fim_scan_realtime),

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -3519,7 +3519,7 @@ static void test_fim_check_db_state_nodes_count_database_error(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
 #endif
-    expect_string(__wrap__mwarn, formatted_msg, "(6947): Unable to get the number of entries in database.");
+    expect_string(__wrap__mwarn, formatted_msg, "(6948): Unable to get the number of entries in database.");
 
     assert_int_equal(_db_state, FIM_STATE_DB_NORMAL);
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/5823|

## Description

This PR fixes an error in the log messages caused by the output of a function not being checked correctly.
It now checks that the **nodes_count** variable cannot be negative, and also, the type of the variable has been changed to match the type of the function.
Added the unit test that tests this specific case.


## Logs/Alerts example

When nodes_count is negative, we got this warning:
`(6947): Unable to get the number of entries in database.`
And function **fim_check_db_state** will terminate in that point.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
 
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

- Memory tests for Windows
  - [x] Scan-build report
