### PR TITLE
7335 remove os patch from packages agent

### DIFF
--- a/src/data_provider/cppcheckSuppress.txt
+++ b/src/data_provider/cppcheckSuppress.txt
@@ -1,2 +1,2 @@
-*:*src/sysInfoLinux.cpp:378
+*:*src/sysInfoLinux.cpp:301
 *:*src/packages/pkgWrapper.h:101

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -90,6 +90,7 @@ static bool findCodeNameInString(const std::string& in,
 static void findMajorMinorVersionInString(const std::string& in,
                                           nlohmann::json& output)
 {
+    constexpr auto PATCH_VERSION_PATTERN{"^[0-9]+\\.[0-9]+\\.([0-9]+)\\.*"};
     constexpr auto MINOR_VERSION_PATTERN{"^[0-9]+\\.([0-9]+)\\.*"};
     constexpr auto MAJOR_VERSION_PATTERN{"^([0-9]+)\\.*"};
     std::string version;
@@ -102,6 +103,11 @@ static void findMajorMinorVersionInString(const std::string& in,
     if (findRegexInString(in, version, pattern, 1))
     {
         output["os_minor"] = version;
+    }
+    pattern = PATCH_VERSION_PATTERN;
+    if (findRegexInString(in, version, pattern, 1))
+    {
+        output["os_patch"] = version;
     }
 }
 

--- a/src/data_provider/src/packages/packageMac.cpp
+++ b/src/data_provider/src/packages/packageMac.cpp
@@ -45,5 +45,4 @@ void BSDPackageImpl::buildPackageData(nlohmann::json& package)
     package["description"] = m_packageWrapper->description();
     package["architecture"] = m_packageWrapper->architecture();
     package["format"] = m_packageWrapper->format();
-    package["os_patch"] = m_packageWrapper->osPatch();
 }

--- a/src/data_provider/src/packages/packagesLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packagesLinuxParserHelper.h
@@ -116,7 +116,6 @@ namespace PackageLinuxHelper
             ret["version"]      = version.empty() ? UNKNOWN_VALUE : version;
             ret["architecture"] = architecture;
             ret["format"]       = "rpm";
-            ret["os_patch"]     = UNKNOWN_VALUE;
             ret["vendor"]       = vendor;
             ret["description"]  = description;
         }
@@ -205,7 +204,6 @@ namespace PackageLinuxHelper
             ret["source"]       = source;
             ret["version"]      = version;
             ret["format"]       = "deb";
-            ret["os_patch"]     = UNKNOWN_VALUE;
             ret["vendor"]       = vendor;
             ret["description"]  = description;
         }

--- a/src/data_provider/src/sysInfoFreeBSD.cpp
+++ b/src/data_provider/src/sysInfoFreeBSD.cpp
@@ -105,7 +105,6 @@ nlohmann::json SysInfo::getPackages() const
             package["architecture"] = data[3];
             package["description"] = data[4];
             package["format"] = "pkg";
-            package["os_patch"] = UNKNOWN_VALUE;
             ret.push_back(package);
         }
     }

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -389,7 +389,6 @@ static void getPackagesFromReg(const HKEY key, const std::string& subKey, nlohma
                 packageJson["location"]     = location;
                 packageJson["architecture"] = architecture;
                 packageJson["format"]       = "win";
-                packageJson["os_patch"]     = UNKNOWN_VALUE;
 
                 data.push_back(packageJson);
             }

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -127,6 +127,7 @@ TEST_F(SysInfoParsersTest, Centos)
     EXPECT_EQ("Core", output["os_codename"]);
     EXPECT_EQ("8", output["os_major"]);
     EXPECT_EQ("2", output["os_minor"]);
+    EXPECT_EQ("2004", output["os_patch"]);
 }
 
 TEST_F(SysInfoParsersTest, BSDFreeBSD)
@@ -428,4 +429,5 @@ TEST_F(SysInfoParsersTest, MacOS)
     EXPECT_EQ("Sierra", output["os_codename"]);
     EXPECT_EQ("10", output["os_major"]);
     EXPECT_EQ("12", output["os_minor"]);
+    EXPECT_EQ("6", output["os_patch"]);
 }

--- a/src/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
@@ -54,7 +54,6 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationCentosGreaterThan5)
     EXPECT_EQ("1-0.9.git5baa1e5.el8-1.0.1", jsPackageInfo["version"]);
     EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
     EXPECT_EQ("rpm", jsPackageInfo["format"]);
-    EXPECT_EQ(UNKNOWN_VALUE, jsPackageInfo["os_patch"]);
     EXPECT_EQ("CentOS", jsPackageInfo["vendor"]);
     EXPECT_EQ("GLX support for libglvnd", jsPackageInfo["description"]);
 }
@@ -88,7 +87,6 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationCentos5)
     EXPECT_EQ("6.el5_5-1.0.3", jsPackageInfo["version"]);
     EXPECT_EQ(UNKNOWN_VALUE, jsPackageInfo["architecture"]);
     EXPECT_EQ("rpm", jsPackageInfo["format"]);
-    EXPECT_EQ(UNKNOWN_VALUE, jsPackageInfo["os_patch"]);
     EXPECT_EQ("CentOS", jsPackageInfo["vendor"]);
     EXPECT_EQ("Header files and libraries for developing apps which will use bzip2.", jsPackageInfo["description"]);
 }
@@ -134,7 +132,6 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseDpkgInformation)
     EXPECT_EQ("1:1.2.11.dfsg-2ubuntu1.2", jsPackageInfo["version"]);
     EXPECT_EQ("amd64", jsPackageInfo["architecture"]);
     EXPECT_EQ("deb", jsPackageInfo["format"]);
-    EXPECT_EQ(UNKNOWN_VALUE, jsPackageInfo["os_patch"]);
     EXPECT_EQ("Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>", jsPackageInfo["vendor"]);
     EXPECT_EQ("compression library - development\n\
          zlib is a library implementing the deflate compression method found\n\

--- a/src/data_provider/tests/sysInfoPackagesMAC/sysInfoMacPackages_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesMAC/sysInfoMacPackages_test.cpp
@@ -52,5 +52,4 @@ TEST_F(SysInfoMacPackagesTest, Test_SPEC_Data)
     EXPECT_EQ("4",packages.at("description").get_ref<const std::string&>());
     EXPECT_EQ("5",packages.at("architecture").get_ref<const std::string&>());
     EXPECT_EQ("6",packages.at("format").get_ref<const std::string&>());
-    EXPECT_EQ("7",packages.at("os_patch").get_ref<const std::string&>());
 }

--- a/src/wazuh_modules/syscollector/cppcheckSuppress.txt
+++ b/src/wazuh_modules/syscollector/cppcheckSuppress.txt
@@ -1,3 +1,3 @@
 *:*.c
 *:*syscollector.h
-*:*src/syscollectorImp.cpp:915
+*:*src/syscollectorImp.cpp:914

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -310,7 +310,6 @@ constexpr auto PACKAGES_SQL_STATEMENT
     format TEXT,
     checksum TEXT,
     item_id TEXT,
-    os_patch TEXT,
     PRIMARY KEY (name,version,architecture)) WITHOUT ROWID;)"
 };
 static const std::vector<std::string> PACKAGES_ITEM_ID_FIELDS{"name", "version", "architecture"};


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7335   |

This issue aims to correct a rebase problem when a git merge was done with master.
- [X] RTR sys info
![image](https://user-images.githubusercontent.com/54002291/106523011-4a1edd80-64bf-11eb-8bab-7314b8a87149.png)
- [X] RTR syscollector
![image](https://user-images.githubusercontent.com/54002291/106523442-e3e68a80-64bf-11eb-85c0-1a6183831f4c.png)
- [X] Manual test macos/server
![image](https://user-images.githubusercontent.com/54002291/106523574-155f5600-64c0-11eb-9807-0613b8baf0b0.png)
![image](https://user-images.githubusercontent.com/54002291/106523602-1f815480-64c0-11eb-940b-0c40d755b6d4.png)
