### PR TITLE
Fix version detection for macOS Big Sur

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -648,120 +648,29 @@ os_info *get_unix_version()
             } else if(strcmp(strtok_r(buff, "\n", &save_ptr),"Darwin") == 0){
                 info->os_platform = strdup("darwin");
 
-                //plist
-                if (os_release = fopen(MAC_SYSVERSION,"r"), os_release){
-                    bool build=false, name=false, version=false;
-                    while (fgets(buff, sizeof(buff) - 1, os_release)) {
-                        if(build){
-                            strtok_r(buff, ">", &save_ptr);
-                            id=strtok_r(NULL, "<", &save_ptr);
-                            w_strdup(id, info->os_build);
-                            if(info->os_build == NULL){
-                                mdebug1("Cannot read OS build from file %s.", MAC_SYSVERSION);
-                            }
-                            build=false;
-                        }
-                        if(name){
-                            strtok_r(buff, ">", &save_ptr);
-                            id=strtok_r(NULL, "<", &save_ptr);
-                            w_strdup(id, info->os_name);
-                            if(info->os_name == NULL){
-                                mdebug1("Cannot read OS name from file %s.", MAC_SYSVERSION);
-                            }
-                            name=false;
-                        }
-                        if(version){
-                            strtok_r(buff, ">", &save_ptr);
-                            id=strtok_r(NULL, "<", &save_ptr);
-                            w_strdup(id, info->os_version);
-                            if(info->os_version == NULL){
-                                mdebug1("Cannot read OS version from file %s.", MAC_SYSVERSION);
-                            }
-                            version=false;
-                        }
-                        if (strstr(buff,"ProductBuildVersion")){
-                            build=true;
-                        }
-                        if (strstr(buff,"ProductName")){
-                            name=true;
-                        }
-                        if (strstr(buff,"ProductVersion")){
-                            version=true;
-                        }
+                if (cmd_output_ver = popen("sw_vers -productName", "r"), cmd_output_ver) {
+                    if(fgets(buff, sizeof(buff) - 1, cmd_output_ver) == NULL){
+                        mdebug1("Cannot read from command output (sw_vers -productName).");
+                    } else {
+                        w_strdup(strtok_r(buff, "\n", &save_ptr), info->os_name);
                     }
-
-                    fclose(os_release);
+                    pclose(cmd_output_ver);
                 }
-                //plist server
-                else if(os_release = fopen(MAC_SERVERVERSION,"r"), os_release) {
-                    bool build=false, name=false, version=false;
-                    while (fgets(buff, sizeof(buff) - 1, os_release)) {
-                        if(build){
-                            strtok_r(buff, ">", &save_ptr);
-                            id=strtok_r(NULL, "<", &save_ptr);
-                            w_strdup(id, info->os_build);
-                            if(info->os_build == NULL){
-                                mdebug1("Cannot read OS build from file %s.", MAC_SERVERVERSION);
-                            }
-                            build=false;
-                        }
-                        if(name){
-                            strtok_r(buff, ">", &save_ptr);
-                            id=strtok_r(NULL, "<", &save_ptr);
-                            w_strdup(id, info->os_name);
-                            if(info->os_name == NULL){
-                                mdebug1("Cannot read OS name from file %s.", MAC_SERVERVERSION);
-                            }
-                            name=false;
-                        }
-                        if(version){
-                            strtok_r(buff, ">", &save_ptr);
-                            id=strtok_r(NULL, "<", &save_ptr);
-                            w_strdup(id, info->os_version);
-                            if(info->os_version == NULL){
-                                mdebug1("Cannot read OS version from file %s.", MAC_SERVERVERSION);
-                            }
-                            version=false;
-                        }
-                        if (strstr(buff,"ProductBuildVersion")){
-                            build=true;
-                        }
-                        if (strstr(buff,"ProductName")){
-                            name=true;
-                        }
-                        if (strstr(buff,"ProductVersion")){
-                            version=true;
-                        }
+                if (cmd_output_ver = popen("sw_vers -productVersion", "r"), cmd_output_ver) {
+                    if(fgets(buff, sizeof(buff) - 1, cmd_output_ver) == NULL){
+                        mdebug1("Cannot read from command output (sw_vers -productVersion).");
+                    } else {
+                        w_strdup(strtok_r(buff, "\n", &save_ptr), info->os_version);
                     }
-
-                    fclose(os_release);
+                    pclose(cmd_output_ver);
                 }
-                //cmd
-                else{
-                    if (cmd_output_ver = popen("sw_vers -productName", "r"), cmd_output_ver) {
-                        if(fgets(buff, sizeof(buff) - 1, cmd_output_ver) == NULL){
-                            mdebug1("Cannot read from command output (sw_vers -productName).");
-                        } else {
-                            w_strdup(strtok_r(buff, "\n", &save_ptr), info->os_name);
-                        }
-                        pclose(cmd_output_ver);
+                if (cmd_output_ver = popen("sw_vers -buildVersion", "r"), cmd_output_ver) {
+                    if(fgets(buff, sizeof(buff) - 1, cmd_output_ver) == NULL){
+                        mdebug1("Cannot read from command output (sw_vers -buildVersion).");
+                    } else {
+                        w_strdup(strtok_r(buff, "\n", &save_ptr), info->os_build);
                     }
-                    if (cmd_output_ver = popen("sw_vers -productVersion", "r"), cmd_output_ver) {
-                        if(fgets(buff, sizeof(buff) - 1, cmd_output_ver) == NULL){
-                            mdebug1("Cannot read from command output (sw_vers -productVersion).");
-                        } else {
-                            w_strdup(strtok_r(buff, "\n", &save_ptr), info->os_version);
-                        }
-                        pclose(cmd_output_ver);
-                    }
-                    if (cmd_output_ver = popen("sw_vers -buildVersion", "r"), cmd_output_ver) {
-                        if(fgets(buff, sizeof(buff) - 1, cmd_output_ver) == NULL){
-                            mdebug1("Cannot read from command output (sw_vers -buildVersion).");
-                        } else {
-                            w_strdup(strtok_r(buff, "\n", &save_ptr), info->os_build);
-                        }
-                        pclose(cmd_output_ver);
-                    }
+                    pclose(cmd_output_ver);
                 }
                 if (cmd_output_ver = popen("uname -r", "r"), cmd_output_ver) {
                     if(fgets(buff, sizeof(buff) - 1, cmd_output_ver) == NULL){


### PR DESCRIPTION
|Related issue|
|---|
| #7241 |

## Description

For 4.1 the macOS support for Vulnerability Detector has been added. Inside these changes, we changed the way of gathering the macOS OS information, from calling the `sw_vers` command to reading the file `/System/Library/CoreServices/SystemVersion.plist`. The goal of the change was not to run commands to get the inventory data.

With the new release of macOS 11 (Big Sur), they have been added a solution for maintaining backward compatibility with older versions which makes the agent read the version of macOS Big Sur as 10.16. More information [here](https://github.com/wazuh/wazuh/issues/7241#issuecomment-767031279).

To fix this issue, we have considered several solutions:

1. Build the macOS agent in macOS Big Sur, currently, it is done in macOS Sierra. That way, the code is built in against the 11.0 SDK and returns the correct version. It implies changes in the CICD procedures and should be considered for the future.

2. Change the value of the environment variable `SYSTEM_VERSION_COMPAT` at runtime to read the correct version. This solution has been tested without success, and it is not persistent.

3. Map the version 10.16 manually to 11.x, this solution is neither robust nor maintainable.

4. For now, **the final solution** consists of reverting the changes introduced in 4.1 by gathering the macOS version through the `sw_vers` call. It is not affected by the double version problem and always returns the correct version, 11.x.

## Logs/Alerts example

**Before the changes**
```
2021/01/26 09:34:37 ossec-agentd: INFO: Version detected -> Darwin |sur2 |20.0.0 |Darwin Kernel Version 20.0.0: Thu Jul 30 22:49:28 PDT 2020; root:xnu-7195.0.0.141.5~1/RELEASE_X86_64 |x86_64 [Mac OS X|darwin: 10.16 (Big Sur)] - Wazuh v4.1.0
```

**After the changes**
```
2021/01/26 10:03:34 ossec-agentd: INFO: Version detected -> Darwin |sur2 |20.0.0 |Darwin Kernel Version 20.0.0: Thu Jul 30 22:49:28 PDT 2020; root:xnu-7195.0.0.141.5~1/RELEASE_X86_64 |x86_64 [macOS|darwin: 11.0 (Big Sur)] - Wazuh v4.1.0
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Package upgrade
- [x] Review logs syntax and correct language
