### PR TITLE
Validate JSON read from alerts file

### DIFF
--- a/src/headers/file-queue.h
+++ b/src/headers/file-queue.h
@@ -13,6 +13,7 @@
 
 #define MAX_FQUEUE  256
 #define FQ_TIMEOUT  5
+#define MAX_READ_ATTEMPTS   3
 
 /* File queue */
 typedef struct _file_queue {
@@ -20,6 +21,7 @@ typedef struct _file_queue {
     int year;
     int day;
     int flags;
+    int read_attempts;
 
     char mon[4];
     char file_name[MAX_FQUEUE + 1];

--- a/src/headers/json-queue.h
+++ b/src/headers/json-queue.h
@@ -31,4 +31,14 @@ cJSON * jqueue_next(file_queue * queue);
 // Close queue
 void jqueue_close(file_queue * queue);
 
+/**
+ * @brief Validate and parse a JSON object from a buffer
+ *
+ * @param queue pointer to the file_queue struct
+ * @param buffer string with the JSON to be parsed
+ * @param current_pos File position located as a backup
+ * @return cJSON object with the read JSON, NULL in the JSON is invalid
+ */
+cJSON * jqueue_parse_json(file_queue * queue, char * buffer, int64_t current_pos);
+
 #endif

--- a/src/headers/json-queue.h
+++ b/src/headers/json-queue.h
@@ -32,10 +32,12 @@ cJSON * jqueue_next(file_queue * queue);
 void jqueue_close(file_queue * queue);
 
 /**
- * @brief Validate and parse a JSON object from a buffer
+ * @brief Read and validate a JSON alert from the file queue
  *
  * @param queue pointer to the file_queue struct
- * @return cJSON object with the read JSON, NULL in the JSON is invalid
+ * @post The flag variable may be set to CRALERT_READ_FAILED if the read operation got no data.
+ * @post The read position is restored if failed to get a JSON object.
+ * @retval NULL No data read or could not get a valid JSON object. Pointer to the JSON object otherwise.
  */
 cJSON * jqueue_parse_json(file_queue * queue);
 

--- a/src/headers/json-queue.h
+++ b/src/headers/json-queue.h
@@ -35,10 +35,8 @@ void jqueue_close(file_queue * queue);
  * @brief Validate and parse a JSON object from a buffer
  *
  * @param queue pointer to the file_queue struct
- * @param buffer string with the JSON to be parsed
- * @param current_pos File position located as a backup
  * @return cJSON object with the read JSON, NULL in the JSON is invalid
  */
-cJSON * jqueue_parse_json(file_queue * queue, char * buffer, int64_t current_pos);
+cJSON * jqueue_parse_json(file_queue * queue);
 
 #endif

--- a/src/headers/read-alert.h
+++ b/src/headers/read-alert.h
@@ -14,6 +14,7 @@
 #define CRALERT_MAIL_SET    0x001
 #define CRALERT_EXEC_SET    0x002
 #define CRALERT_READ_ALL    0x004
+#define CRALERT_READ_FAILED 0x008
 #define CRALERT_FP_SET      0x010
 
 /* File queue */

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -125,13 +125,15 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
         /* Get JSON message if available (timeout of 5 seconds) */
         mdebug2("jqueue_next()");
         al_json = jqueue_next(&jfileq);
-        if(!al_json)
+        if(!al_json) {
+            sleep(1);
             continue;
+        }
 
         mdebug1("sending new alert.");
         temp_file_created = 0;
 
-        /* If JSON does not contain rule block, continue*/
+        /* If JSON does not contain rule block, continue */
         if (rule = cJSON_GetObjectItem(al_json, "rule"), !rule){
                 s++;
                 mdebug2("skipping: Alert does not contain a rule block");

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -136,7 +136,8 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
         /* If JSON does not contain rule block, continue */
         if (rule = cJSON_GetObjectItem(al_json, "rule"), !rule){
                 s++;
-                mdebug2("skipping: Alert does not contain a rule block");
+                mdebug2("skipping: Alert does not contain a rule block.");
+                cJSON_Delete(al_json);
                 continue;
         }
 
@@ -208,7 +209,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                 }
 
                 if (!found) {
-                    mdebug2("skipping: group doesn't match");
+                    mdebug2("skipping: group doesn't match.");
                     s++; continue;
                 }
             }
@@ -240,7 +241,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                 /* skip integration if none are matched */
                 if(rule_match == -1)
                 {
-                    mdebug2("skipping: rule doesn't match");
+                    mdebug2("skipping: rule doesn't match.");
                     s++; continue;
                 }
             }
@@ -412,7 +413,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                                 merror("While running %s -> %s. Output: %s ",  integrator_config[s]->name, integrator_config[s]->path, buffer);
                                 merror("Exit status was: %d", wstatus);
                             } else {
-                                mdebug1("Command ran successfully");
+                                mdebug1("Command ran successfully.");
                             }
                         } else {
                             merror("Command (%s) execution exited abnormally.", exec_full_cmd);

--- a/src/shared/file-queue.c
+++ b/src/shared/file-queue.c
@@ -109,6 +109,7 @@ int Init_FileQueue(file_queue *fileq, const struct tm *p, int flags)
     }
     fileq->last_change = 0;
     fileq->flags = 0;
+    fileq->read_attempts = 0;
 
     fileq->day = p->tm_mday;
     fileq->year = p->tm_year + 1900;

--- a/src/shared/json-queue.c
+++ b/src/shared/json-queue.c
@@ -136,7 +136,7 @@ cJSON * jqueue_parse_json(file_queue * queue, char * buffer, int64_t current_pos
     }
 
     queue->read_attempts++;
-    merror("Invalid JSON alert read from '%s'. Remaining attempts: %d", queue->file_name, MAX_READ_ATTEMPTS - queue->read_attempts);
+    mdebug2("Invalid JSON alert read from '%s'. Remaining attempts: %d", queue->file_name, MAX_READ_ATTEMPTS - queue->read_attempts);
 
     if (queue->read_attempts < MAX_READ_ATTEMPTS) {
         if (current_pos >= 0) {
@@ -144,6 +144,7 @@ cJSON * jqueue_parse_json(file_queue * queue, char * buffer, int64_t current_pos
         }
     } else {
         queue->read_attempts = 0;
+        merror("Invalid JSON alert read from '%s'. Skipping it.", queue->file_name);
     }
 
     return NULL;

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -113,8 +113,9 @@ endif()
 
 if(${TARGET} STREQUAL "server")
 list(APPEND shared_tests_names "test_json-queue")
-list(APPEND shared_tests_flags "-Wl,--wrap,_merror -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
-                                -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf -Wl,--wrap,fgets")
+list(APPEND shared_tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug2 -Wl,--wrap,fopen -Wl,--wrap,fclose \
+                                -Wl,--wrap,fflush -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
+                                -Wl,--wrap,remove -Wl,--wrap,fprintf -Wl,--wrap,fgets")
 endif()
 
 # Compiling tests

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -115,7 +115,7 @@ if(${TARGET} STREQUAL "server")
 list(APPEND shared_tests_names "test_json-queue")
 list(APPEND shared_tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mdebug2 -Wl,--wrap,fopen -Wl,--wrap,fclose \
                                 -Wl,--wrap,fflush -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite \
-                                -Wl,--wrap,remove -Wl,--wrap,fprintf -Wl,--wrap,fgets")
+                                -Wl,--wrap,remove -Wl,--wrap,fprintf -Wl,--wrap,fgets -Wl,--wrap,w_ftell")
 endif()
 
 # Compiling tests

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -111,6 +111,11 @@ list(APPEND shared_tests_names "test_remoted_op")
 list(APPEND shared_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mwarn -Wl,--wrap,_merror")
 endif()
 
+if(${TARGET} STREQUAL "server")
+list(APPEND shared_tests_names "test_json-queue")
+list(APPEND shared_tests_flags "-Wl,--wrap,_merror -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fread \
+                                -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fprintf -Wl,--wrap,fgets")
+endif()
 
 # Compiling tests
 list(LENGTH shared_tests_names count)

--- a/src/unit_tests/shared/test_json-queue.c
+++ b/src/unit_tests/shared/test_json-queue.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "shared.h"
+#include "../wrappers/common.h"
+#include "../wrappers/libc/stdio_wrappers.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+// setup / teardown
+
+static int setup_group(void **state) {
+    test_mode = 1;
+    return 0;
+}
+
+static int teardown_group(void **state) {
+    test_mode = 0;
+    return 0;
+}
+
+int setup_queue(void **state) {
+
+    file_queue * queue;
+
+    os_calloc(1, sizeof(file_queue), queue);
+    queue->read_attempts = 0;
+    *state = queue;
+    return 0;
+}
+
+int teardown_queue(void **state) {
+
+    file_queue * queue = *state;
+    os_free(queue);
+
+    return 0;
+}
+
+// jqueue_parse_json
+
+void test_jqueue_parse_json_valid(void ** state) {
+
+    file_queue * queue = *state; 
+    char buffer[OS_MAXSTR + 1];
+    int64_t current_pos = 0;
+    cJSON * object = NULL;
+    char * output = NULL;
+
+    snprintf(queue->file_name, MAX_FQUEUE, "%s", "/home/test");
+    snprintf(buffer, OS_MAXSTR, "%s\n", "{\"test\":\"valid_json\"}");
+    object = jqueue_parse_json(queue, buffer, current_pos);
+
+    output = cJSON_PrintUnformatted(object);
+    assert_string_equal(output, "{\"test\":\"valid_json\"}");
+
+    os_free(output);
+    cJSON_Delete(object);
+}
+
+void test_jqueue_parse_json_invalid(void ** state) {
+
+    file_queue * queue = *state; 
+    char buffer[OS_MAXSTR + 1];
+    int64_t current_pos = 0;
+    cJSON * object = NULL;
+    char * output = NULL;
+
+    snprintf(queue->file_name, MAX_FQUEUE, "%s", "/home/test");
+    snprintf(buffer, OS_MAXSTR, "%s\n", "{\"test\":\"invalid_value");
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid JSON alert read from '/home/test'. Remaining attempts: 2");
+    will_return(__wrap_fseek, 0);
+
+    object = jqueue_parse_json(queue, buffer, current_pos);
+
+    assert_null(object);
+}
+
+void test_jqueue_parse_json_max_attempts(void ** state) {
+
+    file_queue * queue = *state; 
+    char buffer[OS_MAXSTR + 1];
+    int64_t current_pos = 0;
+    cJSON * object = NULL;
+    char * output = NULL;
+    queue->read_attempts = 2;
+
+    snprintf(queue->file_name, MAX_FQUEUE, "%s", "/home/test");
+    snprintf(buffer, OS_MAXSTR, "%s\n", "{\"test\":\"invalid_value");
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid JSON alert read from '/home/test'. Remaining attempts: 0");
+
+    object = jqueue_parse_json(queue, buffer, current_pos);
+
+    assert_null(object);
+    assert_int_equal(queue->read_attempts, 0); // It is restarted
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+            cmocka_unit_test_setup_teardown(test_jqueue_parse_json_valid, setup_queue, teardown_queue),
+            cmocka_unit_test_setup_teardown(test_jqueue_parse_json_invalid, setup_queue, teardown_queue),
+            cmocka_unit_test_setup_teardown(test_jqueue_parse_json_max_attempts, setup_queue, teardown_queue)
+    };
+    return cmocka_run_group_tests(tests, setup_group, teardown_group);
+}

--- a/src/unit_tests/shared/test_json-queue.c
+++ b/src/unit_tests/shared/test_json-queue.c
@@ -33,17 +33,17 @@ static int teardown_group(void **state) {
 }
 
 int setup_queue(void **state) {
-
     file_queue * queue;
 
     os_calloc(1, sizeof(file_queue), queue);
     queue->read_attempts = 0;
+    queue->flags = 0;
+    queue->fp = (FILE *)1;
     *state = queue;
     return 0;
 }
 
 int teardown_queue(void **state) {
-
     file_queue * queue = *state;
     os_free(queue);
 
@@ -53,69 +53,100 @@ int teardown_queue(void **state) {
 // jqueue_parse_json
 
 void test_jqueue_parse_json_valid(void ** state) {
-
-    file_queue * queue = *state; 
+    file_queue * queue = *state;
     char buffer[OS_MAXSTR + 1];
     int64_t current_pos = 0;
     cJSON * object = NULL;
     char * output = NULL;
 
-    snprintf(queue->file_name, MAX_FQUEUE, "%s", "/home/test");
     snprintf(buffer, OS_MAXSTR, "%s\n", "{\"test\":\"valid_json\"}");
-    object = jqueue_parse_json(queue, buffer, current_pos);
+
+    will_return(__wrap_w_ftell, 1);
+
+    expect_value(__wrap_fgets, __stream, queue->fp);
+    will_return(__wrap_fgets, buffer);
+
+    object = jqueue_parse_json(queue);
 
     output = cJSON_PrintUnformatted(object);
     assert_string_equal(output, "{\"test\":\"valid_json\"}");
+    assert_int_equal(queue->read_attempts, 0);
+    assert_int_equal(queue->flags, 0);
 
     os_free(output);
     cJSON_Delete(object);
 }
 
 void test_jqueue_parse_json_invalid(void ** state) {
-
-    file_queue * queue = *state; 
+    file_queue * queue = *state;
     char buffer[OS_MAXSTR + 1];
     int64_t current_pos = 0;
     cJSON * object = NULL;
-    char * output = NULL;
 
     snprintf(queue->file_name, MAX_FQUEUE, "%s", "/home/test");
     snprintf(buffer, OS_MAXSTR, "%s\n", "{\"test\":\"invalid_value");
 
+    will_return(__wrap_w_ftell, 1);
+    expect_value(__wrap_fgets, __stream, queue->fp);
+    will_return(__wrap_fgets, buffer);
+
     expect_string(__wrap__mdebug2, formatted_msg, "Invalid JSON alert read from '/home/test'. Remaining attempts: 2");
     will_return(__wrap_fseek, 0);
 
-    object = jqueue_parse_json(queue, buffer, current_pos);
+    object = jqueue_parse_json(queue);
 
     assert_null(object);
+    assert_int_equal(queue->read_attempts, 1);
+    assert_int_equal(queue->flags, 0);
 }
 
 void test_jqueue_parse_json_max_attempts(void ** state) {
-
-    file_queue * queue = *state; 
+    file_queue * queue = *state;
     char buffer[OS_MAXSTR + 1];
     int64_t current_pos = 0;
     cJSON * object = NULL;
-    char * output = NULL;
+
     queue->read_attempts = 2;
 
     snprintf(queue->file_name, MAX_FQUEUE, "%s", "/home/test");
     snprintf(buffer, OS_MAXSTR, "%s\n", "{\"test\":\"invalid_value");
 
+    will_return(__wrap_w_ftell, 1);
+    expect_value(__wrap_fgets, __stream, queue->fp);
+    will_return(__wrap_fgets, buffer);
+
     expect_string(__wrap__mdebug2, formatted_msg, "Invalid JSON alert read from '/home/test'. Remaining attempts: 0");
     expect_string(__wrap__merror, formatted_msg, "Invalid JSON alert read from '/home/test'. Skipping it.");
 
-    object = jqueue_parse_json(queue, buffer, current_pos);
+    object = jqueue_parse_json(queue);
 
     assert_null(object);
-    assert_int_equal(queue->read_attempts, 0); // It is restarted
+    assert_int_equal(queue->read_attempts, 0);
+    assert_int_equal(queue->flags, 0);
+}
+
+void test_jqueue_parse_json_fgets_fail(void ** state) {
+    file_queue * queue = *state;
+    int64_t current_pos = 0;
+    cJSON * object = NULL;
+
+    will_return(__wrap_w_ftell, 1);
+    expect_value(__wrap_fgets, __stream, queue->fp);
+    will_return(__wrap_fgets, NULL);
+
+    object = jqueue_parse_json(queue);
+
+    assert_null(object);
+    assert_int_equal(queue->read_attempts, 0);
+    assert_int_equal(queue->flags, 1);
 }
 
 int main(void) {
     const struct CMUnitTest tests[] = {
             cmocka_unit_test_setup_teardown(test_jqueue_parse_json_valid, setup_queue, teardown_queue),
             cmocka_unit_test_setup_teardown(test_jqueue_parse_json_invalid, setup_queue, teardown_queue),
-            cmocka_unit_test_setup_teardown(test_jqueue_parse_json_max_attempts, setup_queue, teardown_queue)
+            cmocka_unit_test_setup_teardown(test_jqueue_parse_json_max_attempts, setup_queue, teardown_queue),
+            cmocka_unit_test_setup_teardown(test_jqueue_parse_json_fgets_fail, setup_queue, teardown_queue)
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }

--- a/src/unit_tests/shared/test_json-queue.c
+++ b/src/unit_tests/shared/test_json-queue.c
@@ -138,7 +138,7 @@ void test_jqueue_parse_json_fgets_fail(void ** state) {
 
     assert_null(object);
     assert_int_equal(queue->read_attempts, 0);
-    assert_int_equal(queue->flags, 1);
+    assert_int_equal(queue->flags, CRALERT_READ_FAILED);
 }
 
 int main(void) {

--- a/src/unit_tests/shared/test_json-queue.c
+++ b/src/unit_tests/shared/test_json-queue.c
@@ -82,7 +82,7 @@ void test_jqueue_parse_json_invalid(void ** state) {
     snprintf(queue->file_name, MAX_FQUEUE, "%s", "/home/test");
     snprintf(buffer, OS_MAXSTR, "%s\n", "{\"test\":\"invalid_value");
 
-    expect_string(__wrap__merror, formatted_msg, "Invalid JSON alert read from '/home/test'. Remaining attempts: 2");
+    expect_string(__wrap__mdebug2, formatted_msg, "Invalid JSON alert read from '/home/test'. Remaining attempts: 2");
     will_return(__wrap_fseek, 0);
 
     object = jqueue_parse_json(queue, buffer, current_pos);
@@ -102,7 +102,8 @@ void test_jqueue_parse_json_max_attempts(void ** state) {
     snprintf(queue->file_name, MAX_FQUEUE, "%s", "/home/test");
     snprintf(buffer, OS_MAXSTR, "%s\n", "{\"test\":\"invalid_value");
 
-    expect_string(__wrap__merror, formatted_msg, "Invalid JSON alert read from '/home/test'. Remaining attempts: 0");
+    expect_string(__wrap__mdebug2, formatted_msg, "Invalid JSON alert read from '/home/test'. Remaining attempts: 0");
+    expect_string(__wrap__merror, formatted_msg, "Invalid JSON alert read from '/home/test'. Skipping it.");
 
     object = jqueue_parse_json(queue, buffer, current_pos);
 

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
@@ -187,6 +187,10 @@ int __wrap_UnmergeFiles(const char *finalpath, const char *optdir, int mode) {
     return mock();
 }
 
+int64_t __wrap_w_ftell(__attribute__((unused)) FILE *fp) {
+    return mock();
+}
+
 #ifdef WIN32
 long long __wrap_get_UTC_modification_time(const char *file_path) {
     check_expected(file_path);

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
@@ -16,6 +16,7 @@
 #include <stdbool.h>
 
 #ifdef WIN32
+#include <stdint.h>
 #include <winsock2.h>
 #include <windows.h>
 #endif

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
@@ -72,6 +72,8 @@ int __wrap_cldir_ex(const char *name);
 
 int __wrap_UnmergeFiles(const char *finalpath, const char *optdir, int mode);
 
+int64_t __wrap_w_ftell(FILE *fp);
+
 #ifdef WIN32
 long long __wrap_get_UTC_modification_time(const char *file_path);
 #endif


### PR DESCRIPTION
|Related issue|
|---|
| #7336 |

## Description

This pull request adds the following changes when reading alerts by other components:

- Validate the JSON read before returning it by `cJSON_ParseWithOpts()`
- When the reading of a line fails, it is reattempted three times before skipping the line.
- Using `fseek()` since the pull request points to branch 4.1. In `master` branch it would be desirable to use `w_fseek()` which is already implemented.
- Fixed a memory leak when the returned JSON does not contain the `rule` object.

## Logs/Alerts example

When reading an invalid JSON, the following errors appear:

```
2021/02/01 19:35:53 wazuh-integratord: ERROR: Invalid JSON alert read from '/var/ossec/logs/alerts/alerts.json'. Remaining attempts: 2
2021/02/01 19:35:54 wazuh-integratord: ERROR: Invalid JSON alert read from '/var/ossec/logs/alerts/alerts.json'. Remaining attempts: 1
2021/02/01 19:35:55 wazuh-integratord: ERROR: Invalid JSON alert read from '/var/ossec/logs/alerts/alerts.json'. Remaining attempts: 0
```

After the attempts are wasted and the JSON is still unreadable, it continues reading the next line.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- [x] Added unit tests (for new features)
- [x] Stress test for affected components
