### PR TITLE
[7272] Added sanity check to prevent vulnerability detector crash

### DIFF
--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -162,7 +162,8 @@ private:
             if (nullptr != xml)
             {
                 xmlContent.assign(xml, xml+length);
-                free(xml);
+                plist_to_xml_free(xml);
+                plist_free(rootNode);
             }
         }
         return std::stringstream{xmlContent};

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4524,7 +4524,9 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
 
                 if (cpe_str) {
                     s_cpe = wm_vuldet_decode_cpe(cpe_str);
-                    w_strdup(msu_name, s_cpe->msu_name);
+                    if (s_cpe) {
+                        w_strdup(msu_name, s_cpe->msu_name);
+                    }
                 }
 
                 if (agent->dist != FEED_WIN && agent->dist != FEED_MAC) {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7272 |


## Description
Issue found during exploratory / functional test.

When the vendor is empty, it possibly generates a segmentation fault, since the return of wm_vuldet_decode_cpe is not being controlled.

## DoD
- [X] Implement fix
- [x] CI PASS
