### PR TITLE
[7266] cmake min version update

### DIFF
--- a/src/data_provider/CMakeLists.txt
+++ b/src/data_provider/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(sysinfo)
 

--- a/src/data_provider/tests/CMakeLists.txt
+++ b/src/data_provider/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(unit_tests)
 

--- a/src/data_provider/testtool/CMakeLists.txt
+++ b/src/data_provider/testtool/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(sysinfo_test_tool)
 

--- a/src/shared_modules/dbsync/CMakeLists.txt
+++ b/src/shared_modules/dbsync/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(dbsync)
 

--- a/src/shared_modules/dbsync/example/CMakeLists.txt
+++ b/src/shared_modules/dbsync/example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(dbsync_example)
 

--- a/src/shared_modules/dbsync/integrationTests/CMakeLists.txt
+++ b/src/shared_modules/dbsync/integrationTests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(integration_tests)
 

--- a/src/shared_modules/dbsync/integrationTests/fim/CMakeLists.txt
+++ b/src/shared_modules/dbsync/integrationTests/fim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(fim_integration_test)
 

--- a/src/shared_modules/dbsync/tests/CMakeLists.txt
+++ b/src/shared_modules/dbsync/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(unit_tests)
 

--- a/src/shared_modules/dbsync/testtool/CMakeLists.txt
+++ b/src/shared_modules/dbsync/testtool/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(dbsync_test_tool)
 

--- a/src/shared_modules/rsync/CMakeLists.txt
+++ b/src/shared_modules/rsync/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(rsync)
 

--- a/src/shared_modules/rsync/integrationTests/CMakeLists.txt
+++ b/src/shared_modules/rsync/integrationTests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(integration_tests)
 

--- a/src/shared_modules/rsync/tests/CMakeLists.txt
+++ b/src/shared_modules/rsync/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(unit_tests)
 

--- a/src/shared_modules/rsync/tests/implementation/CMakeLists.txt
+++ b/src/shared_modules/rsync/tests/implementation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(rsync_implementation_unit_test)
 

--- a/src/shared_modules/rsync/tests/interface/CMakeLists.txt
+++ b/src/shared_modules/rsync/tests/interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(rsync_unit_test)
 

--- a/src/shared_modules/rsync/testtool/CMakeLists.txt
+++ b/src/shared_modules/rsync/testtool/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(rsync_test_tool)
 

--- a/src/shared_modules/utils/tests/CMakeLists.txt
+++ b/src/shared_modules/utils/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(utils_unit_test)
 

--- a/src/wazuh_modules/syscollector/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(syscollector)
 

--- a/src/wazuh_modules/syscollector/tests/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(unit_tests)
 

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(syscollectorimp_unit_test)
 

--- a/src/wazuh_modules/syscollector/tests/sysNormalizer/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/tests/sysNormalizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(sys_normalizer_unit_test)
 

--- a/src/wazuh_modules/syscollector/testtool/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/testtool/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(syscollector_test_tool)
 

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -444,7 +444,7 @@
                             <Component Id="SYSCOLLECTOR_NORM_CONFIG" DiskId="1" Guid="40284747-C50C-4905-9A72-6236276E192E">
                                 <File Id="SYSCOLLECTOR_NORM_CONFIG" Name="norm_config.json" Source="..\wazuh_modules\syscollector\norm_config.json" />
                             </Component>
-                            <Directory Id="SYSCOLLECTOR_DB" Name="syscollector_db" />
+                            <Directory Id="SYSCOLLECTOR_DB" Name="db" />
                         </Directory>
                         <Directory Id="LOGCOLLECTOR" Name="logcollector" />
                     </Directory>


### PR DESCRIPTION
|Related issue|
|---|
|Closes [#7266](https://github.com/wazuh/wazuh/issues/7266) |
|Closes [#7267](https://github.com/wazuh/wazuh/issues/7267) |

## Description
With the fact of updating versions, the only operating system that had an old version was centos 5 with 2.6.4, this was updated to version 3.12.4 in the centos 5 dockers files in wazuh-packages.

This issue aims to correct the minimum supported version.

## DoD
- [X] CMakeLists.txt updates
- [x] CI PASS
