### PR TITLE
Escape backslash on queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - **API:**
   - Fixed an error with the RBAC permissions in the `GET /groups` endpoint. ([#7328](https://github.com/wazuh/wazuh/issues/7328))
+  - Fixed a bug with Windows registries when parsing backslashes. ([#7309](https://github.com/wazuh/wazuh/pull/7309))
 - **AWS Module:**
   - Fixed a bug that caused an error when attempting to use an IAM Role with **CloudWatchLogs** service. ([#7330](https://github.com/wazuh/wazuh/pull/7330))
 

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -981,6 +981,8 @@ class WazuhDBBackend(AbstractDatabaseBackend):
                 value = f"'{v}'"
             else:
                 raise TypeError(f'Invalid type for request parameters: {type(v)}')
+            # Escape backslash to avoid re error
+            value = value.replace('\\', '\\\\')
             query = re.sub(r':\b' + re.escape(str(k)) + r'\b', value, query)
         return query
 

--- a/framework/wazuh/tests/data/schema_syscheck_test.sql
+++ b/framework/wazuh/tests/data/schema_syscheck_test.sql
@@ -33,3 +33,4 @@ INSERT INTO "fim_entry" VALUES('/usr/bin/apt-key','/usr/bin/apt-key','file',1578
 -- Registries
 INSERT INTO "fim_entry" VALUES('registry_key_1','registry_key_1','registry_key',1578640718,1,'[x64]',NULL,NULL,4096,'perm','uid','gid','hash_md5','hash_sha1','root','root',12345678,1024,'hash_sha256',0,NULL,NULL);
 INSERT INTO "fim_entry" VALUES('registry_value_1','registry_value_1','registry_value',1578640718,1,'[x32]','value_name','value_type',4096,'perm','uid','gid','hash_md5','hash_sha1','root','root',12345678,1024,'hash_sha256',NULL,NULL,NULL);
+INSERT INTO "fim_entry" VALUES('HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\W32Time\SecureTimeLimits\RunTime','HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\W32Time\SecureTimeLimits\RunTime','registry_key',1578640718,1,'[x32]','value_name','value_type',4096,'perm','uid','gid','hash_md5','hash_sha1','root','root',12345678,1024,'hash_sha256',NULL,NULL,NULL);

--- a/framework/wazuh/tests/test_syscheck.py
+++ b/framework/wazuh/tests/test_syscheck.py
@@ -245,7 +245,8 @@ def test_syscheck_last_scan_internal_error(glob_mock, version):
     (['007'], ['file', 'arch', 'value.name', 'value.type'], None, True),
     (['008'], ['file', 'value.name'], None, True),
     (['009'], ['value.name'], None, True),
-    (['000'], ['attributes'], None, True)
+    (['000'], ['attributes'], None, True),
+    (['000'], None, {'file': 'HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\W32Time\\SecureTimeLimits\\RunTime'}, True)
 ])
 @patch('socket.socket.connect')
 @patch('wazuh.core.common.wdb_path', new=test_data_path)


### PR DESCRIPTION
Hello team,
this closes #7117 .

We are now escaping backslashes to prevent an error with the python `re` module. A new unit test was also added to try this use case.

### Example
#### API request

```
root@wazuh-master:/# curl -k -X GET "https://127.0.0.1:55000/syscheck/006?file=HKEY_LOCAL_MACHINE%5CSystem%5CCurrentControlSet%5CServices%5CW32Time%5CSecureTimeLimits%5CRunTime" -H "Authorization: Bearer $TOKEN"
```


#### Response

```json
{
  "data": {
    "affected_items": [
      {
        "gid": "0",
        "size": 20599,
        "type": "registry",
        "date": "2020-01-10T07:18:38Z",
        "inode": 16393722,
        "md5": "40141b833e183a0ea826ed500e25b8f1",
        "attributes": "0",
        "sha256": "760885b6142d0c6e52df29cffa9026d1cfbc928b9d123979951e3ba547b5937c",
        "gname": "root",
        "perm": "100755",
        "uid": "0",
        "changes": 1,
        "mtime": "2019-05-21T20:12:23Z",
        "file": "HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\W32Time\\SecureTimeLimits\\RunTime",
        "sha1": "65792d780476ca9033c230937017532cfd1a4461",
        "uname": "root"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "FIM findings of the agent were returned",
  "error": 0
}
```

### Tests performed
#### Unit tests
```
wazuh/core/cluster/dapi/tests/test_dapi.py
	22 passed, 11 warnings
wazuh/core/cluster/tests/test_cluster.py
	19 passed
wazuh/core/cluster/tests/test_common.py
	7 passed
wazuh/core/cluster/tests/test_control.py
	5 passed
wazuh/core/cluster/tests/test_local_client.py
	1 passed
wazuh/core/cluster/tests/test_utils.py
	7 passed
wazuh/core/cluster/tests/test_worker.py
	16 passed, 2 warnings
wazuh/core/tests/test_active_response.py
	12 passed
wazuh/core/tests/test_agent.py
	187 passed, 11 warnings
wazuh/core/tests/test_cdb_list.py
	33 passed
wazuh/core/tests/test_common.py
	7 passed
wazuh/core/tests/test_configuration.py
	34 passed
wazuh/core/tests/test_decoder.py
	15 passed
wazuh/core/tests/test_input_validator.py
	3 passed
wazuh/core/tests/test_manager.py
	30 passed
wazuh/core/tests/test_ossec_queue.py
	19 passed
wazuh/core/tests/test_pyDaemonModule.py
	6 passed
wazuh/core/tests/test_results.py
	40 passed
wazuh/core/tests/test_rule.py
	21 passed
wazuh/core/tests/test_syscollector.py
	3 passed
wazuh/core/tests/test_utils.py
	204 passed
wazuh/core/tests/test_wazuh_socket.py
	15 passed
wazuh/core/tests/test_wdb.py
	21 passed
wazuh/rbac/tests/test_auth_context.py
	2 passed, 1 warning
wazuh/rbac/tests/test_decorators.py
	105 passed
wazuh/rbac/tests/test_default_configuration.py
	47 passed
wazuh/rbac/tests/test_orm.py
	53 passed
wazuh/rbac/tests/test_preprocessor.py
	11 passed
wazuh/tests/test_active_response.py
	9 passed
wazuh/tests/test_agent.py
	90 passed, 11 warnings
wazuh/tests/test_cdb_list.py
	47 passed
wazuh/tests/test_ciscat.py
	2 passed
wazuh/tests/test_cluster.py
	7 passed
wazuh/tests/test_decoders.py
	31 passed
wazuh/tests/test_group.py
	8 passed
wazuh/tests/test_manager.py
	38 passed
wazuh/tests/test_mitre.py
	180 passed
wazuh/tests/test_rule.py
	52 passed
wazuh/tests/test_sca.py
	7 passed
wazuh/tests/test_security.py
	69 passed, 12 warnings
wazuh/tests/test_stats.py
	13 passed
wazuh/tests/test_syscheck.py
	18 passed
wazuh/tests/test_syscollector.py
	12 passed

```

#### Integration tests

```
Collected tests [7]:
test_agents_GET_endpoints.tavern.yaml, test_decoders_endpoints.tavern.yaml, test_lists_endpoints.tavern.yaml, test_mitre_endpoints.tavern.yaml, test_overview_endpoints.tavern.yaml, test_syscheck_endpoints.tavern.yaml, test_syscollector_endpoints.tavern.yaml


test_agents_GET_endpoints.tavern.yaml 
	 90 passed, 97 warnings

test_decoders_endpoints.tavern.yaml 
	 23 passed, 29 warnings

test_lists_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_mitre_endpoints.tavern.yaml 
	 1 passed, 3 warnings

test_overview_endpoints.tavern.yaml 
	 1 passed, 3 warnings

test_syscheck_endpoints.tavern.yaml 
	 35 passed, 39 warnings

test_syscollector_endpoints.tavern.yaml 
	 161 passed, 176 warnings

```

Regards,
Víctor Fernández.