### PR TITLE
Add CIS policy "Ensure XD/NX support is enabled" back for SCA

### DIFF
--- a/ruleset/sca/centos/6/cis_centos6_linux.yml
+++ b/ruleset/sca/centos/6/cis_centos6_linux.yml
@@ -598,6 +598,22 @@ checks:
       - 'c:sysctl fs.suid_dumpable -> r:^fs.suid_dumpable\s*=\s*0\s*$'
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
+# 1.5.2 XD/NX enabled
+  - id: 5533 
+    title: "Ensure XD/NX support is enabled"
+    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
+    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
+    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
+    compliance:
+      - cis: ["1.5.2"]
+      - cis_csc: ["8.4"]
+      - pci_dss: ["2.2.4"]
+      - nist_800_53: ["CM.1"]
+      - tsc: ["CC5.2"]
+    condition: all
+    rules:
+      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+
 # 1.5.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 5534 
     title: "Ensure address space layout randomization (ASLR) is enabled"

--- a/ruleset/sca/centos/6/cis_centos6_linux.yml
+++ b/ruleset/sca/centos/6/cis_centos6_linux.yml
@@ -612,7 +612,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+      - 'c:sh -c "dmesg | grep NX" -> r:NX \(Execute Disable\) protection: active'
 
 # 1.5.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 5534

--- a/ruleset/sca/centos/6/cis_centos6_linux.yml
+++ b/ruleset/sca/centos/6/cis_centos6_linux.yml
@@ -30,7 +30,7 @@ variables:
 
 checks:
 # 1.1.1.1 cramfs: filesystem
-  - id: 5500 
+  - id: 5500
     title: "Ensure mounting of cramfs filesystems is disabled"
     description: "The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
@@ -48,7 +48,7 @@ checks:
       - 'not c:lsmod -> r:cramfs'
 
 # 1.1.1.2 freevxfs: filesystem
-  - id: 5501 
+  - id: 5501
     title: "Ensure mounting of freevxfs filesystems is disabled"
     description: "The freevxfs filesystem type is a free version of the Veritas type filesystem. This is the primary filesystem type for HP-UX operating systems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -66,7 +66,7 @@ checks:
       - 'not c:lsmod -> r:freevxfs'
 
 # 1.1.1.3 jffs2: filesystem
-  - id: 5502 
+  - id: 5502
     title: "Ensure mounting of jffs2 filesystems is disabled"
     description: "The jffs2 (journaling flash filesystem 2) filesystem type is a log-structured filesystem used in flash memory devices."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -84,7 +84,7 @@ checks:
       - 'not c:lsmod -> r:jffs2'
 
 # 1.1.1.4 hfs: filesystem
-  - id: 5503 
+  - id: 5503
     title: "Ensure mounting of hfs filesystems is disabled"
     description: "The hfs filesystem type is a hierarchical filesystem that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -101,7 +101,7 @@ checks:
       - 'c:modprobe -n -v hfs -> r:install /bin/true|Module hfs not found'
       - 'not c:lsmod -> r:hfs'
 # 1.1.1.5 hfsplus: filesystem
-  - id: 5504 
+  - id: 5504
     title: "Ensure mounting of hfsplus filesystems is disabled"
     description: "The hfsplus filesystem type is a hierarchical filesystem designed to replace hfs that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -118,7 +118,7 @@ checks:
       - 'c:modprobe -n -v hfsplus -> r:install /bin/true|Module hfsplus not found'
       - 'not c:lsmod -> r:hfsplus'
 # 1.1.1.6 squashfs: filesystem
-  - id: 5505 
+  - id: 5505
     title: "Ensure mounting of squashfs filesystems is disabled"
     description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs ). A squashfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -136,7 +136,7 @@ checks:
       - 'not c:lsmod -> r:squashfs'
 
 # 1.1.1.7 udfs: filesystem
-  - id: 5506 
+  - id: 5506
     title: "Ensure mounting of udf filesystems is disabled"
     description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -154,7 +154,7 @@ checks:
       - 'not c:lsmod -> r:udf'
 
 # 1.1.1.8 FAT: filesystem
-  - id: 5507 
+  - id: 5507
     title: "Ensure mounting of FAT filesystems is disabled"
     description: "The FAT filesystem format is primarily used on older windows systems and portable USB drives or flash modules. It comes in three types FAT12 , FAT16 , and FAT32 all of which are supported by the vfat kernel module."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -172,7 +172,7 @@ checks:
       - 'not c:lsmod -> r:vfat'
 
 # 1.1.2 /tmp: partition
-  - id: 5508 
+  - id: 5508
     title: "Ensure separate partition exists for /tmp"
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -190,7 +190,7 @@ checks:
 
 
 # 1.1.3 /tmp: nodev
-  - id: 5509 
+  - id: 5509
     title: "Ensure nodev option set on /tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
@@ -205,7 +205,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:nodev'
 
 # 1.1.4 /tmp: nosuid
-  - id: 5510 
+  - id: 5510
     title: "Ensure nosuid option set on /tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
@@ -220,7 +220,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:nosuid'
 
 # 1.1.5 /tmp: noexec
-  - id: 5511 
+  - id: 5511
     title: "Ensure noexec option set on /tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
@@ -237,7 +237,7 @@ checks:
 
 
 # 1.1.6 Build considerations - Partition scheme.
-  - id: 5512 
+  - id: 5512
     title: "Ensure separate partition exists for /var"
     description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
     rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
@@ -254,7 +254,7 @@ checks:
       - 'c:mount -> r:\s/var\s'
 
 # 1.1.7 bind mount /var/tmp to /tmp
-  - id: 5513 
+  - id: 5513
     title: "Ensure separate partition exists for /var/tmp"
     description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /var/tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own file system allows an administrator to set the noexec option on the mount, making /var/tmp useless for an attacker to install executable code."
@@ -271,7 +271,7 @@ checks:
 
 
 # 1.1.8 nodev set on /var/tmp
-  - id: 5514 
+  - id: 5514
     title: "Ensure nodev option set on /var/tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /var/tmp ."
@@ -286,7 +286,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s && r:nodev'
 
 # 1.1.9 nosuid set on /var/tmp
-  - id: 5515 
+  - id: 5515
     title: "Ensure nosuid option set on /var/tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
@@ -301,7 +301,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s && r:nosuid'
 
 # 1.1.10 noexec set on /var/tmp
-  - id: 5516 
+  - id: 5516
     title: "Ensure noexec option set on /var/tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
@@ -319,7 +319,7 @@ checks:
 
 
 # 1.1.11 /var/log: partition
-  - id: 5517 
+  - id: 5517
     title: "Ensure separate partition exists for /var/log"
     description: "The /var/log directory is used by system services to store log data ."
     rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
@@ -337,7 +337,7 @@ checks:
       - 'c:mount -> r:\s/var/log\s'
 
 # 1.1.12 /var/log/audit: partition
-  - id: 5518 
+  - id: 5518
     title: "Ensure separate partition exists for /var/log/audit"
     description: "The auditing daemon, auditd , stores log data in the /var/log/audit directory."
     rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data."
@@ -355,7 +355,7 @@ checks:
       - 'c:mount -> r:\s/var/log/audit\s'
 
 # 1.1.13 /home: partition
-  - id: 5519 
+  - id: 5519
     title: "Ensure separate partition exists for /home"
     description: "The /home directory is used to support disk storage needs of local users."
     rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
@@ -373,7 +373,7 @@ checks:
 
 
 # 1.1.14 /home: nodev
-  - id: 5520 
+  - id: 5520
     title: "Ensure nodev option set on /home partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
@@ -388,7 +388,7 @@ checks:
       - 'c:mount -> r:\s/home\s && r:nodev'
 
 # 1.1.15 /dev/shm: nodev
-  - id: 5521 
+  - id: 5521
     title: "Ensure nodev option set on /dev/shm partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
@@ -403,7 +403,7 @@ checks:
       - 'c:mount -> r:\s/dev/shm\s && r:nodev'
 
 # 1.1.16 /dev/shm: nosuid
-  - id: 5522 
+  - id: 5522
     title: "Ensure nosuid option set on /dev/shm partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
@@ -418,7 +418,7 @@ checks:
       - 'c:mount -> r:\s/dev/shm\s && r:nosuid'
 
 # 1.1.17 /dev/shm: noexec
-  - id: 5523 
+  - id: 5523
     title: "Ensure noexec option set on /dev/shm partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
@@ -435,7 +435,7 @@ checks:
 
 
 # 1.1.22 Disable Automounting
-  - id: 5524 
+  - id: 5524
     title: "Disable Automounting"
     description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
     rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
@@ -455,7 +455,7 @@ checks:
 ###############################################
 
 # 1.2.2 Activate gpgcheck
-  - id: 5525 
+  - id: 5525
     title: "Ensure gpgcheck is globally activated"
     description: "The gpgcheck option, found in the main section of the /etc/yum.conf and individual /etc/yum/repos.d/* files determines if an RPM package's signature is checked prior to its installation."
     rationale: "It is important to ensure that an RPM's package signature is always checked prior to installation to ensure that the software is obtained from a trusted source."
@@ -480,7 +480,7 @@ checks:
 ###############################################
 
 # 1.3.1 install AIDE
-  - id: 5526 
+  - id: 5526
     title: "Ensure AIDE is installed"
     description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
     rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
@@ -496,7 +496,7 @@ checks:
       - 'c:rpm -q aide -> r:aide-\S*'
 
 # 1.3.2 AIDE regular checks
-  - id: 5527 
+  - id: 5527
     title: "Ensure filesystem integrity is regularly checked"
     description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
     rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
@@ -516,7 +516,7 @@ checks:
 # 1.4 Secure Boot Settings
 ###############################################
 # 1.4.1 Configure bootloader
-  - id: 5528 
+  - id: 5528
     title: "Ensure permissions on bootloader config are configured"
     description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options. The grub configuration is usually located at /boot/grub/grub.conf and linked as /boot/grub/menu.lst and /etc/grub.conf ."
     rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
@@ -532,7 +532,7 @@ checks:
       - 'c:stat /boot/grub/grub.conf -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.4.2 Set Boot Loader Password (Scored)
-  - id: 5529 
+  - id: 5529
     title: "Ensure bootloader password is set"
     description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
     rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
@@ -548,7 +548,7 @@ checks:
       - 'f:/boot/grub/grub.conf -> r:^password --md5\s\.+'
 
 # 1.4.3 Single user authentication
-  - id: 5530 
+  - id: 5530
     title: "Ensure authentication required for single user mode"
     description: "Single user mode is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
     rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
@@ -564,7 +564,7 @@ checks:
       - 'f:/etc/sysconfig/init -> r:SINGLE\s*=\s*/sbin/sulogin'
 
 # 1.4.4 Ensure interactive boot is not enabled (Scored)
-  - id: 5531 
+  - id: 5531
     title: "Ensure interactive boot is not enabled"
     description: "Interactive boot allows console users to interactively select which services start on boot. The PROMPT option provides console users the ability to interactively boot the system and select which services to start on boot . "
     rationale: "Turn off the PROMPT option on the console to prevent console users from potentially overriding established security settings. "
@@ -581,7 +581,7 @@ checks:
 # 1.5 Additional Process Hardening
 ###############################################
 # 1.5.1 Restrict Core Dumps (Scored)
-  - id: 5532 
+  - id: 5532
     title: "Ensure core dumps are restricted"
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file."
     rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
@@ -599,7 +599,7 @@ checks:
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
 # 1.5.2 XD/NX enabled
-  - id: 5533 
+  - id: 5533
     title: "Ensure XD/NX support is enabled"
     description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
     rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
@@ -615,7 +615,7 @@ checks:
       - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
 
 # 1.5.3 Enable Randomized Virtual Memory Region Placement (Scored)
-  - id: 5534 
+  - id: 5534
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
     rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
@@ -632,7 +632,7 @@ checks:
       - 'c:sysctl kernel.randomize_va_space -> r:^\s*kernel.randomize_va_space\s*=\s*2'
 
 # 1.5.4 Disable prelink
-  - id: 5535 
+  - id: 5535
     title: "Ensure prelink is disabled"
     description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
     rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
@@ -653,7 +653,7 @@ checks:
 ###############################################
 
 # 1.6.1.1 SELinux not disabled
-  - id: 5536 
+  - id: 5536
     title: "Ensure SELinux is not disabled in bootloader configuration"
     description: "Configure SELINUX to be enabled at boot time and verify that it has not been overwritten by the grub boot parameters."
     rationale: "SELinux must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
@@ -669,7 +669,7 @@ checks:
       - 'f:/boot/grub/grub.conf -> r:^\s*\t*kernel\.*selinux=0|^\s*\t*kernel\.*enforcing=0'
 
 # 1.6.1.2 Set selinux state
-  - id: 5537 
+  - id: 5537
     title: "Ensure the SELinux state is enforcing"
     description: "Set SELinux to enable when the system is booted."
     rationale: "SELinux must be enabled at boot time in to ensure that the controls it provides are in effect at all times."
@@ -688,7 +688,7 @@ checks:
       - 'f:/etc/selinux/config -> r:^SELINUX\s*=\s*enforcing'
 
 # 1.6.1.3 Set selinux policy
-  - id: 5538 
+  - id: 5538
     title: "Ensure SELinux policy is configured"
     description: "Configure SELinux to meet or exceed the default targeted policy, which constrains daemons and system software only."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that at least the default recommendations are met."
@@ -704,7 +704,7 @@ checks:
       - 'f:/etc/selinux/config -> r:^\s*SELINUXTYPE\s*=\s*targeted|^\s*SELINUXTYPE\s*=\s*mls'
 
 # 1.6.1.4 Remove SETroubleshoot
-  - id: 5539 
+  - id: 5539
     title: "Ensure SETroubleshoot is not installed"
     description: "The SETroubleshoot service notifies desktop users of SELinux denials through a user-friendly interface. The service provides important information around configuration errors, unauthorized intrusions, and other potential errors."
     rationale: "The SETroubleshoot service is an unnecessary daemon to have running on a server, especially if X Windows is disabled."
@@ -719,7 +719,7 @@ checks:
       - 'c:rpm -qa setroubleshoot -> r:setroubleshoot'
 
 # 1.6.1.5 Disable MCS Translation service mcstrans
-  - id: 5540 
+  - id: 5540
     title: "Ensure the MCS Translation Service (mcstrans) is not installed"
     description: "The mcstransd daemon provides category label information to client processes requesting information. The label translations are defined in /etc/selinux/targeted/setrans.conf"
     rationale: "Since this service is not used very often, remove it to reduce the amount of potentially vulnerable code running on the system."
@@ -734,7 +734,7 @@ checks:
       - 'c:rpm -qa mcstrans -> r:mcstrans'
 
 # 1.6.1.6 Ensure no unconfined daemons exist
-  - id: 5541 
+  - id: 5541
     title: "Ensure no unconfined daemons exist"
     description: "Daemons that are not defined in SELinux policy will inherit the security context of their parent process."
     rationale: "Since daemons are launched and descend from the init process, they will inherit the security context label initrc_t . This could cause the unintended consequence of giving the process more permission than it requires."
@@ -749,7 +749,7 @@ checks:
     rules:
       - 'c:ps -eZ -> r:initrc && !r:tr|ps|egrep|bash|awk'
 # 1.6.2 Install SELinux
-  - id: 5542 
+  - id: 5542
     title: "Ensure SELinux is installed"
     description: "SELinux provides Mandatory Access Controls."
     rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
@@ -769,7 +769,7 @@ checks:
 # 1.7  Warning Banners
 ###############################################
 # 1.7.1.1 Configure message of the day (Scored)
-  - id: 5543 
+  - id: 5543
     title: "Ensure message of the day is configured properly"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -783,7 +783,7 @@ checks:
       - 'f:/etc/motd -> r:\\v|\\r|\\m|\\s'
 
 # 1.7.1.2 Configure local login warning banner (Not Scored)
-  - id: 5544 
+  - id: 5544
     title: "Ensure local login warning banner is configured properly"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -797,7 +797,7 @@ checks:
       - 'f:/etc/issue -> r:\\v|\\r|\\m|\\s'
 
 # 1.7.1.3 Configure remote login warning banner (Not Scored)
-  - id: 5545 
+  - id: 5545
     title: "Ensure remote login warning banner is configured properly"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -811,7 +811,7 @@ checks:
       - 'f:/etc/issue.net -> r:\\v|\\r|\\m|\\s'
 
 # 1.7.1.4 Configure /etc/motd permissions (Not Scored)
-  - id: 5546 
+  - id: 5546
     title: "Ensure permissions on /etc/motd are configured"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
     rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -830,7 +830,7 @@ checks:
       - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.7.1.5 Configure /etc/issue permissions (Scored)
-  - id: 5547 
+  - id: 5547
     title: "Ensure permissions on /etc/issue are configured"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
     rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -848,7 +848,7 @@ checks:
     rules:
       - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 # 1.7.1.6 Configure /etc/issue.net permissions (Not Scored)
-  - id: 5548 
+  - id: 5548
     title: "Ensure permissions on /etc/issue.net are configured"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
     rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -861,13 +861,13 @@ checks:
       - nist_800_53: ["AU.14", "AC.7"]
       - gpg_13: ["7.8"]
       - gdpr_IV: ["35.7","32.2"]
-      - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"] 
+      - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
       - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.7.2 Ensure GDM login banner is configured (Scored)
-  - id: 5549 
+  - id: 5549
     title: "Ensure GDM login banner is configured"
     description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems."
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place."
@@ -886,7 +886,7 @@ checks:
 
 
 # 1.8 Ensure updates, patches, and additional security software are installed (Not Scored)
-  - id: 5550 
+  - id: 5550
     title: "Ensure updates, patches, and additional security software are installed"
     description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
     rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
@@ -912,7 +912,7 @@ checks:
 ###############################################
 # 2.1.1 Disable chargen services (Scored)
 
-  - id: 5551 
+  - id: 5551
     title: "Ensure chargen services are not enabled"
     description: "chargen is a network service that responds with 0 to 512 ASCII characters for each connection it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -932,7 +932,7 @@ checks:
       - 'c:chkconfig --list chargen-stream-> r:^\s*\t*chargen-stream:\s*\t*on'
 
 # 2.1.2 Disable daytime services (Scored)
-  - id: 5552 
+  - id: 5552
     title: "Ensure daytime services are not enabled"
     description: "daytime is a network service that responds with the server's current date and time. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -952,7 +952,7 @@ checks:
       - 'c:chkconfig --list daytime-stream -> r:^\s*\t*daytime-stream:\s*\t*on'
 
 # 2.1.3 Disable discard services (Scored)
-  - id: 5553 
+  - id: 5553
     title: "Ensure discard services are not enabled"
     description: "discardis a network service that simply discards all data it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -972,7 +972,7 @@ checks:
       - 'c:chkconfig --list discard-stream -> r:^\s*\t*discard-stream:\s*\t*on'
 
 # 2.1.4 Disable echo-dgram (Scored)
-  - id: 5554 
+  - id: 5554
     title: "Ensure echo services are not enabled"
     description: "echo is a network service that responds to clients with the data sent to it by the client. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -992,7 +992,7 @@ checks:
       - 'c:chkconfig --list echo-stream -> r:^\s*\t*echo-stream:\s*\t*on'
 
 # 2.1.5 Disable time-stream (Scored)
-  - id: 5555 
+  - id: 5555
     title: "Ensure time services are not enabled"
     description: "time is a network service that responds with the server's current date and time as a 32 bit integer. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -1012,7 +1012,7 @@ checks:
       - 'c:chkconfig --list time-stream -> r:^\s*\t*time-stream:\s*\t*on'
 
 # 2.1.6 Remove rsh-server (Scored)
-  - id: 5556 
+  - id: 5556
     title: "Ensure rsh server is not enabled"
     description: "The Berkeley rsh-server ( rsh , rlogin , rexec ) package contains legacy services that exchange credentials in clear-text."
     rationale: "These legacy services contain numerous security exposures and have been replaced with the more secure SSH package."
@@ -1034,7 +1034,7 @@ checks:
 
 
 # 2.1.7 Remove talk server (Scored)
-  - id: 5557 
+  - id: 5557
     title: "Ensure talk server is not enabled"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client (allows initiate of talk sessions) is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -1053,7 +1053,7 @@ checks:
       - 'c:chkconfig --list talk -> r:^\s*\t*talk:\s*\t*on'
 
 # 2.1.8 Remove telnet-server (Scored)
-  - id: 5558 
+  - id: 5558
     title: "Ensure telnet server is not enabled"
     description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
@@ -1072,7 +1072,7 @@ checks:
       - 'c:chkconfig --list telnet -> r:^\s*\t*telnet:\s*\t*on'
 
 # 2.1.9 Ensure tftp server is not enabled (Scored)
-  - id: 5559 
+  - id: 5559
     title: "Ensure tftp server is not enabled"
     description: "Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot machines from a boot server. The package tftp-server is used to define and support a TFTP server."
     rationale: "TFTP does not support authentication nor does it ensure the confidentiality or integrity of data. It is recommended that TFTP be removed, unless there is a specific need for TFTP. In that case, extreme caution must be used when configuring the services."
@@ -1091,7 +1091,7 @@ checks:
       - 'c:chkconfig --list tftp -> r:^\s*\t*tftp:\s*\t*on'
 
 # 2.1.10 Remove rsync service (Scored)
-  - id: 5560 
+  - id: 5560
     title: "Ensure rsync service is not enabled"
     description: "The rsyncd service can be used to synchronize files between systems over network links."
     rationale: "The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
@@ -1110,7 +1110,7 @@ checks:
       - 'c:chkconfig --list rsync -> r:^\s*\t*rsync:\s*\t*on'
 
 # 2.1.11 Remove xinetd (Scored)
-  - id: 5561 
+  - id: 5561
     title: "Ensure xinetd is not enabled"
     description: "The eXtended InterNET Daemon ( xinetd ) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no xinetd services required, it is recommended that the daemon be disabled."
@@ -1133,7 +1133,7 @@ checks:
 ###############################################
 
 # 2.2.1.1 Ensure time synchronization is in use (Not Scored)
-  - id: 5562 
+  - id: 5562
     title: "Ensure time synchronization is in use"
     description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
     rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
@@ -1150,7 +1150,7 @@ checks:
       - 'not c:rpm -q chrony -> r:^package chrony is not installed'
 
 # 2.2.1.2 Configure Network Time Protocol (NTP) (Scored)
-  - id: 5563 
+  - id: 5563
     title: "Ensure ntp is configured"
     description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://www.ntp.org. ntp can be configured to be a client and/or a server."
     rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
@@ -1169,7 +1169,7 @@ checks:
       - 'f:/etc/sysconfig/ntpd -> r:^OPTIONS\s*=\s* && r:-u ntp:ntp'
 
 # 2.2.1.3 Configure Network Time Protocol (Chrony) (Scored)
-  - id: 5564 
+  - id: 5564
     title: "Ensure chrony is configured"
     description: "chrony is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://www.ntp.org. ntp can be configured to be a client and/or a server."
     rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
@@ -1186,7 +1186,7 @@ checks:
       - 'f:/etc/sysconfig/chronyd -> r:^OPTIONS\s*=\s* && r:-u chrony'
 
 # 2.2.2 Remove X Windows (Scored)
-  - id: 5565 
+  - id: 5565
     title: "Ensure X Window System is not installed"
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
@@ -1202,7 +1202,7 @@ checks:
       - 'c:rpm -qa xorg-x11* -> r:^xorg-x11'
 
 # 2.2.3 Disable Avahi Server (Scored)
-  - id: 5566 
+  - id: 5566
     title: "Ensure Avahi Server is not enabled"
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to disable the service to reduce the potential attack surface."
@@ -1218,7 +1218,7 @@ checks:
       - 'c:chkconfig --list avahi-daemon -> r:^\s*\t*avahi-daemon\.*on'
 
 # 2.2.4 Ensure CUPS is not enabled (Scored)
-  - id: 5567 
+  - id: 5567
     title: "Ensure CUPS is not enabled"
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be disabled to reduce the potential attack surface."
@@ -1234,7 +1234,7 @@ checks:
       - 'c:chkconfig --list cups -> r:^\s*\t*cups\.*on'
 
 # 2.2.5 Remove DHCP Server (Scored)
-  - id: 5568 
+  - id: 5568
     title: "Ensure DHCP Server is not enabled"
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this service be disabled to reduce the potential attack surface."
@@ -1252,7 +1252,7 @@ checks:
       - 'c:chkconfig --list dhcpd -> r:^\s*\t*dhcpd\.*on'
 
 # 2.2.6 Remove LDAP Server (Scored)
-  - id: 5569 
+  - id: 5569
     title: "Ensure LDAP Server is not enabled"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be disabled to reduce the potential attack surface."
@@ -1272,7 +1272,7 @@ checks:
 
 
 # 2.2.7 Disable NFS and RPC (Scored)
-  - id: 5570 
+  - id: 5570
     title: "Ensure NFS and RPC are not enabled"
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not export NFS shares or act as an NFS client, it is recommended that these services be disabled to reduce remote attack surface."
@@ -1289,7 +1289,7 @@ checks:
       - 'c:chkconfig --list rpcbind -> r:^\s*\t*rpcbind\.*on'
 
 # 2.2.8 Ensure DNS Server is not enabled (Scored)
-  - id: 5571 
+  - id: 5571
     title: "Ensure DNS Server is not enabled"
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the service be disabled to reduce the potential attack surface."
@@ -1305,7 +1305,7 @@ checks:
       - 'c:chkconfig --list named -> r:^\s*\t*named\.*on'
 
 # 2.2.9 Remove FTP Server (Scored)
-  - id: 5572 
+  - id: 5572
     title: "Ensure FTP Server is not enabled"
     description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the service be disabled to reduce the potential attack surface."
@@ -1321,7 +1321,7 @@ checks:
       - 'c:chkconfig --list vsftpd -> r:^\s*\t*vsftpd\.*on'
 
 # 2.2.10 Remove HTTP Server (Scored)
-  - id: 5573 
+  - id: 5573
     title: "Ensure HTTP server is not enabled"
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the service be disabled to reduce the potential attack surface."
@@ -1337,7 +1337,7 @@ checks:
       - 'c:chkconfig --list httpd -> r:^\s*\t*httpd\.*on'
 
 # 2.2.11 Remove Dovecot (IMAP and POP3 services) (Scored)
-  - id: 5574 
+  - id: 5574
     title: "Ensure IMAP and POP3 server is not enabled"
     description: "dovecot is an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the service be disabled to reduce the potential attack surface."
@@ -1353,7 +1353,7 @@ checks:
       - 'c:chkconfig --list dovecot -> r:^\s*\t*dovecot\.*on'
 
 # 2.2.12 Remove Samba (Scored)
-  - id: 5575 
+  - id: 5575
     title: "Ensure Samba is not enabled"
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this service can be disabled to reduce the potential attack surface."
@@ -1369,7 +1369,7 @@ checks:
       - 'c:chkconfig --list smb -> r:^\s*\t*smb\.*on'
 
 # 2.2.13 Remove HTTP Proxy Server (Scored)
-  - id: 5576 
+  - id: 5576
     title: "Ensure HTTP Proxy Server is not enabled"
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be disabled to reduce the potential attack surface."
@@ -1385,7 +1385,7 @@ checks:
       - 'c:chkconfig --list squid -> r:^\s*\t*squid\.*on'
 
 # 2.2.14 Remove SNMP Server (Not Scored)
-  - id: 5577 
+  - id: 5577
     title: "Ensure SNMP Server is not enabled"
     description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
     rationale: "The SNMP server can communicate using SNMP v1, which transmits data in the clear and does not require authentication to execute commands. Unless absolutely necessary, it is recommended that the SNMP service not be used. If SNMP is required the server should be configured to disallow SNMP v1."
@@ -1401,7 +1401,7 @@ checks:
       - 'c:chkconfig --list snmpd -> r:^\s*\t*snmpd\.*on'
 
 # 2.2.15 Ensure mail transfer agent is configured for local-only mode (Scored)
-  - id: 5578 
+  - id: 5578
     title: "Ensure mail transfer agent is configured for local-only mode"
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
@@ -1417,7 +1417,7 @@ checks:
       - 'c:netstat -an -> r:\.*:25\.*LISTEN && !r:127.0.0.1:25\.+LISTEN|::1:25\.+LISTEN'
 
 # 2.2.16 Remove NIS Server (Scored)
-  - id: 5579 
+  - id: 5579
     title: "Ensure NIS Server is not enabled"
     description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be disabled and other, more secure services be used"
@@ -1439,7 +1439,7 @@ checks:
 # 2.3 Service Clients
 ###############################################
 # 2.3.1 Remove NIS Client (Scored)
-  - id: 5580 
+  - id: 5580
     title: "Ensure NIS Client is not installed"
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client ( ypbind ) was used to bind a machine to an NIS server and receive the distributed configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
@@ -1458,7 +1458,7 @@ checks:
       - 'c:rpm -q ypbind -> package ypbind is not installed'
 
 # 2.3.2 Ensure rsh client is not installed (Scored)
-  - id: 5581 
+  - id: 5581
     title: "Ensure rsh client is not installed"
     description: "The rsh package contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh , rcp and rlogin ."
@@ -1477,7 +1477,7 @@ checks:
       - 'c:rpm -q rsh -> package rsh is not installed'
 
 # 2.3.3 Ensure talk client is not installed (Scored)
-  - id: 5582 
+  - id: 5582
     title: "Ensure talk client is not installed"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -1496,7 +1496,7 @@ checks:
       - 'c:rpm -q talk -> package talk is not installed'
 
 # 2.3.4 Ensure telnet client is not installed (Scored)
-  - id: 5583 
+  - id: 5583
     title: "Ensure telnet client is not installed"
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
@@ -1515,7 +1515,7 @@ checks:
       - 'c:rpm -q telnet -> package telnet is not installed'
 
 # 2.3.5 Ensure LDAP client is not installed (Scored)
-  - id: 5584 
+  - id: 5584
     title: "Ensure LDAP client is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
@@ -1540,7 +1540,7 @@ checks:
 # 3.1 Modify Network Parameters (Host Only)
 ###############################################
 # 3.1.1 Disable IP Forwarding (Scored)
-  - id: 5585 
+  - id: 5585
     title: "Ensure IP forwarding is disabled"
     description: "The net.ipv4.ip_forward flag is used to tell the system whether it can forward packets or not."
     rationale: "Setting the flag to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
@@ -1557,7 +1557,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.ip_forward /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.ip_forward\s*=\s*0$'
 
 # 3.1.2 Disable Send Packet Redirects (Scored)
-  - id: 5586 
+  - id: 5586
     title: "Ensure packet redirect sending is disabled"
     description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
     rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
@@ -1579,7 +1579,7 @@ checks:
 # 3.2 Modify Network Parameters (Host and Router)
 ###############################################
 # 3.2.1 Disable Source Routed Packet Acceptance (Scored)
-  - id: 5587 
+  - id: 5587
     title: "Ensure source routed packets are not accepted"
     description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
     rationale: "Setting net.ipv4.conf.all.accept_source_route and net.ipv4.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
@@ -1598,7 +1598,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
 
 # 3.2.2 Disable ICMP Redirect Acceptance (Scored)
-  - id: 5588 
+  - id: 5588
     title: "Ensure ICMP redirects are not accepted"
     description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables."
     rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
@@ -1617,7 +1617,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
 
 # 3.2.3 Disable Secure ICMP Redirect Acceptance (Scored)
-  - id: 5589 
+  - id: 5589
     title: "Ensure secure ICMP redirects are not accepted"
     description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
     rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
@@ -1636,7 +1636,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
 
 # 3.2.4 Log Suspicious Packets (Scored)
-  - id: 5590 
+  - id: 5590
     title: "Ensure suspicious packets are logged"
     description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
     rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their system."
@@ -1655,7 +1655,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
 
 # 3.2.5 Enable Ignore Broadcast Requests (Scored)
-  - id: 5591 
+  - id: 5591
     title: "Ensure broadcast ICMP requests are ignored"
     description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
     rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address."
@@ -1672,7 +1672,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
 # 3.2.6 Enable Bad Error Message Protection (Scored)
-  - id: 5592 
+  - id: 5592
     title: "Ensure bogus ICMP responses are ignored"
     description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
     rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
@@ -1689,7 +1689,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
 # 3.2.7 Enable RFC-recommended Source Route Validation (Scored)
-  - id: 5593 
+  - id: 5593
     title: "Ensure Reverse Path Filtering is enabled"
     description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
     rationale: "Setting these flags is a good way to deter attackers from sending your server bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing."
@@ -1708,7 +1708,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
 
 # 3.2.8 Enable TCP SYN Cookies (Scored)
-  - id: 5594 
+  - id: 5594
     title: "Ensure TCP SYN Cookies is enabled"
     description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent."
     rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
@@ -1728,7 +1728,7 @@ checks:
 # 3.3 IPv6
 ###############################################
 # 3.3.1 Ensure IPv6 router advertisements are not accepted (Not Scored)
-  - id: 5595 
+  - id: 5595
     title: "Ensure IPv6 router advertisements are not accepted"
     description: "This setting disables the system's ability to accept IPv6 router advertisements."
     rationale: "It is recommended that systems not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
@@ -1751,7 +1751,7 @@ checks:
 
 
 # 3.3.2 Ensure IPv6 redirects are not accepted (Not Scored)
-  - id: 5596 
+  - id: 5596
     title: "Ensure IPv6 redirects are not accepted"
     description: "This setting prevents the system from accepting ICMP redirects. ICMP redirects tell the system about alternate routes for sending traffic."
     rationale: "It is recommended that systems not accept ICMP redirects as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
@@ -1773,7 +1773,7 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_redirect /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0'
 
 # 3.3.3 Ensure IPv6 is disabled (Not Scored)
-  - id: 5597 
+  - id: 5597
     title: "Ensure IPv6 is disabled"
     description: "Although IPv6 has many advantages over IPv4, few organizations have implemented IPv6."
     rationale: "If IPv6 is not to be used, it is recommended that it be disabled to reduce the attack surface of the system."
@@ -1796,7 +1796,7 @@ checks:
 # 3.4 TCP Wrappers
 ###############################################
 # 3.4.1 Ensure TCP Wrappers is installed (Scored)
-  - id: 5598 
+  - id: 5598
     title: "Ensure TCP Wrappers is installed"
     description: "TCP Wrappers provides a simple access list and standardized logging method for services capable of supporting it. In the past, services that were called from inetd and xinetd supported the use of tcp wrappers. As inetd and xinetd have been falling in disuse, any service that can support tcp wrappers will have the libwrap.so library attached to it."
     rationale: "TCP Wrappers provide a good simple access list mechanism to services that may not have that support built in. It is recommended that all services that can support TCP Wrappers, use it."
@@ -1811,7 +1811,7 @@ checks:
       - 'c:rpm -q tcp_wrappers-libs -> r:^tcp_wrappers-libs-'
 
 # 3.4.3 Ensure /etc/hosts.deny is configured (Scored)
-  - id: 5599 
+  - id: 5599
     title: "Ensure /etc/hosts.deny is configured"
     description: "The /etc/hosts.deny file specifies which IP addresses are not permitted to connect to the host. It is intended to be used in conjunction with the /etc/hosts.allow file."
     rationale: "The /etc/hosts.allow file supports access control by IP and helps ensure that only authorized systems can connect to the system."
@@ -1825,7 +1825,7 @@ checks:
       - 'f:/etc/hosts.deny -> r:^ALL\s*:\s*ALL'
 
 # 3.4.4 Ensure permissions on /etc/hosts.allow are configured (Scored)
-  - id: 5600 
+  - id: 5600
     title: "Ensure permissions on /etc/hosts.allow are configured."
     description: "The /etc/hosts.allow file contains networking information that is used by many applications and therefore must be readable for these applications to operate."
     rationale: "It is critical to ensure that the /etc/hosts.allow file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -1840,7 +1840,7 @@ checks:
 
 
 # 3.4.5 Ensure permissions on /etc/hosts.deny are configured (Scored)
-  - id: 5601 
+  - id: 5601
     title: "Ensure permissions on /etc/hosts.deny are configured."
     description: "The /etc/hosts.deny file contains network information that is used by many system applications and therefore must be readable for these applications to operate."
     rationale: "It is critical to ensure that the /etc/hosts.deny file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -1860,7 +1860,7 @@ checks:
 # 3.5 Uncommon Network Protocols
 ###############################################
 # 3.5.1 Ensure DCCP is disabled (Not Scored)
-  - id: 5602 
+  - id: 5602
     title: "Ensure DCCP is disabled"
     description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery."
     rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce
@@ -1883,7 +1883,7 @@ the potential attack surface."
 
 
 # 3.5.2 Ensure SCTP is disabled (Not Scored)
-  - id: 5603 
+  - id: 5603
     title: "Ensure SCTP is disabled"
     description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1904,7 +1904,7 @@ the potential attack surface."
 
 
 # 3.5.3 Ensure RDS is disabled (Not Scored)
-  - id: 5604 
+  - id: 5604
     title: "Ensure RDS is disabled"
     description: "The Reliable Datagram Sockets (RDS) protocol is a transport layer protocol designed to provide low-latency, high-bandwidth communications between cluster nodes. It was developed by the Oracle Corporation."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1925,7 +1925,7 @@ the potential attack surface."
 
 
 # 3.5.4 Ensure TIPC is disabled (Not Scored)
-  - id: 5605 
+  - id: 5605
     title: "Ensure TIPC is disabled"
     description: "The Transparent Inter-Process Communication (TIPC) protocol is designed to provide communication between cluster nodes."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1948,7 +1948,7 @@ the potential attack surface."
 # 3.6 Firewall Configuration
 ###############################################
 # 3.6.1 Ensure iptables is installed (Scored)
-  - id: 5606 
+  - id: 5606
     title: "Ensure iptables is installed"
     description: "iptables allows configuration of the IPv4 tables in the linux kernel and the rules stored within them. Most firewall configuration utilities operate as a front end to iptables ."
     rationale: "iptables is required for firewall management and configuration."
@@ -1962,7 +1962,7 @@ the potential attack surface."
       - 'c:rpm -q iptables -> r:iptables-'
 
 # 3.6.2 Ensure default deny firewall policy (Scored)
-  - id: 5607 
+  - id: 5607
     title: "Ensure default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -1979,7 +1979,7 @@ the potential attack surface."
       - 'c:iptables -L -> r:Chain OUTPUT \(policy DROP\)'
 
 # 3.6.3 Ensure loopback traffic is configured (Scored)
-  - id: 5608 
+  - id: 5608
     title: "Ensure loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -2011,7 +2011,7 @@ the potential attack surface."
 ###############################################
 
 # 4.1.1.1 Ensure audit log storage size is configured (Not Scored)
-  - id: 5609 
+  - id: 5609
     title: "Ensure audit log storage size is configured"
     description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
     rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
@@ -2025,7 +2025,7 @@ the potential attack surface."
       - 'f:/etc/audit/auditd.conf -> r:^max_log_file\s*=\s*\d+'
 
 # 4.1.1.2 Ensure system is disabled when audit logs are full (Scored)
-  - id: 5610 
+  - id: 5610
     title: "Ensure system is disabled when audit logs are full"
     description: "The auditd daemon can be configured to halt the system when the audit logs are full."
     rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
@@ -2041,7 +2041,7 @@ the potential attack surface."
       - 'f:/etc/audit/auditd.conf -> r:^admin_space_left_action\s*=\s*halt'
 
 # 4.1.1.3 Ensure audit logs are not automatically deleted (Scored)
-  - id: 5611 
+  - id: 5611
     title: "Ensure audit logs are not automatically deleted"
     description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
     rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
@@ -2055,7 +2055,7 @@ the potential attack surface."
       - 'f:/etc/audit/auditd.conf -> r:^max_log_file_action\s*=\s*keep_logs'
 
 # 4.1.2 Ensure auditd service is enabled (Scored)
-  - id: 5612 
+  - id: 5612
     title: "Ensure auditd service is enabled"
     description: "Turn on the auditd daemon to record system events."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -2071,7 +2071,7 @@ the potential attack surface."
 
 
 # 4.1.3 Ensure auditing for processes that start prior to auditd is enabled (Scored)
-  - id: 5613 
+  - id: 5613
     title: "Ensure auditing for processes that start prior to auditd is enabled"
     description: "Configure grub so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
     rationale: "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected."
@@ -2086,9 +2086,9 @@ the potential attack surface."
     condition: none
     rules:
       - 'f:/boot/grub/grub.conf -> r:^\s*\t*kernel && !r:audit=1'
-      
+
 # 4.1.4 Ensure events that modify date and time information are collected (Scored)
-  - id: 5614 
+  - id: 5614
     title: "Ensure events that modify date and time information are collected"
     description: "Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier \"time-change\"."
     rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
@@ -2109,7 +2109,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /etc/localtime && r:-p wa && r:-k time-change'
 
 # 4.1.5 Ensure events that modify user/group information are collected (Scored)
-  - id: 5615 
+  - id: 5615
     title: "Ensure events that modify user/group information are collected"
     description: "Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier \"identity\" in the audit log file."
     rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
@@ -2132,7 +2132,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /etc/security/opasswd && r:-p wa && r:-k identity'
 
 # 4.1.6 Ensure events that modify the system's network environment are collected (Scored)
-  - id: 5616 
+  - id: 5616
     title: "Ensure events that modify the system's network environment are collected"
     description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed pre-login), /etc/hosts (file containing host names and associated IP addresses), /etc/sysconfig/network file and /etc/sysconfig/network-scripts/ directory (containing network interface scripts and configurations)."
     rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/sysconfig/network and /etc/sysconfig/network-scripts/ is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier \"system-locale.\""
@@ -2156,7 +2156,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /etc/sysconfig/network-scripts/ && r:-p wa && r:-k system-locale'
 
 # 4.1.7 Ensure events that modify the system's Mandatory Access Controls are collected (Scored)
-  - id: 5617 
+  - id: 5617
     title: "Ensure events that modify the system's Mandatory Access Controls are collected"
     description: "Monitor SELinux mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/selinux or directory."
     rationale: "Changes to files in these directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
@@ -2176,7 +2176,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /usr/share/selinux/ && r:-p wa && r:-k MAC-policy'
 
 # 4.1.8 Ensure login and logout events are collected (Scored)
-  - id: 5618 
+  - id: 5618
     title: "Ensure login and logout events are collected"
     description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. The file /var/log/lastlog maintain records of the last time a user successfully logged in. The /var/run/failock directory maintains records of login failures via the pam_faillock module."
     rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
@@ -2196,7 +2196,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /var/run/faillock/ && r:-p wa && r:-k logins'
 
 # 4.1.9 Ensure session initiation information is collected (Scored)
-  - id: 5619 
+  - id: 5619
     title: "Ensure session initiation information is collected"
     description: "Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp file tracks all currently logged in users. All audit records will be tagged with the identifier \"session.\" The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp . All audit records will be tagged with the identifier \"logins.\"."
     rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
@@ -2213,7 +2213,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /var/log/btmp && r:-p wa && r:-k logins'
 
 # 4.1.10 Ensure discretionary access control permission modification events are collected (Scored)
-  - id: 5620 
+  - id: 5620
     title: "Ensure discretionary access control permission modification events are collected"
     description: "Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The chmod , fchmod and fchmodat system calls affect the permissions associated with a file. The chown , fchown , fchownat and lchown system calls affect owner and group attributes on a file. The setxattr , lsetxattr , fsetxattr (set extended file attributes) and removexattr , lremovexattr , fremovexattr (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 500) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier \"perm_mod.\""
     rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
@@ -2234,7 +2234,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S setxattr && r:-S lsetxattr && r:-S fsetxattr && r:-S removexattr && r:-S lremovexattr && r:-S fremovexattr && r:-F auid>=500 && r:-F auid!=4294967295 && r:-k perm_mod'
 
 # 4.1.11 Ensure unsuccessful unauthorized file access attempts are collected (Scored)
-  - id: 5621 
+  - id: 5621
     title: "Ensure unsuccessful unauthorized file access attempts are collected"
     description: "Monitor for unsuccessful attempts to access files. The parameters below are associated  with system calls that control creation ( creat ), opening ( open , openat ) and truncation (  truncate , ftruncate ) of files. An audit log record will only be written if the user is a non-  privileged user (auid > = 500), is not a Daemon event (auid=4294967295) and if the  system call returned EACCES (permission denied to the file) or EPERM (some other  permanent error associated with the specific system call). All audit records will be tagged  with the identifier \"access.\""
     rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
@@ -2254,7 +2254,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-S ftruncate && r:-F exit=-EPERM && r:-F auid>=500 && r:-F auid!=4294967295 && r:-k access'
 
 # 4.1.13 Ensure successful file system mounts are collected (Scored)
-  - id: 5622 
+  - id: 5622
     title: "Ensure successful file system mounts are collected"
     description: "Monitor the use of the mount system call. The mount (and umount ) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user."
     rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open , creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
@@ -2274,7 +2274,7 @@ the potential attack surface."
 
 
 # 4.1.14 Ensure file deletion events by users are collected (Scored)
-  - id: 5623 
+  - id: 5623
     title: "Ensure file deletion events by users are collected"
     description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for the unlink (remove a file), unlinkat (remove a file attribute), rename (rename a file) and renameat (rename a file attribute) system calls and tags them with the identifier \"delete\"."
     rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
@@ -2288,7 +2288,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S unlink && r:-S unlinkat && r:-S rename && r:-S renameat && r:-F auid>=500 && r:-F auid!=4294967295 && r:-k delete'
 
 # 4.1.15 Ensure changes to system administration scope (sudoers) is collected (Scored)
-  - id: 5624 
+  - id: 5624
     title: "Ensure changes to system administration scope (sudoers) is collected"
     description: "Monitor scope changes for system administrations. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers will be written to when the file or its attributes have changed. The audit records will be tagged with the identifier \"scope.\""
     rationale: "Changes in the /etc/sudoers file can indicate that an unauthorized change has been made to scope of system administrator activity."
@@ -2308,7 +2308,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /etc/sudoers.d/ && r:-p wa && r:-k scope'
 
 # 4.1.16 Ensure system administrator actions (sudolog) are collected (Scored)
-  - id: 5625 
+  - id: 5625
     title: "Ensure system administrator actions (sudolog) are collected"
     description: "Monitor the sudo log file. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to /var/log/sudo.log . Any time a command is executed, an audit event will be triggered as the /var/log/sudo.log file will be opened for write and the executed administration command will be written to the log."
     rationale: "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed."
@@ -2327,7 +2327,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /var/log/sudo.log && r:-p wa && r:-k actions'
 
 # 4.1.17 Ensure kernel module loading and unloading is collected (Scored)
-  - id: 5626 
+  - id: 5626
     title: "Ensure kernel module loading and unloading is collected"
     description: "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\"."
     rationale: "Monitoring the use of insmod , rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
@@ -2349,7 +2349,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b\d\d && r:-S init_module && r:-S delete_module && r:-k modules'
 
 # 4.1.18 Ensure the audit configuration is immutable (Scored)
-  - id: 5627 
+  - id: 5627
     title: "Ensure the audit configuration is immutable"
     description: "Set system audit so that audit rules cannot be modified with auditctl . Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot."
     rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
@@ -2368,7 +2368,7 @@ the potential attack surface."
 ###############################################
 
 # 4.2.1.1 Ensure rsyslog Service is enabled (Scored)
-  - id: 5628 
+  - id: 5628
     title: "Ensure rsyslog Service is enabled"
     description: "Once the rsyslog package is installed it needs to be activated."
     rationale: "If the rsyslog service is not activated the system may default to the syslogd service or lackblogging instead."
@@ -2382,21 +2382,21 @@ the potential attack surface."
     rules:
       - 'c:chkconfig --list rsyslog -> r:2:on && r:3:on && r:4:on && r:5:on'
 # 4.2.1.3 Ensure rsyslog default file permissions configured (Scored)
-  - id: 5629 
+  - id: 5629
     title: "Ensure rsyslog default file permissions configured"
     description: "rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
     remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to 0640 or more restrictive:   $FileCreateMode 0640"
     compliance:
       - cis: ["4.2.1.3"]
-      - cis_csc: ["5.1"]  
+      - cis_csc: ["5.1"]
     condition: any
     rules:
       - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
       - 'd:/etc/rsyslog.d/ -> r:\. -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
 
 # 4.2.1.4 Ensure rsyslog is configured to send logs to a remote log host (Scored)
-  - id: 5630 
+  - id: 5630
     title: "Ensure rsyslog is configured to send logs to a remote log host"
     description: "The rsyslog utility supports the ability to send logs it gathers to a remote log host running syslogd(8) or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2409,11 +2409,11 @@ the potential attack surface."
     condition: all
     rules:
       - 'c:grep *.*[^I][^I]*@ /etc/rsyslog.conf /etc/rsyslog.d/*.conf -> !r:# && r:*.* @@\.+'
-  
+
 
 
 # 4.2.2.1 Ensure syslog-ng service is enabled (Scored)
-  - id: 5631 
+  - id: 5631
     title: "Ensure syslog-ng service is enabled"
     description: "Once the syslog-ng package is installed it needs to be activated."
     rationale: "If the syslog-ng service is not activated the system may default to the syslogd service or lack logging instead."
@@ -2428,22 +2428,22 @@ the potential attack surface."
       - 'c:chkconfig --list syslog-ng -> r:2:on && r:3:on && r:4:on && r:5:on'
 
 # 4.2.2.3 Ensure syslog-ng default file permissions configured (Scored)
-  - id: 5632 
+  - id: 5632
     title: "Ensure syslog-ng default file permissions configured"
     description: "syslog-ng will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive syslog-ng data is archived and protected."
     remediation: "Edit the /etc/syslog-ng/syslog-ng.conf and set perm option to 0640 or more restrictive:     options { chain_hostnames(off); flush_lines(0); perm(0640); stats_freq(3600); threaded(yes); };"
     compliance:
       - cis: ["4.2.2.3"]
-      - cis_csc: ["5.1"]    
+      - cis_csc: ["5.1"]
       - pci_dss: ["10.5"]
-      - tsc: ["CC6.1","CC7.2","CC7.3","CC7.4"]  
+      - tsc: ["CC6.1","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
       - 'f:/etc/syslog-ng/syslog-ng.conf -> r:^options && r:perm\(0600\)|perm\(0640\)|perm\(0440\)|perm\(0400\)|perm\(0000\)'
 
 # 4.2.2.4 Ensure syslog-ng is configured to send logs to a remote log host (Not Scored)
-  - id: 5633 
+  - id: 5633
     title: "Ensure syslog-ng is configured to send logs to a remote log host"
     description: "The syslog-ng utility supports the ability to send logs it gathers to a remote log host or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2459,7 +2459,7 @@ the potential attack surface."
       - 'f:/etc/syslog-ng/syslog-ng.conf -> !r:^# && r:log\.+source\.+destination'
 
 # 4.2.3 Ensure rsyslog or syslog-ng is installed (Scored)
-  - id: 5634 
+  - id: 5634
     title: "Ensure rsyslog or syslog-ng is installed"
     description: "The rsyslog and syslog-ng software are recommended replacements to the original syslogd daemon which provide improvements over syslogd , such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server."
     rationale: "The security enhancements of rsyslog and syslog-ng such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
@@ -2475,7 +2475,7 @@ the potential attack surface."
       - 'not c:rpm -q syslog-ng -> package syslog-ng is not installed'
 
   # 4.2.4 Ensure permissions on all logfiles are configured (Scored)
-  - id: 5635 
+  - id: 5635
     title: "Ensure permissions on all logfiles are configured"
     description: "Log files stored in /var/log/ contain logged information from many services on the system, or on log hosts others as well."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitivebdata is archived and protected."
@@ -2497,7 +2497,7 @@ the potential attack surface."
 ###############################################
 
 # 5.1.1 Ensure cron daemon is enabled (Scored)
-  - id: 5636 
+  - id: 5636
     title: "Ensure cron daemon is enabled"
     description: "The cron daemon is used to execute batch jobs on the system."
     rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
@@ -2513,7 +2513,7 @@ the potential attack surface."
       - 'c:chkconfig --list crond -> r:2:on && r:3:on && r:4:on && r:5:on'
 
 # 5.1.2 Ensure permissions on /etc/crontab are configured (Scored)
-  - id: 5637 
+  - id: 5637
     title: "Ensure permissions on /etc/crontab are configured"
     description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
     rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
@@ -2529,7 +2529,7 @@ the potential attack surface."
       - 'c:stat /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
-  - id: 5638 
+  - id: 5638
     title: "Ensure permissions on /etc/cron.hourly are configured"
     description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2545,7 +2545,7 @@ the potential attack surface."
       - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
-  - id: 5639 
+  - id: 5639
     title: "Ensure permissions on /etc/cron.daily are configured"
     description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2561,7 +2561,7 @@ the potential attack surface."
       - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
-  - id: 5640 
+  - id: 5640
     title: "Ensure permissions on /etc/cron.weekly are configured"
     description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2578,7 +2578,7 @@ the potential attack surface."
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
-  - id: 5641 
+  - id: 5641
     title: "Ensure permissions on /etc/cron.monthly are configured"
     description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2594,7 +2594,7 @@ the potential attack surface."
       - 'c:stat /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
-  - id: 5642 
+  - id: 5642
     title: "Ensure permissions on /etc/cron.d are configured"
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow , cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2610,7 +2610,7 @@ the potential attack surface."
       - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.8 Ensure at/cron is restricted to authorized users (Scored)
-  - id: 5643 
+  - id: 5643
     title: "Ensure at/cron is restricted to authorized users"
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow , cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2632,7 +2632,7 @@ the potential attack surface."
 # 5.2 Configure SSH
 ###############################################
 # 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured (Scored)
-  - id: 5644 
+  - id: 5644
     title: "Ensure permissions on /etc/ssh/sshd_config are configured"
     description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
     rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
@@ -2648,7 +2648,7 @@ the potential attack surface."
       - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.2 Set SSH Protocol to 2 (Scored)
-  - id: 5645 
+  - id: 5645
     title: "Ensure SSH Protocol is set to 2"
     description: "SSH supports two different and incompatible protocols: SSH1 and SSH2. SSH1 was the original protocol and was subject to security issues. SSH2 is more advanced and secure."
     rationale: "SSH v1 suffers from insecurities that do not affect SSH v2."
@@ -2665,7 +2665,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:Protocol\s*\t*2'
 
 # 5.2.3 Set LogLevel to INFO (Scored)
-  - id: 5646 
+  - id: 5646
     title: "Ensure SSH LogLevel is set to INFO"
     description: "The INFO parameter specifies that login and logout activity will be logged."
     rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
@@ -2682,7 +2682,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:LogLevel\s*\t*INFO'
 
 # 5.2.5 Set SSH MaxAuthTries to 4 or Less (Scored)
-  - id: 5647 
+  - id: 5647
     title: "Ensure SSH MaxAuthTries is set to 4 or less"
     description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
     rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
@@ -2698,7 +2698,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
 
 # 5.2.6 Set SSH IgnoreRhosts to Yes (Scored)
-  - id: 5648 
+  - id: 5648
     title: "Ensure SSH IgnoreRhosts is enabled"
     description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
     rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
@@ -2714,7 +2714,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:IgnoreRhosts\s*\t*yes'
 
 # 5.2.7 Set SSH HostbasedAuthentication to No (Scored)
-  - id: 5649 
+  - id: 5649
     title: "Ensure SSH HostbasedAuthentication is disabled"
     description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts , or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
     rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
@@ -2731,7 +2731,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:HostbasedAuthentication\s*\t*no'
 
 # 5.2.8 Disable SSH Root Login (Scored)
-  - id: 5650 
+  - id: 5650
     title: "Ensure SSH root login is disabled"
     description: "The PermitRootLogin parameter specifies if the root user can log in using ssh(1). The default is no."
     rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su . This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident"
@@ -2748,7 +2748,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:PermitRootLogin\s*\t*no'
 
 # 5.2.9 Set SSH PermitEmptyPasswords to No (Scored)
-  - id: 5651 
+  - id: 5651
     title: "Ensure SSH PermitEmptyPasswords is disabled"
     description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
     rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system"
@@ -2765,7 +2765,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:PermitEmptyPasswords\s*\t*no'
 
 # 5.2.10 Ensure SSH PermitUserEnvironment is disabled (Scored)
-  - id: 5652 
+  - id: 5652
     title: "Ensure SSH PermitUserEnvironment is disabled"
     description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
     rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing trojan'd programs)"
@@ -2782,7 +2782,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:PermitUserEnvironment\s*\t*no'
 
 # 5.2.12 Ensure SSH Idle Timeout Interval is configured (Scored)
-  - id: 5653 
+  - id: 5653
     title: "Ensure SSH Idle Timeout Interval is configured"
     description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the ClientAliveCountMax variable is set, sshd will send client alive messages at every ClientAliveInterval interval. When the number of consecutive client alive messages are sent with no response from the client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
     rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent."
@@ -2797,7 +2797,7 @@ the potential attack surface."
       - 'f:$sshd_file -> n:^\s*ClientAliveCountMax\s*\t*(\d+) compare <= 3'
 
 # 5.2.13 Ensure SSH LoginGraceTime is set to one minute or less (Scored)
-  - id: 5654 
+  - id: 5654
     title: "Ensure SSH LoginGraceTime is set to one minute or less"
     description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
     rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
@@ -2811,7 +2811,7 @@ the potential attack surface."
       - 'f:$sshd_file -> n:^\s*LoginGraceTime\s*\t*(\d+) compare <= 60'
 
 # 5.2.14 Ensure SSH access is limited (Scored)
-  - id: 5655 
+  - id: 5655
     title: "Ensure SSH access is limited"
     description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: AllowUsers The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. AllowGroups The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable. DenyUsers The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. DenyGroups The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
     rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
@@ -2829,7 +2829,7 @@ the potential attack surface."
       - 'f:$sshd_file -> r:^\s*DenyGroups'
 
 # 5.2.15 Ensure SSH warning banner is configured (Scored)
-  - id: 5656 
+  - id: 5656
     title: "Ensure SSH warning banner is configured"
     description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
     rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
@@ -2847,7 +2847,7 @@ the potential attack surface."
 # 5.3 Configure PAM
 ###############################################
 # 5.3.1 Ensure password creation requirements are configured (Scored)
-  - id: 5657 
+  - id: 5657
     title: "Ensure password creation requirements are configured"
     description: "The pam_cracklib.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more"
     rationale: "Strong passwords protect systems from being hacked through brute force methods."
@@ -2863,7 +2863,7 @@ the potential attack surface."
       - 'c:grep pam_cracklib.so /etc/pam.d/system-auth -> r:try_first_pass && n:minlen\s*\t*=\s*\t*(\d+) compare >= 14'
 
 # 5.3.3 Ensure password reuse is limited (Scored)
-  - id: 5658 
+  - id: 5658
     title: "Ensure password reuse is limited"
     description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
     rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password. Note that these change only apply to accounts configured on the local system."
@@ -2879,7 +2879,7 @@ the potential attack surface."
       - 'f:/etc/pam.d/system-auth -> n:^password\s+sufficient\s+pam_unix.so\.+remember=(\d+)|^password\s+required\s+pam_pwhistory.so\.+remember=(\d+) compare >= 5'
 
 # 5.3.4 Ensure password hashing algorithm is SHA-512 (Scored)
-  - id: 5659 
+  - id: 5659
     title: "Ensure password hashing algorithm is SHA-512"
     description: "The commands below change password encryption from md5 to sha512 (a much stronger hashing algorithm). All existing accounts will need to perform a password change to upgrade the stored hashes to the new algorithm."
     rationale: "The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note that these change only apply to accounts configured on the local system."
@@ -2900,7 +2900,7 @@ the potential attack surface."
 # 5.4.1 Set Shadow Password Suite Parameters
 ###############################################
 # 5.4.1.1 Ensure password expiration is 365 days or less (Scored)
-  - id: 5660 
+  - id: 5660
     title: "Ensure password expiration is 365 days or less"
     description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 365 days."
     rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity."
@@ -2915,7 +2915,7 @@ the potential attack surface."
       - 'f:/etc/login.defs -> n:^\s*PASS_MAX_DAYS\s*\t*(\d+) compare <= 365'
 
 # 5.4.1.2 Ensure minimum days between password changes is 7 or more (Scored)
-  - id: 5661 
+  - id: 5661
     title: "Ensure minimum days between password changes is 7 or more"
     description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 7 or more days."
     rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
@@ -2930,7 +2930,7 @@ the potential attack surface."
       - 'f:/etc/login.defs -> n:^\s*PASS_MIN_DAYS\s*\t*(\d+) compare >= 7'
 
 # 5.4.1.3 Ensure password expiration warning days is 7 or more (Scored)
-  - id: 5662 
+  - id: 5662
     title: "Ensure password expiration warning days is 7 or more"
     description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
     rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
@@ -2945,7 +2945,7 @@ the potential attack surface."
       - 'f:/etc/login.defs -> n:^\s*PASS_WARN_AGE\s*\t*(\d+) compare >= 7'
 
 # 5.4.1.4 Ensure inactive password lock is 30 days or less (Scored)
-  - id: 5663 
+  - id: 5663
     title: "Ensure inactive password lock is 30 days or less"
     description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
     rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
@@ -2960,7 +2960,7 @@ the potential attack surface."
       - 'c:useradd -D -> n:^\s*INACTIVE\s*=\s*(\d+) compare <= 30'
 
 # 5.4.3 Ensure default group for the root account is GID 0 (Scored)
-  - id: 5664 
+  - id: 5664
     title: "Ensure default group for the root account is GID 0"
     description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
     rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
@@ -2975,7 +2975,7 @@ the potential attack surface."
       - 'f:/etc/passwd -> r:^root:\w:\w:0'
 
 # 5.4.4 Ensure default user umask is 027 or more restrictive (Scored)
-  - id: 5665 
+  - id: 5665
     title: "Ensure default user umask is 027 or more restrictive"
     description: "The default umask determines the permissions of files created by users. The user creating the file has the discretion of making their files and directories readable by others via the chmod command. Users who wish to allow their files and directories to be readable by others by default may choose a different default umask by inserting the umask command into the standard shell configuration files ( .profile , .bashrc , etc.) in their home directories."
     rationale: "Setting a very secure default value for umask ensures that users make a conscious choice about their file permissions. A default umask setting of 077 causes files and directories created by users to not be readable by any other user on the system. A umask of 027 would make files and directories readable by users in the same Unix group, while a umask of 022 would make files readable by every user on the system."
@@ -2997,7 +2997,7 @@ the potential attack surface."
 
 
 # 5.4.5 Ensure default user shell timeout is 900 seconds or less (Scored)
-  - id: 5666 
+  - id: 5666
     title: "Ensure default user shell timeout is 900 seconds or less"
     description: "The default TMOUT determines the shell timeout for users. The TMOUT value is measured in seconds."
     rationale: "Having no timeout value associated with a shell could allow an unauthorized user access to another user's shell session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening."
@@ -3015,7 +3015,7 @@ the potential attack surface."
 
 
 # 5.6 Ensure access to the su command is restricted (Scored)
-  - id: 5667 
+  - id: 5667
     title: "Ensure access to the su command is restricted."
     description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo , which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su , the su command will only allow users in the wheel group to execute su ."
     rationale: "Restricting the use of su , and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo , whereas su can only record that a user executed the su program."
@@ -3044,7 +3044,7 @@ the potential attack surface."
 
 
 # 6.1.2 Configure /etc/passwd permissions (Scored)
-  - id: 5668 
+  - id: 5668
     title: "Ensure permissions on /etc/passwd are configured"
     description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
     rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3061,7 +3061,7 @@ the potential attack surface."
 
 
 # 6.1.3 Configure /etc/shadow permissions (Scored)
-  - id: 5669 
+  - id: 5669
     title: "Ensure permissions on /etc/shadow are configured"
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
@@ -3077,7 +3077,7 @@ the potential attack surface."
       - 'c:stat /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.4 Configure /etc/group permissions (Scored)
-  - id: 5670 
+  - id: 5670
     title: "Ensure permissions on /etc/group are configured"
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
@@ -3093,7 +3093,7 @@ the potential attack surface."
       - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.5 Configure /etc/gshadow permissions (Scored)
-  - id: 5671 
+  - id: 5671
     title: "Ensure permissions on /etc/gshadow are configured"
     description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/gshadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/gshadow file (such as group administrators) could also be useful to subvert the group"
@@ -3109,7 +3109,7 @@ the potential attack surface."
       - 'c:stat /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.6 Configure /etc/passwd- permissions (Scored)
-  - id: 5672 
+  - id: 5672
     title: "Ensure permissions on /etc/passwd- are configured"
     description: "The /etc/passwd- file contains backup user account information."
     rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3125,7 +3125,7 @@ the potential attack surface."
       - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Configure /etc/shadow- permissions (Scored)
-  - id: 5673 
+  - id: 5673
     title: "Ensure permissions on /etc/shadow- are configured"
     description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3141,7 +3141,7 @@ the potential attack surface."
       - 'c:stat /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.8 Configure /etc/group- permissions (Scored)
-  - id: 5674 
+  - id: 5674
     title: "Ensure permissions on /etc/group- are configured"
     description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
     rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3157,7 +3157,7 @@ the potential attack surface."
       - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Configure /etc/gshadow- permissions (Scored)
-  - id: 5675 
+  - id: 5675
     title: "Ensure permissions on /etc/gshadow- are configured"
     description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3176,7 +3176,7 @@ the potential attack surface."
 # 6.2 Review User and Group Settings
 ###############################################
 # 6.2.1 Check passwords fields (Scored)
-  - id: 5676 
+  - id: 5676
     title: "Ensure password fields are not empty"
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
@@ -3191,7 +3191,7 @@ the potential attack surface."
       - 'f:/etc/shadow -> !r:^# && r:^\w+::'
 
 # 6.2.2 Delete legacy entries in /etc/passwd (Scored)
-  - id: 5677 
+  - id: 5677
     title: "Ensure no legacy \"+\" entries exist in /etc/passwd"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -3210,7 +3210,7 @@ the potential attack surface."
       - 'f:/etc/passwd -> !r:^# && r:^+:'
 
 # 6.2.3 Delete legacy entries in /etc/shadow (Scored)
-  - id: 5678 
+  - id: 5678
     title: "Ensure no legacy \"+\" entries exist in /etc/shadow"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -3229,7 +3229,7 @@ the potential attack surface."
       - 'f:/etc/shadow -> !r:^# && r:^+:'
 
 # 6.2.4 Delete legacy entries in /etc/group (Scored)
-  - id: 5679 
+  - id: 5679
     title: "Ensure no legacy \"+\" entries exist in /etc/group"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -3248,7 +3248,7 @@ the potential attack surface."
       - 'f:/etc/group -> !r:^# && r:^+:'
 
 # 6.2.5 Verify No UID 0 Accounts Exist Other Than root (Scored)
-  - id: 5680 
+  - id: 5680
     title: "Ensure root is the only UID 0 account"
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."

--- a/ruleset/sca/centos/7/cis_centos7_linux.yml
+++ b/ruleset/sca/centos/7/cis_centos7_linux.yml
@@ -8,7 +8,7 @@
 # Foundation
 #
 # Based on:
-# Center for Internet Security CentOS 7 Benchmark v3.0.0 - 06-30-2020 
+# Center for Internet Security CentOS 7 Benchmark v3.0.0 - 06-30-2020
 
 policy:
   id: "cis_centos7_linux"
@@ -32,7 +32,7 @@ variables:
 checks:
 
 # 1.1.1.1 cramfs: filesystem
-  - id: 6000 
+  - id: 6000
     title: "Ensure mounting of cramfs filesystems is disabled"
     description: "The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
@@ -50,7 +50,7 @@ checks:
       - 'not c:lsmod -> r:cramfs'
 
 # 1.1.1.2 squashfs: filesystem
-  - id: 6001 
+  - id: 6001
     title: "Ensure mounting of squashfs filesystems is disabled"
     description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs ). A squashfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -68,7 +68,7 @@ checks:
       - 'not c:lsmod -> r:squashfs'
 
 # 1.1.1.3 udf: filesystem
-  - id: 6002 
+  - id: 6002
     title: "Ensure mounting of udf filesystems is disabled"
     description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -86,7 +86,7 @@ checks:
       - 'not c:lsmod -> r:udf'
 
 # 1.1.1.4 FAT: filesystem
-  - id: 6003 
+  - id: 6003
     title: "Ensure mounting of FAT filesystems is disabled"
     description: "The FAT filesystem format is primarily used on older windows systems and portable USB drives or flash modules. It comes in three types FAT12, FAT16, and FAT32 all of which are supported by the vfat kernel module."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -109,7 +109,7 @@ checks:
 
 
   # 1.1.2 /tmp: partition
-  - id: 6004 
+  - id: 6004
     title: "Ensure /tmp is configured"
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -129,7 +129,7 @@ checks:
       - 'c:systemctl is-enabled tmp.mount -> r:enabled'
 
 # 1.1.3 /tmp: noexec
-  - id: 6005 
+  - id: 6005
     title: "Ensure noexec option set on /tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
@@ -145,7 +145,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:noexec'
 
 # 1.1.4 /tmp: nodev
-  - id: 6006 
+  - id: 6006
     title: "Ensure nodev option set on /tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
@@ -161,7 +161,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:nodev'
 
 # 1.1.5 /tmp: nosuid
-  - id: 6007 
+  - id: 6007
     title: "Ensure nosuid option set on /tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
@@ -177,8 +177,8 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:nosuid'
 
 
-# 1.1.6 /dev/shm: 
-  - id: 6008 
+# 1.1.6 /dev/shm:
+  - id: 6008
     title: "Ensure /dev/shm is configured "
     description: "/dev/shm is a traditional shared memory concept. One program will create a memory portion, which other processes (if permitted) can access. Mounting tmpfs at /dev/shm is handled automatically by systemd."
     rationale: "Any user can upload and execute files inside the /dev/shm similar to the /tmp partition. Configuring /dev/shm allows an administrator to set the noexec option on the mount, making /dev/shm useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -198,7 +198,7 @@ checks:
 
 
 # 1.1.7 /dev/shm: noexec
-  - id: 6009 
+  - id: 6009
     title: "Ensure noexec option set on /dev/shm partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
@@ -214,7 +214,7 @@ checks:
       - 'c:mount -> r:\s/dev/shm\s && r:noexec'
 
 # 1.1.8 /dev/shm: nodev
-  - id: 6010 
+  - id: 6010
     title: "Ensure nodev option set on /dev/shm partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
@@ -231,7 +231,7 @@ checks:
 
 
 # 1.1.9 /dev/shm: nosuid
-  - id: 6011 
+  - id: 6011
     title: "Ensure nosuid option set on /dev/shm partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
@@ -249,7 +249,7 @@ checks:
 
 
 # 1.1.10 Build considerations - Partition scheme.
-  - id: 6012 
+  - id: 6012
     title: "Ensure separate partition exists for /var"
     description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
     rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
@@ -267,7 +267,7 @@ checks:
       - 'c:mount -> r:\s/var\s'
 
 # 1.1.11 bind mount /var/tmp to /tmp
-  - id: 6013 
+  - id: 6013
     title: "Ensure separate partition exists for /var/tmp"
     description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications and is intended for temporary files that are preserved across reboots."
     rationale: "Since the /var/tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own file system allows an administrator to set the noexec option on the mount, making /var/tmp useless for an attacker to install executable code."
@@ -283,7 +283,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s'
 
 # 1.1.12 noexec set on /var/tmp
-  - id: 6014 
+  - id: 6014
     title: "Ensure noexec option set on /var/tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
@@ -299,7 +299,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s && r:noexec'
 
 # 1.1.13 nodev set on /var/tmp
-  - id: 6015 
+  - id: 6015
     title: "Ensure nodev option set on /var/tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /var/tmp ."
@@ -315,7 +315,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s && r:nodev'
 
 # 1.1.14 nosuid set on /var/tmp
-  - id: 6016 
+  - id: 6016
     title: "Ensure nosuid option set on /var/tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
@@ -332,7 +332,7 @@ checks:
 
 
 # 1.1.15 /var/log: partition
-  - id: 6017 
+  - id: 6017
     title: "Ensure separate partition exists for /var/log"
     description: "The /var/log directory is used by system services to store log data ."
     rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
@@ -350,7 +350,7 @@ checks:
       - 'c:mount -> r:\s/var/log\s'
 
 # 1.1.16 /var/log/audit: partition
-  - id: 6018 
+  - id: 6018
     title: "Ensure separate partition exists for /var/log/audit"
     description: "The auditing daemon, auditd, stores log data in the /var/log/audit directory."
     rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data."
@@ -368,7 +368,7 @@ checks:
       - 'c:mount -> r:\s/var/log/audit\s'
 
 # 1.1.17 /home: partition
-  - id: 6019 
+  - id: 6019
     title: "Ensure separate partition exists for /home"
     description: "The /home directory is used to support disk storage needs of local users."
     rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
@@ -389,7 +389,7 @@ checks:
 
 
 # 1.1.18 /home: nodev
-  - id: 6020 
+  - id: 6020
     title: "Ensure nodev option set on /home partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
@@ -409,7 +409,7 @@ checks:
 
 
 # 1.1.23 Disable Automounting
-  - id: 6021 
+  - id: 6021
     title: "Disable Automounting"
     description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
     rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
@@ -425,7 +425,7 @@ checks:
       - 'c:systemctl is-enabled autofs -> r:enabled'
 
 # 1.1.24 Disable USB Storage
-  - id: 6022 
+  - id: 6022
     title: "Disable USB Storage"
     description: "USB storage provides a means to transfer and store files insuring persistence and availability of the files independent of network connection status. Its popularity and utility has led to USB-based malware being a simple and common means for network infiltration and a first step to establishing a persistent threat within a networked environment."
     rationale: "Restricting USB access on the system will decrease the physical attack surface for a device and diminish the possible vectors to introduce malware."
@@ -447,7 +447,7 @@ checks:
 ###############################################
 
 # 1.2.3 Activate gpgcheck
-  - id: 6023 
+  - id: 6023
     title: "Ensure gpgcheck is globally activated"
     description: "The gpgcheck option, found in the main section of the /etc/yum.conf and individual /etc/yum/repos.d/* files determines if an RPM package's signature is checked prior to its installation."
     rationale: "It is important to ensure that an RPM's package signature is always checked prior to installation to ensure that the software is obtained from a trusted source."
@@ -460,7 +460,7 @@ checks:
       - gpg_13: ["4.3"]
       - gdpr_IV: ["35.7.d"]
       - hipaa: ["164.312.b"]
-      - tsc: ["A1.2","CC6.8"]      
+      - tsc: ["A1.2","CC6.8"]
     condition: all
     rules:
       - 'f:/etc/yum.conf -> r:gpgcheck=1'
@@ -471,7 +471,7 @@ checks:
 ###############################################
 
 # 1.3.1 install sudo
-  - id: 6024 
+  - id: 6024
     title: "Ensure sudo is installed"
     description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy."
     rationale: "sudo supports a plugin architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plugins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
@@ -489,7 +489,7 @@ checks:
 
 
 # 1.3.2 Configure sudo
-  - id: 6025 
+  - id: 6025
     title: "Ensure sudo commands use pty"
     description: "sudo can be configured to run only from a pseudo-pty"
     rationale: "Attackers can run a malicious program using sudo, which would again fork a background process that remains even when the main program has finished executing. This can be mitigated by configuring sudo to run other commands only from a pseudo-pty, whether I/O logging is turned on or not."
@@ -507,7 +507,7 @@ checks:
       - 'd:/etc/sudoers.d/ -> r:\. -> r:^\s*Defaults\s*\t*\s*use_pty'
 
 # 1.3.3 Ensure sudo log file exists
-  - id: 6026 
+  - id: 6026
     title: "Ensure sudo log file exists"
     description: "sudo can use a custom log file"
     rationale: "A sudo log file simplifies auditing of sudo commands"
@@ -529,7 +529,7 @@ checks:
 ###############################################
 
 # 1.4.1 install AIDE
-  - id: 6027 
+  - id: 6027
     title: "Ensure AIDE is installed"
     description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
     rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
@@ -545,7 +545,7 @@ checks:
       - 'c:rpm -q aide -> r:aide-\S*'
 
 # 1.4.2 AIDE regular checks
-  - id: 6028 
+  - id: 6028
     title: "Ensure filesystem integrity is regularly checked"
     description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
     rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
@@ -568,7 +568,7 @@ checks:
 ###############################################
 
 # 1.5.1 Set Boot Loader Password (Scored)
-  - id: 6029 
+  - id: 6029
     title: "Ensure bootloader password is set"
     description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
     rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
@@ -587,7 +587,7 @@ checks:
 
 
 # 1.5.2 Configure bootloader
-  - id: 6030 
+  - id: 6030
     title: "Ensure permissions on bootloader config are configured"
     description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options. The grub configuration is usually located at /boot/grub2/grub.cfg and linked as /etc/grub2.cfg .  On newer grub2 systems the encrypted bootloader password is contained in /boot/grub2/user.cfg"
     rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
@@ -604,7 +604,7 @@ checks:
       - 'c:stat /boot/grub2/user.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|cannot stat'
 
 # 1.5.3 Single user authentication
-  - id: 6031 
+  - id: 6031
     title: "Ensure authentication required for single user mode"
     description: "Single user mode (rescue mode) is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
     rationale: "Requiring authentication in single user mode (rescue mode) prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
@@ -624,7 +624,7 @@ checks:
 # 1.6 Additional Process Hardening
 ###############################################
 # 1.6.1 Restrict Core Dumps (Scored)
-  - id: 6032 
+  - id: 6032
     title: "Ensure core dumps are restricted"
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file."
     rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
@@ -642,7 +642,7 @@ checks:
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
 # 1.6.2 XD/NX enabled
-  - id: 6033 
+  - id: 6033
     title: "Ensure XD/NX support is enabled"
     description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
     rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
@@ -659,7 +659,7 @@ checks:
       - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
 
 # 1.6.3 Enable Randomized Virtual Memory Region Placement (Scored)
-  - id: 6034 
+  - id: 6034
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
     rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
@@ -676,7 +676,7 @@ checks:
       - 'c:sysctl kernel.randomize_va_space -> r:^\s*kernel.randomize_va_space\s*=\s*2'
 
 # 1.6.4 Disable prelink
-  - id: 6035 
+  - id: 6035
     title: "Ensure prelink is disabled"
     description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
     rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
@@ -696,7 +696,7 @@ checks:
 ###############################################
 
 # 1.7.1.1 Install SELinux
-  - id: 6036 
+  - id: 6036
     title: "Ensure SELinux is installed"
     description: "SELinux provides Mandatory Access Controls."
     rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
@@ -713,7 +713,7 @@ checks:
 
 
 # 1.7.1.2 SELinux not disabled
-  - id: 6037 
+  - id: 6037
     title: "Ensure SELinux is not disabled in bootloader configuration"
     description: "Configure SELINUX to be enabled at boot time and verify that it has not been overwritten by the grub boot parameters."
     rationale: "SELinux must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
@@ -731,7 +731,7 @@ checks:
 
 
 # 1.7.1.3 Set selinux policy
-  - id: 6038 
+  - id: 6038
     title: "Ensure SELinux policy is configured"
     description: "Configure SELinux to meet or exceed the default targeted policy, which constrains daemons and system software only."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that at least the default recommendations are met."
@@ -751,7 +751,7 @@ checks:
 
 
 # 1.7.1.4 Set selinux mode
-  - id: 6039 
+  - id: 6039
     title: "Ensure the SELinux mode is enforcing or permissive"
     description: "SELinux can run in one of three modes: disabled, permissive, or enforcing:  Enforcing - Is the default, and recommended, mode of operation; in enforcing mode SELinux operates normally, enforcing the loaded security policy on the entire system.  Permissive - The system acts as if SELinux is enforcing the loaded security policy, including labeling objects and emitting access denial entries in the logs, but it does not actually deny any operations. While not recommended for production systems, permissive mode can be helpful for SELinux policy development.   Disabled -Is strongly discouraged; not only does the system avoid enforcing the SELinux policy, it also avoids labeling any persistent objects such as files, making it difficult to enable SELinux in the future"
     rationale: "Running SELinux in disabled modeis strongly discouraged; not only does the system avoid enforcing the SELinux policy, it also avoids labeling any persistent objects such as files, making it difficult to enable SELinux in the future."
@@ -769,7 +769,7 @@ checks:
 
 
 # 1.7.1.6 Ensure no unconfined services exist
-  - id: 6040 
+  - id: 6040
     title: "Ensure no unconfined services exist"
     description: "Unconfined processes run in unconfined domains"
     rationale: "For unconfined processes, SELinux policy rules are applied, but policy rules exist that allow processes running in unconfined domains almost all access. Processes running in unconfined domains fall back to using DAC rules exclusively. If an unconfined process is compromised, SELinux does not prevent an attacker from gaining access to system resources and data, but of course, DAC rules are still used. SELinux is a security enhancement on top of DAC rules – it does not replace them"
@@ -786,7 +786,7 @@ checks:
 
 
 # 1.7.1.7 Remove SETroubleshoot
-  - id: 6041 
+  - id: 6041
     title: "Ensure SETroubleshoot is not installed"
     description: "The SETroubleshoot service notifies desktop users of SELinux denials through a user-friendly interface. The service provides important information around configuration errors, unauthorized intrusions, and other potential errors."
     rationale: "The SETroubleshoot service is an unnecessary daemon to have running on a server, especially if X Windows is disabled."
@@ -803,7 +803,7 @@ checks:
 
 
 # 1.7.1.8 Disable MCS Translation service mcstrans
-  - id: 6042 
+  - id: 6042
     title: "Ensure the MCS Translation Service (mcstrans) is not installed"
     description: "The mcstransd daemon provides category label information to client processes requesting information. The label translations are defined in /etc/selinux/targeted/setrans.conf"
     rationale: "Since this service is not used very often, remove it to reduce the amount of potentially vulnerable code running on the system."
@@ -824,7 +824,7 @@ checks:
 # 1.8  Warning Banners
 ###############################################
 # 1.8.1.1 Configure message of the day (Scored)
-  - id: 6043 
+  - id: 6043
     title: "Ensure message of the day is configured properly"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -839,7 +839,7 @@ checks:
       - 'f:/etc/motd -> r:\\v|\\r|\\m|\\s'
 
 # 1.8.1.2 Configure local login warning banner (Not Scored)
-  - id: 6044 
+  - id: 6044
     title: "Ensure local login warning banner is configured properly"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version -or the operating system's name."
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -854,7 +854,7 @@ checks:
       - 'f:/etc/issue -> r:\\v|\\r|\\m|\\s'
 
 # 1.8.1.3 Configure remote login warning banner (Not Scored)
-  - id: 6045 
+  - id: 6045
     title: "Ensure remote login warning banner is configured properly"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -869,7 +869,7 @@ checks:
       - 'f:/etc/issue.net -> r:\\v|\\r|\\m|\\s'
 
 # 1.8.1.4 Configure /etc/motd permissions (Not Scored)
-  - id: 6046 
+  - id: 6046
     title: "Ensure permissions on /etc/motd are configured"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
     rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -888,7 +888,7 @@ checks:
       - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.8.1.5 Configure /etc/issue permissions (Scored)
-  - id: 6047 
+  - id: 6047
     title: "Ensure permissions on /etc/issue are configured"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
     rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -906,7 +906,7 @@ checks:
     rules:
       - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 # 1.8.1.6 Configure /etc/issue.net permissions (Not Scored)
-  - id: 6048 
+  - id: 6048
     title: "Ensure permissions on /etc/issue.net are configured"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
     rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -925,8 +925,8 @@ checks:
       - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 
-# 1.9 Ensure updates, patches, and additional security software are installed 
-  - id: 6049 
+# 1.9 Ensure updates, patches, and additional security software are installed
+  - id: 6049
     title: "Ensure updates, patches, and additional security software are installed"
     description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
     rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
@@ -946,7 +946,7 @@ checks:
 
 
 # 1.10 Ensure GDM login banner is configured (Scored)
-  - id: 6050 
+  - id: 6050
     title: "Ensure GDM login banner is configured"
     description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems."
     rationale: "If a graphical login is not required, it should be removed to reduce the attack surface of the system. If a graphical login is required, last logged in user display should be disabled, and a warning banner should be configured. Displaying the last logged in user eliminates half of the Userid/Password equation that an unauthorized person would need to log on. Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place."
@@ -978,7 +978,7 @@ checks:
 
 
 # 2.1.1 Ensure xinetd is not installed (Automated)
-  - id: 6051 
+  - id: 6051
     title: "Ensure daytime services are not enabled"
     description: "The eXtended InterNET Daemon ( xinetd ) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no xinetd services required, it is recommended that the package be removed to reduce the attack surface area of the system. Note: If an xinetd service or services are required, ensure that any xinetd service not required is stopped and disabled"
@@ -1003,7 +1003,7 @@ checks:
 
 
 # 2.2.1.1 Ensure time synchronization is in use (Manual)
-  - id: 6052 
+  - id: 6052
     title: "Ensure time synchronization is in use"
     description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
     rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
@@ -1020,7 +1020,7 @@ checks:
       - 'not c:rpm -q chrony -> r:^package chrony is not installed'
 
 # 2.2.1.2  Ensure chrony is configured (Automated)
-  - id: 6053 
+  - id: 6053
     title: "Ensure chrony is configured"
     description: "chrony is a daemon which implements the Network Time Protocol (NTP) and is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on chrony can be found at http://chrony.tuxfamily.org/. chrony can be configured to be a client and/or a server."
     rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly. Note: This recommendation only applies if chrony is in use on the system."
@@ -1037,7 +1037,7 @@ checks:
       - 'f:/etc/sysconfig/chronyd -> r:^OPTIONS\s*=\s* && r:-u chrony'
 
 # 2.2.1.3  Ensure ntp is configured (Automated)
-  - id: 6054 
+  - id: 6054
     title: "Ensure ntp is configured"
     description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://www.ntp.org. ntp can be configured to be a client and/or a server."
     rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
@@ -1057,7 +1057,7 @@ checks:
       - 'f:/usr/lib/systemd/system/ntpd.service -> r:^Execstart\s*=\s*/usr/sbin/ntpd\s+-u\s+ntp:ntp'
 
 # 2.2.2 Remove X Windows (Scored)
-  - id: 6055 
+  - id: 6055
     title: " Ensure X11 Server components are not installed"
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
@@ -1073,7 +1073,7 @@ checks:
       - 'c:rpm -q xorg-x11-server* -> r:package xorg-x11 is not installed'
 
 # 2.2.3 Ensure Avahi Server is not installed (Automated)
-  - id: 6056 
+  - id: 6056
     title: " Ensure Avahi Server is not installed"
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
@@ -1090,7 +1090,7 @@ checks:
       - 'c:rpm -q avahi-> r:pacakge avahi is not installed'
 
 # 2.2.4 Ensure CUPS is not installed (Automated)
-  - id: 6057 
+  - id: 6057
     title: "Ensure CUPS is not installed"
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface. Disabling CUPS will prevent printing from the system, a common task for workstation systems."
@@ -1106,7 +1106,7 @@ checks:
       - 'c:rpm -q cups-> r:package cups is not installed'
 
 # 2.2.5 Ensure DHCP Server is not installed (Automated)
-  - id: 6058 
+  - id: 6058
     title: "Ensure DHCP Server is not installed"
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this the dhcp package be removed to reduce the potential attack surface."
@@ -1124,7 +1124,7 @@ checks:
       - 'c:rpm -q dhcp-> r:package dhcp is not installed'
 
 # 2.2.6  Ensure LDAP server is not installed (Automated)
-  - id: 6059 
+  - id: 6059
     title: "Ensure LDAP Server is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
@@ -1144,7 +1144,7 @@ checks:
 
 
 # 2.2.7 Ensure nfs-utils is not installed or the nfs-server service is masked (Automated)
-  - id: 6060 
+  - id: 6060
     title: "Ensure nfs-utils is not installed or the nfs-server service is masked"
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not require network shares, it is recommended that the nfs-utils package be removed to reduce the attack surface of the system."
@@ -1161,7 +1161,7 @@ checks:
       - 'c:systemctl is-enabled nfs-server -> r:masked'
 
 # 2.2.8 Ensure rpcbind is not installed or the rpcbind services are masked (Automated)
-  - id: 6061 
+  - id: 6061
     title: "Ensure nfs-utils is not installed or the nfs-server service is masked"
     description: "The rpcbind utility maps RPC services to the ports on which they listen. RPC processes notify rpcbind when they start, registering the ports they are listening on and the RPC program numbers they expect to serve. The client system then contacts rpcbind on the server with a particular RPC program number. The rpcbind service redirects the client to the proper port number so it can communicate with the requested service Portmapper is an RPC service, which always listens on tcp and udp 111, and is used to map other RPC services (such as nfs, nlockmgr, quotad, mountd, etc.) to their corresponding port number on the server. When a remote host makes an RPC call to that server, it first consults with portmap to determine where the RPC server is listening"
     rationale: "A small request (~82 bytes via UDP) sent to the Portmapper generates a large response (7x to 28x amplification), which makes it a suitable tool for DDoS attacks. If rpcbind is not required, it is recommended that the rpcbind package be removed to reduce the attack surface of the system."
@@ -1180,7 +1180,7 @@ checks:
 
 
 # 2.2.9 Ensure DNS Server is not installed (Automate)
-  - id: 6062 
+  - id: 6062
     title: " Ensure DNS Server is not installed "
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be removed to reduce the potential attack surface."
@@ -1196,7 +1196,7 @@ checks:
       - 'c:rpm -q bind-> r:package bind is not installed'
 
 # 2.2.10 Ensure FTP Server is not installed (Automated)
-  - id: 6063 
+  - id: 6063
     title: "Ensure FTP Server is not installed"
     description: "FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring files between a server and clients over a network, especially where no authentication is necessary (permits anonymous users to connect to a server)"
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be removed to reduce the potential attack surface."
@@ -1212,7 +1212,7 @@ checks:
       - 'c:rpm -q vsftpd-> r:package vsftpd is not installed'
 
 # 2.2.11 Ensure HTTP server is not installed (Automated)
-  - id: 6064 
+  - id: 6064
     title: "Ensure HTTP server is not installed"
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be removed to reduce the potential attack surface."
@@ -1228,7 +1228,7 @@ checks:
       - 'c:rpm -q httpd-> r:package httpd is not installed'
 
 # 2.2.12 Ensure IMAP and POP3 server is not installed (Automated)
-  - id: 6065 
+  - id: 6065
     title: "Ensure IMAP and POP3 server is not installed"
     description: "dovecot is an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
@@ -1244,7 +1244,7 @@ checks:
       - 'c:rpm -q dovecot-> r:package dovecot is not installed'
 
 # 2.2.13 Ensure Samba is not installed (Automated)
-  - id: 6066 
+  - id: 6066
     title: "Ensure Samba is not installed"
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this package can be removed to reduce the potential attack surface."
@@ -1260,7 +1260,7 @@ checks:
       - 'c:rpm -q samba-> r:package samba is not installed'
 
 # 2.2.14 Ensure HTTP Proxy Server is not installed (Automated)
-  - id: 6067 
+  - id: 6067
     title: "Ensure HTTP Proxy Server is not installed"
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid package be removed to reduce the potential attack surface."
@@ -1276,7 +1276,7 @@ checks:
       - 'c:rpm -q squid-> r:package squid is not installed'
 
 # 2.2.15 Ensure net-snmp is not installed (Automated)
-  - id: 6068 
+  - id: 6068
     title: "Ensure SNMP Server is not installed"
     description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
     rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3replaces the simple/clear text password sharing used in SNMPv2with more securely encoded parameters. If the SNMP service is not required, the net-snmp package should be removed to reduce the attack surface of the system."
@@ -1292,7 +1292,7 @@ checks:
       - 'c:rpm -q net-snmp-> r:package net-snmp is not installed'
 
 # 2.2.16 Ensure mail transfer agent is configured for local-only mode (Automated)
-  - id: 6069 
+  - id: 6069
     title: "Ensure mail transfer agent is configured for local-only mode"
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems."
@@ -1308,7 +1308,7 @@ checks:
       - 'c:ss -lntu -> r:\.*:25\s* && !r:127.0.0.1:25\.*|::1:25\.*'
 
 # 2.2.17 Ensure rsync is not installed or the  ervice is masked (Automated)
-  - id: 6070 
+  - id: 6070
     title: "Ensure rsync is not installed or the rsyncd service is masked"
     description: "The rsyncd service can be used to synchronize files between systems over network links."
     rationale: "Unless required, the rsync package should be removed to reduce the attack surface area of the system. The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
@@ -1325,7 +1325,7 @@ checks:
       - 'c:systemctl is-enabled rsyncd-> r:masked'
 
   # 2.2.18 Ensure NIS server is not installed (Automated)
-  - id: 6071 
+  - id: 6071
     title: "Ensure NIS Server is not installed"
     description: "The ypserv package provides the Network Information Service (NIS). This service, formally known as Yellow Pages, is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the ypservpackage be removed, and if required a more secure services be used."
@@ -1345,7 +1345,7 @@ checks:
 
 
 # 2.2.19 Ensure telnet-server is not installed (Automated)
-  - id: 6072 
+  - id: 6072
     title: "Ensure telnet server is not installed"
     description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
@@ -1369,7 +1369,7 @@ checks:
 ###############################################
 
 # 2.3.1 Ensure NIS Client is not installed (Automated)
-  - id: 6073 
+  - id: 6073
     title: "Ensure NIS Client is not installed"
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client ( ypbind ) was used to bind a machine to an NIS server and receive the distributed configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
@@ -1388,7 +1388,7 @@ checks:
       - 'c:rpm -q ypbind -> r:package ypbind is not installed'
 
 # 2.3.2 Ensure rsh client is not installed (Automated)
-  - id: 6074 
+  - id: 6074
     title: "Ensure rsh client is not installed"
     description: "The rsh package contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh, rcp and rlogin ."
@@ -1407,7 +1407,7 @@ checks:
       - 'c:rpm -q rsh -> r:^package rsh is not installed'
 
 # 2.3.3 Ensure talk client is not installed (Automated)
-  - id: 6075 
+  - id: 6075
     title: "Ensure talk client is not installed"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -1426,7 +1426,7 @@ checks:
       - 'c:rpm -q talk -> r:^package talk is not installed'
 
 # 2.3.4 Ensure telnet client is not installed (Automated)
-  - id: 6076 
+  - id: 6076
     title: "Ensure telnet client is not installed"
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
@@ -1445,7 +1445,7 @@ checks:
       - 'c:rpm -q telnet -> r:^package telnet is not installed'
 
 # 2.3.5 Ensure LDAP client is not installed (Automated)
-  - id: 6077 
+  - id: 6077
     title: "Ensure LDAP client is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
@@ -1464,7 +1464,7 @@ checks:
       - 'c:rpm -q openldap-clients -> r:^package openldap-clients is not installed'
 
 # 2.5 Ensure nonessential services are removed or masked (Manual)
-  - id: 6078 
+  - id: 6078
     title: "Ensure nonessential services are removed or masked"
     description: "A network port is identified by its number, the associated IP address, and the type of the communication protocol such as TCP or UDP.A listening port is a network port on which an application or process listens on, acting as a communication endpoint. Each listening port can be open or closed (filtered) using a firewall. In general terms, an open port is a network port that accepts incoming packets from remote locations"
     rationale: "Services listening on the system pose a potential risk as an attack vector. These services should be reviewed, and if not required, the service should be stopped, and the package containing the service should be removed. If required packages have a dependency, the service should be stopped and masked to reduce the attack surface of the system."
@@ -1490,7 +1490,7 @@ checks:
 ###############################################
 
 # 3.1.1 Disable IPv6 (Manual)
-  - id: 6079 
+  - id: 6079
     title: "Disable IPv6"
     description: "Although IPv6 has many advantages over IPv4, not all organizations have IPv6 or dual stack configurations implemented."
     rationale: "If IPv6 or dual stack is not to be used, it is recommended that IPv6be disabled to reduce the attack surface of the system."
@@ -1508,8 +1508,8 @@ checks:
       - 'c:sysctl net.ipv6.conf.default.disable_ipv6-> r:net.ipv6.conf.default.disable_ipv6\s*=\s*0'
 
 
-# 3.1.2 Ensure wireless interfaces are disabled (Manual) 
-  - id: 6080 
+# 3.1.2 Ensure wireless interfaces are disabled (Manual)
+  - id: 6080
     title: "Ensure wireless interfaces are disabled"
     description: "Wireless networking is used when wired networks are unavailable."
     rationale: "If wireless is not to be used, wireless devices should be disabled to reduce the potential attack surface"
@@ -1530,7 +1530,7 @@ checks:
 
 
 # 3.2.1 Ensure IP forwarding is disabled (Automated)
-  - id: 6081 
+  - id: 6081
     title: "Ensure IP forwarding is disabled"
     description: "The net.ipv4.ip_forward flag is used to tell the system whether it can forward packets or not."
     rationale: "Setting the flag to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
@@ -1550,7 +1550,7 @@ checks:
 
 
 # 3.2.2 Ensure packet redirect sending is disabled (Automated)
-  - id: 6082 
+  - id: 6082
     title: "Ensure packet redirect sending is disabled"
     description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
     rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
@@ -1573,7 +1573,7 @@ checks:
 ##################################################
 
 # 3.3.1 Ensure source routed packets are not accepted (Automated)
-  - id: 6083 
+  - id: 6083
     title: "Ensure source routed packets are not accepted"
     description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
     rationale: "Setting net.ipv4.conf.all.accept_source_route and net.ipv4.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
@@ -1596,8 +1596,8 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_source_route /etc/sysctl.conf /etc/sysctl.d/* -> r:^net.ipv6.conf.default.accept_source_route\s*=\s*0'
 
 
-# 3.3.2 Ensure ICMP redirects are not accepted (Automated)  
-  - id: 6084 
+# 3.3.2 Ensure ICMP redirects are not accepted (Automated)
+  - id: 6084
     title: "Ensure ICMP redirects are not accepted"
     description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables."
     rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
@@ -1618,7 +1618,7 @@ checks:
 
 
 # 3.3.3 Ensure secure ICMP redirects are not accepted (Automated)
-  - id: 6085 
+  - id: 6085
     title: "Ensure secure ICMP redirects are not accepted"
     description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
     rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
@@ -1637,7 +1637,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0'
 
 # 3.3.4 Ensure suspicious packets are logged (Automated)
-  - id: 6086 
+  - id: 6086
     title: "Ensure suspicious packets are logged"
     description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
     rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their system."
@@ -1656,7 +1656,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1'
 
 # 3.3.5 Ensure broadcast ICMP requests are ignored (Automated)
-  - id: 6087 
+  - id: 6087
     title: "Ensure broadcast ICMP requests are ignored"
     description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
     rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
@@ -1673,7 +1673,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1'
 
 # 3.3.6 Ensure bogus ICMP responses are ignored (Automated)
-  - id: 6088 
+  - id: 6088
     title: "Ensure bogus ICMP responses are ignored"
     description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
     rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
@@ -1690,7 +1690,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1'
 
 # 3.3.7 Ensure Reverse Path Filtering is enabled (Automated)
-  - id: 6089 
+  - id: 6089
     title: "Ensure Reverse Path Filtering is enabled"
     description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
     rationale: "Setting these flags is a good way to deter attackers from sending your server bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing."
@@ -1709,7 +1709,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1'
 
 # 3.3.8 Ensure TCP SYN Cookies is enabled (Automated)
-  - id: 6090 
+  - id: 6090
     title: "Ensure TCP SYN Cookies is enabled"
     description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent."
     rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
@@ -1726,7 +1726,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.tcp_syncookies\s*=\s*1'
 
 # 3.3.9 Ensure IPv6 router advertisements are not accepted (Automated)
-  - id: 6091 
+  - id: 6091
     title: "Ensure IPv6 router advertisements are not accepted"
     description: "This setting disables the system's ability to accept IPv6 router advertisements."
     rationale: "It is recommended that systems not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
@@ -1753,7 +1753,7 @@ checks:
 # 3.4 Uncommon Network Protocols
 ###############################################
 # 3.4.1 Ensure DCCP is disabled (Automated)
-  - id: 6092 
+  - id: 6092
     title: "Ensure DCCP is disabled"
     description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery."
     rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
@@ -1775,7 +1775,7 @@ checks:
 
 
 # 3.4.2 Ensure SCTP is disabled (Automated)
-  - id: 6093 
+  - id: 6093
     title: "Ensure SCTP is disabled"
     description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1806,7 +1806,7 @@ checks:
 # 3.5.2.1 Ensure nftables is installed (Automated)
 # 3.5.3.1.1 Ensure iptables packages are installed (Automated)
 # 3 rules here:
-  - id: 6094 
+  - id: 6094
     title: "Ensure FirewallD or nftables or iptables-services is installed"
     description: "firewalld is a firewall management tool for Linux operating systems. It provides firewall features by acting as a front-end for the Linux kernel's net filter framework via the iptables backend or provides firewall features by acting as a front-end for the Linux kernel's netfilter framework via the nftables utility. FirewallD replaces iptables as the default firewall management tool. Use the firewalld utility to configure a firewall for less complex firewalls. The utility is easy to use and covers the typical use cases scenario. FirewallD supports both IPv4 and IPv6 networks and can administer separate firewall zones with varying degrees of trust as defined in zone profiles."
     rationale: "A firewall utility is required to configure the Linux kernel's netfilter framework via the iptables or nftables back-end. The Linux kernel's netfilter framework host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host."
@@ -1825,7 +1825,7 @@ checks:
 # 3.5.1.2 Ensure iptables-services package is not installed (Automated)
 # 3.5.3.1.3 Ensure firewalld is not installed or stopped and masked(Automated)
 # both of the rules are here
-  - id: 6095 
+  - id: 6095
     title: "Ensure iptables-services and FirewallD are not installed at the same time"
     description: "The iptables-services package contains the iptables.service and ip6tables.service. These services allow for management of the Host Based Firewall provided by the iptables package."
     rationale: "iptables.service and ip6tables.service are still supported and can be installed with the iptables-services package. Running both firewalld and the services included in the iptables-services package may lead to conflict."
@@ -1843,9 +1843,9 @@ checks:
 
 
 # 3.5.1.3 Ensure nftables is not installed or stopped and masked (Automated)
-# 3.5.2.2 Ensure firewalld is not installed or stopped and masked (Automated) 
+# 3.5.2.2 Ensure firewalld is not installed or stopped and masked (Automated)
 # Both of the rules are here
-  - id: 6096 
+  - id: 6096
     title: "Ensure nftables and FirewallD are not installed at the same time or ensure one of them is stopped and masked"
     description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables.Note: Support for using nftables as the back-end for firewalld was added in release v0.6.0. In Fedora 19 Linux derivatives, firewalld utilizes iptables as its back-end by default."
     rationale: "Running both firewalld and nftables may lead to conflict."
@@ -1863,7 +1863,7 @@ checks:
 # 3.5.3.1.2 Ensure nftables is not installed (Automated)
 # Both of the rules are here
 
-  - id: 6097 
+  - id: 6097
     title: "Ensure nftables and iptables-services are not installed at the same time or ensure one of them is stopped and masked"
     description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables.Note: Support for using nftables as the back-end for firewalld was added in release v0.6.0. In Fedora 19 Linux derivatives, firewalld utilizes iptables as its back-end by default."
     rationale: "Running both nftables and nftables may lead to conflict."
@@ -1882,7 +1882,7 @@ checks:
 
 
 # 3.5.1.4 Ensure firewalld service is enabled and running (Automated)
-  - id: 6098 
+  - id: 6098
     title: "Ensure firewalld service is enabled and running"
     description: "firewalld.serviceenables the enforcement of firewall rules configured through firewalld"
     rationale: "Ensure that the firewalld.service is enabled and running to enforce firewall rules configured through firewalld"
@@ -1903,7 +1903,7 @@ checks:
 ###############################################
 
 # 3.5.2.5 Ensure a table exists (Automated)
-  - id: 6099 
+  - id: 6099
     title: "Ensure a table exists"
     description: "nTables hold chains. Each table only has one address family and only applies to packets of this family. Tables can have one of five families."
     rationale: "nftables doesn't have any default tables. Without a table being build, nftables will not filter network traffic."
@@ -1918,7 +1918,7 @@ checks:
       - 'c:nft list tables-> r:table'
 
 # 3.5.2.6 Ensure base chains exist (Automated)
-  - id: 6100 
+  - id: 6100
     title: "Ensure base chains exist"
     description: "Chains are containers for rules. They exist in two kinds, base chains and regular chains. A base chain is an entry point for packets from the networking stack, a regular chain may be used as jump target and is used for better rule organization."
     rationale: "If a base chain doesn't exist with a hook for input, forward, and delete, packets that would flow through those chains will not be touched by nftables."
@@ -1935,7 +1935,7 @@ checks:
       - 'c:nft list ruleset-> r:type filter hook output priority 0'
 
 # 3.5.2.7 Ensure loopback traffic is configured (Automated)
-  - id: 6101 
+  - id: 6101
     title: "Ensure loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network"
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -1951,7 +1951,7 @@ checks:
       - 'c:nft list ruleset-> r:ip saddr 127.0.0.0/8 counter packets 0 bytes 0 drop'
 
 # 3.5.2.8 Ensure outbound and established connections are configured (Manual)
-  - id: 6102 
+  - id: 6102
     title: "Ensure outbound and established connections are configured"
     description: "Configure the firewall rules for new outbound and established connections."
     rationale: "If rules are not in place for new outbound and established connections, all packets will be dropped by the default policy preventing network usage."
@@ -1972,7 +1972,7 @@ checks:
 
 
 # 3.5.2.9 Ensure default deny firewall policy (Automated)
-  - id: 6103 
+  - id: 6103
     title: "Ensure default deny firewall policy"
     description: "Base chain policy is the default verdict that will be applied to packets reaching the end of the chain."
     rationale: "There are two policies: accept (Default) and drop. If the policy is set to accept, the firewall will accept any packet that is not configured to be denied and the packet will continue traversing the network stack. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -1989,7 +1989,7 @@ checks:
       - 'c:nft list ruleset-> r:type filter hook output priority 0; policy drop;'
 
 # 3.5.2.10 Ensure nftables service is enabled (Automated)
-  - id: 6104 
+  - id: 6104
     title: "Ensure nftables service is enabled"
     description: "The nftables service allows for the loading of nftables rulesets during boot, or starting on the nftables service"
     rationale: "The nftables service restores the nftables rules from the rules files referenced in the /etc/sysconfig/nftables.conffile during boot or the starting of the nftables service"
@@ -2003,10 +2003,10 @@ checks:
     rules:
       - 'c:systemctl is-enabled nftables-> r:enabled'
       - 'c:nft list ruleset-> r:type filter hook forward priority 0; policy drop;'
-      - 'c:nft list ruleset-> r:type filter hook output priority 0; policy drop;'   
+      - 'c:nft list ruleset-> r:type filter hook output priority 0; policy drop;'
 
 # 3.5.2.11 Ensure nftables rules are permanent (Automated)
-  - id: 6105 
+  - id: 6105
     title: "Ensure nftables rules are permanent"
     description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames. The nftables service reads the /etc/sysconfig/nftables.conffile for a nftables file or files to include in the nftables ruleset. A nftables ruleset containing the input, forward, and output base chains allow network traffic to be filtered."
     remediation: "Run the following command to enable the nftables service: # systemctl enable nftables"
@@ -2030,7 +2030,7 @@ checks:
 ###############################################
 
 # 3.5.3.2.1 Ensure default deny firewall policy (Automated)
-  - id: 6106 
+  - id: 6106
     title: "Ensure default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -2048,7 +2048,7 @@ checks:
 
 
 # 3.5.3.2.2 Ensure loopback traffic is configured (Automated)
-  - id: 6107 
+  - id: 6107
     title: "Ensure loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -2065,7 +2065,7 @@ checks:
       - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
 
 # 3.5.3.2.6 Ensure iptables is enabled and running (Automated)
-  - id: 6108 
+  - id: 6108
     title: "Ensure iptables is enabled and running"
     description: "iptables.service is a utility for configuring and maintaining iptables."
     rationale: "iptables.service willload the iptables rules saved in the file /etc/sysconfig/iptablesat boot, otherwise the iptables rules will be cleared during a re-boot of the system."
@@ -2085,7 +2085,7 @@ checks:
 ###############################################
 
 # 3.5.3.3.1 Ensure IPv6 default deny firewall policy (Automated)
-  - id: 6109 
+  - id: 6109
     title: "Ensure IPv6 default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -2103,7 +2103,7 @@ checks:
 
 
 # 3.5.3.3.2 Ensure IPv6 loopback traffic is configured (Automated)
-  - id: 6110 
+  - id: 6110
     title: "Ensure IPv6 loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic tothe loopback network (::1)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (::1) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure"
@@ -2120,7 +2120,7 @@ checks:
       - 'c:ip6tables -L OUTPUT -v -n-> r:ACCEPT'
 
 # 3.5.3.3.3 Ensure IPv6 outbound and established connections are configured (Manual)
-  - id: 6111 
+  - id: 6111
     title: "Ensure IPv6 outbound and established connections are configured"
     description: "Configure the firewall rules for new outbound, and established IPv6 connections."
     rationale: "If rules are not in place for new outbound, and established connections all packets will be dropped by the default policy preventing network usage"
@@ -2137,7 +2137,7 @@ checks:
 
 
 # 3.5.3.3.6 Ensure ip6tables is enabled and running (Automated)
-  - id: 6112 
+  - id: 6112
     title: "Ensure ip6tables is enabled and running"
     description: "ip6tables.service is a utility for configuring and maintaining ip6tables."
     rationale: "ip6tables.service will load the iptables rules saved in the file /etc/sysconfig/ip6tables at boot, otherwise the ip6tables rules will be cleared during a re-boot of the system."
@@ -2162,7 +2162,7 @@ checks:
 ###############################################
 
 # 4.1.1.1 Ensure auditd is installed
-  - id: 6113 
+  - id: 6113
     title: "Ensure auditd is installed"
     description: "auditd is the userspace component to the Linux Auditing System. It's responsible for writing audit records to the disk."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -2178,7 +2178,7 @@ checks:
       - 'c:rpm -q audit-libs -> r:^audit-libs-\S+'
 
 # 4.1.1.2 Ensure auditd service is enabled (Scored)
-  - id: 6114 
+  - id: 6114
     title: "Ensure auditd service is enabled and running"
     description: "Turn on the auditd daemon to record system events."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -2195,7 +2195,7 @@ checks:
 
 
 # 4.1.1.3 Ensure auditing for processes that start prior to auditd is enabled (Scored)
-  - id: 6115 
+  - id: 6115
     title: "Ensure auditing for processes that start prior to auditd is enabled"
     description: "Configure grub so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
     rationale: "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected. Note: This recommendation is designed around the grub2 bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings."
@@ -2212,7 +2212,7 @@ checks:
       - 'f:/boot/grub2/grub.cfg -> r:^\s*\t*linux && !r:audit=1'
 
 # 4.1.2.1 Ensure audit log storage size is configured (Not Scored)
-  - id: 6116 
+  - id: 6116
     title: "Ensure audit log storage size is configured"
     description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
     rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
@@ -2226,7 +2226,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^max_log_file = \d+'
 
 # 4.1.2.2 Ensure audit logs are not automatically deleted (Scored)
-  - id: 6117 
+  - id: 6117
     title: "Ensure audit logs are not automatically deleted"
     description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
     rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
@@ -2240,7 +2240,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file_action\s*=\s*keep_logs'
 
 # 4.1.2.3 Ensure system is disabled when audit logs are full (Scored)
-  - id: 6118 
+  - id: 6118
     title: "Ensure system is disabled when audit logs are full"
     description: "The auditd daemon can be configured to halt the system when the audit logs are full."
     rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
@@ -2256,7 +2256,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*admin_space_left_action\s*=\s*halt'
 
 # 4.1.2.4 Ensure audit_backlog_limit is sufficient
-  - id: 6119 
+  - id: 6119
     title: "Ensure audit_backlog_limit is sufficient"
     description: "The backlog limit has a default setting of 64"
     rationale: "During boot if audit=1, then the backlog will hold 64 records. If more than 64 records are created during boot, auditd records will be lost and potential malicious activity could go undetected"
@@ -2270,9 +2270,9 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:audit_backlog_limit='
 
 
-      
+
 # 4.1.3 Ensure events that modify date and time information are collected (Scored)
-  - id: 6120 
+  - id: 6120
     title: "Ensure events that modify date and time information are collected"
     description: "Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier \"time-change\"."
     rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
@@ -2293,7 +2293,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/localtime && r:-p wa && r:-k time-change'
 
 # 4.1.4 Ensure events that modify user/group information are collected (Scored)
-  - id: 6121 
+  - id: 6121
     title: "Ensure events that modify user/group information are collected"
     description: "Record events affecting the group, passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier \"identity\" in the audit log file."
     rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
@@ -2316,7 +2316,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/security/opasswd && r:-p wa && r:-k identity'
 
 # 4.1.5 Ensure events that modify the system's network environment are collected (Scored)
-  - id: 6122 
+  - id: 6122
     title: "Ensure events that modify the system's network environment are collected"
     description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed pre-login), /etc/hosts (file containing host names and associated IP addresses), /etc/sysconfig/network file and /etc/sysconfig/network-scripts/ directory (containing network interface scripts and configurations)."
     rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/sysconfig/network and /etc/sysconfig/network-scripts/ is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier \"system-locale.\""
@@ -2340,7 +2340,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/sysconfig/network-scripts/ && r:-p wa && r:-k system-locale'
 
 # 4.1.6 Ensure events that modify the system's Mandatory Access Controls are collected (Scored)
-  - id: 6123 
+  - id: 6123
     title: "Ensure events that modify the system's Mandatory Access Controls are collected"
     description: "Monitor SELinux mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to  the /etc/selinux/ and /usr/share/selinux/ directories."
     rationale: "Changes to files in the /etc/selinux/ and /usr/share/selinux/ directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
@@ -2360,7 +2360,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /usr/share/selinux/ && r:-p wa && r:-k MAC-policy'
 
 # 4.1.7 Ensure login and logout events are collected (Scored)
-  - id: 6124 
+  - id: 6124
     title: "Ensure login and logout events are collected"
     description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. The file /var/log/faillog tracks failed events from login. The file /var/log/lastlog maintain records of the last time a user successfully logged in. The /var/run/faillock/ directory maintains records of login failures via the pam_faillock module. The file /var/log/tallylog maintains records of failures via the pam_tally2 module"
     rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
@@ -2380,7 +2380,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /var/run/faillog/ && r:-p wa && r:-k logins'
 
 # 4.1.8 Ensure session initiation information is collected (Scored)
-  - id: 6125 
+  - id: 6125
     title: "Ensure session initiation information is collected"
     description: "Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp file tracks all currently logged in users. All audit records will be tagged with the identifier \"session.\" The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp . All audit records will be tagged with the identifier \"logins.\"."
     rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
@@ -2397,7 +2397,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /var/log/btmp && r:-p wa && r:-k logins'
 
 # 4.1.9 Ensure discretionary access control permission modification events are collected (Scored)
-  - id: 6126 
+  - id: 6126
     title: "Ensure discretionary access control permission modification events are collected"
     description: "Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The chmod, fchmod and fchmodat system calls affect the permissions associated with a file. The chown, fchown, fchownat and lchown system calls affect owner and group attributes on a file. The setxattr, lsetxattr, fsetxattr (set extended file attributes) and removexattr, lremovexattr, fremovexattr (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier \"perm_mod.\""
     rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
@@ -2418,7 +2418,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S setxattr && r:-S lsetxattr && r:-S fsetxattr && r:-S removexattr && r:-S lremovexattr && r:-S fremovexattr && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
 
 # 4.1.10 Ensure unsuccessful unauthorized file access attempts are collected (Scored)
-  - id: 6127 
+  - id: 6127
     title: "Ensure unsuccessful unauthorized file access attempts are collected"
     description: "Monitor for unsuccessful attempts to access files. The parameters below are associated  with system calls that control creation ( creat ), opening ( open, openat ) and truncation (  truncate, ftruncate ) of files. An audit log record will only be written if the user is a non-  privileged user (auid > = 1000), is not a Daemon event (auid=4294967295) and if the  system call returned EACCES (permission denied to the file) or EPERM (some other  permanent error associated with the specific system call). All audit records will be tagged  with the identifier \"access.\""
     rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
@@ -2438,7 +2438,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-S ftruncate && r:-F exit=-EPERM && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
 
 # 4.1.12 Ensure successful file system mounts are collected (Scored)
-  - id: 6128 
+  - id: 6128
     title: "Ensure successful file system mounts are collected"
     description: "Monitor the use of the mount system call. The mount (and umount ) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user."
     rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open, creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
@@ -2458,7 +2458,7 @@ checks:
 
 
 # 4.1.13 Ensure file deletion events by users are collected (Scored)
-  - id: 6129 
+  - id: 6129
     title: "Ensure file deletion events by users are collected"
     description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for ollowing system calls and tags them with the identifier \"delete\": unlink -remove a file     unlinkat - remove a file attribute), rename (rename a file and renameat - rename a file attribute."
     rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
@@ -2473,7 +2473,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S unlink && r:-S unlinkat && r:-S rename && r:-S renameat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k delete'
 
 # 4.1.14 Ensure changes to system administration scope (sudoers) is collected (Scored)
-  - id: 6130 
+  - id: 6130
     title: "Ensure changes to system administration scope (sudoers) is collected"
     description: "Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers or a file in the /etc/sudoers.d directory will be written to when the file or its attributes have changed."
     rationale: "Changes in the /etc/sudoers file, or a file in the /etc/sudoers.d/ directory can indicate that an unauthorized change has been made to scope of system administrator activity."
@@ -2493,7 +2493,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/sudoers.d/ && r:-p wa && r:-k scope'
 
 # 4.1.15 Ensure system administrator actions (sudolog) are collected (Scored)
-  - id: 6131 
+  - id: 6131
     title: "Ensure system administrator actions (sudolog) are collected"
     description: "Monitor the sudo log file. The sudo log file is configured in /etc/sudoersor a file in /etc/sudoers.d. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to the sudo log file. Any time a command is executed, an audit event will be triggered as the sudo log file will be opened for write and the executed administration command will be written to the log."
     rationale: "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed."
@@ -2512,7 +2512,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /var/log/sudo.log && r:-p wa && r:-k actions'
 
 # 4.1.16 Ensure kernel module loading and unloading is collected (Scored)
-  - id: 6132 
+  - id: 6132
     title: "Ensure kernel module loading and unloading is collected"
     description: "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\"."
     rationale: "Monitoring the use of insmod, rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
@@ -2532,9 +2532,9 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /sbin/rmmod && r:-p x && r:-k modules'
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /sbin/modprobe && r:-p x && r:-k modules'
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b\d\d && r:-S init_module && r:-S delete_module && r:-k modules'
-      
+
 # 4.1.17 Ensure the audit configuration is immutable (Scored)
-  - id: 6133 
+  - id: 6133
     title: "Ensure the audit configuration is immutable"
     description: "Set system audit so that audit rules cannot be modified with auditctl . Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot."
     rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
@@ -2555,7 +2555,7 @@ checks:
 
 
 # 4.2.1.1 Ensure rsyslog is installed (Scored)
-  - id: 6134 
+  - id: 6134
     title: "Ensure rsyslog is installed"
     description: "The rsyslog software is a recommended replacement to the original syslogd daemon. rsyslog provides improvements over syslogd, including:   - connection-oriented (i.e. TCP) transmission of logs     - The option to log to database formats    - Encryption of log data en route to a central logging server"
     rationale: "The security enhancements of rsyslog and syslog-ng such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
@@ -2571,7 +2571,7 @@ checks:
 
 
 # 4.2.1.2 Ensure rsyslog Service is enabled (Scored)
-  - id: 6135 
+  - id: 6135
     title: "Ensure rsyslog Service is enabled and running"
     description: "rsyslogneeds to be enabled and running to perform logging"
     rationale: "If the rsyslog service is not activated the system may default to the syslogd service or lackblogging instead."
@@ -2587,14 +2587,14 @@ checks:
       - 'c:systemctl status rsyslog -> r:active \(running\)'
 
 # 4.2.1.3 Ensure rsyslog default file permissions configured (Scored)
-  - id: 6136 
+  - id: 6136
     title: "Ensure rsyslog default file permissions configured"
     description: "rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
     remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to 0640 or more restrictive:   $FileCreateMode 0640"
     compliance:
       - cis: ["4.2.1.3"]
-      - cis_csc: ["5.1"]  
+      - cis_csc: ["5.1"]
       - pci_dss: ["10.5"]
       - tsc: ["CC6.1","CC7.2","CC7.3","CC7.4"]
     condition: all
@@ -2603,7 +2603,7 @@ checks:
       - 'd:/etc/rsyslog.d/ -> r:\.*.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
 
 # 4.2.1.5 Ensure rsyslog is configured to send logs to a remote log host (Scored)
-  - id: 6137 
+  - id: 6137
     title: "Ensure rsyslog is configured to send logs to a remote log host"
     description: "The rsyslog utility supports the ability to send logs it gathers to a remote log host running syslogd(8) or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2620,11 +2620,11 @@ checks:
 
 ###############################################
 # 4.2 Configure journald
-############################################### 
+###############################################
 
 
-# 4.2.2.1 Ensure journald is configured to send logs to rsyslog 
-  - id: 6138 
+# 4.2.2.1 Ensure journald is configured to send logs to rsyslog
+  - id: 6138
     title: "Ensure journald is configured to send logs to rsyslog "
     description: "Data from journald may be stored in volatile memory or persisted locally on the server. Utilities exist to accept remote export of journald logs, however, use of the rsyslog service provides a consistent means of log collection and export."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2639,30 +2639,30 @@ checks:
       - 'f:/etc/systemd/journald.conf -> r:^\s*ForwardToSyslog\s*=\s*yes'
 
 # 4.2.2.2 Ensure journald is configured to compress large log files
-  - id: 6139 
+  - id: 6139
     title: "Ensure journald is configured to compress large log files"
     description: "The journald system includes the capability of compressing overly large files to avoid filling up the system with logs or making the logs unmanageably large."
     rationale: "Uncompressed large files may unexpectedly fill a filesystem leading to resource unavailability. Compressing logs prior to write can prevent sudden, unexpected filesystem impacts."
     remediation: "Edit the /etc/systemd/journald.conf file and add the following line: Compress=yes"
     compliance:
       - cis: ["4.2.2.2"]
-      - cis_csc: ["6.4"]    
-      - pci_dss: ["10.5"]  
+      - cis_csc: ["6.4"]
+      - pci_dss: ["10.5"]
       - tsc: ["CC6.1","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
       - 'f:/etc/systemd/journald.conf -> r:^\s*Compress\s*=\s*yes'
 
 # 4.2.2.3 Ensure journald is configured to write logfiles to persistent disk
-  - id: 6140 
+  - id: 6140
     title: "Ensure journald is configured to compress large log files"
     description: "Data from journald may be stored in volatile memory or persisted locally on the server. Logs in memory will be lost upon a system reboot. By persisting logs to local disk on the server they are protected from loss."
     rationale: "Writing log data to disk will provide the ability to forensically reconstruct events which may have impacted the operations or security of a system even after a system crash or reboot."
     remediation: "Edit the /etc/systemd/journald.conf file and add the following line: Storage=persistent"
     compliance:
       - cis: ["4.2.2.3"]
-      - cis_csc: ["6.2","6.3"]    
-      - pci_dss: ["10.5"]  
+      - cis_csc: ["6.2","6.3"]
+      - pci_dss: ["10.5"]
       - tsc: ["CC6.1","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
@@ -2671,7 +2671,7 @@ checks:
 
 
   # 4.2.3 Ensure permissions on all logfiles are configured (Scored)
-  - id: 6141 
+  - id: 6141
     title: "Ensure permissions on all logfiles are configured"
     description: "Log files stored in /var/log/ contain logged information from many services on the system, or on log hosts others as well."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected.  Other/world should not have the ability to view this information. Group should not have the ability to modify this information."
@@ -2692,7 +2692,7 @@ checks:
 # 5.1 Configure time-based job schedulers
 ####################################################
 # 5.1.1 Ensure cron daemon is enabled and running (Automated)
-  - id: 6142 
+  - id: 6142
     title: "Ensure cron daemon is enabled"
     description: "The cron daemon is used to execute batch jobs on the system."
     rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
@@ -2710,7 +2710,7 @@ checks:
 
 
 # 5.1.2 Ensure permissions on /etc/crontab are configured (Automated)
-  - id: 6143 
+  - id: 6143
     title: "Ensure permissions on /etc/crontab are configured"
     description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
     rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
@@ -2727,7 +2727,7 @@ checks:
 
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Automated)
-  - id: 6144 
+  - id: 6144
     title: "Ensure permissions on /etc/cron.hourly are configured"
     description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2743,7 +2743,7 @@ checks:
       - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Automated)
-  - id: 6145 
+  - id: 6145
     title: "Ensure permissions on /etc/cron.daily are configured"
     description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2759,7 +2759,7 @@ checks:
       - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Automated)
-  - id: 6146 
+  - id: 6146
     title: "Ensure permissions on /etc/cron.weekly are configured"
     description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2776,7 +2776,7 @@ checks:
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Automated)
-  - id: 6147 
+  - id: 6147
     title: "Ensure permissions on /etc/cron.monthly are configured"
     description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2792,7 +2792,7 @@ checks:
       - 'c:stat /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Automated)
-  - id: 6148 
+  - id: 6148
     title: "Ensure permissions on /etc/cron.d are configured"
     description: "The /etc/cron.d/directory contains system cronjobs that need to run in a similar manner to the hourly, daily weekly and monthly jobs from /etc/crontab, but require more granular control as to when they run. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2808,7 +2808,7 @@ checks:
       - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.8 Ensure cron is restricted to authorized users (Scored)
-  - id: 6149 
+  - id: 6149
     title: "Ensure cron is restricted to authorized users"
     description: "If cronis installed in the system, configure /etc/cron.allowto allow specific users to use these services. If /etc/cron.allowdoes not exist, then /etc/cron.denyis checked. Any user not specifically defined in those files is allowed to use cron. By removing the file, only users in /etc/cron.alloware allowed to use cron."
     rationale: "On many systems, only the system administrator is authorized to schedule cronjobs. Using the cron.allowfile to control who can run cronjobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2826,7 +2826,7 @@ checks:
       - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.9 Ensure at is restricted to authorized users (Automated)
-  - id: 6150 
+  - id: 6150
     title: "Ensure at is restricted to authorized users"
     description: "If atis installed in the system, configure /etc/at.allowto allow specific users to use these services. If /etc/at.allowdoes not exist, then /etc/at.denyis checked. Any user not specifically defined in those files is allowed to use at. By removing the file, only users in /etc/at.alloware allowed to use at."
     rationale: "On many systems, only the system administrator is authorized to schedule atjobs. Using the at.allowfile to control who can run atjobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2843,12 +2843,12 @@ checks:
       - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
-      
+
 ###############################################
 # 5.2 Configure SSH Server
 ###############################################
 # 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured (Automated)
-  - id: 6151 
+  - id: 6151
     title: "Ensure permissions on /etc/ssh/sshd_config are configured"
     description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
     rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
@@ -2866,7 +2866,7 @@ checks:
 
 
 # 5.2.2 Ensure permissions on SSH private host key files are configured (Automated)
-  - id: 6152 
+  - id: 6152
     title: "Ensure permissions on SSH private host key files are configured"
     description: "An SSH private key is one of two files used in SSH public key authentication. In this authentication method, The possession of the private key is proof of identity. Only a private key that corresponds to a public key will be able to authenticate successfully. The private keys need to be stored and handled carefully, and no copies of the private key should be distributed."
     rationale: "If an unauthorized user obtains the private SSH host key file, the host could be impersonated"
@@ -2885,7 +2885,7 @@ checks:
 
 
 # 5.2.3 Ensure permissions on SSH public host key files are configured  (Automated)
-  - id: 6153 
+  - id: 6153
     title: "Ensure permissions on SSH private host key files are configured"
     description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
     rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
@@ -2901,11 +2901,11 @@ checks:
       - 'c:find /etc/ssh -xdev -type f -name "ssh_host_rsa_key.pub" -exec stat {} \;->^Access: \(0\d444/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
       - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ecdsa_key.pub" -exec stat {} \;->^Access: \(0\d44/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
       - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ed25519_key.pub" -exec stat {} \;->^Access: \(0\d44/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      
-   
-    
+
+
+
 # 5.2.4 Ensure SSH access is limited (Scored)
-  - id: 6154 
+  - id: 6154
     title: "Ensure SSH access is limited"
     description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: AllowUsers The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. AllowGroups The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable. DenyUsers The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. DenyGroups The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
     rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
@@ -2923,7 +2923,7 @@ checks:
       - 'f:$sshd_file -> r:^\s*DenyGroups'
 
 # 5.2.5 Ensure SSH LogLevel is appropriate (Automated)
-  - id: 6155 
+  - id: 6155
     title: "Ensure SSH LogLevel is appropriate"
     description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field.VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
     rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
@@ -2942,7 +2942,7 @@ checks:
 
 
 # 5.2.6 Ensure SSH X11 forwarding is disabled (Automated)
-  - id: 6156 
+  - id: 6156
     title: "Ensure SSH X11 forwarding is disabled"
     description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
     rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
@@ -2960,7 +2960,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> r:^\s*X11Forwarding\s*\t*no'
 
 # 5.2.7 Ensure SSH MaxAuthTries is set to 4 or less (Automated)
-  - id: 6157 
+  - id: 6157
     title: "Ensure SSH MaxAuthTries is set to 4 or less"
     description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
     rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
@@ -2978,7 +2978,7 @@ checks:
 
 
 # 5.2.8 Ensure SSH IgnoreRhosts is enabled (Automated)
-  - id: 6158 
+  - id: 6158
     title: "Ensure SSH IgnoreRhosts is enabled"
     description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
     rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
@@ -2995,7 +2995,7 @@ checks:
       - 'f:$sshd_file -> !r:^# && r:IgnoreRhosts\s*\t*yes'
 
 # 5.2.9 Ensure SSH HostbasedAuthentication is disabled (Automated)
-  - id: 6159 
+  - id: 6159
     title: "Ensure SSH HostbasedAuthentication is disabled"
     description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
     rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
@@ -3012,7 +3012,7 @@ checks:
       - 'f:$sshd_file -> !r:^# && r:HostbasedAuthentication\s*\t*no'
 
 # 5.2.10 Ensure SSH root login is disabled (Automated)
-  - id: 6160 
+  - id: 6160
     title: "Ensure SSH root login is disabled"
     description: "The PermitRootLogin parameter specifies if the root user can log in using ssh. The default is no."
     rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su . This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
@@ -3029,7 +3029,7 @@ checks:
       - 'f:$sshd_file -> !r:^# && r:PermitRootLogin\s*\t*no'
 
 # 5.2.11 Ensure SSH PermitEmptyPasswords is disabled (Automated)
-  - id: 6161 
+  - id: 6161
     title: "Ensure SSH PermitEmptyPasswords is disabled"
     description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
     rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
@@ -3046,7 +3046,7 @@ checks:
       - 'f:$sshd_file -> !r:^# && r:PermitEmptyPasswords\s*\t*no'
 
 # 5.2.12 Ensure SSH PermitUserEnvironment is disabled (Automated)
-  - id: 6162 
+  - id: 6162
     title: "Ensure SSH PermitUserEnvironment is disabled"
     description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
     rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing trojan'd programs)"
@@ -3063,7 +3063,7 @@ checks:
       - 'f:$sshd_file -> r:^\s*PermitUserEnvironment\s*\t*no'
 
 # 5.2.13 Ensure only strong Ciphers are used (Automated)
-  - id: 6163 
+  - id: 6163
     title: "Ensure SSH Idle Timeout Interval is configured"
     description: "This variable limits the ciphers that SSH can use during communication."
     rationale: "Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised.: The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain cleartext data via a birthday attack against a long-duration encrypted session, aka a 'Sweet32' attack; The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly combine state data with key data during the initialization phase, which makes it easier for remote attackers to conduct plaintext-recovery attacks against the initial bytes of a stream by sniffing network traffic that occasionally relies on keys affected by the Invariance Weakness, and then using a brute-force approach involvingLSB values, aka the 'Bar Mitzvah' issue; The passwords used during an SSH session encrypted with RC4 can be recovered by an attacker who is able to capture and replay the session; Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plaintext data from an arbitrary block of ciphertext in an SSH session via unknown vectors; The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher is used, does not properly initialize memory for a MAC context data structure, which allows remote authenticated users to bypass intended ForceCommand and login-shell restrictions via packet data that provides a crafted callback address"
@@ -3074,10 +3074,10 @@ checks:
       - pci_dss: ["12.3.8"]
     condition: none
     rules:
-      - 'c:sshd -T -> r:ciphers && r:3des-cbc|aes192-cbc|aes256-cbc|arcfour|blowfish-cbc|cast128-cbc|rijndael-cbc@lysator.liu.se'      
+      - 'c:sshd -T -> r:ciphers && r:3des-cbc|aes192-cbc|aes256-cbc|arcfour|blowfish-cbc|cast128-cbc|rijndael-cbc@lysator.liu.se'
 
 # 5.2.14 Ensure only strong MAC algorithms are used (Automated)
-  - id: 6164 
+  - id: 6164
     title: "Ensure only strong MAC algorithms are used"
     description: "This variable limits the types of MAC algorithms that SSH can use during communication."
     rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information"
@@ -3088,11 +3088,11 @@ checks:
       - pci_dss: ["12.3.8"]
     condition: none
     rules:
-      - 'c:sshd -T -> r:macs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|umac-128@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com'      
+      - 'c:sshd -T -> r:macs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|umac-128@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com'
 
 
 # 5.2.15 Ensure only strong Key Exchange algorithms are used (Automated)
-  - id: 6165 
+  - id: 6165
     title: "Ensure only strong Key Exchange algorithms are used"
     description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received"
     rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks"
@@ -3103,12 +3103,12 @@ checks:
       - pci_dss: ["12.3.8"]
     condition: none
     rules:
-      - 'c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1'      
+      - 'c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1'
 
 
 
 # 5.2.16 Ensure SSH Idle Timeout Interval is configured (Automated)
-  - id: 6166 
+  - id: 6166
     title: "Ensure SSH Idle Timeout Interval is configured"
     description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the ClientAliveCountMax variable is set, sshd will send client alive messages at every ClientAliveInterval interval. When the number of consecutive client alive messages are sent with no response from the client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
     rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent."
@@ -3125,7 +3125,7 @@ checks:
       - 'f:$sshd_file -> n:^\s*ClientAliveCountMax\s*\t*(\d+) compare >= 1'
 
 # 5.2.17 Ensure SSH LoginGraceTime is set to one minute or less (Automated)
-  - id: 6167 
+  - id: 6167
     title: "Ensure SSH LoginGraceTime is set to one minute or less"
     description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
     rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
@@ -3140,7 +3140,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> n:^\s*LoginGraceTime\s*\t*(\d+) compare <= 60'
 
 # 5.2.18 Ensure SSH warning banner is configured (Automated)
-  - id: 6168 
+  - id: 6168
     title: "Ensure SSH warning banner is configured"
     description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
     rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
@@ -3157,7 +3157,7 @@ checks:
 
 
 # 5.2.19 Ensure SSH PAM is enabled (Automated)
-  - id: 6169 
+  - id: 6169
     title: "Ensure SSH PAM is enabled"
     description: "UsePAM Enables the Pluggable Authentication Module interface. If set to “yes” this will enable PAM authentication using ChallengeResponseAuthenticationand PasswordAuthentication in addition to PAM account and session module processing for all authentication types"
     rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server"
@@ -3174,7 +3174,7 @@ checks:
 
 
 # 5.2.20 Ensure SSH AllowTcpForwarding is disabled (Automated)
-  - id: 6170 
+  - id: 6170
     title: "Ensure SSH AllowTcpForwarding is disabled"
     description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines"
     rationale: "Leaving port forwarding enabled can expose the organization to security risks and back-doors.SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network"
@@ -3191,7 +3191,7 @@ checks:
 
 
 # 5.2.21 Ensure SSH MaxStartups is configured (Automated)
-  - id: 6171 
+  - id: 6171
     title: "Ensure SSH MaxStartups is configured"
     description: "The MaxStartupsparameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon"
     rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon"
@@ -3208,7 +3208,7 @@ checks:
 
 
 # 5.2.22 Ensure SSH MaxSessions is limited (Automated)
-  - id: 6172 
+  - id: 6172
     title: "Ensure SSH MaxSessions is limited"
     description: "The MaxSessionsparameter specifies the maximum number of open sessions permitted from a given connection."
     rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon"
@@ -3229,7 +3229,7 @@ checks:
 # 5.3 Configure PAM
 ###############################################
 # 5.3.1 Ensure password creation requirements are configured (Automated)
-  - id: 6173 
+  - id: 6173
     title: "Ensure password creation requirements are configured"
     description: "The pam_pwquality.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more"
     rationale: "Strong passwords protect systems from being hacked through brute force methods."
@@ -3247,7 +3247,7 @@ checks:
       - 'f:/etc/pam.d/system-auth -> n:try_first_pass retry=(\d+) compare <=3'
 
 # 5.3.3 Ensure password hashing algorithm is SHA-512 (Automated)
-  - id: 6174 
+  - id: 6174
     title: "Ensure password hashing algorithm is SHA-512"
     description: "The commands below change password encryption from md5 to sha512 (a much stronger hashing algorithm). All existing accounts will need to perform a password change to upgrade the stored hashes to the new algorithm."
     rationale: "The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note that these changes only apply to accounts configured on the local system."
@@ -3263,7 +3263,7 @@ checks:
       - 'f:/etc/pam.d/system-auth -> r:^password\s*sufficient\s*pam_unix.so\s*sha512'
 
 # 5.3.4 Ensure password reuse is limited (Automated)
-  - id: 6175 
+  - id: 6175
     title: "Ensure password reuse is limited"
     description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
     rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password. Note that these changes only apply to accounts configured on the local system."
@@ -3286,7 +3286,7 @@ checks:
 # 5.4.1 Set Shadow Password Suite Parameters
 ###############################################
 # 5.4.1.1 Ensure password expiration is 365 days or less (Automated)
-  - id: 6176 
+  - id: 6176
     title: "Ensure password expiration is 365 days or less"
     description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 365 days."
     rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity."
@@ -3302,7 +3302,7 @@ checks:
 
 
 # 5.4.1.2 Ensure minimum days between password changes is configured (Automated)
-  - id: 6177 
+  - id: 6177
     title: "Ensure minimum days between password changes is configured"
     description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 1 or more days."
     rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
@@ -3317,7 +3317,7 @@ checks:
       - 'f:/etc/login.defs -> n:^\s*PASS_MIN_DAYS\s*\t*(\d+) compare >= 1'
 
 # 5.4.1.3 Ensure password expiration warning days is 7 or more (Automated)
-  - id: 6178 
+  - id: 6178
     title: "Ensure minimum days between password changes is 7 or more"
     description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
     rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
@@ -3330,10 +3330,10 @@ checks:
     condition: all
     rules:
       - 'f:/etc/login.defs -> n:^\s*PASS_WARN_AGE\s*\t*(\d+) compare >= 7'
-    
+
 
 # 5.4.1.4 Ensure inactive password lock is 30 days or less (Automated)
-  - id: 6179 
+  - id: 6179
     title: "Ensure inactive password lock is 30 days or less"
     description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
     rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
@@ -3349,7 +3349,7 @@ checks:
 
 
 # 5.4.3 Ensure default group for the root account is GID 0 (Automated)
-  - id: 6180 
+  - id: 6180
     title: "Ensure default group for the root account is GID 0"
     description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
     rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
@@ -3365,7 +3365,7 @@ checks:
 
 
 # 5.4.4 Ensure default user shell timeout is configured (Automated)
-  - id: 6181 
+  - id: 6181
     title: " Ensure default user shell timeout is configured"
     description: "TMOUT is an environmental setting that determines the timeout of a shell in seconds."
     rationale: "Setting a timeout value reduces the window of opportunity for unauthorized user access to another user's shell session that has been left unattended. It also ends the inactive session and releases the resources associated with that session."
@@ -3382,7 +3382,7 @@ checks:
       - 'f:/etc/profile -> n:^\s*\t*TMOUT\s*\t*=\s*\t*(\d+) compare <= 900'
 
 # 5.4.5 Ensure default user umask is configured (Automated)
-  - id: 6182 
+  - id: 6182
     title: "Ensure default user umask is configured"
     description: "The user file-creation mode mask (umask) is use to determine the file permission for newly created directories and files. In Linux, the default permissions for any newly created directory is 0777 (rwxrwxrwx), and for any newly created file it is 0666 (rw-rw-rw-). The umask modifies the default Linux permissions by restricting (masking) these permissions. The umask is not simply subtracted, but is processed bitwise. Bits set in the umaskare cleared in the resulting file mode."
     rationale: "Setting a very secure default value for umask ensures that users make a conscious choice about their file permissions. A default umask setting of 077 causes files and directories created by users to not be readable by any other user on the system. A umask of 027 would make files and directories readable by users in the same Unix group, while a umask of 022 would make files readable by every user on the system."
@@ -3405,7 +3405,7 @@ checks:
 
 
 # 5.6 Ensure access to the su command is restricted (Automated)
-  - id: 6183 
+  - id: 6183
     title: "Ensure access to the su command is restricted."
     description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in the wheel group to execute su ."
     rationale: "Restricting the use of su, and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo, whereas su can only record that a user executed the su program."
@@ -3433,7 +3433,7 @@ checks:
 
 
 # 6.1.2 Configure /etc/passwd permissions (Automated)
-  - id: 6184 
+  - id: 6184
     title: "Ensure permissions on /etc/passwd are configured"
     description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
     rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3449,7 +3449,7 @@ checks:
       - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.3 Ensure permissions on /etc/shadow are configured (Automated)
-  - id: 6185 
+  - id: 6185
     title: "Ensure permissions on /etc/shadow are configured"
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
@@ -3464,7 +3464,7 @@ checks:
       - 'c:stat /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.4 Ensure permissions on /etc/group are configured (Automated)
-  - id: 6186 
+  - id: 6186
     title: "Ensure permissions on /etc/group are configured"
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
@@ -3480,7 +3480,7 @@ checks:
       - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.5 Ensure permissions on /etc/gshadow are configured (Automated)
-  - id: 6187 
+  - id: 6187
     title: "Ensure permissions on /etc/gshadow are configured"
     description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/gshadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/gshadow file (such as group administrators) could also be useful to subvert the group"
@@ -3496,7 +3496,7 @@ checks:
       - 'c:stat /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.6 Ensure permissions on /etc/passwd-are configured (Automated)
-  - id: 6188 
+  - id: 6188
     title: "Ensure permissions on /etc/passwd- are configured"
     description: "The /etc/passwd- file contains backup user account information."
     rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3512,7 +3512,7 @@ checks:
       - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Ensure permissions on /etc/shadow-are configured (Automated)
-  - id: 6189 
+  - id: 6189
     title: "Ensure permissions on /etc/shadow- are configured"
     description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3528,7 +3528,7 @@ checks:
       - 'c:stat /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.8 Ensure permissions on /etc/group-are configured (Automated)
-  - id: 6190 
+  - id: 6190
     title: "Ensure permissions on /etc/group- are configured"
     description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
     rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3544,7 +3544,7 @@ checks:
       - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Ensure permissions on /etc/gshadow-are configured (Automated)
-  - id: 6191 
+  - id: 6191
     title: "Ensure permissions on /etc/gshadow- are configured"
     description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3567,7 +3567,7 @@ checks:
 
 
 # 6.2.1 Ensure accounts in /etc/passwd use shadowed passwords (Automated)
-  - id: 6192 
+  - id: 6192
     title: "Ensure accounts in /etc/passwd use shadowed passwords"
     description: "Local accounts can uses shadowed passwords. With shadowed passwords, The passwords are saved in shadow password file, /etc/shadow, encrypted by a salted one-way hash. Accounts with a shadowed password have an xin the second field in /etc/passwd."
     rationale: "The /etc/passwd file also contains information like user ID's and group ID's that are used by many system programs. Therefore, the /etc/passwd file must remain world readable. In spite of encoding the password with a randomly-generated one-way hash function, an attacker could still break the system if they got access to the /etc/passwd file. This can be mitigated by using shadowed passwords, thus moving the passwords in the /etc/passwd file to /etc/shadow. The /etc/shadow file is set so only root will be able to read and write. This helps mitigate the risk of an attacker gaining access to the encoded passwords with which to perform a dictionary attack."
@@ -3583,7 +3583,7 @@ checks:
 
 
 # 6.2.2 Ensure /etc/shadow password fields are not empty (Automated)
-  - id: 6193 
+  - id: 6193
     title: "Ensure password fields are not empty"
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
@@ -3598,7 +3598,7 @@ checks:
       - 'f:/etc/shadow -> !r:^# && r:^\w+::'
 
 # 6.2.3 Ensure root is the only UID 0 account (Automated)
-  - id: 6194 
+  - id: 6194
     title: "Ensure root is the only UID 0 account"
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
@@ -3618,7 +3618,7 @@ checks:
 
 
 # 6.2.18 Ensure shadow group is empty (Automated)
-  - id: 6195 
+  - id: 6195
     title: "Ensure shadow group is empty"
     description: "The shadow group allows system programs which require access the ability to read the /etc/shadow file. No users should be assigned to the shadow group"
     rationale: "Any users assigned to the shadow group would be granted read access to the /etc/shadow file. If attackers can gain read access to the /etc/shadow file, they can easily runa password cracking program against the hashed passwords to break them. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts."

--- a/ruleset/sca/centos/7/cis_centos7_linux.yml
+++ b/ruleset/sca/centos/7/cis_centos7_linux.yml
@@ -641,6 +641,23 @@ checks:
       - 'c:sysctl fs.suid_dumpable -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
+# 1.6.2 XD/NX enabled
+  - id: 6033 
+    title: "Ensure XD/NX support is enabled"
+    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
+    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
+    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
+    compliance:
+      - cis: ["1.6.2"]
+      - cis_csc: ["8.3"]
+      - pci_dss: ["2.2.4"]
+      - nist_800_53: ["CM.1"]
+      - tsc: ["CC5.2"]
+    condition: any
+    rules:
+      - 'c:journalctl -> r:^kernel:\s+NX \(Execute Disable\) protection: active'
+      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+
 # 1.6.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 6034 
     title: "Ensure address space layout randomization (ASLR) is enabled"

--- a/ruleset/sca/centos/7/cis_centos7_linux.yml
+++ b/ruleset/sca/centos/7/cis_centos7_linux.yml
@@ -655,8 +655,8 @@ checks:
       - tsc: ["CC5.2"]
     condition: any
     rules:
-      - 'c:journalctl -> r:^kernel:\s+NX \(Execute Disable\) protection: active'
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+      - 'c:sh -c "journalctl | grep \"protection: active\"" -> r:kernel:\s+NX \(Execute Disable\) protection: active'
+      - 'c:sh -c "[[ -n $(grep noexec[0-9]*=off /proc/cmdline) || -z $(grep -E -i \" (pae|nx) \" /proc/cpuinfo) || -n $(grep \"\\sNX\\s.*\\sprotection:\\s\" /var/log/dmesg | grep -v active) ]] && echo \"NX Protection is not active\"" -> r:^$'
 
 # 1.6.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 6034

--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -570,6 +570,21 @@ checks:
 
 # 1.6 Additional Process Hardening
 
+  - id: 2533 
+    title: "Ensure XD/NX support is enabled"
+    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
+    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
+    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
+    compliance:
+      - cis: ["1.6.1"]
+      - cis_csc: ["8.3"]
+      - pci_dss: ["2.2.4"]
+      - nist_800_53: ["CM.1"]
+      - tsc: ["CC5.2"]
+    condition: all
+    rules:
+      - 'c:journalctl -> r:NX \(Execute Disable\) protection: active'
+
   - id: 2534 
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."

--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -583,7 +583,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:journalctl -> r:NX \(Execute Disable\) protection: active'
+      - 'c:sh -c "journalctl | grep \"protection: active\"" -> r:NX \(Execute Disable\) protection: active'
 
   - id: 2534
     title: "Ensure address space layout randomization (ASLR) is enabled"

--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -34,7 +34,7 @@ checks:
 ############################################################
 
 # 1.1 Filesystem configuration
-  - id: 2500 
+  - id: 2500
     title: "Ensure mounting of freevxfs filesystems is disabled"
     description: "The freevxfs filesystem type is a free version of the Veritas type filesystem. This is the primary filesystem type for HP-UX operating systems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -49,7 +49,7 @@ checks:
       - 'c:/sbin/modprobe -n -v freevxfs -> r:^install /bin/true'
       - 'not c:lsmod -> r:freevxfs'
 
-  - id: 2501 
+  - id: 2501
     title: "Ensure mounting of jffs2 filesystems is disabled"
     description: "The jffs2 (journaling flash filesystem 2) filesystem type is a log-structured filesystem used in flash memory devices."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -64,7 +64,7 @@ checks:
       - 'c:/sbin/modprobe -n -v jffs2 -> r:^install /bin/true'
       - 'not c:lsmod -> r:jffs2'
 
-  - id: 2502 
+  - id: 2502
     title: "Ensure mounting of hfs filesystems is disabled"
     description: "The hfs filesystem type is a hierarchical filesystem that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -79,7 +79,7 @@ checks:
       - 'c:/sbin/modprobe -n -v hfs -> r:^install /bin/true'
       - 'not c:lsmod -> r:hfs'
 
-  - id: 2503 
+  - id: 2503
     title: "Ensure mounting of hfsplus filesystems is disabled"
     description: "The hfsplus filesystem type is a hierarchical filesystem designed to replace hfs that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -94,7 +94,7 @@ checks:
       - 'c:/sbin/modprobe -n -v hfsplus -> r:^install /bin/true'
       - 'not c:lsmod -> r:hfsplus'
 
-  - id: 2504 
+  - id: 2504
     title: "Ensure mounting of squashfs filesystems is disabled"
     description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs ). A squashfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -111,7 +111,7 @@ checks:
       - 'c:modprobe -n -v squashfs -> r:install /bin/true|Module squashfs not found'
       - 'not c:lsmod -> r:squashfs'
 
-  - id: 2505 
+  - id: 2505
     title: "Ensure mounting of udf filesystems is disabled"
     description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -126,7 +126,7 @@ checks:
       - 'c:/sbin/modprobe -n -v udf -> r:^install /bin/true'
       - 'not c:lsmod -> r:udf'
 
-  - id: 2506 
+  - id: 2506
     title: "Ensure mounting of FAT filesystems is disabled"
     description: "The FAT filesystem format is primarily used on older windows systems and portable USB drives or flash modules. It comes in three types FAT12 , FAT16 , and FAT32 all of which are supported by the vfat kernel module."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -144,7 +144,7 @@ checks:
       - 'not c:lsmod -> r:vfat'
 
 # 1.1.x Filesystem Configuration
-  - id: 2507 
+  - id: 2507
     title: "Ensure /tmp is configured"
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp."
@@ -162,7 +162,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s'
 
-  - id: 2508 
+  - id: 2508
     title: "Ensure nodev option set on /tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
@@ -177,7 +177,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s && r:nodev'
 
-  - id: 2509 
+  - id: 2509
     title: "Ensure nosuid option set on /tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain set userid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create set userid files in /tmp."
@@ -192,7 +192,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s && r:nosuid'
 
-  - id: 2510 
+  - id: 2510
     title: "Ensure noexec option set on /tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create set userid files in /tmp."
@@ -208,7 +208,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:noexec'
 
 
-  - id: 2511 
+  - id: 2511
     title: "Ensure separate partition exists for /var"
     description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
     rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
@@ -225,7 +225,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var\s'
 
-  - id: 2512 
+  - id: 2512
     title: "Ensure separate partition exists for /var/tmp"
     description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /var/tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own file system allows an administrator to set the noexec option on the mount, making /var/tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -241,8 +241,8 @@ checks:
     condition: all
     rules:
       - 'c:mount -> r:\s/var/tmp\s'
-  
-  - id: 2513 
+
+  - id: 2513
     title: "Ensure nodev option set on /var/tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /var/tmp."
@@ -257,7 +257,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/tmp\s && r:nodev'
 
-  - id: 2514 
+  - id: 2514
     title: "Ensure nosuid option set on /var/tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
@@ -272,7 +272,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/tmp\s && r:nosuid'
 
-  - id: 2515 
+  - id: 2515
     title: "Ensure noexec option set on /var/tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
@@ -289,7 +289,7 @@ checks:
 
 
 
-  - id: 2516 
+  - id: 2516
     title: "Ensure separate partition exists for /var/log"
     description: "The /var/log directory is used by system services to store log data."
     rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
@@ -306,7 +306,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/log\s'
 
-  - id: 2517 
+  - id: 2517
     title: "Ensure separate partition exists for /var/log/audit"
     description: "The auditing daemon, auditd, stores log data in the /var/log/audit directory."
     rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data. The audit daemon calculates how much free space is left and performs actions based on the results. If other processes (such as syslog) consume space in the same partition as auditd, it may not perform as desired."
@@ -323,7 +323,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/log/audit\s'
 
-  - id: 2518 
+  - id: 2518
     title: "Ensure separate partition exists for /home"
     description: "The /home directory is used to support disk storage needs of local users."
     rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
@@ -341,7 +341,7 @@ checks:
       - 'c:mount -> r:\s/home\s'
 
 
-  - id: 2519 
+  - id: 2519
     title: "Ensure nodev option set on /home partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices.  Note: The actions in the item refer to the /home partition, which is the default user partition that is defined in many distributions. If you have created other user partitions, it is recommended that the Remediation and Audit steps be applied to these partitions as well."
@@ -356,7 +356,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/home\s && r:nodev'
 
-  - id: 2520 
+  - id: 2520
     title: "Ensure nodev option set on /dev/shm partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
@@ -373,7 +373,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/dev/shm\s && r:nodev'
 
-  - id: 2521 
+  - id: 2521
     title: "Ensure nosuid option set on /dev/shm partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
@@ -388,7 +388,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/dev/shm\s && r:nosuid'
 
-  - id: 2522 
+  - id: 2522
     title: "Ensure noexec option set on /dev/shm partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
@@ -403,7 +403,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/dev/shm\s && r:noexec'
 
-  - id: 2523 
+  - id: 2523
     title: "Disable Automounting"
     description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
     rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have it's contents available in system even if they lacked permissions to mount it themselves."
@@ -419,7 +419,7 @@ checks:
       - 'c:systemctl is-enabled autofs -> enabled'
 
 
-  - id: 2524 
+  - id: 2524
     title: "Disable USB Storage"
     description: "USB storage provides a means to transfer and store files insuring persistence and availability of the files independent of network connection status. Its popularity and utility has led to USB-based malware being a simple and common means for network infiltration and a first step to establishing a persistent threat within a networked environment."
     rationale: "Restricting USB access on the system will decrease the physical attack surface for a device and diminish the possible vectors to introduce malware."
@@ -437,7 +437,7 @@ checks:
 
 # 1.3 Configure Sudo
 
-  - id: 2525 
+  - id: 2525
     title: "Ensure sudo is installed"
     description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy."
     rationale: "sudo supports a plugin architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plugins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
@@ -455,7 +455,7 @@ checks:
       - 'c:dpkg -s sudo -> r:install ok installed'
       - 'c:dpkg -s sudo-ldap -> r:install ok installed'
 
-  - id: 2526 
+  - id: 2526
     title: "Ensure sudo commands use pty"
     description: "sudo can be configured to run only froma pseudo-pty"
     rationale: "Attackers can run a malicious program using sudo, which would again fork a background process that remains even when the main program has finished executing."
@@ -471,7 +471,7 @@ checks:
       - 'f:/etc/sudoers -> r:^\s*\t*Defaults\s*\t*use_pty'
       - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*use_pty'
 
-  - id: 2527 
+  - id: 2527
     title: "Ensure sudo log file exists"
     description: "sudo can use a custom log file"
     rationale: "A sudo log file simplifies auditing of sudo commands"
@@ -488,7 +488,7 @@ checks:
       - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*logfile='
 
 # 1.4 Filesystem Integrity Checking
-  - id: 2528 
+  - id: 2528
     title: "Ensure AIDE is installed"
     description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
     rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
@@ -502,7 +502,7 @@ checks:
     rules:
       - 'c:dpkg -s aide -> r:install ok installed'
 
-  - id: 2529 
+  - id: 2529
     title: "Ensure filesystem integrity is regularly checked"
     description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
     rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
@@ -521,7 +521,7 @@ checks:
       - 'c:crontab -u root -l -> r:aide'
 
 # 1.5 Secure Boot Settings
-  - id: 2530 
+  - id: 2530
     title: "Ensure permissions on bootloader config are configured"
     description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options. The grub configuration is usually grub.cfg stored in /boot/grub."
     rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
@@ -536,7 +536,7 @@ checks:
     rules:
       - 'c:stat /boot/grub/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 2531 
+  - id: 2531
     title: "Ensure bootloader password is set"
     description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
     rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
@@ -552,7 +552,7 @@ checks:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*set superusers'
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*password'
 
-  - id: 2532 
+  - id: 2532
     title: "Ensure authentication required for single user mode"
     description: "Single user mode is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
     rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
@@ -570,7 +570,7 @@ checks:
 
 # 1.6 Additional Process Hardening
 
-  - id: 2533 
+  - id: 2533
     title: "Ensure XD/NX support is enabled"
     description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
     rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
@@ -585,7 +585,7 @@ checks:
     rules:
       - 'c:journalctl -> r:NX \(Execute Disable\) protection: active'
 
-  - id: 2534 
+  - id: 2534
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
     rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
@@ -601,7 +601,7 @@ checks:
       - 'c:grep -Rh ^kernel\.randomize_va_space /etc/sysctl.conf /etc/sysctl.d -> r:\s*\t*2$'
       - 'c:sysctl kernel.randomize_va_space -> r:^kernel.randomize_va_space\s*\t*=\s*\t*2'
 
-  - id: 2535 
+  - id: 2535
     title: "Ensure prelink is disabled"
     description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
     rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
@@ -616,7 +616,7 @@ checks:
     rules:
       - 'c:dpkg -s prelink -> r:install ok installed'
 
-  - id: 2536 
+  - id: 2536
     title: "Ensure core dumps are restricted"
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
     rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5) ). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
@@ -635,7 +635,7 @@ checks:
 
 # 1.7 Mandatory Access Control
 
-  - id: 2537 
+  - id: 2537
     title: "Ensure AppArmor is installed"
     description: "AppArmor provides Mandatory Access Controls."
     rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
@@ -651,7 +651,7 @@ checks:
       - 'c:dpkg -s apparmor-utils -> r:install ok installed'
       - 'c:dpkg -s apparmor -> r:install ok installed'
 
-  - id: 2538 
+  - id: 2538
     title: "Ensure AppArmor is enabled in the bootloader configuration"
     description: "Configure AppArmor to be enabled at boot time and verify that it has not been overwrittenby the bootloader boot parameters."
     rationale: "AppArmor must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
@@ -667,7 +667,7 @@ checks:
       - 'f:/boot/grub/grub.cfg -> r:^\s*linux && !r:apparmor=1'
       - 'f:/boot/grub/grub.cfg -> r:^\s*linux && !r:security=apparmor'
 
-  - id: 2539 
+  - id: 2539
     title: "Ensure all AppArmor Profiles are in enforce or complain mode"
     description: "AppArmor profiles define what resources applicatons are able to access."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that any policies that exist on the system are activated.."
@@ -683,7 +683,7 @@ checks:
       - 'c:apparmor_status -> r:0 processes are unconfined'
 
 
-  - id: 2540 
+  - id: 2540
     title: "Ensure all AppArmor Profiles are enforcing"
     description: "AppArmor profiles define what resources applicatons are able to access."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that any policies that exist on the system are activated.."
@@ -701,7 +701,7 @@ checks:
       - 'c:apparmor_status -> r:^0\s*processes are unconfined'
 
 # 1.8 Warning Banners
-  - id: 2541 
+  - id: 2541
     title: "Ensure message of the day is configured properly"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -715,8 +715,8 @@ checks:
     rules:
       - 'not f:/etc/motd -> r:\\v|\\r|\\m|\\s|Debian|Ubuntu'
       - 'not f:/etc/motd'
-      
-  - id: 2542 
+
+  - id: 2542
     title: "Ensure local login warning banner is configured properly"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -730,7 +730,7 @@ checks:
     rules:
       - 'f:/etc/issue -> r:\\v|\\r|\\m|\\s|Debian|Ubuntu'
 
-  - id: 2543 
+  - id: 2543
     title: "Ensure remote login warning banner is configured properly"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -744,7 +744,7 @@ checks:
     rules:
       - 'f:/etc/issue.net -> r:\\v|\\r|\\m|\\s|Debian|Ubuntu'
 
-  - id: 2544 
+  - id: 2544
     title: "Ensure permissions on /etc/motd are configured"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
     rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -762,7 +762,7 @@ checks:
     rules:
       - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 2545 
+  - id: 2545
     title: "Ensure permissions on /etc/issue are configured"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
     rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -780,7 +780,7 @@ checks:
     rules:
       - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 2546 
+  - id: 2546
     title: "Ensure permissions on /etc/issue.net are configured"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
     rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -798,7 +798,7 @@ checks:
     rules:
       - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 2547 
+  - id: 2547
     title: "Ensure GDM login banner is configured"
     description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems."
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place."
@@ -815,7 +815,7 @@ checks:
       - 'f:/etc/gdm3/greeter.dconf-defaults -> r:^banner-message-enable=true'
       - 'f:/etc/gdm3/greeter.dconf-defaults -> r:^banner-message-text=\.+'
 
-  - id: 2548 
+  - id: 2548
     title: "Ensure updates, patches, and additional security software are installed"
     description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
     rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
@@ -837,7 +837,7 @@ checks:
 # 2 Services
 ############################################################
 
-  - id: 2549 
+  - id: 2549
     title: "Ensure xinetd is not installed"
     description: "The eXtended InterNET Daemon (xinetd) is an open source super daemon that replaced the original inetd daemon. The xinetddaemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no xinetd services required, it is recommended that the package be removed."
@@ -855,7 +855,7 @@ checks:
     rules:
       - 'c:dpkg -s xinetd -> r:install ok installed'
 
-  - id: 2550 
+  - id: 2550
     title: "Ensure openbsd-inetd is not installed"
     description: "The inetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no inetd services required, it is recommended that the daemon be removed."
@@ -873,7 +873,7 @@ checks:
     rules:
       - 'c:dpkg -s openbsd-inetd -> r:install ok installed'
 
-  - id: 2551 
+  - id: 2551
     title: "Ensure time synchronization is in use"
     description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
     rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
@@ -890,7 +890,7 @@ checks:
       - 'c:dpkg -s chrony -> r:install ok installed'
       - 'c:systemctl is-enabled systemd-timescynd -> enabled'
 
-  - id: 2552 
+  - id: 2552
     title: "Ensure systemd-timesyncd is configured"
     description: "systemd-timesyncd is a daemon that has been added for synchronizing the system clock across the network. It implements an SNTP client. In contrast to NTP implementations such as chrony or the NTP reference server this only implements a client side, and does not bother with the full NTP complexity, focusing only on querying time from one remote server and synchronizing the local clock to it. The daemon runs with minimal privileges, and has been hooked up with networkd to only operate when network connectivity is available. The daemon saves the current clock to disk every time a new NTP sync has been acquired, and uses this to possibly correct the system clock early at bootup, in order to accommodate for systems that lack an RTC such as the Raspberry Pi and embedded devices, and make sure that time monotonically progresses on these systems, even if it is not always correct. To make use of this daemon a new system user and group \"systemd- timesync\" needs to be created on installation of systemd. Note: The systemd-timesyncd service specifically implements only SNTP. This minimalistic service will set the system clock for large offsets or slowly adjust it for smaller deltas. More complex use cases are not covered by systemd-timesyncd. This recommendation only applies if timesyncd is in use on the system."
     rationale: "Proper configuration is vital to ensuring time synchronization is working properly. This recommendation only applies if timesyncd is in use on the system."
@@ -905,7 +905,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled systemd-timesyncd.service -> enabled'
 
-  - id: 2553 
+  - id: 2553
     title: "Ensure chrony is configured"
     description: "chrony is a daemon which implements the Network Time Protocol (NTP) is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on chrony can be found at http://chrony.tuxfamily.org/. chrony can be configured to be a client and/or a server."
     rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly. This recommendation only applies if chrony is in use on the system."
@@ -920,7 +920,7 @@ checks:
     rules:
       - 'f:/etc/chrony/chrony.conf -> r:^server\.+|^pool\.+'
 
-  - id: 2554 
+  - id: 2554
     title: "Ensure ntp is configured"
     description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at http://www.ntp.org. ntp can be configured to be a client and/or a server. This recommendation only applies if ntp is in use on the system."
     rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
@@ -941,7 +941,7 @@ checks:
       - 'f:/etc/init.d/ntp -> r:^RUNASUSER\s*\t*=\s*\t*ntp'
 
 # 2.2.2 Ensure the X Window system is not installed (Scored)
-  - id: 2555 
+  - id: 2555
     title: "Ensure the X Window system is not installed"
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
@@ -956,7 +956,7 @@ checks:
     rules:
       - 'c:dpkg -l xserver-xorg-core* -> r:^\wi\s*xserver-xorg'
 
-  - id: 2556 
+  - id: 2556
     title: "Ensure Avahi Server is not enabled"
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to disable the service to reduce the potential attach surface."
@@ -971,7 +971,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled avahi-daemon -> enabled'
 
-  - id: 2557 
+  - id: 2557
     title: "Ensure CUPS is not enabled"
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be disabled to reduce the potential attack surface."
@@ -988,7 +988,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled cups -> enabled'
 
-  - id: 2558 
+  - id: 2558
     title: "Ensure DHCP Server is not enabled"
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this service be disabled to reduce the potential attack surface."
@@ -1006,7 +1006,7 @@ checks:
       - 'c:systemctl is-enabled isc-dhcp-server -> enabled'
       - 'c:systemctl is-enabled isc-dhcp-server6 -> enabled'
 
-  - id: 2559 
+  - id: 2559
     title: "Ensure LDAP server is not enabled"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be disabled to reduce the potential attack surface."
@@ -1023,7 +1023,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled slapd -> enabled'
 
-  - id: 2560 
+  - id: 2560
     title: "Ensure NFS and RPC are not enabled"
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not export NFS shares or act as an NFS client, it is recommended that these services be disabled to reduce remote attack surface."
@@ -1039,7 +1039,7 @@ checks:
       - 'c:systemctl is-enabled nfs-server -> enabled'
       - 'c:systemctl is-enabled rpcbind -> enabled'
 
-  - id: 2561 
+  - id: 2561
     title: "Ensure DNS Server is not enabled"
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
@@ -1054,7 +1054,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled bind9 -> enabled'
 
-  - id: 2562 
+  - id: 2562
     title: "Ensure FTP Server is not enabled"
     description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
@@ -1069,7 +1069,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled vsftpd -> enabled'
 
-  - id: 2563 
+  - id: 2563
     title: "Ensure HTTP Server is not enabled"
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
@@ -1084,7 +1084,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled apache2 -> enabled'
 
-  - id: 2564 
+  - id: 2564
     title: "Ensure email services are not enabled"
     description: "dovecot is an open source mail submission and transport server for Linux based systems."
     rationale: "Unless mail transport services are to be provided by this system, it is recommended that the service be disabled or deleted to reduce the potential attack surface."
@@ -1099,7 +1099,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled dovecot -> enabled'
 
-  - id: 2565 
+  - id: 2565
     title: "Ensure Samba is not enabled"
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this service can be deleted to reduce the potential attack surface."
@@ -1114,7 +1114,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled smbd -> enabled'
 
-  - id: 2566 
+  - id: 2566
     title: "Ensure HTTP Proxy Server is not enabled"
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
@@ -1129,7 +1129,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled squid -> enabled'
 
-  - id: 2567 
+  - id: 2567
     title: "Ensure SNMP Server is not enabled"
     description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
     rationale: "The SNMP server can communicate using SNMP v1, which transmits data in the clear and does not require authentication to execute commands. Unless absolutely necessary, it is recommended that the SNMP service not be used. If SNMP is required the server should be configured to disallow SNMP v1."
@@ -1144,7 +1144,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled snmpd -> enabled'
 
-  - id: 2568 
+  - id: 2568
     title: "Ensure mail transfer agent is configured for local-only mode"
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems."
@@ -1159,7 +1159,7 @@ checks:
     rules:
       - 'c:ss -lntu -> r:\.*:25\.*LISTEN && !r:127.0.0.1:25\.+LISTEN|::1:25\.*LISTEN'
 
-  - id: 2569 
+  - id: 2569
     title: "Ensure rsync service is not enabled"
     description: "The rsyncd service can be used to synchronize files between systems over network links."
     rationale: "The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
@@ -1173,7 +1173,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled rsync -> enabled'
 
-  - id: 2570 
+  - id: 2570
     title: "Ensure NIS Server is not enabled"
     description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be disabled and other, more secure services be used"
@@ -1191,7 +1191,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled nis -> enabled'
 
-  - id: 2571 
+  - id: 2571
     title: "Ensure NIS Client is not installed"
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
@@ -1209,7 +1209,7 @@ checks:
     rules:
       - 'c:dpkg -s nis -> r:install ok installed'
 
-  - id: 2572 
+  - id: 2572
     title: "Ensure rsh client is not installed"
     description: "The rsh-client package contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh , rcp and rlogin ."
@@ -1227,7 +1227,7 @@ checks:
     rules:
       - 'c:dpkg -s rsh-client -> r:install ok installed'
 
-  - id: 2573 
+  - id: 2573
     title: "Ensure talk client is not installed"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talkclient, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -1245,7 +1245,7 @@ checks:
     rules:
       - 'c:dpkg -s talk -> r:install ok installed'
 
-  - id: 2574 
+  - id: 2574
     title: "Ensure telnet client is not installed"
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
@@ -1263,7 +1263,7 @@ checks:
     rules:
       - 'c:dpkg -s telnet -> r:install ok installed'
 
-  - id: 2575 
+  - id: 2575
     title: "Ensure LDAP client is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
@@ -1289,7 +1289,7 @@ checks:
 ############################################################
 
 # 3.1.1 Disable IPv6 (Not Scored)
-  - id: 2576 
+  - id: 2576
     title: "Disable IPv6"
     description: "Although IPv6 has many advantages over IPv4, not all organizations have IPv6 or dual stack configurations implemented."
     rationale: "If IPv6 or dual stack is not to be used, it is recommended that IPv6 be disabled to reduce the attack surface of the system."
@@ -1308,8 +1308,8 @@ checks:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:ipv6.disable=1'
 
 
-# 3.1.2 Ensure wireless interfaces are disabled (Scored)  
-  - id: 2577 
+# 3.1.2 Ensure wireless interfaces are disabled (Scored)
+  - id: 2577
     title: "Ensure wireless interfaces are disabled"
     description: "Wireless networking is used when wired networks are unavailable. Debian contains a wireless tool kit to allow system administrators to configure and use wireless networks."
     rationale: "If wireless is not to be used, wireless devices can be disabled to reduce the potential attack surface."
@@ -1324,12 +1324,12 @@ checks:
     condition: all
     rules:
       - 'c:nmcli radio wifi -> r:^disabled'
-      - 'c:nmcli radio wwan -> r:^disabled'  
+      - 'c:nmcli radio wwan -> r:^disabled'
 ##########################################################
 # 3.2 Network Parameters
 ##########################################################
 # 3.2.1 Ensure packet redirect sending is disabled
-  - id: 2578 
+  - id: 2578
     title: "Ensure packet redirect sending is disabled"
     description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
     rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
@@ -1347,7 +1347,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
 # 3.2.2 Ensure IP forwarding is disabled
-  - id: 2579 
+  - id: 2579
     title: "Ensure IP forwarding is disabled"
     description: "The net.ipv4.ip_forward and net.ipv6.conf.all.forwarding flags are used to tell the system whether it can forward packets or not."
     rationale: "Setting the flags to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
@@ -1369,11 +1369,11 @@ checks:
 # 3.3 Network Parameters
 #############################################################
 # 3.3.1 Ensure source routed packets are not accepted
-  - id: 2580 
+  - id: 2580
     title: "Ensure source routed packets are not accepted"
     description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
     rationale: "Setting net.ipv4.conf.all.accept_source_route, net.ipv4.conf.default.accept_source_route, net.ipv6.conf.all.accept_source_route and net.ipv6.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
-    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_source_route = 0 net.ipv4.conf.default.accept_source_route = 0 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.accept_source_route=0 # sysctl -w net.ipv4.conf.default.accept_source_route=0 # sysctl -w net.ipv4.route.flush=1 IF IPv6 is enabled: Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv6.conf.all.accept_source_route = 0 net.ipv6.conf.default.accept_source_route = 0 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv6.conf.all.accept_source_route=0 # sysctl -w net.ipv6.conf.default.accept_source_route=0 # sysctl -w net.ipv6.route.flush=1"     
+    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.conf.all.accept_source_route = 0 net.ipv4.conf.default.accept_source_route = 0 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.conf.all.accept_source_route=0 # sysctl -w net.ipv4.conf.default.accept_source_route=0 # sysctl -w net.ipv4.route.flush=1 IF IPv6 is enabled: Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv6.conf.all.accept_source_route = 0 net.ipv6.conf.default.accept_source_route = 0 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv6.conf.all.accept_source_route=0 # sysctl -w net.ipv6.conf.default.accept_source_route=0 # sysctl -w net.ipv6.route.flush=1"
     compliance:
       - cis: ["3.3.1"]
       - cis_csc: ["5.1"]
@@ -1392,7 +1392,7 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_source_route\s*=\s*0$'
 
 # 3.3.2 Ensure ICMP redirects are not accepted
-  - id: 2581 
+  - id: 2581
     title: "Ensure ICMP redirects are not accepted"
     description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables. By setting net.ipv4.conf.all.accept_redirects to 0, the system will not accept any ICMP redirect messages, and therefore, won't allow outsiders to update the system's routing tables."
     rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
@@ -1415,7 +1415,7 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0$'
 
 # 3.3.3 Ensure secure ICMP redirects are not accepted
-  - id: 2582 
+  - id: 2582
     title: "Ensure secure ICMP redirects are not accepted"
     description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
     rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
@@ -1434,7 +1434,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
 
 # 3.3.4 Ensure suspicious packets are logged (Scored)
-  - id: 2583 
+  - id: 2583
     title: "Ensure suspicious packets are logged"
     description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
     rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their server."
@@ -1453,7 +1453,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
 
 # 3.3.5 Ensure broadcast ICMP requests are ignored
-  - id: 2584 
+  - id: 2584
     title: "Ensure broadcast ICMP requests are ignored"
     description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
     rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
@@ -1470,7 +1470,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
 # 3.3.6 Ensure bogus ICMP responses are ignored (Scored)
-  - id: 2585 
+  - id: 2585
     title: "Ensure bogus ICMP responses are ignored"
     description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
     rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
@@ -1487,7 +1487,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
 # 3.3.7 Ensure Reverse Path Filtering is enabled (Scored)
-  - id: 2586 
+  - id: 2586
     title: "Ensure Reverse Path Filtering is enabled"
     description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
     rationale: "Setting these flags is a good way to deter attackers from sending your system bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing."
@@ -1506,7 +1506,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
 
 # 3.3.8 Ensure TCP SYN Cookies is enabled (Scored)
-  - id: 2587 
+  - id: 2587
     title: "Ensure TCP SYN Cookies is enabled"
     description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue."
     rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
@@ -1523,7 +1523,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
 
 # 3.3.9 Ensure IPv6 router advertisements are not accepted (Scored)
-  - id: 2588 
+  - id: 2588
     title: "Ensure IPv6 router advertisements are not accepted"
     description: "This setting disables the systems ability to accept router advertisements"
     rationale: "It is recommended that systems not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
@@ -1549,7 +1549,7 @@ checks:
 # 3.4 Uncommon Network Protocols
 #####################################################################
 # 3.4.1 Ensure DCCP is disabled (Scored)
-  - id: 2589 
+  - id: 2589
     title: "Ensure DCCP is disabled"
     description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in- sequence delivery."
     rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
@@ -1569,7 +1569,7 @@ checks:
       - 'c:lsmod -> r:dccp'
 
 # 3.4.2 Ensure SCTP is disabled (Scored)
-  - id: 2590 
+  - id: 2590
     title: "Ensure SCTP is disabled"
     description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1590,7 +1590,7 @@ checks:
 
 
 # 3.4.3 Ensure RDS is disabled (Scored)
-  - id: 2591 
+  - id: 2591
     title: "Ensure RDS is disabled"
     description: "The Reliable Datagram Sockets (RDS) protocol is a transport layer protocol designed to provide low-latency, high-bandwidth communications between cluster nodes. It was developed by the Oracle Corporation."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1610,7 +1610,7 @@ checks:
       - 'c:lsmod -> r:rds'
 
 # 3.4.4 Ensure TIPC is disabled (Scored)
-  - id: 2592 
+  - id: 2592
     title: "Ensure TIPC is disabled"
     description: "The Transparent Inter-Process Communication (TIPC) protocol is designed to provide communication between cluster nodes."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1638,7 +1638,7 @@ checks:
 # 3.5.1 Ensure Firewall software is installed
 #################################################################
 # 3.5.1.1 Ensure a Firewall package is installed (Scored)
-  - id: 2593 
+  - id: 2593
     title: "Ensure a Firewall package is installed"
     description: "A Firewall package should be selected. Most firewall configuration utilities operate as a front end to nftables or iptables."
     rationale: "A Firewall package is required for firewall management and configuration."
@@ -1657,7 +1657,7 @@ checks:
 # 3.5.2 Configure UncomplicatedFirewall
 #################################################################
 # 3.5.2.1 Ensure ufw service is enabled (Scored)
-  - id: 2594 
+  - id: 2594
     title: "Ensure ufw service is enabled"
     description: "UncomplicatedFirewall (ufw) is a frontend for iptables. ufw provides a framework for managing netfilter, as well as a command-line and available graphical user interface for manipulating the firewall. Ensure that the ufw service is enabled to protect your system."
     rationale: "The ufw service must be enabled and running in order for ufw to protect the system"
@@ -1675,7 +1675,7 @@ checks:
       - 'c:ufw status -> Status: active'
 
 # 3.5.2.2 Ensure default deny firewall policy (Scored)
-  - id: 2595 
+  - id: 2595
     title: "Ensure default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -1692,7 +1692,7 @@ checks:
       - 'c:ufw status verbose -> r:^Default && r:deny\W+(routed)|reject\W+(routed)'
 
 # 3.5.2.3 Ensure loopback traffic is configured (Scored)
-  - id: 2596 
+  - id: 2596
     title: "Ensure loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8 for IPv4 and ::1/128 for IPv6)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -1716,7 +1716,7 @@ checks:
 ######################################################################
 
 # 3.5.3.2 Ensure a table exists (Scored)
-  - id: 2597 
+  - id: 2597
     title: "Ensure a table exists"
     description: "Tables hold chains. Each table only has one address family and only applies to packets of this family. Tables can have one of five families."
     rationale: "nftables doesn't have any default tables. Without a table being build, nftables will not filter network traffic."
@@ -1731,7 +1731,7 @@ checks:
       - 'c:nft list tables -> r:\w+'
 
 # 3.5.3.3 Ensure base chains exist (Scored)
-  - id: 2598 
+  - id: 2598
     title: "Ensure base chains exist"
     description: "Chains are containers for rules. They exist in two kinds, base chains and regular chains. A base chain is an entry point for packets from the networking stack, a regular chain may be used as jump target and is used for better rule organization."
     rationale: "If a base chain doesn't exist with a hook for input, forward, and delete, packets that would flow through those chains will not be touched by nftables."
@@ -1748,7 +1748,7 @@ checks:
       - 'c:nft list ruleset -> r:hook output'
 
 # 3.5.3.6 Ensure default deny firewall policy (Scored)
-  - id: 2599 
+  - id: 2599
     title: "Ensure default deny firewall policy"
     description: "Base chain policy is the default verdict that will be applied to packets reaching the end of the chain."
     rationale: "There are two policies: accept (Default) and drop. If the policy is set to accept , the firewall will accept any packet that is not configured to be denied and the packet will continue transversing the network stack. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -1765,7 +1765,7 @@ checks:
       - 'c:nft list ruleset -> r:hook output && r:policy drop'
 
 # 3.5.3.7 Ensure nftables service is enabled (Scored)
-  - id: 2600 
+  - id: 2600
     title: "Ensure nftables service is enabled"
     description: "The nftables service allows for the loading of nftables rulesets during boot, or starting of the nftables service."
     rationale: "The nftables service restores the nftables rules from the rules files referenced in the /etc/sysconfig/nftables.conf file during boot or the starting of the nftables service."
@@ -1786,7 +1786,7 @@ checks:
 # 3.5.4.1 Configure IPv4 iptables
 #######################################################################
 # 3.5.4.1.1 Ensure default deny firewall policy (Scored)
-  - id: 2601 
+  - id: 2601
     title: "Ensure default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -1803,7 +1803,7 @@ checks:
       - 'c:iptables -L -> r:Chain OUTPUT \(policy DROP\)|Chain OUTPUT \(policy REJECT\)'
 
 # 3.5.4.1.2 Ensure loopback traffic is configured (Scored)
-  - id: 2602 
+  - id: 2602
     title: "Ensure loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -1823,7 +1823,7 @@ checks:
 # 3.5.4.2 Configure IPv6 ip6tables
 #########################################################################
 # 3.5.4.2.1 Ensure IPv6 default deny firewall policy (Scored)
-  - id: 2603 
+  - id: 2603
     title: "Ensure IPv6 default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -1840,7 +1840,7 @@ checks:
       - 'c:ip6tables -L -> r:^Chain OUTPUT && r:policy DROP'
 
 # 3.5.4.2.2 Ensure IPv6 loopback traffic is configured (Scored)
-  - id: 2604 
+  - id: 2604
     title: "Ensure IPv6 loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (::1)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (::1) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -1864,7 +1864,7 @@ checks:
 
 
 
-  - id: 2605 
+  - id: 2605
     title: "Ensure auditd is installed"
     description: "auditd is the userspace component to the Linux Auditing System. It's responsible for writing audit records to the disk"
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -1881,7 +1881,7 @@ checks:
       - 'c:dpkg -s auditd -> r:install ok installed'
       - 'c:dpkg -s audispd-plugins -> r:install ok installed'
 
-  - id: 2606 
+  - id: 2606
     title: "Ensure auditd service is enabled"
     description: "Enable and start the auditd daemon to record system events."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -1897,7 +1897,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled auditd -> enabled'
 
-  - id: 2607 
+  - id: 2607
     title: "Ensure auditing for processes that start prior to auditd is enabled"
     description: "Configure grub so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
     rationale: "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected."
@@ -1915,7 +1915,7 @@ checks:
     rules:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:audit=1'
 
-  - id: 2608 
+  - id: 2608
     title: "Ensure audit log storage size is configured"
     description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
     rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
@@ -1932,7 +1932,7 @@ checks:
       - 'f:/etc/audit/auditd.conf'
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file\s*\t*=\s*\t*\d+'
 
-  - id: 2609 
+  - id: 2609
     title: "Ensure audit logs are not automatically deleted"
     description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
     rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
@@ -1949,7 +1949,7 @@ checks:
       - 'f:/etc/audit/auditd.conf'
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file_action\s*\t*=\s*\t*keep_logs'
 
-  - id: 2610 
+  - id: 2610
     title: "Ensure system is disabled when audit logs are full"
     description: "The auditd daemon can be configured to halt the system when the audit logs are full."
     rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
@@ -1965,9 +1965,9 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*action_mail_acct\s*\t*=\s*\t*root'
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*space_left_action\s*\t*=\s*\t*email'
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*admin_space_left_action\s*\t*=\s*\t*halt'
- 
 
-  - id: 2611 
+
+  - id: 2611
     title: "Ensure events that modify date and time information are collected"
     description: "Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier \"time-change\""
     rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
@@ -1989,7 +1989,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S clock_settime && r:-k time-change'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/localtime && r:-p wa && r:-k time-change'
 
-  - id: 2612 
+  - id: 2612
     title: "Ensure events that modify user/group information are collected"
     description: "Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier \"identity\" in the audit log file."
     rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
@@ -2013,7 +2013,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/shadow && r:-p wa && r:-k identity'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/security/opasswd && r:-p wa && r:-k identity'
 
-  - id: 2613 
+  - id: 2613
     title: "Ensure events that modify the system's network environment are collected"
     description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed pre- login), /etc/hosts (file containing host names and associated IP addresses) and /etc/sysconfig/network (directory containing network interface scripts and configurations) files."
     rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/network is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier \"system-locale.\""
@@ -2037,7 +2037,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/hosts && r:-p wa && r:-k system-locale'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/network && r:-p wa && r:-k system-locale'
 
-  - id: 2614 
+  - id: 2614
     title: "Ensure events that modify the system's Mandatory Access Controls are collected"
     description: "Monitor AppArmor mandatory access control. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/apparmor and /etc/apparmor.d directories."
     rationale: "Changes to files in these directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
@@ -2058,7 +2058,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/apparmor/ && r:-p wa && r:-k MAC-policy'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/apparmor.d/ && r:-p wa && r:-k MAC-policy'
 
-  - id: 2615 
+  - id: 2615
     title: "Ensure login and logout events are collected"
     description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. The file /var/log/faillog tracks failed events from login. The file /var/log/lastlog maintain records of the last time a user successfully logged in. The file /var/log/tallylog maintains records of failures via the pam_tally2 module"
     rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
@@ -2080,7 +2080,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/lastlog && r:-p wa && r:-k logins'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/tallylog && r:-p wa && r:-k logins'
 
-  - id: 2616 
+  - id: 2616
     title: "Ensure session initiation information is collected"
     description: "Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp file tracks all currently logged in users. All audit records will be tagged with the identifier \"session.\" The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp . All audit records will be tagged with the identifier \"logins.\""
     rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
@@ -2099,7 +2099,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/wtmp && r:-p wa && r:-k logins'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/btmp && r:-p wa && r:-k logins'
 
-  - id: 2617 
+  - id: 2617
     title: "Ensure discretionary access control permission modification events are collected"
     description: "Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The chmod , fchmod and fchmodat system calls affect the permissions associated with a file. The chown , fchown , fchownat and lchown system calls affect owner and group attributes on a file. The setxattr , lsetxattr , fsetxattr (set extended file attributes) and removexattr , lremovexattr , fremovexattr (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier \"perm_mod.\""
     rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
@@ -2121,7 +2121,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S chown && r:-S fchown && r:-S fchownat && r:-S lchown && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S setxattr && r:-S lsetxattr && r:-S fsetxattr && r:-S removexattr && r:-S lremovexattr && r:-S fremovexattr && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
 
-  - id: 2618 
+  - id: 2618
     title: "Ensure unsuccessful unauthorized file access attempts are collected"
     description: "Monitor for unsuccessful attempts to access files. The parameters below are associated with system calls that control creation ( creat ), opening ( open , openat ) and truncation ( truncate , ftruncate ) of files. An audit log record will only be written if the user is a non- privileged user (auid > = 1000), is not a Daemon event (auid=4294967295) and if the system call returned EACCES (permission denied to the file) or EPERM (some other permanent error associated with the specific system call). All audit records will be tagged with the identifier \"access.\""
     rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
@@ -2142,7 +2142,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-F exit=-EACCES && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-F exit=-EPERM && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
 
-  - id: 2619 
+  - id: 2619
     title: "Ensure successful file system mounts are collected"
     description: "Monitor the use of the mount system call. The mount (and umount ) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user."
     rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open , creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
@@ -2162,7 +2162,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S mount && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k mounts'
 
-  - id: 2620 
+  - id: 2620
     title: "Ensure file deletion events by users are collected"
     description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for the unlink (remove a file), unlinkat (remove a file attribute), rename (rename a file) and renameat (rename a file attribute) system calls and tags them with the identifier \"delete\"."
     rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
@@ -2180,7 +2180,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S unlink && r:-S unlinkat && r:-S rename && r:-S renameat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k delete'
 
-  - id: 2621 
+  - id: 2621
     title: "Ensure changes to system administration scope (sudoers) is collected"
     description: "Monitor scope changes for system administrations. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers will be written to when the file or its attributes have changed. The audit records will be tagged with the identifier \"scope.\""
     rationale: "Changes in the /etc/sudoers file can indicate that an unauthorized change has been made to scope of system administrator activity."
@@ -2199,7 +2199,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/sudoers && r:-p wa && r:-k scope'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/sudoers.d/ && r:-p wa && r:-k scope'
 
-  - id: 2622 
+  - id: 2622
     title: "Ensure system administrator actions (sudolog) are collected"
     description: "Monitor the sudo log file. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to /var/log/sudo.log . Any time a command is executed, an audit event will be triggered as the /var/log/sudo.log file will be opened for write and the executed administration command will be written to the log."
     rationale: "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed."
@@ -2219,7 +2219,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w \.+ && r:-p wa && r:-k actions'
 
-  - id: 2623 
+  - id: 2623
     title: "Ensure kernel module loading and unloading is collected"
     description: "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\"."
     rationale: "Monitoring the use of insmod, rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
@@ -2242,7 +2242,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/sbin/modprobe && r:-p x && r:-k modules'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S init_module && r:-S delete_module && r:-k modules'
 
-  - id: 2624 
+  - id: 2624
     title: "Ensure the audit configuration is immutable"
     description: "Set system audit so that audit rules cannot be modified with auditctl. Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot."
     rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
@@ -2261,7 +2261,7 @@ checks:
 
 
 # 4.2,1 Configure rsyslog
-  - id: 2625 
+  - id: 2625
     title: "Ensure rsyslog is installed"
     description: "The rsyslog software are recommended replacements to the original syslogd daemon which provide improvements over syslogd , such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server."
     rationale: "The security enhancements of rsyslogsuch as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
@@ -2276,7 +2276,7 @@ checks:
     condition: any
     rules:
       - 'c:dpkg -s rsyslog -> r:install ok installed'
-  - id: 2626 
+  - id: 2626
     title: "Ensure rsyslog Service is enabled"
     description: "Once the rsyslog package is installed it needs to be activated."
     rationale: "If the rsyslog service is not activated the system will not have a syslog service running."
@@ -2292,14 +2292,14 @@ checks:
     rules:
       - 'c:systemctl is-enabled rsyslog -> enabled'
 
-  - id: 2627 
+  - id: 2627
     title: "Ensure rsyslog default file permissions configured"
     description: "rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
     remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to 0640 or more restrictive:   $FileCreateMode 0640"
     compliance:
       - cis: ["4.2.1.4"]
-      - cis_csc: ["5.1"]  
+      - cis_csc: ["5.1"]
       - pci_dss: ["10.5.1","10.5.2"]
       - nist_800_53: ["CM.1","AU.9"]
       - tsc: ["CC5.2", "CC6.1", "CC7.2", "CC.7.3", "CC7.4"]
@@ -2308,7 +2308,7 @@ checks:
       - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
       - 'd:/etc/rsyslog.d/ -> r:\. -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
 
-  - id: 2628 
+  - id: 2628
     title: "Ensure rsyslog is configured to send logs to a remote log host"
     description: "The rsyslog utility supports the ability to send logs it gathers to a remote log host running syslogd(8) or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2325,7 +2325,7 @@ checks:
     rules:
       - 'c:grep -Rh ^*.* /etc/rsyslog.conf /etc/rsyslog.d/ -> r:^*.* action\.+target='
 
-  - id: 2629 
+  - id: 2629
     title: "Ensure remote rsyslog messages are only accepted on designated log hosts"
     description: "By default, rsyslog does not listen for log messages coming in from remote systems. The ModLoad tells rsyslog to load the imtcp.so module so it can listen over a network via TCP. The InputTCPServerRun option instructs rsyslogd to listen on the specified TCP port."
     rationale: "The guidance in the section ensures that remote log hosts are configured to only accept rsyslog data from hosts within the specified domain and that those systems that are not designed to be log hosts do not accept any remote rsyslog messages. This provides protection from spoofed log data and ensures that system administrators are reviewing reasonably complete syslog data in a central location."
@@ -2342,7 +2342,7 @@ checks:
       - 'c:grep -Rh ^\$InputTCPServerRun /etc/rsyslog.conf /etc/rsyslog.d/ -> r:^\$InputTCPServerRun\s*\t*514'
 
 # 4.2.2.1 Ensure journald is configured to send logs to rsyslog (Scored)
-  - id: 2630 
+  - id: 2630
     title: "Ensure journald is configured to send logs to rsyslog"
     description: "Data from journald may be stored in volatile memory or persisted locally on the server. Utilities exist to accept remote export of journald logs, however, use of the rsyslog service provides a consistent means of log collection and export."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2360,7 +2360,7 @@ checks:
       - 'f:/etc/systemd/journald.conf -> r:^\s*\t*ForwardToSyslog\s*=\s*yes'
 
 # 4.2.2.2 Ensure journald is configured to compress large log files (Scored)
-  - id: 2631 
+  - id: 2631
     title: "Ensure journald is configured to compress large log files"
     description: "The journald system includes the capability of compressing overly large files to avoid filling up the system with logs or making the logs unmanageably large."
     rationale: "Uncompressed large files may unexpectedly fill a filesystem leading to resource unavailability. Compressing logs prior to write can prevent sudden, unexpected filesystem impacts."
@@ -2378,7 +2378,7 @@ checks:
       - 'f:/etc/systemd/journald.conf -> r:^\s*\t*Compress\s*=\s*yes'
 
 # 4.2.2.3 Ensure journald is configured to write logfiles to persistent disk (Scored)
-  - id: 2632 
+  - id: 2632
     title: "Ensure journald is configured to write logfiles to persistent disk"
     description: "Data from journald may be stored in volatile memory or persisted locally on the server. Logs in memory will be lost upon a system reboot. By persisting logs to local disk on the server they are protected from loss."
     rationale: "Writing log data to disk will provide the ability to forensically reconstruct events which may have impacted the operations or security of a system even after a system crash or reboot."
@@ -2396,7 +2396,7 @@ checks:
       - 'f:/etc/systemd/journald.conf -> r:^\s*\t*Storage\s*=\s*persistent'
 
   # 4.2.3 Ensure permissions on all logfiles are configured (Scored)
-  - id: 2633 
+  - id: 2633
     title: "Ensure permissions on all logfiles are configured"
     description: "Log files stored in /var/log/ contain logged information from many services on the system, or on log hosts others as well."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitivebdata is archived and protected."
@@ -2411,7 +2411,7 @@ checks:
     rules:
       - 'c:find /var/log -type f -ls -> r:-\w\w\w\ww\w\w\w\w|-\w\w\w\w\wx\w\w\w|-\w\w\w\w\w\w\ww\w|-\w\w\w\w\w\wr\w\w|-\w\w\w\w\w\w\w\wx'
 
-  - id: 2634 
+  - id: 2634
     title: "Ensure logrotate assigns appropriate permissions"
     description: "Log files stored in /var/log/ contain logged information from many services on the system, or on log hosts others as well."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
@@ -2430,7 +2430,7 @@ checks:
 ############################################################
 # 5.1 Configure cron
 ############################################################
-  - id: 2635 
+  - id: 2635
     title: "Ensure cron daemon is enabled"
     description: "The cron daemon is used to execute batch jobs on the system."
     rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
@@ -2447,7 +2447,7 @@ checks:
 
 
 # 5.1.2 Ensure permissions on /etc/crontab are configured (Scored)
-  - id: 2636 
+  - id: 2636
     title: "Ensure permissions on /etc/crontab are configured"
     description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
     rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
@@ -2467,7 +2467,7 @@ checks:
 
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
-  - id: 2637 
+  - id: 2637
     title: "Ensure permissions on /etc/cron.hourly are configured"
     description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2483,7 +2483,7 @@ checks:
       - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
-  - id: 2638 
+  - id: 2638
     title: "Ensure permissions on /etc/cron.daily are configured"
     description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2499,7 +2499,7 @@ checks:
       - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
-  - id: 2639 
+  - id: 2639
     title: "Ensure permissions on /etc/cron.weekly are configured"
     description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2516,7 +2516,7 @@ checks:
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
-  - id: 2640 
+  - id: 2640
     title: "Ensure permissions on /etc/cron.monthly are configured"
     description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2532,7 +2532,7 @@ checks:
       - 'c:stat /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
-  - id: 2641 
+  - id: 2641
     title: "Ensure permissions on /etc/cron.d are configured"
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow , cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2548,7 +2548,7 @@ checks:
       - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.8 Ensure at/cron is restricted to authorized users (Scored)
-  - id: 2642 
+  - id: 2642
     title: "Ensure at/cron is restricted to authorized users"
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow, cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cronjobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2572,7 +2572,7 @@ checks:
 # 5.2 SSH Server Configuration
 ######################################################
 # 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured
-  - id: 2643 
+  - id: 2643
     title: "Ensure permissions on /etc/ssh/sshd_config are configured"
     description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
     rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non- privileged users."
@@ -2588,7 +2588,7 @@ checks:
       - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.2 Ensure permissions on SSH private host key files are configured (Scored)
-  - id: 2644 
+  - id: 2644
     title: "Ensure permissions on SSH private host key files are configured"
     description: "An SSH private key is one of two files used in SSH public key authentication. In this authentication method, The possession of the private key is proof of identity. Only a private key that corresponds to a public key will be able to authenticate successfully. The private keys need to be stored and handled carefully, and no copies of the private key should be distributed."
     rationale: "If an unauthorized user obtains the private SSH host key file, the host could be impersonated"
@@ -2606,7 +2606,7 @@ checks:
       - 'c:stat /etc/ssh/ssh_host_ed25519_key -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.3 Ensure permissions on SSH public host key files are configured (Scored)
-  - id: 2645 
+  - id: 2645
     title: "Ensure permissions on SSH public host key files are configured"
     description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
     rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
@@ -2624,7 +2624,7 @@ checks:
       - 'c:stat /etc/ssh/ssh_host_ed25519_key.pub -> r:^Access: \(0\d\d\d/-\w\w\w\w--\w--\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.4 Ensure SSH Protocol is not set to 1 (Scored)
-  - id: 2646 
+  - id: 2646
     title: "Ensure SSH Protocol is not set to 1"
     description: "Older versions of SSH support two different and incompatible protocols: SSH1 and SSH2. SSH1 was the original protocol and was subject to security issues. SSH2 is more advanced and secure."
     rationale: "SSH v1 suffers from insecurities that do not affect SSH v2. Notes: This command not longer exists in newer versions of SSH. This check is still being included for systems that may be running an older version of SSH. As of openSSH version 7.4 this parameter will not cause an issue when included."
@@ -2641,7 +2641,7 @@ checks:
       - 'c:sshd -T -> r:Protocol\s*\t*1'
 
 # 5.2.5 Ensure SSH LogLevel is appropriate (Scored)
-  - id: 2647 
+  - id: 2647
     title: "Ensure SSH LogLevel is appropriate"
     description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
     rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
@@ -2660,7 +2660,7 @@ checks:
       - 'c:sshd -T -> r:LogLevel\s+INFO|LogLevel\s+VERBOSE'
 
 # 5.2.6 Ensure SSH X11 forwarding is disabled (Scored)
-  - id: 2648 
+  - id: 2648
     title: "Ensure SSH X11 forwarding is disabled"
     description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
     rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
@@ -2679,7 +2679,7 @@ checks:
       - 'c:sshd -T -> r:X11Forwarding\s+no'
 
 # 5.2.7 Ensure SSH MaxAuthTries is set to 4 or less (Scored)
-  - id: 2649 
+  - id: 2649
     title: "Ensure SSH MaxAuthTries is set to 4 or less"
     description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
     rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
@@ -2695,7 +2695,7 @@ checks:
       - 'c:sshd -T -> n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
 
 # 5.2.8 Ensure SSH IgnoreRhosts is enabled (Scored)
-  - id: 2650 
+  - id: 2650
     title: "Ensure SSH IgnoreRhosts is enabled"
     description: "The IgnoreRhosts parameter specifies that .rhostsand .shostsfiles will not be used in RhostsRSAAuthenticationor HostbasedAuthentication."
     rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
@@ -2712,7 +2712,7 @@ checks:
       - 'c:sshd -T -> r:IgnoreRhosts\s+yes'
 
 # 5.2.9 Ensure SSH HostbasedAuthentication is disabled (Scored)
-  - id: 2651 
+  - id: 2651
     title: "Ensure SSH HostbasedAuthentication is disabled"
     description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
     rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
@@ -2729,7 +2729,7 @@ checks:
       - 'c:sshd -T -> r:HostbasedAuthentication\s+no'
 
 # 5.2.10 Ensure SSH root login is disabled (Scored)
-  - id: 2652 
+  - id: 2652
     title: "Ensure SSH root login is disabled"
     description: "The PermitRootLogin parameter specifies if the root user can log in using ssh(1). The default is no."
     rationale: "Disallowing root logins over SSH requires server admins to authenticate using their own individual account, then escalating to root via sudo or su. This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
@@ -2746,7 +2746,7 @@ checks:
       - 'c:sshd -T -> r:PermitRootLogin\s+no'
 
 # 5.2.11 Ensure SSH PermitEmptyPasswords is disabled (Scored)
-  - id: 2653 
+  - id: 2653
     title: "Ensure SSH PermitEmptyPasswords is disabled"
     description: "The PermitEmptyPasswords parameter specifies if the server allows login to accounts with empty password strings."
     rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system"
@@ -2763,7 +2763,7 @@ checks:
       - 'c:sshd -T -> r:PermitEmptyPasswords\s+no'
 
 # 5.2.12 Ensure SSH PermitUserEnvironment is disabled (Scored)
-  - id: 2654 
+  - id: 2654
     title: "Ensure SSH PermitUserEnvironment is disabled"
     description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
     rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing trojan'd programs)"
@@ -2780,10 +2780,10 @@ checks:
       - 'c:sshd -T -> r:PermitUserEnvironment\s+no'
 
 # 5.2.13 Ensure only strong Ciphers are used (Scored)
-  - id: 2655 
+  - id: 2655
     title: "Ensure only strong ciphers are used"
     description: "This variable limits the ciphers that SSH can use during communication."
-    rationale: "Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain cleartext data via a birthday attack against a long-duration encrypted session, aka a \"Sweet32\" attack The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly combine state data with key data during the initialization phase, which makes it easier for remote attackers to conduct plaintext-recovery attacks against the initial bytes of a stream by sniffing network traffic that occasionally relies on keys affected by the Invariance Weakness, and then using a brute-force approach involving LSB values, aka the \"Bar Mitzvah\" issue The passwords used during an SSH session encrypted with RC4 can be recovered by an attacker who is able to capture and replay the session Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plaintext data from an arbitrary block of ciphertext in an SSH session via unknown vectors The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher is used, does not properly initialize memory for a MAC context data structure, which allows remote authenticated users to bypass intended ForceCommand and login-shell restrictions via packet data that provides a crafted callback address" 
+    rationale: "Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain cleartext data via a birthday attack against a long-duration encrypted session, aka a \"Sweet32\" attack The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly combine state data with key data during the initialization phase, which makes it easier for remote attackers to conduct plaintext-recovery attacks against the initial bytes of a stream by sniffing network traffic that occasionally relies on keys affected by the Invariance Weakness, and then using a brute-force approach involving LSB values, aka the \"Bar Mitzvah\" issue The passwords used during an SSH session encrypted with RC4 can be recovered by an attacker who is able to capture and replay the session Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plaintext data from an arbitrary block of ciphertext in an SSH session via unknown vectors The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher is used, does not properly initialize memory for a MAC context data structure, which allows remote authenticated users to bypass intended ForceCommand and login-shell restrictions via packet data that provides a crafted callback address"
     remediation: "Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma separated list of the site approved ciphers Example: Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
     compliance:
       - cis: ["5.2.13"]
@@ -2806,10 +2806,10 @@ checks:
       - 'c:sshd -T -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc|arcfour|arcfour128|arcfour256|blowfish-cbc|cast128-cbc|rijndael-cbc@lysator.liu.se'
 
 # 5.2.14 Ensure only strong MAC algorithms are used (Scored)
-  - id: 2656 
+  - id: 2656
     title: "Ensure only strong MAC algorithms are used"
     description: "This variable limits the types of MAC algorithms that SSH can use during communication."
-    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information" 
+    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information"
     remediation: "Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma separated list of the site approved MACs Example: MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256"
     compliance:
       - cis: ["5.2.14"]
@@ -2825,10 +2825,10 @@ checks:
       - 'c:sshd -T -> r:MACs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|umac-128@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com'
 
 # 5.2.15 Ensure only strong Key Exchange algorithms are used (Scored)
-  - id: 2657 
+  - id: 2657
     title: "Ensure only strong Key Exchange algorithms are used"
     description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received"
-    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks" 
+    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks"
     remediation: "Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to contain a comma separated list of the site approved key exchange algorithms Example: KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
     compliance:
       - cis: ["5.2.15"]
@@ -2842,7 +2842,7 @@ checks:
       - 'c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1'
 
 # 5.2.16 Ensure SSH Idle Timeout Interval is configured (Scored)
-  - id: 2658 
+  - id: 2658
     title: "Ensure SSH Idle Timeout Interval is configured"
     description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the ClientAliveCountMax variable is set, sshd will send client alive messages at every ClientAliveInterval interval. When the number of consecutive client alive messages are sent with no response from the client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
     rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent."
@@ -2857,7 +2857,7 @@ checks:
       - 'c:sshd -T -> n:ClientAliveCountMax\s*\t*(\d+) compare <= 3'
 
 # 5.2.17 Ensure SSH LoginGraceTime is set to one minute or less (Scored)
-  - id: 2659 
+  - id: 2659
     title: "Ensure SSH LoginGraceTime is set to one minute or less"
     description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
     rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
@@ -2872,7 +2872,7 @@ checks:
       - 'c:sshd -T -> n:LoginGraceTime\s*\t*(\d+) compare <= 60 && n:LoginGraceTime\s*\t*(\d+) compare != 0'
 
 # 5.2.18 Ensure SSH access is limited (Scored)
-  - id: 2660 
+  - id: 2660
     title: "Ensure SSH access is limited"
     description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: AllowUsers, AllowGroups, DenyUsers, DenyGroups."
     rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
@@ -2887,7 +2887,7 @@ checks:
       - 'c:sshd -T -> r:AllowUsers\s+\w+|AllowGroups\s+\w+|DenyUsers\s+\w+|DenyGroups\s+\w+'
 
 # 5.2.19 Ensure SSH warning banner is configured (Scored)
-  - id: 2661 
+  - id: 2661
     title: "Ensure SSH warning banner is configured"
     description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
     rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
@@ -2903,7 +2903,7 @@ checks:
       - 'c:sshd -T -> r:Banner\s*\t*/etc/issue.net'
 
 # 5.2.20 Ensure SSH PAM is enabled (Scored)
-  - id: 2662 
+  - id: 2662
     title: "Ensure SSH PAM is enabled"
     description: "UsePAM Enables the Pluggable Authentication Module interface. If set to “yes” this will enable PAM authentication using ChallengeResponseAuthentication and PasswordAuthentication in addition to PAM account and session module processing for all authentication types."
     rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server."
@@ -2920,7 +2920,7 @@ checks:
 
 
 # 5.2.21 Ensure SSH AllowTcpForwarding is disabled (Scored)
-  - id: 2663 
+  - id: 2663
     title: "Ensure SSH AllowTcpForwarding is disabled"
     description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines."
     rationale: "Leaving port forwarding enabled can expose the organization to security risks and back-doors. SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network."
@@ -2939,7 +2939,7 @@ checks:
       - 'c:sshd -T -> r:^\s*AllowTcpForwarding\s+no'
 
 
-  - id: 2664 
+  - id: 2664
     title: "Ensure SSH MaxStartups is configured"
     description: "The MaxStartups parameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon."
     rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon."
@@ -2952,7 +2952,7 @@ checks:
       - 'c:sshd -T -> r:^\s*maxstartups\s+10:30:60'
 
 # 5.2.23 Ensure SSH MaxSessions is limited (Scored)
-  - id: 2665 
+  - id: 2665
     title: "Ensure SSH MaxSessions is limited"
     description: "The MaxSessions parameter specifies the maximum number of open sessions permitted from a given connection."
     rationale: "To protect a system from denial of service due to a large number of concurrent sessions, use the rate limiting function of MaxSessions to protect availability of sshd logins and prevent overwhelming the daemon."
@@ -2971,7 +2971,7 @@ checks:
 # 5.3 Configure PAM
 ######################################################
 # 5.3.1 Ensure password creation requirements are configured (Scored)
-  - id: 2666 
+  - id: 2666
     title: "Ensure password creation requirements are configured"
     description: "The pam_pwquality.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more. The following are definitions of the pam_pwquality.so options: - retry=3 (Allow 3 tries before sending back a failure). The following options are set in the /etc/security/pwquality.conf file: - minlen = 14 dcredit = -1 ucredit = -1 ocredit = -1 lcredit = -1 (The settings shown above are one possible policy. Alter these values to conform to your own organization's password policies.)"
     rationale: "Strong passwords protect systems from being hacked through brute force methods."
@@ -2987,7 +2987,7 @@ checks:
       - 'f:/etc/pam.d/common-password -> !r:^# && n:password\s*\t*requisite\s*\t*pam_pwquality.so\s*\t*retry=(\d+) compare <=3'
 
 # 5.3.2 Ensure lockout for failed password attempts is configured (Scored)
-  - id: 2667 
+  - id: 2667
     title: "Ensure lockout for failed password attempts is configured"
     description: "Lock out users after n unsuccessful consecutive login attempts. The first sets of changes are made to the PAM configuration files. The second set of changes are applied to the program specific PAM configuration file. The second set of changes must be applied to each program that will lock out users. Check the documentation for each secondary program for instructions on how to configure them to work with PAM. Set the lockout number to the policy in effect at your site."
     rationale: "Locking out user IDs after n unsuccessful consecutive login attempts mitigates brute force password attacks against your systems."
@@ -3004,7 +3004,7 @@ checks:
       - 'f:/etc/pam.d/common-account -> !r:^# && r:account\s*\t*required\s*\t*pam_tally2.so'
 
 # 5.3.3 Ensure password reuse is limited (Scored)
-  - id: 2668 
+  - id: 2668
     title: "Ensure password reuse is limited"
     description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
     rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password. Note that these change only apply to accounts configured on the local system."
@@ -3020,7 +3020,7 @@ checks:
       - 'f:/etc/pam.d/common-password -> !r:^# && r:password\s*\t*required\s*\t*pam_pwhistory.so && !r:remember'
 
 # 5.3.4 Ensure password hashing algorithm is SHA-512 (Scored)
-  - id: 2669 
+  - id: 2669
     title: "Ensure password hashing algorithm is SHA-512"
     description: "The commands below change password encryption from md5 to sha512 (a much stronger hashing algorithm). All existing accounts will need to perform a password change to upgrade the stored hashes to the new algorithm."
     rationale: "The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note that these change only apply to accounts configured on the local system."
@@ -3041,7 +3041,7 @@ checks:
 # 5.4.1 Set Shadow Password Suite Parameters
 ####################################################
 # 5.4.1.1 Ensure password expiration is 365 days or less (Scored)
-  - id: 2670 
+  - id: 2670
     title: "Ensure password expiration is 365 days or less"
     description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 365 days."
     rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity."
@@ -3057,7 +3057,7 @@ checks:
       - 'not f:/etc/login.defs -> n:^\s*\t*PASS_MAX_DAYS\s*\t*(\d+) compare < 0'
 
 # 5.4.1.2 Ensure minimum days between password changes is configured
-  - id: 2671 
+  - id: 2671
     title: "Ensure minimum days between password changes is 7 or more"
     description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 7 or more days."
     rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
@@ -3072,7 +3072,7 @@ checks:
       - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 1'
 
 # 5.4.1.3 Ensure password expiration warning days is 7 or more (Scored)
-  - id: 2672 
+  - id: 2672
     title: "Ensure password expiration warning days is 7 or more"
     description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
     rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
@@ -3087,7 +3087,7 @@ checks:
       - 'f:/etc/login.defs -> n:^\s*\t*PASS_WARN_AGE\s*\t*(\d+) compare >= 7'
 
 # 5.4.1.4 Ensure inactive password lock is 30 days or less (Scored)
-  - id: 2673 
+  - id: 2673
     title: "Ensure inactive password lock is 30 days or less"
     description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
     rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
@@ -3103,7 +3103,7 @@ checks:
       - 'not c:useradd -D -> n:^INACTIVE=(\d+) compare < 0'
 
 # 5.4.3 Ensure default group for the root account is GID 0 (Scored)
-  - id: 2674 
+  - id: 2674
     title: "Ensure default group for the root account is GID 0"
     description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
     rationale: "Using GID 0 for the root account helps prevent root-owned files from accidentally becoming accessible to non-privileged users."
@@ -3118,7 +3118,7 @@ checks:
       - 'f:/etc/passwd -> !r:^# && r:root:\w+:\w+:0:'
 
 # 5.4.4 Ensure default user umask is 027 or more restrictive (Scored)
-  - id: 2675 
+  - id: 2675
     title: "Ensure default user umask is 027 or more restrictive"
     description: "The default umask determines the permissions of files created by users. The user creating the file has the discretion of making their files and directories readable by others via the chmod command. Users who wish to allow their files and directories to be readable by others by default may choose a different default umask by inserting the umask command into the standard shell configuration files ( .profile , .bashrc , etc.) in their home directories."
     rationale: "Setting a very secure default value for umask ensures that users make a conscious choice about their file permissions. A default umask setting of 077 causes files and directories created by users to not be readable by any other user on the system. A umask of 027 would make files and directories readable by users in the same Unix group, while a umask of 022 would make files readable by every user on the system."
@@ -3140,7 +3140,7 @@ checks:
 
 
 # 5.4.5 Ensure default user shell timeout is 900 seconds or less (Scored)
-  - id: 2676 
+  - id: 2676
     title: "Ensure default user shell timeout is 900 seconds or less"
     description: "The default TMOUT determines the shell timeout for users. The TMOUT value is measured in seconds."
     rationale: "Having no timeout value associated with a shell could allow an unauthorized user access to another user's shell session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening."
@@ -3159,7 +3159,7 @@ checks:
       - 'f:/etc/profile -> r:^\s*\t*readonly && n:TMOUT\s*\t*=\s*\t*(\d+) compare <= 900'
 
 # 5.6 Ensure access to the su command is restricted (Scored)
-  - id: 2677 
+  - id: 2677
     title: "Ensure access to the su command is restricted"
     description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in the sudo group to execute su."
     rationale: "Restricting the use of su, and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo, whereas su can only record that a user executed the su program."
@@ -3185,7 +3185,7 @@ checks:
 # 6.1 System File Permissions
 ############################################################
 # 6.1.2 Ensure permissions on /etc/passwd are configured (Scored)
-  - id: 2678 
+  - id: 2678
     title: "Ensure permissions on /etc/passwd are configured"
     description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
     rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3201,7 +3201,7 @@ checks:
       - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.3 Ensure permissions on /etc/gshadow- are configured (Scored)
-  - id: 2679 
+  - id: 2679
     title: "Ensure permissions on /etc/gshadow- are configured"
     description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3217,7 +3217,7 @@ checks:
       - 'c:stat /etc/gshadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.4 Ensure permissions on /etc/shadow are configured (Scored)
-  - id: 2680 
+  - id: 2680
     title: "Ensure permissions on /etc/shadow are configured"
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
@@ -3233,7 +3233,7 @@ checks:
       - 'c:stat /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
 # 6.1.5 Ensure permissions on /etc/group are configured (Scored)
-  - id: 2681 
+  - id: 2681
     title: "Ensure permissions on /etc/group are configured"
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
@@ -3249,7 +3249,7 @@ checks:
       - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.6 Ensure permissions on /etc/passwd- are configured (Scored)
-  - id: 2682 
+  - id: 2682
     title: "Ensure permissions on /etc/passwd- are configured"
     description: "The /etc/passwd- file contains backup user account information."
     rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3265,7 +3265,7 @@ checks:
       - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Ensure permissions on /etc/shadow- are configured (Scored)
-  - id: 2683 
+  - id: 2683
     title: "Ensure permissions on /etc/shadow- are configured"
     description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3281,7 +3281,7 @@ checks:
       - 'c:stat /etc/shadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)|Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.8 Ensure permissions on /etc/group- are configured (Scored)
-  - id: 2684 
+  - id: 2684
     title: "Ensure permissions on /etc/group- are configured"
     description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
     rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3297,7 +3297,7 @@ checks:
       - 'c:stat /etc/group- -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Ensure permissions on /etc/gshadow are configured (Scored)
-  - id: 2685 
+  - id: 2685
     title: "Ensure permissions on /etc/gshadow are configured"
     description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/gshadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/gshadow file (such as group administrators) could also be useful to subvert the group"
@@ -3317,7 +3317,7 @@ checks:
 ####################################################
 
 # 6.2.1 Ensure password fields are not empty (Scored)
-  - id: 2686 
+  - id: 2686
     title: "Ensure password fields are not empty"
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
@@ -3332,7 +3332,7 @@ checks:
       - 'f:/etc/shadow -> r:^\w+::'
 
 # 6.2.2 Ensure no legacy "+" entries exist in /etc/passwd (Scored)
-  - id: 2687 
+  - id: 2687
     title: "Ensure no legacy \"+\" entries exist in /etc/passwd"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -3351,7 +3351,7 @@ checks:
       - 'f:/etc/passwd -> !r:^# && r:^+:'
 
 # 6.2.4 Ensure no legacy "+" entries exist in /etc/shadow (Scored)
-  - id: 2688 
+  - id: 2688
     title: "Ensure no legacy \"+\" entries exist in /etc/shadow"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -3370,7 +3370,7 @@ checks:
       - 'f:/etc/shadow -> !r:^# && r:^+:'
 
 # 6.2.5 Ensure no legacy "+" entries exist in /etc/group (Scored)
-  - id: 2689 
+  - id: 2689
     title: "Ensure no legacy \"+\" entries exist in /etc/group"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -3389,7 +3389,7 @@ checks:
       - 'f:/etc/group -> !r:^# && r:^+:'
 
 # 6.2.6 Ensure root is the only UID 0 account (Scored)
-  - id: 2690 
+  - id: 2690
     title: "Ensure root is the only UID 0 account"
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
@@ -3407,7 +3407,7 @@ checks:
       - 'f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:'
 
 # 6.2.20 Ensure shadow group is empty (Scored)
-  - id: 2691 
+  - id: 2691
     title: "Ensure shadow group is empty"
     description: "The shadow group allows system programs which require access the ability to read the /etc/shadow file. No users should be assigned to the shadow group."
     rationale: "Any users assigned to the shadow group would be granted read access to the /etc/shadow file. If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed passwords to break them. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts."

--- a/ruleset/sca/debian/cis_debian7.yml
+++ b/ruleset/sca/debian/cis_debian7.yml
@@ -30,7 +30,7 @@ checks:
 
 # 2 Filesystem Configuration
 
-  - id: 1000 
+  - id: 1000
     title: "Create Separate Partition for /tmp"
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -45,7 +45,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s'
 
-  - id: 1001 
+  - id: 1001
     title: "Set nodev option for /tmp Partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
@@ -59,7 +59,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s && r:nodev'
 
-  - id: 1002 
+  - id: 1002
     title: "Set nosuid option for /tmp Partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain set userid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create set userid files in /tmp."
@@ -73,7 +73,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s && r:nosuid'
 
-  - id: 1003 
+  - id: 1003
     title: "Set noexec option for /tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
@@ -87,7 +87,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s && r:noexec'
 
-  - id: 1004 
+  - id: 1004
     title: "Create Separate Partition for /var"
     description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
     rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
@@ -103,7 +103,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var\s'
 
-  - id: 1005 
+  - id: 1005
     title: "Bind mount the /var/tmp directory to /tmp"
     description: "The /var/tmp directory is normally a standalone directory in the /var file system. Binding /var/tmp to /tmp establishes an unbreakable link to /tmp that cannot be removed (even by the root user). It also allows /var/tmp to inherit the same mount options that /tmp owns, allowing /var/tmp to be protected in the same manner /tmp is protected. It will also prevent /var from filling up with temporary files as the contents of /var/tmp will actually reside in the file system containing /tmp."
     rationale: "All programs that use /var/tmp and /tmp to read/write temporary files will always be write to tmp file system, preventing a user from running the /var file system out of space or trying to perform operations that have been blocked in the /tmp filesystem."
@@ -118,7 +118,7 @@ checks:
       - 'c:findmnt -> r:/var/tmp && r:[/tmp]'
       - 'f:/etc/fstab -> r:^/tmp && r:\s*/var/tmp\s* && r:bind'
 
-  - id: 1006 
+  - id: 1006
     title: "Create Separate Partition for /var/log"
     description: "The /var/log directory is used by system services to store log data."
     rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
@@ -134,7 +134,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/log\s'
 
-  - id: 1007 
+  - id: 1007
     title: "Create Separate Partition for /var/log/audit"
     description: "The auditing daemon, auditd, stores log data in the /var/log/audit directory."
     rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data. The audit daemon calculates how much free space is left and performs actions based on the results. If other processes (such as syslog) consume space in the same partition as auditd, it may not perform as desired."
@@ -150,7 +150,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/log/audit\s'
 
-  - id: 1008 
+  - id: 1008
     title: "Create Separate Partition for /home"
     description: "The /home directory is used to support disk storage needs of local users."
     rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
@@ -166,7 +166,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/home\s'
 
-  - id: 1009 
+  - id: 1009
     title: "Add nodev Option to /home"
     description: "When set on a file system, this option prevents character and block special devices from being defined, or if they exist, from being used as character and block special devices."
     rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices.  Note: The actions in the item refer to the /home partition, which is the default user partition that is defined in many distributions. If you have created other user partitions, it is recommended that the Remediation and Audit steps be applied to these partitions as well."
@@ -182,7 +182,7 @@ checks:
 
 
 
-  - id: 1010 
+  - id: 1010
     title: "Add nodev Option to /run/shm Partition"
     description: "The nodev mount option specifies that the /run/shm (temporary filesystem stored in memory) cannot contain block or character special devices."
     rationale: "Since the /run/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /run/shm partitions."
@@ -196,7 +196,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/run/shm\s && r:nodev'
 
-  - id: 1011 
+  - id: 1011
     title: "Add nosuid Option to /run/shm Partition"
     description: "The nosuid mount option specifies that the /run/shm (temporary filesystem stored in memory) will not execute setuid and setgid on executable programs as such, but rather execute them with the uid and gid of the user executing the program."
     rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
@@ -210,7 +210,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/run/shm\s && r:nosuid'
 
-  - id: 1012 
+  - id: 1012
     title: "Add noexec Option to /run/shm Partition"
     description: "Set noexec on the shared memory partition to prevent programs from executing from there."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
@@ -226,7 +226,7 @@ checks:
 
 
 
-  - id: 1013 
+  - id: 1013
     title: "Disable Mounting of cramfs Filesystems"
     description: "The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
@@ -239,7 +239,7 @@ checks:
       - 'c:/sbin/modprobe -n -v cramfs -> r:^install /bin/true'
       - 'not c:/sbin/lsmod -> r:cramfs'
 
-  - id: 1014 
+  - id: 1014
     title: "Disable Mounting of freevxfs Filesystems"
     description: "The freevxfs filesystem type is a free version of the Veritas type filesystem. This is the primary filesystem type for HP-UX operating systems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
@@ -252,7 +252,7 @@ checks:
       - 'c:/sbin/modprobe -n -v freevxfs -> r:^install /bin/true'
       - 'not c:/sbin/lsmod -> r:freevxfs'
 
-  - id: 1015 
+  - id: 1015
     title: "Disable Mounting of jffs2 Filesystems"
     description: "The jffs2 (journaling flash filesystem 2) filesystem type is a log-structured filesystem used in flash memory devices."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
@@ -265,7 +265,7 @@ checks:
       - 'c:/sbin/modprobe -n -v jffs2 -> r:^install /bin/true'
       - 'not c:/sbin/lsmod -> r:jffs2'
 
-  - id: 1016 
+  - id: 1016
     title: "Disable Mounting of hfs Filesystems"
     description: "The hfs filesystem type is a hierarchical filesystem that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
@@ -278,7 +278,7 @@ checks:
       - 'c:/sbin/modprobe -n -v hfs -> r:^install /bin/true'
       - 'not c:/sbin/lsmod -> r:hfs'
 
-  - id: 1017 
+  - id: 1017
     title: "Disable Mounting of hfsplus Filesystems"
     description: "The hfsplus filesystem type is a hierarchical filesystem designed to replace hfs that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
@@ -291,7 +291,7 @@ checks:
       - 'c:/sbin/modprobe -n -v hfsplus -> r:^install /bin/true'
       - 'not c:/sbin/lsmod -> r:hfsplus'
 
-  - id: 1018 
+  - id: 1018
     title: "Disable Mounting of squashfs Filesystems"
     description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs). A squashfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
@@ -304,7 +304,7 @@ checks:
       - 'c:/sbin/modprobe -n -v squashfs -> r:^install /bin/true'
       - 'not c:/sbin/lsmod -> r:squashfs'
 
-  - id: 1019 
+  - id: 1019
     title: "Disable Mounting of udf Filesystems"
     description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats"
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
@@ -318,7 +318,7 @@ checks:
       - 'not c:/sbin/lsmod -> r:udf'
 
 
-  - id: 1020 
+  - id: 1020
     title: "Disable Automounting"
     description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
     rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have it's contents available in system even if they lacked permissions to mount it themselves."
@@ -330,11 +330,11 @@ checks:
       - tsc: ["CC5.2"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *autofs* -> r:/etc/rc\d+.d/S\d+autofs'    
+      - 'c:find /etc/ -name *autofs* -> r:/etc/rc\d+.d/S\d+autofs'
 
 # 3 Secure Boot Settings
 
-  - id: 1021 
+  - id: 1021
     title: "Set User/Group Owner on bootloader config"
     description: "Set the owner and group of your boot loaders config file to the root user. These instructions default to GRUB stored at /boot/grub/grub.cfg ."
     rationale: "Setting the owner and group to root prevents non-root users from changing the file."
@@ -348,7 +348,7 @@ checks:
     rules:
       - 'c:stat /boot/grub/grub.cfg -> r:Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 1022 
+  - id: 1022
     title: "Set Permissions on bootloader config"
     description: "Set permission on the your boot loaders config file to read and write for root only."
     rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
@@ -362,7 +362,7 @@ checks:
     rules:
       - 'c:stat /boot/grub/grub.cfg -> r:^Access: \(0\d00/-\w\w\w------\)'
 
-  - id: 1023 
+  - id: 1023
     title: "Set Boot Loader Password"
     description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters"
     rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
@@ -377,7 +377,7 @@ checks:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*set superusers'
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*password'
 
-  - id: 1024 
+  - id: 1024
     title: "Require authentication for Single-User mode"
     description: "Setting a password for the root user will force authentication in single user mode."
     rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
@@ -394,7 +394,7 @@ checks:
 # 4 Additional Process Hardening
 ###########################################
 # 4.1 Restrict Core Dumps (Scored)
-  - id: 1025 
+  - id: 1025
     title: "Restrict Core Dumps"
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
     rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5)). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
@@ -410,7 +410,7 @@ checks:
       - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:\s0$|\t0$'
 
 # 4.2 Enable XD/NX Support on 32-bit x86 Systems (Not Scored)
-  - id: 1026 
+  - id: 1026
     title: "Enable XD/NX Support on 32-bit x86 Systems"
     description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
     rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
@@ -425,7 +425,7 @@ checks:
       - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
 
 # 4.3 Enable Randomized Virtual Memory Region Placement (Scored)
-  - id: 1027 
+  - id: 1027
     title: "Enable Randomized Virtual Memory Region Placement"
     description: "Set the system flag to force randomized virtual memory region placement."
     rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
@@ -440,7 +440,7 @@ checks:
       - 'c:sysctl kernel.randomize_va_space -> r:^kernel.randomize_va_space\s*\t*=\s*\t*2'
 
 # 4.4 Disable prelink
-  - id: 1028 
+  - id: 1028
     title: "Disable Prelink"
     description: "The prelinking feature changes binaries in an attempt to decrease their startup time."
     rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
@@ -454,7 +454,7 @@ checks:
     rules:
       - 'c:dpkg -s prelink -> r:install ok installed'
 
-  - id: 1029 
+  - id: 1029
     title: "Activate AppArmor"
     description: "AppArmor provides a Mandatory Access Control (MAC) system that greatly augments the default Discretionary Access Control (DAC) model."
     rationale: "For an action to occur, both the traditional DAC permissions must be satisfied as well as the AppArmor MAC rules. The action will not be allowed if either one of these models does not permit the action. In this way, AppArmor rules can only make a system's permissions more restrictive and secure."
@@ -471,7 +471,7 @@ checks:
 # 5 OS Services
 ######################################
 # 5.1.1 Ensure NIS is not installed (Scored)
-  - id: 1030 
+  - id: 1030
     title: "Ensure NIS is not installed"
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
@@ -489,7 +489,7 @@ checks:
       - 'c:dpkg -s nis -> r:install ok installed'
 
 # 5.1.2 Ensure rsh server is not enabled (Scored)
-  - id: 1031 
+  - id: 1031
     title: "Ensure rsh server is not enabled"
     description: "The Berkeley rsh-server (rsh, rlogin, rcp) package contains legacy services that exchange credentials in clear-text."
     rationale: "These legacy service contain numerous security exposures and have been replaced with the more secure SSH package."
@@ -507,7 +507,7 @@ checks:
       - 'f:/etc/inetd.conf -> !r:^# && r:^shell|^login|^exec'
 
 # 5.1.3 Ensure rsh client is not installed (Scored)
-  - id: 1032 
+  - id: 1032
     title: "Ensure rsh client is not installed"
     description: "The rsh package contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh , rcp and rlogin ."
@@ -526,7 +526,7 @@ checks:
       - 'c:dpkg -s rsh-redone-client -> r:install ok installed'
 
 # 5.1.4 Ensure talk server is not enabled (Scored)
-  - id: 1033 
+  - id: 1033
     title: "Ensure talk server is not enabled"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client (allows initiate of talk sessions) is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -544,7 +544,7 @@ checks:
       - 'f:/etc/inetd.conf -> !r:^# && r:^talk|^ntalk'
 
 # 5.1.5 Ensure talk client is not installed (Scored)
-  - id: 1034 
+  - id: 1034
     title: "Ensure talk client is not installed"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -562,7 +562,7 @@ checks:
       - 'c:dpkg -s talk -> r:install ok installed'
 
 # 5.1.6 Ensure telnet server is not enabled (Scored)
-  - id: 1035 
+  - id: 1035
     title: "Ensure telnet server is not enabled"
     description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
@@ -580,7 +580,7 @@ checks:
       - 'f:/etc/inetd.conf -> !r:^# && r:telnet'
 
 # 5.1.7 Ensure tftp-server is not enabled (Scored)
-  - id: 1036 
+  - id: 1036
     title: "Ensure tftp-server is not enabled"
     description: "Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot machines from a boot server. The packages tftp and atftp are both used to define and support a TFTP server."
     rationale: "TFTP does not support authentication nor does it ensure the confidentiality or integrity of data. It is recommended that TFTP be removed, unless there is a specific need for TFTP. In that case, extreme caution must be used when configuring the services."
@@ -598,7 +598,7 @@ checks:
       - 'f:/etc/inetd.conf -> !r:^# && r:tftp'
 
 # 5.1.8 Ensure xinetd is not enabled (Scored)
-  - id: 1037 
+  - id: 1037
     title: "Ensure xinetd is not enabled"
     description: "The eXtended InterNET Daemon (xinetd) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests.  Note: Several other services recommended to be disabled in this benchmark have xinetd versions as well, if xinetd is required in your environment ensure they are disabled in xinetd configuration as well."
     rationale: "If there are no xinetd services required, it is recommended that the daemon be disabled."
@@ -613,10 +613,10 @@ checks:
       - hipaa: ["164.312.b"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *xinetd* -> r:/etc/rc\d+.d/S\d+xinetd'    
+      - 'c:find /etc/ -name *xinetd* -> r:/etc/rc\d+.d/S\d+xinetd'
 
 # 5.2 Ensure chargen is not enabled (Scored)
-  - id: 1038 
+  - id: 1038
     title: "Ensure chargen is not enabled"
     description: "chargen is a network service that responds with 0 to 512 ASCII characters for each connection it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -634,7 +634,7 @@ checks:
       - 'f:/etc/inetd.conf -> !r:^# && r:chargen'
 
 # 5.3 Ensure daytime is not enabled (Scored)
-  - id: 1039 
+  - id: 1039
     title: "Ensure daytime is not enabled"
     description: "daytime is a network service that responds with the server's current date and time. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -652,7 +652,7 @@ checks:
       - 'f:/etc/inetd.conf -> !r:^# && r:daytime'
 
 # 5.4 Ensure echo is not enabled (Scored)
-  - id: 1040 
+  - id: 1040
     title: "Ensure echo is not enabled"
     description: "echo is a network service that responds to clients with the data sent to it by the client. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -670,7 +670,7 @@ checks:
       - 'f:/etc/inetd.conf -> !r:^# && r:echo'
 
 # 5.5 Ensure discard is not enabled (Scored)
-  - id: 1041 
+  - id: 1041
     title: "Ensure discard is not enabled"
     description: "discard is a network service that simply discards all data it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -688,7 +688,7 @@ checks:
       - 'f:/etc/inetd.conf -> !r:^# && r:discard'
 
 # 5.6 Ensure time is not enabled (Scored)
-  - id: 1042 
+  - id: 1042
     title: "Ensure time is not enabled"
     description: "time is a network service that responds with the server's current date and time as a 32 bit integer. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -710,7 +710,7 @@ checks:
 ###############################################
 
 # 6.1 Ensure the X Window system is not installed (Scored)
-  - id: 1043 
+  - id: 1043
     title: "Ensure the X Window system is not installed"
     description: "The X Window system provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Window system is typically used on desktops where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
@@ -726,7 +726,7 @@ checks:
       - 'c:dpkg -l xserver-xorg-core* -> r:^\wi\s*xserver-xorg'
 
 # 6.2 Ensure Avahi Server is not enabled (Scored)
-  - id: 1044 
+  - id: 1044
     title: "Ensure Avahi Server is not enabled"
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Since servers are not normally used for printing, this service is not needed unless dependencies require it. If this is the case, disable the service to reduce the potential attack surface."
@@ -739,10 +739,10 @@ checks:
       - tsc: ["CC5.2","CC6.1","CC6.8","CC7.1","CC7.2","CC8.1"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *avahi-daemon* -> r:/etc/rc\d+.d/S\d+avahi-daemon'    
+      - 'c:find /etc/ -name *avahi-daemon* -> r:/etc/rc\d+.d/S\d+avahi-daemon'
 
 # 6.3 Ensure print server is not enabled (Scored)
-  - id: 1045 
+  - id: 1045
     title: "Ensure print server is not enabled"
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be disabled to reduce the potential attack surface."
@@ -755,10 +755,10 @@ checks:
       - tsc: ["CC5.2","CC6.1","CC6.8","CC7.1","CC7.2","CC8.1"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *cups* -> r:/etc/rc\d+.d/S\d+cups'    
+      - 'c:find /etc/ -name *cups* -> r:/etc/rc\d+.d/S\d+cups'
 
 # 6.4 Ensure DHCP Server is not enabled (Scored)
-  - id: 1046 
+  - id: 1046
     title: "Ensure DHCP Server is not enabled"
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a server is specifically set up to act as a DHCP server, it is recommended that this service be deleted to reduce the potential attack surface."
@@ -773,10 +773,10 @@ checks:
       - tsc: ["CC5.2","CC6.1","CC6.8","CC7.1","CC7.2","CC8.1"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *isc-dhcp-server* -> r:/etc/rc\d+.d/S\d+isc-dhcp-server'    
+      - 'c:find /etc/ -name *isc-dhcp-server* -> r:/etc/rc\d+.d/S\d+isc-dhcp-server'
 
 # 6.5 Configure Network Time Protocol (Scored)
-  - id: 1047 
+  - id: 1047
     title: "Configure Network Time Protocol (NTP)"
     description: "The Network Time Protocol (NTP) is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at http://www.ntp.org. NTP can be configured to be a client and/or a server."
     rationale: "It is recommended that physical systems and virtual guests lacking direct access to the physical host's clock be configured as NTP clients to synchronize their clocks (especially to support time sensitive security mechanisms like Kerberos). This also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
@@ -798,7 +798,7 @@ checks:
       - 'f:/etc/init.d/ntp -> r:^RUNASUSER\s*\t*=\s*\t*ntp'
 
 # 6.6 Ensure LDAP is not enabled (Scored)
-  - id: 1048 
+  - id: 1048
     title: "Ensure LDAP is not enabled"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the server will not need to act as an LDAP client or server, it is recommended that the software be disabled to reduce the potential attack surface."
@@ -816,7 +816,7 @@ checks:
       - 'c:dpkg -s slapd -> r:install ok installed'
 
 # 6.7 Ensure NFS and RPC are not enabled (Scored)
-  - id: 1049 
+  - id: 1049
     title: "Ensure NFS and RPC are not enabled"
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the server does not export NFS shares or act as an NFS client, it is recommended that these services be disabled to reduce remote attack surface."
@@ -829,11 +829,11 @@ checks:
       - tsc: ["CC5.2","CC6.1","CC6.8","CC7.1","CC7.2","CC8.1"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *rpcbind* -> r:/etc/rc\d+.d/S\d+rpcbind'    
-      - 'c:find /etc/ -name *nfs-kernel-server* -> r:/etc/rc\d+.d/S\d+nfs-kernel-server'    
+      - 'c:find /etc/ -name *rpcbind* -> r:/etc/rc\d+.d/S\d+rpcbind'
+      - 'c:find /etc/ -name *nfs-kernel-server* -> r:/etc/rc\d+.d/S\d+nfs-kernel-server'
 
 # 6.8 Ensure DNS Server is not enabled (Scored)
-  - id: 1050 
+  - id: 1050
     title: "Ensure DNS Server is not enabled"
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a server is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
@@ -846,10 +846,10 @@ checks:
       - tsc: ["CC5.2","CC6.1","CC6.8","CC7.1","CC7.2","CC8.1"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *bind9* -> r:/etc/rc\d+.d/S\d+bind9'    
+      - 'c:find /etc/ -name *bind9* -> r:/etc/rc\d+.d/S\d+bind9'
 
 # 6.9 Ensure FTP Server is not enabled (Scored)
-  - id: 1051 
+  - id: 1051
     title: "Ensure FTP Server is not enabled"
     description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
@@ -862,10 +862,10 @@ checks:
       - tsc: ["CC5.2","CC6.1","CC6.8","CC7.1","CC7.2","CC8.1"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *vsftpd* -> r:/etc/rc\d+.d/S\d+vsftp'    
+      - 'c:find /etc/ -name *vsftpd* -> r:/etc/rc\d+.d/S\d+vsftp'
 
 # 6.10 Ensure HTTP Server is not enabled (Scored)
-  - id: 1052 
+  - id: 1052
     title: "Ensure HTTP Server is not enabled"
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
@@ -878,10 +878,10 @@ checks:
       - tsc: ["CC5.2","CC6.1","CC6.8","CC7.1","CC7.2","CC8.1"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *apache2* -> r:/etc/rc\d+.d/S\d+apache2'    
+      - 'c:find /etc/ -name *apache2* -> r:/etc/rc\d+.d/S\d+apache2'
 
 # 6.11 Ensure IMAP and POP Server is not enabled (Scored)
-  - id: 1053 
+  - id: 1053
     title: "Ensure IMAP and POP server is not enabled"
     description: "Dovecot is an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided to this server, it is recommended that the service be deleted to reduce the potential attack surface."
@@ -894,10 +894,10 @@ checks:
       - tsc: ["CC5.2","CC6.1","CC6.8","CC7.1","CC7.2","CC8.1"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *dovecot* -> r:/etc/rc\d+.d/S\d+dovecot'    
+      - 'c:find /etc/ -name *dovecot* -> r:/etc/rc\d+.d/S\d+dovecot'
 
 # 6.12 Ensure Samba is not enabled (Scored)
-  - id: 1054 
+  - id: 1054
     title: "Ensure Samba is not enabled"
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this service can be deleted to reduce the potential attack surface."
@@ -910,10 +910,10 @@ checks:
       - tsc: ["CC5.2","CC6.1","CC6.8","CC7.1","CC7.2","CC8.1"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *samba* -> r:/etc/rc\d+.d/S\d+samba'    
+      - 'c:find /etc/ -name *samba* -> r:/etc/rc\d+.d/S\d+samba'
 
 # 6.13 Ensure HTTP Proxy Server is not enabled (Scored)
-  - id: 1055 
+  - id: 1055
     title: "Ensure HTTP Proxy Server is not enabled"
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
@@ -926,10 +926,10 @@ checks:
       - tsc: ["CC5.2","CC6.1","CC6.8","CC7.1","CC7.2","CC8.1"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *squid3* -> r:/etc/rc\d+.d/S\d+squid3'    
+      - 'c:find /etc/ -name *squid3* -> r:/etc/rc\d+.d/S\d+squid3'
 
 # 6.14 Ensure SNMP Server is not enabled (Scored)
-  - id: 1056 
+  - id: 1056
     title: "Ensure SNMP Server is not enabled"
     description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
     rationale: "The SNMP server communicates using SNMP v1, which transmits data in the clear and does not require authentication to execute commands. Unless absolutely necessary, it is recommended that the SNMP service not be used."
@@ -942,10 +942,10 @@ checks:
       - tsc: ["CC5.2","CC6.1","CC6.8","CC7.1","CC7.2","CC8.1"]
     condition: none
     rules:
-      - 'c:find /etc/ -name *snmpd* -> r:/etc/rc\d+.d/S\d+snmpd'    
+      - 'c:find /etc/ -name *snmpd* -> r:/etc/rc\d+.d/S\d+snmpd'
 
 # 6.15 Ensure Mail Transfer Agent for Local-Only Mode (Scored)
-  - id: 1057 
+  - id: 1057
     title: "Configure Mail Transfer Agent for Local-Only Mode"
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Note: The remediation given here provides instructions for configuring the postfix mail server, depending on your environment you may have an alternative MTA installed such as sendmail.  If this is the case consult the documentation for your installed MTA to configure the recommended state."
@@ -961,7 +961,7 @@ checks:
       - 'c:netstat -an -> r:\.*25\.*LISTEN && !r:127.0.0.1:25\.+LISTEN|::1:25\.*LISTEN'
 
 # 6.16 Ensure rsync service is not enabled (Scored)
-  - id: 1058 
+  - id: 1058
     title: "Ensure rsync service is not enabled"
     description: "The rsyncd service can be used to synchronize files between systems over network links."
     rationale: "The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
@@ -988,7 +988,7 @@ checks:
 ###############################################
 
 # 7.1.1 Disable IP Forwarding (Scored)
-  - id: 1059 
+  - id: 1059
     title: "Disable IP Forwarding"
     description: "The net.ipv4.ip_forward flag is used to tell the server whether it can forward packets or not. If the server is not to be used as a router, set the flag to 0."
     rationale: "Setting the flag to 0 ensures that a server with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
@@ -1004,7 +1004,7 @@ checks:
       - 'c:/sbin/sysctl net.ipv4.ip_forward -> r:=\s*\t*0$'
 
 # 7.1.2 Disable Send Packet Redirects (Scored)
-  - id: 1060 
+  - id: 1060
     title: "Disable Send Packet Redirects"
     description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
     rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
@@ -1019,13 +1019,13 @@ checks:
     rules:
       - 'c:/sbin/sysctl net.ipv4.conf.all.send_redirects -> r:=\s*\t*0$'
       - 'c:/sbin/sysctl net.ipv4.conf.default.send_redirects -> r:=\s*\t*0$'
-      
+
 ###############################################
 # 7.2 Modify Network Parameters (Host and Router)
 ###############################################
 
 # 7.2.1 Disable Source Routed Packet Acceptance (Scored)
-  - id: 1061 
+  - id: 1061
     title: "Disable Source Routed Packet Acceptance"
     description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
     rationale: "Setting net.ipv4.conf.all.accept_source_route and net.ipv4.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this server was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the server as a way to reach the private address servers. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
@@ -1042,7 +1042,7 @@ checks:
       - 'c:/sbin/sysctl net.ipv4.conf.default.accept_source_route -> r:=\s*\t*0$'
 
 # 7.2.2 Disable ICMP Redirect Acceptance (Scored)
-  - id: 1062 
+  - id: 1062
     title: "Disable ICMP Redirect Acceptance"
     description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables. By setting net.ipv4.conf.all.accept_redirects to 0, the system will not accept any ICMP redirect messages, and therefore, won't allow outsiders to update the system's routing tables."
     rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
@@ -1059,7 +1059,7 @@ checks:
       - 'c:/sbin/sysctl net.ipv4.conf.default.accept_redirects -> r:=\s*\t*0$'
 
 # 7.2.3 Disable Secure ICMP Redirect Acceptance (Scored)
-  - id: 1063 
+  - id: 1063
     title: "Disable Secure ICMP Redirect Acceptance"
     description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
     rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
@@ -1076,7 +1076,7 @@ checks:
       - 'c:/sbin/sysctl net.ipv4.conf.default.secure_redirects -> r:=\s*\t*0$'
 
 # 7.2.4 Log Suspicious Packets (Scored)
-  - id: 1064 
+  - id: 1064
     title: "Log Suspicious Packets"
     description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
     rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their server."
@@ -1093,7 +1093,7 @@ checks:
       - 'c:/sbin/sysctl net.ipv4.conf.default.log_martians -> r:=\s*\t*1$'
 
 # 7.2.5 Enable Ignore Broadcast Requests (Scored)
-  - id: 1065 
+  - id: 1065
     title: "Enable Ignore Broadcast Requests"
     description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
     rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
@@ -1109,7 +1109,7 @@ checks:
       - 'c:/sbin/sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:=\s*\t*1$'
 
 # 7.2.6 Enable Bad Error Message Protection (Scored)
-  - id: 1066 
+  - id: 1066
     title: "Enable Bad Error Message Protection"
     description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
     rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
@@ -1125,7 +1125,7 @@ checks:
       - 'c:/sbin/sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:=\s*\t*1$'
 
 # 7.2.7 Enable RFC-recommended Source Route Validation (Scored)
-  - id: 1067 
+  - id: 1067
     title: "Enable RFC-recommended Source Route Validation"
     description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
     rationale: "Setting these flags is a good way to deter attackers from sending your server bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your server, you will not be able to enable this feature without breaking the routing."
@@ -1142,7 +1142,7 @@ checks:
       - 'c:/sbin/sysctl net.ipv4.conf.default.rp_filter -> r:=\s*\t*1$'
 
 # 7.2.8 Enable TCP SYN Cookies (Scored)
-  - id: 1068 
+  - id: 1068
     title: "Enable TCP SYN Cookies"
     description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the server to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue."
     rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a server by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the server to keep accepting valid connections, even if under a denial of service attack."
@@ -1158,7 +1158,7 @@ checks:
       - 'c:/sbin/sysctl net.ipv4.tcp_syncookies -> r:=\s*\t*1$'
 
 # 7.3.1 Disable IPv6 Router Advertisements (Not Scored)
-  - id: 1069 
+  - id: 1069
     title: "Disable IPv6 Router Advertisements"
     description: "This setting disables the systems ability to accept router advertisements"
     rationale: "It is recommended that systems not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
@@ -1178,7 +1178,7 @@ checks:
       - 'c:/sbin/sysctl net.ipv6.conf.default.accept_ra -> r:=\s*\t*0$'
 
 # 7.3.2 Disable IPv6 Redirect Acceptance (Not Scored)
-  - id: 1070 
+  - id: 1070
     title: "Disable IPv6 Redirect Acceptance"
     description: "This setting prevents the system from accepting ICMP redirects. ICMP redirects tell the system about alternate routes for sending traffic."
     rationale: "It is recommended that systems not accept ICMP redirects as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
@@ -1198,7 +1198,7 @@ checks:
       - 'c:/sbin/sysctl net.ipv6.conf.default.accept_redirects -> r:=\s*\t*0$'
 
 # 7.3.3 Disable IPv6 (Not Scored)
-  - id: 1071 
+  - id: 1071
     title: "Disable IPv6"
     description: "Although IPv6 has many advantages over IPv4, few organizations have implemented IPv6."
     rationale: "If IPv6 is not to be used, it is recommended that it be disabled to reduce the attack surface of the system."
@@ -1217,7 +1217,7 @@ checks:
       - 'not c:ip addr -> r:inet6'
 
 # 7.4.1 Install TCP Wrappers (Scored)
-  - id: 1072 
+  - id: 1072
     title: "Install TCP Wrappers"
     description: "TCP Wrappers provides a simple access list and standardized logging method for services capable of supporting it. In the past, services that were called from inetd and xinetd supported the use of tcp wrappers. As inetd and xinetd have been falling in disuse, any service that can support tcp wrappers will have the libwrap.so library attached to it."
     rationale: "TCP Wrappers provide a good simple access list mechanism to services that may not have that support built in. It is recommended that all services that can support TCP Wrappers, use it."
@@ -1231,7 +1231,7 @@ checks:
       - 'c:dpkg -s tcpd -> r:install ok installed'
 
 # 7.4.2 Create /etc/hosts.allow (Not Scored)
-  - id: 1073 
+  - id: 1073
     title: "Create /etc/hosts.allow"
     description: "The /etc/hosts.allow file specifies which IP addresses are permitted to connect to the host. It is intended to be used in conjunction with the /etc/hosts.deny file."
     rationale: "The /etc/hosts.allow file supports access control by IP and helps ensure that only authorized systems can connect to the server."
@@ -1243,9 +1243,9 @@ checks:
     condition: all
     rules:
       - 'f:/etc/hosts.allow'
-      
+
 # 7.4.3 Verify permissions on /etc/hosts.allow (Scored)
-  - id: 1074 
+  - id: 1074
     title: "Verify permissions on /etc/hosts.allow"
     description: "The /etc/hosts.allow file contains network information that is used by many system applications and therefore must be readable for these applications to operate."
     rationale: "It is critical to ensure that the /etc/hosts.allow file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -1259,7 +1259,7 @@ checks:
       - 'c:/bin/ls -l /etc/hosts.allow -> r:-rw-r--r--'
 
 # 7.4.4 Create /etc/hosts.deny (Not Scored)
-  - id: 1075 
+  - id: 1075
     title: "Create /etc/hosts.deny"
     description: "The /etc/hosts.deny file specifies which IP addresses are not permitted to connect to the host. It is intended to be used in conjunction with the /etc/hosts.allow file."
     rationale: "The /etc/hosts.deny file serves as a failsafe so that any host not specified in /etc/hosts.allow is denied access to the server."
@@ -1274,7 +1274,7 @@ checks:
       - 'f:/etc/hosts.deny -> r:^ALL:\s*ALL'
 
 # 7.4.5 Verify permissions on /etc/hosts.deny (Scored)
-  - id: 1076 
+  - id: 1076
     title: "Verify permissions on /etc/hosts.deny"
     description: "The /etc/hosts.deny file contains network information that is used by many system applications and therefore must be readable for these applications to operate."
     rationale: "It is critical to ensure that the /etc/hosts.deny file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -1288,7 +1288,7 @@ checks:
       - 'c:/bin/ls -l /etc/hosts.deny -> r:-rw-r--r--'
 
 # 7.5.1 Disable DCCP (Not Scored)
-  - id: 1077 
+  - id: 1077
     title: "Disable DCCP"
     description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery."
     rationale: "If the protocol is not required, it is recommended that the drivers not be installed  to reduce the potential attack surface."
@@ -1308,7 +1308,7 @@ checks:
       - 'f:/etc/modprobe.d/CIS.conf -> r:install dccp /bin/true'
 
 # 7.5.2 Disable SCTP (Not Scored)
-  - id: 1078 
+  - id: 1078
     title: "Disable SCTP"
     description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1328,7 +1328,7 @@ checks:
       - 'f:/etc/modprobe.d/CIS.conf -> r:install sctp /bin/true'
 
 # 7.5.3 Disable RDS (Not Scored)
-  - id: 1079 
+  - id: 1079
     title: "Disable RDS"
     description: "The Reliable Datagram Sockets (RDS) protocol is a transport layer protocol designed to provide low-latency, high-bandwidth communications between cluster nodes. It was developed by the Oracle Corporation."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1348,7 +1348,7 @@ checks:
       - 'f:/etc/modprobe.d/CIS.conf -> r:install rds /bin/true'
 
 # 7.5.4 Disable TIPC (Not Scored)
-  - id: 1080 
+  - id: 1080
     title: "Disable TIPC"
     description: "The Transparent Inter-Process Communication (TIPC) protocol is designed to provide communication between cluster nodes."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1368,7 +1368,7 @@ checks:
       - 'f:/etc/modprobe.d/CIS.conf -> r:install tipc /bin/true'
 
 # 7.6 Deactivate Wireless Interfaces (Not Scored)
-  - id: 1081 
+  - id: 1081
     title: "Deactivate Wireless Interfaces"
     description: "Wireless networking is used when wired networks are unavailable. Debian provides the nmcli interface which allows system administrators to configure and use wireless networks."
     rationale: "If wireless is not to be used, wireless devices can be disabled to reduce the potential attack surface."
@@ -1382,7 +1382,7 @@ checks:
       - 'c:nmcli nm wifi -> r:disabled'
 
 # 7.7 Ensure Firewall is active (Scored)
-  - id: 1082 
+  - id: 1082
     title: "Ensure Firewall is active"
     description: "IPtables is an application that allows a system administrator to configure the IPv4 tables, chains and rules provided by the Linux kernel firewall.  The iptables-persistent package in Debian provides one way to ensure iptables rules are reapplied on reboot. Note: the audit and remediation included provide instructions for using iptables-persistent to reapply iptables rules.  Other methods are available which may be in use in your environment and may conflict with these steps."
     rationale: "IPtables provides extra protection for the Linux system by limiting communications in and out of the box to specific IPv4 addresses and ports."
@@ -1395,10 +1395,10 @@ checks:
     rules:
       - 'c:dpkg -s iptables -> r:install ok installed'
       - 'c:dpkg -s iptables-persistent -> r:install ok installed'
-      - 'c:find /etc/rc2.d -name *iptables-persistent* -> r:/etc/rc2.d/S\d+iptables-persistent'    
-      - 'c:find /etc/rc3.d -name *iptables-persistent* -> r:/etc/rc3.d/S\d+iptables-persistent'    
-      - 'c:find /etc/rc4.d -name *iptables-persistent* -> r:/etc/rc4.d/S\d+iptables-persistent'    
-      - 'c:find /etc/rc5.d -name *iptables-persistent* -> r:/etc/rc5.d/S\d+iptables-persistent'    
+      - 'c:find /etc/rc2.d -name *iptables-persistent* -> r:/etc/rc2.d/S\d+iptables-persistent'
+      - 'c:find /etc/rc3.d -name *iptables-persistent* -> r:/etc/rc3.d/S\d+iptables-persistent'
+      - 'c:find /etc/rc4.d -name *iptables-persistent* -> r:/etc/rc4.d/S\d+iptables-persistent'
+      - 'c:find /etc/rc5.d -name *iptables-persistent* -> r:/etc/rc5.d/S\d+iptables-persistent'
 
 ###############################################
 # 8 Logging and Auditing
@@ -1409,7 +1409,7 @@ checks:
 ###############################################
 
 # 8.1.1.1 Configure Audit Log Storage Size (Not Scored)
-  - id: 1083 
+  - id: 1083
     title: "Configure Audit Log Storage Size"
     description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
     rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
@@ -1425,7 +1425,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:max_log_file\s*=\s*\d+'
 
 # 8.1.1.2 Disable System on Audit Log Full (Not Scored)
-  - id: 1084 
+  - id: 1084
     title: "Disable System on Audit Log Full"
     description: "The auditd daemon can be configured to halt the system when the audit logs are full."
     rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
@@ -1443,7 +1443,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*admin_space_left_action\s*=\s*halt'
 
 # 8.1.1.3 Keep All Auditing Information (Scored)
-  - id: 1085 
+  - id: 1085
     title: "Keep All Auditing Information"
     description: "Normally, auditd will hold 4 logs of maximum log file size before deleting older log files."
     rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
@@ -1459,7 +1459,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file_action\s*=\s*keep_logs'
 
 # 8.1.2 Install and Enable auditd Service (Scored)
-  - id: 1086 
+  - id: 1086
     title: "Install and Enable auditd Service"
     description: "Install and turn on the auditd daemon to record system events."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -1472,13 +1472,13 @@ checks:
     condition: all
     rules:
       - 'c:dpkg -s auditd -> r:install ok installed'
-      - 'c:find /etc/rc2.d -name *auditd* -> r:/etc/rc2.d/S\d+auditd'    
-      - 'c:find /etc/rc3.d -name *auditd* -> r:/etc/rc3.d/S\d+auditd'    
-      - 'c:find /etc/rc4.d -name *auditd* -> r:/etc/rc4.d/S\d+auditd'    
-      - 'c:find /etc/rc5.d -name *auditd* -> r:/etc/rc5.d/S\d+auditd'    
+      - 'c:find /etc/rc2.d -name *auditd* -> r:/etc/rc2.d/S\d+auditd'
+      - 'c:find /etc/rc3.d -name *auditd* -> r:/etc/rc3.d/S\d+auditd'
+      - 'c:find /etc/rc4.d -name *auditd* -> r:/etc/rc4.d/S\d+auditd'
+      - 'c:find /etc/rc5.d -name *auditd* -> r:/etc/rc5.d/S\d+auditd'
 
 # 8.1.3 Enable Auditing for Processes That Start Prior to auditd (Scored)
-  - id: 1087 
+  - id: 1087
     title: "Enable Auditing for Processes That Start Prior to auditd"
     description: "Configure grub or lilo so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
     rationale: "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected."
@@ -1495,7 +1495,7 @@ checks:
       - 'f:/etc/default/grub -> r:^GRUB_CMDLINE_LINUX\s*=\s*\p*audit\s*=\s*1\p*'
 
 # 8.1.4 Record Events That Modify Date and Time Information (Scored)
-  - id: 1088 
+  - id: 1088
     title: "Record Events That Modify Date and Time Information"
     description: "Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier \"time-change\""
     rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
@@ -1518,7 +1518,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w /etc/localtime && r:-p wa && r:-k time-change'
 
 # 8.1.5 Record Events That Modify User/Group Information (Scored)
-  - id: 1089 
+  - id: 1089
     title: "Record Events That Modify User/Group Information"
     description: "Record events affecting the group, passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier \"identity\" in the audit log file."
     rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
@@ -1543,7 +1543,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w /etc/security/opasswd && r:-p wa && r:-k identity'
 
 # 8.1.6 Record Events That Modify the System's Network Environment (Scored)
-  - id: 1090 
+  - id: 1090
     title: "Record Events That Modify the System's Network Environment"
     description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed prelogin), /etc/hosts (file containing host names and associated IP addresses) and /etc/network (directory containing network interface scripts and configurations) files."
     rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/network is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier \"system-locale.\""
@@ -1568,7 +1568,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w /etc/network && r:-p wa && r:-k system-locale'
 
 # 8.1.7 Record Events That Modify the System's Mandatory Access Controls (Scored)
-  - id: 1091 
+  - id: 1091
     title: "Record Events That Modify the System's Mandatory Access Controls"
     description: "Monitor SELinux mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/selinux directory."
     rationale: "Changes to files in this directory could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
@@ -1589,7 +1589,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w /etc/selinux/ && r:-p wa && r:-k MAC-policy'
 
 # 8.1.8 Collect Login and Logout Events (Scored)
-  - id: 1092 
+  - id: 1092
     title: "Collect Login and Logout Events"
     description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. The file /var/log/faillog tracks failed events from login. The file /var/log/lastlog maintain records of the last time a user successfully logged in. The file /var/log/tallylog maintains records of failures via the pam_tally2 module"
     rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
@@ -1612,7 +1612,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w /var/log/tallylog && r:-p wa && r:-k logins'
 
 # 8.1.9 Collect Session Initiation Information (Scored)
-  - id: 1093 
+  - id: 1093
     title: "Collect Session Initiation Information"
     description: "Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp file tracks all currently logged in users. The /var/log/wtmp file tracks logins, logouts, shutdown and reboot events. All audit records will be tagged with the identifier \"session.\" The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp. All audit records will be tagged with the identifier \"logins.\""
     rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
@@ -1630,7 +1630,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w /var/log/btmp && r:-p wa && r:-k session'
 
 # 8.1.10 Collect Discretionary Access Control Permission Modification Events (Scored)
-  - id: 1094 
+  - id: 1094
     title: "Collect Discretionary Access Control Permission Modification Events"
     description: "Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permis&& r:sions and attributes. The chmod, fchmod and fchmodat system calls affect the permissions associated with a file. The chown, fchown, fchownat and lchown system calls affect owner and group attributes on a file. The setxattr, lsetxattr, fsetxattr (set extended file attributes) and removexattr, lremovexattr, fremovexattr (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system userids (auid >= 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier \"perm_mod.\""
     rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
@@ -1653,7 +1653,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S setxattr && r:-S lsetxattr && r:-S fsetxattr && r:-S removexattr && r:-S lremovexattr && r:-S fremovexattr && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
 
 # 8.1.11 Collect Unsuccessful Unauthorized Access Attempts to Files (Scored)
-  - id: 1095 
+  - id: 1095
     title: "Collect Unsuccessful Unauthorized Access Attempts to Files"
     description: "Monitor for unsuccessful attempts to access files. The parameters below are associated with system calls that control creation (creat), opening (open, openat) and truncation (truncate, ftruncate) of files. An audit log record will only be written if the user is a nonprivileged user (auid > = 500), is not a Daemon event (auid=4294967295) and if the system call returned EACCES (permission denied to the file) or EPERM (some other permanent error associated with the specific system call). All audit records will be tagged with the identifier \"access.\""
     rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
@@ -1675,7 +1675,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-F exit=-EPERM && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
 
 # 8.1.13 Collect Successful File System Mounts (Scored)
-  - id: 1096 
+  - id: 1096
     title: "Collect Successful File System Mounts"
     description: "Monitor the use of the mount system call. The mount (and umount) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user"
     rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open, creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
@@ -1696,7 +1696,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S mount && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k mounts'
 
 # 8.1.14 Collect File Deletion Events by User (Scored)
-  - id: 1097 
+  - id: 1097
     title: "Collect File Deletion Events by User"
     description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for the unlink (remove a file), unlinkat (remove a file attribute), rename (rename a file) and renameat (rename a file attribute) system calls and tags them with the identifier \"delete\"."
     rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
@@ -1712,7 +1712,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S unlink && r:-S unlinkat && r:-S rename && r:-S renameat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k delete'
 
 # 8.1.15 Collect Changes to System Administration Scope (sudoers) (Scored)
-  - id: 1098 
+  - id: 1098
     title: "Collect Changes to System Administration Scope (sudoers)"
     description: "Monitor scope changes for system administrations. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers will be written to when the file or its attributes have changed. The audit records will be tagged with the identifier \"scope.\""
     rationale: "Changes in the /etc/sudoers file can indicate that an unauthorized change has been made to scope of system administrator activity."
@@ -1733,7 +1733,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w /etc/sudoers && r:-p wa && r:-k scope'
 
 # 8.1.16 Collect System Administrator Actions (sudolog) (Scored)
-  - id: 1099 
+  - id: 1099
     title: "Collect System Administrator Actions (sudolog)"
     description: "Monitor the sudo log file. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to /var/log/sudo.log. Any time a command is executed, an audit event will be triggered as the /var/log/sudo.log file will be opened for write and the executed administration command will be written to the log."
     rationale: "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed."
@@ -1754,7 +1754,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w /var/log/sudo.log && r:-p wa && r:-k actions'
 
 # 8.1.17 Collect Kernel Module Loading and Unloading (Scored)
-  - id: 1100 
+  - id: 1100
     title: "Collect Kernel Module Loading and Unloading"
     description: "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\"."
     rationale: "Monitoring the use of insmod, rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
@@ -1778,7 +1778,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S init_module && r:-S delete_module && r:-k modules'
 
 # 8.1.18 Make the Audit Configuration Immutable (Scored)
-  - id: 1101 
+  - id: 1101
     title: "Make the Audit Configuration Immutable"
     description: "Set system audit so that audit rules cannot be modified with auditctl. Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot"
     rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
@@ -1798,7 +1798,7 @@ checks:
 ###############################################
 
 # 8.2.1 Install the rsyslog package (Scored)
-  - id: 1102 
+  - id: 1102
     title: "Install the rsyslog package"
     description: "The rsyslog package is a third party package that provides many enhancements to syslog, such as multi-threading, TCP communication, message filtering and data base support."
     rationale: "The security enhancements of rsyslog such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
@@ -1811,7 +1811,7 @@ checks:
       - 'c:dpkg -s rsyslog -> r:install ok installed'
 
 # 8.2.2 Ensure the rsyslog Service is activated (Scored)
-  - id: 1103 
+  - id: 1103
     title: "Ensure the rsyslog Service is activated"
     description: "Once the rsyslog package is installed it needs to be activated."
     rationale: "If the rsyslog service is not activated the system will not have a syslog service running."
@@ -1821,13 +1821,13 @@ checks:
       - cis_csc: ["6.2"]
     condition: all
     rules:
-      - 'c:find /etc/rc2.d -name *rsyslog* -> r:/etc/rc2.d/S\d+rsyslog'   
-      - 'c:find /etc/rc3.d -name *rsyslog* -> r:/etc/rc3.d/S\d+rsyslog'    
-      - 'c:find /etc/rc4.d -name *rsyslog* -> r:/etc/rc4.d/S\d+rsyslog'    
-      - 'c:find /etc/rc5.d -name *rsyslog* -> r:/etc/rc5.d/S\d+rsyslog'     
+      - 'c:find /etc/rc2.d -name *rsyslog* -> r:/etc/rc2.d/S\d+rsyslog'
+      - 'c:find /etc/rc3.d -name *rsyslog* -> r:/etc/rc3.d/S\d+rsyslog'
+      - 'c:find /etc/rc4.d -name *rsyslog* -> r:/etc/rc4.d/S\d+rsyslog'
+      - 'c:find /etc/rc5.d -name *rsyslog* -> r:/etc/rc5.d/S\d+rsyslog'
 
 # 8.2.5 Configure rsyslog to send logs to a Remote Log Host (Scored)
-  - id: 1104 
+  - id: 1104
     title: "Configure rsyslog to Send Logs to a Remote Log Host"
     description: "The rsyslog utility supports the ability to send logs it gathers to a remote log host running syslogd(8) or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system"
@@ -1842,7 +1842,7 @@ checks:
       - 'f:/etc/rsyslog.conf -> r:^\s*\t**.* @@\.+'
 
 # 8.2.6 Accept remote rsyslog messages only on designated log hosts (Not Scored)
-  - id: 1105 
+  - id: 1105
     title: "Accept Remote rsyslog Messages Only on Designated Log Hosts"
     description: "By default, rsyslog does not listen for log messages coming in from remote systems. The ModLoad tells rsyslog to load the imtcp.so module so it can listen over a network via TCP. The InputTCPServerRun option instructs rsyslogd to listen on the specified TCP port."
     rationale: "The guidance in the section ensures that remote log hosts are configured to only accept rsyslog data from hosts within the specified domain and that those systems that are not designed to be log hosts do not accept any remote rsyslog messages. This provides protection from spoofed log data and ensures that system administrators are reviewing reasonably complete syslog data in a central location."
@@ -1863,7 +1863,7 @@ checks:
 ###############################################
 
 # 8.3.1 Install AIDE (Scored)
-  - id: 1106 
+  - id: 1106
     title: "Install AIDE"
     description: "In some installations, AIDE is not installed automatically"
     rationale: "Install AIDE to make use of the file integrity features to monitor critical files for changes that could affect the security of the system."
@@ -1877,7 +1877,7 @@ checks:
       - 'c:dpkg -s aide -> r:install ok installed'
 
 # 8.3.2 Implement Periodic Execution of File Integrity (Scored)
-  - id: 1107 
+  - id: 1107
     title: "Implement Periodic Execution of File Integrity"
     description: "Implement periodic file checking, in compliance with site policy"
     rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
@@ -1896,7 +1896,7 @@ checks:
 # 9 System Access, Authentication and Authorization
 #######################################################
 # 9.1.1 Enable cron Daemon (Scored)
-  - id: 1108 
+  - id: 1108
     title: "Enable cron Daemon"
     description: "The cron daemon is used to execute batch jobs on the system."
     rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run and cron is used to execute them."
@@ -1908,18 +1908,18 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:find /etc/rc2.d -name *cron* -> r:/etc/rc2.d/S\d+cron' 
-      - 'c:find /etc/rc3.d -name *cron* -> r:/etc/rc3.d/S\d+cron'    
-      - 'c:find /etc/rc4.d -name *cron* -> r:/etc/rc4.d/S\d+cron'    
-      - 'c:find /etc/rc5.d -name *cron* -> r:/etc/rc5.d/S\d+cron'    
-      - 'c:find /etc/rc2.d -name *anacron* -> r:/etc/rc2.d/S\d+anacron'    
-      - 'c:find /etc/rc3.d -name *anacron* -> r:/etc/rc3.d/S\d+anacron'    
-      - 'c:find /etc/rc4.d -name *anacron* -> r:/etc/rc4.d/S\d+anacron'    
-      - 'c:find /etc/rc5.d -name *anacron* -> r:/etc/rc5.d/S\d+anacron'    
+      - 'c:find /etc/rc2.d -name *cron* -> r:/etc/rc2.d/S\d+cron'
+      - 'c:find /etc/rc3.d -name *cron* -> r:/etc/rc3.d/S\d+cron'
+      - 'c:find /etc/rc4.d -name *cron* -> r:/etc/rc4.d/S\d+cron'
+      - 'c:find /etc/rc5.d -name *cron* -> r:/etc/rc5.d/S\d+cron'
+      - 'c:find /etc/rc2.d -name *anacron* -> r:/etc/rc2.d/S\d+anacron'
+      - 'c:find /etc/rc3.d -name *anacron* -> r:/etc/rc3.d/S\d+anacron'
+      - 'c:find /etc/rc4.d -name *anacron* -> r:/etc/rc4.d/S\d+anacron'
+      - 'c:find /etc/rc5.d -name *anacron* -> r:/etc/rc5.d/S\d+anacron'
 
 
 # 9.1.2 Set User/Group Owner and Permission on /etc/crontab (Scored)
-  - id: 1109 
+  - id: 1109
     title: "Set User/Group Owner and Permission on /etc/crontab"
     description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
     rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
@@ -1936,7 +1936,7 @@ checks:
       - 'c:stat /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 9.1.3 Set User/Group Owner and Permission on /etc/cron.hourly (Scored)
-  - id: 1110 
+  - id: 1110
     title: "Set User/Group Owner and Permission on /etc/cron.hourly"
     description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -1951,7 +1951,7 @@ checks:
       - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 9.1.4 Set User/Group Owner and Permission on /etc/cron.daily (Scored)
-  - id: 1111 
+  - id: 1111
     title: "Set User/Group Owner and Permission on /etc/cron.daily"
     description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -1966,7 +1966,7 @@ checks:
       - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 9.1.5 Set User/Group Owner and Permission on /etc/cron.weekly (Scored)
-  - id: 1112 
+  - id: 1112
     title: "Set User/Group Owner and Permission on /etc/cron.weekly"
     description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -1982,7 +1982,7 @@ checks:
 
 
 # 9.1.6 Set User/Group Owner and Permission on /etc/cron.monthly (Scored)
-  - id: 1113 
+  - id: 1113
     title: "Set User/Group Owner and Permission on /etc/cron.monthly"
     description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -1997,7 +1997,7 @@ checks:
       - 'c:stat /etc/cron.monthly -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 9.1.7 Set User/Group Owner and Permission on /etc/cron.d (Scored)
-  - id: 1114 
+  - id: 1114
     title: "Set User/Group Owner and Permission on /etc/cron.d"
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow , cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2012,7 +2012,7 @@ checks:
       - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/d\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 9.1.8 Restrict at/cron to Authorized Users (Scored)
-  - id: 1115 
+  - id: 1115
     title: "Restrict at/cron to Authorized Users"
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow, cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2036,7 +2036,7 @@ checks:
 ###########################################
 
 # 9.2.1 Set Password Creation Requirement Parameters Using pam_cracklib (Scored)
-  - id: 1116 
+  - id: 1116
     title: "Set Password Creation Requirement Parameters Using pam_cracklib"
     description: "The pam_cracklib module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more. The following are definitions of the pam_cracklib.so options.  # retry=3 - Allow 3 tries before sending back a failure.  # minlen=14 - password must be 14 characters or more # dcredit=-1 - provide at least one digit # ucredit=-1 - provide at least one uppercase character # ocredit=-1 - provide at least one special character # lcredit=-1 - provide at least one lowercase character    The setting shown above is one possible policy. Alter these values to conform to your own organization's password policies."
     rationale: "Strong passwords protect systems from being hacked through brute force methods."
@@ -2050,7 +2050,7 @@ checks:
       - 'f:/etc/pam.d/common-password -> !r:^# && r:password\s*\t*required\s*\t*pam_cracklib.so && r:retry=\d && n:minlen=(\d+) compare >= 14 && r:dcredit=-\d+ && r:ucredit=-\d+ && r:ocredit=-\d+ && r:lcredit=-\d+'
 
 # 9.2.2 Set Lockout for Failed Password Attempts (Not Scored)
-  - id: 1117 
+  - id: 1117
     title: "Set Lockout for Failed Password Attempts"
     description: "Lock out users after n unsuccessful consecutive login attempts. The first sets of changes are made to the PAM configuration file /etc/pam.d/login. The second set of changes are applied to the program specific PAM configuration file. The second set of changes must be applied to each program that will lock out users.  Check the documentation for each secondary program for instructions on how to configure them to work with PAM.  Set the lockout number to the policy in effect at your site."
     rationale: "Locking out userIDs after n unsuccessful consecutive login attempts mitigates brute force password attacks against your systems."
@@ -2063,7 +2063,7 @@ checks:
       - 'f:/etc/pam.d/login -> !r:^# && r:auth\s*\t*required\s*\t*pam_tally2.so && r:onerr=fail && r:audit && r:silent && r:deny=\d && r:unlock_time=\d\d\d+'
 
 # 9.2.3 Limit Password Reuse (Scored)
-  - id: 1118 
+  - id: 1118
     title: "Limit Password Reuse"
     description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
     rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password.  Note that these change only apply to accounts configured on the local system."
@@ -2079,7 +2079,7 @@ checks:
 # 9.3 Configure SSH
 ###########################################
 # 9.3.1 Set SSH Protocol to 2 (Scored)
-  - id: 1119 
+  - id: 1119
     title: "Set SSH Protocol to 2"
     description: "SSH supports two different and incompatible protocols: SSH1 and SSH2. SSH1 was the original protocol and was subject to security issues. SSH2 is more advanced and secure."
     rationale: "SSH v1 suffers from insecurities that do not affect SSH v2."
@@ -2094,7 +2094,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> !r:^# && r:Protocol\s*\t*2'
 
 # 9.3.2 Set LogLevel to INFO (Scored)
-  - id: 1120 
+  - id: 1120
     title: "Set LogLevel to INFO"
     description: "The INFO parameter specifices that record login and logout activity will be logged."
     rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information. INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field."
@@ -2109,7 +2109,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> !r:^# && r:^\s*\t*LogLevel\s+INFO'
 
 # 9.3.3 Set Permissions on /etc/ssh/sshd_config (Scored)
-  - id: 1121 
+  - id: 1121
     title: "Set Permissions on /etc/ssh/sshd_config"
     description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
     rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
@@ -2124,7 +2124,7 @@ checks:
       - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/-\w\w-------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 9.3.4 Disable SSH X11 Forwarding (Scored)
-  - id: 1122 
+  - id: 1122
     title: "Disable SSH X11 Forwarding"
     description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
     rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
@@ -2142,7 +2142,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> !r:^# && r:X11Forwarding\s+no'
 
 # 9.3.5 Set SSH MaxAuthTries to 4 or Less (Scored)
-  - id: 1123 
+  - id: 1123
     title: "Set SSH MaxAuthTries to 4 or Less"
     description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
     rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, it is set the number based on site policy."
@@ -2157,7 +2157,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> !r:^# && n:MaxAuthTries\s*\t*(\d+) compare <= 4'
 
 # 9.3.6 Set SSH IgnoreRhosts to Yes (Scored)
-  - id: 1124 
+  - id: 1124
     title: "Set SSH IgnoreRhosts to Yes"
     description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
     rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
@@ -2172,7 +2172,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> !r:^# && r:IgnoreRhosts\s+yes'
 
 # 9.3.7 Set SSH HostbasedAuthentication to No (Scored)
-  - id: 1125 
+  - id: 1125
     title: "Set SSH HostbasedAuthentication to No"
     description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
     rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
@@ -2187,7 +2187,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> !r:^# && r:HostbasedAuthentication\s+no'
 
 # 9.3.8 Disable SSH Root Login (Scored)
-  - id: 1126 
+  - id: 1126
     title: "Disable SSH Root Login"
     description: "The PermitRootLogin parameter specifies if the root user can log in using ssh(1). The default is no."
     rationale: "Disallowing root logins over SSH requires server admins to authenticate using their own individual account, then escalating to root via sudo or su. This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
@@ -2202,7 +2202,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> !r:^# && r:PermitRootLogin\s+no'
 
 # 9.3.9 Set SSH PermitEmptyPasswords to No (Scored)
-  - id: 1127 
+  - id: 1127
     title: "Set SSH PermitEmptyPasswords to No"
     description: "The PermitEmptyPasswords parameter specifies if the server allows login to accounts with empty password strings."
     rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
@@ -2217,7 +2217,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> !r:^# && r:PermitEmptyPasswords\s+no'
 
 # 9.3.10 Do Not Allow Users to Set Environment Options (Scored)
-  - id: 1128 
+  - id: 1128
     title: "Do Not Allow Users to Set Environment Options"
     description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
     rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing trojan'd programs)"
@@ -2232,7 +2232,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> !r:^# && r:PermitUserEnvironment\s+no'
 
 # 9.3.11 Use Only Approved Cipher in Counter Mode (Scored)
-  - id: 1129 
+  - id: 1129
     title: "Use Only Approved Cipher in Counter Mode"
     description: "This variable limits the types of ciphers that SSH can use during communication."
     rationale: "Based on research conducted at various institutions, it was determined that the symmetric portion of the SSH Transport Protocol (as described in RFC 4253) has security weaknesses that allowed recovery of up to 32 bits of plaintext from a block of ciphertext that was encrypted with the Cipher Block Chaining (CBD) method. From that research, new Counter mode algorithms (as described in RFC4344) were designed that are not vulnerable to these types of attacks and these algorithms are now recommended for standard use."
@@ -2247,7 +2247,7 @@ checks:
 
 
 # 9.3.12 Set Idle Timeout Interval for User Login (Scored)
-  - id: 1130 
+  - id: 1130
     title: "Set Idle Timeout Interval for User Login"
     description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the ClientAliveCountMax variable is set, sshd will send client alive messages at every ClientAliveInterval interval. When the number of consecutive client alive messages are sent with no response from the client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
     rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening..  While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent."
@@ -2261,7 +2261,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> !r:^# && r:ClientAliveCountMax\s+0'
 
 # 9.3.13 Limit Access via SSH (Scored)
-  - id: 1131 
+  - id: 1131
     title: "Limit Access via SSH"
     description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: AllowUsers, AllowGroups, DenyUsers, DenyGroups."
     rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
@@ -2277,7 +2277,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> !r:^# && r:DenyGroups\s+\w+'
 
 # 9.3.14 Set SSH Banner (Scored)
-  - id: 1132 
+  - id: 1132
     title: "Set SSH Banner"
     description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
     rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Consult with your legal department for the appropriate warning banner for your site."
@@ -2292,7 +2292,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> !r:^# && r:Banner\s*\t*/etc/issue.net|Banner\s\t*/etc/issue'
 
 # 9.5 Restrict Access to the su Command (Scored)
-  - id: 1133 
+  - id: 1133
     title: "Restrict Access to the su Command"
     description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in the wheel group to execute su."
     rationale: "Restricting the use of su, and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo, whereas su can only record that a user executed the su program."
@@ -2313,7 +2313,7 @@ checks:
 # 10 User Accounts and Environment
 ######################################
 # 10.1.1 Set Password Expiration Days (Scored)
-  - id: 1134 
+  - id: 1134
     title: "Set Password Expiration Days"
     description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 90 days."
     rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity."
@@ -2326,7 +2326,7 @@ checks:
       - 'f:/etc/login.defs -> !r:^# && n:PASS_MAX_DAYS\s*\t*(\d+) compare <= 90'
 
 # 10.1.2 Set Password Change Minimum Number of Days (Scored)
-  - id: 1135 
+  - id: 1135
     title: "Set Password Change Minimum Number of Days"
     description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 7 or more days."
     rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
@@ -2339,7 +2339,7 @@ checks:
       - 'f:/etc/login.defs -> !r:^# && n:PASS_MIN_DAYS\s*\t*(\d+) compare >= 7'
 
 # 10.1.3 Set Password Expiring Warning Days (Scored)
-  - id: 1136 
+  - id: 1136
     title: "Set Password Expiring Warning Days"
     description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
     rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
@@ -2352,7 +2352,7 @@ checks:
       - 'f:/etc/login.defs -> !r:^# && n:PASS_WARN_AGE\s*\t*(\d+) compare >= 7'
 
 # 10.3 Set Default Group for root Account (Scored)
-  - id: 1137 
+  - id: 1137
     title: "Set Default Group for root Account"
     description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
     rationale: "Using GID 0 for the root account helps prevent root-owned files from accidentally becoming accessible to non-privileged users."
@@ -2365,7 +2365,7 @@ checks:
       - 'f:/etc/passwd -> !r:^# && r:root:\w+:\w+:0:'
 
 # 10.4 Set Default umask for Users (Scored)
-  - id: 1138 
+  - id: 1138
     title: "Set Default umask for Users"
     description: "The default umask determines the permissions of files created by users. The user creating the file has the discretion of making their files and directories readable by others via the chmod command. Users who wish to allow their files and directories to be readable by others by default may choose a different default umask by inserting the umask command into the standard shell configuration files (.profile, .bashrc, etc.) in their home directories."
     rationale: "Setting a very secure default value for umask ensures that users make a conscious choice about their file permissions. A default umask setting of 077 causes files and directories created by users to not be readable by any other user on the system. A umask of 027 would make files and directories readable by users in the same Unix group, while a umask of 022 would make files readable by every user on the system.  Note: The directives in this section apply to bash and shell. If other shells are supported on the system, it is recommended that their configuration files also are checked."
@@ -2379,7 +2379,7 @@ checks:
       - 'f:/etc/bash.bashrc -> !r:^# && r:umask\s*\t*077'
 
 # 10.5 Lock Inactive User Accounts (Scored)
-  - id: 1139 
+  - id: 1139
     title: "Lock Inactive User Accounts"
     description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 35 or more days be disabled."
     rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
@@ -2395,7 +2395,7 @@ checks:
 # 11 Warning Banners
 ##########################################
 # 11.1 Set Warning Banner for Standard Login Services (Scored)
-  - id: 1140 
+  - id: 1140
     title: "Set Warning Banner for Standard Login Services"
     description: "The contents of the /etc/issue file are displayed prior to the login prompt on the system's console and serial devices, and also prior to logins via telnet. The contents of the /etc/motd file is generally displayed after all successful logins, no matter where the user is logging in from, but is thought to be less useful because it only provides notification to the user after the machine has been accessed."
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Consult with your organization's legal counsel for the appropriate wording for your specific organization."
@@ -2417,7 +2417,7 @@ checks:
       - 'c:stat -c%u-%g-%a /etc/issue.net -> 0-0-644'
 
 # 11.2 Remove OS Information from Login Warning Banners (Scored)
-  - id: 1141 
+  - id: 1141
     title: "Remove OS Information from Login Warning Banners"
     description: "Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform."
     rationale: "Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \"uname -a\" command once they have logged in."
@@ -2436,7 +2436,7 @@ checks:
       - 'f:/etc/issue.net -> r:\\v|\\r|\\m|\\s'
 
 # 11.3 Ensure GDM login banner is configured (Scored)
-  - id: 1142 
+  - id: 1142
     title: "Ensure GDM login banner is configured"
     description: "Debian defaults to using GNOME Display Manager for graphical login session management. KDM is also available as well as lightdm. Instructions are provided for GDM only, if you are using another display manager you will need to follow different procedures to audit and remediate this setting."
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Consult with your organization's legal counsel for the appropriate wording for your specific organization."
@@ -2455,7 +2455,7 @@ checks:
 ###############################################
 
 # 12.1 Verify Permissions on /etc/passwd (Scored)
-  - id: 1143 
+  - id: 1143
     title: "Verify permissions on /etc/passwd"
     description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
     rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -2471,7 +2471,7 @@ checks:
       - 'c:/bin/ls -l /etc/passwd -> r:-rw-r--r--'
 
 # 12.2 Verify Permissions on /etc/shadow (Scored)
-  - id: 1144 
+  - id: 1144
     title: "Verify permissions on /etc/shadow"
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
@@ -2487,7 +2487,7 @@ checks:
       - 'c:/bin/ls -l /etc/shadow -> r:-rw-r-----'
 
 # 12.3 Verify Permissions on /etc/group (Scored)
-  - id: 1145 
+  - id: 1145
     title: "Verify permissions on /etc/group"
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
@@ -2503,7 +2503,7 @@ checks:
       - 'c:/bin/ls -l /etc/group -> r:-rw-r--r--'
 
 # 12.4 Verify User/Group Ownership on /etc/passwd
-  - id: 1146 
+  - id: 1146
     title: "Verify User/Group Ownership on /etc/passwd"
     description: "The /etc/passwd file contains a list of all the valid userIDs defined in the system, but not the passwords. The command below sets the owner and group of the file to root."
     rationale: "The /etc/passwd file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
@@ -2519,7 +2519,7 @@ checks:
       - 'c:/bin/ls -l /etc/passwd -> r:root\s*\t*root'
 
 # 12.5 Verify User/Group Ownership on /etc/shadow (Scored)
-  - id: 1147 
+  - id: 1147
     title: "Verify User/Group Ownership on /etc/shadow"
     description: "The /etc/shadow file contains the one-way cipher text passwords for each user defined in the /etc/passwd file. The command below sets the user and group ownership of the file to root."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
@@ -2535,7 +2535,7 @@ checks:
       - 'c:/bin/ls -l /etc/shadow -> r:root\s*\t*shadow|root\s*\t*root'
 
 # 12.6 Verify User/Group Ownership on /etc/group (Scored)
-  - id: 1148 
+  - id: 1148
     title: "Verify User/Group Ownership on /etc/group"
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
@@ -2556,7 +2556,7 @@ checks:
 ###############################################
 
 # 13.1 Ensure Password Fields are Not Empty
-  - id: 1149 
+  - id: 1149
     title: "Ensure Password Fields are Not Empty"
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
@@ -2570,7 +2570,7 @@ checks:
       - 'f:/etc/shadow -> r:^\w+::'
 
 # 13.2 Verify No Legacy "+" Entries Exist in /etc/passwd File
-  - id: 1150 
+  - id: 1150
     title: "Verify No Legacy \"+\" Entries Exist in /etc/passwd File"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -2589,7 +2589,7 @@ checks:
       - 'f:/etc/passwd -> !r:^# && r:^+:'
 
 # 13.3 Verify No Legacy "+" Entries Exist in /etc/shadow File
-  - id: 1151 
+  - id: 1151
     title: "Verify No Legacy \"+\" Entries Exist in /etc/shadow File"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -2608,7 +2608,7 @@ checks:
       - 'f:/etc/shadow -> !r:^# && r:^+:'
 
 # 13.4 Verify No Legacy "+" Entries Exist in /etc/group File
-  - id: 1152 
+  - id: 1152
     title: "Verify No Legacy \"+\" Entries Exist in /etc/group File"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -2627,7 +2627,7 @@ checks:
       - 'f:/etc/group -> !r:^# && r:^+:'
 
 # 13.5 Verify No UID 0 Accounts Exist Other Than root
-  - id: 1153 
+  - id: 1153
     title: "Verify No UID 0 Accounts Exist Other Than root"
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 9.4 Restrict root Login to System Console."
@@ -2646,7 +2646,7 @@ checks:
       - 'f:/etc/passwd -> !r:^# && !r:^\s*\t*root: && r:^\w+:\w+:0:'
 
 # 13.20 Ensure shadow group is empty
-  - id: 1154 
+  - id: 1154
     title: "Ensure shadow group is empty"
     description: "The shadow group allows system programs which require access the ability to read the /etc/shadow file. No users should be assigned to the shadow group."
     rationale: "Any users assigned to the shadow group would be granted read access to the /etc/shadow file. If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed passwords to break them. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts."

--- a/ruleset/sca/debian/cis_debian7.yml
+++ b/ruleset/sca/debian/cis_debian7.yml
@@ -409,6 +409,21 @@ checks:
       - 'c:sysctl fs.suid_dumpable -> r:=\s*0$'
       - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:\s0$|\t0$'
 
+# 4.2 Enable XD/NX Support on 32-bit x86 Systems (Not Scored)
+  - id: 1026 
+    title: "Enable XD/NX Support on 32-bit x86 Systems"
+    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
+    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
+    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
+    compliance:
+      - cis: ["4.2"]
+      - pci_dss: ["2.2.4"]
+      - nist_800_53: ["CM.1"]
+      - tsc: ["CC5.2"]
+    condition: all
+    rules:
+      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+
 # 4.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 1027 
     title: "Enable Randomized Virtual Memory Region Placement"

--- a/ruleset/sca/debian/cis_debian7.yml
+++ b/ruleset/sca/debian/cis_debian7.yml
@@ -422,7 +422,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+      - 'c:sh -c "dmesg | grep NX" -> r:NX \(Execute Disable\) protection: active'
 
 # 4.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 1027

--- a/ruleset/sca/debian/cis_debian8.yml
+++ b/ruleset/sca/debian/cis_debian8.yml
@@ -28,7 +28,7 @@ requirements:
 
 checks:
 # 1.1.1 Disable unused filesystems
-  - id: 1500 
+  - id: 1500
     title: "Ensure mounting of cramfs filesystems is disabled"
     description: "The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
@@ -43,7 +43,7 @@ checks:
       - 'c:modprobe -n -v cramfs -> r:^install /bin/true'
       - 'not c:lsmod -> r:cramfs'
 
-  - id: 1501 
+  - id: 1501
     title: "Ensure mounting of freevxfs filesystems is disabled"
     description: "The freevxfs filesystem type is a free version of the Veritas type filesystem. This is the primary filesystem type for HP-UX operating systems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -58,7 +58,7 @@ checks:
       - 'c:modprobe -n -v freevxfs -> r:^install /bin/true'
       - 'not c:lsmod -> r:freevxfs'
 
-  - id: 1502 
+  - id: 1502
     title: "Ensure mounting of jffs2 filesystems is disabled"
     description: "The jffs2 (journaling flash filesystem 2) filesystem type is a log-structured filesystem used in flash memory devices."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -73,7 +73,7 @@ checks:
       - 'c:modprobe -n -v jffs2 -> r:^install /bin/true'
       - 'not c:lsmod -> r:jffs2'
 
-  - id: 1503 
+  - id: 1503
     title: "Ensure mounting of hfs filesystems is disabled"
     description: "The hfs filesystem type is a hierarchical filesystem that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -88,7 +88,7 @@ checks:
       - 'c:modprobe -n -v hfs -> r:^install /bin/true'
       - 'not c:lsmod -> r:hfs'
 
-  - id: 1504 
+  - id: 1504
     title: "Ensure mounting of hfsplus filesystems is disabled"
     description: "The hfsplus filesystem type is a hierarchical filesystem designed to replace hfs that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -103,7 +103,7 @@ checks:
       - 'c:modprobe -n -v hfsplus -> r:^install /bin/true'
       - 'not c:lsmod -> r:hfsplus'
 
-  - id: 1505 
+  - id: 1505
     title: "Ensure mounting of squashfs filesystems is disabled"
     description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs ). A squashfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -118,7 +118,7 @@ checks:
       - 'c:modprobe -n -v squashfs -> r:^install /bin/true'
       - 'not c:lsmod -> r:squashfs'
 
-  - id: 1506 
+  - id: 1506
     title: "Ensure mounting of udf filesystems is disabled"
     description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -134,7 +134,7 @@ checks:
       - 'not c:lsmod -> r:udf'
 
 # 1.1.2 Filesystem Configuration
-  - id: 1507 
+  - id: 1507
     title: "Ensure /tmp is configured"
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -153,7 +153,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s'
       - 'c:systemctl is-enabled tmp.mount -> enabled'
 
-  - id: 1508 
+  - id: 1508
     title: "Ensure nodev option set on /tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
@@ -168,7 +168,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s && r:nodev'
 
-  - id: 1509 
+  - id: 1509
     title: "Ensure nosuid option set on /tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain set userid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create set userid files in /tmp."
@@ -184,7 +184,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:nosuid'
 
 
-  - id: 1510 
+  - id: 1510
     title: "Ensure separate partition exists for /var"
     description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
     rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
@@ -201,7 +201,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var\s'
 
-  - id: 1511 
+  - id: 1511
     title: "Ensure separate partition exists for /var/tmp"
     description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /var/tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own file system allows an administrator to set the noexec option on the mount, making /var/tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated."
@@ -219,7 +219,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s'
 
 
-  - id: 1512 
+  - id: 1512
     title: "Ensure nodev option set on /var/tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /var/tmp."
@@ -234,7 +234,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/tmp\s && r:nodev'
 
-  - id: 1513 
+  - id: 1513
     title: "Ensure nosuid option set on /var/tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
@@ -249,7 +249,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/tmp\s && r:nosuid'
 
-  - id: 1514 
+  - id: 1514
     title: "Ensure noexec option set on /var/tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
@@ -266,7 +266,7 @@ checks:
 
 
 
-  - id: 1515 
+  - id: 1515
     title: "Ensure separate partition exists for /var/log"
     description: "The /var/log directory is used by system services to store log data."
     rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
@@ -283,7 +283,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/log\s'
 
-  - id: 1516 
+  - id: 1516
     title: "Ensure separate partition exists for /var/log/audit"
     description: "The auditing daemon, auditd, stores log data in the /var/log/audit directory."
     rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data. The audit daemon calculates how much free space is left and performs actions based on the results. If other processes (such as syslog) consume space in the same partition as auditd, it may not perform as desired."
@@ -300,7 +300,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/log/audit\s'
 
-  - id: 1517 
+  - id: 1517
     title: "Ensure separate partition exists for /home"
     description: "The /home directory is used to support disk storage needs of local users."
     rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
@@ -317,7 +317,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/home\s'
 
-  - id: 1518 
+  - id: 1518
     title: "Ensure nodev option set on /home partition"
     description: "When set on a file system, this option prevents character and block special devices from being defined, or if they exist, from being used as character and block special devices."
     rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices.  Note: The actions in the item refer to the /home partition, which is the default user partition that is defined in many distributions. If you have created other user partitions, it is recommended that the Remediation and Audit steps be applied to these partitions as well."
@@ -332,7 +332,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/home\s && r:nodev'
 
-  - id: 1519 
+  - id: 1519
     title: "Ensure nodev option set on /dev/shm partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /run/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
@@ -347,7 +347,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/dev/shm\s && r:nodev'
 
-  - id: 1520 
+  - id: 1520
     title: "Ensure nosuid option set on /dev/shm partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
@@ -362,7 +362,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/dev/shm\s && r:nosuid'
 
-  - id: 1521 
+  - id: 1521
     title: "Ensure noexec option set on /dev/shm partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
@@ -377,7 +377,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/dev/shm\s && r:noexec'
 
-  - id: 1522 
+  - id: 1522
     title: "Disable Automounting"
     description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
     rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have it's contents available in system even if they lacked permissions to mount it themselves."
@@ -393,7 +393,7 @@ checks:
       - 'c:systemctl is-enabled autofs -> enabled'
 
 # 1.3 Filesystem Integrity Checking
-  - id: 1523 
+  - id: 1523
     title: "Ensure AIDE is installed"
     description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
     rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
@@ -407,7 +407,7 @@ checks:
     rules:
       - 'c:dpkg -s aide -> r:install ok installed'
 
-  - id: 1524 
+  - id: 1524
     title: "Ensure filesystem integrity is regularly checked"
     description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
     rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
@@ -422,7 +422,7 @@ checks:
       - 'c:crontab -u root -l -> !r:^# && r:/usr/bin/aide && r:--check'
 
 # 1.4 Secure Boot Settings
-  - id: 1525 
+  - id: 1525
     title: "Ensure permissions on bootloader config are configured"
     description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options. The grub configuration is usually grub.cfg stored in /boot/grub."
     rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
@@ -437,7 +437,7 @@ checks:
     rules:
       - 'c:stat /boot/grub/grub.cfg -> r:Access:\s*\(0\w00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 1526 
+  - id: 1526
     title: "Ensure bootloader password is set"
     description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
     rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
@@ -453,7 +453,7 @@ checks:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*set superusers'
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*password'
 
-  - id: 1527 
+  - id: 1527
     title: "Ensure authentication required for single user mode"
     description: "Single user mode is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
     rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
@@ -469,7 +469,7 @@ checks:
       - 'f:/etc/shadow -> r:^root:*:|^root:!:'
 
 # 1.5 Additional Process Hardening
-  - id: 1528 
+  - id: 1528
     title: "Ensure core dumps are restricted"
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
     rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5) ). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
@@ -486,7 +486,7 @@ checks:
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:=\s*\t*0$'
       - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:\s*\t*0$'
 
-  - id: 1529 
+  - id: 1529
     title: "Ensure XD/NX support is enabled"
     description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
     rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
@@ -501,7 +501,7 @@ checks:
     rules:
       - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
 
-  - id: 1530 
+  - id: 1530
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
     rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
@@ -517,7 +517,7 @@ checks:
       - 'c:grep -Rh ^kernel\.randomize_va_space /etc/sysctl.conf /etc/sysctl.d -> r:=\s*\t*2$'
       - 'c:sysctl kernel.randomize_va_space -> r:^kernel.randomize_va_space\s*\t*=\s*\t*2'
 
-  - id: 1531 
+  - id: 1531
     title: "Ensure prelink is disabled"
     description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
     rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
@@ -535,7 +535,7 @@ checks:
 # 1.6 Configure SELinux
 
 
-  - id: 1532 
+  - id: 1532
     title: "Ensure SELinux is not disabled in bootloader configuration"
     description: "Configure SELINUX to be enabled at boot time and verify that it has not been overwritten by the grub boot parameters."
     rationale: "SELinux must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
@@ -550,7 +550,7 @@ checks:
     rules:
       - 'f:/boot/grub/grub.cfg -> r:linux\.*selinux=0|linux\.*enforcing=0'
 
-  - id: 1533 
+  - id: 1533
     title: "Ensure the SELinux state is enforcing"
     description: "Set SELinux to enable when the system is booted."
     rationale: "SELinux must be enabled at boot time in to ensure that the controls it provides are in effect at all times."
@@ -568,7 +568,7 @@ checks:
       - 'c:sestatus -> r:^Mode from config file:\s+enforcing$'
       - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing'
 
-  - id: 1534 
+  - id: 1534
     title: "Ensure SELinux policy is configured"
     description: "Configure SELinux to meet or exceed the default targeted policy, which constrains daemons and system software only."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that at least the default recommendations are met."
@@ -584,7 +584,7 @@ checks:
       - 'c:sestatus -> r:^Loaded policy name:\s+targeted$'
       - 'f:/etc/selinux/config -> r:^\s*SELINUXTYPE\s*=\s*targeted|^\s*SELINUXTYPE\s*=\s*mls'
 
-  - id: 1535 
+  - id: 1535
     title: "Ensure no unconfined daemons exist"
     description: "Daemons that are not defined in SELinux policy will inherit the security context of their parent process."
     rationale: "Since daemons are launched and descend from the init process, they will inherit the security context label initrc_t . This could cause the unintended consequence of giving the process more permission than it requires."
@@ -599,7 +599,7 @@ checks:
     rules:
       - 'c:ps -eZ -> r:initrc && !r:tr|ps|egrep|bash|awk'
 
-  - id: 1536 
+  - id: 1536
     title: "Ensure AppArmor is enabled in the bootloader configuration"
     description: "Configure AppArmor to be enabled at boot time and verify that it has not been overwrittenby the bootloader boot parameters."
     rationale: "AppArmor must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
@@ -615,7 +615,7 @@ checks:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:apparmor=1'
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:security=apparmor'
 
-  - id: 1537 
+  - id: 1537
     title: "Ensure all AppArmor Profiles are enforcing"
     description: "AppArmor profiles define what resources applicatons are able to access."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that any policies that exist on the system are activated.."
@@ -632,7 +632,7 @@ checks:
       - 'c:apparmor_status -> r:^0\s*processes are in complain mode'
       - 'c:apparmor_status -> r:^0\s*processes are unconfined'
 
-  - id: 1538 
+  - id: 1538
     title: "Ensure SELinux or AppArmor are installed"
     description: "SELinux and AppArmor provide Mandatory Access Controls."
     rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
@@ -650,7 +650,7 @@ checks:
 
 
 # 1.7 Warning Banners
-  - id: 1539 
+  - id: 1539
     title: "Ensure message of the day is configured properly"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -662,8 +662,8 @@ checks:
     condition: none
     rules:
       - 'f:/etc/motd -> r:\\v|\\r|\\m|\\s|Debian|Ubuntu'
-      
-  - id: 1540 
+
+  - id: 1540
     title: "Ensure local login warning banner is configured properly"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -676,7 +676,7 @@ checks:
     rules:
       - 'f:/etc/issue -> r:\\v|\\r|\\m|\\s|Debian|Ubuntu'
 
-  - id: 1541 
+  - id: 1541
     title: "Ensure remote login warning banner is configured properly"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -689,7 +689,7 @@ checks:
     rules:
       - 'f:/etc/issue.net -> r:\\v|\\r|\\m|\\s|Debian|Ubuntu'
 
-  - id: 1542 
+  - id: 1542
     title: "Ensure permissions on /etc/motd are configured"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
     rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -707,7 +707,7 @@ checks:
     rules:
       - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 1543 
+  - id: 1543
     title: "Ensure permissions on /etc/issue are configured"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
     rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -725,7 +725,7 @@ checks:
     rules:
       - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 1544 
+  - id: 1544
     title: "Ensure permissions on /etc/issue.net are configured"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
     rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -743,14 +743,14 @@ checks:
     rules:
       - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 1545 
+  - id: 1545
     title: "Ensure GDM login banner is configured"
     description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems."
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place."
     remediation: "Edit or create the file /etc/gdm3/greeter.dconf-defaults and add: [org/gnome/login-screen], banner-message-enable=true, banner-message-text='Authorized uses only. All activity may be monitored and reported.'"
     compliance:
       - cis: ["1.7.2"]
-      - cis_csc: ["5.1"] 
+      - cis_csc: ["5.1"]
       - pci_dss: ["2.2.2"]
       - nist_800_53: ["CM.1"]
       - tsc: ["CC5.2"]
@@ -760,7 +760,7 @@ checks:
       - 'f:/etc/gdm3/greeter.dconf-defaults -> r:^banner-message-enable=true'
       - 'f:/etc/gdm3/greeter.dconf-defaults -> r:^banner-message-text=\.+'
 
-  - id: 1546 
+  - id: 1546
     title: "Ensure updates, patches, and additional security software are installed"
     description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
     rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
@@ -779,7 +779,7 @@ checks:
       - 'c:apt-get -s upgrade -> r:^The following packages will be upgraded'
 
 # 2 Services
-  - id: 1547 
+  - id: 1547
     title: "Ensure xinetd is not installed"
     description: "The eXtended InterNET Daemon (xinetd) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no xinetd services required, it is recommended that the daemon be disabled."
@@ -797,7 +797,7 @@ checks:
     rules:
       - 'c:dpkg -s xinetd -> r:install ok installed'
 
-  - id: 1548 
+  - id: 1548
     title: "Ensure inetd is not installed"
     description: "The inetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no inetd services required, it is recommended that the daemon be removed."
@@ -816,7 +816,7 @@ checks:
       - 'c:dpkg -s openbsd-inetd -> r:install ok installed'
       - 'c:dpkg -s inetutils-inetd -> r:install ok installed'
 
-  - id: 1549 
+  - id: 1549
     title: "Ensure time synchronization is in use"
     description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
     rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
@@ -832,7 +832,7 @@ checks:
       - 'c:dpkg -s ntp -> r:install ok installed'
       - 'c:dpkg -s chrony -> r:install ok installed'
 
-  - id: 1550 
+  - id: 1550
     title: "Ensure ntp is configured"
     description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at http://www.ntp.org. ntp can be configured to be a client and/or a server. This recommendation only applies if ntp is in use on the system."
     rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
@@ -852,7 +852,7 @@ checks:
       - 'f:/etc/ntp.conf -> r:^server\.+|^pool\.+'
       - 'f:/etc/init.d/ntp -> r:^RUNASUSER\s*\t*=\s*\t*ntp'
 
-  - id: 1551 
+  - id: 1551
     title: "Ensure chrony is configured"
     description: "chrony is a daemon which implements the Network Time Protocol (NTP) is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on chrony can be found at http://chrony.tuxfamily.org/. chrony can be configured to be a client and/or a server."
     rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly. This recommendation only applies if chrony is in use on the system."
@@ -869,7 +869,7 @@ checks:
 
 
 # 2.2.2 Ensure the X Window system is not installed (Scored)
-  - id: 1552 
+  - id: 1552
     title: "Ensure the X Window system is not installed"
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
@@ -884,7 +884,7 @@ checks:
     rules:
       - 'c:dpkg -l xserver-xorg-core* -> r:^\wi\s*xserver-xorg'
 
-  - id: 1553 
+  - id: 1553
     title: "Ensure Avahi Server is not enabled"
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to disable the service to reduce the potential attach surface."
@@ -899,7 +899,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled avahi-daemon -> enabled'
 
-  - id: 1554 
+  - id: 1554
     title: "Ensure CUPS is not enabled"
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be disabled to reduce the potential attack surface."
@@ -916,7 +916,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled cups -> enabled'
 
-  - id: 1555 
+  - id: 1555
     title: "Ensure DHCP Server is not enabled"
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this service be disabled to reduce the potential attack surface."
@@ -934,7 +934,7 @@ checks:
       - 'c:systemctl is-enabled isc-dhcp-server -> enabled'
       - 'c:systemctl is-enabled isc-dhcp-server6 -> enabled'
 
-  - id: 1556 
+  - id: 1556
     title: "Ensure LDAP server is not enabled"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be disabled to reduce the potential attack surface."
@@ -951,7 +951,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled slapd -> enabled'
 
-  - id: 1557 
+  - id: 1557
     title: "Ensure NFS and RPC are not enabled"
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not export NFS shares or act as an NFS client, it is recommended that these services be disabled to reduce remote attack surface."
@@ -967,7 +967,7 @@ checks:
       - 'c:systemctl is-enabled nfs-server -> enabled'
       - 'c:systemctl is-enabled rpcbind -> enabled'
 
-  - id: 1558 
+  - id: 1558
     title: "Ensure DNS Server is not enabled"
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
@@ -982,7 +982,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled bind9 -> enabled'
 
-  - id: 1559 
+  - id: 1559
     title: "Ensure FTP Server is not enabled"
     description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
@@ -997,7 +997,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled vsftpd -> enabled'
 
-  - id: 1560 
+  - id: 1560
     title: "Ensure HTTP Server is not enabled"
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
@@ -1012,7 +1012,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled apache2 -> enabled'
 
-  - id: 1561 
+  - id: 1561
     title: "Ensure IMAP and POP3 server is not enabled"
     description: "exim is an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
@@ -1027,7 +1027,7 @@ checks:
     rules:
       - 'c:dpkg -s exim4 -> r:install ok installed'
 
-  - id: 1562 
+  - id: 1562
     title: "Ensure Samba is not enabled"
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this service can be deleted to reduce the potential attack surface."
@@ -1042,7 +1042,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled smbd -> enabled'
 
-  - id: 1563 
+  - id: 1563
     title: "Ensure HTTP Proxy Server is not enabled"
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
@@ -1057,7 +1057,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled squid -> enabled'
 
-  - id: 1564 
+  - id: 1564
     title: "Ensure SNMP Server is not enabled"
     description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
     rationale: "The SNMP server can communicate using SNMP v1, which transmits data in the clear and does not require authentication to execute commands. Unless absolutely necessary, it is recommended that the SNMP service not be used. If SNMP is required the server should be configured to disallow SNMP v1."
@@ -1072,7 +1072,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled snmpd -> enabled'
 
-  - id: 1565 
+  - id: 1565
     title: "Ensure mail transfer agent is configured for local-only mode"
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems."
@@ -1087,7 +1087,7 @@ checks:
     rules:
       - 'c:netstat -an -> r:\.*:25\.*LISTEN && !r:127.0.0.1:25\.+LISTEN|::1:25\.*LISTEN'
 
-  - id: 1566 
+  - id: 1566
     title: "Ensure rsync service is not enabled"
     description: "The rsyncd service can be used to synchronize files between systems over network links."
     rationale: "The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
@@ -1101,7 +1101,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled rsync -> enabled'
 
-  - id: 1567 
+  - id: 1567
     title: "Ensure NIS Server is not enabled"
     description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be disabled and other, more secure services be used"
@@ -1119,7 +1119,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled nis -> enabled'
 
-  - id: 1568 
+  - id: 1568
     title: "Ensure NIS Client is not installed"
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
@@ -1137,7 +1137,7 @@ checks:
     rules:
       - 'c:dpkg -s nis -> r:install ok installed'
 
-  - id: 1569 
+  - id: 1569
     title: "Ensure rsh client is not installed"
     description: "The rsh package contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rshpackage removes the clients for rsh, rcpand rlogin."
@@ -1156,7 +1156,7 @@ checks:
       - 'c:dpkg -s rsh-client -> r:install ok installed'
       - 'c:dpkg -s rsh-redone-client -> r:install ok installed'
 
-  - id: 1570 
+  - id: 1570
     title: "Ensure talk client is not installed"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talkclient, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -1174,7 +1174,7 @@ checks:
     rules:
       - 'c:dpkg -s talk -> r:install ok installed'
 
-  - id: 1571 
+  - id: 1571
     title: "Ensure telnet client is not installed"
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
@@ -1192,7 +1192,7 @@ checks:
     rules:
       - 'c:dpkg -s telnet -> r:install ok installed'
 
-  - id: 1572 
+  - id: 1572
     title: "Ensure LDAP client is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
@@ -1211,7 +1211,7 @@ checks:
       - 'c:dpkg -s ldap-utils -> r:install ok installed'
 
 # 3 Network Configuration
-  - id: 1573 
+  - id: 1573
     title: "Ensure IP forwarding is disabled"
     description: "The net.ipv4.ip_forward and net.ipv6.conf.all.forwarding flags are used to tell the system whether it can forward packets or not."
     rationale: "Setting the flags to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
@@ -1229,7 +1229,7 @@ checks:
       - 'c:sysctl net.ipv6.conf.all.forwarding -> r:=\s*\t*0$'
       - 'c:grep -Rh net\.ipv6\.conf\.all\.forwarding /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.forwarding\s*=\s*0$'
 
-  - id: 1574 
+  - id: 1574
     title: "Ensure packet redirect sending is disabled"
     description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
     rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
@@ -1247,7 +1247,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
 
-  - id: 1575 
+  - id: 1575
     title: "Ensure source routed packets are not accepted"
     description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
     rationale: "Setting net.ipv4.conf.all.accept_source_route, net.ipv4.conf.default.accept_source_route, net.ipv6.conf.all.accept_source_route and net.ipv6.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
@@ -1269,7 +1269,7 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.all\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.accept_source_route\s*=\s*0$'
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_source_route\s*=\s*0$'
 
-  - id: 1576 
+  - id: 1576
     title: "Ensure ICMP redirects are not accepted"
     description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables. By setting net.ipv4.conf.all.accept_redirects to 0, the system will not accept any ICMP redirect messages, and therefore, won't allow outsiders to update the system's routing tables."
     rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
@@ -1291,7 +1291,7 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.all\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.accept_redirects\s*=\s*0$'
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0$'
 
-  - id: 1577 
+  - id: 1577
     title: "Ensure secure ICMP redirects are not accepted"
     description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
     rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
@@ -1309,7 +1309,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
 
-  - id: 1578 
+  - id: 1578
     title: "Ensure suspicious packets are logged"
     description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
     rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their server."
@@ -1327,7 +1327,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
 
-  - id: 1579 
+  - id: 1579
     title: "Ensure broadcast ICMP requests are ignored"
     description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
     rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
@@ -1343,7 +1343,7 @@ checks:
       - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:=\s*\t*1$'
       - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
-  - id: 1580 
+  - id: 1580
     title: "Ensure bogus ICMP responses are ignored"
     description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
     rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
@@ -1359,7 +1359,7 @@ checks:
       - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:=\s*\t*1$'
       - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
-  - id: 1581 
+  - id: 1581
     title: "Ensure Reverse Path Filtering is enabled"
     description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
     rationale: Setting these flags is a good way to deter attackers from sending your system bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing.
@@ -1377,7 +1377,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
 
-  - id: 1582 
+  - id: 1582
     title: "Ensure TCP SYN Cookies is enabled"
     description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue."
     rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
@@ -1393,7 +1393,7 @@ checks:
       - 'c:sysctl net.ipv4.tcp_syncookies -> r:=\s*\t*1$'
       - 'c:grep -Rh net\.ipv4\.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
 
-  - id: 1583 
+  - id: 1583
     title: "Ensure IPv6 router advertisements are not accepted"
     description: "This setting disables the systems ability to accept router advertisements"
     rationale: "It is recommended that systems not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
@@ -1414,7 +1414,7 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.all\.accept_ra /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.accept_ra\s*=\s*0$'
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_ra /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_ra\s*=\s*0$'
 
-  - id: 1584 
+  - id: 1584
     title: "Install TCP Wrappers"
     description: "TCP Wrappers provides a simple access list and standardized logging method for services capable of supporting it. In the past, services that were called from inetd and xinetd supported the use of tcp wrappers. As inetd and xinetd have been falling in disuse, any service that can support tcp wrappers will have the libwrap.so library attached to it."
     rationale: "TCP Wrappers provide a good simple access list mechanism to services that may not have that support built in. It is recommended that all services that can support TCP Wrappers, use it."
@@ -1427,7 +1427,7 @@ checks:
     rules:
       - 'c:dpkg -s tcpd -> r:install ok installed'
 
-  - id: 1585 
+  - id: 1585
     title: "Ensure /etc/hosts.allow is configured"
     description: "The /etc/hosts.allow file specifies which IP addresses are permitted to connect to the host. It is intended to be used in conjunction with the /etc/hosts.deny file."
     rationale: "The /etc/hosts.allow file supports access control by IP and helps ensure that only authorized systems can connect to the system."
@@ -1440,7 +1440,7 @@ checks:
     rules:
       - 'f:/etc/hosts.allow'
 
-  - id: 1586 
+  - id: 1586
     title: "Ensure /etc/hosts.deny is configured"
     description: "The /etc/hosts.deny file specifies which IP addresses are not permitted to connect to the host. It is intended to be used in conjunction with the /etc/hosts.allow file."
     rationale: "The /etc/hosts.deny file serves as a failsafe so that any host not specified in /etc/hosts.allow is denied access to the server."
@@ -1454,7 +1454,7 @@ checks:
       - 'f:/etc/hosts.deny'
       - 'f:/etc/hosts.deny -> r:^ALL:\s*ALL'
 
-  - id: 1587 
+  - id: 1587
     title: "Verify permissions on /etc/hosts.allow"
     description: "The /etc/hosts.allow file contains network information that is used by many system applications and therefore must be readable for these applications to operate."
     rationale: "It is critical to ensure that the /etc/hosts.allow file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -1468,7 +1468,7 @@ checks:
     rules:
       - 'c:stat /etc/hosts.allow -> r:^Access: \(0644/-rw-r--r--\)\s*\t*Uid:\s*\t*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\t*\(\s*\t*0/\s*\t*root\)$'
 
-  - id: 1588 
+  - id: 1588
     title: "Verify permissions on /etc/hosts.deny"
     description: "The /etc/hosts.deny file contains network information that is used by many system applications and therefore must be readable for these applications to operate."
     rationale: "It is critical to ensure that the /etc/hosts.deny file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -1484,7 +1484,7 @@ checks:
 
 # 3.4 Uncommon Network Protocols
 
-  - id: 1589 
+  - id: 1589
     title: "Ensure DCCP is disabled"
     description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in- sequence delivery."
     rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
@@ -1503,7 +1503,7 @@ checks:
       - 'not c:modprobe -n -v dccp -> r:install /bin/true'
       - 'c:lsmod -> r:dccp'
 
-  - id: 1590 
+  - id: 1590
     title: "Ensure SCTP is disabled"
     description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1522,7 +1522,7 @@ checks:
       - 'not c:modprobe -n -v sctp -> r:install /bin/true'
       - 'c:lsmod -> r:sctp'
 
-  - id: 1591 
+  - id: 1591
     title: "Ensure RDS is disabled"
     description: "The Reliable Datagram Sockets (RDS) protocol is a transport layer protocol designed to provide low-latency, high-bandwidth communications between cluster nodes. It was developed by the Oracle Corporation."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1541,7 +1541,7 @@ checks:
       - 'not c:modprobe -n -v rds -> r:install /bin/true'
       - 'c:lsmod -> r:rds'
 
-  - id: 1592 
+  - id: 1592
     title: "Ensure TIPC is disabled"
     description: "The Transparent Inter-Process Communication (TIPC) protocol is designed to provide communication between cluster nodes."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1562,7 +1562,7 @@ checks:
 
 # 3.5 Firewall configuration
 
-  - id: 1593 
+  - id: 1593
     title: "Ensure default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -1578,7 +1578,7 @@ checks:
       - 'c:iptables -L -> r:^Chain FORWARD && r:policy DROP'
       - 'c:iptables -L -> r:^Chain OUTPUT && r:policy DROP'
 
-  - id: 1594 
+  - id: 1594
     title: "Ensure loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -1595,7 +1595,7 @@ checks:
       - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
 
 
-  - id: 1595 
+  - id: 1595
     title: "Ensure IPv6 default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -1611,7 +1611,7 @@ checks:
       - 'c:ip6tables -L -> r:^Chain FORWARD && r:policy DROP'
       - 'c:ip6tables -L -> r:^Chain OUTPUT && r:policy DROP'
 
-  - id: 1596 
+  - id: 1596
     title: "Ensure IPv6 loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (::1)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (::1) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -1627,7 +1627,7 @@ checks:
       - 'c:ip6tables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*::1\.*::/0'
       - 'c:ip6tables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*::/0\.*::/0'
 
-  - id: 1597 
+  - id: 1597
     title: "Ensure iptables is installed"
     description: "iptables allows configuration of the IPv4 tables in the linux kernel and the rules stored within them. Most firewall configuration utilities operate as a front end to iptables."
     rationale: "iptables is required for firewall management and configuration."
@@ -1643,7 +1643,7 @@ checks:
 
 
 # 3.7 Disable IPv6 (Not Scored)
-  - id: 1598 
+  - id: 1598
     title: "Disable IPv6"
     description: "Although IPv6 has many advantages over IPv4, few organizations have implemented IPv6."
     rationale: "If IPv6 is not to be used, it is recommended that it be disabled to reduce the attack surface of the system."
@@ -1665,7 +1665,7 @@ checks:
 
 # 4 Logging and Auditing
 
-  - id: 1599 
+  - id: 1599
     title: "Ensure audit log storage size is configured"
     description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
     rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
@@ -1679,7 +1679,7 @@ checks:
       - 'f:/etc/audit/auditd.conf'
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file\s*\t*=\s*\t*\d+'
 
-  - id: 1600 
+  - id: 1600
     title: "Ensure system is disabled when audit logs are full"
     description: "The auditd daemon can be configured to halt the system when the audit logs are full."
     rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
@@ -1695,7 +1695,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*space_left_action\s*\t*=\s*\t*email'
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*admin_space_left_action\s*\t*=\s*\t*halt'
 
-  - id: 1601 
+  - id: 1601
     title: "Ensure audit logs are not automatically deleted"
     description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
     rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
@@ -1710,7 +1710,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file_action\s*\t*=\s*\t*keep_logs'
 
 
-  - id: 1602 
+  - id: 1602
     title: "Ensure auditd service is enabled"
     description: "Turn on the auditd daemon to record system events."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -1724,7 +1724,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled auditd -> enabled'
 
-  - id: 1603 
+  - id: 1603
     title: "Ensure auditing for processes that start prior to auditd is enabled"
     description: "Configure grub or lilo so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
     rationale: "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected."
@@ -1740,7 +1740,7 @@ checks:
     rules:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:audit=1'
 
-  - id: 1604 
+  - id: 1604
     title: "Ensure events that modify date and time information are collected"
     description: "Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier \"time-change\""
     rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
@@ -1762,7 +1762,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S clock_settime && r:-k time-change'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/localtime && r:-p wa && r:-k time-change'
 
-  - id: 1605 
+  - id: 1605
     title: "Ensure events that modify user/group information are collected"
     description: "Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier \"identity\" in the audit log file."
     rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
@@ -1786,7 +1786,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/shadow && r:-p wa && r:-k identity'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/security/opasswd && r:-p wa && r:-k identity'
 
-  - id: 1606 
+  - id: 1606
     title: "Ensure events that modify the system's network environment are collected"
     description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed pre- login), /etc/hosts (file containing host names and associated IP addresses) and /etc/sysconfig/network (directory containing network interface scripts and configurations) files."
     rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/sysconfig/network is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier \"system-locale.\""
@@ -1810,7 +1810,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/hosts && r:-p wa && r:-k system-locale'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/sysconfig/network && r:-p wa && r:-k system-locale'
 
-  - id: 1607 
+  - id: 1607
     title: "Ensure events that modify the system's Mandatory Access Controls are collected"
     description: "Monitor SELinux/AppArmor mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/selinux or /etc/apparmor and /etc/apparmor.d directories."
     rationale: "Changes to files in these directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
@@ -1831,7 +1831,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/selinux/ && r:-p wa && r:-k MAC-policy'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/usr/share/selinux/ && r:-p wa && r:-k MAC-policy'
 
-  - id: 1608 
+  - id: 1608
     title: "Ensure login and logout events are collected"
     description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. The file /var/log/faillog tracks failed events from login. The file /var/log/lastlog maintain records of the last time a user successfully logged in. The file /var/log/tallylog maintains records of failures via the pam_tally2 module"
     rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
@@ -1853,7 +1853,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/var/log/lastlog && r:-p wa && r:-k logins'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/var/log/tallylog && r:-p wa && r:-k logins'
 
-  - id: 1609 
+  - id: 1609
     title: "Ensure session initiation information is collected"
     description: "Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp file tracks all currently logged in users. All audit records will be tagged with the identifier \"session.\" The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp . All audit records will be tagged with the identifier \"logins.\""
     rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
@@ -1872,7 +1872,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/var/log/wtmp && r:-p wa && r:-k logins'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/var/log/btmp && r:-p wa && r:-k logins'
 
-  - id: 1610 
+  - id: 1610
     title: "Ensure discretionary access control permission modification events are collected"
     description: "Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The chmod , fchmod and fchmodat system calls affect the permissions associated with a file. The chown , fchown , fchownat and lchown system calls affect owner and group attributes on a file. The setxattr , lsetxattr , fsetxattr (set extended file attributes) and removexattr , lremovexattr , fremovexattr (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier \"perm_mod.\""
     rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
@@ -1894,7 +1894,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S chown && r:-S fchown && r:-S fchownat && r:-S lchown && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S setxattr && r:-S lsetxattr && r:-S fsetxattr && r:-S removexattr && r:-S lremovexattr && r:-S fremovexattr && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
 
-  - id: 1611 
+  - id: 1611
     title: "Ensure unsuccessful unauthorized file access attempts are collected"
     description: "Monitor for unsuccessful attempts to access files. The parameters below are associated with system calls that control creation ( creat ), opening ( open , openat ) and truncation ( truncate , ftruncate ) of files. An audit log record will only be written if the user is a non- privileged user (auid > = 1000), is not a Daemon event (auid=4294967295) and if the system call returned EACCES (permission denied to the file) or EPERM (some other permanent error associated with the specific system call). All audit records will be tagged with the identifier \"access.\""
     rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
@@ -1915,7 +1915,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-S ftruncate && r:-F exit=-EACCES && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-S ftruncate && r:-F exit=-EPERM && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
 
-  - id: 1612 
+  - id: 1612
     title: "Ensure successful file system mounts are collected"
     description: "Monitor the use of the mount system call. The mount (and umount ) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user."
     rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open , creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
@@ -1935,7 +1935,7 @@ checks:
       - 'f:/etc/audit/audit.rules'
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S mount && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k mounts'
 
-  - id: 1613 
+  - id: 1613
     title: "Ensure file deletion events by users are collected"
     description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for the unlink (remove a file), unlinkat (remove a file attribute), rename (rename a file) and renameat (rename a file attribute) system calls and tags them with the identifier \"delete\"."
     rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
@@ -1953,7 +1953,7 @@ checks:
       - 'f:/etc/audit/audit.rules'
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S unlink && r:-S unlinkat && r:-S rename && r:-S renameat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k delete'
 
-  - id: 1614 
+  - id: 1614
     title: "Ensure changes to system administration scope (sudoers) is collected"
     description: "Monitor scope changes for system administrations. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers will be written to when the file or its attributes have changed. The audit records will be tagged with the identifier \"scope.\""
     rationale: "Changes in the /etc/sudoers file can indicate that an unauthorized change has been made to scope of system administrator activity."
@@ -1974,7 +1974,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/sudoers && r:-p wa && r:-k scope'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/sudoers.d/ && r:-p wa && r:-k scope'
 
-  - id: 1615 
+  - id: 1615
     title: "Ensure system administrator actions (sudolog) are collected"
     description: "Monitor the sudo log file. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to /var/log/sudo.log . Any time a command is executed, an audit event will be triggered as the /var/log/sudo.log file will be opened for write and the executed administration command will be written to the log."
     rationale: "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed."
@@ -1994,7 +1994,7 @@ checks:
       - 'f:/etc/audit/audit.rules'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/var/log/sudo.log && r:-p wa && r:-k actions'
 
-  - id: 1616 
+  - id: 1616
     title: "Ensure kernel module loading and unloading is collected"
     description: "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\"."
     rationale: "Monitoring the use of insmod, rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
@@ -2017,7 +2017,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/sbin/modprobe && r:-p x && r:-k modules'
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S init_module && r:-S delete_module && r:-k modules'
 
-  - id: 1617 
+  - id: 1617
     title: "Ensure the audit configuration is immutable"
     description: "Set system audit so that audit rules cannot be modified with auditctl. Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot."
     rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
@@ -2036,7 +2036,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^\s*\t*-e 2$'
 
 
-  - id: 1618 
+  - id: 1618
     title: "Ensure rsyslog Service is enabled"
     description: "Once the rsyslog package is installed it needs to be activated."
     rationale: "If the rsyslog service is not activated the system will not have a syslog service running."
@@ -2053,14 +2053,14 @@ checks:
       - 'c:systemctl is-enabled rsyslog -> enabled'
 
 # 4.2.1.3 Ensure rsyslog default file permissions configured (Scored)
-  - id: 1619 
+  - id: 1619
     title: "Ensure rsyslog default file permissions configured"
     description: "rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
     remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to 0640 or more restrictive:   $FileCreateMode 0640"
     compliance:
       - cis: ["4.2.1.3"]
-      - cis_csc: ["5.1"]  
+      - cis_csc: ["5.1"]
       - pci_dss: ["10.5.1","10.5.2"]
       - nist_800_53: ["CM.1","AU.9"]
       - tsc: ["CC5.2", "CC6.1", "CC7.2", "CC.7.3", "CC7.4"]
@@ -2069,7 +2069,7 @@ checks:
       - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
       - 'd:/etc/rsyslog.d/ -> r:\. -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
 
-  - id: 1620 
+  - id: 1620
     title: "Ensure rsyslog is configured to send logs to a remote log host"
     description: "The rsyslog utility supports the ability to send logs it gathers to a remote log host running syslogd(8) or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2086,7 +2086,7 @@ checks:
     rules:
       - 'c:grep -Rh ^*.*[^I][^I]*@ /etc/rsyslog.conf /etc/rsyslog.d/ -> r:^*.* @@\.+'
 
-  - id: 1621 
+  - id: 1621
     title: "Ensure remote rsyslog messages are only accepted on designated log hosts"
     description: "By default, rsyslog does not listen for log messages coming in from remote systems. The ModLoad tells rsyslog to load the imtcp.so module so it can listen over a network via TCP. The InputTCPServerRun option instructs rsyslogd to listen on the specified TCP port."
     rationale: "The guidance in the section ensures that remote log hosts are configured to only accept rsyslog data from hosts within the specified domain and that those systems that are not designed to be log hosts do not accept any remote rsyslog messages. This provides protection from spoofed log data and ensures that system administrators are reviewing reasonably complete syslog data in a central location."
@@ -2103,7 +2103,7 @@ checks:
       - 'c:grep -Rh ^\$InputTCPServerRun /etc/rsyslog.conf /etc/rsyslog.d/ -> r:^\$InputTCPServerRun\s*\t*514'
 
 # 4.2.2.1 Ensure syslog-ng service is enabled (Scored)
-  - id: 1622 
+  - id: 1622
     title: "Ensure syslog-ng service is enabled"
     description: "Once the syslog-ng package is installed it needs to be activated."
     rationale: "If the syslog-ng service is not activated the system may default to the syslogd service or lack logging instead."
@@ -2120,14 +2120,14 @@ checks:
       - 'c:systemctl is-enabled syslog-ng -> enabled'
 
 # 4.2.2.3 Ensure syslog-ng default file permissions configured (Scored)
-  - id: 1623 
+  - id: 1623
     title: "Ensure syslog-ng default file permissions configured"
     description: "syslog-ng will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive syslog-ng data is archived and protected."
     remediation: "Edit the /etc/syslog-ng/syslog-ng.conf and set perm option to 0640 or more restrictive:     options { chain_hostnames(off); flush_lines(0); perm(0640); stats_freq(3600); threaded(yes); };"
     compliance:
       - cis: ["4.2.2.3"]
-      - cis_csc: ["5.1"]  
+      - cis_csc: ["5.1"]
       - pci_dss: ["10.5.1","10.5.2"]
       - nist_800_53: ["CM.1","AU.9"]
       - tsc: ["CC5.2", "CC6.1", "CC7.2", "CC.7.3", "CC7.4"]
@@ -2136,7 +2136,7 @@ checks:
       - 'f:/etc/syslog-ng/syslog-ng.conf -> r:^options && r:perm\(06\d0\)|perm\(04\d0\)|perm\(02\d0\)|perm\(00\d0\) && r:perm\(0\d40\)|perm\(0\d00\)'
 
 # 4.2.2.4 Ensure syslog-ng is configured to send logs to a remote log host (Not Scored)
-  - id: 1624 
+  - id: 1624
     title: "Ensure syslog-ng is configured to send logs to a remote log host"
     description: "The syslog-ng utility supports the ability to send logs it gathers to a remote log host or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2153,7 +2153,7 @@ checks:
       - 'f:/etc/syslog-ng/syslog-ng.conf -> r:log\.+source\.+destination'
 
 # 4.2.3 Ensure rsyslog or syslog-ng is installed (Scored)
-  - id: 1625 
+  - id: 1625
     title: "Ensure rsyslog or syslog-ng is installed"
     description: "The rsyslog and syslog-ng software are recommended replacements to the original syslogd daemon which provide improvements over syslogd , such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server."
     rationale: "The security enhancements of rsyslog and syslog-ng such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
@@ -2171,7 +2171,7 @@ checks:
       - 'c:dpkg -s syslog-ng -> r:install ok installed'
 
 # 5 Access, Authentication and Authorization
-  - id: 1626 
+  - id: 1626
     title: "Ensure cron daemon is enabled"
     description: "The cron daemon is used to execute batch jobs on the system."
     rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
@@ -2188,7 +2188,7 @@ checks:
 
 
 # 5.1.2 Ensure permissions on /etc/crontab are configured (Scored)
-  - id: 1627 
+  - id: 1627
     title: "Ensure permissions on /etc/crontab are configured"
     description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
     rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
@@ -2208,7 +2208,7 @@ checks:
 
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
-  - id: 1628 
+  - id: 1628
     title: "Ensure permissions on /etc/cron.hourly are configured"
     description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2225,7 +2225,7 @@ checks:
       - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
-  - id: 1629 
+  - id: 1629
     title: "Ensure permissions on /etc/cron.daily are configured"
     description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2241,7 +2241,7 @@ checks:
       - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
-  - id: 1630 
+  - id: 1630
     title: "Ensure permissions on /etc/cron.weekly are configured"
     description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2258,7 +2258,7 @@ checks:
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
-  - id: 1631 
+  - id: 1631
     title: "Ensure permissions on /etc/cron.monthly are configured"
     description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2274,7 +2274,7 @@ checks:
       - 'c:stat /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
-  - id: 1632 
+  - id: 1632
     title: "Ensure permissions on /etc/cron.d are configured"
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow , cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2290,7 +2290,7 @@ checks:
       - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
-  - id: 1633 
+  - id: 1633
     title: "Ensure at/cron is restricted to authorized users"
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow, cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cronjobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2312,7 +2312,7 @@ checks:
 
 # 5.2 SSH Server Configuration
 
-  - id: 1634 
+  - id: 1634
     title: "Ensure permissions on /etc/ssh/sshd_config are configured"
     description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
     rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non- privileged users."
@@ -2327,7 +2327,7 @@ checks:
     rules:
       - 'c:stat -c%u-%g-%a /etc/ssh/sshd_config -> r:^0-0-\d00'
 
-  - id: 1635 
+  - id: 1635
     title: "Ensure SSH Protocol is set to 2"
     description: "SSH supports two different and incompatible protocols: SSH1 and SSH2. SSH1 was the original protocol and was subject to security issues. SSH2 is more advanced and secure."
     rationale: "SSH v1 suffers from insecurities that do not affect SSH v2."
@@ -2343,7 +2343,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:Protocol\s*2'
 
-  - id: 1636 
+  - id: 1636
     title: "Ensure SSH LogLevel is appropriate"
     description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
     rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
@@ -2361,7 +2361,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:LogLevel\s+INFO|LogLevel\s+VERBOSE'
 
-  - id: 1637 
+  - id: 1637
     title: "Ensure SSH X11 forwarding is disabled"
     description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
     rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
@@ -2381,7 +2381,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:X11Forwarding\s+no'
 
-  - id: 1638 
+  - id: 1638
     title: "Ensure SSH MaxAuthTries is set to 4 or less"
     description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
     rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
@@ -2396,7 +2396,7 @@ checks:
     rules:
       - 'c:sshd -T -> n:MaxAuthTries\s*\t*(\d+) compare <= 4'
 
-  - id: 1639 
+  - id: 1639
     title: "Ensure SSH IgnoreRhosts is enabled"
     description: "The IgnoreRhosts parameter specifies that .rhostsand .shostsfiles will not be used in RhostsRSAAuthenticationor HostbasedAuthentication."
     rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
@@ -2412,7 +2412,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:IgnoreRhosts\s+yes'
 
-  - id: 1640 
+  - id: 1640
     title: "Ensure SSH HostbasedAuthentication is disabled"
     description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
     rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
@@ -2428,7 +2428,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:HostbasedAuthentication\s+no'
 
-  - id: 1641 
+  - id: 1641
     title: "Ensure SSH root login is disabled"
     description: "The PermitRootLogin parameter specifies if the root user can log in using ssh(1). The default is no."
     rationale: "Disallowing root logins over SSH requires server admins to authenticate using their own individual account, then escalating to root via sudo or su. This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
@@ -2444,7 +2444,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:PermitRootLogin\s+no'
 
-  - id: 1642 
+  - id: 1642
     title: "Ensure SSH PermitEmptyPasswords is disabled"
     description: "The PermitEmptyPasswords parameter specifies if the server allows login to accounts with empty password strings."
     rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system"
@@ -2460,7 +2460,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:PermitEmptyPasswords\s+no'
 
-  - id: 1643 
+  - id: 1643
     title: "Ensure SSH PermitUserEnvironment is disabled"
     description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
     rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing trojan'd programs)"
@@ -2477,10 +2477,10 @@ checks:
       - 'c:sshd -T -> r:PermitUserEnvironment\s+no'
 
 # 5.2.13 Ensure only strong ciphers are used (Scored)
-  - id: 1644 
+  - id: 1644
     title: "Ensure only strong ciphers are used"
     description: "This variable limits the ciphers that SSH can use during communication."
-    rationale: "Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain cleartext data via a birthday attack against a long-duration encrypted session, aka a \"Sweet32\" attack The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly combine state data with key data during the initialization phase, which makes it easier for remote attackers to conduct plaintext-recovery attacks against the initial bytes of a stream by sniffing network traffic that occasionally relies on keys affected by the Invariance Weakness, and then using a brute-force approach involving LSB values, aka the \"Bar Mitzvah\" issue The passwords used during an SSH session encrypted with RC4 can be recovered by an attacker who is able to capture and replay the session Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plaintext data from an arbitrary block of ciphertext in an SSH session via unknown vectors The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher is used, does not properly initialize memory for a MAC context data structure, which allows remote authenticated users to bypass intended ForceCommand and login-shell restrictions via packet data that provides a crafted callback address" 
+    rationale: "Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain cleartext data via a birthday attack against a long-duration encrypted session, aka a \"Sweet32\" attack The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly combine state data with key data during the initialization phase, which makes it easier for remote attackers to conduct plaintext-recovery attacks against the initial bytes of a stream by sniffing network traffic that occasionally relies on keys affected by the Invariance Weakness, and then using a brute-force approach involving LSB values, aka the \"Bar Mitzvah\" issue The passwords used during an SSH session encrypted with RC4 can be recovered by an attacker who is able to capture and replay the session Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plaintext data from an arbitrary block of ciphertext in an SSH session via unknown vectors The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher is used, does not properly initialize memory for a MAC context data structure, which allows remote authenticated users to bypass intended ForceCommand and login-shell restrictions via packet data that provides a crafted callback address"
     remediation: "Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma separated list of the site approved ciphers Example: Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
     compliance:
       - cis: ["5.2.13"]
@@ -2501,10 +2501,10 @@ checks:
       - 'c:sshd -T -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc|arcfour|arcfour128|arcfour256|blowfish-cbc|cast128-cbc|rijndael-cbc@lysator.liu.se'
 
 # 5.2.14 Ensure only sytrong MAC algorithms are used (Scored)
-  - id: 1645 
+  - id: 1645
     title: "Ensure only strong MAC algorithms are used"
     description: "This variable limits the types of MAC algorithms that SSH can use during communication."
-    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information" 
+    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information"
     remediation: "Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma separated list of the site approved MACs Example: MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2- 512,hmac-sha2-256"
     compliance:
       - cis: ["5.2.14"]
@@ -2520,10 +2520,10 @@ checks:
       - 'c:sshd -T -> r:MACs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|umac-128@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com'
 
 # 5.2.15 Ensure only strong Key Exchange algorithms are used (Scored)
-  - id: 1646 
+  - id: 1646
     title: "Ensure only strong Key Exchange algorithms are used"
     description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received"
-    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks" 
+    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks"
     remediation: "Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to contain a comma separated list of the site approved key exchange algorithms Example: KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
     compliance:
       - cis: ["5.2.15"]
@@ -2537,7 +2537,7 @@ checks:
       - 'c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1'
 
 
-  - id: 1647 
+  - id: 1647
     title: "Ensure SSH Idle Timeout Interval is configured"
     description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the ClientAliveCountMax variable is set, sshd will send client alive messages at every ClientAliveInterval interval. When the number of consecutive client alive messages are sent with no response from the client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
     rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent."
@@ -2553,7 +2553,7 @@ checks:
 
 
 # 5.2.17 Ensure SSH LoginGraceTime is set to one minute or less (Scored)
-  - id: 1648 
+  - id: 1648
     title: "Ensure SSH LoginGraceTime is set to one minute or less"
     description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
     rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
@@ -2566,7 +2566,7 @@ checks:
     rules:
       - 'c:sshd -T -> n:LoginGraceTime\s*\t*(\d+) compare <= 60 && n:LoginGraceTime\s*\t*(\d+) compare != 0'
 
-  - id: 1649 
+  - id: 1649
     title: "Ensure SSH access is limited"
     description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: AllowUsers, AllowGroups, DenyUsers, DenyGroups."
     rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
@@ -2579,7 +2579,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:AllowUsers\s+\w+|AllowGroups\s+\w+|DenyUsers\s+\w+|DenyGroups\s+\w+'
 
-  - id: 1650 
+  - id: 1650
     title: "Ensure SSH warning banner is configured"
     description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
     rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
@@ -2596,7 +2596,7 @@ checks:
 
 # 5.3 Configure PAM
 
-  - id: 1651 
+  - id: 1651
     title: "Ensure password creation requirements are configured"
     description: "The pam_pwquality.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more. The following are definitions of the pam_pwquality.so options: - retry=3 (Allow 3 tries before sending back a failure). The following options are set in the /etc/security/pwquality.conf file: - minlen = 14 dcredit = -1 ucredit = -1 ocredit = -1 lcredit = -1 (The settings shown above are one possible policy. Alter these values to conform to your own organization's password policies.)"
     rationale: "Strong passwords protect systems from being hacked through brute force methods."
@@ -2615,7 +2615,7 @@ checks:
       - 'f:/etc/security/pwquality.conf -> !r:^# && r:ocredit'
       - 'f:/etc/security/pwquality.conf -> !r:^# && r:lcredit'
 
-  - id: 1652 
+  - id: 1652
     title: "Ensure lockout for failed password attempts is configured"
     description: "Lock out users after n unsuccessful consecutive login attempts. The first sets of changes are made to the PAM configuration files. The second set of changes are applied to the program specific PAM configuration file. The second set of changes must be applied to each program that will lock out users. Check the documentation for each secondary program for instructions on how to configure them to work with PAM. Set the lockout number to the policy in effect at your site."
     rationale: "Locking out user IDs after n unsuccessful consecutive login attempts mitigates brute force password attacks against your systems."
@@ -2628,7 +2628,7 @@ checks:
     rules:
       - 'f:/etc/pam.d/common-auth -> !r:^# && r:auth\s*\t*required\s*\t*pam_tally2.so && r:onerr=fail && r:audit && r:silent && r:deny\s*=\s*\d+ && r:unlock_time\s*=\s*\d+'
 
-  - id: 1653 
+  - id: 1653
     title: "Ensure password reuse is limited"
     description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
     rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password. Note that these change only apply to accounts configured on the local system."
@@ -2643,7 +2643,7 @@ checks:
       - 'f:/etc/pam.d/common-password -> !r:^# && r:password\s*\t*required\s*\t*pam_pwhistory.so && !r:remember'
 
 # 5.3.4 Ensure password hashing algorithm is SHA-512 (Scored)
-  - id: 1654 
+  - id: 1654
     title: "Ensure password hashing algorithm is SHA-512"
     description: "The commands below change password encryption from md5 to sha512 (a much stronger hashing algorithm). All existing accounts will need to perform a password change to upgrade the stored hashes to the new algorithm."
     rationale: "The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note that these change only apply to accounts configured on the local system."
@@ -2658,7 +2658,7 @@ checks:
 
 # 5.4 User Accounts and Environment
 
-  - id: 1655 
+  - id: 1655
     title: "Ensure password expiration is 365 days or less"
     description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 365 days."
     rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity."
@@ -2672,7 +2672,7 @@ checks:
       - 'f:/etc/login.defs -> n:^\s*\t*PASS_MAX_DAYS\s*\t*(\d+) compare <= 365'
       - 'not f:/etc/login.defs -> n:^\s*\t*PASS_MAX_DAYS\s*\t*(\d+) compare < 0'
 
-  - id: 1656 
+  - id: 1656
     title: "Ensure minimum days between password changes is 7 or more"
     description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 7 or more days."
     rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
@@ -2685,7 +2685,7 @@ checks:
     rules:
       - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 7'
 
-  - id: 1657 
+  - id: 1657
     title: "Ensure password expiration warning days is 7 or more"
     description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
     rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
@@ -2698,7 +2698,7 @@ checks:
     rules:
       - 'f:/etc/login.defs -> n:^\s*\t*PASS_WARN_AGE\s*\t*(\d+) compare >= 7'
 
-  - id: 1658 
+  - id: 1658
     title: "Ensure inactive password lock is 30 days or less"
     description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
     rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
@@ -2712,7 +2712,7 @@ checks:
       - 'c:useradd -D -> n:^INACTIVE=(\d+) compare <= 30'
       - 'not f:/etc/login.defs -> n:^\s*\t*PASS_MAX_DAYS\s*\t*(\d+) compare < 0'
 
-  - id: 1659 
+  - id: 1659
     title: "Ensure default group for the root account is GID 0"
     description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
     rationale: "Using GID 0 for the root account helps prevent root-owned files from accidentally becoming accessible to non-privileged users."
@@ -2726,7 +2726,7 @@ checks:
       - 'f:/etc/passwd -> !r:^# && r:root:\w+:\w+:0:'
 
 # 5.4.4 Ensure default user umask is 027 or more restrictive (Scored)
-  - id: 1660 
+  - id: 1660
     title: "Ensure default user umask is 027 or more restrictive"
     description: "The default umask determines the permissions of files created by users. The user creating the file has the discretion of making their files and directories readable by others via the chmod command. Users who wish to allow their files and directories to be readable by others by default may choose a different default umask by inserting the umask command into the standard shell configuration files ( .profile , .bashrc , etc.) in their home directories."
     rationale: "Setting a very secure default value for umask ensures that users make a conscious choice about their file permissions. A default umask setting of 077 causes files and directories created by users to not be readable by any other user on the system. A umask of 027 would make files and directories readable by users in the same Unix group, while a umask of 022 would make files readable by every user on the system."
@@ -2746,7 +2746,7 @@ checks:
 
 
 # 5.4.5 Ensure default user shell timeout is 900 seconds or less (Scored)
-  - id: 1661 
+  - id: 1661
     title: "Ensure default user shell timeout is 900 seconds or less"
     description: "The default TMOUT determines the shell timeout for users. The TMOUT value is measured in seconds."
     rationale: "Having no timeout value associated with a shell could allow an unauthorized user access to another user's shell session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening."
@@ -2763,9 +2763,9 @@ checks:
       - 'd:/etc/profile.d -> .sh -> n:^\s*\t*TMOUT\s*\t*=\s*\t*(\d+) compare <= 900'
       - 'f:/etc/bash.bashrc -> n:^\s*\t*TMOUT\s*\t*=\s*\t*(\d+) compare <= 900'
       - 'f:/etc/profile -> n:^\s*\t*TMOUT\s*\t*=\s*\t*(\d+) compare <= 900'
-      
 
-  - id: 1662 
+
+  - id: 1662
     title: "Ensure access to the su command is restricted"
     description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in the sudo group to execute su."
     rationale: "Restricting the use of su, and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo, whereas su can only record that a user executed the su program."
@@ -2785,7 +2785,7 @@ checks:
       - 'f:/etc/group -> !r:^# && r:sudo:\w+:\d+:\.'
 
 # 6.1.2 Ensure permissions on /etc/passwd are configured (Scored)
-  - id: 1663 
+  - id: 1663
     title: "Ensure permissions on /etc/passwd are configured"
     description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
     rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -2801,7 +2801,7 @@ checks:
       - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.3 Ensure permissions on /etc/shadow are configured (Scored)
-  - id: 1664 
+  - id: 1664
     title: "Ensure permissions on /etc/shadow are configured"
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
@@ -2817,7 +2817,7 @@ checks:
       - 'c:stat /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
 # 6.1.4 Configure /etc/group permissions (Scored)
-  - id: 1665 
+  - id: 1665
     title: "Ensure permissions on /etc/group are configured"
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
@@ -2833,7 +2833,7 @@ checks:
       - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.5 Ensure permissions on /etc/gshadow are configured (Scored)
-  - id: 1666 
+  - id: 1666
     title: "Ensure permissions on /etc/gshadow are configured"
     description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/gshadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/gshadow file (such as group administrators) could also be useful to subvert the group"
@@ -2849,7 +2849,7 @@ checks:
       - 'c:stat /etc/gshadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
 # 6.1.6 Ensure permissions on /etc/passwd- are configured (Scored)
-  - id: 1667 
+  - id: 1667
     title: "Ensure permissions on /etc/passwd- are configured"
     description: "The /etc/passwd- file contains backup user account information."
     rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -2865,7 +2865,7 @@ checks:
       - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Ensure permissions on /etc/shadow- are configured (Scored)
-  - id: 1668 
+  - id: 1668
     title: "Ensure permissions on /etc/shadow- are configured"
     description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -2881,7 +2881,7 @@ checks:
       - 'c:stat /etc/shadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\) && r:Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)|Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.8 Configure /etc/group- permissions (Scored)
-  - id: 1669 
+  - id: 1669
     title: "Ensure permissions on /etc/group- are configured"
     description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
     rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -2897,7 +2897,7 @@ checks:
       - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Ensure permissions on /etc/gshadow- are configured (Scored)
-  - id: 1670 
+  - id: 1670
     title: "Ensure permissions on /etc/gshadow- are configured"
     description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -2914,7 +2914,7 @@ checks:
 
 # 6.2 User and Group Settings
 
-  - id: 1671 
+  - id: 1671
     title: "Ensure password fields are not empty"
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
@@ -2927,7 +2927,7 @@ checks:
     rules:
       - 'f:/etc/shadow -> r:^\w+::'
 
-  - id: 1672 
+  - id: 1672
     title: "Ensure no legacy \"+\" entries exist in /etc/passwd"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -2945,7 +2945,7 @@ checks:
     rules:
       - 'f:/etc/passwd -> !r:^# && r:^+:'
 
-  - id: 1673 
+  - id: 1673
     title: "Ensure no legacy \"+\" entries exist in /etc/shadow"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -2963,7 +2963,7 @@ checks:
     rules:
       - 'f:/etc/shadow -> !r:^# && r:^+:'
 
-  - id: 1674 
+  - id: 1674
     title: "Ensure no legacy \"+\" entries exist in /etc/group"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -2981,7 +2981,7 @@ checks:
     rules:
       - 'f:/etc/group -> !r:^# && r:^+:'
 
-  - id: 1675 
+  - id: 1675
     title: "Ensure root is the only UID 0 account"
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
@@ -2999,7 +2999,7 @@ checks:
     rules:
       - 'f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:'
 
-  - id: 1676 
+  - id: 1676
     title: "Ensure shadow group is empty"
     description: "The shadow group allows system programs which require access the ability to read the /etc/shadow file. No users should be assigned to the shadow group."
     rationale: "Any users assigned to the shadow group would be granted read access to the /etc/shadow file. If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed passwords to break them. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts."

--- a/ruleset/sca/debian/cis_debian8.yml
+++ b/ruleset/sca/debian/cis_debian8.yml
@@ -486,6 +486,21 @@ checks:
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:=\s*\t*0$'
       - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:\s*\t*0$'
 
+  - id: 1529 
+    title: "Ensure XD/NX support is enabled"
+    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
+    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
+    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
+    compliance:
+      - cis: ["1.5.2"]
+      - cis_csc: ["8.4"]
+      - pci_dss: ["2.2.4"]
+      - nist_800_53: ["CM.1"]
+      - tsc: ["CC5.2"]
+    condition: all
+    rules:
+      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+
   - id: 1530 
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."

--- a/ruleset/sca/debian/cis_debian8.yml
+++ b/ruleset/sca/debian/cis_debian8.yml
@@ -499,7 +499,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+      - 'c:sh -c "dmesg | grep NX" -> r:NX \(Execute Disable\) protection: active'
 
   - id: 1530
     title: "Ensure address space layout randomization (ASLR) is enabled"

--- a/ruleset/sca/debian/cis_debian9.yml
+++ b/ruleset/sca/debian/cis_debian9.yml
@@ -487,7 +487,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+      - 'c:sh -c "dmesg | grep NX" -> r:NX \(Execute Disable\) protection: active'
 
   - id: 2029
     title: "Ensure address space layout randomization (ASLR) is enabled"

--- a/ruleset/sca/debian/cis_debian9.yml
+++ b/ruleset/sca/debian/cis_debian9.yml
@@ -29,7 +29,7 @@ requirements:
 
 checks:
 # 1.1.1 Disable unused filesystems
-  - id: 2000 
+  - id: 2000
     title: "Ensure mounting of freevxfs filesystems is disabled"
     description: "The freevxfs filesystem type is a free version of the Veritas type filesystem. This is the primary filesystem type for HP-UX operating systems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -44,7 +44,7 @@ checks:
       - 'c:modprobe -n -v freevxfs -> r:^install /bin/true'
       - 'not c:lsmod -> r:freevxfs'
 
-  - id: 2001 
+  - id: 2001
     title: "Ensure mounting of jffs2 filesystems is disabled"
     description: "The jffs2 (journaling flash filesystem 2) filesystem type is a log-structured filesystem used in flash memory devices."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -59,7 +59,7 @@ checks:
       - 'c:modprobe -n -v jffs2 -> r:^install /bin/true'
       - 'not c:lsmod -> r:jffs2'
 
-  - id: 2002 
+  - id: 2002
     title: "Ensure mounting of hfs filesystems is disabled"
     description: "The hfs filesystem type is a hierarchical filesystem that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -74,7 +74,7 @@ checks:
       - 'c:modprobe -n -v hfs -> r:^install /bin/true'
       - 'not c:lsmod -> r:hfs'
 
-  - id: 2003 
+  - id: 2003
     title: "Ensure mounting of hfsplus filesystems is disabled"
     description: "The hfsplus filesystem type is a hierarchical filesystem designed to replace hfs that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -89,7 +89,7 @@ checks:
       - 'c:modprobe -n -v hfsplus -> r:^install /bin/true'
       - 'not c:lsmod -> r:hfsplus'
 
-  - id: 2004 
+  - id: 2004
     title: "Ensure mounting of udf filesystems is disabled"
     description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -105,7 +105,7 @@ checks:
       - 'not c:lsmod -> r:udf'
 
 # 2 Filesystem Configuration
-  - id: 2005 
+  - id: 2005
     title: "Ensure /tmp is configured"
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -124,7 +124,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s'
       - 'c:systemctl is-enabled tmp.mount -> enabled'
 
-  - id: 2006 
+  - id: 2006
     title: "Ensure nodev option set on /tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
@@ -139,7 +139,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s && r:nodev'
 
-  - id: 2007 
+  - id: 2007
     title: "Ensure nosuid option set on /tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain set userid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create set userid files in /tmp."
@@ -154,7 +154,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s && r:nosuid'
 
-  - id: 2008 
+  - id: 2008
     title: "Ensure noexec option set on /tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp ."
@@ -169,7 +169,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/tmp\s && r:noexec'
 
-  - id: 2009 
+  - id: 2009
     title: "Ensure separate partition exists for /var"
     description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
     rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
@@ -186,7 +186,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var\s'
 
-  - id: 2010 
+  - id: 2010
     title: "Ensure separate partition exists for /var/tmp"
     description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /var/tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own file system allows an administrator to set the noexec option on the mount, making /var/tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated."
@@ -203,7 +203,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/tmp\s'
 
-  - id: 2011 
+  - id: 2011
     title: "Ensure nodev option set on /var/tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /var/tmp."
@@ -218,7 +218,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/tmp\s && r:nodev'
 
-  - id: 2012 
+  - id: 2012
     title: "Ensure nosuid option set on /var/tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
@@ -233,7 +233,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/tmp\s && r:nosuid'
 
-  - id: 2013 
+  - id: 2013
     title: "Ensure noexec option set on /var/tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
@@ -250,7 +250,7 @@ checks:
 
 
 
-  - id: 2014 
+  - id: 2014
     title: "Ensure separate partition exists for /var/log"
     description: "The /var/log directory is used by system services to store log data."
     rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
@@ -267,7 +267,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/log\s'
 
-  - id: 2015 
+  - id: 2015
     title: "Ensure separate partition exists for /var/log/audit"
     description: "The auditing daemon, auditd, stores log data in the /var/log/audit directory."
     rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data. The audit daemon calculates how much free space is left and performs actions based on the results. If other processes (such as syslog) consume space in the same partition as auditd, it may not perform as desired."
@@ -284,7 +284,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/var/log/audit\s'
 
-  - id: 2016 
+  - id: 2016
     title: "Ensure separate partition exists for /home"
     description: "The /home directory is used to support disk storage needs of local users."
     rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
@@ -302,7 +302,7 @@ checks:
       - 'c:mount -> r:\s/home\s'
 
 
-  - id: 2017 
+  - id: 2017
     title: "Ensure nodev option set on /home partition"
     description: "When set on a file system, this option prevents character and block special devices from being defined, or if they exist, from being used as character and block special devices."
     rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices.  Note: The actions in the item refer to the /home partition, which is the default user partition that is defined in many distributions. If you have created other user partitions, it is recommended that the Remediation and Audit steps be applied to these partitions as well."
@@ -317,7 +317,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/home\s && r:nodev'
 
-  - id: 2018 
+  - id: 2018
     title: "Ensure nodev option set on /dev/shm partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /run/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
@@ -332,7 +332,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/dev/shm\s && r:nodev'
 
-  - id: 2019 
+  - id: 2019
     title: "Ensure nosuid option set on /dev/shm partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
@@ -347,7 +347,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/dev/shm\s && r:nosuid'
 
-  - id: 2020 
+  - id: 2020
     title: "Ensure noexec option set on /dev/shm partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
@@ -362,7 +362,7 @@ checks:
     rules:
       - 'c:mount -> r:\s/dev/shm\s && r:noexec'
 
-  - id: 2021 
+  - id: 2021
     title: "Disable Automounting"
     description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
     rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have it's contents available in system even if they lacked permissions to mount it themselves."
@@ -378,7 +378,7 @@ checks:
       - 'c:systemctl is-enabled autofs -> r:^enabled'
 
 # 1.3 Filesystem Integrity Checking
-  - id: 2022 
+  - id: 2022
     title: "Ensure AIDE is installed"
     description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
     rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
@@ -394,7 +394,7 @@ checks:
     rules:
       - 'c:dpkg -s aide -> r:install ok installed'
 
-  - id: 2023 
+  - id: 2023
     title: "Ensure filesystem integrity is regularly checked"
     description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
     rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
@@ -410,7 +410,7 @@ checks:
       - 'c:crontab -u root -l -> !r:^# && r:/usr/bin/aide && r:--check'
 
 # 1.4 Secure Boot Settings
-  - id: 2024 
+  - id: 2024
     title: "Ensure permissions on bootloader config are configured"
     description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options. The grub configuration is usually grub.cfg stored in /boot/grub."
     rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
@@ -425,7 +425,7 @@ checks:
     rules:
       - 'c:stat /boot/grub/grub.cfg -> r:Access:\s*\(0\d00/-\w\w-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 2025 
+  - id: 2025
     title: "Ensure bootloader password is set"
     description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
     rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
@@ -441,7 +441,7 @@ checks:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*set superusers'
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*password'
 
-  - id: 2026 
+  - id: 2026
     title: "Ensure authentication required for single user mode"
     description: "Single user mode is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
     rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
@@ -457,7 +457,7 @@ checks:
       - 'f:/etc/shadow -> r:^root:*:|^root:!:'
 
 # 1.5 Additional Process Hardening
-  - id: 2027 
+  - id: 2027
     title: "Ensure core dumps are restricted"
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file. The system provides the ability to set a soft limit for core dumps, but this can be overridden by the user."
     rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf(5) ). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
@@ -474,7 +474,7 @@ checks:
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> !r:^# && r:=\s*\t*0$'
       - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:\s*\t*0$'
 
-  - id: 2028 
+  - id: 2028
     title: "Ensure XD/NX support is enabled"
     description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
     rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
@@ -489,7 +489,7 @@ checks:
     rules:
       - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
 
-  - id: 2029 
+  - id: 2029
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
     rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
@@ -505,7 +505,7 @@ checks:
       - 'c:grep -Rh ^kernel\.randomize_va_space /etc/sysctl.conf /etc/sysctl.d -> r:\s*\t*2$'
       - 'c:sysctl kernel.randomize_va_space -> r:^kernel.randomize_va_space\s*\t*=\s*\t*2'
 
-  - id: 2030 
+  - id: 2030
     title: "Ensure prelink is disabled"
     description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
     rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
@@ -524,7 +524,7 @@ checks:
 
 # 1.6 Configure SELinux
 
-  - id: 2031 
+  - id: 2031
     title: "Ensure SELinux is enabled in the bootloader configuration"
     description: "Configure SELINUX to be enabled at boot time and verify that it has not been overwritten by the grub boot parameters."
     rationale: "SELinux must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
@@ -540,7 +540,7 @@ checks:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:selinux=1'
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:security=selinux'
 
-  - id: 2032 
+  - id: 2032
     title: "Ensure the SELinux state is enforcing"
     description: "Set SELinux to enable when the system is booted."
     rationale: "SELinux must be enabled at boot time in to ensure that the controls it provides are in effect at all times."
@@ -559,7 +559,7 @@ checks:
       - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing'
       - 'not f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:enforcing=1'
 
-  - id: 2033 
+  - id: 2033
     title: "Ensure SELinux policy is configured"
     description: "Configure SELinux to meet or exceed the default targeted policy, which constrains daemons and system software only."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that at least the default recommendations are met."
@@ -575,7 +575,7 @@ checks:
       - 'c:sestatus -> r:^Loaded policy name:\s+default|^Loaded policy name:\s+mls'
       - 'f:/etc/selinux/config -> r:^\s*SELINUXTYPE\s*=\s*default|^\s*SELINUXTYPE\s*=\s*mls'
 
-  - id: 2034 
+  - id: 2034
     title: "Ensure no unconfined daemons exist"
     description: "Daemons that are not defined in SELinux policy will inherit the security context of their parent process."
     rationale: "Since daemons are launched and descend from the init process, they will inherit the security context label initrc_t . This could cause the unintended consequence of giving the process more permission than it requires."
@@ -591,7 +591,7 @@ checks:
       - 'c:ps -eZ -> r:initrc && !r:tr|ps|egrep|bash|awk'
 
 
-  - id: 2035 
+  - id: 2035
     title: "Ensure AppArmor is enabled in the bootloader configuration"
     description: "Configure AppArmor to be enabled at boot time and verify that it has not been overwrittenby the bootloader boot parameters."
     rationale: "AppArmor must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
@@ -607,7 +607,7 @@ checks:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:apparmor=1'
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:security=apparmor'
 
-  - id: 2036 
+  - id: 2036
     title: "Ensure all AppArmor Profiles are enforcing"
     description: "AppArmor profiles define what resources applicatons are able to access."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that any policies that exist on the system are activated.."
@@ -620,11 +620,11 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:apparmor status -> r:0 profiles are in complain mode' 
+      - 'c:apparmor status -> r:0 profiles are in complain mode'
       - 'c:apparmor status -> r:0 processes are unconfined'
       - 'c:apparmor status -> n:(\d+) profiles are loaded compare > 0'
 
-  - id: 2037 
+  - id: 2037
     title: "Ensure SELinux or AppArmor are installed"
     description: "SELinux and AppArmor provide Mandatory Access Controls."
     rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
@@ -642,7 +642,7 @@ checks:
 
 
 # 1.7 Warning Banners
-  - id: 2038 
+  - id: 2038
     title: "Ensure message of the day is configured properly"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -654,8 +654,8 @@ checks:
     condition: none
     rules:
       - 'f:/etc/motd -> r:\\v|\\r|\\m|\\s|Debian'
-      
-  - id: 2039 
+
+  - id: 2039
     title: "Ensure local login warning banner is configured properly"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -667,7 +667,7 @@ checks:
     rules:
       - 'f:/etc/issue -> r:\\v|\\r|\\m|\\s|Debian'
 
-  - id: 2040 
+  - id: 2040
     title: "Ensure remote login warning banner is configured properly"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -680,7 +680,7 @@ checks:
     rules:
       - 'f:/etc/issue.net -> r:\\v|\\r|\\m|\\s|Debian'
 
-  - id: 2041 
+  - id: 2041
     title: "Ensure permissions on /etc/motd are configured"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
     rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -698,7 +698,7 @@ checks:
     rules:
       - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 2042 
+  - id: 2042
     title: "Ensure permissions on /etc/issue are configured"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
     rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -716,7 +716,7 @@ checks:
     rules:
       - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 2043 
+  - id: 2043
     title: "Ensure permissions on /etc/issue.net are configured"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
     rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -734,7 +734,7 @@ checks:
     rules:
       - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 2044 
+  - id: 2044
     title: "Ensure GDM login banner is configured"
     description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems."
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place."
@@ -751,7 +751,7 @@ checks:
       - 'f:/etc/gdm3/greeter.dconf-defaults -> r:^banner-message-enable=true'
       - 'f:/etc/gdm3/greeter.dconf-defaults -> r:^banner-message-text=\.+'
 
-  - id: 2045 
+  - id: 2045
     title: "Ensure updates, patches, and additional security software are installed"
     description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
     rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
@@ -770,7 +770,7 @@ checks:
       - 'c:apt-get -s upgrade -> r:^The following packages will be upgraded'
 
 # 2 Services
-  - id: 2046 
+  - id: 2046
     title: "Ensure xinetd is not installed"
     description: "The eXtended InterNET Daemon (xinetd) is an open source super daemon that replaced the original inetd daemon. The xinetddaemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no xinetd services required, it is recommended that the package be removed."
@@ -788,7 +788,7 @@ checks:
     rules:
       - 'c:dpkg -s xinetd -> r:dpkg-query: package \.+ is not installed'
 
-  - id: 2047 
+  - id: 2047
     title: "Ensure openbsd-inetd is not installed"
     description: "The inetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no inetd services required, it is recommended that the daemon be removed."
@@ -806,7 +806,7 @@ checks:
     rules:
       - 'c:dpkg -s openbsd-inetd -> r:install ok installed'
 
-  - id: 2048 
+  - id: 2048
     title: "Ensure time synchronization is in use"
     description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
     rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
@@ -822,7 +822,7 @@ checks:
       - 'c:dpkg -s ntp -> r:install ok installed'
       - 'c:dpkg -s chrony -> r:install ok installed'
 
-  - id: 2049 
+  - id: 2049
     title: "Ensure ntp is configured"
     description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at http://www.ntp.org. ntp can be configured to be a client and/or a server. This recommendation only applies if ntp is in use on the system."
     rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
@@ -842,7 +842,7 @@ checks:
       - 'f:/etc/ntp.conf -> r:^server\.+|^pool\.+'
       - 'f:/etc/init.d/ntp -> r:^RUNASUSER\s*\t*=\s*\t*ntp'
 
-  - id: 2050 
+  - id: 2050
     title: "Ensure chrony is configured"
     description: "chrony is a daemon which implements the Network Time Protocol (NTP) is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on chrony can be found at http://chrony.tuxfamily.org/. chrony can be configured to be a client and/or a server."
     rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly. This recommendation only applies if chrony is in use on the system."
@@ -858,7 +858,7 @@ checks:
       - 'f:/etc/chrony.conf -> r:^server\.+|^pool\.+'
 
 # 2.2.2 Ensure the X Window system is not installed (Scored)
-  - id: 2051 
+  - id: 2051
     title: "Ensure the X Window system is not installed"
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
@@ -873,7 +873,7 @@ checks:
     rules:
       - 'c:dpkg -l xserver-xorg-core* -> r:^\wi\s*xserver-xorg'
 
-  - id: 2052 
+  - id: 2052
     title: "Ensure Avahi Server is not enabled"
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to disable the service to reduce the potential attach surface."
@@ -888,7 +888,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled avahi-daemon -> enabled'
 
-  - id: 2053 
+  - id: 2053
     title: "Ensure CUPS is not enabled"
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be disabled to reduce the potential attack surface."
@@ -905,7 +905,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled cups -> enabled'
 
-  - id: 2054 
+  - id: 2054
     title: "Ensure DHCP Server is not enabled"
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this service be disabled to reduce the potential attack surface."
@@ -923,7 +923,7 @@ checks:
       - 'c:systemctl is-enabled isc-dhcp-server -> enabled'
       - 'c:systemctl is-enabled isc-dhcp-server6 -> enabled'
 
-  - id: 2055 
+  - id: 2055
     title: "Ensure LDAP server is not enabled"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be disabled to reduce the potential attack surface."
@@ -940,7 +940,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled slapd -> enabled'
 
-  - id: 2056 
+  - id: 2056
     title: "Ensure NFS and RPC are not enabled"
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not export NFS shares or act as an NFS client, it is recommended that these services be disabled to reduce remote attack surface."
@@ -956,7 +956,7 @@ checks:
       - 'c:systemctl is-enabled nfs-server -> enabled'
       - 'c:systemctl is-enabled rpcbind -> enabled'
 
-  - id: 2057 
+  - id: 2057
     title: "Ensure DNS Server is not enabled"
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be deleted to reduce the potential attack surface."
@@ -971,7 +971,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled bind9 -> enabled'
 
-  - id: 2058 
+  - id: 2058
     title: "Ensure FTP Server is not enabled"
     description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be deleted to reduce the potential attack surface."
@@ -986,7 +986,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled vsftpd -> enabled'
 
-  - id: 2059 
+  - id: 2059
     title: "Ensure HTTP Server is not enabled"
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be deleted to reduce the potential attack surface."
@@ -1001,7 +1001,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled apache2 -> enabled'
 
-  - id: 2060 
+  - id: 2060
     title: "Ensure IMAP and POP3 server is not enabled"
     description: "exim is an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
@@ -1016,7 +1016,7 @@ checks:
     rules:
       - 'c:dpkg -s exim4 -> r:install ok installed'
 
-  - id: 2061 
+  - id: 2061
     title: "Ensure Samba is not enabled"
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this service can be deleted to reduce the potential attack surface."
@@ -1031,7 +1031,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled smbd -> enabled'
 
-  - id: 2062 
+  - id: 2062
     title: "Ensure HTTP Proxy Server is not enabled"
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be deleted to reduce the potential attack surface."
@@ -1046,7 +1046,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled squid -> enabled'
 
-  - id: 2063 
+  - id: 2063
     title: "Ensure SNMP Server is not enabled"
     description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
     rationale: "The SNMP server can communicate using SNMP v1, which transmits data in the clear and does not require authentication to execute commands. Unless absolutely necessary, it is recommended that the SNMP service not be used. If SNMP is required the server should be configured to disallow SNMP v1."
@@ -1061,7 +1061,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled snmpd -> enabled'
 
-  - id: 2064 
+  - id: 2064
     title: "Ensure mail transfer agent is configured for local-only mode"
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems."
@@ -1076,7 +1076,7 @@ checks:
     rules:
       - 'c:netstat -an -> r:\.*:25\.*LISTEN && !r:127.0.0.1:25\.+LISTEN|::1:25\.*LISTEN'
 
-  - id: 2065 
+  - id: 2065
     title: "Ensure rsync service is not enabled"
     description: "The rsyncd service can be used to synchronize files between systems over network links."
     rationale: "The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
@@ -1090,7 +1090,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled rsync -> enabled'
 
-  - id: 2066 
+  - id: 2066
     title: "Ensure NIS Server is not enabled"
     description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be disabled and other, more secure services be used"
@@ -1108,7 +1108,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled nis -> enabled'
 
-  - id: 2067 
+  - id: 2067
     title: "Ensure NIS Client is not installed"
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
@@ -1126,7 +1126,7 @@ checks:
     rules:
       - 'c:dpkg -s nis -> r:install ok installed'
 
-  - id: 2068 
+  - id: 2068
     title: "Ensure rsh client is not installed"
     description: "The rshpackage contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rshpackage removes the clients for rsh, rcpand rlogin."
@@ -1145,7 +1145,7 @@ checks:
       - 'c:dpkg -s rsh-client -> r:install ok installed'
       - 'c:dpkg -s rsh-redone-client -> r:install ok installed'
 
-  - id: 2069 
+  - id: 2069
     title: "Ensure talk client is not installed"
     description: "The talksoftware makes it possible for users to send and receive messages across systems through a terminal session. The talkclient, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -1163,7 +1163,7 @@ checks:
     rules:
       - 'c:dpkg -s talk -> r:install ok installed'
 
-  - id: 2070 
+  - id: 2070
     title: "Ensure telnet client is not installed"
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
@@ -1181,7 +1181,7 @@ checks:
     rules:
       - 'c:dpkg -s telnet -> r:install ok installed'
 
-  - id: 2071 
+  - id: 2071
     title: "Ensure LDAP client is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
@@ -1200,7 +1200,7 @@ checks:
       - 'c:dpkg -s ldap-utils -> r:install ok installed'
 
 # 3 Network Configuration
-  - id: 2072 
+  - id: 2072
     title: "Ensure IP forwarding is disabled"
     description: "The net.ipv4.ip_forward and net.ipv6.conf.all.forwarding flags are used to tell the system whether it can forward packets or not."
     rationale: "Setting the flags to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
@@ -1218,7 +1218,7 @@ checks:
       - 'c:sysctl net.ipv6.conf.all.forwarding -> r:=\s*\t*0$'
       - 'c:grep -Rh net\.ipv6\.conf\.all\.forwarding /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.forwarding\s*=\s*0$'
 
-  - id: 2073 
+  - id: 2073
     title: "Ensure packet redirect sending is disabled"
     description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
     rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
@@ -1236,7 +1236,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
 
-  - id: 2074 
+  - id: 2074
     title: "Ensure source routed packets are not accepted"
     description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
     rationale: "Setting net.ipv4.conf.all.accept_source_route, net.ipv4.conf.default.accept_source_route, net.ipv6.conf.all.accept_source_route and net.ipv6.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
@@ -1258,7 +1258,7 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.all\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.accept_source_route\s*=\s*0$'
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_source_route\s*=\s*0$'
 
-  - id: 2075 
+  - id: 2075
     title: "Ensure ICMP redirects are not accepted"
     description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables. By setting net.ipv4.conf.all.accept_redirects and net.ipv6.conf.all.accept_redirects to 0, the system will not accept any ICMP redirect messages, and therefore, won't allow outsiders to update the system's routing tables."
     rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
@@ -1280,7 +1280,7 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.all\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.accept_redirects\s*=\s*0$'
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0$'
 
-  - id: 2076 
+  - id: 2076
     title: "Ensure secure ICMP redirects are not accepted"
     description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
     rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
@@ -1298,7 +1298,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
 
-  - id: 2077 
+  - id: 2077
     title: "Ensure suspicious packets are logged"
     description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
     rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their server."
@@ -1316,7 +1316,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
 
-  - id: 2078 
+  - id: 2078
     title: "Ensure broadcast ICMP requests are ignored"
     description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
     rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
@@ -1332,7 +1332,7 @@ checks:
       - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:=\s*\t*1$'
       - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
-  - id: 2079 
+  - id: 2079
     title: "Ensure bogus ICMP responses are ignored"
     description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
     rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
@@ -1348,7 +1348,7 @@ checks:
       - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:=\s*\t*1$'
       - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
-  - id: 2080 
+  - id: 2080
     title: "Ensure Reverse Path Filtering is enabled"
     description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
     rationale: Setting these flags is a good way to deter attackers from sending your system bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing.
@@ -1366,7 +1366,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.all\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
       - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
 
-  - id: 2081 
+  - id: 2081
     title: "Ensure TCP SYN Cookies is enabled"
     description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue."
     rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
@@ -1382,7 +1382,7 @@ checks:
       - 'c:sysctl net.ipv4.tcp_syncookies -> r:=\s*\t*1$'
       - 'c:grep -Rh net\.ipv4\.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
 
-  - id: 2082 
+  - id: 2082
     title: "Ensure IPv6 router advertisements are not accepted"
     description: "This setting disables the systems ability to accept router advertisements"
     rationale: "It is recommended that systems not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
@@ -1403,7 +1403,7 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.all\.accept_ra /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.all.accept_ra\s*=\s*0$'
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_ra /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_ra\s*=\s*0$'
 
-  - id: 2083 
+  - id: 2083
     title: "Install TCP Wrappers"
     description: "TCP Wrappers provides a simple access list and standardized logging method for services capable of supporting it. In the past, services that were called from inetd and xinetd supported the use of tcp wrappers. As inetd and xinetd have been falling in disuse, any service that can support tcp wrappers will have the libwrap.so library attached to it."
     rationale: "TCP Wrappers provide a good simple access list mechanism to services that may not have that support built in. It is recommended that all services that can support TCP Wrappers, use it."
@@ -1416,7 +1416,7 @@ checks:
     rules:
       - 'c:dpkg -s tcpd -> r:install ok installed'
 
-  - id: 2084 
+  - id: 2084
     title: "Ensure /etc/hosts.allow is configured"
     description: "The /etc/hosts.allow file specifies which IP addresses are permitted to connect to the host. It is intended to be used in conjunction with the /etc/hosts.deny file."
     rationale: "The /etc/hosts.allow file supports access control by IP and helps ensure that only authorized systems can connect to the system."
@@ -1429,7 +1429,7 @@ checks:
     rules:
       - 'f:/etc/hosts.allow'
 
-  - id: 2085 
+  - id: 2085
     title: "Ensure /etc/hosts.deny is configured"
     description: "The /etc/hosts.deny file specifies which IP addresses are not permitted to connect to the host. It is intended to be used in conjunction with the /etc/hosts.allow file."
     rationale: "The /etc/hosts.deny file serves as a failsafe so that any host not specified in /etc/hosts.allow is denied access to the server."
@@ -1443,7 +1443,7 @@ checks:
       - 'f:/etc/hosts.deny'
       - 'f:/etc/hosts.deny -> r:^ALL:\s*ALL'
 
-  - id: 2086 
+  - id: 2086
     title: "Verify permissions on /etc/hosts.allow"
     description: "The /etc/hosts.allow file contains network information that is used by many system applications and therefore must be readable for these applications to operate."
     rationale: "It is critical to ensure that the /etc/hosts.allow file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -1457,7 +1457,7 @@ checks:
     rules:
       - 'c:stat /etc/hosts.allow -> r:^Access: \(0644/-rw-r--r--\)\s*\t*Uid:\s*\t*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\t*\(\s*\t*0/\s*\t*root\)$'
 
-  - id: 2087 
+  - id: 2087
     title: "Verify permissions on /etc/hosts.deny"
     description: "The /etc/hosts.deny file contains network information that is used by many system applications and therefore must be readable for these applications to operate."
     rationale: "It is critical to ensure that the /etc/hosts.deny file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -1471,7 +1471,7 @@ checks:
     rules:
       - 'c:stat /etc/hosts.deny -> r:^Access: \(0644/-rw-r--r--\)\s*\t*Uid:\s*\t*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\t*\(\s*\t*0/\s*\t*root\)$'
 
-  - id: 2088 
+  - id: 2088
     title: "Ensure DCCP is disabled"
     description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in- sequence delivery."
     rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
@@ -1490,7 +1490,7 @@ checks:
       - 'not c:modprobe -n -v dccp -> r:install /bin/true'
       - 'c:lsmod -> r:dccp'
 
-  - id: 2089 
+  - id: 2089
     title: "Ensure SCTP is disabled"
     description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1509,7 +1509,7 @@ checks:
       - 'not c:modprobe -n -v sctp -> r:install /bin/true'
       - 'c:lsmod -> r:sctp'
 
-  - id: 2090 
+  - id: 2090
     title: "Ensure RDS is disabled"
     description: "The Reliable Datagram Sockets (RDS) protocol is a transport layer protocol designed to provide low-latency, high-bandwidth communications between cluster nodes. It was developed by the Oracle Corporation."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1528,7 +1528,7 @@ checks:
       - 'not c:modprobe -n -v rds -> r:install /bin/true'
       - 'c:lsmod -> r:rds'
 
-  - id: 2091 
+  - id: 2091
     title: "Ensure TIPC is disabled"
     description: "The Transparent Inter-Process Communication (TIPC) protocol is designed to provide communication between cluster nodes."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1549,7 +1549,7 @@ checks:
 
 # 3.5 Firewall configuration
 
-  - id: 2092 
+  - id: 2092
     title: "Ensure default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -1565,7 +1565,7 @@ checks:
       - 'c:iptables -L -> r:^Chain FORWARD && r:policy DROP'
       - 'c:iptables -L -> r:^Chain OUTPUT && r:policy DROP'
 
-  - id: 2093 
+  - id: 2093
     title: "Ensure loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -1582,7 +1582,7 @@ checks:
       - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
 
 
-  - id: 2094 
+  - id: 2094
     title: "Ensure IPv6 default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -1598,7 +1598,7 @@ checks:
       - 'c:ip6tables -L -> r:^Chain FORWARD && r:policy DROP'
       - 'c:ip6tables -L -> r:^Chain OUTPUT && r:policy DROP'
 
-  - id: 2095 
+  - id: 2095
     title: "Ensure IPv6 loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (::1)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (::1) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -1614,7 +1614,7 @@ checks:
       - 'c:ip6tables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*::1\.*::/0'
       - 'c:ip6tables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*::/0\.*::/0'
 
-  - id: 2096 
+  - id: 2096
     title: "Ensure iptables is installed"
     description: "iptables allows configuration of the IPv4 tables in the linux kernel and the rules stored within them. Most firewall configuration utilities operate as a front end to iptables."
     rationale: "iptables is required for firewall management and configuration."
@@ -1632,7 +1632,7 @@ checks:
 # 4 Logging and Auditing
 #########################################
 
-  - id: 2097 
+  - id: 2097
     title: "Ensure audit log storage size is configured"
     description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
     rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
@@ -1646,7 +1646,7 @@ checks:
       - 'f:/etc/audit/auditd.conf'
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file\s*\t*=\s*\t*\d+'
 
-  - id: 2098 
+  - id: 2098
     title: "Ensure system is disabled when audit logs are full"
     description: "The auditd daemon can be configured to halt the system when the audit logs are full."
     rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
@@ -1662,7 +1662,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*space_left_action\s*\t*=\s*\t*email'
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*admin_space_left_action\s*\t*=\s*\t*halt'
 
-  - id: 2099 
+  - id: 2099
     title: "Ensure audit logs are not automatically deleted"
     description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
     rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
@@ -1676,7 +1676,7 @@ checks:
       - 'f:/etc/audit/auditd.conf'
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file_action\s*\t*=\s*\t*keep_logs'
 
-  - id: 2100 
+  - id: 2100
     title: "Ensure auditd service is enabled"
     description: "Turn on the auditd daemon to record system events."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -1690,7 +1690,7 @@ checks:
     rules:
       - 'c:systemctl is-enabled auditd -> enabled'
 
-  - id: 2101 
+  - id: 2101
     title: "Ensure auditing for processes that start prior to auditd is enabled"
     description: "Configure grub or lilo so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
     rationale: "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected."
@@ -1706,7 +1706,7 @@ checks:
     rules:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:audit=1'
 
-  - id: 2102 
+  - id: 2102
     title: "Ensure events that modify date and time information are collected"
     description: "Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier \"time-change\""
     rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
@@ -1728,7 +1728,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S clock_settime && r:-k time-change'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/localtime && r:-p wa && r:-k time-change'
 
-  - id: 2103 
+  - id: 2103
     title: "Ensure events that modify user/group information are collected"
     description: "Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier \"identity\" in the audit log file."
     rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
@@ -1752,7 +1752,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/shadow && r:-p wa && r:-k identity'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/security/opasswd && r:-p wa && r:-k identity'
 
-  - id: 2104 
+  - id: 2104
     title: "Ensure events that modify the system's network environment are collected"
     description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed pre- login), /etc/hosts (file containing host names and associated IP addresses) and /etc/sysconfig/network (directory containing network interface scripts and configurations) files."
     rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/sysconfig/network is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier \"system-locale.\""
@@ -1776,7 +1776,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/hosts && r:-p wa && r:-k system-locale'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/network && r:-p wa && r:-k system-locale'
 
-  - id: 2105 
+  - id: 2105
     title: "Ensure events that modify the system's Mandatory Access Controls are collected"
     description: "Monitor SELinux/AppArmor mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/selinux or /etc/apparmor and /etc/apparmor.d directories."
     rationale: "Changes to files in these directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
@@ -1797,7 +1797,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/selinux/|/etc/apparmor/ && r:-p wa && r:-k MAC-policy'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/usr/share/selinux/|/etc/apparmor.d/ && r:-p wa && r:-k MAC-policy'
 
-  - id: 2106 
+  - id: 2106
     title: "Ensure login and logout events are collected"
     description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. The file /var/log/faillog tracks failed events from login. The file /var/log/lastlog maintain records of the last time a user successfully logged in. The file /var/log/tallylog maintains records of failures via the pam_tally2 module"
     rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
@@ -1819,7 +1819,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/var/log/lastlog && r:-p wa && r:-k logins'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/var/log/tallylog && r:-p wa && r:-k logins'
 
-  - id: 2107 
+  - id: 2107
     title: "Ensure session initiation information is collected"
     description: "Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp file tracks all currently logged in users. All audit records will be tagged with the identifier \"session.\" The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp . All audit records will be tagged with the identifier \"logins.\""
     rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
@@ -1838,7 +1838,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/var/log/wtmp && r:-p wa && r:-k logins'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/var/log/btmp && r:-p wa && r:-k logins'
 
-  - id: 2108 
+  - id: 2108
     title: "Ensure discretionary access control permission modification events are collected"
     description: "Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The chmod , fchmod and fchmodat system calls affect the permissions associated with a file. The chown , fchown , fchownat and lchown system calls affect owner and group attributes on a file. The setxattr , lsetxattr , fsetxattr (set extended file attributes) and removexattr , lremovexattr , fremovexattr (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier \"perm_mod.\""
     rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
@@ -1860,7 +1860,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S chown && r:-S fchown && r:-S fchownat && r:-S lchown && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S setxattr && r:-S lsetxattr && r:-S fsetxattr && r:-S removexattr && r:-S lremovexattr && r:-S fremovexattr && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
 
-  - id: 2109 
+  - id: 2109
     title: "Ensure unsuccessful unauthorized file access attempts are collected"
     description: "Monitor for unsuccessful attempts to access files. The parameters below are associated with system calls that control creation ( creat ), opening ( open , openat ) and truncation ( truncate , ftruncate ) of files. An audit log record will only be written if the user is a non- privileged user (auid > = 1000), is not a Daemon event (auid=4294967295) and if the system call returned EACCES (permission denied to the file) or EPERM (some other permanent error associated with the specific system call). All audit records will be tagged with the identifier \"access.\""
     rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
@@ -1881,7 +1881,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-F exit=-EACCES && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-F exit=-EPERM && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
 
-  - id: 2110 
+  - id: 2110
     title: "Ensure successful file system mounts are collected"
     description: "Monitor the use of the mount system call. The mount (and umount ) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user."
     rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open , creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
@@ -1901,7 +1901,7 @@ checks:
       - 'f:/etc/audit/audit.rules'
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S mount && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k mounts'
 
-  - id: 2111 
+  - id: 2111
     title: "Ensure file deletion events by users are collected"
     description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for the unlink (remove a file), unlinkat (remove a file attribute), rename (rename a file) and renameat (rename a file attribute) system calls and tags them with the identifier \"delete\"."
     rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
@@ -1919,7 +1919,7 @@ checks:
       - 'f:/etc/audit/audit.rules'
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S unlink && r:-S unlinkat && r:-S rename && r:-S renameat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k delete'
 
-  - id: 2112 
+  - id: 2112
     title: "Ensure changes to system administration scope (sudoers) is collected"
     description: "Monitor scope changes for system administrations. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers will be written to when the file or its attributes have changed. The audit records will be tagged with the identifier \"scope.\""
     rationale: "Changes in the /etc/sudoers file can indicate that an unauthorized change has been made to scope of system administrator activity."
@@ -1940,7 +1940,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/sudoers && r:-p wa && r:-k scope'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/etc/sudoers.d/ && r:-p wa && r:-k scope'
 
-  - id: 2113 
+  - id: 2113
     title: "Ensure system administrator actions (sudolog) are collected"
     description: "Monitor the sudo log file. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to /var/log/sudo.log . Any time a command is executed, an audit event will be triggered as the /var/log/sudo.log file will be opened for write and the executed administration command will be written to the log."
     rationale: "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed."
@@ -1960,7 +1960,7 @@ checks:
       - 'f:/etc/audit/audit.rules'
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/var/log/sudo.log && r:-p wa && r:-k actions'
 
-  - id: 2114 
+  - id: 2114
     title: "Ensure kernel module loading and unloading is collected"
     description: "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\"."
     rationale: "Monitoring the use of insmod, rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
@@ -1983,7 +1983,7 @@ checks:
       - 'f:/etc/audit/audit.rules -> r:^-w && r:/sbin/modprobe && r:-p x && r:-k modules'
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32|-F arch=b64 && r:-S init_module && r:-S delete_module && r:-k modules'
 
-  - id: 2115 
+  - id: 2115
     title: "Ensure the audit configuration is immutable"
     description: "Set system audit so that audit rules cannot be modified with auditctl. Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot."
     rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
@@ -2002,7 +2002,7 @@ checks:
       - 'c:tail -1 /etc/audit/audit.rules -> -e 2'
 
 
-  - id: 2116 
+  - id: 2116
     title: "Ensure rsyslog Service is enabled"
     description: "Once the rsyslog package is installed it needs to be activated."
     rationale: "If the rsyslog service is not activated the system will not have a syslog service running."
@@ -2019,14 +2019,14 @@ checks:
       - 'c:systemctl is-enabled rsyslog -> enabled'
 
 # 4.2.1.3 Ensure rsyslog default file permissions configured (Scored)
-  - id: 2117 
+  - id: 2117
     title: "Ensure rsyslog default file permissions configured"
     description: "rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
     remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to 0640 or more restrictive:   $FileCreateMode 0640"
     compliance:
       - cis: ["4.2.1.3"]
-      - cis_csc: ["5.1"]  
+      - cis_csc: ["5.1"]
       - pci_dss: ["10.5.1","10.5.2"]
       - nist_800_53: ["CM.1","AU.9"]
       - tsc: ["CC5.2", "CC6.1", "CC7.2", "CC.7.3", "CC7.4"]
@@ -2035,7 +2035,7 @@ checks:
       - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
       - 'd:/etc/rsyslog.d/ -> r:\. -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
 
-  - id: 2118 
+  - id: 2118
     title: "Ensure rsyslog is configured to send logs to a remote log host"
     description: "The rsyslog utility supports the ability to send logs it gathers to a remote log host running syslogd(8) or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2052,7 +2052,7 @@ checks:
     rules:
       - 'c:grep -Rh ^*.*[^I][^I]*@ /etc/rsyslog.conf /etc/rsyslog.d/ -> r:^*.* @@\.+'
 
-  - id: 2119 
+  - id: 2119
     title: "Ensure remote rsyslog messages are only accepted on designated log hosts"
     description: "By default, rsyslog does not listen for log messages coming in from remote systems. The ModLoad tells rsyslog to load the imtcp.so module so it can listen over a network via TCP. The InputTCPServerRun option instructs rsyslogd to listen on the specified TCP port."
     rationale: "The guidance in the section ensures that remote log hosts are configured to only accept rsyslog data from hosts within the specified domain and that those systems that are not designed to be log hosts do not accept any remote rsyslog messages. This provides protection from spoofed log data and ensures that system administrators are reviewing reasonably complete syslog data in a central location."
@@ -2069,7 +2069,7 @@ checks:
       - 'c:grep -Rh ^\$InputTCPServerRun /etc/rsyslog.conf /etc/rsyslog.d/ -> r:^\$InputTCPServerRun\s*\t*514'
 
 # 4.2.2.1 Ensure syslog-ng service is enabled (Scored)
-  - id: 2120 
+  - id: 2120
     title: "Ensure syslog-ng service is enabled"
     description: "Once the syslog-ng package is installed it needs to be activated."
     rationale: "If the syslog-ng service is not activated the system may default to the syslogd service or lack logging instead."
@@ -2086,14 +2086,14 @@ checks:
       - 'c:systemctl is-enabled syslog-ng -> enabled'
 
 # 4.2.2.3 Ensure syslog-ng default file permissions configured (Scored)
-  - id: 2121 
+  - id: 2121
     title: "Ensure syslog-ng default file permissions configured"
     description: "syslog-ng will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive syslog-ng data is archived and protected."
     remediation: "Edit the /etc/syslog-ng/syslog-ng.conf and set perm option to 0640 or more restrictive:     options { chain_hostnames(off); flush_lines(0); perm(0640); stats_freq(3600); threaded(yes); };"
     compliance:
       - cis: ["4.2.2.3"]
-      - cis_csc: ["5.1"]  
+      - cis_csc: ["5.1"]
       - pci_dss: ["10.5.1","10.5.2"]
       - nist_800_53: ["CM.1","AU.9"]
       - tsc: ["CC5.2", "CC6.1", "CC7.2", "CC.7.3", "CC7.4"]
@@ -2102,7 +2102,7 @@ checks:
       - 'f:/etc/syslog-ng/syslog-ng.conf -> r:^options && r:perm\(06\d0\)|perm\(04\d0\)|perm\(02\d0\)|perm\(00\d0\) && r:perm\(0\d40\)|perm\(0\d00\)'
 
 # 4.2.2.4 Ensure syslog-ng is configured to send logs to a remote log host (Not Scored)
-  - id: 2122 
+  - id: 2122
     title: "Ensure syslog-ng is configured to send logs to a remote log host"
     description: "The syslog-ng utility supports the ability to send logs it gathers to a remote log host or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2119,7 +2119,7 @@ checks:
       - 'f:/etc/syslog-ng/syslog-ng.conf -> r:log\.+source\.+destination'
 
 # 4.2.3 Ensure rsyslog or syslog-ng is installed (Scored)
-  - id: 2123 
+  - id: 2123
     title: "Ensure rsyslog or syslog-ng is installed"
     description: "The rsyslog and syslog-ng software are recommended replacements to the original syslogd daemon which provide improvements over syslogd , such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server."
     rationale: "The security enhancements of rsyslog and syslog-ng such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
@@ -2140,7 +2140,7 @@ checks:
 # 5 Access, Authentication and Authorization
 #########################################
 
-  - id: 2124 
+  - id: 2124
     title: "Ensure cron daemon is enabled"
     description: "The cron daemon is used to execute batch jobs on the system."
     rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
@@ -2157,7 +2157,7 @@ checks:
 
 
 # 5.1.2 Ensure permissions on /etc/crontab are configured (Scored)
-  - id: 2125 
+  - id: 2125
     title: "Ensure permissions on /etc/crontab are configured"
     description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
     rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
@@ -2177,7 +2177,7 @@ checks:
 
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
-  - id: 2126 
+  - id: 2126
     title: "Ensure permissions on /etc/cron.hourly are configured"
     description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2194,7 +2194,7 @@ checks:
       - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
-  - id: 2127 
+  - id: 2127
     title: "Ensure permissions on /etc/cron.daily are configured"
     description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2210,7 +2210,7 @@ checks:
       - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
-  - id: 2128 
+  - id: 2128
     title: "Ensure permissions on /etc/cron.weekly are configured"
     description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2227,7 +2227,7 @@ checks:
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
-  - id: 2129 
+  - id: 2129
     title: "Ensure permissions on /etc/cron.monthly are configured"
     description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2243,7 +2243,7 @@ checks:
       - 'c:stat /etc/cron.monthly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
-  - id: 2130 
+  - id: 2130
     title: "Ensure permissions on /etc/cron.d are configured"
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow , cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2258,7 +2258,7 @@ checks:
     rules:
       - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
-  - id: 2131 
+  - id: 2131
     title: "Ensure at/cron is restricted to authorized users"
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow, cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cronjobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2280,7 +2280,7 @@ checks:
 
 # 5.2 SSH Server Configuration
 
-  - id: 2132 
+  - id: 2132
     title: "Ensure permissions on /etc/ssh/sshd_config are configured"
     description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
     rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non- privileged users."
@@ -2295,7 +2295,7 @@ checks:
     rules:
       - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
-  - id: 2133 
+  - id: 2133
     title: "Ensure SSH Protocol is set to 2"
     description: "Older versions of SSH support two different and incompatible protocols: SSH1 and SSH2. SSH1 was the original protocol and was subject to security issues. SSH2 is more advanced and secure."
     rationale: "SSH v1 suffers from insecurities that do not affect SSH v2. Notes: This command not longer exists in newer versions of SSH. This check is still being included for systems that may be running an older version of SSH. As of openSSH version 7.4 this parameter will not cause an issue when included."
@@ -2311,7 +2311,7 @@ checks:
     rules:
       - 'f:/etc/ssh/sshd_config -> !r:^# && r:Protocol\s*\t*2'
 
-  - id: 2134 
+  - id: 2134
     title: "Ensure SSH LogLevel is appropriate"
     description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
     rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
@@ -2329,7 +2329,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:LogLevel\s+INFO|LogLevel\s+VERBOSE'
 
-  - id: 2135 
+  - id: 2135
     title: "Ensure SSH X11 forwarding is disabled"
     description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
     rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
@@ -2347,7 +2347,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:X11Forwarding\s+no'
 
-  - id: 2136 
+  - id: 2136
     title: "Ensure SSH MaxAuthTries is set to 4 or less"
     description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
     rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
@@ -2362,7 +2362,7 @@ checks:
     rules:
       - 'c:sshd -T -> n:MaxAuthTries\s*\t*(\d+) compare <= 4'
 
-  - id: 2137 
+  - id: 2137
     title: "Ensure SSH IgnoreRhosts is enabled"
     description: "The IgnoreRhosts parameter specifies that .rhostsand .shostsfiles will not be used in RhostsRSAAuthenticationor HostbasedAuthentication."
     rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
@@ -2378,7 +2378,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:IgnoreRhosts\s+yes'
 
-  - id: 2138 
+  - id: 2138
     title: "Ensure SSH HostbasedAuthentication is disabled"
     description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
     rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
@@ -2394,7 +2394,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:HostbasedAuthentication\s+no'
 
-  - id: 2139 
+  - id: 2139
     title: "Ensure SSH root login is disabled"
     description: "The PermitRootLogin parameter specifies if the root user can log in using ssh(1). The default is no."
     rationale: "Disallowing root logins over SSH requires server admins to authenticate using their own individual account, then escalating to root via sudo or su. This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
@@ -2410,7 +2410,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:PermitRootLogin\s+no'
 
-  - id: 2140 
+  - id: 2140
     title: "Ensure SSH PermitEmptyPasswords is disabled"
     description: "The PermitEmptyPasswords parameter specifies if the server allows login to accounts with empty password strings."
     rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system"
@@ -2426,7 +2426,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:PermitEmptyPasswords\s+no'
 
-  - id: 2141 
+  - id: 2141
     title: "Ensure SSH PermitUserEnvironment is disabled"
     description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
     rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing trojan'd programs)"
@@ -2442,10 +2442,10 @@ checks:
     rules:
       - 'c:sshd -T -> r:PermitUserEnvironment\s+no'
 
-  - id: 2142 
+  - id: 2142
     title: "Ensure only strong ciphers are used"
     description: "This variable limits the ciphers that SSH can use during communication."
-    rationale: "Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain cleartext data via a birthday attack against a long-duration encrypted session, aka a \"Sweet32\" attack The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly combine state data with key data during the initialization phase, which makes it easier for remote attackers to conduct plaintext-recovery attacks against the initial bytes of a stream by sniffing network traffic that occasionally relies on keys affected by the Invariance Weakness, and then using a brute-force approach involving LSB values, aka the \"Bar Mitzvah\" issue The passwords used during an SSH session encrypted with RC4 can be recovered by an attacker who is able to capture and replay the session Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plaintext data from an arbitrary block of ciphertext in an SSH session via unknown vectors The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher is used, does not properly initialize memory for a MAC context data structure, which allows remote authenticated users to bypass intended ForceCommand and login-shell restrictions via packet data that provides a crafted callback address" 
+    rationale: "Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain cleartext data via a birthday attack against a long-duration encrypted session, aka a \"Sweet32\" attack The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly combine state data with key data during the initialization phase, which makes it easier for remote attackers to conduct plaintext-recovery attacks against the initial bytes of a stream by sniffing network traffic that occasionally relies on keys affected by the Invariance Weakness, and then using a brute-force approach involving LSB values, aka the \"Bar Mitzvah\" issue The passwords used during an SSH session encrypted with RC4 can be recovered by an attacker who is able to capture and replay the session Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plaintext data from an arbitrary block of ciphertext in an SSH session via unknown vectors The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher is used, does not properly initialize memory for a MAC context data structure, which allows remote authenticated users to bypass intended ForceCommand and login-shell restrictions via packet data that provides a crafted callback address"
     remediation: "Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma separated list of the site approved ciphers Example: Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
     compliance:
       - cis: ["5.2.13"]
@@ -2465,10 +2465,10 @@ checks:
     rules:
       - 'c:sshd -T -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc|arcfour|arcfour128|arcfour256|blowfish-cbc|cast128-cbc|rijndael-cbc@lysator.liu.se'
 
-  - id: 2143 
+  - id: 2143
     title: "Ensure only strong MAC algorithms are used"
     description: "This variable limits the types of MAC algorithms that SSH can use during communication."
-    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information" 
+    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information"
     remediation: "Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma separated list of the site approved MACs Example: MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2- 512,hmac-sha2-256"
     compliance:
       - cis: ["5.2.14"]
@@ -2483,10 +2483,10 @@ checks:
     rules:
       - 'c:sshd -T -> r:MACs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|umac-128@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com'
 
-  - id: 2144 
+  - id: 2144
     title: "Ensure only strong Key Exchange algorithms are used"
     description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received"
-    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks" 
+    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks"
     remediation: "Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to contain a comma separated list of the site approved key exchange algorithms Example: KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman- group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18- sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie- hellman-group-exchange-sha256"
     compliance:
       - cis: ["5.2.15"]
@@ -2500,7 +2500,7 @@ checks:
       - 'c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1'
 
 
-  - id: 2145 
+  - id: 2145
     title: "Ensure SSH Idle Timeout Interval is configured"
     description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the ClientAliveCountMax variable is set, sshd will send client alive messages at every ClientAliveInterval interval. When the number of consecutive client alive messages are sent with no response from the client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
     rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent."
@@ -2514,7 +2514,7 @@ checks:
       - 'c:sshd -T -> n:ClientAliveInterval\s*\t*(\d+) compare <= 300 && n:ClientAliveInterval\s*\t*(\d+) compare != 0'
       - 'c:sshd -T -> n:ClientAliveCountMax\s*\t*(\d+) compare <= 3'
 
-  - id: 2146 
+  - id: 2146
     title: "Ensure SSH LoginGraceTime is set to one minute or less"
     description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
     rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
@@ -2527,7 +2527,7 @@ checks:
     rules:
       - 'c:sshd -T -> n:LoginGraceTime\s*\t*(\d+) compare <= 60 && n:LoginGraceTime\s*\t*(\d+) compare != 0'
 
-  - id: 2147 
+  - id: 2147
     title: "Ensure SSH access is limited"
     description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: AllowUsers, AllowGroups, DenyUsers, DenyGroups."
     rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
@@ -2540,7 +2540,7 @@ checks:
     rules:
       - 'c:sshd -T -> r:AllowUsers\s+\w+|AllowGroups\s+\w+|DenyUsers\s+\w+|DenyGroups\s+\w+'
 
-  - id: 2148 
+  - id: 2148
     title: "Ensure SSH warning banner is configured"
     description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
     rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
@@ -2557,7 +2557,7 @@ checks:
 
 # 5.3 Configure PAM
 
-  - id: 2149 
+  - id: 2149
     title: "Ensure password creation requirements are configured"
     description: "The pam_pwquality.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more. The following are definitions of the pam_pwquality.so options: - retry=3 (Allow 3 tries before sending back a failure). The following options are set in the /etc/security/pwquality.conf file: - minlen = 14 dcredit = -1 ucredit = -1 ocredit = -1 lcredit = -1 (The settings shown above are one possible policy. Alter these values to conform to your own organization's password policies.)"
     rationale: "Strong passwords protect systems from being hacked through brute force methods."
@@ -2572,7 +2572,7 @@ checks:
       - 'f:/etc/pam.d/common-password -> !r:^# && r:password\s*\t*requisite\s*\t*pam_pwquality.so\s*\t*retry=\d'
       - 'f:/etc/security/pwquality.conf -> !r:^# && n:minlen\s*\t*=\s*\t*(\d+) compare >= 14'
 
-  - id: 2150 
+  - id: 2150
     title: "Ensure lockout for failed password attempts is configured"
     description: "Lock out users after n unsuccessful consecutive login attempts. The first sets of changes are made to the PAM configuration files. The second set of changes are applied to the program specific PAM configuration file. The second set of changes must be applied to each program that will lock out users. Check the documentation for each secondary program for instructions on how to configure them to work with PAM. Set the lockout number to the policy in effect at your site."
     rationale: "Locking out user IDs after n unsuccessful consecutive login attempts mitigates brute force password attacks against your systems."
@@ -2586,7 +2586,7 @@ checks:
       - 'f:/etc/pam.d/common-auth -> !r:^# && r:auth\s*\t*required\s*\t*pam_tally2.so && r:onerr=fail && r:audit && r:silent && r:deny\s*=\s*\d+ && r:unlock_time\s*=\s*\d+'
       - 'f:/etc/pam.d/common-account -> !r:^# && r:pam_tally2.so'
 
-  - id: 2151 
+  - id: 2151
     title: "Ensure password reuse is limited"
     description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
     rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password. Note that these change only apply to accounts configured on the local system."
@@ -2601,7 +2601,7 @@ checks:
       - 'f:/etc/pam.d/common-password -> !r:^# && r:password\s*\t*required\s*\t*pam_pwhistory.so && !r:remember'
 
 # 5.3.4 Ensure password hashing algorithm is SHA-512 (Scored)
-  - id: 2152 
+  - id: 2152
     title: "Ensure password hashing algorithm is SHA-512"
     description: "The commands below change password encryption from md5 to sha512 (a much stronger hashing algorithm). All existing accounts will need to perform a password change to upgrade the stored hashes to the new algorithm."
     rationale: "The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note that these change only apply to accounts configured on the local system."
@@ -2616,7 +2616,7 @@ checks:
 
 # 5.4 User Accounts and Environment
 
-  - id: 2153 
+  - id: 2153
     title: "Ensure password expiration is 365 days or less"
     description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 365 days."
     rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity."
@@ -2630,7 +2630,7 @@ checks:
       - 'f:/etc/login.defs -> n:^\s*\t*PASS_MAX_DAYS\s*\t*(\d+) compare <= 365'
       - 'not f:/etc/login.defs -> n:^\s*\t*PASS_MAX_DAYS\s*\t*(\d+) compare < 0'
 
-  - id: 2154 
+  - id: 2154
     title: "Ensure minimum days between password changes is 7 or more"
     description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 7 or more days."
     rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
@@ -2643,7 +2643,7 @@ checks:
     rules:
       - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 7'
 
-  - id: 2155 
+  - id: 2155
     title: "Ensure password expiration warning days is 7 or more"
     description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
     rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
@@ -2656,7 +2656,7 @@ checks:
     rules:
       - 'f:/etc/login.defs -> n:^\s*\t*PASS_WARN_AGE\s*\t*(\d+) compare >= 7'
 
-  - id: 2156 
+  - id: 2156
     title: "Ensure inactive password lock is 30 days or less"
     description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
     rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
@@ -2670,7 +2670,7 @@ checks:
       - 'c:useradd -D -> n:^INACTIVE=(\d+) compare <= 30'
       - 'not c:useradd -D -> n:^INACTIVE=(\d+) compare < 0'
 
-  - id: 2157 
+  - id: 2157
     title: "Ensure default group for the root account is GID 0"
     description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
     rationale: "Using GID 0 for the root account helps prevent root-owned files from accidentally becoming accessible to non-privileged users."
@@ -2684,7 +2684,7 @@ checks:
       - 'f:/etc/passwd -> !r:^# && r:root:\w+:\w+:0:'
 
 
-  - id: 2158 
+  - id: 2158
     title: "Ensure default user umask is 027 or more restrictive"
     description: "The default umask determines the permissions of files created by users. The user creating the file has the discretion of making their files and directories readable by others via the chmod command. Users who wish to allow their files and directories to be readable by others by default may choose a different default umask by inserting the umask command into the standard shell configuration files ( .profile , .bashrc , etc.) in their home directories."
     rationale: "Setting a very secure default value for umask ensures that users make a conscious choice about their file permissions. A default umask setting of 077 causes files and directories created by users to not be readable by any other user on the system. A umask of 027 would make files and directories readable by users in the same Unix group, while a umask of 022 would make files readable by every user on the system."
@@ -2704,7 +2704,7 @@ checks:
 
 
 # 5.4.5 Ensure default user shell timeout is 900 seconds or less (Scored)
-  - id: 2159 
+  - id: 2159
     title: "Ensure default user shell timeout is 900 seconds or less"
     description: "The default TMOUT determines the shell timeout for users. The TMOUT value is measured in seconds."
     rationale: "Having no timeout value associated with a shell could allow an unauthorized user access to another user's shell session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening."
@@ -2723,7 +2723,7 @@ checks:
       - 'f:/etc/profile -> n:^\s*\t*TMOUT\s*\t*=\s*\t*(\d+) compare <= 900'
 
 
-  - id: 2160 
+  - id: 2160
     title: "Ensure access to the su command is restricted"
     description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in the sudo group to execute su."
     rationale: "Restricting the use of su, and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo, whereas su can only record that a user executed the su program."
@@ -2747,7 +2747,7 @@ checks:
 # 6 System Maintenance
 ###############################
 
-  - id: 2161 
+  - id: 2161
     title: "Ensure permissions on /etc/gshadow are configured"
     description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/gshadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/gshadow file (such as group administrators) could also be useful to subvert the group"
@@ -2762,7 +2762,7 @@ checks:
     rules:
       - 'c:stat /etc/gshadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
-  - id: 2162 
+  - id: 2162
     title: "Ensure permissions on /etc/shadow- are configured"
     description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -2777,7 +2777,7 @@ checks:
     rules:
       - 'c:stat /etc/shadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
-  - id: 2163 
+  - id: 2163
     title: "Ensure permissions on /etc/gshadow- are configured"
     description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -2791,8 +2791,8 @@ checks:
     condition: all
     rules:
       - 'c:stat /etc/gshadow- -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
-     
-  - id: 2164 
+
+  - id: 2164
     title: "Ensure permissions on /etc/passwd are configured"
     description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
     rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -2807,7 +2807,7 @@ checks:
     rules:
       - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 2165 
+  - id: 2165
     title: "Ensure permissions on /etc/shadow are configured"
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
@@ -2822,7 +2822,7 @@ checks:
     rules:
       - 'c:stat /etc/shadow -> r:Access:\s*\(0\d\d0/-\w\w-\w-----\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)'
 
-  - id: 2166 
+  - id: 2166
     title: "Ensure permissions on /etc/group are configured"
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
@@ -2837,7 +2837,7 @@ checks:
     rules:
       - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
-  - id: 2167 
+  - id: 2167
     title: "Ensure permissions on /etc/passwd- are configured"
     description: "The /etc/passwd- file contains backup user account information."
     rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -2853,7 +2853,7 @@ checks:
       - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 
-  - id: 2168 
+  - id: 2168
     title: "Ensure permissions on /etc/group- are configured"
     description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
     rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -2871,7 +2871,7 @@ checks:
 
 # 6.2 User and Group Settings
 
-  - id: 2169 
+  - id: 2169
     title: "Ensure password fields are not empty"
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
@@ -2884,7 +2884,7 @@ checks:
     rules:
       - 'f:/etc/shadow -> r:^\w+::'
 
-  - id: 2170 
+  - id: 2170
     title: "Ensure no legacy \"+\" entries exist in /etc/passwd"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -2902,7 +2902,7 @@ checks:
     rules:
       - 'f:/etc/passwd -> !r:^# && r:^+:'
 
-  - id: 2171 
+  - id: 2171
     title: "Ensure no legacy \"+\" entries exist in /etc/shadow"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -2920,7 +2920,7 @@ checks:
     rules:
       - 'f:/etc/shadow -> !r:^# && r:^+:'
 
-  - id: 2172 
+  - id: 2172
     title: "Ensure no legacy \"+\" entries exist in /etc/group"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -2938,7 +2938,7 @@ checks:
     rules:
       - 'f:/etc/group -> !r:^# && r:^+:'
 
-  - id: 2173 
+  - id: 2173
     title: "Ensure root is the only UID 0 account"
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
@@ -2956,7 +2956,7 @@ checks:
     rules:
       - 'f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:'
 
-  - id: 2174 
+  - id: 2174
     title: "Ensure shadow group is empty"
     description: "The shadow group allows system programs which require access the ability to read the /etc/shadow file. No users should be assigned to the shadow group."
     rationale: "Any users assigned to the shadow group would be granted read access to the /etc/shadow file. If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed passwords to break them. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts."

--- a/ruleset/sca/debian/cis_debian9.yml
+++ b/ruleset/sca/debian/cis_debian9.yml
@@ -474,6 +474,21 @@ checks:
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> !r:^# && r:=\s*\t*0$'
       - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:\s*\t*0$'
 
+  - id: 2028 
+    title: "Ensure XD/NX support is enabled"
+    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
+    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
+    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
+    compliance:
+      - cis: ["1.5.2"]
+      - cis_csc: ["8.3"]
+      - pci_dss: ["2.2.4"]
+      - nist_800_53: ["CM.1"]
+      - tsc: ["CC5.2"]
+    condition: all
+    rules:
+      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+
   - id: 2029 
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."

--- a/ruleset/sca/rhel/6/cis_rhel6_linux.yml
+++ b/ruleset/sca/rhel/6/cis_rhel6_linux.yml
@@ -628,7 +628,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+      - 'c:sh -c "dmesg | grep NX" -> r:NX \(Execute Disable\) protection: active'
 
 # 1.5.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 4035

--- a/ruleset/sca/rhel/6/cis_rhel6_linux.yml
+++ b/ruleset/sca/rhel/6/cis_rhel6_linux.yml
@@ -34,7 +34,7 @@ variables:
 
 checks:
 # 1.1.1.1 cramfs: filesystem
-  - id: 4000 
+  - id: 4000
     title: "Ensure mounting of cramfs filesystems is disabled"
     description: "The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
@@ -52,7 +52,7 @@ checks:
       - 'not c:lsmod -> r:cramfs'
 
 # 1.1.1.2 freevxfs: filesystem
-  - id: 4001 
+  - id: 4001
     title: "Ensure mounting of freevxfs filesystems is disabled"
     description: "The freevxfs filesystem type is a free version of the Veritas type filesystem. This is the primary filesystem type for HP-UX operating systems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -70,7 +70,7 @@ checks:
       - 'not c:lsmod -> r:freevxfs'
 
 # 1.1.1.3 jffs2: filesystem
-  - id: 4002 
+  - id: 4002
     title: "Ensure mounting of jffs2 filesystems is disabled"
     description: "The jffs2 (journaling flash filesystem 2) filesystem type is a log-structured filesystem used in flash memory devices."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -88,7 +88,7 @@ checks:
       - 'not c:lsmod -> r:jffs2'
 
 # 1.1.1.4 hfs: filesystem
-  - id: 4003 
+  - id: 4003
     title: "Ensure mounting of hfs filesystems is disabled"
     description: "The hfs filesystem type is a hierarchical filesystem that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -105,7 +105,7 @@ checks:
       - 'c:modprobe -n -v hfs -> r:install /bin/true|Module hfs not found'
       - 'not c:lsmod -> r:hfs'
 # 1.1.1.5 hfsplus: filesystem
-  - id: 4004 
+  - id: 4004
     title: "Ensure mounting of hfsplus filesystems is disabled"
     description: "The hfsplus filesystem type is a hierarchical filesystem designed to replace hfs that allows you to mount Mac OS filesystems."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -122,7 +122,7 @@ checks:
       - 'c:modprobe -n -v hfsplus -> r:install /bin/true|Module hfsplus not found'
       - 'not c:lsmod -> r:hfsplus'
 # 1.1.1.6 squashfs: filesystem
-  - id: 4005 
+  - id: 4005
     title: "Ensure mounting of squashfs filesystems is disabled"
     description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs ). A squashfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -139,7 +139,7 @@ checks:
       - 'c:modprobe -n -v squashfs -> r:install /bin/true|Module squashfs not found'
       - 'not c:lsmod -> r:squashfs'
 # 1.1.1.7 udfs: filesystem
-  - id: 4006 
+  - id: 4006
     title: "Ensure mounting of udf filesystems is disabled"
     description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -157,7 +157,7 @@ checks:
       - 'not c:lsmod -> r:udf'
 
 # 1.1.1.8 FAT: filesystem
-  - id: 4007 
+  - id: 4007
     title: "Ensure mounting of FAT filesystems is disabled"
     description: "The FAT filesystem format is primarily used on older windows systems and portable USB drives or flash modules. It comes in three types FAT12 , FAT16 , and FAT32 all of which are supported by the vfat kernel module."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -175,7 +175,7 @@ checks:
       - 'not c:lsmod -> r:vfat'
 
 # 1.1.2 /tmp: partition
-  - id: 4008 
+  - id: 4008
     title: "Ensure separate partition exists for /tmp"
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -193,7 +193,7 @@ checks:
 
 
 # 1.1.3 /tmp: nodev
-  - id: 4009 
+  - id: 4009
     title: "Ensure nodev option set on /tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
@@ -208,7 +208,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:nodev'
 
 # 1.1.4 /tmp: nosuid
-  - id: 4010 
+  - id: 4010
     title: "Ensure nosuid option set on /tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
@@ -223,7 +223,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:nosuid'
 
 # 1.1.5 /tmp: noexec
-  - id: 4011 
+  - id: 4011
     title: "Ensure noexec option set on /tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
@@ -241,7 +241,7 @@ checks:
 
 
 # 1.1.6 Build considerations - Partition scheme.
-  - id: 4012 
+  - id: 4012
     title: "Ensure separate partition exists for /var"
     description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
     rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
@@ -258,7 +258,7 @@ checks:
       - 'c:mount -> r:\s/var\s'
 
 # 1.1.7 bind mount /var/tmp to /tmp
-  - id: 4013 
+  - id: 4013
     title: "Ensure separate partition exists for /var/tmp"
     description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /var/tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own file system allows an administrator to set the noexec option on the mount, making /var/tmp useless for an attacker to install executable code."
@@ -273,7 +273,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s'
 
 # 1.1.8 nodev set on /var/tmp
-  - id: 4014 
+  - id: 4014
     title: "Ensure nodev option set on /var/tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /var/tmp ."
@@ -288,7 +288,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s && r:nodev'
 
 # 1.1.9 nosuid set on /var/tmp
-  - id: 4015 
+  - id: 4015
     title: "Ensure nosuid option set on /var/tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
@@ -303,7 +303,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s && r:nosuid'
 
 # 1.1.10 noexec set on /var/tmp
-  - id: 4016 
+  - id: 4016
     title: "Ensure noexec option set on /var/tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
@@ -320,7 +320,7 @@ checks:
 
 
 # 1.1.11 /var/log: partition
-  - id: 4017 
+  - id: 4017
     title: "Ensure separate partition exists for /var/log"
     description: "The /var/log directory is used by system services to store log data ."
     rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
@@ -338,7 +338,7 @@ checks:
       - 'c:mount -> r:\s/var/log\s'
 
 # 1.1.12 /var/log/audit: partition
-  - id: 4018 
+  - id: 4018
     title: "Ensure separate partition exists for /var/log/audit"
     description: "The auditing daemon, auditd , stores log data in the /var/log/audit directory."
     rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data."
@@ -356,7 +356,7 @@ checks:
       - 'c:mount -> r:\s/var/log/audit\s'
 
 # 1.1.13 /home: partition
-  - id: 4019 
+  - id: 4019
     title: "Ensure separate partition exists for /home"
     description: "The /home directory is used to support disk storage needs of local users."
     rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
@@ -373,7 +373,7 @@ checks:
       - 'c:mount -> r:\s/home\s'
 
 # 1.1.14 /home: nodev
-  - id: 4020 
+  - id: 4020
     title: "Ensure nodev option set on /home partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
@@ -388,7 +388,7 @@ checks:
       - 'c:mount -> r:\s/home\s && r:nodev'
 
 # 1.1.15 /dev/shm: nodev
-  - id: 4021 
+  - id: 4021
     title: "Ensure nodev option set on /dev/shm partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
@@ -403,7 +403,7 @@ checks:
       - 'c:mount -> r:\s/dev/shm\s && r:nodev'
 
 # 1.1.16 /dev/shm: nosuid
-  - id: 4022 
+  - id: 4022
     title: "Ensure nosuid option set on /dev/shm partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
@@ -418,7 +418,7 @@ checks:
       - 'c:mount -> r:\s/dev/shm\s && r:nosuid'
 
 # 1.1.17 /dev/shm: noexec
-  - id: 4023 
+  - id: 4023
     title: "Ensure noexec option set on /dev/shm partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
@@ -434,7 +434,7 @@ checks:
       - 'c:mount -> r:\s/dev/shm\s && r:noexec'
 
 # 1.1.22 Disable Automounting
-  - id: 4024 
+  - id: 4024
     title: "Disable Automounting"
     description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
     rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
@@ -455,7 +455,7 @@ checks:
 ###############################################
 
 # 1.2.2 Activate gpgcheck
-  - id: 4025 
+  - id: 4025
     title: "Ensure gpgcheck is globally activated"
     description: "The gpgcheck option, found in the main section of the /etc/yum.conf and individual /etc/yum/repos.d/* files determines if an RPM package's signature is checked prior to its installation."
     rationale: "It is important to ensure that an RPM's package signature is always checked prior to installation to ensure that the software is obtained from a trusted source."
@@ -475,7 +475,7 @@ checks:
       - 'not c:grep -Rh ^gpgcheck /etc/yum.repos.d/ -> r:gpgcheck=0'
 
       # 1.2.5 Disable the rhnsd Daemon (Not Scored)
-  - id: 4026 
+  - id: 4026
     title: "Disable the rhnsd Daemon"
     description: "The rhnsd daemon polls the Red Hat Network web site for scheduled actions and, if there are, executes those actions."
     rationale: "Patch management policies may require that organizations test the impact of a patch before it is deployed in a production environment. Having patches automatically deployed could have a negative impact on the environment. It is best to not allow an action by default but only after appropriate consideration has been made. It is recommended that the service be disabled unless the risk is understood and accepted or you are running your own satellite . This item is not scored because organizations may have addressed the risk."
@@ -496,7 +496,7 @@ checks:
 ###############################################
 
 # 1.3.1 install AIDE
-  - id: 4027 
+  - id: 4027
     title: "Ensure AIDE is installed"
     description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
     rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
@@ -512,7 +512,7 @@ checks:
       - 'c:rpm -q aide -> r:aide-\S*'
 
 # 1.3.2 AIDE regular checks
-  - id: 4028 
+  - id: 4028
     title: "Ensure filesystem integrity is regularly checked"
     description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
     rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
@@ -532,7 +532,7 @@ checks:
 # 1.4 Secure Boot Settings
 ###############################################
 # 1.4.1 Configure bootloader
-  - id: 4029 
+  - id: 4029
     title: "Ensure permissions on bootloader config are configured"
     description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options. The grub configuration is usually located at /boot/grub/grub.conf and linked as /boot/grub/menu.lst and /etc/grub.conf ."
     rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
@@ -548,7 +548,7 @@ checks:
       - 'c:stat /boot/grub/grub.conf -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.4.2 Set Boot Loader Password (Scored)
-  - id: 4030 
+  - id: 4030
     title: "Ensure bootloader password is set"
     description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
     rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
@@ -564,7 +564,7 @@ checks:
       - 'f:/boot/grub/grub.conf -> r:^password --md5\s\.+'
 
 # 1.4.3 Single user authentication
-  - id: 4031 
+  - id: 4031
     title: "Ensure authentication required for single user mode"
     description: "Single user mode is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
     rationale: "Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
@@ -580,7 +580,7 @@ checks:
       - 'f:/etc/sysconfig/init -> r:SINGLE\s*=\s*/sbin/sulogin'
 
 # 1.4.4 Ensure interactive boot is not enabled (Scored)
-  - id: 4032 
+  - id: 4032
     title: "Ensure interactive boot is not enabled"
     description: "Interactive boot allows console users to interactively select which services start on boot. The PROMPT option provides console users the ability to interactively boot the system and select which services to start on boot . "
     rationale: "Turn off the PROMPT option on the console to prevent console users from potentially overriding established security settings. "
@@ -597,7 +597,7 @@ checks:
 # 1.5 Additional Process Hardening
 ###############################################
 # 1.5.1 Restrict Core Dumps (Scored)
-  - id: 4033 
+  - id: 4033
     title: "Ensure core dumps are restricted"
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file."
     rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
@@ -615,7 +615,7 @@ checks:
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
 # 1.5.2 XD/NX enabled
-  - id: 4034 
+  - id: 4034
     title: "Ensure XD/NX support is enabled"
     description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
     rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
@@ -631,7 +631,7 @@ checks:
       - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
 
 # 1.5.3 Enable Randomized Virtual Memory Region Placement (Scored)
-  - id: 4035 
+  - id: 4035
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
     rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
@@ -648,7 +648,7 @@ checks:
       - 'c:sysctl kernel.randomize_va_space -> r:^\s*kernel.randomize_va_space\s*=\s*2'
 
 # 1.5.4 Disable prelink
-  - id: 4036 
+  - id: 4036
     title: "Ensure prelink is disabled"
     description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
     rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
@@ -668,7 +668,7 @@ checks:
 ###############################################
 
 # 1.6.1.1 SELinux not disabled
-  - id: 4037 
+  - id: 4037
     title: "Ensure SELinux is not disabled in bootloader configuration"
     description: "Configure SELINUX to be enabled at boot time and verify that it has not been overwritten by the grub boot parameters."
     rationale: "SELinux must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
@@ -684,7 +684,7 @@ checks:
       - 'f:/boot/grub/grub.conf -> r:^\s*\t*kernel\.*selinux=0|^\s*\t*kernel\.*enforcing=0'
 
 # 1.6.1.2 Set selinux state
-  - id: 4038 
+  - id: 4038
     title: "Ensure the SELinux state is enforcing"
     description: "Set SELinux to enable when the system is booted."
     rationale: "SELinux must be enabled at boot time in to ensure that the controls it provides are in effect at all times."
@@ -703,7 +703,7 @@ checks:
       - 'f:/etc/selinux/config -> r:^SELINUX\s*=\s*enforcing'
 
 # 1.6.1.3 Set selinux policy
-  - id: 4039 
+  - id: 4039
     title: "Ensure SELinux policy is configured"
     description: "Configure SELinux to meet or exceed the default targeted policy, which constrains daemons and system software only."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that at least the default recommendations are met."
@@ -719,7 +719,7 @@ checks:
       - 'f:/etc/selinux/config -> r:^\s*SELINUXTYPE\s*=\s*targeted|^\s*SELINUXTYPE\s*=\s*mls'
 
 # 1.6.1.4 Remove SETroubleshoot
-  - id: 4040 
+  - id: 4040
     title: "Ensure SETroubleshoot is not installed"
     description: "The SETroubleshoot service notifies desktop users of SELinux denials through a user-friendly interface. The service provides important information around configuration errors, unauthorized intrusions, and other potential errors."
     rationale: "The SETroubleshoot service is an unnecessary daemon to have running on a server, especially if X Windows is disabled."
@@ -734,7 +734,7 @@ checks:
       - 'c:rpm -qa setroubleshoot -> r:setroubleshoot'
 
 # 1.6.1.5 Disable MCS Translation service mcstrans
-  - id: 4041 
+  - id: 4041
     title: "Ensure the MCS Translation Service (mcstrans) is not installed"
     description: "The mcstransd daemon provides category label information to client processes requesting information. The label translations are defined in /etc/selinux/targeted/setrans.conf"
     rationale: "Since this service is not used very often, remove it to reduce the amount of potentially vulnerable code running on the system."
@@ -749,7 +749,7 @@ checks:
       - 'c:rpm -qa mcstrans -> r:mcstrans'
 
 # 1.6.1.6 Ensure no unconfined daemons exist
-  - id: 4042 
+  - id: 4042
     title: "Ensure no unconfined daemons exist"
     description: "Daemons that are not defined in SELinux policy will inherit the security context of their parent process."
     rationale: "Since daemons are launched and descend from the init process, they will inherit the security context label initrc_t . This could cause the unintended consequence of giving the process more permission than it requires."
@@ -764,7 +764,7 @@ checks:
     rules:
       - 'c:ps -eZ -> r:initrc && !r:tr|ps|egrep|bash|awk'
 # 1.6.2 Install SELinux
-  - id: 4043 
+  - id: 4043
     title: "Ensure SELinux is installed"
     description: "SELinux provides Mandatory Access Controls."
     rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
@@ -783,7 +783,7 @@ checks:
 # 1.7  Warning Banners
 ###############################################
 # 1.7.1.1 Configure message of the day (Scored)
-  - id: 4044 
+  - id: 4044
     title: "Ensure message of the day is configured properly"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -797,7 +797,7 @@ checks:
       - 'f:/etc/motd -> r:\\v|\\r|\\m|\\s'
 
 # 1.7.1.2 Configure local login warning banner (Not Scored)
-  - id: 4045 
+  - id: 4045
     title: "Ensure local login warning banner is configured properly"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -811,7 +811,7 @@ checks:
       - 'f:/etc/issue -> r:\\v|\\r|\\m|\\s'
 
 # 1.7.1.3 Configure remote login warning banner (Not Scored)
-  - id: 4046 
+  - id: 4046
     title: "Ensure remote login warning banner is configured properly"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -825,7 +825,7 @@ checks:
       - 'f:/etc/issue.net -> r:\\v|\\r|\\m|\\s'
 
 # 1.7.1.4 Configure /etc/motd permissions (Not Scored)
-  - id: 4047 
+  - id: 4047
     title: "Ensure permissions on /etc/motd are configured"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
     rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -844,7 +844,7 @@ checks:
       - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.7.1.5 Configure /etc/issue permissions (Scored)
-  - id: 4048 
+  - id: 4048
     title: "Ensure permissions on /etc/issue are configured"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
     rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -862,7 +862,7 @@ checks:
     rules:
       - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 # 1.7.1.6 Configure /etc/issue.net permissions (Not Scored)
-  - id: 4049 
+  - id: 4049
     title: "Ensure permissions on /etc/issue.net are configured"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
     rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -875,13 +875,13 @@ checks:
       - nist_800_53: ["AU.14", "AC.7"]
       - gpg_13: ["7.8"]
       - gdpr_IV: ["35.7","32.2"]
-      - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"] 
+      - tsc: ["CC6.1","CC6.8","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
       - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.7.2 Ensure GDM login banner is configured (Scored)
-  - id: 4050 
+  - id: 4050
     title: "Ensure GDM login banner is configured"
     description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems."
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place."
@@ -900,7 +900,7 @@ checks:
 
 
 # 1.8 Ensure updates, patches, and additional security software are installed (Not Scored)
-  - id: 4051 
+  - id: 4051
     title: "Ensure updates, patches, and additional security software are installed"
     description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
     rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
@@ -926,7 +926,7 @@ checks:
 ###############################################
 # 2.1.1 Disable chargen services (Scored)
 
-  - id: 4052 
+  - id: 4052
     title: "Ensure chargen services are not enabled"
     description: "chargen is a network service that responds with 0 to 512 ASCII characters for each connection it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -946,7 +946,7 @@ checks:
       - 'c:chkconfig --list chargen-stream-> r:^\s*\t*chargen-stream:\s*\t*on'
 
 # 2.1.2 Disable daytime services (Scored)
-  - id: 4053 
+  - id: 4053
     title: "Ensure daytime services are not enabled"
     description: "daytime is a network service that responds with the server's current date and time. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -966,7 +966,7 @@ checks:
       - 'c:chkconfig --list daytime-stream -> r:^\s*\t*daytime-stream:\s*\t*on'
 
 # 2.1.3 Disable discard services (Scored)
-  - id: 4054 
+  - id: 4054
     title: "Ensure discard services are not enabled"
     description: "discardis a network service that simply discards all data it receives. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -986,7 +986,7 @@ checks:
       - 'c:chkconfig --list discard-stream -> r:^\s*\t*discard-stream:\s*\t*on'
 
 # 2.1.4 Disable echo-dgram (Scored)
-  - id: 4055 
+  - id: 4055
     title: "Ensure echo services are not enabled"
     description: "echo is a network service that responds to clients with the data sent to it by the client. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -1006,7 +1006,7 @@ checks:
       - 'c:chkconfig --list echo-stream -> r:^\s*\t*echo-stream:\s*\t*on'
 
 # 2.1.5 Disable time-stream (Scored)
-  - id: 4056 
+  - id: 4056
     title: "Ensure time services are not enabled"
     description: "time is a network service that responds with the server's current date and time as a 32 bit integer. This service is intended for debugging and testing purposes. It is recommended that this service be disabled."
     rationale: "Disabling this service will reduce the remote attack surface of the system."
@@ -1026,7 +1026,7 @@ checks:
       - 'c:chkconfig --list time-stream -> r:^\s*\t*time-stream:\s*\t*on'
 
 # 2.1.6 Remove rsh-server (Scored)
-  - id: 4057 
+  - id: 4057
     title: "Ensure rsh server is not enabled"
     description: "The Berkeley rsh-server ( rsh , rlogin , rexec ) package contains legacy services that exchange credentials in clear-text."
     rationale: "These legacy services contain numerous security exposures and have been replaced with the more secure SSH package."
@@ -1048,7 +1048,7 @@ checks:
 
 
 # 2.1.7 Remove talk server (Scored)
-  - id: 4058 
+  - id: 4058
     title: "Ensure talk server is not enabled"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client (allows initiate of talk sessions) is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -1067,7 +1067,7 @@ checks:
       - 'c:chkconfig --list talk -> r:^\s*\t*talk:\s*\t*on'
 
 # 2.1.8 Remove telnet-server (Scored)
-  - id: 4059 
+  - id: 4059
     title: "Ensure telnet server is not enabled"
     description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
@@ -1086,7 +1086,7 @@ checks:
       - 'c:chkconfig --list telnet -> r:^\s*\t*telnet:\s*\t*on'
 
 # 2.1.9 Ensure tftp server is not enabled (Scored)
-  - id: 4060 
+  - id: 4060
     title: "Ensure tftp server is not enabled"
     description: "Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot machines from a boot server. The package tftp-server is used to define and support a TFTP server."
     rationale: "TFTP does not support authentication nor does it ensure the confidentiality or integrity of data. It is recommended that TFTP be removed, unless there is a specific need for TFTP. In that case, extreme caution must be used when configuring the services."
@@ -1105,7 +1105,7 @@ checks:
       - 'c:chkconfig --list tftp -> r:^\s*\t*tftp:\s*\t*on'
 
 # 2.1.10 Remove rsync service (Scored)
-  - id: 4061 
+  - id: 4061
     title: "Ensure rsync service is not enabled"
     description: "The rsyncd service can be used to synchronize files between systems over network links."
     rationale: "The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
@@ -1124,7 +1124,7 @@ checks:
       - 'c:chkconfig --list rsync -> r:^\s*\t*rsync:\s*\t*on'
 
 # 2.1.11 Remove xinetd (Scored)
-  - id: 4062 
+  - id: 4062
     title: "Ensure xinetd is not enabled"
     description: "The eXtended InterNET Daemon ( xinetd ) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no xinetd services required, it is recommended that the daemon be disabled."
@@ -1147,7 +1147,7 @@ checks:
 ###############################################
 
 # 2.2.1.1 Ensure time synchronization is in use (Not Scored)
-  - id: 4063 
+  - id: 4063
     title: "Ensure time synchronization is in use"
     description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
     rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
@@ -1164,7 +1164,7 @@ checks:
       - 'not c:rpm -q chrony -> r:^package chrony is not installed'
 
 # 2.2.1.2 Configure Network Time Protocol (NTP) (Scored)
-  - id: 4064 
+  - id: 4064
     title: "Ensure ntp is configured"
     description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://www.ntp.org. ntp can be configured to be a client and/or a server."
     rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
@@ -1183,7 +1183,7 @@ checks:
       - 'f:/etc/sysconfig/ntpd -> r:^OPTIONS\s*=\s* && r:-u ntp:ntp'
 
 # 2.2.1.3 Configure Network Time Protocol (Chrony) (Scored)
-  - id: 4065 
+  - id: 4065
     title: "Ensure chrony is configured"
     description: "chrony is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://www.ntp.org. ntp can be configured to be a client and/or a server."
     rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
@@ -1200,7 +1200,7 @@ checks:
       - 'f:/etc/sysconfig/chronyd -> r:^OPTIONS\s*=\s* && r:-u chrony'
 
 # 2.2.2 Remove X Windows (Scored)
-  - id: 4066 
+  - id: 4066
     title: "Ensure X Window System is not installed"
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
@@ -1216,7 +1216,7 @@ checks:
       - 'c:rpm -qa xorg-x11* -> r:^xorg-x11'
 
 # 2.2.3 Disable Avahi Server (Scored)
-  - id: 4067 
+  - id: 4067
     title: "Ensure Avahi Server is not enabled"
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to disable the service to reduce the potential attack surface."
@@ -1232,7 +1232,7 @@ checks:
       - 'c:chkconfig --list avahi-daemon -> r:^\s*\t*avahi-daemon\.*on'
 
 # 2.2.4 Ensure CUPS is not enabled (Scored)
-  - id: 4068 
+  - id: 4068
     title: "Ensure CUPS is not enabled"
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be disabled to reduce the potential attack surface."
@@ -1248,7 +1248,7 @@ checks:
       - 'c:chkconfig --list cups -> r:^\s*\t*cups\.*on'
 
 # 2.2.5 Remove DHCP Server (Scored)
-  - id: 4069 
+  - id: 4069
     title: "Ensure DHCP Server is not enabled"
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this service be disabled to reduce the potential attack surface."
@@ -1266,7 +1266,7 @@ checks:
       - 'c:chkconfig --list dhcpd -> r:^\s*\t*dhcpd\.*on'
 
 # 2.2.6 Remove LDAP Server (Scored)
-  - id: 4070 
+  - id: 4070
     title: "Ensure LDAP Server is not enabled"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be disabled to reduce the potential attack surface."
@@ -1286,7 +1286,7 @@ checks:
 
 
 # 2.2.7 Disable NFS and RPC (Scored)
-  - id: 4071 
+  - id: 4071
     title: "Ensure NFS and RPC are not enabled"
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not export NFS shares or act as an NFS client, it is recommended that these services be disabled to reduce remote attack surface."
@@ -1303,7 +1303,7 @@ checks:
       - 'c:chkconfig --list rpcbind -> r:^\s*\t*rpcbind\.*on'
 
 # 2.2.8 Ensure DNS Server is not enabled (Scored)
-  - id: 4072 
+  - id: 4072
     title: "Ensure DNS Server is not enabled"
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the service be disabled to reduce the potential attack surface."
@@ -1319,7 +1319,7 @@ checks:
       - 'c:chkconfig --list named -> r:^\s*\t*named\.*on'
 
 # 2.2.9 Remove FTP Server (Scored)
-  - id: 4073 
+  - id: 4073
     title: "Ensure FTP Server is not enabled"
     description: "The File Transfer Protocol (FTP) provides networked computers with the ability to transfer files."
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the service be disabled to reduce the potential attack surface."
@@ -1335,7 +1335,7 @@ checks:
       - 'c:chkconfig --list vsftpd -> r:^\s*\t*vsftpd\.*on'
 
 # 2.2.10 Remove HTTP Server (Scored)
-  - id: 4074 
+  - id: 4074
     title: "Ensure HTTP server is not enabled"
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the service be disabled to reduce the potential attack surface."
@@ -1351,7 +1351,7 @@ checks:
       - 'c:chkconfig --list httpd -> r:^\s*\t*httpd\.*on'
 
 # 2.2.11 Remove Dovecot (IMAP and POP3 services) (Scored)
-  - id: 4075 
+  - id: 4075
     title: "Ensure IMAP and POP3 server is not enabled"
     description: "dovecot is an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the service be disabled to reduce the potential attack surface."
@@ -1367,7 +1367,7 @@ checks:
       - 'c:chkconfig --list dovecot -> r:^\s*\t*dovecot\.*on'
 
 # 2.2.12 Remove Samba (Scored)
-  - id: 4076 
+  - id: 4076
     title: "Ensure Samba is not enabled"
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this service can be disabled to reduce the potential attack surface."
@@ -1383,7 +1383,7 @@ checks:
       - 'c:chkconfig --list smb -> r:^\s*\t*smb\.*on'
 
 # 2.2.13 Remove HTTP Proxy Server (Scored)
-  - id: 4077 
+  - id: 4077
     title: "Ensure HTTP Proxy Server is not enabled"
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid proxy be disabled to reduce the potential attack surface."
@@ -1399,7 +1399,7 @@ checks:
       - 'c:chkconfig --list squid -> r:^\s*\t*squid\.*on'
 
 # 2.2.14 Remove SNMP Server (Not Scored)
-  - id: 4078 
+  - id: 4078
     title: "Ensure SNMP Server is not enabled"
     description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
     rationale: "The SNMP server can communicate using SNMP v1, which transmits data in the clear and does not require authentication to execute commands. Unless absolutely necessary, it is recommended that the SNMP service not be used. If SNMP is required the server should be configured to disallow SNMP v1."
@@ -1415,7 +1415,7 @@ checks:
       - 'c:chkconfig --list snmpd -> r:^\s*\t*snmpd\.*on'
 
 # 2.2.15 Ensure mail transfer agent is configured for local-only mode (Scored)
-  - id: 4079 
+  - id: 4079
     title: "Ensure mail transfer agent is configured for local-only mode"
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
@@ -1431,7 +1431,7 @@ checks:
       - 'c:netstat -an -> r:\.*:25\.*LISTEN && !r:127.0.0.1:25\.+LISTEN|::1:25\.+LISTEN'
 
 # 2.2.16 Remove NIS Server (Scored)
-  - id: 4080 
+  - id: 4080
     title: "Ensure NIS Server is not enabled"
     description: "The Network Information Service (NIS) (formally known as Yellow Pages) is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be disabled and other, more secure services be used"
@@ -1453,7 +1453,7 @@ checks:
 # 2.3 Service Clients
 ###############################################
 # 2.3.1 Remove NIS Client (Scored)
-  - id: 4081 
+  - id: 4081
     title: "Ensure NIS Client is not installed"
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client ( ypbind ) was used to bind a machine to an NIS server and receive the distributed configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
@@ -1472,7 +1472,7 @@ checks:
       - 'c:rpm -q ypbind -> package ypbind is not installed'
 
 # 2.3.2 Ensure rsh client is not installed (Scored)
-  - id: 4082 
+  - id: 4082
     title: "Ensure rsh client is not installed"
     description: "The rsh package contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh , rcp and rlogin ."
@@ -1491,7 +1491,7 @@ checks:
       - 'c:rpm -q rsh -> package rsh is not installed'
 
 # 2.3.3 Ensure talk client is not installed (Scored)
-  - id: 4083 
+  - id: 4083
     title: "Ensure talk client is not installed"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -1510,7 +1510,7 @@ checks:
       - 'c:rpm -q talk -> package talk is not installed'
 
 # 2.3.4 Ensure telnet client is not installed (Scored)
-  - id: 4084 
+  - id: 4084
     title: "Ensure telnet client is not installed"
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
@@ -1529,7 +1529,7 @@ checks:
       - 'c:rpm -q telnet -> package telnet is not installed'
 
 # 2.3.5 Ensure LDAP client is not installed (Scored)
-  - id: 4085 
+  - id: 4085
     title: "Ensure LDAP client is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
@@ -1554,7 +1554,7 @@ checks:
 # 3.1 Modify Network Parameters (Host Only)
 ###############################################
 # 3.1.1 Disable IP Forwarding (Scored)
-  - id: 4086 
+  - id: 4086
     title: "Ensure IP forwarding is disabled"
     description: "The net.ipv4.ip_forward flag is used to tell the system whether it can forward packets or not."
     rationale: "Setting the flag to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
@@ -1571,7 +1571,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.ip_forward /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.ip_forward\s*=\s*0$'
 
 # 3.1.2 Disable Send Packet Redirects (Scored)
-  - id: 4087 
+  - id: 4087
     title: "Ensure packet redirect sending is disabled"
     description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
     rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
@@ -1593,7 +1593,7 @@ checks:
 # 3.2 Modify Network Parameters (Host and Router)
 ###############################################
 # 3.2.1 Disable Source Routed Packet Acceptance (Scored)
-  - id: 4088 
+  - id: 4088
     title: "Ensure source routed packets are not accepted"
     description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
     rationale: "Setting net.ipv4.conf.all.accept_source_route and net.ipv4.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
@@ -1612,7 +1612,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.accept_source_route /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
 
 # 3.2.2 Disable ICMP Redirect Acceptance (Scored)
-  - id: 4089 
+  - id: 4089
     title: "Ensure ICMP redirects are not accepted"
     description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables."
     rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
@@ -1631,7 +1631,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.accept_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
 
 # 3.2.3 Disable Secure ICMP Redirect Acceptance (Scored)
-  - id: 4090 
+  - id: 4090
     title: "Ensure secure ICMP redirects are not accepted"
     description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
     rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
@@ -1650,7 +1650,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
 
 # 3.2.4 Log Suspicious Packets (Scored)
-  - id: 4091 
+  - id: 4091
     title: "Ensure suspicious packets are logged"
     description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
     rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their system."
@@ -1669,7 +1669,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
 
 # 3.2.5 Enable Ignore Broadcast Requests (Scored)
-  - id: 4092 
+  - id: 4092
     title: "Ensure broadcast ICMP requests are ignored"
     description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
     rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address."
@@ -1686,7 +1686,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
 # 3.2.6 Enable Bad Error Message Protection (Scored)
-  - id: 4093 
+  - id: 4093
     title: "Ensure bogus ICMP responses are ignored"
     description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
     rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
@@ -1703,7 +1703,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
 # 3.2.7 Enable RFC-recommended Source Route Validation (Scored)
-  - id: 4094 
+  - id: 4094
     title: "Ensure Reverse Path Filtering is enabled"
     description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
     rationale: "Setting these flags is a good way to deter attackers from sending your server bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing."
@@ -1722,7 +1722,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
 
 # 3.2.8 Enable TCP SYN Cookies (Scored)
-  - id: 4095 
+  - id: 4095
     title: "Ensure TCP SYN Cookies is enabled"
     description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent."
     rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
@@ -1742,7 +1742,7 @@ checks:
 # 3.3 IPv6
 ###############################################
 # 3.3.1 Ensure IPv6 router advertisements are not accepted (Not Scored)
-  - id: 4096 
+  - id: 4096
     title: "Ensure IPv6 router advertisements are not accepted"
     description: "This setting disables the system's ability to accept IPv6 router advertisements."
     rationale: "It is recommended that systems not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
@@ -1765,7 +1765,7 @@ checks:
 
 
 # 3.3.2 Ensure IPv6 redirects are not accepted (Not Scored)
-  - id: 4097 
+  - id: 4097
     title: "Ensure IPv6 redirects are not accepted"
     description: "This setting prevents the system from accepting ICMP redirects. ICMP redirects tell the system about alternate routes for sending traffic."
     rationale: "It is recommended that systems not accept ICMP redirects as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
@@ -1787,7 +1787,7 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_redirect /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0'
 
 # 3.3.3 Ensure IPv6 is disabled (Not Scored)
-  - id: 4098 
+  - id: 4098
     title: "Ensure IPv6 is disabled"
     description: "Although IPv6 has many advantages over IPv4, few organizations have implemented IPv6."
     rationale: "If IPv6 is not to be used, it is recommended that it be disabled to reduce the attack surface of the system."
@@ -1810,7 +1810,7 @@ checks:
 # 3.4 TCP Wrappers
 ###############################################
 # 3.4.1 Ensure TCP Wrappers is installed (Scored)
-  - id: 4099 
+  - id: 4099
     title: "Ensure TCP Wrappers is installed"
     description: "TCP Wrappers provides a simple access list and standardized logging method for services capable of supporting it. In the past, services that were called from inetd and xinetd supported the use of tcp wrappers. As inetd and xinetd have been falling in disuse, any service that can support tcp wrappers will have the libwrap.so library attached to it."
     rationale: "TCP Wrappers provide a good simple access list mechanism to services that may not have that support built in. It is recommended that all services that can support TCP Wrappers, use it."
@@ -1825,7 +1825,7 @@ checks:
       - 'c:rpm -q tcp_wrappers-libs -> r:^tcp_wrappers-libs-'
 
 # 3.4.3 Ensure /etc/hosts.deny is configured (Scored)
-  - id: 4100 
+  - id: 4100
     title: "Ensure /etc/hosts.deny is configured"
     description: "The /etc/hosts.deny file specifies which IP addresses are not permitted to connect to the host. It is intended to be used in conjunction with the /etc/hosts.allow file."
     rationale: "The /etc/hosts.allow file supports access control by IP and helps ensure that only authorized systems can connect to the system."
@@ -1839,7 +1839,7 @@ checks:
       - 'f:/etc/hosts.deny -> r:^ALL\s*:\s*ALL'
 
 # 3.4.4 Ensure permissions on /etc/hosts.allow are configured (Scored)
-  - id: 4101 
+  - id: 4101
     title: "Ensure permissions on /etc/hosts.allow are configured."
     description: "The /etc/hosts.allow file contains networking information that is used by many applications and therefore must be readable for these applications to operate."
     rationale: "It is critical to ensure that the /etc/hosts.allow file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -1854,7 +1854,7 @@ checks:
 
 
 # 3.4.5 Ensure permissions on /etc/hosts.deny are configured (Scored)
-  - id: 4102 
+  - id: 4102
     title: "Ensure permissions on /etc/hosts.deny are configured."
     description: "The /etc/hosts.deny file contains network information that is used by many system applications and therefore must be readable for these applications to operate."
     rationale: "It is critical to ensure that the /etc/hosts.deny file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -1874,7 +1874,7 @@ checks:
 # 3.5 Uncommon Network Protocols
 ###############################################
 # 3.5.1 Ensure DCCP is disabled (Not Scored)
-  - id: 4103 
+  - id: 4103
     title: "Ensure DCCP is disabled"
     description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery."
     rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce
@@ -1897,7 +1897,7 @@ the potential attack surface."
 
 
 # 3.5.2 Ensure SCTP is disabled (Not Scored)
-  - id: 4104 
+  - id: 4104
     title: "Ensure SCTP is disabled"
     description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1918,7 +1918,7 @@ the potential attack surface."
 
 
 # 3.5.3 Ensure RDS is disabled (Not Scored)
-  - id: 4105 
+  - id: 4105
     title: "Ensure RDS is disabled"
     description: "The Reliable Datagram Sockets (RDS) protocol is a transport layer protocol designed to provide low-latency, high-bandwidth communications between cluster nodes. It was developed by the Oracle Corporation."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1939,7 +1939,7 @@ the potential attack surface."
 
 
 # 3.5.4 Ensure TIPC is disabled (Not Scored)
-  - id: 4106 
+  - id: 4106
     title: "Ensure TIPC is disabled"
     description: "The Transparent Inter-Process Communication (TIPC) protocol is designed to provide communication between cluster nodes."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1962,7 +1962,7 @@ the potential attack surface."
 # 3.6 Firewall Configuration
 ###############################################
 # 3.6.1 Ensure iptables is installed (Scored)
-  - id: 4107 
+  - id: 4107
     title: "Ensure iptables is installed"
     description: "iptables allows configuration of the IPv4 tables in the linux kernel and the rules stored within them. Most firewall configuration utilities operate as a front end to iptables ."
     rationale: "iptables is required for firewall management and configuration."
@@ -1976,7 +1976,7 @@ the potential attack surface."
       - 'c:rpm -q iptables -> r:iptables-'
 
 # 3.6.2 Ensure default deny firewall policy (Scored)
-  - id: 4108 
+  - id: 4108
     title: "Ensure default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -1993,7 +1993,7 @@ the potential attack surface."
       - 'c:iptables -L -> r:Chain OUTPUT \(policy DROP\)'
 
 # 3.6.3 Ensure loopback traffic is configured (Scored)
-  - id: 4109 
+  - id: 4109
     title: "Ensure loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -2019,7 +2019,7 @@ the potential attack surface."
 ###############################################
 
 # 4.1.1.1 Ensure audit log storage size is configured (Not Scored)
-  - id: 4110 
+  - id: 4110
     title: "Ensure audit log storage size is configured"
     description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
     rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
@@ -2033,7 +2033,7 @@ the potential attack surface."
       - 'f:/etc/audit/auditd.conf -> r:^max_log_file\s*=\s*\d+'
 
 # 4.1.1.2 Ensure system is disabled when audit logs are full (Scored)
-  - id: 4111 
+  - id: 4111
     title: "Ensure system is disabled when audit logs are full"
     description: "The auditd daemon can be configured to halt the system when the audit logs are full."
     rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
@@ -2049,7 +2049,7 @@ the potential attack surface."
       - 'f:/etc/audit/auditd.conf -> r:^admin_space_left_action\s*=\s*halt'
 
 # 4.1.1.3 Ensure audit logs are not automatically deleted (Scored)
-  - id: 4112 
+  - id: 4112
     title: "Ensure audit logs are not automatically deleted"
     description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
     rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
@@ -2063,7 +2063,7 @@ the potential attack surface."
       - 'f:/etc/audit/auditd.conf -> r:^max_log_file_action\s*=\s*keep_logs'
 
 # 4.1.2 Ensure auditd service is enabled (Scored)
-  - id: 4113 
+  - id: 4113
     title: "Ensure auditd service is enabled"
     description: "Turn on the auditd daemon to record system events."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -2079,7 +2079,7 @@ the potential attack surface."
 
 
 # 4.1.3 Ensure auditing for processes that start prior to auditd is enabled (Scored)
-  - id: 4114 
+  - id: 4114
     title: "Ensure auditing for processes that start prior to auditd is enabled"
     description: "Configure grub so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
     rationale: "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected."
@@ -2094,9 +2094,9 @@ the potential attack surface."
     condition: none
     rules:
       - 'f:/boot/grub/grub.conf -> r:^\s*\t*kernel && !r:audit=1'
-      
+
 # 4.1.4 Ensure events that modify date and time information are collected (Scored)
-  - id: 4115 
+  - id: 4115
     title: "Ensure events that modify date and time information are collected"
     description: "Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier \"time-change\"."
     rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
@@ -2117,7 +2117,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /etc/localtime && r:-p wa && r:-k time-change'
 
 # 4.1.5 Ensure events that modify user/group information are collected (Scored)
-  - id: 4116 
+  - id: 4116
     title: "Ensure events that modify user/group information are collected"
     description: "Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier \"identity\" in the audit log file."
     rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
@@ -2140,7 +2140,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /etc/security/opasswd && r:-p wa && r:-k identity'
 
 # 4.1.6 Ensure events that modify the system's network environment are collected (Scored)
-  - id: 4117 
+  - id: 4117
     title: "Ensure events that modify the system's network environment are collected"
     description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed pre-login), /etc/hosts (file containing host names and associated IP addresses), /etc/sysconfig/network file and /etc/sysconfig/network-scripts/ directory (containing network interface scripts and configurations)."
     rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/sysconfig/network and /etc/sysconfig/network-scripts/ is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier \"system-locale.\""
@@ -2164,7 +2164,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /etc/sysconfig/network-scripts/ && r:-p wa && r:-k system-locale'
 
 # 4.1.7 Ensure events that modify the system's Mandatory Access Controls are collected (Scored)
-  - id: 4118 
+  - id: 4118
     title: "Ensure events that modify the system's Mandatory Access Controls are collected"
     description: "Monitor SELinux mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/selinux or directory."
     rationale: "Changes to files in these directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
@@ -2184,7 +2184,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /usr/share/selinux/ && r:-p wa && r:-k MAC-policy'
 
 # 4.1.8 Ensure login and logout events are collected (Scored)
-  - id: 4119 
+  - id: 4119
     title: "Ensure login and logout events are collected"
     description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. The file /var/log/lastlog maintain records of the last time a user successfully logged in. The /var/run/failock directory maintains records of login failures via the pam_faillock module."
     rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
@@ -2204,7 +2204,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /var/run/faillock/ && r:-p wa && r:-k logins'
 
 # 4.1.9 Ensure session initiation information is collected (Scored)
-  - id: 4120 
+  - id: 4120
     title: "Ensure session initiation information is collected"
     description: "Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp file tracks all currently logged in users. All audit records will be tagged with the identifier \"session.\" The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp . All audit records will be tagged with the identifier \"logins.\"."
     rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
@@ -2221,7 +2221,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /var/log/btmp && r:-p wa && r:-k logins'
 
 # 4.1.10 Ensure discretionary access control permission modification events are collected (Scored)
-  - id: 4121 
+  - id: 4121
     title: "Ensure discretionary access control permission modification events are collected"
     description: "Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The chmod , fchmod and fchmodat system calls affect the permissions associated with a file. The chown , fchown , fchownat and lchown system calls affect owner and group attributes on a file. The setxattr , lsetxattr , fsetxattr (set extended file attributes) and removexattr , lremovexattr , fremovexattr (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 500) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier \"perm_mod.\""
     rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
@@ -2242,7 +2242,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S setxattr && r:-S lsetxattr && r:-S fsetxattr && r:-S removexattr && r:-S lremovexattr && r:-S fremovexattr && r:-F auid>=500 && r:-F auid!=4294967295 && r:-k perm_mod'
 
 # 4.1.11 Ensure unsuccessful unauthorized file access attempts are collected (Scored)
-  - id: 4122 
+  - id: 4122
     title: "Ensure unsuccessful unauthorized file access attempts are collected"
     description: "Monitor for unsuccessful attempts to access files. The parameters below are associated  with system calls that control creation ( creat ), opening ( open , openat ) and truncation (  truncate , ftruncate ) of files. An audit log record will only be written if the user is a non-  privileged user (auid > = 500), is not a Daemon event (auid=4294967295) and if the  system call returned EACCES (permission denied to the file) or EPERM (some other  permanent error associated with the specific system call). All audit records will be tagged  with the identifier \"access.\""
     rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
@@ -2262,7 +2262,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-S ftruncate && r:-F exit=-EPERM && r:-F auid>=500 && r:-F auid!=4294967295 && r:-k access'
 
 # 4.1.13 Ensure successful file system mounts are collected (Scored)
-  - id: 4123 
+  - id: 4123
     title: "Ensure successful file system mounts are collected"
     description: "Monitor the use of the mount system call. The mount (and umount ) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user."
     rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open , creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
@@ -2282,7 +2282,7 @@ the potential attack surface."
 
 
 # 4.1.14 Ensure file deletion events by users are collected (Scored)
-  - id: 4124 
+  - id: 4124
     title: "Ensure file deletion events by users are collected"
     description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for the unlink (remove a file), unlinkat (remove a file attribute), rename (rename a file) and renameat (rename a file attribute) system calls and tags them with the identifier \"delete\"."
     rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
@@ -2296,7 +2296,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S unlink && r:-S unlinkat && r:-S rename && r:-S renameat && r:-F auid>=500 && r:-F auid!=4294967295 && r:-k delete'
 
 # 4.1.15 Ensure changes to system administration scope (sudoers) is collected (Scored)
-  - id: 4125 
+  - id: 4125
     title: "Ensure changes to system administration scope (sudoers) is collected"
     description: "Monitor scope changes for system administrations. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers will be written to when the file or its attributes have changed. The audit records will be tagged with the identifier \"scope.\""
     rationale: "Changes in the /etc/sudoers file can indicate that an unauthorized change has been made to scope of system administrator activity."
@@ -2316,7 +2316,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /etc/sudoers.d/ && r:-p wa && r:-k scope'
 
 # 4.1.16 Ensure system administrator actions (sudolog) are collected (Scored)
-  - id: 4126 
+  - id: 4126
     title: "Ensure system administrator actions (sudolog) are collected"
     description: "Monitor the sudo log file. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to /var/log/sudo.log . Any time a command is executed, an audit event will be triggered as the /var/log/sudo.log file will be opened for write and the executed administration command will be written to the log."
     rationale: "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed."
@@ -2335,7 +2335,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:-w /var/log/sudo.log && r:-p wa && r:-k actions'
 
 # 4.1.17 Ensure kernel module loading and unloading is collected (Scored)
-  - id: 4127 
+  - id: 4127
     title: "Ensure kernel module loading and unloading is collected"
     description: "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\"."
     rationale: "Monitoring the use of insmod , rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
@@ -2357,7 +2357,7 @@ the potential attack surface."
       - 'f:/etc/audit/audit.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b\d\d && r:-S init_module && r:-S delete_module && r:-k modules'
 
 # 4.1.18 Ensure the audit configuration is immutable (Scored)
-  - id: 4128 
+  - id: 4128
     title: "Ensure the audit configuration is immutable"
     description: "Set system audit so that audit rules cannot be modified with auditctl . Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot."
     rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
@@ -2377,7 +2377,7 @@ the potential attack surface."
 ###############################################
 
 # 4.2.1.1 Ensure rsyslog Service is enabled (Scored)
-  - id: 4129 
+  - id: 4129
     title: "Ensure rsyslog Service is enabled"
     description: "Once the rsyslog package is installed it needs to be activated."
     rationale: "If the rsyslog service is not activated the system may default to the syslogd service or lackblogging instead."
@@ -2391,20 +2391,20 @@ the potential attack surface."
     rules:
       - 'c:chkconfig --list rsyslog -> r:2:on && r:3:on && r:4:on && r:5:on'
 # 4.2.1.3 Ensure rsyslog default file permissions configured (Scored)
-  - id: 4130 
+  - id: 4130
     title: "Ensure rsyslog default file permissions configured"
     description: "rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
     remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to 0640 or more restrictive:   $FileCreateMode 0640"
     compliance:
       - cis: ["4.2.1.3"]
-      - cis_csc: ["5.1"]  
+      - cis_csc: ["5.1"]
     condition: all
     rules:
       - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 0600|^\$FileCreateMode 0640|^\$FileCreateMode 0440|^\$FileCreateMode 0400|^\$FileCreateMode 0040|^\$FileCreateMode 0000'
 
 # 4.2.1.4 Ensure rsyslog is configured to send logs to a remote log host (Scored)
-  - id: 4131 
+  - id: 4131
     title: "Ensure rsyslog is configured to send logs to a remote log host"
     description: "The rsyslog utility supports the ability to send logs it gathers to a remote log host running syslogd(8) or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2417,11 +2417,11 @@ the potential attack surface."
     condition: all
     rules:
       - 'c:grep *.*[^I][^I]*@ /etc/rsyslog.conf /etc/rsyslog.d/*.conf -> !r:# && r:*.* @@\.+'
-  
+
 
 
 # 4.2.2.1 Ensure syslog-ng service is enabled (Scored)
-  - id: 4132 
+  - id: 4132
     title: "Ensure syslog-ng service is enabled"
     description: "Once the syslog-ng package is installed it needs to be activated."
     rationale: "If the syslog-ng service is not activated the system may default to the syslogd service or lack logging instead."
@@ -2436,22 +2436,22 @@ the potential attack surface."
       - 'c:chkconfig --list syslog-ng -> r:2:on && r:3:on && r:4:on && r:5:on'
 
 # 4.2.2.3 Ensure syslog-ng default file permissions configured (Scored)
-  - id: 4133 
+  - id: 4133
     title: "Ensure syslog-ng default file permissions configured"
     description: "syslog-ng will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive syslog-ng data is archived and protected."
     remediation: "Edit the /etc/syslog-ng/syslog-ng.conf and set perm option to 0640 or more restrictive:     options { chain_hostnames(off); flush_lines(0); perm(0640); stats_freq(3600); threaded(yes); };"
     compliance:
       - cis: ["4.2.2.3"]
-      - cis_csc: ["5.1"]    
+      - cis_csc: ["5.1"]
       - pci_dss: ["10.5"]
-      - tsc: ["CC6.1","CC7.2","CC7.3","CC7.4"]  
+      - tsc: ["CC6.1","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
       - 'f:/etc/syslog-ng/syslog-ng.conf -> r:^options && r:perm\(0600\)|perm\(0640\)|perm\(0440\)|perm\(0400\)|perm\(0000\)'
 
 # 4.2.2.4 Ensure syslog-ng is configured to send logs to a remote log host (Not Scored)
-  - id: 4134 
+  - id: 4134
     title: "Ensure syslog-ng is configured to send logs to a remote log host"
     description: "The syslog-ng utility supports the ability to send logs it gathers to a remote log host or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2467,7 +2467,7 @@ the potential attack surface."
       - 'f:/etc/syslog-ng/syslog-ng.conf -> !r:^# && r:log\.+source\.+destination'
 
 # 4.2.3 Ensure rsyslog or syslog-ng is installed (Scored)
-  - id: 4135 
+  - id: 4135
     title: "Ensure rsyslog or syslog-ng is installed"
     description: "The rsyslog and syslog-ng software are recommended replacements to the original syslogd daemon which provide improvements over syslogd , such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server."
     rationale: "The security enhancements of rsyslog and syslog-ng such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
@@ -2483,7 +2483,7 @@ the potential attack surface."
       - 'not c:rpm -q syslog-ng -> package syslog-ng is not installed'
 
   # 4.2.4 Ensure permissions on all logfiles are configured (Scored)
-  - id: 4136 
+  - id: 4136
     title: "Ensure permissions on all logfiles are configured"
     description: "Log files stored in /var/log/ contain logged information from many services on the system, or on log hosts others as well."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitivebdata is archived and protected."
@@ -2505,7 +2505,7 @@ the potential attack surface."
 ###############################################
 
 # 5.1.1 Ensure cron daemon is enabled (Scored)
-  - id: 4137 
+  - id: 4137
     title: "Ensure cron daemon is enabled"
     description: "The cron daemon is used to execute batch jobs on the system."
     rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
@@ -2521,7 +2521,7 @@ the potential attack surface."
       - 'c:chkconfig --list crond -> r:2:on && r:3:on && r:4:on && r:5:on'
 
 # 5.1.2 Ensure permissions on /etc/crontab are configured (Scored)
-  - id: 4138 
+  - id: 4138
     title: "Ensure permissions on /etc/crontab are configured"
     description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
     rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
@@ -2537,7 +2537,7 @@ the potential attack surface."
       - 'c:stat /etc/crontab -> r:^Access: \(0\d00/-\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Scored)
-  - id: 4139 
+  - id: 4139
     title: "Ensure permissions on /etc/cron.hourly are configured"
     description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2553,7 +2553,7 @@ the potential attack surface."
       - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
-  - id: 4140 
+  - id: 4140
     title: "Ensure permissions on /etc/cron.daily are configured"
     description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2569,7 +2569,7 @@ the potential attack surface."
       - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
-  - id: 4141 
+  - id: 4141
     title: "Ensure permissions on /etc/cron.weekly are configured"
     description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2586,7 +2586,7 @@ the potential attack surface."
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
-  - id: 4142 
+  - id: 4142
     title: "Ensure permissions on /etc/cron.monthly are configured"
     description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2602,7 +2602,7 @@ the potential attack surface."
       - 'c:stat /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Scored)
-  - id: 4143 
+  - id: 4143
     title: "Ensure permissions on /etc/cron.d are configured"
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow , cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2618,7 +2618,7 @@ the potential attack surface."
       - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.8 Ensure at/cron is restricted to authorized users (Scored)
-  - id: 4144 
+  - id: 4144
     title: "Ensure at/cron is restricted to authorized users"
     description: "Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and /etc/cron.deny are checked. Any user not specifically defined in those files is allowed to use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow are allowed to use at and cron. Note that even though a given user is not listed in cron.allow , cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2640,7 +2640,7 @@ the potential attack surface."
 # 5.2 Configure SSH
 ###############################################
 # 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured (Scored)
-  - id: 4145 
+  - id: 4145
     title: "Ensure permissions on /etc/ssh/sshd_config are configured"
     description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
     rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
@@ -2656,7 +2656,7 @@ the potential attack surface."
       - 'c:stat /etc/ssh/sshd_config -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.2.2 Set SSH Protocol to 2 (Scored)
-  - id: 4146 
+  - id: 4146
     title: "Ensure SSH Protocol is set to 2"
     description: "SSH supports two different and incompatible protocols: SSH1 and SSH2. SSH1 was the original protocol and was subject to security issues. SSH2 is more advanced and secure."
     rationale: "SSH v1 suffers from insecurities that do not affect SSH v2."
@@ -2673,7 +2673,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:Protocol\s*\t*2'
 
 # 5.2.3 Set LogLevel to INFO (Scored)
-  - id: 4147 
+  - id: 4147
     title: "Ensure SSH LogLevel is set to INFO"
     description: "The INFO parameter specifies that login and logout activity will be logged."
     rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
@@ -2690,7 +2690,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:LogLevel\s*\t*INFO'
 
 # 5.2.5 Set SSH MaxAuthTries to 4 or Less (Scored)
-  - id: 4148 
+  - id: 4148
     title: "Ensure SSH MaxAuthTries is set to 4 or less"
     description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
     rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
@@ -2706,7 +2706,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
 
 # 5.2.6 Set SSH IgnoreRhosts to Yes (Scored)
-  - id: 4149 
+  - id: 4149
     title: "Ensure SSH IgnoreRhosts is enabled"
     description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
     rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
@@ -2723,7 +2723,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:IgnoreRhosts\s*\t*yes'
 
 # 5.2.7 Set SSH HostbasedAuthentication to No (Scored)
-  - id: 4150 
+  - id: 4150
     title: "Ensure SSH HostbasedAuthentication is disabled"
     description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts , or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
     rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
@@ -2740,7 +2740,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:HostbasedAuthentication\s*\t*no'
 
 # 5.2.8 Disable SSH Root Login (Scored)
-  - id: 4151 
+  - id: 4151
     title: "Ensure SSH root login is disabled"
     description: "The PermitRootLogin parameter specifies if the root user can log in using ssh(1). The default is no."
     rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su . This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident"
@@ -2757,7 +2757,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:PermitRootLogin\s*\t*no'
 
 # 5.2.9 Set SSH PermitEmptyPasswords to No (Scored)
-  - id: 4152 
+  - id: 4152
     title: "Ensure SSH PermitEmptyPasswords is disabled"
     description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
     rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system"
@@ -2774,7 +2774,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:PermitEmptyPasswords\s*\t*no'
 
 # 5.2.10 Ensure SSH PermitUserEnvironment is disabled (Scored)
-  - id: 4153 
+  - id: 4153
     title: "Ensure SSH PermitUserEnvironment is disabled"
     description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
     rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing trojan'd programs)"
@@ -2791,7 +2791,7 @@ the potential attack surface."
       - 'f:$sshd_file -> !r:^# && r:PermitUserEnvironment\s*\t*no'
 
 # 5.2.12 Ensure SSH Idle Timeout Interval is configured (Scored)
-  - id: 4154 
+  - id: 4154
     title: "Ensure SSH Idle Timeout Interval is configured"
     description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the ClientAliveCountMax variable is set, sshd will send client alive messages at every ClientAliveInterval interval. When the number of consecutive client alive messages are sent with no response from the client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
     rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent."
@@ -2806,7 +2806,7 @@ the potential attack surface."
       - 'f:$sshd_file -> n:^\s*ClientAliveCountMax\s*\t*(\d+) compare <= 3'
 
 # 5.2.13 Ensure SSH LoginGraceTime is set to one minute or less (Scored)
-  - id: 4155 
+  - id: 4155
     title: "Ensure SSH LoginGraceTime is set to one minute or less"
     description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
     rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
@@ -2820,7 +2820,7 @@ the potential attack surface."
       - 'f:$sshd_file -> n:^\s*LoginGraceTime\s*\t*(\d+) compare <= 60'
 
 # 5.2.14 Ensure SSH access is limited (Scored)
-  - id: 4156 
+  - id: 4156
     title: "Ensure SSH access is limited"
     description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: AllowUsers The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. AllowGroups The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable. DenyUsers The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. DenyGroups The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
     rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
@@ -2838,7 +2838,7 @@ the potential attack surface."
       - 'f:$sshd_file -> r:^\s*DenyGroups'
 
 # 5.2.15 Ensure SSH warning banner is configured (Scored)
-  - id: 4157 
+  - id: 4157
     title: "Ensure SSH warning banner is configured"
     description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
     rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
@@ -2856,7 +2856,7 @@ the potential attack surface."
 # 5.3 Configure PAM
 ###############################################
 # 5.3.1 Ensure password creation requirements are configured (Scored)
-  - id: 4158 
+  - id: 4158
     title: "Ensure password creation requirements are configured"
     description: "The pam_cracklib.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more"
     rationale: "Strong passwords protect systems from being hacked through brute force methods."
@@ -2872,7 +2872,7 @@ the potential attack surface."
       - 'c:grep pam_cracklib.so /etc/pam.d/system-auth -> r:try_first_pass && n:minlen\s*\t*=\s*\t*(\d+) compare >= 14'
 
 # 5.3.3 Ensure password reuse is limited (Scored)
-  - id: 4159 
+  - id: 4159
     title: "Ensure password reuse is limited"
     description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
     rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password. Note that these change only apply to accounts configured on the local system."
@@ -2888,7 +2888,7 @@ the potential attack surface."
       - 'f:/etc/pam.d/system-auth -> n:^password\s+sufficient\s+pam_unix.so\.+remember=(\d+)|^password\s+required\s+pam_pwhistory.so\.+remember=(\d+) compare >= 5'
 
 # 5.3.4 Ensure password hashing algorithm is SHA-512 (Scored)
-  - id: 4160 
+  - id: 4160
     title: "Ensure password hashing algorithm is SHA-512"
     description: "The commands below change password encryption from md5 to sha512 (a much stronger hashing algorithm). All existing accounts will need to perform a password change to upgrade the stored hashes to the new algorithm."
     rationale: "The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note that these change only apply to accounts configured on the local system."
@@ -2909,7 +2909,7 @@ the potential attack surface."
 # 5.4.1 Set Shadow Password Suite Parameters
 ###############################################
 # 5.4.1.1 Ensure password expiration is 365 days or less (Scored)
-  - id: 4161 
+  - id: 4161
     title: "Ensure password expiration is 365 days or less"
     description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 365 days."
     rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity."
@@ -2924,7 +2924,7 @@ the potential attack surface."
       - 'f:/etc/login.defs -> n:^\s*PASS_MAX_DAYS\s*\t*(\d+) compare <= 365'
 
 # 5.4.1.2 Ensure minimum days between password changes is 7 or more (Scored)
-  - id: 4162 
+  - id: 4162
     title: "Ensure minimum days between password changes is 7 or more"
     description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 7 or more days."
     rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
@@ -2939,7 +2939,7 @@ the potential attack surface."
       - 'f:/etc/login.defs -> n:^\s*PASS_MIN_DAYS\s*\t*(\d+) compare >= 7'
 
 # 5.4.1.3 Ensure password expiration warning days is 7 or more (Scored)
-  - id: 4163 
+  - id: 4163
     title: "Ensure password expiration warning days is 7 or more"
     description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
     rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
@@ -2954,7 +2954,7 @@ the potential attack surface."
       - 'f:/etc/login.defs -> n:^\s*PASS_WARN_AGE\s*\t*(\d+) compare >= 7'
 
 # 5.4.1.4 Ensure inactive password lock is 30 days or less (Scored)
-  - id: 4164 
+  - id: 4164
     title: "Ensure inactive password lock is 30 days or less"
     description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
     rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
@@ -2969,7 +2969,7 @@ the potential attack surface."
       - 'c:useradd -D -> n:^\s*INACTIVE\s*=\s*(\d+) compare <= 30'
 
 # 5.4.3 Ensure default group for the root account is GID 0 (Scored)
-  - id: 4165 
+  - id: 4165
     title: "Ensure default group for the root account is GID 0"
     description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
     rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
@@ -2984,7 +2984,7 @@ the potential attack surface."
       - 'f:/etc/passwd -> r:^root:\w:\w:0'
 
 # 5.4.4 Ensure default user umask is 027 or more restrictive (Scored)
-  - id: 4166 
+  - id: 4166
     title: "Ensure default user umask is 027 or more restrictive"
     description: "The default umask determines the permissions of files created by users. The user creating the file has the discretion of making their files and directories readable by others via the chmod command. Users who wish to allow their files and directories to be readable by others by default may choose a different default umask by inserting the umask command into the standard shell configuration files ( .profile , .bashrc , etc.) in their home directories."
     rationale: "Setting a very secure default value for umask ensures that users make a conscious choice about their file permissions. A default umask setting of 077 causes files and directories created by users to not be readable by any other user on the system. A umask of 027 would make files and directories readable by users in the same Unix group, while a umask of 022 would make files readable by every user on the system."
@@ -3002,7 +3002,7 @@ the potential attack surface."
 
 
 # 5.4.5 Ensure default user shell timeout is 900 seconds or less (Scored)
-  - id: 4167 
+  - id: 4167
     title: "Ensure default user shell timeout is 900 seconds or less"
     description: "The default TMOUT determines the shell timeout for users. The TMOUT value is measured in seconds."
     rationale: "Having no timeout value associated with a shell could allow an unauthorized user access to another user's shell session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening."
@@ -3020,7 +3020,7 @@ the potential attack surface."
 
 
 # 5.6 Ensure access to the su command is restricted (Scored)
-  - id: 4168 
+  - id: 4168
     title: "Ensure access to the su command is restricted."
     description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo , which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su , the su command will only allow users in the wheel group to execute su ."
     rationale: "Restricting the use of su , and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo , whereas su can only record that a user executed the su program."
@@ -3049,7 +3049,7 @@ the potential attack surface."
 
 
 # 6.1.2 Configure /etc/passwd permissions (Scored)
-  - id: 4169 
+  - id: 4169
     title: "Ensure permissions on /etc/passwd are configured"
     description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
     rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3066,7 +3066,7 @@ the potential attack surface."
 
 
 # 6.1.3 Configure /etc/shadow permissions (Scored)
-  - id: 4170 
+  - id: 4170
     title: "Ensure permissions on /etc/shadow are configured"
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
@@ -3082,7 +3082,7 @@ the potential attack surface."
       - 'c:stat /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.4 Configure /etc/group permissions (Scored)
-  - id: 4171 
+  - id: 4171
     title: "Ensure permissions on /etc/group are configured"
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
@@ -3098,7 +3098,7 @@ the potential attack surface."
       - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.5 Configure /etc/gshadow permissions (Scored)
-  - id: 4172 
+  - id: 4172
     title: "Ensure permissions on /etc/gshadow are configured"
     description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/gshadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/gshadow file (such as group administrators) could also be useful to subvert the group"
@@ -3114,7 +3114,7 @@ the potential attack surface."
       - 'c:stat /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.6 Configure /etc/passwd- permissions (Scored)
-  - id: 4173 
+  - id: 4173
     title: "Ensure permissions on /etc/passwd- are configured"
     description: "The /etc/passwd- file contains backup user account information."
     rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3130,7 +3130,7 @@ the potential attack surface."
       - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Configure /etc/shadow- permissions (Scored)
-  - id: 4174 
+  - id: 4174
     title: "Ensure permissions on /etc/shadow- are configured"
     description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3146,7 +3146,7 @@ the potential attack surface."
       - 'c:stat /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.8 Configure /etc/group- permissions (Scored)
-  - id: 4175 
+  - id: 4175
     title: "Ensure permissions on /etc/group- are configured"
     description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
     rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3162,7 +3162,7 @@ the potential attack surface."
       - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Configure /etc/gshadow- permissions (Scored)
-  - id: 4176 
+  - id: 4176
     title: "Ensure permissions on /etc/gshadow- are configured"
     description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3181,7 +3181,7 @@ the potential attack surface."
 # 6.2 Review User and Group Settings
 ###############################################
 # 6.2.1 Check passwords fields (Scored)
-  - id: 4177 
+  - id: 4177
     title: "Ensure password fields are not empty"
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
@@ -3196,7 +3196,7 @@ the potential attack surface."
       - 'f:/etc/shadow -> !r:^# && r:^\w+::'
 
 # 6.2.2 Delete legacy entries in /etc/passwd (Scored)
-  - id: 4178 
+  - id: 4178
     title: "Ensure no legacy \"+\" entries exist in /etc/passwd"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -3215,7 +3215,7 @@ the potential attack surface."
       - 'f:/etc/passwd -> !r:^# && r:^+:'
 
 # 6.2.3 Delete legacy entries in /etc/shadow (Scored)
-  - id: 4179 
+  - id: 4179
     title: "Ensure no legacy \"+\" entries exist in /etc/shadow"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -3234,7 +3234,7 @@ the potential attack surface."
       - 'f:/etc/shadow -> !r:^# && r:^+:'
 
 # 6.2.4 Delete legacy entries in /etc/group (Scored)
-  - id: 4180 
+  - id: 4180
     title: "Ensure no legacy \"+\" entries exist in /etc/group"
     description: "The character + in various files used to be markers for systems to insert data from NIS maps at a certain point in a system configuration file. These entries are no longer required on most systems, but may exist in files that have been imported from other platforms."
     rationale: "These entries may provide an avenue for attackers to gain privileged access on the system."
@@ -3253,7 +3253,7 @@ the potential attack surface."
       - 'f:/etc/group -> !r:^# && r:^+:'
 
 # 6.2.5 Verify No UID 0 Accounts Exist Other Than root (Scored)
-  - id: 4181 
+  - id: 4181
     title: "Ensure root is the only UID 0 account"
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
@@ -3270,7 +3270,3 @@ the potential attack surface."
     condition: none
     rules:
       - 'f:/etc/passwd -> !r:^# && !r:^\s*\t*root: && r:^\w+:\w+:0:'
-
-
-
-

--- a/ruleset/sca/rhel/6/cis_rhel6_linux.yml
+++ b/ruleset/sca/rhel/6/cis_rhel6_linux.yml
@@ -614,6 +614,22 @@ checks:
       - 'c:sysctl fs.suid_dumpable -> r:^fs.suid_dumpable\s*=\s*0\s*$'
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
+# 1.5.2 XD/NX enabled
+  - id: 4034 
+    title: "Ensure XD/NX support is enabled"
+    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
+    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
+    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
+    compliance:
+      - cis: ["1.5.2"]
+      - cis_csc: ["8.4"]
+      - pci_dss: ["2.2.4"]
+      - nist_800_53: ["CM.1"]
+      - tsc: ["CC5.2"]
+    condition: all
+    rules:
+      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+
 # 1.5.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 4035 
     title: "Ensure address space layout randomization (ASLR) is enabled"
@@ -3254,3 +3270,7 @@ the potential attack surface."
     condition: none
     rules:
       - 'f:/etc/passwd -> !r:^# && !r:^\s*\t*root: && r:^\w+:\w+:0:'
+
+
+
+

--- a/ruleset/sca/rhel/7/cis_rhel7_linux.yml
+++ b/ruleset/sca/rhel/7/cis_rhel7_linux.yml
@@ -36,7 +36,7 @@ variables:
 checks:
 
 # 1.1.1.1 cramfs: filesystem
-  - id: 4500 
+  - id: 4500
     title: "Ensure mounting of cramfs filesystems is disabled"
     description: "The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the server. If this filesystem type is not needed, disable it."
@@ -54,7 +54,7 @@ checks:
       - 'not c:lsmod -> r:cramfs'
 
 # 1.1.1.2 squashfs: filesystem
-  - id: 4501 
+  - id: 4501
     title: "Ensure mounting of squashfs filesystems is disabled"
     description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs ). A squashfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -72,7 +72,7 @@ checks:
       - 'not c:lsmod -> r:squashfs'
 
 # 1.1.1.3 udf: filesystem
-  - id: 4502 
+  - id: 4502
     title: "Ensure mounting of udf filesystems is disabled"
     description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -90,7 +90,7 @@ checks:
       - 'not c:lsmod -> r:udf'
 
 # 1.1.1.4 FAT: filesystem
-  - id: 4503 
+  - id: 4503
     title: "Ensure mounting of FAT filesystems is disabled"
     description: "The FAT filesystem format is primarily used on older windows systems and portable USB drives or flash modules. It comes in three types FAT12, FAT16, and FAT32 all of which are supported by the vfat kernel module."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -113,7 +113,7 @@ checks:
 
 
   # 1.1.2 /tmp: partition
-  - id: 4504 
+  - id: 4504
     title: "Ensure /tmp is configured"
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -133,7 +133,7 @@ checks:
       - 'c:systemctl is-enabled tmp.mount -> r:enabled'
 
 # 1.1.3 /tmp: noexec
-  - id: 4505 
+  - id: 4505
     title: "Ensure noexec option set on /tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
@@ -149,7 +149,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:noexec'
 
 # 1.1.4 /tmp: nodev
-  - id: 4506 
+  - id: 4506
     title: "Ensure nodev option set on /tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
@@ -165,7 +165,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:nodev'
 
 # 1.1.5 /tmp: nosuid
-  - id: 4507 
+  - id: 4507
     title: "Ensure nosuid option set on /tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
@@ -181,8 +181,8 @@ checks:
       - 'c:mount -> r:\s/tmp\s && r:nosuid'
 
 
-# 1.1.6 /dev/shm: 
-  - id: 4508 
+# 1.1.6 /dev/shm:
+  - id: 4508
     title: "Ensure /dev/shm is configured "
     description: "/dev/shm is a traditional shared memory concept. One program will create a memory portion, which other processes (if permitted) can access. Mounting tmpfs at /dev/shm is handled automatically by systemd."
     rationale: "Any user can upload and execute files inside the /dev/shm similar to the /tmp partition. Configuring /dev/shm allows an administrator to set the noexec option on the mount, making /dev/shm useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -202,7 +202,7 @@ checks:
 
 
 # 1.1.7 /dev/shm: noexec
-  - id: 4509 
+  - id: 4509
     title: "Ensure noexec option set on /dev/shm partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
@@ -218,7 +218,7 @@ checks:
       - 'c:mount -> r:\s/dev/shm\s && r:noexec'
 
 # 1.1.8 /dev/shm: nodev
-  - id: 4510 
+  - id: 4510
     title: "Ensure nodev option set on /dev/shm partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
@@ -235,7 +235,7 @@ checks:
 
 
 # 1.1.9 /dev/shm: nosuid
-  - id: 4511 
+  - id: 4511
     title: "Ensure nosuid option set on /dev/shm partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
@@ -253,7 +253,7 @@ checks:
 
 
 # 1.1.10 Build considerations - Partition scheme.
-  - id: 4512 
+  - id: 4512
     title: "Ensure separate partition exists for /var"
     description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
     rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
@@ -271,7 +271,7 @@ checks:
       - 'c:mount -> r:\s/var\s'
 
 # 1.1.11 bind mount /var/tmp to /tmp
-  - id: 4513 
+  - id: 4513
     title: "Ensure separate partition exists for /var/tmp"
     description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications and is intended for temporary files that are preserved across reboots."
     rationale: "Since the /var/tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own file system allows an administrator to set the noexec option on the mount, making /var/tmp useless for an attacker to install executable code."
@@ -287,7 +287,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s'
 
 # 1.1.12 noexec set on /var/tmp
-  - id: 4514 
+  - id: 4514
     title: "Ensure noexec option set on /var/tmp partition"
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
@@ -303,7 +303,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s && r:noexec'
 
 # 1.1.13 nodev set on /var/tmp
-  - id: 4515 
+  - id: 4515
     title: "Ensure nodev option set on /var/tmp partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /var/tmp ."
@@ -319,7 +319,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s && r:nodev'
 
 # 1.1.14 nosuid set on /var/tmp
-  - id: 4516 
+  - id: 4516
     title: "Ensure nosuid option set on /var/tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
@@ -336,7 +336,7 @@ checks:
 
 
 # 1.1.15 /var/log: partition
-  - id: 4517 
+  - id: 4517
     title: "Ensure separate partition exists for /var/log"
     description: "The /var/log directory is used by system services to store log data ."
     rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
@@ -354,7 +354,7 @@ checks:
       - 'c:mount -> r:\s/var/log\s'
 
 # 1.1.16 /var/log/audit: partition
-  - id: 4518 
+  - id: 4518
     title: "Ensure separate partition exists for /var/log/audit"
     description: "The auditing daemon, auditd, stores log data in the /var/log/audit directory."
     rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data."
@@ -372,7 +372,7 @@ checks:
       - 'c:mount -> r:\s/var/log/audit\s'
 
 # 1.1.17 /home: partition
-  - id: 4519 
+  - id: 4519
     title: "Ensure separate partition exists for /home"
     description: "The /home directory is used to support disk storage needs of local users."
     rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
@@ -393,7 +393,7 @@ checks:
 
 
 # 1.1.18 /home: nodev
-  - id: 4520 
+  - id: 4520
     title: "Ensure nodev option set on /home partition"
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
@@ -413,7 +413,7 @@ checks:
 
 
 # 1.1.23 Disable Automounting
-  - id: 4521 
+  - id: 4521
     title: "Disable Automounting"
     description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
     rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
@@ -429,7 +429,7 @@ checks:
       - 'c:systemctl is-enabled autofs -> r:enabled'
 
 # 1.1.24 Disable USB Storage
-  - id: 4522 
+  - id: 4522
     title: "Disable USB Storage"
     description: "USB storage provides a means to transfer and store files insuring persistence and availability of the files independent of network connection status. Its popularity and utility has led to USB-based malware being a simple and common means for network infiltration and a first step to establishing a persistent threat within a networked environment."
     rationale: "Restricting USB access on the system will decrease the physical attack surface for a device and diminish the possible vectors to introduce malware."
@@ -451,7 +451,7 @@ checks:
 ###############################################
 
 # 1.2.3 Activate gpgcheck
-  - id: 4523 
+  - id: 4523
     title: "Ensure gpgcheck is globally activated"
     description: "The gpgcheck option, found in the main section of the /etc/yum.conf and individual /etc/yum/repos.d/* files determines if an RPM package's signature is checked prior to its installation."
     rationale: "It is important to ensure that an RPM's package signature is always checked prior to installation to ensure that the software is obtained from a trusted source."
@@ -464,7 +464,7 @@ checks:
       - gpg_13: ["4.3"]
       - gdpr_IV: ["35.7.d"]
       - hipaa: ["164.312.b"]
-      - tsc: ["A1.2","CC6.8"]      
+      - tsc: ["A1.2","CC6.8"]
     condition: all
     rules:
       - 'f:/etc/yum.conf -> r:gpgcheck=1'
@@ -472,7 +472,7 @@ checks:
 
 
 # 1.2.5 Disable the rhnsd Daemon (Not Scored)
-  - id: 4524 
+  - id: 4524
     title: "Disable the rhnsd Daemon"
     description: "The rhnsd daemon polls the Red Hat Network web site for scheduled actions and, if there are, executes those actions."
     rationale: "Patch management policies may require that organizations test the impact of a patch before it is deployed in a production environment. Having patches automatically deployed could have a negative impact on the environment. It is best to not allow an action by default but only after appropriate consideration has been made. It is recommended that the service be disabled unless the risk is understood and accepted or you are running your own satellite . This item is not scored because organizations may have addressed the risk."
@@ -491,7 +491,7 @@ checks:
 ###############################################
 
 # 1.3.1 install sudo
-  - id: 4525 
+  - id: 4525
     title: "Ensure sudo is installed"
     description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy."
     rationale: "sudo supports a plugin architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plugins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
@@ -509,7 +509,7 @@ checks:
 
 
 # 1.3.2 Configure sudo
-  - id: 4526 
+  - id: 4526
     title: "Ensure sudo commands use pty"
     description: "sudo can be configured to run only from a pseudo-pty"
     rationale: "Attackers can run a malicious program using sudo, which would again fork a background process that remains even when the main program has finished executing. This can be mitigated by configuring sudo to run other commands only from a pseudo-pty, whether I/O logging is turned on or not."
@@ -527,7 +527,7 @@ checks:
       - 'd:/etc/sudoers.d/ -> r:\. -> r:^\s*Defaults\s*\t*\s*use_pty'
 
 # 1.3.3 Ensure sudo log file exists
-  - id: 4527 
+  - id: 4527
     title: "Ensure sudo log file exists"
     description: "sudo can use a custom log file"
     rationale: "A sudo log file simplifies auditing of sudo commands"
@@ -549,7 +549,7 @@ checks:
 ###############################################
 
 # 1.4.1 install AIDE
-  - id: 4528 
+  - id: 4528
     title: "Ensure AIDE is installed"
     description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
     rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
@@ -565,7 +565,7 @@ checks:
       - 'c:rpm -q aide -> r:aide-\S*'
 
 # 1.4.2 AIDE regular checks
-  - id: 4529 
+  - id: 4529
     title: "Ensure filesystem integrity is regularly checked"
     description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
     rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
@@ -588,7 +588,7 @@ checks:
 ###############################################
 
 # 1.5.1 Set Boot Loader Password (Scored)
-  - id: 4530 
+  - id: 4530
     title: "Ensure bootloader password is set"
     description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
     rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
@@ -607,7 +607,7 @@ checks:
 
 
 # 1.5.2 Configure bootloader
-  - id: 4531 
+  - id: 4531
     title: "Ensure permissions on bootloader config are configured"
     description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options. The grub configuration is usually located at /boot/grub2/grub.cfg and linked as /etc/grub2.cfg .  On newer grub2 systems the encrypted bootloader password is contained in /boot/grub2/user.cfg"
     rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
@@ -624,7 +624,7 @@ checks:
       - 'c:stat /boot/grub2/user.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|cannot stat'
 
 # 1.5.3 Single user authentication
-  - id: 4532 
+  - id: 4532
     title: "Ensure authentication required for single user mode"
     description: "Single user mode (rescue mode) is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
     rationale: "Requiring authentication in single user mode (rescue mode) prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
@@ -644,7 +644,7 @@ checks:
 # 1.6 Additional Process Hardening
 ###############################################
 # 1.6.1 Restrict Core Dumps (Scored)
-  - id: 4533 
+  - id: 4533
     title: "Ensure core dumps are restricted"
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file."
     rationale: "Setting a hard limit on core dumps prevents users from overriding the soft variable. If core dumps are required, consider setting limits for user groups (see limits.conf). In addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from dumping core."
@@ -662,7 +662,7 @@ checks:
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
 # 1.6.2 XD/NX enabled
-  - id: 4534 
+  - id: 4534
     title: "Ensure XD/NX support is enabled"
     description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
     rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
@@ -679,7 +679,7 @@ checks:
       - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
 
 # 1.6.3 Enable Randomized Virtual Memory Region Placement (Scored)
-  - id: 4535 
+  - id: 4535
     title: "Ensure address space layout randomization (ASLR) is enabled"
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
     rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
@@ -696,7 +696,7 @@ checks:
       - 'c:sysctl kernel.randomize_va_space -> r:^\s*kernel.randomize_va_space\s*=\s*2'
 
 # 1.6.4 Disable prelink
-  - id: 4536 
+  - id: 4536
     title: "Ensure prelink is disabled"
     description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
     rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
@@ -716,7 +716,7 @@ checks:
 ###############################################
 
 # 1.7.1.1 Install SELinux
-  - id: 4537 
+  - id: 4537
     title: "Ensure SELinux is installed"
     description: "SELinux provides Mandatory Access Controls."
     rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
@@ -733,7 +733,7 @@ checks:
 
 
 # 1.7.1.2 SELinux not disabled
-  - id: 4538 
+  - id: 4538
     title: "Ensure SELinux is not disabled in bootloader configuration"
     description: "Configure SELINUX to be enabled at boot time and verify that it has not been overwritten by the grub boot parameters."
     rationale: "SELinux must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
@@ -751,7 +751,7 @@ checks:
 
 
 # 1.7.1.3 Set selinux policy
-  - id: 4539 
+  - id: 4539
     title: "Ensure SELinux policy is configured"
     description: "Configure SELinux to meet or exceed the default targeted policy, which constrains daemons and system software only."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that at least the default recommendations are met."
@@ -770,7 +770,7 @@ checks:
 
 
 # 1.7.1.4 Set selinux mode
-  - id: 4540 
+  - id: 4540
     title: "Ensure the SELinux mode is enforcing or permissive"
     description: "SELinux can run in one of three modes: disabled, permissive, or enforcing:  Enforcing - Is the default, and recommended, mode of operation; in enforcing mode SELinux operates normally, enforcing the loaded security policy on the entire system.  Permissive - The system acts as if SELinux is enforcing the loaded security policy, including labeling objects and emitting access denial entries in the logs, but it does not actually deny any operations. While not recommended for production systems, permissive mode can be helpful for SELinux policy development.   Disabled -Is strongly discouraged; not only does the system avoid enforcing the SELinux policy, it also avoids labeling any persistent objects such as files, making it difficult to enable SELinux in the future"
     rationale: "Running SELinux in disabled modeis strongly discouraged; not only does the system avoid enforcing the SELinux policy, it also avoids labeling any persistent objects such as files, making it difficult to enable SELinux in the future."
@@ -788,7 +788,7 @@ checks:
 
 
 # 1.7.1.6 Ensure no unconfined services exist
-  - id: 4541 
+  - id: 4541
     title: "Ensure no unconfined services exist"
     description: "Unconfined processes run in unconfined domains"
     rationale: "For unconfined processes, SELinux policy rules are applied, but policy rules exist that allow processes running in unconfined domains almost all access. Processes running in unconfined domains fall back to using DAC rules exclusively. If an unconfined process is compromised, SELinux does not prevent an attacker from gaining access to system resources and data, but of course, DAC rules are still used. SELinux is a security enhancement on top of DAC rules – it does not replace them"
@@ -805,7 +805,7 @@ checks:
 
 
 # 1.7.1.7 Remove SETroubleshoot
-  - id: 4542 
+  - id: 4542
     title: "Ensure SETroubleshoot is not installed"
     description: "The SETroubleshoot service notifies desktop users of SELinux denials through a user-friendly interface. The service provides important information around configuration errors, unauthorized intrusions, and other potential errors."
     rationale: "The SETroubleshoot service is an unnecessary daemon to have running on a server, especially if X Windows is disabled."
@@ -822,7 +822,7 @@ checks:
 
 
 # 1.7.1.8 Disable MCS Translation service mcstrans
-  - id: 4543 
+  - id: 4543
     title: "Ensure the MCS Translation Service (mcstrans) is not installed"
     description: "The mcstransd daemon provides category label information to client processes requesting information. The label translations are defined in /etc/selinux/targeted/setrans.conf"
     rationale: "Since this service is not used very often, remove it to reduce the amount of potentially vulnerable code running on the system."
@@ -843,7 +843,7 @@ checks:
 # 1.8  Warning Banners
 ###############################################
 # 1.8.1.1 Configure message of the day (Scored)
-  - id: 4544 
+  - id: 4544
     title: "Ensure message of the day is configured properly"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -858,7 +858,7 @@ checks:
       - 'f:/etc/motd -> r:\\v|\\r|\\m|\\s'
 
 # 1.8.1.2 Configure local login warning banner (Not Scored)
-  - id: 4545 
+  - id: 4545
     title: "Ensure local login warning banner is configured properly"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version -or the operating system's name."
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -873,7 +873,7 @@ checks:
       - 'f:/etc/issue -> r:\\v|\\r|\\m|\\s'
 
 # 1.8.1.3 Configure remote login warning banner (Not Scored)
-  - id: 4546 
+  - id: 4546
     title: "Ensure remote login warning banner is configured properly"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version"
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the \" uname -a \" command once they have logged in."
@@ -888,7 +888,7 @@ checks:
       - 'f:/etc/issue.net -> r:\\v|\\r|\\m|\\s'
 
 # 1.8.1.4 Configure /etc/motd permissions (Not Scored)
-  - id: 4547 
+  - id: 4547
     title: "Ensure permissions on /etc/motd are configured"
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
     rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -907,7 +907,7 @@ checks:
       - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 1.8.1.5 Configure /etc/issue permissions (Scored)
-  - id: 4548 
+  - id: 4548
     title: "Ensure permissions on /etc/issue are configured"
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
     rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -925,7 +925,7 @@ checks:
     rules:
       - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 # 1.8.1.6 Configure /etc/issue.net permissions (Not Scored)
-  - id: 4549 
+  - id: 4549
     title: "Ensure permissions on /etc/issue.net are configured"
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
     rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -944,8 +944,8 @@ checks:
       - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 
-# 1.9 Ensure updates, patches, and additional security software are installed 
-  - id: 4550 
+# 1.9 Ensure updates, patches, and additional security software are installed
+  - id: 4550
     title: "Ensure updates, patches, and additional security software are installed"
     description: "Periodically patches are released for included software either due to security flaws or to include additional functionality."
     rationale: "Newer patches may contain security enhancements that would not be available through the latest full update. As a result, it is recommended that the latest software patches be used to take advantage of the latest functionality. As with any software installation, organizations need to determine if a given update meets their requirements and verify the compatibility and supportability of any additional software against the update revision that is selected."
@@ -965,7 +965,7 @@ checks:
 
 
 # 1.10 Ensure GDM login banner is configured (Scored)
-  - id: 4551 
+  - id: 4551
     title: "Ensure GDM login banner is configured"
     description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems."
     rationale: "If a graphical login is not required, it should be removed to reduce the attack surface of the system. If a graphical login is required, last logged in user display should be disabled, and a warning banner should be configured. Displaying the last logged in user eliminates half of the Userid/Password equation that an unauthorized person would need to log on. Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place."
@@ -997,7 +997,7 @@ checks:
 
 
 # 2.1.2 Ensure xinetd is not installed (Automated)
-  - id: 4552 
+  - id: 4552
     title: "Ensure daytime services are not enabled"
     description: "The eXtended InterNET Daemon ( xinetd ) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no xinetd services required, it is recommended that the package be removed to reduce the attack surface area of the system. Note: If an xinetd service or services are required, ensure that any xinetd service not required is stopped and disabled"
@@ -1022,7 +1022,7 @@ checks:
 
 
 # 2.2.1.1 Ensure time synchronization is in use (Manual)
-  - id: 4553 
+  - id: 4553
     title: "Ensure time synchronization is in use"
     description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them."
     rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
@@ -1039,7 +1039,7 @@ checks:
       - 'not c:rpm -q chrony -> r:^package chrony is not installed'
 
 # 2.2.1.2  Ensure chrony is configured (Automated)
-  - id: 4554 
+  - id: 4554
     title: "Ensure chrony is configured"
     description: "chrony is a daemon which implements the Network Time Protocol (NTP) and is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on chrony can be found at http://chrony.tuxfamily.org/. chrony can be configured to be a client and/or a server."
     rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly. Note: This recommendation only applies if chrony is in use on the system."
@@ -1056,7 +1056,7 @@ checks:
       - 'f:/etc/sysconfig/chronyd -> r:^OPTIONS\s*=\s* && r:-u chrony'
 
 # 2.2.1.3  Ensure ntp is configured (Automated)
-  - id: 4555 
+  - id: 4555
     title: "Ensure ntp is configured"
     description: "ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on NTP can be found at https://www.ntp.org. ntp can be configured to be a client and/or a server."
     rationale: "If ntp is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
@@ -1076,7 +1076,7 @@ checks:
       - 'f:/usr/lib/systemd/system/ntpd.service -> r:^Execstart\s*=\s*/usr/sbin/ntpd\s+-u\s+ntp:ntp'
 
 # 2.2.2 Remove X Windows (Scored)
-  - id: 4556 
+  - id: 4556
     title: " Ensure X11 Server components are not installed"
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
@@ -1092,7 +1092,7 @@ checks:
       - 'c:rpm -q xorg-x11-server* -> r:package xorg-x11 is not installed'
 
 # 2.2.3 Ensure Avahi Server is not installed (Automated)
-  - id: 4557 
+  - id: 4557
     title: " Ensure Avahi Server is not installed"
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
@@ -1109,7 +1109,7 @@ checks:
       - 'c:rpm -q avahi-> r:pacakge avahi is not installed'
 
 # 2.2.4 Ensure CUPS is not installed (Automated)
-  - id: 4558 
+  - id: 4558
     title: "Ensure CUPS is not installed"
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface. Disabling CUPS will prevent printing from the system, a common task for workstation systems."
@@ -1125,7 +1125,7 @@ checks:
       - 'c:rpm -q cups-> r:package cups is not installed'
 
 # 2.2.5 Ensure DHCP Server is not installed (Automated)
-  - id: 4559 
+  - id: 4559
     title: "Ensure DHCP Server is not installed"
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that this the dhcp package be removed to reduce the potential attack surface."
@@ -1143,7 +1143,7 @@ checks:
       - 'c:rpm -q dhcp-> r:package dhcp is not installed'
 
 # 2.2.6  Ensure LDAP server is not installed (Automated)
-  - id: 4560 
+  - id: 4560
     title: "Ensure LDAP Server is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
@@ -1163,7 +1163,7 @@ checks:
 
 
 # 2.2.7 Ensure nfs-utils is not installed or the nfs-server service is masked (Automated)
-  - id: 4561 
+  - id: 4561
     title: "Ensure nfs-utils is not installed or the nfs-server service is masked"
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not require network shares, it is recommended that the nfs-utils package be removed to reduce the attack surface of the system."
@@ -1180,7 +1180,7 @@ checks:
       - 'c:systemctl is-enabled nfs-server -> r:masked'
 
 # 2.2.8 Ensure rpcbind is not installed or the rpcbind services are masked (Automated)
-  - id: 4562 
+  - id: 4562
     title: "Ensure nfs-utils is not installed or the nfs-server service is masked"
     description: "The rpcbind utility maps RPC services to the ports on which they listen. RPC processes notify rpcbind when they start, registering the ports they are listening on and the RPC program numbers they expect to serve. The client system then contacts rpcbind on the server with a particular RPC program number. The rpcbind service redirects the client to the proper port number so it can communicate with the requested service Portmapper is an RPC service, which always listens on tcp and udp 111, and is used to map other RPC services (such as nfs, nlockmgr, quotad, mountd, etc.) to their corresponding port number on the server. When a remote host makes an RPC call to that server, it first consults with portmap to determine where the RPC server is listening"
     rationale: "A small request (~82 bytes via UDP) sent to the Portmapper generates a large response (7x to 28x amplification), which makes it a suitable tool for DDoS attacks. If rpcbind is not required, it is recommended that the rpcbind package be removed to reduce the attack surface of the system."
@@ -1199,7 +1199,7 @@ checks:
 
 
 # 2.2.9 Ensure DNS Server is not installed (Automate)
-  - id: 4563 
+  - id: 4563
     title: " Ensure DNS Server is not installed "
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be removed to reduce the potential attack surface."
@@ -1215,7 +1215,7 @@ checks:
       - 'c:rpm -q bind-> r:package bind is not installed'
 
 # 2.2.10 Ensure FTP Server is not installed (Automated)
-  - id: 4564 
+  - id: 4564
     title: "Ensure FTP Server is not installed"
     description: "FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring files between a server and clients over a network, especially where no authentication is necessary (permits anonymous users to connect to a server)"
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended sftp be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be removed to reduce the potential attack surface."
@@ -1231,7 +1231,7 @@ checks:
       - 'c:rpm -q vsftpd-> r:package vsftpd is not installed'
 
 # 2.2.11 Ensure HTTP server is not installed (Automated)
-  - id: 4565 
+  - id: 4565
     title: "Ensure HTTP server is not installed"
     description: "HTTP or web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be removed to reduce the potential attack surface."
@@ -1247,7 +1247,7 @@ checks:
       - 'c:rpm -q httpd-> r:package httpd is not installed'
 
 # 2.2.12 Ensure IMAP and POP3 server is not installed (Automated)
-  - id: 4566 
+  - id: 4566
     title: "Ensure IMAP and POP3 server is not installed"
     description: "dovecot is an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface."
@@ -1263,7 +1263,7 @@ checks:
       - 'c:rpm -q dovecot-> r:package dovecot is not installed'
 
 # 2.2.13 Ensure Samba is not installed (Automated)
-  - id: 4567 
+  - id: 4567
     title: "Ensure Samba is not installed"
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Small Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this package can be removed to reduce the potential attack surface."
@@ -1279,7 +1279,7 @@ checks:
       - 'c:rpm -q samba-> r:package samba is not installed'
 
 # 2.2.14 Ensure HTTP Proxy Server is not installed (Automated)
-  - id: 4568 
+  - id: 4568
     title: "Ensure HTTP Proxy Server is not installed"
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "If there is no need for a proxy server, it is recommended that the squid package be removed to reduce the potential attack surface."
@@ -1295,7 +1295,7 @@ checks:
       - 'c:rpm -q squid-> r:package squid is not installed'
 
 # 2.2.15 Ensure net-snmp is not installed (Automated)
-  - id: 4569 
+  - id: 4569
     title: "Ensure SNMP Server is not installed"
     description: "The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system."
     rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3replaces the simple/clear text password sharing used in SNMPv2with more securely encoded parameters. If the SNMP service is not required, the net-snmp package should be removed to reduce the attack surface of the system."
@@ -1311,7 +1311,7 @@ checks:
       - 'c:rpm -q net-snmp-> r:package net-snmp is not installed'
 
 # 2.2.16 Ensure mail transfer agent is configured for local-only mode (Automated)
-  - id: 4570 
+  - id: 4570
     title: "Ensure mail transfer agent is configured for local-only mode"
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems."
@@ -1327,7 +1327,7 @@ checks:
       - 'c:ss -lntu -> r:\.*:25\s* && !r:127.0.0.1:25\.*|::1:25\.*'
 
 # 2.2.17 Ensure rsync is not installed or the  ervice is masked (Automated)
-  - id: 4571 
+  - id: 4571
     title: "Ensure rsync is not installed or the rsyncd service is masked"
     description: "The rsyncd service can be used to synchronize files between systems over network links."
     rationale: "Unless required, the rsync package should be removed to reduce the attack surface area of the system. The rsyncd service presents a security risk as it uses unencrypted protocols for communication."
@@ -1344,7 +1344,7 @@ checks:
       - 'c:systemctl is-enabled rsyncd-> r:masked'
 
   # 2.2.18 Ensure NIS server is not installed (Automated)
-  - id: 4572 
+  - id: 4572
     title: "Ensure NIS Server is not installed"
     description: "The ypserv package provides the Network Information Service (NIS). This service, formally known as Yellow Pages, is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the ypservpackage be removed, and if required a more secure services be used."
@@ -1364,7 +1364,7 @@ checks:
 
 
 # 2.2.19 Ensure telnet-server is not installed (Automated)
-  - id: 4573 
+  - id: 4573
     title: "Ensure telnet server is not installed"
     description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
@@ -1389,7 +1389,7 @@ checks:
 ###############################################
 
 # 2.3.1 Ensure NIS Client is not installed (Automated)
-  - id: 4574 
+  - id: 4574
     title: "Ensure NIS Client is not installed"
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client ( ypbind ) was used to bind a machine to an NIS server and receive the distributed configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
@@ -1408,7 +1408,7 @@ checks:
       - 'c:rpm -q ypbind -> r:package ypbind is not installed'
 
 # 2.3.2 Ensure rsh client is not installed (Automated)
-  - id: 4575 
+  - id: 4575
     title: "Ensure rsh client is not installed"
     description: "The rsh package contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh, rcp and rlogin ."
@@ -1427,7 +1427,7 @@ checks:
       - 'c:rpm -q rsh -> r:^package rsh is not installed'
 
 # 2.3.3 Ensure talk client is not installed (Automated)
-  - id: 4576 
+  - id: 4576
     title: "Ensure talk client is not installed"
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -1446,7 +1446,7 @@ checks:
       - 'c:rpm -q talk -> r:^package talk is not installed'
 
 # 2.3.4 Ensure telnet client is not installed (Automated)
-  - id: 4577 
+  - id: 4577
     title: "Ensure telnet client is not installed"
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
@@ -1465,7 +1465,7 @@ checks:
       - 'c:rpm -q telnet -> r:^package telnet is not installed'
 
 # 2.3.5 Ensure LDAP client is not installed (Automated)
-  - id: 4578 
+  - id: 4578
     title: "Ensure LDAP client is not installed"
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
@@ -1484,7 +1484,7 @@ checks:
       - 'c:rpm -q openldap-clients -> r:^package openldap-clients is not installed'
 
 # 2.5 Ensure nonessential services are removed or masked (Manual)
-  - id: 4579 
+  - id: 4579
     title: "Ensure nonessential services are removed or masked"
     description: "A network port is identified by its number, the associated IP address, and the type of the communication protocol such as TCP or UDP.A listening port is a network port on which an application or process listens on, acting as a communication endpoint. Each listening port can be open or closed (filtered) using a firewall. In general terms, an open port is a network port that accepts incoming packets from remote locations"
     rationale: "Services listening on the system pose a potential risk as an attack vector. These services should be reviewed, and if not required, the service should be stopped, and the package containing the service should be removed. If required packages have a dependency, the service should be stopped and masked to reduce the attack surface of the system."
@@ -1510,7 +1510,7 @@ checks:
 ###############################################
 
 # 3.1.1 Disable IPv6 (Manual)
-  - id: 4580 
+  - id: 4580
     title: "Disable IPv6"
     description: "Although IPv6 has many advantages over IPv4, not all organizations have IPv6 or dual stack configurations implemented."
     rationale: "If IPv6 or dual stack is not to be used, it is recommended that IPv6be disabled to reduce the attack surface of the system."
@@ -1528,8 +1528,8 @@ checks:
       - 'c:sysctl net.ipv6.conf.default.disable_ipv6-> r:net.ipv6.conf.default.disable_ipv6\s*=\s*0'
 
 
-# 3.1.2 Ensure wireless interfaces are disabled (Manual) 
-  - id: 4581 
+# 3.1.2 Ensure wireless interfaces are disabled (Manual)
+  - id: 4581
     title: "Ensure wireless interfaces are disabled"
     description: "Wireless networking is used when wired networks are unavailable."
     rationale: "If wireless is not to be used, wireless devices should be disabled to reduce the potential attack surface"
@@ -1550,7 +1550,7 @@ checks:
 
 
 # 3.2.1 Ensure IP forwarding is disabled (Automated)
-  - id: 4582 
+  - id: 4582
     title: "Ensure IP forwarding is disabled"
     description: "The net.ipv4.ip_forward flag is used to tell the system whether it can forward packets or not."
     rationale: "Setting the flag to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router."
@@ -1570,7 +1570,7 @@ checks:
 
 
 # 3.2.2 Ensure packet redirect sending is disabled (Automated)
-  - id: 4583 
+  - id: 4583
     title: "Ensure packet redirect sending is disabled"
     description: "ICMP Redirects are used to send routing information to other hosts. As a host itself does not act as a router (in a host only configuration), there is no need to send redirects."
     rationale: "An attacker could use a compromised host to send invalid ICMP redirects to other router devices in an attempt to corrupt routing and have users access a system set up by the attacker as opposed to a valid system."
@@ -1593,7 +1593,7 @@ checks:
 ##################################################
 
 # 3.3.1 Ensure source routed packets are not accepted (Automated)
-  - id: 4584 
+  - id: 4584
     title: "Ensure source routed packets are not accepted"
     description: "In networking, source routing allows a sender to partially or fully specify the route packets take through a network. In contrast, non-source routed packets travel a path determined by routers in the network. In some cases, systems may not be routable or reachable from some locations (e.g. private addresses vs. Internet routable), and so source routed packets would need to be used."
     rationale: "Setting net.ipv4.conf.all.accept_source_route and net.ipv4.conf.default.accept_source_route to 0 disables the system from accepting source routed packets. Assume this system was capable of routing packets to Internet routable addresses on one interface and private addresses on another interface. Assume that the private addresses were not routable to the Internet routable addresses and vice versa. Under normal routing circumstances, an attacker from the Internet routable addresses could not use the system as a way to reach the private address systems. If, however, source routed packets were allowed, they could be used to gain access to the private address systems as the route could be specified, rather than rely on routing protocols that did not allow this routing."
@@ -1616,8 +1616,8 @@ checks:
       - 'c:grep -Rh net\.ipv6\.conf\.default\.accept_source_route /etc/sysctl.conf /etc/sysctl.d/* -> r:^net.ipv6.conf.default.accept_source_route\s*=\s*0'
 
 
-# 3.3.2 Ensure ICMP redirects are not accepted (Automated)  
-  - id: 4585 
+# 3.3.2 Ensure ICMP redirects are not accepted (Automated)
+  - id: 4585
     title: "Ensure ICMP redirects are not accepted"
     description: "ICMP redirect messages are packets that convey routing information and tell your host (acting as a router) to send packets via an alternate path. It is a way of allowing an outside routing device to update your system routing tables."
     rationale: "Attackers could use bogus ICMP redirect messages to maliciously alter the system routing tables and get them to send packets to incorrect networks and allow your system packets to be captured."
@@ -1638,7 +1638,7 @@ checks:
 
 
 # 3.3.3 Ensure secure ICMP redirects are not accepted (Automated)
-  - id: 4586 
+  - id: 4586
     title: "Ensure secure ICMP redirects are not accepted"
     description: "Secure ICMP redirects are the same as ICMP redirects, except they come from gateways listed on the default gateway list. It is assumed that these gateways are known to your system, and that they are likely to be secure."
     rationale: "It is still possible for even known gateways to be compromised. Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table updates by possibly compromised known gateways."
@@ -1657,7 +1657,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0'
 
 # 3.3.4 Ensure suspicious packets are logged (Automated)
-  - id: 4587 
+  - id: 4587
     title: "Ensure suspicious packets are logged"
     description: "When enabled, this feature logs packets with un-routable source addresses to the kernel log."
     rationale: "Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their system."
@@ -1676,7 +1676,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1'
 
 # 3.3.5 Ensure broadcast ICMP requests are ignored (Automated)
-  - id: 4588 
+  - id: 4588
     title: "Ensure broadcast ICMP requests are ignored"
     description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
     rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
@@ -1693,7 +1693,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1'
 
 # 3.3.6 Ensure bogus ICMP responses are ignored (Automated)
-  - id: 4589 
+  - id: 4589
     title: "Ensure bogus ICMP responses are ignored"
     description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
     rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
@@ -1710,7 +1710,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1'
 
 # 3.3.7 Ensure Reverse Path Filtering is enabled (Automated)
-  - id: 4590 
+  - id: 4590
     title: "Ensure Reverse Path Filtering is enabled"
     description: "Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if the packet was valid. Essentially, with reverse path filtering, if the return packet does not go out the same interface that the corresponding source packet came from, the packet is dropped (and logged if log_martians is set)."
     rationale: "Setting these flags is a good way to deter attackers from sending your server bogus packets that cannot be responded to. One instance where this feature breaks down is if asymmetrical routing is employed. This would occur when using dynamic routing protocols (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you will not be able to enable this feature without breaking the routing."
@@ -1729,7 +1729,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1'
 
 # 3.3.8 Ensure TCP SYN Cookies is enabled (Automated)
-  - id: 4591 
+  - id: 4591
     title: "Ensure TCP SYN Cookies is enabled"
     description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent."
     rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
@@ -1746,7 +1746,7 @@ checks:
       - 'c:grep -Rh net\.ipv4\.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.tcp_syncookies\s*=\s*1'
 
 # 3.3.9 Ensure IPv6 router advertisements are not accepted (Automated)
-  - id: 4592 
+  - id: 4592
     title: "Ensure IPv6 router advertisements are not accepted"
     description: "This setting disables the system's ability to accept IPv6 router advertisements."
     rationale: "It is recommended that systems not accept router advertisements as they could be tricked into routing traffic to compromised machines. Setting hard routes within the system (usually a single default route to a trusted router) protects the system from bad routes."
@@ -1773,7 +1773,7 @@ checks:
 # 3.4 Uncommon Network Protocols
 ###############################################
 # 3.4.1 Ensure DCCP is disabled (Automated)
-  - id: 4593 
+  - id: 4593
     title: "Ensure DCCP is disabled"
     description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery."
     rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
@@ -1795,7 +1795,7 @@ checks:
 
 
 # 3.4.2 Ensure SCTP is disabled (Automated)
-  - id: 4594 
+  - id: 4594
     title: "Ensure SCTP is disabled"
     description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1826,7 +1826,7 @@ checks:
 # 3.5.2.1 Ensure nftables is installed (Automated)
 # 3.5.3.1.1 Ensure iptables packages are installed (Automated)
 # 3 rules here:
-  - id: 4595 
+  - id: 4595
     title: "Ensure FirewallD or nftables or iptables-services is installed"
     description: "firewalld is a firewall management tool for Linux operating systems. It provides firewall features by acting as a front-end for the Linux kernel's net filter framework via the iptables backend or provides firewall features by acting as a front-end for the Linux kernel's netfilter framework via the nftables utility. FirewallD replaces iptables as the default firewall management tool. Use the firewalld utility to configure a firewall for less complex firewalls. The utility is easy to use and covers the typical use cases scenario. FirewallD supports both IPv4 and IPv6 networks and can administer separate firewall zones with varying degrees of trust as defined in zone profiles."
     rationale: "A firewall utility is required to configure the Linux kernel's netfilter framework via the iptables or nftables back-end. The Linux kernel's netfilter framework host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host."
@@ -1845,7 +1845,7 @@ checks:
 # 3.5.1.2 Ensure iptables-services package is not installed (Automated)
 # 3.5.3.1.3 Ensure firewalld is not installed or stopped and masked(Automated)
 # both of the rules are here
-  - id: 4596 
+  - id: 4596
     title: "Ensure iptables-services and FirewallD are not installed at the same time"
     description: "The iptables-services package contains the iptables.service and ip6tables.service. These services allow for management of the Host Based Firewall provided by the iptables package."
     rationale: "iptables.service and ip6tables.service are still supported and can be installed with the iptables-services package. Running both firewalld and the services included in the iptables-services package may lead to conflict."
@@ -1863,9 +1863,9 @@ checks:
 
 
 # 3.5.1.3 Ensure nftables is not installed or stopped and masked (Automated)
-# 3.5.2.2 Ensure firewalld is not installed or stopped and masked (Automated) 
+# 3.5.2.2 Ensure firewalld is not installed or stopped and masked (Automated)
 # Both of the rules are here
-  - id: 4597 
+  - id: 4597
     title: "Ensure nftables and FirewallD are not installed at the same time or ensure one of them is stopped and masked"
     description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables.Note: Support for using nftables as the back-end for firewalld was added in release v0.6.0. In Fedora 19 Linux derivatives, firewalld utilizes iptables as its back-end by default."
     rationale: "Running both firewalld and nftables may lead to conflict."
@@ -1883,7 +1883,7 @@ checks:
 # 3.5.3.1.2 Ensure nftables is not installed (Automated)
 # Both of the rules are here
 
-  - id: 4598 
+  - id: 4598
     title: "Ensure nftables and iptables-services are not installed at the same time or ensure one of them is stopped and masked"
     description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables.Note: Support for using nftables as the back-end for firewalld was added in release v0.6.0. In Fedora 19 Linux derivatives, firewalld utilizes iptables as its back-end by default."
     rationale: "Running both nftables and nftables may lead to conflict."
@@ -1902,7 +1902,7 @@ checks:
 
 
 # 3.5.1.4 Ensure firewalld service is enabled and running (Automated)
-  - id: 4599 
+  - id: 4599
     title: "Ensure firewalld service is enabled and running"
     description: "firewalld.serviceenables the enforcement of firewall rules configured through firewalld"
     rationale: "Ensure that the firewalld.service is enabled and running to enforce firewall rules configured through firewalld"
@@ -1923,7 +1923,7 @@ checks:
 ###############################################
 
 # 3.5.2.5 Ensure a table exists (Automated)
-  - id: 4600 
+  - id: 4600
     title: "Ensure a table exists"
     description: "nTables hold chains. Each table only has one address family and only applies to packets of this family. Tables can have one of five families."
     rationale: "nftables doesn't have any default tables. Without a table being build, nftables will not filter network traffic."
@@ -1938,7 +1938,7 @@ checks:
       - 'c:nft list tables-> r:table'
 
 # 3.5.2.6 Ensure base chains exist (Automated)
-  - id: 4601 
+  - id: 4601
     title: "Ensure base chains exist"
     description: "Chains are containers for rules. They exist in two kinds, base chains and regular chains. A base chain is an entry point for packets from the networking stack, a regular chain may be used as jump target and is used for better rule organization."
     rationale: "If a base chain doesn't exist with a hook for input, forward, and delete, packets that would flow through those chains will not be touched by nftables."
@@ -1955,7 +1955,7 @@ checks:
       - 'c:nft list ruleset-> r:type filter hook output priority 0'
 
 # 3.5.2.7 Ensure loopback traffic is configured (Automated)
-  - id: 4602 
+  - id: 4602
     title: "Ensure loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network"
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -1971,7 +1971,7 @@ checks:
       - 'c:nft list ruleset-> r:ip saddr 127.0.0.0/8 counter packets 0 bytes 0 drop'
 
 # 3.5.2.8 Ensure outbound and established connections are configured (Manual)
-  - id: 4603 
+  - id: 4603
     title: "Ensure outbound and established connections are configured"
     description: "Configure the firewall rules for new outbound and established connections."
     rationale: "If rules are not in place for new outbound and established connections, all packets will be dropped by the default policy preventing network usage."
@@ -1992,7 +1992,7 @@ checks:
 
 
 # 3.5.2.9 Ensure default deny firewall policy (Automated)
-  - id: 4604 
+  - id: 4604
     title: "Ensure default deny firewall policy"
     description: "Base chain policy is the default verdict that will be applied to packets reaching the end of the chain."
     rationale: "There are two policies: accept (Default) and drop. If the policy is set to accept, the firewall will accept any packet that is not configured to be denied and the packet will continue traversing the network stack. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -2009,7 +2009,7 @@ checks:
       - 'c:nft list ruleset-> r:type filter hook output priority 0; policy drop;'
 
 # 3.5.2.10 Ensure nftables service is enabled (Automated)
-  - id: 4605 
+  - id: 4605
     title: "Ensure nftables service is enabled"
     description: "The nftables service allows for the loading of nftables rulesets during boot, or starting on the nftables service"
     rationale: "The nftables service restores the nftables rules from the rules files referenced in the /etc/sysconfig/nftables.conffile during boot or the starting of the nftables service"
@@ -2023,10 +2023,10 @@ checks:
     rules:
       - 'c:systemctl is-enabled nftables-> r:enabled'
       - 'c:nft list ruleset-> r:type filter hook forward priority 0; policy drop;'
-      - 'c:nft list ruleset-> r:type filter hook output priority 0; policy drop;'   
+      - 'c:nft list ruleset-> r:type filter hook output priority 0; policy drop;'
 
 # 3.5.2.11 Ensure nftables rules are permanent (Automated)
-  - id: 4606 
+  - id: 4606
     title: "Ensure nftables rules are permanent"
     description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames. The nftables service reads the /etc/sysconfig/nftables.conffile for a nftables file or files to include in the nftables ruleset. A nftables ruleset containing the input, forward, and output base chains allow network traffic to be filtered."
     remediation: "Run the following command to enable the nftables service: # systemctl enable nftables"
@@ -2050,7 +2050,7 @@ checks:
 ###############################################
 
 # 3.5.3.2.1 Ensure default deny firewall policy (Automated)
-  - id: 4607 
+  - id: 4607
     title: "Ensure default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -2068,7 +2068,7 @@ checks:
 
 
 # 3.5.3.2.2 Ensure loopback traffic is configured (Automated)
-  - id: 4608 
+  - id: 4608
     title: "Ensure loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -2085,7 +2085,7 @@ checks:
       - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
 
 # 3.5.3.2.6 Ensure iptables is enabled and running (Automated)
-  - id: 4609 
+  - id: 4609
     title: "Ensure iptables is enabled and running"
     description: "iptables.service is a utility for configuring and maintaining iptables."
     rationale: "iptables.service willload the iptables rules saved in the file /etc/sysconfig/iptablesat boot, otherwise the iptables rules will be cleared during a re-boot of the system."
@@ -2105,7 +2105,7 @@ checks:
 ###############################################
 
 # 3.5.3.3.1 Ensure IPv6 default deny firewall policy (Automated)
-  - id: 4610 
+  - id: 4610
     title: "Ensure IPv6 default deny firewall policy"
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage."
@@ -2123,7 +2123,7 @@ checks:
 
 
 # 3.5.3.3.2 Ensure IPv6 loopback traffic is configured (Automated)
-  - id: 4611 
+  - id: 4611
     title: "Ensure IPv6 loopback traffic is configured"
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic tothe loopback network (::1)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (::1) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure"
@@ -2140,7 +2140,7 @@ checks:
       - 'c:ip6tables -L OUTPUT -v -n-> r:ACCEPT'
 
 # 3.5.3.3.3 Ensure IPv6 outbound and established connections are configured (Manual)
-  - id: 4612 
+  - id: 4612
     title: "Ensure IPv6 outbound and established connections are configured"
     description: "Configure the firewall rules for new outbound, and established IPv6 connections."
     rationale: "If rules are not in place for new outbound, and established connections all packets will be dropped by the default policy preventing network usage"
@@ -2157,7 +2157,7 @@ checks:
 
 
 # 3.5.3.3.6 Ensure ip6tables is enabled and running (Automated)
-  - id: 4613 
+  - id: 4613
     title: "Ensure ip6tables is enabled and running"
     description: "ip6tables.service is a utility for configuring and maintaining ip6tables."
     rationale: "ip6tables.service will load the iptables rules saved in the file /etc/sysconfig/ip6tables at boot, otherwise the ip6tables rules will be cleared during a re-boot of the system."
@@ -2182,7 +2182,7 @@ checks:
 ###############################################
 
 # 4.1.1.1 Ensure auditd is installed
-  - id: 4614 
+  - id: 4614
     title: "Ensure auditd is installed"
     description: "auditd is the userspace component to the Linux Auditing System. It's responsible for writing audit records to the disk."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -2198,7 +2198,7 @@ checks:
       - 'c:rpm -q audit-libs -> r:^audit-libs-\S+'
 
 # 4.1.1.2 Ensure auditd service is enabled (Scored)
-  - id: 4615 
+  - id: 4615
     title: "Ensure auditd service is enabled and running"
     description: "Turn on the auditd daemon to record system events."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -2215,7 +2215,7 @@ checks:
 
 
 # 4.1.1.3 Ensure auditing for processes that start prior to auditd is enabled (Scored)
-  - id: 4616 
+  - id: 4616
     title: "Ensure auditing for processes that start prior to auditd is enabled"
     description: "Configure grub so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
     rationale: "Audit events need to be captured on processes that start up prior to auditd, so that potential malicious activity cannot go undetected. Note: This recommendation is designed around the grub2 bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings."
@@ -2232,7 +2232,7 @@ checks:
       - 'f:/boot/grub2/grub.cfg -> r:^\s*\t*linux && !r:audit=1'
 
 # 4.1.2.1 Ensure audit log storage size is configured (Not Scored)
-  - id: 4617 
+  - id: 4617
     title: "Ensure audit log storage size is configured"
     description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
     rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
@@ -2246,7 +2246,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^max_log_file = \d+'
 
 # 4.1.2.2 Ensure audit logs are not automatically deleted (Scored)
-  - id: 4618 
+  - id: 4618
     title: "Ensure audit logs are not automatically deleted"
     description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
     rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
@@ -2260,7 +2260,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file_action\s*=\s*keep_logs'
 
 # 4.1.2.3 Ensure system is disabled when audit logs are full (Scored)
-  - id: 4619 
+  - id: 4619
     title: "Ensure system is disabled when audit logs are full"
     description: "The auditd daemon can be configured to halt the system when the audit logs are full."
     rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
@@ -2276,7 +2276,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*admin_space_left_action\s*=\s*halt'
 
 # 4.1.2.4 Ensure audit_backlog_limit is sufficient
-  - id: 4620 
+  - id: 4620
     title: "Ensure audit_backlog_limit is sufficient"
     description: "The backlog limit has a default setting of 64"
     rationale: "During boot if audit=1, then the backlog will hold 64 records. If more than 64 records are created during boot, auditd records will be lost and potential malicious activity could go undetected"
@@ -2290,9 +2290,9 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:audit_backlog_limit='
 
 
-      
+
 # 4.1.3 Ensure events that modify date and time information are collected (Scored)
-  - id: 4621 
+  - id: 4621
     title: "Ensure events that modify date and time information are collected"
     description: "Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier \"time-change\"."
     rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
@@ -2313,7 +2313,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/localtime && r:-p wa && r:-k time-change'
 
 # 4.1.4 Ensure events that modify user/group information are collected (Scored)
-  - id: 4622 
+  - id: 4622
     title: "Ensure events that modify user/group information are collected"
     description: "Record events affecting the group, passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier \"identity\" in the audit log file."
     rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
@@ -2336,7 +2336,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/security/opasswd && r:-p wa && r:-k identity'
 
 # 4.1.5 Ensure events that modify the system's network environment are collected (Scored)
-  - id: 4623 
+  - id: 4623
     title: "Ensure events that modify the system's network environment are collected"
     description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed pre-login), /etc/hosts (file containing host names and associated IP addresses), /etc/sysconfig/network file and /etc/sysconfig/network-scripts/ directory (containing network interface scripts and configurations)."
     rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/sysconfig/network and /etc/sysconfig/network-scripts/ is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier \"system-locale.\""
@@ -2360,7 +2360,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/sysconfig/network-scripts/ && r:-p wa && r:-k system-locale'
 
 # 4.1.6 Ensure events that modify the system's Mandatory Access Controls are collected (Scored)
-  - id: 4624 
+  - id: 4624
     title: "Ensure events that modify the system's Mandatory Access Controls are collected"
     description: "Monitor SELinux mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to  the /etc/selinux/ and /usr/share/selinux/ directories."
     rationale: "Changes to files in the /etc/selinux/ and /usr/share/selinux/ directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
@@ -2380,7 +2380,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /usr/share/selinux/ && r:-p wa && r:-k MAC-policy'
 
 # 4.1.7 Ensure login and logout events are collected (Scored)
-  - id: 4625 
+  - id: 4625
     title: "Ensure login and logout events are collected"
     description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. The file /var/log/faillog tracks failed events from login. The file /var/log/lastlog maintain records of the last time a user successfully logged in. The /var/run/faillock/ directory maintains records of login failures via the pam_faillock module. The file /var/log/tallylog maintains records of failures via the pam_tally2 module"
     rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
@@ -2400,7 +2400,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /var/run/faillog/ && r:-p wa && r:-k logins'
 
 # 4.1.8 Ensure session initiation information is collected (Scored)
-  - id: 4626 
+  - id: 4626
     title: "Ensure session initiation information is collected"
     description: "Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp file tracks all currently logged in users. All audit records will be tagged with the identifier \"session.\" The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp . All audit records will be tagged with the identifier \"logins.\"."
     rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
@@ -2417,7 +2417,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /var/log/btmp && r:-p wa && r:-k logins'
 
 # 4.1.9 Ensure discretionary access control permission modification events are collected (Scored)
-  - id: 4627 
+  - id: 4627
     title: "Ensure discretionary access control permission modification events are collected"
     description: "Monitor changes to file permissions, attributes, ownership and group. The parameters in this section track changes for system calls that affect file permissions and attributes. The chmod, fchmod and fchmodat system calls affect the permissions associated with a file. The chown, fchown, fchownat and lchown system calls affect owner and group attributes on a file. The setxattr, lsetxattr, fsetxattr (set extended file attributes) and removexattr, lremovexattr, fremovexattr (remove extended file attributes) control extended file attributes. In all cases, an audit record will only be written for non-system user ids (auid >= 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be tagged with the identifier \"perm_mod.\""
     rationale: "Monitoring for changes in file attributes could alert a system administrator to activity that could indicate intruder activity or policy violation."
@@ -2438,7 +2438,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S setxattr && r:-S lsetxattr && r:-S fsetxattr && r:-S removexattr && r:-S lremovexattr && r:-S fremovexattr && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k perm_mod'
 
 # 4.1.10 Ensure unsuccessful unauthorized file access attempts are collected (Scored)
-  - id: 4628 
+  - id: 4628
     title: "Ensure unsuccessful unauthorized file access attempts are collected"
     description: "Monitor for unsuccessful attempts to access files. The parameters below are associated  with system calls that control creation ( creat ), opening ( open, openat ) and truncation (  truncate, ftruncate ) of files. An audit log record will only be written if the user is a non-  privileged user (auid > = 1000), is not a Daemon event (auid=4294967295) and if the  system call returned EACCES (permission denied to the file) or EPERM (some other  permanent error associated with the specific system call). All audit records will be tagged  with the identifier \"access.\""
     rationale: "Failed attempts to open, create or truncate files could be an indication that an individual or process is trying to gain unauthorized access to the system."
@@ -2458,7 +2458,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S creat && r:-S open && r:-S openat && r:-S truncate && r:-S ftruncate && r:-F exit=-EPERM && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k access'
 
 # 4.1.12 Ensure successful file system mounts are collected (Scored)
-  - id: 4629 
+  - id: 4629
     title: "Ensure successful file system mounts are collected"
     description: "Monitor the use of the mount system call. The mount (and umount ) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user."
     rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open, creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
@@ -2478,7 +2478,7 @@ checks:
 
 
 # 4.1.13 Ensure file deletion events by users are collected (Scored)
-  - id: 4630 
+  - id: 4630
     title: "Ensure file deletion events by users are collected"
     description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for ollowing system calls and tags them with the identifier \"delete\": unlink -remove a file     unlinkat - remove a file attribute), rename (rename a file and renameat - rename a file attribute."
     rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
@@ -2493,7 +2493,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S unlink && r:-S unlinkat && r:-S rename && r:-S renameat && r:-F auid>=1000 && r:-F auid!=4294967295 && r:-k delete'
 
 # 4.1.14 Ensure changes to system administration scope (sudoers) is collected (Scored)
-  - id: 4631 
+  - id: 4631
     title: "Ensure changes to system administration scope (sudoers) is collected"
     description: "Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers or a file in the /etc/sudoers.d directory will be written to when the file or its attributes have changed."
     rationale: "Changes in the /etc/sudoers file, or a file in the /etc/sudoers.d/ directory can indicate that an unauthorized change has been made to scope of system administrator activity."
@@ -2513,7 +2513,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /etc/sudoers.d/ && r:-p wa && r:-k scope'
 
 # 4.1.15 Ensure system administrator actions (sudolog) are collected (Scored)
-  - id: 4632 
+  - id: 4632
     title: "Ensure system administrator actions (sudolog) are collected"
     description: "Monitor the sudo log file. The sudo log file is configured in /etc/sudoersor a file in /etc/sudoers.d. If the system has been properly configured to disable the use of the su command and force all administrators to have to log in first and then use sudo to execute privileged commands, then all administrator commands will be logged to the sudo log file. Any time a command is executed, an audit event will be triggered as the sudo log file will be opened for write and the executed administration command will be written to the log."
     rationale: "Changes in /var/log/sudo.log indicate that an administrator has executed a command or the log file itself has been tampered with. Administrators will want to correlate the events written to the audit trail with the records written to /var/log/sudo.log to verify if unauthorized commands have been executed."
@@ -2532,7 +2532,7 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /var/log/sudo.log && r:-p wa && r:-k actions'
 
 # 4.1.16 Ensure kernel module loading and unloading is collected (Scored)
-  - id: 4633 
+  - id: 4633
     title: "Ensure kernel module loading and unloading is collected"
     description: "Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of \"modules\"."
     rationale: "Monitoring the use of insmod, rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
@@ -2552,9 +2552,9 @@ checks:
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /sbin/rmmod && r:-p x && r:-k modules'
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:-w /sbin/modprobe && r:-p x && r:-k modules'
       - 'd:/etc/audit/rules.d/ -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b\d\d && r:-S init_module && r:-S delete_module && r:-k modules'
-      
+
 # 4.1.17 Ensure the audit configuration is immutable (Scored)
-  - id: 4634 
+  - id: 4634
     title: "Ensure the audit configuration is immutable"
     description: "Set system audit so that audit rules cannot be modified with auditctl . Setting the flag \"-e 2\" forces audit to be put in immutable mode. Audit changes can only be made on system reboot."
     rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
@@ -2575,7 +2575,7 @@ checks:
 
 
 # 4.2.1.1 Ensure rsyslog is installed (Scored)
-  - id: 4635 
+  - id: 4635
     title: "Ensure rsyslog is installed"
     description: "The rsyslog software is a recommended replacement to the original syslogd daemon. rsyslog provides improvements over syslogd, including:   - connection-oriented (i.e. TCP) transmission of logs     - The option to log to database formats    - Encryption of log data en route to a central logging server"
     rationale: "The security enhancements of rsyslog and syslog-ng such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
@@ -2591,7 +2591,7 @@ checks:
 
 
 # 4.2.1.2 Ensure rsyslog Service is enabled (Scored)
-  - id: 4636 
+  - id: 4636
     title: "Ensure rsyslog Service is enabled and running"
     description: "rsyslogneeds to be enabled and running to perform logging"
     rationale: "If the rsyslog service is not activated the system may default to the syslogd service or lackblogging instead."
@@ -2607,14 +2607,14 @@ checks:
       - 'c:systemctl status rsyslog -> r:active \(running\)'
 
 # 4.2.1.3 Ensure rsyslog default file permissions configured (Scored)
-  - id: 4637 
+  - id: 4637
     title: "Ensure rsyslog default file permissions configured"
     description: "rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
     remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to 0640 or more restrictive:   $FileCreateMode 0640"
     compliance:
       - cis: ["4.2.1.3"]
-      - cis_csc: ["5.1"]  
+      - cis_csc: ["5.1"]
       - pci_dss: ["10.5"]
       - tsc: ["CC6.1","CC7.2","CC7.3","CC7.4"]
     condition: all
@@ -2623,7 +2623,7 @@ checks:
       - 'd:/etc/rsyslog.d/ -> r:\.*.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
 
 # 4.2.1.5 Ensure rsyslog is configured to send logs to a remote log host (Scored)
-  - id: 4638 
+  - id: 4638
     title: "Ensure rsyslog is configured to send logs to a remote log host"
     description: "The rsyslog utility supports the ability to send logs it gathers to a remote log host running syslogd(8) or to receive messages from remote hosts, reducing administrative overhead."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2640,11 +2640,11 @@ checks:
 
 ###############################################
 # 4.2 Configure journald
-############################################### 
+###############################################
 
 
-# 4.2.2.1 Ensure journald is configured to send logs to rsyslog 
-  - id: 4639 
+# 4.2.2.1 Ensure journald is configured to send logs to rsyslog
+  - id: 4639
     title: "Ensure journald is configured to send logs to rsyslog "
     description: "Data from journald may be stored in volatile memory or persisted locally on the server. Utilities exist to accept remote export of journald logs, however, use of the rsyslog service provides a consistent means of log collection and export."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -2659,30 +2659,30 @@ checks:
       - 'f:/etc/systemd/journald.conf -> r:^\s*ForwardToSyslog\s*=\s*yes'
 
 # 4.2.2.2 Ensure journald is configured to compress large log files
-  - id: 4640 
+  - id: 4640
     title: "Ensure journald is configured to compress large log files"
     description: "The journald system includes the capability of compressing overly large files to avoid filling up the system with logs or making the logs unmanageably large."
     rationale: "Uncompressed large files may unexpectedly fill a filesystem leading to resource unavailability. Compressing logs prior to write can prevent sudden, unexpected filesystem impacts."
     remediation: "Edit the /etc/systemd/journald.conf file and add the following line: Compress=yes"
     compliance:
       - cis: ["4.2.2.2"]
-      - cis_csc: ["6.4"]    
-      - pci_dss: ["10.5"]  
+      - cis_csc: ["6.4"]
+      - pci_dss: ["10.5"]
       - tsc: ["CC6.1","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
       - 'f:/etc/systemd/journald.conf -> r:^\s*Compress\s*=\s*yes'
 
 # 4.2.2.3 Ensure journald is configured to write logfiles to persistent disk
-  - id: 4641 
+  - id: 4641
     title: "Ensure journald is configured to compress large log files"
     description: "Data from journald may be stored in volatile memory or persisted locally on the server. Logs in memory will be lost upon a system reboot. By persisting logs to local disk on the server they are protected from loss."
     rationale: "Writing log data to disk will provide the ability to forensically reconstruct events which may have impacted the operations or security of a system even after a system crash or reboot."
     remediation: "Edit the /etc/systemd/journald.conf file and add the following line: Storage=persistent"
     compliance:
       - cis: ["4.2.2.3"]
-      - cis_csc: ["6.2","6.3"]    
-      - pci_dss: ["10.5"]  
+      - cis_csc: ["6.2","6.3"]
+      - pci_dss: ["10.5"]
       - tsc: ["CC6.1","CC7.2","CC7.3","CC7.4"]
     condition: all
     rules:
@@ -2691,7 +2691,7 @@ checks:
 
 
   # 4.2.3 Ensure permissions on all logfiles are configured (Scored)
-  - id: 4642 
+  - id: 4642
     title: "Ensure permissions on all logfiles are configured"
     description: "Log files stored in /var/log/ contain logged information from many services on the system, or on log hosts others as well."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected.  Other/world should not have the ability to view this information. Group should not have the ability to modify this information."
@@ -2712,7 +2712,7 @@ checks:
 # 5.1 Configure time-based job schedulers
 ####################################################
 # 5.1.1 Ensure cron daemon is enabled and running (Automated)
-  - id: 4643 
+  - id: 4643
     title: "Ensure cron daemon is enabled"
     description: "The cron daemon is used to execute batch jobs on the system."
     rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
@@ -2730,7 +2730,7 @@ checks:
 
 
 # 5.1.2 Ensure permissions on /etc/crontab are configured (Automated)
-  - id: 4644 
+  - id: 4644
     title: "Ensure permissions on /etc/crontab are configured"
     description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
     rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
@@ -2747,7 +2747,7 @@ checks:
 
 
 # 5.1.3 Ensure permissions on /etc/cron.hourly are configured (Automated)
-  - id: 4645 
+  - id: 4645
     title: "Ensure permissions on /etc/cron.hourly are configured"
     description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2763,7 +2763,7 @@ checks:
       - 'c:stat /etc/cron.hourly -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.4 Ensure permissions on /etc/cron.daily are configured (Automated)
-  - id: 4646 
+  - id: 4646
     title: "Ensure permissions on /etc/cron.daily are configured"
     description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2779,7 +2779,7 @@ checks:
       - 'c:stat /etc/cron.daily -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Automated)
-  - id: 4647 
+  - id: 4647
     title: "Ensure permissions on /etc/cron.weekly are configured"
     description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2796,7 +2796,7 @@ checks:
 
 
 # 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Automated)
-  - id: 4648 
+  - id: 4648
     title: "Ensure permissions on /etc/cron.monthly are configured"
     description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2812,7 +2812,7 @@ checks:
       - 'c:stat /etc/cron.monthly -> r:^Access: \(0\w00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.7 Ensure permissions on /etc/cron.d are configured (Automated)
-  - id: 4649 
+  - id: 4649
     title: "Ensure permissions on /etc/cron.d are configured"
     description: "The /etc/cron.d/directory contains system cronjobs that need to run in a similar manner to the hourly, daily weekly and monthly jobs from /etc/crontab, but require more granular control as to when they run. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -2828,7 +2828,7 @@ checks:
       - 'c:stat /etc/cron.d -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.8 Ensure cron is restricted to authorized users (Scored)
-  - id: 4650 
+  - id: 4650
     title: "Ensure cron is restricted to authorized users"
     description: "If cronis installed in the system, configure /etc/cron.allowto allow specific users to use these services. If /etc/cron.allowdoes not exist, then /etc/cron.denyis checked. Any user not specifically defined in those files is allowed to use cron. By removing the file, only users in /etc/cron.alloware allowed to use cron."
     rationale: "On many systems, only the system administrator is authorized to schedule cronjobs. Using the cron.allowfile to control who can run cronjobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2846,7 +2846,7 @@ checks:
       - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 # 5.1.9 Ensure at is restricted to authorized users (Automated)
-  - id: 4651 
+  - id: 4651
     title: "Ensure at is restricted to authorized users"
     description: "If atis installed in the system, configure /etc/at.allowto allow specific users to use these services. If /etc/at.allowdoes not exist, then /etc/at.denyis checked. Any user not specifically defined in those files is allowed to use at. By removing the file, only users in /etc/at.alloware allowed to use at."
     rationale: "On many systems, only the system administrator is authorized to schedule atjobs. Using the at.allowfile to control who can run atjobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -2863,12 +2863,12 @@ checks:
       - 'c:stat /etc/at.allow -> r:^Access: \(0\d00/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
 
 
-      
+
 ###############################################
 # 5.2 Configure SSH Server
 ###############################################
 # 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured (Automated)
-  - id: 4652 
+  - id: 4652
     title: "Ensure permissions on /etc/ssh/sshd_config are configured"
     description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
     rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
@@ -2886,7 +2886,7 @@ checks:
 
 
 # 5.2.2 Ensure permissions on SSH private host key files are configured (Automated)
-  - id: 4653 
+  - id: 4653
     title: "Ensure permissions on SSH private host key files are configured"
     description: "An SSH private key is one of two files used in SSH public key authentication. In this authentication method, The possession of the private key is proof of identity. Only a private key that corresponds to a public key will be able to authenticate successfully. The private keys need to be stored and handled carefully, and no copies of the private key should be distributed."
     rationale: "If an unauthorized user obtains the private SSH host key file, the host could be impersonated"
@@ -2905,7 +2905,7 @@ checks:
 
 
 # 5.2.3 Ensure permissions on SSH public host key files are configured  (Automated)
-  - id: 4654 
+  - id: 4654
     title: "Ensure permissions on SSH private host key files are configured"
     description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
     rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
@@ -2921,11 +2921,11 @@ checks:
       - 'c:find /etc/ssh -xdev -type f -name "ssh_host_rsa_key.pub" -exec stat {} \;->^Access: \(0\d444/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
       - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ecdsa_key.pub" -exec stat {} \;->^Access: \(0\d44/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
       - 'c:find /etc/ssh -xdev -type f -name "ssh_host_ed25519_key.pub" -exec stat {} \;->^Access: \(0\d44/\w\w\w\w------\)  Uid: \(    0/    root\)   Gid: \(    0/    root\)$'
-      
-   
-    
+
+
+
 # 5.2.4 Ensure SSH access is limited (Scored)
-  - id: 4655 
+  - id: 4655
     title: "Ensure SSH access is limited"
     description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: AllowUsers The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. AllowGroups The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable. DenyUsers The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. DenyGroups The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
     rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
@@ -2943,7 +2943,7 @@ checks:
       - 'f:$sshd_file -> r:^\s*DenyGroups'
 
 # 5.2.5 Ensure SSH LogLevel is appropriate (Automated)
-  - id: 4656 
+  - id: 4656
     title: "Ensure SSH LogLevel is appropriate"
     description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field.VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
     rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
@@ -2962,7 +2962,7 @@ checks:
 
 
 # 5.2.6 Ensure SSH X11 forwarding is disabled (Automated)
-  - id: 4657 
+  - id: 4657
     title: "Ensure SSH X11 forwarding is disabled"
     description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
     rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
@@ -2980,7 +2980,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> r:^\s*X11Forwarding\s*\t*no'
 
 # 5.2.7 Ensure SSH MaxAuthTries is set to 4 or less (Automated)
-  - id: 4658 
+  - id: 4658
     title: "Ensure SSH MaxAuthTries is set to 4 or less"
     description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
     rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
@@ -2998,7 +2998,7 @@ checks:
 
 
 # 5.2.8 Ensure SSH IgnoreRhosts is enabled (Automated)
-  - id: 4659 
+  - id: 4659
     title: "Ensure SSH IgnoreRhosts is enabled"
     description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
     rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
@@ -3015,7 +3015,7 @@ checks:
       - 'f:$sshd_file -> !r:^# && r:IgnoreRhosts\s*\t*yes'
 
 # 5.2.9 Ensure SSH HostbasedAuthentication is disabled (Automated)
-  - id: 4660 
+  - id: 4660
     title: "Ensure SSH HostbasedAuthentication is disabled"
     description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
     rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
@@ -3032,7 +3032,7 @@ checks:
       - 'f:$sshd_file -> !r:^# && r:HostbasedAuthentication\s*\t*no'
 
 # 5.2.10 Ensure SSH root login is disabled (Automated)
-  - id: 4661 
+  - id: 4661
     title: "Ensure SSH root login is disabled"
     description: "The PermitRootLogin parameter specifies if the root user can log in using ssh. The default is no."
     rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su . This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
@@ -3049,7 +3049,7 @@ checks:
       - 'f:$sshd_file -> !r:^# && r:PermitRootLogin\s*\t*no'
 
 # 5.2.11 Ensure SSH PermitEmptyPasswords is disabled (Automated)
-  - id: 4662 
+  - id: 4662
     title: "Ensure SSH PermitEmptyPasswords is disabled"
     description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
     rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
@@ -3066,7 +3066,7 @@ checks:
       - 'f:$sshd_file -> !r:^# && r:PermitEmptyPasswords\s*\t*no'
 
 # 5.2.12 Ensure SSH PermitUserEnvironment is disabled (Automated)
-  - id: 4663 
+  - id: 4663
     title: "Ensure SSH PermitUserEnvironment is disabled"
     description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
     rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing trojan'd programs)"
@@ -3083,7 +3083,7 @@ checks:
       - 'f:$sshd_file -> r:^\s*PermitUserEnvironment\s*\t*no'
 
 # 5.2.13 Ensure only strong Ciphers are used (Automated)
-  - id: 4664 
+  - id: 4664
     title: "Ensure SSH Idle Timeout Interval is configured"
     description: "This variable limits the ciphers that SSH can use during communication."
     rationale: "Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised.: The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain cleartext data via a birthday attack against a long-duration encrypted session, aka a 'Sweet32' attack; The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly combine state data with key data during the initialization phase, which makes it easier for remote attackers to conduct plaintext-recovery attacks against the initial bytes of a stream by sniffing network traffic that occasionally relies on keys affected by the Invariance Weakness, and then using a brute-force approach involvingLSB values, aka the 'Bar Mitzvah' issue; The passwords used during an SSH session encrypted with RC4 can be recovered by an attacker who is able to capture and replay the session; Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plaintext data from an arbitrary block of ciphertext in an SSH session via unknown vectors; The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher is used, does not properly initialize memory for a MAC context data structure, which allows remote authenticated users to bypass intended ForceCommand and login-shell restrictions via packet data that provides a crafted callback address"
@@ -3094,12 +3094,12 @@ checks:
       - pci_dss: ["12.3.8"]
     condition: none
     rules:
-      - 'c:sshd -T -> r:ciphers && r:3des-cbc|aes192-cbc|aes256-cbc|arcfour|blowfish-cbc|cast128-cbc|rijndael-cbc@lysator.liu.se'      
+      - 'c:sshd -T -> r:ciphers && r:3des-cbc|aes192-cbc|aes256-cbc|arcfour|blowfish-cbc|cast128-cbc|rijndael-cbc@lysator.liu.se'
 
 
 
 # 5.2.14 Ensure only strong MAC algorithms are used (Automated)
-  - id: 4665 
+  - id: 4665
     title: "Ensure only strong MAC algorithms are used"
     description: "This variable limits the types of MAC algorithms that SSH can use during communication."
     rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information"
@@ -3110,11 +3110,11 @@ checks:
       - pci_dss: ["12.3.8"]
     condition: none
     rules:
-      - 'c:sshd -T -> r:macs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|umac-128@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com'      
+      - 'c:sshd -T -> r:macs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|umac-128@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com'
 
 
 # 5.2.15 Ensure only strong Key Exchange algorithms are used (Automated)
-  - id: 4666 
+  - id: 4666
     title: "Ensure only strong Key Exchange algorithms are used"
     description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received"
     rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks"
@@ -3125,12 +3125,12 @@ checks:
       - pci_dss: ["12.3.8"]
     condition: none
     rules:
-      - 'c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1'      
+      - 'c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1'
 
 
 
 # 5.2.16 Ensure SSH Idle Timeout Interval is configured (Automated)
-  - id: 4667 
+  - id: 4667
     title: "Ensure SSH Idle Timeout Interval is configured"
     description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the ClientAliveCountMax variable is set, sshd will send client alive messages at every ClientAliveInterval interval. When the number of consecutive client alive messages are sent with no response from the client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
     rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent."
@@ -3147,7 +3147,7 @@ checks:
       - 'f:$sshd_file -> n:^\s*ClientAliveCountMax\s*\t*(\d+) compare >= 1'
 
 # 5.2.17 Ensure SSH LoginGraceTime is set to one minute or less (Automated)
-  - id: 4668 
+  - id: 4668
     title: "Ensure SSH LoginGraceTime is set to one minute or less"
     description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
     rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
@@ -3164,7 +3164,7 @@ checks:
 
 
 # 5.2.18 Ensure SSH warning banner is configured (Automated)
-  - id: 4669 
+  - id: 4669
     title: "Ensure SSH warning banner is configured"
     description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
     rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
@@ -3181,7 +3181,7 @@ checks:
 
 
 # 5.2.19 Ensure SSH PAM is enabled (Automated)
-  - id: 4670 
+  - id: 4670
     title: "Ensure SSH PAM is enabled"
     description: "UsePAM Enables the Pluggable Authentication Module interface. If set to “yes” this will enable PAM authentication using ChallengeResponseAuthenticationand PasswordAuthentication in addition to PAM account and session module processing for all authentication types"
     rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server"
@@ -3198,7 +3198,7 @@ checks:
 
 
 # 5.2.20 Ensure SSH AllowTcpForwarding is disabled (Automated)
-  - id: 4671 
+  - id: 4671
     title: "Ensure SSH AllowTcpForwarding is disabled"
     description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines"
     rationale: "Leaving port forwarding enabled can expose the organization to security risks and back-doors.SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network"
@@ -3215,7 +3215,7 @@ checks:
 
 
 # 5.2.21 Ensure SSH MaxStartups is configured (Automated)
-  - id: 4672 
+  - id: 4672
     title: "Ensure SSH MaxStartups is configured"
     description: "The MaxStartupsparameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon"
     rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon"
@@ -3232,7 +3232,7 @@ checks:
 
 
 # 5.2.22 Ensure SSH MaxSessions is limited (Automated)
-  - id: 4673 
+  - id: 4673
     title: "Ensure SSH MaxSessions is limited"
     description: "The MaxSessionsparameter specifies the maximum number of open sessions permitted from a given connection."
     rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon"
@@ -3253,7 +3253,7 @@ checks:
 # 5.3 Configure PAM
 ###############################################
 # 5.3.1 Ensure password creation requirements are configured (Automated)
-  - id: 4674 
+  - id: 4674
     title: "Ensure password creation requirements are configured"
     description: "The pam_pwquality.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more"
     rationale: "Strong passwords protect systems from being hacked through brute force methods."
@@ -3271,7 +3271,7 @@ checks:
       - 'f:/etc/pam.d/system-auth -> n:try_first_pass retry=(\d+) compare <=3'
 
 # 5.3.3 Ensure password hashing algorithm is SHA-512 (Automated)
-  - id: 4675 
+  - id: 4675
     title: "Ensure password hashing algorithm is SHA-512"
     description: "The commands below change password encryption from md5 to sha512 (a much stronger hashing algorithm). All existing accounts will need to perform a password change to upgrade the stored hashes to the new algorithm."
     rationale: "The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note that these changes only apply to accounts configured on the local system."
@@ -3287,7 +3287,7 @@ checks:
       - 'f:/etc/pam.d/system-auth -> r:^password\s*sufficient\s*pam_unix.so\s*sha512'
 
 # 5.3.4 Ensure password reuse is limited (Automated)
-  - id: 4676 
+  - id: 4676
     title: "Ensure password reuse is limited"
     description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords."
     rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password. Note that these changes only apply to accounts configured on the local system."
@@ -3310,7 +3310,7 @@ checks:
 # 5.4.1 Set Shadow Password Suite Parameters
 ###############################################
 # 5.4.1.1 Ensure password expiration is 365 days or less (Automated)
-  - id: 4677 
+  - id: 4677
     title: "Ensure password expiration is 365 days or less"
     description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 365 days."
     rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity."
@@ -3326,7 +3326,7 @@ checks:
 
 
 # 5.4.1.2 Ensure minimum days between password changes is configured (Automated)
-  - id: 4678 
+  - id: 4678
     title: "Ensure minimum days between password changes is configured"
     description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 1 or more days."
     rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
@@ -3341,7 +3341,7 @@ checks:
       - 'f:/etc/login.defs -> n:^\s*PASS_MIN_DAYS\s*\t*(\d+) compare >= 1'
 
 # 5.4.1.3 Ensure password expiration warning days is 7 or more (Automated)
-  - id: 4679 
+  - id: 4679
     title: "Ensure minimum days between password changes is 7 or more"
     description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
     rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
@@ -3354,10 +3354,10 @@ checks:
     condition: all
     rules:
       - 'f:/etc/login.defs -> n:^\s*PASS_WARN_AGE\s*\t*(\d+) compare >= 7'
-    
+
 
 # 5.4.1.4 Ensure inactive password lock is 30 days or less (Automated)
-  - id: 4680 
+  - id: 4680
     title: "Ensure inactive password lock is 30 days or less"
     description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
     rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
@@ -3373,7 +3373,7 @@ checks:
 
 
 # 5.4.3 Ensure default group for the root account is GID 0 (Automated)
-  - id: 4681 
+  - id: 4681
     title: "Ensure default group for the root account is GID 0"
     description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
     rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
@@ -3389,7 +3389,7 @@ checks:
 
 
 # 5.4.4 Ensure default user shell timeout is configured (Automated)
-  - id: 4682 
+  - id: 4682
     title: " Ensure default user shell timeout is configured"
     description: "TMOUT is an environmental setting that determines the timeout of a shell in seconds."
     rationale: "Setting a timeout value reduces the window of opportunity for unauthorized user access to another user's shell session that has been left unattended. It also ends the inactive session and releases the resources associated with that session."
@@ -3406,7 +3406,7 @@ checks:
       - 'f:/etc/profile -> n:^\s*\t*TMOUT\s*\t*=\s*\t*(\d+) compare <= 900'
 
 # 5.4.5 Ensure default user umask is configured (Automated)
-  - id: 4683 
+  - id: 4683
     title: "Ensure default user umask is configured"
     description: "The user file-creation mode mask (umask) is use to determine the file permission for newly created directories and files. In Linux, the default permissions for any newly created directory is 0777 (rwxrwxrwx), and for any newly created file it is 0666 (rw-rw-rw-). The umask modifies the default Linux permissions by restricting (masking) these permissions. The umask is not simply subtracted, but is processed bitwise. Bits set in the umaskare cleared in the resulting file mode."
     rationale: "Setting a very secure default value for umask ensures that users make a conscious choice about their file permissions. A default umask setting of 077 causes files and directories created by users to not be readable by any other user on the system. A umask of 027 would make files and directories readable by users in the same Unix group, while a umask of 022 would make files readable by every user on the system."
@@ -3429,7 +3429,7 @@ checks:
 
 
 # 5.6 Ensure access to the su command is restricted (Automated)
-  - id: 4684 
+  - id: 4684
     title: "Ensure access to the su command is restricted."
     description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in the wheel group to execute su ."
     rationale: "Restricting the use of su, and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo, whereas su can only record that a user executed the su program."
@@ -3457,7 +3457,7 @@ checks:
 
 
 # 6.1.2 Configure /etc/passwd permissions (Automated)
-  - id: 4685 
+  - id: 4685
     title: "Ensure permissions on /etc/passwd are configured"
     description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
     rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3473,7 +3473,7 @@ checks:
       - 'c:stat /etc/passwd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.3 Ensure permissions on /etc/shadow are configured (Automated)
-  - id: 4686 
+  - id: 4686
     title: "Ensure permissions on /etc/shadow are configured"
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
@@ -3488,7 +3488,7 @@ checks:
       - 'c:stat /etc/shadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.4 Ensure permissions on /etc/group are configured (Automated)
-  - id: 4687 
+  - id: 4687
     title: "Ensure permissions on /etc/group are configured"
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
@@ -3504,7 +3504,7 @@ checks:
       - 'c:stat /etc/group -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.5 Ensure permissions on /etc/gshadow are configured (Automated)
-  - id: 4688 
+  - id: 4688
     title: "Ensure permissions on /etc/gshadow are configured"
     description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/gshadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/gshadow file (such as group administrators) could also be useful to subvert the group"
@@ -3520,7 +3520,7 @@ checks:
       - 'c:stat /etc/gshadow -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.6 Ensure permissions on /etc/passwd-are configured (Automated)
-  - id: 4689 
+  - id: 4689
     title: "Ensure permissions on /etc/passwd- are configured"
     description: "The /etc/passwd- file contains backup user account information."
     rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3536,7 +3536,7 @@ checks:
       - 'c:stat /etc/passwd- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.7 Ensure permissions on /etc/shadow-are configured (Automated)
-  - id: 4690 
+  - id: 4690
     title: "Ensure permissions on /etc/shadow- are configured"
     description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3552,7 +3552,7 @@ checks:
       - 'c:stat /etc/shadow- -> r:Access:\s*\(0000/----------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.8 Ensure permissions on /etc/group-are configured (Automated)
-  - id: 4691 
+  - id: 4691
     title: "Ensure permissions on /etc/group- are configured"
     description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
     rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3568,7 +3568,7 @@ checks:
       - 'c:stat /etc/group- -> r:Access:\s*\(0\d\d\d/-\w\w-\w--\w--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
 # 6.1.9 Ensure permissions on /etc/gshadow-are configured (Automated)
-  - id: 4692 
+  - id: 4692
     title: "Ensure permissions on /etc/gshadow- are configured"
     description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -3591,7 +3591,7 @@ checks:
 
 
 # 6.2.1 Ensure accounts in /etc/passwd use shadowed passwords (Automated)
-  - id: 4693 
+  - id: 4693
     title: "Ensure accounts in /etc/passwd use shadowed passwords"
     description: "Local accounts can uses shadowed passwords. With shadowed passwords, The passwords are saved in shadow password file, /etc/shadow, encrypted by a salted one-way hash. Accounts with a shadowed password have an xin the second field in /etc/passwd."
     rationale: "The /etc/passwd file also contains information like user ID's and group ID's that are used by many system programs. Therefore, the /etc/passwd file must remain world readable. In spite of encoding the password with a randomly-generated one-way hash function, an attacker could still break the system if they got access to the /etc/passwd file. This can be mitigated by using shadowed passwords, thus moving the passwords in the /etc/passwd file to /etc/shadow. The /etc/shadow file is set so only root will be able to read and write. This helps mitigate the risk of an attacker gaining access to the encoded passwords with which to perform a dictionary attack."
@@ -3607,7 +3607,7 @@ checks:
 
 
 # 6.2.2 Ensure /etc/shadow password fields are not empty (Automated)
-  - id: 4694 
+  - id: 4694
     title: "Ensure password fields are not empty"
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
@@ -3622,7 +3622,7 @@ checks:
       - 'f:/etc/shadow -> !r:^# && r:^\w+::'
 
 # 6.2.3 Ensure root is the only UID 0 account (Automated)
-  - id: 4695 
+  - id: 4695
     title: "Ensure root is the only UID 0 account"
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
@@ -3642,7 +3642,7 @@ checks:
 
 
 # 6.2.18 Ensure shadow group is empty (Automated)
-  - id: 4696 
+  - id: 4696
     title: "Ensure shadow group is empty"
     description: "The shadow group allows system programs which require access the ability to read the /etc/shadow file. No users should be assigned to the shadow group"
     rationale: "Any users assigned to the shadow group would be granted read access to the /etc/shadow file. If attackers can gain read access to the /etc/shadow file, they can easily runa password cracking program against the hashed passwords to break them. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts."

--- a/ruleset/sca/rhel/7/cis_rhel7_linux.yml
+++ b/ruleset/sca/rhel/7/cis_rhel7_linux.yml
@@ -661,6 +661,23 @@ checks:
       - 'c:sysctl fs.suid_dumpable -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
       - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
 
+# 1.6.2 XD/NX enabled
+  - id: 4534 
+    title: "Ensure XD/NX support is enabled"
+    description: "Recent processors in the x86 family support the ability to prevent code execution on a per memory page basis. Generically and on AMD processors, this ability is called No Execute (NX), while on Intel processors it is called Execute Disable (XD). This ability can help prevent exploitation of buffer overflow vulnerabilities and should be activated whenever possible. Extra steps must be taken to ensure that this protection is enabled, particularly on 32-bit x86 systems. Other processors, such as Itanium and POWER, have included such support since inception and the standard kernel for those platforms supports the feature."
+    rationale: "Enabling any feature that can protect against buffer overflow attacks enhances the security of the system."
+    remediation: "On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems: If necessary configure your bootloader to load the new kernel and reboot the system. You may need to enable NX or XD support in your bios."
+    compliance:
+      - cis: ["1.6.2"]
+      - cis_csc: ["8.3"]
+      - pci_dss: ["2.2.4"]
+      - nist_800_53: ["CM.1"]
+      - tsc: ["CC5.2"]
+    condition: any
+    rules:
+      - 'c:journalctl -> r:^kernel:\s+NX \(Execute Disable\) protection: active'
+      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+
 # 1.6.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 4535 
     title: "Ensure address space layout randomization (ASLR) is enabled"

--- a/ruleset/sca/rhel/7/cis_rhel7_linux.yml
+++ b/ruleset/sca/rhel/7/cis_rhel7_linux.yml
@@ -675,8 +675,8 @@ checks:
       - tsc: ["CC5.2"]
     condition: any
     rules:
-      - 'c:journalctl -> r:^kernel:\s+NX \(Execute Disable\) protection: active'
-      - 'c:dmesg -> r:NX \(Execute Disable\) protection: active'
+      - 'c:sh -c "journalctl | grep \"protection: active\"" -> r:kernel:\s+NX \(Execute Disable\) protection: active'
+      - 'c:sh -c "[[ -n $(grep noexec[0-9]*=off /proc/cmdline) || -z $(grep -E -i \" (pae|nx) \" /proc/cpuinfo) || -n $(grep \"\\sNX\\s.*\\sprotection:\\s\" /var/log/dmesg | grep -v active) ]] && echo \"NX Protection is not active\"" -> r:^$'
 
 # 1.6.3 Enable Randomized Virtual Memory Region Placement (Scored)
   - id: 4535


### PR DESCRIPTION
|Related issue|
|---|
|#7314|

As explained in #7314, this PR aims to restore the SCA policy "Ensure XD/NX support is enabled", which was removed because it produced a large output that made the agent consume too much memory.

In addition, the command rules were adapted to shell scripts, that SCA will be able to run after completing issue #3340.

## Tests

- [ ] Run the affected policy in CentOS 6.
- [x] Run the affected policy in CentOS 7. 
- [ ] Run the affected policy in Debian 10. 