### PR TITLE
Allow quoting in commands to group arguments

### DIFF
--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -204,7 +204,7 @@ char *encode_base64(int size, const char *src);
 
 /**
  * @brief Verify the string is not truncated after executing snprintf
- * 
+ *
  * @param str Pointer to a buffer where the resulting string is stored.
  * @param size Maximum number of bytes to be used in the buffer.
  * @param format String that contains a format string that follows the same specifications as format in printf.
@@ -215,7 +215,7 @@ int os_snprintf(char *str, size_t size, const char *format, ...);
 
 /**
  * @brief Remove a substring from a string.
- * 
+ *
  * @param str Original string.
  * @param sub Substring to remove from the string.
  * @return char* String after removing the substring.
@@ -224,7 +224,7 @@ char * w_remove_substr(char *str, const char *sub);
 
 /**
  * @brief Returns a copy of the first n characters of str.
- * 
+ *
  * If str is longer than n, only n characters are copied (a terminating character ('\0') is added).
  * if n is zero an empty string is returned.
  * @param str String to copy.
@@ -232,5 +232,51 @@ char * w_remove_substr(char *str, const char *sub);
  * @return char* New string copy of str[:n] or NULL if str is null
  */
 char * w_strndup(const char *str, size_t n);
+
+/**
+ * @brief Append two strings
+ *
+ * This function produces a string with length #a + n, and joins the content
+ * of a and the first n bytes of b.
+ * Semantics are like: a += b[:n].
+ *
+ * @param a First string.
+ * @param b Second string.
+ * @param n Length of the left-substring in b that will be copied.
+ * @return Pointer to a zero-ended string that contains the concatenation of a + b.
+ * @pre a may be NULL. In that case, this function returns strdup(b).
+ * @pre b must contain at less n valid bytes.
+ * @post String a is freed and it's not valid after calling this function.
+ */
+char* w_strcat(char *a, const char *b, size_t n);
+
+/**
+ * @brief Append a string into the n-th position of a string array
+ *
+ * Extends the size of the array to (n + 1) pointers, sets array[n] to string,
+ * and terminates the array with NULL.
+ *
+ * @param array Pointer to the source string array, that will be extended.
+ * @param string Pointer to the string that will be inserted into the array.
+ * @param n Position of the current tail of the array (null pointer).
+ * @return A pointer to a string array.
+ * @pre array has n valid positions before calling this function.
+ * @post array holds the same pointer that this function received, i.e. strings are not duplicated.
+ * @post The pointer to array is no longer valid as it's resized.
+ */
+char** w_strarray_append(char **array, char *string, int n);
+
+/**
+ * @brief Tokenize string separated by spaces, respecting double-quotes
+ *
+ * Splits words in a string separated by spaces into an array.
+ * Parts within double-quotes are not splitted.
+ * The backslash character escapes spaces, double-quotes and backslashes.
+ *
+ * @param string Pointer to the source string.
+ * @return Pointer to a NULL-terminated string array.
+ * @post The structure returned must be freed with free_strarray().
+ */
+char** w_strtok(const char *string);
 
 #endif

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -988,3 +988,92 @@ char * w_strndup(const char * str, size_t n) {
 
     return str_cpy;
 }
+
+// Append two strings
+
+char* w_strcat(char *a, const char *b, size_t n) {
+    if (a == NULL) {
+        return w_strndup(b, n);
+    }
+
+    size_t a_len = strlen(a);
+    size_t output_len = a_len + n;
+
+    os_realloc(a, output_len + 1, a);
+
+    memcpy(a + a_len, b, n);
+    a[output_len] = '\0';
+
+    return a;
+}
+
+// Append a string into the n-th position of a string array
+
+char** w_strarray_append(char **array, char *string, int n) {
+    os_realloc(array, sizeof(char *) * (n + 2), array);
+    array[n] = string;
+    array[n + 1] = NULL;
+
+    return array;
+}
+
+// Tokenize string separated by spaces, respecting double-quotes
+
+char** w_strtok(const char *string) {
+    bool quoting = false;
+    int output_n = 0;
+    char *accum = NULL;
+    char **output;
+
+    os_calloc(1, sizeof(char*), output);
+
+    const char *i;
+    const char *j;
+
+    for (i = string; (j = strpbrk(i, " \"\\")) != NULL; i = j + 1) {
+        switch (*j) {
+        case ' ':
+            if (quoting) {
+                accum = w_strcat(accum, i, j - i + 1);
+            } else {
+                if (j > i) {
+                    accum = w_strcat(accum, i, j - i);
+                }
+
+                if (accum != NULL) {
+                    output = w_strarray_append(output, accum, output_n++);
+                    accum = NULL;
+                }
+            }
+
+            break;
+
+        case '\"':
+            if (j > i || quoting) {
+                accum = w_strcat(accum, i, j - i);
+            }
+
+            quoting = !quoting;
+            break;
+
+        case '\\':
+            if (j > i) {
+                accum = w_strcat(accum, i, j - i);
+            }
+
+            if (j[1] != '\0') {
+                accum = w_strcat(accum, ++j, 1);
+            }
+        }
+    }
+
+    if (*i != '\0') {
+        accum = w_strcat(accum, i, strlen(i));
+    }
+
+    if (accum != NULL) {
+        output = w_strarray_append(output, accum, output_n);
+    }
+
+    return output;
+}

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -979,9 +979,9 @@ char * w_strndup(const char * str, size_t n) {
         str_len = n;
     }
 
-    os_calloc(str_len + 1, sizeof(char), str_cpy);
+    os_malloc(str_len + 1, str_cpy);
     if (str_len > 0) {
-        strncpy(str_cpy, str, str_len);
+        memcpy(str_cpy, str, str_len);
     }
 
     str_cpy[str_len] = '\0';

--- a/src/unit_tests/shared/test_string_op.c
+++ b/src/unit_tests/shared/test_string_op.c
@@ -176,7 +176,7 @@ void test_W_JSON_AddField_JSON_invalid(void **state)
     W_JSON_AddField(root, key, value);
     output = cJSON_PrintUnformatted(root);
     assert_string_equal(output, "{\"files\":\"[\\\"file1\\\",\\\"file2\\\"],\\\"file3\\\"]\"}");
-    
+
     os_free(output);
     cJSON_Delete(root);
 }
@@ -203,7 +203,7 @@ void test_w_strndup_null_str(void ** state)
 }
 
 void test_w_strndup_str_less_than_n(void ** state)
-{    
+{
     const char * str = "Test";
     const char * expected_str = "Test";
     char * retval;
@@ -248,6 +248,70 @@ void test_w_strndup_str_zero_n(void ** state) {
     os_free(retval);
 }
 
+void test_w_strcat_null_input(void ** state) {
+    const char * B = "Hello World";
+    char * a = w_strcat(NULL, B, strlen(B));
+
+    assert_string_equal(a, B);
+
+    free(a);
+}
+
+void test_w_strcat_string_input(void ** state) {
+    char * a = strdup("Hello");
+    const char * B = "World";
+    a = w_strcat(a, B, strlen(B));
+
+    assert_string_equal(a, "HelloWorld");
+
+    free(a);
+}
+
+void test_w_strarray_append(void ** state) {
+    char ** array = NULL;
+    char *a, *b;
+    int n = 0;
+
+    os_strdup("Hello", a);
+    os_strdup("World", b);
+
+    array = w_strarray_append(array, a, n++);
+    array = w_strarray_append(array, b, n++);
+
+    assert_ptr_equal(array[0], a);
+    assert_ptr_equal(array[1], b);
+    assert_null(array[2]);
+
+    free_strarray(array);
+}
+
+void test_w_strtok_empty(void ** state) {
+    char ** array = w_strtok("");
+    assert_null(array[0]);
+    free_strarray(array);
+}
+
+void test_w_strtok_nospaces(void ** state) {
+    char ** array = w_strtok("Hello");
+    assert_string_equal(array[0], "Hello");
+    assert_null(array[1]);
+    free_strarray(array);
+}
+
+void test_w_strtok_string(void ** state) {
+    char ** array = w_strtok("BB\"B BBB BBE\" \"\" F \"\\\"G\\\"\" \"BB\"B BB\\\\E\\ GGF D B");
+    assert_string_equal(array[0], "BBB BBB BBE");
+    assert_string_equal(array[1], "");
+    assert_string_equal(array[2], "F");
+    assert_string_equal(array[3], "\"G\"");
+    assert_string_equal(array[4], "BBB");
+    assert_string_equal(array[5], "BB\\E GGF");
+    assert_string_equal(array[6], "D");
+    assert_string_equal(array[7], "B");
+    assert_null(array[8]);
+    free_strarray(array);
+}
+
 /* Tests */
 
 int main(void) {
@@ -274,6 +338,15 @@ int main(void) {
         cmocka_unit_test(test_w_strndup_str_greater_than_n),
         cmocka_unit_test(test_w_strndup_str_equal_to_n),
         cmocka_unit_test(test_w_strndup_str_zero_n),
+        // Tests w_strcat
+        cmocka_unit_test(test_w_strcat_null_input),
+        cmocka_unit_test(test_w_strcat_string_input),
+        // Tests w_strarray_append
+        cmocka_unit_test(test_w_strarray_append),
+        // Tests w_strtok
+        cmocka_unit_test(test_w_strtok_empty),
+        cmocka_unit_test(test_w_strtok_nospaces),
+        cmocka_unit_test(test_w_strtok_string),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1104,7 +1104,7 @@ cJSON *wdb_remove_multiple_agents(char *agent_list) {
     cJSON_AddItemToObject(response, "agents", json_agents = cJSON_CreateObject());
 
     // Get agents id separated by whitespace
-    agents = wm_strtok(agent_list);
+    agents = w_strtok(agent_list);
 
     for (n = 0; agents && agents[n]; n++) {
         if (strcmp(agents[n], "") != 0) {
@@ -1144,7 +1144,7 @@ cJSON *wdb_remove_multiple_agents(char *agent_list) {
         }
     }
 
-    free(agents);
+    free_strarray(agents);
     json_formated = cJSON_PrintUnformatted(response);
     mdebug1("Deleting databases. JSON output: %s", json_formated);
     os_free(json_formated);

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -54,7 +54,7 @@ void * wm_command_main(wm_command_t * command) {
 
         command_cpy = strdup(command->command);
 
-        argv = wm_strtok(command_cpy);
+        argv = w_strtok(command_cpy);
     #ifndef __clang_analyzer__
         if (!argv) {
             merror("Could not split command: %s", command_cpy);
@@ -73,7 +73,7 @@ void * wm_command_main(wm_command_t * command) {
             os_malloc(strlen(full_path) + strlen(command->command) - strlen(binary) + 1, command->full_command);
         }
         snprintf(command->full_command, strlen(full_path) + strlen(command->command) - strlen(binary) + 1, "%s %s", full_path, command->command + strlen(binary) + 1);
-        free(argv);
+        free_strarray(argv);
 
 
         if (command->md5_hash && command->md5_hash[0]) {

--- a/src/wazuh_modules/wm_exec.c
+++ b/src/wazuh_modules/wm_exec.c
@@ -343,7 +343,7 @@ int wm_exec(char *command, char **output, int *exitcode, int secs, const char * 
             free(new_path);
         }
 
-        argv = wm_strtok(command);
+        argv = w_strtok(command);
 
         int fd = open("/dev/null", O_RDWR, 0);
 

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -474,7 +474,7 @@ void * w_socket_launcher(void * args) {
 
     mdebug1("Running integration daemon: %s", exec_path);
 
-    if (argv = wm_strtok(exec_path), !argv) {
+    if (argv = w_strtok(exec_path), !argv) {
         merror("Could not split integration command: %s", exec_path);
         pthread_exit(NULL);
     }

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -173,56 +173,6 @@ void wm_destroy() {
     wm_free(wmodules);
 }
 
-// Tokenize string separated by spaces, respecting double-quotes
-
-char** wm_strtok(char *string) {
-    char *c = string;
-    char **output = (char**)calloc(2, sizeof(char*));
-    size_t n = 1;
-
-    if (!output)
-        return NULL;
-
-    *output = string;
-
-    while ((c = strpbrk(c, " \"\\"))) {
-        switch (*c) {
-        case ' ':
-            *(c++) = '\0';
-            output[n++] = c;
-            output = (char**)realloc(output, (n + 1) * sizeof(char*));
-            if(!output){
-                merror_exit(MEM_ERROR, errno, strerror(errno));
-            }
-            output[n] = NULL;
-            break;
-
-        case '\"':
-            c++;
-
-            while ((c = strpbrk(c, "\"\\"))) {
-                if (*c == '\\')
-                    c += 2;
-                else
-                    break;
-            }
-
-            if (!c) {
-                free(output);
-                return NULL;
-            }
-
-            c++;
-            break;
-
-        case '\\':
-            c += 2;
-        }
-    }
-
-    return output;
-}
-
 // Load or save the running state
 
 int wm_state_io(const char * tag, int op, void *state, size_t size) {

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -158,9 +158,6 @@ void wm_kill_children();
 // Reads an HTTP header and extracts the size of the response
 long int wm_read_http_size(char *header);
 
-// Tokenize string separated by spaces, respecting double-quotes
-char** wm_strtok(char *string);
-
 /* Load or save the running state
  * op: WM_IO_READ | WM_IO_WRITE
  * Returns 0 if success, or 1 if fail.


### PR DESCRIPTION
|Related issue|
|---|
|#3340|

This PR aims to allow double-quotes and scapes in command lines so that we can handle arguments in command calls.

Before this PR, the system parsed quoted substrings into the same argument but kept the double-quotes. For instance:

### Before this change

`echo "Hello World"` was parsed into:
- `echo`
- `"Helo World"`

### After this change

`echo "Hello World"` will be parsed into:
- `echo`
- `Hello World`

## Examples

### Command module

```xml
<wodle name="command">
  <tag>test</tag>
  <command>/bin/sh -c "grep kernel /var/log/syslog | tail -1"</command>
</wodle>
```

### SCA command rule

```yml
- 'c:sh -c "journalctl | grep \"protection: active\" | head -1" -> r:NX \(Execute Disable\) protection: active'
```

### Affected modules

- SCA
- Command
- Key request

### Affected artifacts

- wazuh-db
- wazuh-modulesd
- wazuh-agent.exe

## Tests

- [X] Command module.
- [X] SCA rule.
- [X] Unit tests on Linux.
- [x] Coverity.
- [X] QA tests for SCA.