### PR TITLE
7275 syscollector disabled issue

### DIFF
--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -196,6 +196,7 @@ void wm_handler(int signum)
     case SIGHUP:
     case SIGINT:
     case SIGTERM:
+        wm_destroy();
         exit(EXIT_SUCCESS);
     default:
         merror("unknown signal (%d)", signum);

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -192,11 +192,18 @@ void wm_cleanup()
 
 void wm_handler(int signum)
 {
+    wmodule * cur_module;
     switch (signum) {
     case SIGHUP:
     case SIGINT:
     case SIGTERM:
-        wm_destroy();
+        // For the moment only gracefull shutdown will be for syscollector, in the future
+        // it will be modified for all wmodules, modifying the mainloop of each thread.
+        for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
+            if (0 == strncmp(cur_module->context->name, "syscollector", strlen(cur_module->context->name))) {
+                cur_module->context->destroy(cur_module->data);
+            }
+        }
         exit(EXIT_SUCCESS);
     default:
         merror("unknown signal (%d)", signum);

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -56,6 +56,11 @@ static void wm_sys_log_error(const char* log) {
 
 void* wm_sys_main(wm_sys_t *sys) 
 {
+    if (!sys->flags.enabled) {
+        mtinfo(WM_SYS_LOGTAG, "Module disabled. Exiting...");
+        pthread_exit(NULL);
+    }
+
     #ifndef WIN32
     // Connect to socket
     queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7275 |

It was found in manual / exploratory testing that the module was not being disabled when the configuration is off.

Static code analysis was done, and it was found that the functionality is not provided.

this is solved, adding a code that skips the dll / so load in the main of the syscollector wmodule.

Take this approach.
![image](https://user-images.githubusercontent.com/14300208/105889768-4e458980-5fed-11eb-872e-d144f37f8db9.png)


