### PR TITLE
Moving wazuh-control helper functions to a common section within the framework

### DIFF
--- a/framework/scripts/wazuh-logtest.py
+++ b/framework/scripts/wazuh-logtest.py
@@ -16,6 +16,7 @@ import struct
 import textwrap
 from wazuh.core.common import LOGTEST_SOCKET
 
+from wazuh.core import common
 
 def init_argparse():
     """Setup argpase for handle command line parameters
@@ -396,7 +397,7 @@ class Wazuh:
         Returns:
             str: install_path
         """
-        return os.path.abspath(os.path.join(__file__, "../../.."))
+        return common.find_wazuh_path()
 
     def get_info(field):
         """Get Wazuh information from wazuh-control
@@ -411,8 +412,8 @@ class Wazuh:
         wazuh_env_vars = dict()
         try:
             proc = subprocess.Popen([wazuh_control, "info"], stdout=subprocess.PIPE)
-            (stdout, stderr) = proc.communicate() 
-        except:            
+            (stdout, stderr) = proc.communicate()
+        except:
             return "ERROR"
 
         env_variables = stdout.decode().rsplit("\n")
@@ -420,7 +421,7 @@ class Wazuh:
         for env_variable in env_variables:
             key, value = env_variable.split("=")
             wazuh_env_vars[key] = value.replace("\"", "")
-        
+
         return wazuh_env_vars[field]
 
     def get_version_str():

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -91,12 +91,12 @@ def get_wazuh_version() -> str:
 
 @lru_cache(maxsize=None)
 def get_wazuh_revision() -> str:
-    return get_wazuh_info("TEST_REVISION")
+    return get_wazuh_info("WAZUH_REVISION")
 
 
 @lru_cache(maxsize=None)
 def get_wazuh_type() -> str:
-    return get_wazuh_info("TEST_TYPE")
+    return get_wazuh_info("WAZUH_TYPE")
 
 
 ossec_path = find_wazuh_path()

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -11,6 +11,7 @@ from grp import getgrnam
 from pwd import getpwnam
 from typing import Dict
 from copy import deepcopy
+from functools import lru_cache
 
 try:
     here = os.path.abspath(os.path.dirname(__file__))
@@ -24,6 +25,7 @@ except (FileNotFoundError, PermissionError):
     }
 
 
+@lru_cache(maxsize=None)
 def find_wazuh_path():
     """
     Gets the path where Wazuh is installed dinamically
@@ -82,14 +84,17 @@ def get_wazuh_info(field) -> str:
     return wazuh_env_vars[field]
 
 
+@lru_cache(maxsize=None)
 def get_wazuh_version() -> str:
     return get_wazuh_info("WAZUH_VERSION")
 
 
+@lru_cache(maxsize=None)
 def get_wazuh_revision() -> str:
     return get_wazuh_info("TEST_REVISION")
 
 
+@lru_cache(maxsize=None)
 def get_wazuh_type() -> str:
     return get_wazuh_info("TEST_TYPE")
 

--- a/framework/wazuh/core/tests/test_common.py
+++ b/framework/wazuh/core/tests/test_common.py
@@ -12,12 +12,12 @@ from pwd import getpwnam
 ])
 def test_find_wazuh_path(fake_path, expected):
     with patch('wazuh.core.common.__file__', new=fake_path):
-        assert(find_wazuh_path() == expected)
+        assert(find_wazuh_path.__wrapped__() == expected)
 
 
 def test_find_wazuh_path_relative_path():
     with patch('os.path.abspath', return_value='~/framework'):
-        assert(find_wazuh_path() == '~')
+        assert(find_wazuh_path.__wrapped__() == '~')
 
 
 def test_ossec_uid():

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -15,6 +15,7 @@ mkdir -p ${WAZUH_HOME}/tmp_bkp/etc
 
 cp -rp ${WAZUH_HOME}/bin ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}
 cp -rp ${WAZUH_HOME}/etc ${WAZUH_HOME}/tmp_bkp/${WAZUH_HOME}
+
 if [ -f /etc/ossec-init.conf ]; then
     cp -p /etc/ossec-init.conf ${WAZUH_HOME}/tmp_bkp/etc
 fi

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -23,11 +23,11 @@
 #   13 - Unexpected error sending message to Wazuh
 #   14 - Empty bucket
 
-import signal
-import sys
-import sqlite3
 import argparse
+import signal
 import socket
+import sqlite3
+import sys
 
 try:
     import boto3

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -20,10 +20,8 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
 import aws_s3
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-wazuh_control_info = 'WAZUH_VERSION="TEST_VERSION"\n\
-                      WAZUH_REVISION="TEST_REVISION"\n\
-                      WAZUH_TYPE="TEST_TYPE"\n'
 wazuh_installation_path = '/var/ossec'
+wazuh_version = 'WAZUH_VERSION'
 
 def get_fake_s3_db(sql_file):
 
@@ -52,8 +50,8 @@ def test_metadata_version_buckets(mocked_db, class_):
     """
     with patch(f'aws_s3.{class_.__name__}.get_client'), \
         patch(f'aws_s3.{class_.__name__}.get_sts_client'), \
-        patch(f'aws_s3.call_wazuh_control', return_value=wazuh_control_info), \
-        patch(f'aws_s3.get_wazuh_path', return_value=wazuh_installation_path):
+        patch(f'common.find_wazuh_path', return_value=wazuh_installation_path), \
+        patch(f'common.get_wazuh_version', return_value=wazuh_version):
         ins = class_(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'profile': None, 'iam_role_arn': None, 'bucket': 'test',
                         'only_logs_after': '19700101', 'skip_on_error': True,
@@ -77,8 +75,8 @@ def test_metadata_version_services(mocked_db, class_):
     """
     with patch(f'aws_s3.{class_.__name__}.get_client'), \
         patch(f'aws_s3.{class_.__name__}.get_sts_client'), \
-        patch(f'aws_s3.call_wazuh_control', return_value=wazuh_control_info), \
-        patch(f'aws_s3.get_wazuh_path', return_value=wazuh_installation_path):
+        patch(f'common.find_wazuh_path', return_value=wazuh_installation_path), \
+        patch(f'common.get_wazuh_version', return_value=wazuh_version):
         ins = class_(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'aws_profile': None, 'iam_role_arn': None,
                         'only_logs_after': '19700101', 'region': None})
@@ -103,8 +101,8 @@ def test_db_maintenance(class_, sql_file, db_name):
     with patch(f'aws_s3.{class_.__name__}.get_client'), \
         patch(f'aws_s3.{class_.__name__}.get_sts_client'), \
         patch('sqlite3.connect', side_effect=get_fake_s3_db(sql_file)), \
-        patch(f'aws_s3.call_wazuh_control', return_value=wazuh_control_info), \
-        patch(f'aws_s3.get_wazuh_path', return_value=wazuh_installation_path):
+        patch(f'common.find_wazuh_path', return_value=wazuh_installation_path), \
+        patch(f'common.get_wazuh_version', return_value=wazuh_version):
         ins = class_(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'profile': None, 'iam_role_arn': None, 'bucket': 'test-bucket',
                         'only_logs_after': '19700101', 'skip_on_error': True,

--- a/wodles/aws/tests/test_aws.py
+++ b/wodles/aws/tests/test_aws.py
@@ -5,12 +5,10 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import os
-import pytest
-import re
 import sys
 from sqlite3 import connect
-from unittest import TestCase
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock
+import pytest
 
 # mock AWS libraries
 sys.modules['boto3'] = MagicMock()
@@ -50,8 +48,8 @@ def test_metadata_version_buckets(mocked_db, class_):
     """
     with patch(f'aws_s3.{class_.__name__}.get_client'), \
         patch(f'aws_s3.{class_.__name__}.get_sts_client'), \
-        patch(f'common.find_wazuh_path', return_value=wazuh_installation_path), \
-        patch(f'common.get_wazuh_version', return_value=wazuh_version):
+        patch(f'aws_s3.common.find_wazuh_path', return_value=wazuh_installation_path), \
+        patch(f'aws_s3.common.get_wazuh_version', return_value=wazuh_version):
         ins = class_(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'profile': None, 'iam_role_arn': None, 'bucket': 'test',
                         'only_logs_after': '19700101', 'skip_on_error': True,
@@ -75,8 +73,8 @@ def test_metadata_version_services(mocked_db, class_):
     """
     with patch(f'aws_s3.{class_.__name__}.get_client'), \
         patch(f'aws_s3.{class_.__name__}.get_sts_client'), \
-        patch(f'common.find_wazuh_path', return_value=wazuh_installation_path), \
-        patch(f'common.get_wazuh_version', return_value=wazuh_version):
+        patch(f'aws_s3.common.find_wazuh_path', return_value=wazuh_installation_path), \
+        patch(f'aws_s3.common.get_wazuh_version', return_value=wazuh_version):
         ins = class_(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'aws_profile': None, 'iam_role_arn': None,
                         'only_logs_after': '19700101', 'region': None})
@@ -101,8 +99,8 @@ def test_db_maintenance(class_, sql_file, db_name):
     with patch(f'aws_s3.{class_.__name__}.get_client'), \
         patch(f'aws_s3.{class_.__name__}.get_sts_client'), \
         patch('sqlite3.connect', side_effect=get_fake_s3_db(sql_file)), \
-        patch(f'common.find_wazuh_path', return_value=wazuh_installation_path), \
-        patch(f'common.get_wazuh_version', return_value=wazuh_version):
+        patch(f'aws_s3.common.find_wazuh_path', return_value=wazuh_installation_path), \
+        patch(f'aws_s3.common.get_wazuh_version', return_value=wazuh_version):
         ins = class_(**{'reparse': False, 'access_key': None, 'secret_key': None,
                         'profile': None, 'iam_role_arn': None, 'bucket': 'test-bucket',
                         'only_logs_after': '19700101', 'skip_on_error': True,

--- a/wodles/gcloud/integration.py
+++ b/wodles/gcloud/integration.py
@@ -13,6 +13,7 @@ import socket
 
 from google.api_core import exceptions as google_exceptions
 from google.cloud import pubsub_v1 as pubsub
+from wazuh.core import common
 
 import tools
 
@@ -33,9 +34,9 @@ class WazuhGCloudSubscriber:
         :params subscription_id: Subscription ID
         """
         # get Wazuh paths
-        self.wazuh_path = tools.get_wazuh_path()
+        self.wazuh_path = common.find_wazuh_path()
         self.wazuh_queue = tools.get_wazuh_queue()
-        self.wazuh_version = tools.get_wazuh_version()
+        self.wazuh_version = common.get_wazuh_version()
         # get subscriber
         self.subscriber = self.get_subscriber_client(credentials_file).api
         self.subscription_path = self.get_subscription_path(project,

--- a/wodles/gcloud/tests/test_integration.py
+++ b/wodles/gcloud/tests/test_integration.py
@@ -54,11 +54,11 @@ def test_send_msg_ok(mock_socket):
     client.send_msg(test_message)
 
 
-@pytest.mark.xfail(raises=socket.error)
 def test_send_msg_ko():
     """Test send_msg method when a socket exception happens."""
-    client = get_wazuhgcloud_subscriber()
-    client.send_msg(test_message)
+    with pytest.raises(FileNotFoundError):
+        client = get_wazuhgcloud_subscriber()
+        client.send_msg(test_message)
 
 
 def test_format_msg():

--- a/wodles/gcloud/tests/test_tools.py
+++ b/wodles/gcloud/tests/test_tools.py
@@ -20,7 +20,7 @@ wazuh_installation_path = '/var/ossec'
 def test_get_wazuh_queue():
     """Test get_wazuh_queue function."""
 
-    with patch(f'common.find_wazuh_path', return_value=wazuh_installation_path):
+    with patch(f'tools.common.find_wazuh_path', return_value=wazuh_installation_path):
         wazuh_queue = get_wazuh_queue()
 
     assert "/var/ossec/queue/ossec/queue" == wazuh_queue

--- a/wodles/gcloud/tests/test_tools.py
+++ b/wodles/gcloud/tests/test_tools.py
@@ -13,16 +13,14 @@ import sys
 from unittest.mock import patch
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))  # noqa: E501
-from tools import get_wazuh_version
+from tools import get_wazuh_queue
 
-wazuh_control_info = 'WAZUH_VERSION="TEST_VERSION"\n\
-                      WAZUH_REVISION="TEST_REVISION"\n\
-                      WAZUH_TYPE="TEST_TYPE"\n'
+wazuh_installation_path = '/var/ossec'
 
-def test_get_wazuh_version():
-    """Test get_wazuh_version function."""
-        
-    with patch(f'tools.call_wazuh_control', return_value=wazuh_control_info):
-        wazuh_version = get_wazuh_version()
+def test_get_wazuh_queue():
+    """Test get_wazuh_queue function."""
 
-    assert "TEST_VERSION" == wazuh_version
+    with patch(f'common.find_wazuh_path', return_value=wazuh_installation_path):
+        wazuh_queue = get_wazuh_queue()
+
+    assert "/var/ossec/queue/ossec/queue" == wazuh_queue

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -14,6 +14,7 @@ import os
 import subprocess
 import re
 import sys
+from wazuh.core import common
 from logging.handlers import TimedRotatingFileHandler
 
 logger_name = 'gcloud_wodle'
@@ -93,36 +94,6 @@ def get_file_logger(output_file: str, level: int = 3) -> logging.Logger:
 
     return logger_file
 
-def call_wazuh_control(option) -> str:
-    wazuh_control = os.path.join(get_wazuh_path(), "bin", "wazuh-control")    
-    try:
-        proc = subprocess.Popen([wazuh_control, option], stdout=subprocess.PIPE)
-        (stdout, stderr) = proc.communicate() 
-        return stdout.decode()
-    except:            
-        return None 
-
-def get_wazuh_path() -> str:
-    """Get Wazuh installation path, obtained relative to the path of this file"""
-    return os.path.abspath(os.path.join(__file__, "../../.."))
-
 def get_wazuh_queue() -> str:
     """Get Wazuh queue"""
-    return os.path.join(get_wazuh_path(), 'queue', 'ossec', 'queue')
-
-def get_wazuh_info(field) -> str:    
-    wazuh_info = call_wazuh_control("info")     
-    if not wazuh_info:
-        return "ERROR"
-    
-    env_variables = wazuh_info.rsplit("\n")
-    env_variables.remove("")
-    wazuh_env_vars = dict()
-    for env_variable in env_variables:
-        key, value = env_variable.split("=")
-        wazuh_env_vars[key] = value.replace("\"", "")
-    
-    return wazuh_env_vars[field]
-
-def get_wazuh_version() -> str:
-    return get_wazuh_info("WAZUH_VERSION")
+    return os.path.join(common.find_wazuh_path(), 'queue', 'ossec', 'queue')

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -11,11 +11,10 @@
 import argparse
 import logging
 import os
-import subprocess
-import re
 import sys
-from wazuh.core import common
 from logging.handlers import TimedRotatingFileHandler
+
+from wazuh.core import common
 
 logger_name = 'gcloud_wodle'
 logger = logging.getLogger(logger_name)


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7087 |

## Description

As part of the epic https://github.com/wazuh/wazuh/issues/7054, we had to modify the way in which multiples components were accessing the information related to the Wazuh version. For doing this, we created a set of functions in the `AWS` and `gcloud` wodles in order to simplify this data request.

During the implementation, the functions were repeated in the code. So this pull request includes all the necessary changes to move the `wazuh-control` helper functions to a common place within the framework.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation