### PR TITLE
#7345 update enterprise attack and mitredb.py

### DIFF
--- a/tools/mitre/mitredb.py
+++ b/tools/mitre/mitredb.py
@@ -191,46 +191,49 @@ def parse_json(pathfile, conn, database):
     :return:
     """
     try:
-        print("start parsing")
         with open(pathfile) as json_file:
             datajson = json.load(json_file)
             data = json.dumps(datajson)
             data = data.replace(': "persistence"', ': "Persistence"')
-            data = data.replace(': "privilege-escalation"', ': "Privilege Escalation"')
+            data = data.replace(': "privilege-escalation"',
+                                ': "Privilege Escalation"')
             data = data.replace(': "defense-evasion"', ': "Defense Evasion"')
             data = data.replace(': "discovery"', ': "Discovery"')
-            data = data.replace(': "credential-access"', ': "Credential Access"')
+            data = data.replace(': "credential-access"',
+                                ': "Credential Access"')
             data = data.replace(': "execution"', ': "Execution"')
             data = data.replace(': "lateral-movement"', ': "Lateral Movement"')
             data = data.replace(': "collection"', ': "Collection"')
             data = data.replace(': "exfiltration"', ': "Exfiltration"')
-            data = data.replace(': "command-and-control"', ': "Command and Control"')
+            data = data.replace(': "command-and-control"',
+                                ': "Command and Control"')
             data = data.replace(': "initial-access"', ': "Initial Access"')
             data = data.replace(': "impact"', ': "Impact"')
             datajson = json.loads(data)
             for data_object in datajson['objects']:
-		print(data_object)
                 if data_object['type'] == 'attack-pattern' and \
                         data_object['external_references'][0]['source_name'] == 'mitre-attack':
-                    string_id = json.dumps(data_object['external_references'][0]['external_id']).replace('"', '')
-                    string_url = json.dumps(data_object['external_references'][0]['url']).replace('"', '')
-		    print("string_id -> "+string_id)
+                    string_id = json.dumps(
+                        data_object['external_references'][0]['external_id']).replace('"', '')
+                    string_url = json.dumps(
+                        data_object['external_references'][0]['url']).replace('"', '')
                     string_object = json.dumps(data_object)
-                    string_name = json.dumps(data_object['name']).replace('"', '')
+                    string_name = json.dumps(
+                        data_object['name']).replace('"', '')
 
                     # Fill the attack table
-                    insert_attack_table(conn, string_id, string_url, string_object, string_name, database)
+                    insert_attack_table(
+                        conn, string_id, string_url, string_object, string_name, database)
 
                     # Fill the phase table
-		    if 'kill_chain_phases' in data_object:
+                    if 'kill_chain_phases' in data_object:
                         n = len(data_object['kill_chain_phases'])
                         for i in range(0, n):
                             string_phase = json.dumps(data_object['kill_chain_phases'][i]['phase_name']).replace('"', '')
-			    print("phase -> "+string_phase+" attack id -> "+string_id)
                             insert_phase_table(conn, string_id, string_phase, database)
 
                     # Fill the platform table
-		    if 'x_mitre_platforms' in data_object:
+                    if 'x_mitre_platforms' in data_object:
                         for platform in data_object['x_mitre_platforms']:
                             string_platform = json.dumps(platform).replace('"', '')
                             insert_platform_table(conn, string_id, string_platform, database)

--- a/tools/mitre/mitredb.py
+++ b/tools/mitre/mitredb.py
@@ -231,12 +231,16 @@ def parse_json(pathfile, conn, database):
                         for i in range(0, n):
                             string_phase = json.dumps(data_object['kill_chain_phases'][i]['phase_name']).replace('"', '')
                             insert_phase_table(conn, string_id, string_phase, database)
+                    else:
+                        insert_phase_table(conn, string_id, 'Undefined', database)
 
                     # Fill the platform table
                     if 'x_mitre_platforms' in data_object:
                         for platform in data_object['x_mitre_platforms']:
                             string_platform = json.dumps(platform).replace('"', '')
                             insert_platform_table(conn, string_id, string_platform, database)
+                    else:
+                        insert_platform_table(conn, string_id, 'Undefined', database)
 
     except TypeError as t_e:
         print(t_e)

--- a/tools/mitre/mitredb.py
+++ b/tools/mitre/mitredb.py
@@ -191,6 +191,7 @@ def parse_json(pathfile, conn, database):
     :return:
     """
     try:
+        print("start parsing")
         with open(pathfile) as json_file:
             datajson = json.load(json_file)
             data = json.dumps(datajson)
@@ -208,10 +209,12 @@ def parse_json(pathfile, conn, database):
             data = data.replace(': "impact"', ': "Impact"')
             datajson = json.loads(data)
             for data_object in datajson['objects']:
+		print(data_object)
                 if data_object['type'] == 'attack-pattern' and \
                         data_object['external_references'][0]['source_name'] == 'mitre-attack':
                     string_id = json.dumps(data_object['external_references'][0]['external_id']).replace('"', '')
                     string_url = json.dumps(data_object['external_references'][0]['url']).replace('"', '')
+		    print("string_id -> "+string_id)
                     string_object = json.dumps(data_object)
                     string_name = json.dumps(data_object['name']).replace('"', '')
 
@@ -219,14 +222,15 @@ def parse_json(pathfile, conn, database):
                     insert_attack_table(conn, string_id, string_url, string_object, string_name, database)
 
                     # Fill the phase table
-        		    if 'kill_chain_phases' in data_object:
+		    if 'kill_chain_phases' in data_object:
                         n = len(data_object['kill_chain_phases'])
                         for i in range(0, n):
                             string_phase = json.dumps(data_object['kill_chain_phases'][i]['phase_name']).replace('"', '')
+			    print("phase -> "+string_phase+" attack id -> "+string_id)
                             insert_phase_table(conn, string_id, string_phase, database)
 
                     # Fill the platform table
-		            if 'x_mitre_platforms' in data_object:
+		    if 'x_mitre_platforms' in data_object:
                         for platform in data_object['x_mitre_platforms']:
                             string_platform = json.dumps(platform).replace('"', '')
                             insert_platform_table(conn, string_id, string_platform, database)


### PR DESCRIPTION
|Related issue|
|---|
|[#7345](https://github.com/wazuh/wazuh/issues/7345)|


## Description

Update enterprise-attack.json file with latest version
Update mitredb.py to support mitre sub-tecniques.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
