### PR TITLE
Avoid updating logcollector's logbuilder every second.

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -145,6 +145,9 @@ logcollector.exclude_files_interval=86400
 # 0 means state file creation and updating is disabled
 logcollector.state_interval=5
 
+# Frecuency that logcollector checks for the host ip and hostname, in seconds [1..60]
+logcollector.check_host_interval=10
+
 # Remoted counter io flush.
 remoted.recv_counter_flush=128
 

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -51,6 +51,7 @@ int LogCollectorConfig(const char *cfgfile)
     reload_delay = getDefine_Int("logcollector", "reload_delay", 0, 30000);
     free_excluded_files_interval = getDefine_Int("logcollector", "exclude_files_interval", 1, 172800);
     state_interval = getDefine_Int("logcollector", "state_interval", 0, 3600);
+    check_host_interval = getDefine_Int("logcollector", "check_host_interval", 1, 60);
 
     /* Current and total files counter */
     total_files = 0;
@@ -257,6 +258,7 @@ cJSON *getLogcollectorInternalOptions(void) {
     cJSON_AddNumberToObject(logcollector,"reload_delay",reload_delay);
     cJSON_AddNumberToObject(logcollector, "exclude_files_interval", free_excluded_files_interval);
     cJSON_AddNumberToObject(logcollector, "state_interval", state_interval);
+    cJSON_AddNumberToObject(logcollector,"check_host_interval", check_host_interval);
 
 #ifndef WIN32
     cJSON_AddNumberToObject(logcollector,"rlimit_nofile",nofile);

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -153,6 +153,7 @@ extern int reload_interval;
 extern int reload_delay;
 extern int free_excluded_files_interval;
 extern int state_interval;
+extern int check_host_interval;
 
 typedef enum {
     CONTINUE_IT,


### PR DESCRIPTION
|Related issue|
|---|
|#7192|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
As explained in #7192. `logcollector` is trying to update the host_name and the host_ip values every second.
When the routing table is really big (in the test I was using around 500k entries) and with no default gateway, this can be a problem, as it provokes a sustained high CPU usage of `modulesd`.
This PR aims to change this behavior, by introducing a new internal variable for `logcollector` (`check_host_interval`) and check it every `check_host_interval` seconds.

Closes #7192

## Configuration options
To replicate this problem, I used the following command:
```bash
root@ubuntu1:/home/vagrant/wazuh/src# ip route del default && for k in {1..8}; do for i in {0..255}; do for j in {0..255}; do ip route add $k.$i.$j.0/24 via 10.0.2.15 metric 50000; done; done; done
```

Making sure that the interface that is connected to the manager is at the bottom of the routing table: 
```bash
root@ubuntu1:/home/vagrant# tail -2 /proc/net/route 
eth0	0202000A	00000000	0005	0	0	100	FFFFFFFF	0	0	0                                                                             
eth1	0000020A	00000000	0001	0	0	0	00FFFFFF	0	0	0                                                                               
root@ubuntu1:/home/vagrant# 
```

After that, the CPU usage of modulesd (without the changes of this branch) will be sustained.

With these changes, instead of a sustained high CPU usage, there will be peaks of high CPU usage while the control module looks for the information in `/proc/net/route`. 

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [x] Windows
  - [ ] MAC OS X
- [X] Source installation
- [X] Source upgrade
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
