### PR TITLE
Fix bug in Windows agent that did not honor buffer's EPS limit

### DIFF
--- a/src/client-agent/buffer.c
+++ b/src/client-agent/buffer.c
@@ -233,9 +233,5 @@ void delay(struct timespec * ts_loop) {
     long interval_ns = 1000000000 / agt->events_persec;
     struct timespec ts_timeout = { interval_ns / 1000000000, interval_ns % 1000000000 };
     time_sub(&ts_timeout, ts_loop);
-
-    if (ts_timeout.tv_sec >= 0 && ts_timeout.tv_nsec >= 0) {
-        struct timeval timeout = { ts_timeout.tv_sec, ts_timeout.tv_nsec / 1000 };
-        select(0 , NULL, NULL, NULL, &timeout);
-    }
+    nanosleep(&ts_timeout, NULL);
 }


### PR DESCRIPTION
|Related issue|
|---|
|#7304|

This PR aims to fix issue #7304 by replacing the call to `select()` with `nanosleep()`. Paradoxically, we used `select()` looking for cross-platform compatibility. As explained in the issue, Windows does not support calling `select()` with the three sets of file descriptor null.

## Tests

- [X] 10 EPS output on Windows Server 2019.
- [X] Isolate `delay` procedure on Solaris 10 (test that `nanosleep` is available).
- [X] Isolate `delay` procedure on AIX 6.1 (test that `nanosleep` is available).