### PR TITLE
Fixing confusing warning message when Vulnerability Detector doesn't found any match

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -398,6 +398,7 @@
 #define VU_OFFLINE_CONFLICT         "(5587): Feed conflict. Only '%s' will be updated offline."
 #define VU_VER_INVALID_FORMAT       "(5588): Invalid format of Wazuh version for agent '%.3d'"
 #define VU_VER_READING_ERROR        "(5589): Couldn't read Wazuh version for agent '%.3d'"
+#define VU_OVAL_VULN_NOT_FOUND      "(5590): No vulnerabilities could be found in the OVAL for agent '%.3d'"
 
 /* File integrity monitoring error messages*/
 #define FIM_ERROR_ADD_FILE                          "(6600): Unable to add file to db: '%s'"

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2691,7 +2691,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_step_done(void **state)
     expect_sqlite3_step_call(SQLITE_DONE);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug1, formatted_msg, "(5575): Unavailable vulnerability data for the agent '000' OS. Skipping it.");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(5590): No vulnerabilities could be found in the OVAL for agent '000'");
 
     int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
 

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2690,8 +2690,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_step_done(void **state)
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
-    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtwarn, formatted_msg, "(5575): Unavailable vulnerability data for the agent '000' OS. Skipping it.");
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(5575): Unavailable vulnerability data for the agent '000' OS. Skipping it.");
 
     int ret = wm_vuldet_linux_oval_vulnerabilities(db, agent, cve_table);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1879,9 +1879,9 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
     case SQLITE_ROW:
         break;
     case SQLITE_DONE:
-        // There is no data in the VULNERABILITIES table for this agent
-        // OVAL scan has to be skipped to avoid false positives
-        mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UNAVAILABLE_DATA, atoi(agents_it->agent_id));
+        // No vulnerabilities could be found after scanning the OVAL for this agent
+        // Leave the function since the query returned no results
+        mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_OVAL_VULN_NOT_FOUND, atoi(agents_it->agent_id));
         wdb_finalize(stmt);
         return 0;
     default:

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1880,8 +1880,8 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
         break;
     case SQLITE_DONE:
         // There is no data in the VULNERABILITIES table for this agent
-        // It has to be skipped instead of being scanned against the NVD to avoid false positives
-        mtwarn(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UNAVAILABLE_DATA, atoi(agents_it->agent_id));
+        // OVAL scan has to be skipped to avoid false positives
+        mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_OVAL_UNAVAILABLE_DATA, atoi(agents_it->agent_id));
         wdb_finalize(stmt);
         return 0;
     default:


### PR DESCRIPTION

## Description

Hi team, 

This PR is intended to modify a `warning` for a new message using `debug1`.

The `warning` that could confuse the user was the following:

`WARNING: (5575): Unavailable vulnerability data for the agent ‘018’ OS. Skipping it.`

And we can see that it does not indicate correctly what the function is doing. 
So the message has been modified using `debug1`, indicating that it has not found vulnerabilities in the _OVAL_. 
After indicating it, internally we exit the function executing the next step of the _VDT_.

The function test has also been modified to prevent it from failing.

## Logs/Alerts example

The debug message currently displayed is as follows:

`DEBUG: (5590): No vulnerabilities could be found in the OVAL for agent '000'`

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux 


