### PR TITLE
Fix authd race conditions

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -710,12 +710,16 @@ void* run_dispatcher(__attribute__((unused)) void *arg) {
                     merror("SSL write error (%d)", ret);
                     merror("Agent key not saved for %s", agentname);
                     ERR_print_errors_fp(stderr);
+                    w_mutex_lock(&mutex_keys);
                     OS_DeleteKey(&keys, keys.keyentries[keys.keysize - 1]->id, 1);
+                    w_mutex_unlock(&mutex_keys);
                 } else {
                     /* Add pending key to write */
+                    w_mutex_lock(&mutex_keys);
                     add_insert(keys.keyentries[keys.keysize - 1], centralized_group);
                     write_pending = 1;
                     w_cond_signal(&cond_pending);
+                    w_mutex_unlock(&mutex_keys);
                 }
             }
         }


### PR DESCRIPTION
|Related issue|
|---|
|#7257|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #7257 by adding locks on the mutex used to protect the client keystore in a couple of operations where it was missing.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] ThreadSanitizer

### ThreadSanitizer report

[authd-ThreadSanitizer-postfix.txt](https://github.com/wazuh/wazuh/files/5874265/authd-ThreadSanitizer-postfix.txt)

As can be seen from the report, after adding the locks on the appropriate mutex the original errors don't show up and only some race conditions remain.

With regards to the remaining race conditions, I've been looking around and it looks like the correct way to handle those is to have a separate thread using [sigwait](https://man7.org/linux/man-pages/man3/sigwait.3.html) to expect the required signals and clean up execution from it instead of using a signal handler.