### PR TITLE
Fix CloudWatchLogs IAM role issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.1.1]
 
+### Fixed
+
+- **AWS Module:**
+  - Fixed a bug that caused an error when attempting to use an IAM Role with **CloudWatchLogs** service. ([#7330](https://github.com/wazuh/wazuh/pull/7330))
+
 
 ## [v4.1.0]
 

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -248,7 +248,7 @@ class WazuhIntegration:
                                             aws_session_token=sts_role_assumption['Credentials']['SessionToken'],
                                             region_name=conn_args.get('region_name')
                                             )
-                client = sts_session.client(service_name=service_name)
+                client = sts_session.client(service_name='logs' if service_name == 'cloudwatchlogs' else service_name)
             elif service_name == 'cloudwatchlogs':
                 client = boto3.client('logs', region_name=region,
                                       aws_access_key_id=access_key, aws_secret_access_key=secret_key)


### PR DESCRIPTION
|Related issue|
|---|
|[#7270](https://github.com/wazuh/wazuh/issues/7270)|

## Description

Hello team,

This PR closes #7270. The issue was present when trying to specify an IAM role inside the `CloudwatchLogs` service tag. This happened because the boto3 library in charge of connecting to  `CloudWatch Logs` needs to have `logs` specified as its `servicename` parameter and if an IAM role was provided the service name provided was not `logs` but `cloudwatchlogs` due to a bug.

## Testing

After applying the fix a IAM role was created in order to tests it. A Wazuh-docker were deployed and AWS-S3 was configured using the following configuration structure:
```
    <wodle name=“aws-s3”>
        <disabled>no</disabled>
        <interval>15m</interval>
        <run_on_start>yes</run_on_start>
        <service type=“cloudwatchlogs”>
            <access_key>REDACTED</access_key>
            <secret_key>REDACTED</secret_key>
            <aws_log_groups>REDACTED</aws_log_groups>
            <aws_account_id>REDACTED</aws_account_id>
            <iam_role_arn>REDACTED</iam_role_arn>
        </service>
    </wodle>
```

With this configuration and the IAM role specigied this was the error that appeared in the ossec.logs before applying the fix:
```
File "/var/ossec/framework/python/lib/python3.8/site-packages/botocore/loaders.py", line 376, in load_service_model
    raise UnknownServiceError(
botocore.exceptions.UnknownServiceError: Unknown service: 'cloudwatchlogs'
```
After the fix, no errors were found. Logs were fetched as expected and alerts were raised accordingly.
