### PR TITLE
[7323] Added max_eps new configuration for syscollector module

### DIFF
--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -56,6 +56,11 @@
     <hardware>yes</hardware>
     <os>yes</os>
     <network>yes</network>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <max_eps>10</max_eps>
+    </synchronization>
   </wodle>
 
   <!-- File integrity monitoring -->

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -67,6 +67,11 @@
     <hardware>yes</hardware>
     <os>yes</os>
     <network>yes</network>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <max_eps>10</max_eps>
+    </synchronization>
   </wodle>
 
   <!-- File integrity monitoring -->

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -67,6 +67,11 @@
     <hardware>yes</hardware>
     <os>yes</os>
     <network>yes</network>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <max_eps>10</max_eps>
+    </synchronization>
   </wodle>
 
   <!-- File integrity monitoring -->

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -72,6 +72,11 @@
     <hardware>yes</hardware>
     <os>yes</os>
     <network>yes</network>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <max_eps>10</max_eps>
+    </synchronization>
   </wodle>
 
   <wodle name="vulnerability-detector">

--- a/etc/templates/config/AIX/wodle-syscollector.template
+++ b/etc/templates/config/AIX/wodle-syscollector.template
@@ -9,5 +9,10 @@
     <packages>no</packages>
     <ports all="no">no</ports>
     <processes>no</processes>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <max_eps>10</max_eps>
+    </synchronization>
   </wodle>
  

--- a/etc/templates/config/HP-UX/wodle-syscollector.template
+++ b/etc/templates/config/HP-UX/wodle-syscollector.template
@@ -9,5 +9,10 @@
     <packages>no</packages>
     <ports all="no">no</ports>
     <processes>no</processes>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <max_eps>10</max_eps>
+    </synchronization>
   </wodle>
  

--- a/etc/templates/config/bsd/wodle-syscollector.template
+++ b/etc/templates/config/bsd/wodle-syscollector.template
@@ -9,4 +9,9 @@
     <packages>yes</packages>
     <ports all="no">no</ports>
     <processes>no</processes>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <max_eps>10</max_eps>
+    </synchronization>
   </wodle>

--- a/etc/templates/config/darwin/wodle-syscollector.template
+++ b/etc/templates/config/darwin/wodle-syscollector.template
@@ -9,4 +9,9 @@
     <packages>yes</packages>
     <ports all="no">yes</ports>
     <processes>yes</processes>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <max_eps>10</max_eps>
+    </synchronization>
   </wodle>

--- a/etc/templates/config/generic/wodle-syscollector.template
+++ b/etc/templates/config/generic/wodle-syscollector.template
@@ -9,4 +9,9 @@
     <packages>yes</packages>
     <ports all="no">yes</ports>
     <processes>yes</processes>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <max_eps>10</max_eps>
+    </synchronization>
   </wodle>

--- a/etc/templates/config/sunos/wodle-syscollector.template
+++ b/etc/templates/config/sunos/wodle-syscollector.template
@@ -9,5 +9,10 @@
     <packages>no</packages>
     <ports all="no">no</ports>
     <processes>no</processes>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <max_eps>10</max_eps>
+    </synchronization>
   </wodle>
  

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -1,6 +1,6 @@
 /*
  * Wazuh Module Configuration
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * April 25, 2016.
  *
  * This program is free software; you can redistribute it

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -88,7 +88,7 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     }
 #ifdef ENABLE_SYSC
     else if (!strcmp(node->values[0], WM_SYS_CONTEXT.name)) {
-        if (wm_sys_read(children, cur_wmodule) < 0) {
+        if (wm_sys_read(xml, children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
         }

--- a/src/config/wmodules_syscollector.c
+++ b/src/config/wmodules_syscollector.c
@@ -27,14 +27,14 @@ static const char *XML_SYNC = "synchronization";
 static void parse_synchronization_section(wm_sys_t * syscollector, XML_NODE node) {
     const char *XML_DB_SYNC_MAX_EPS = "max_eps";
     const int XML_DB_SYNC_MAX_EPS_SIZE = 7;
-    const int MIN_SYNC_MESSAGES_THROUGHOUT = 0; // It means disabled
-    const int MAX_SYNC_MESSAGES_THROUGHOUT = 1000000;
+    const int MIN_SYNC_MESSAGES_THROUGHPUT = 0; // It means disabled
+    const int MAX_SYNC_MESSAGES_THROUGHPUT = 1000000;
     for (int i = 0; node[i]; ++i) {
         if (strncmp(node[i]->element, XML_DB_SYNC_MAX_EPS, XML_DB_SYNC_MAX_EPS_SIZE) == 0) {
             char * end;
             const long value = strtol(node[i]->content, &end, 10);
 
-            if (value < MIN_SYNC_MESSAGES_THROUGHOUT || value > MAX_SYNC_MESSAGES_THROUGHOUT || *end) {
+            if (value < MIN_SYNC_MESSAGES_THROUGHPUT || value > MAX_SYNC_MESSAGES_THROUGHPUT || *end) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 syscollector->sync.sync_max_eps = value;

--- a/src/config/wmodules_syscollector.c
+++ b/src/config/wmodules_syscollector.c
@@ -1,6 +1,6 @@
 /*
  * Wazuh Syscollector Module Configuration
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * March 9, 2017.
  *
  * This program is free software; you can redistribute it
@@ -27,12 +27,14 @@ static const char *XML_SYNC = "synchronization";
 static void parse_synchronization_section(wm_sys_t * syscollector, XML_NODE node) {
     const char *XML_DB_SYNC_MAX_EPS = "max_eps";
     const int XML_DB_SYNC_MAX_EPS_SIZE = 7;
+    const int MIN_SYNC_MESSAGES_THROUGHOUT = 0; // It means disabled
+    const int MAX_SYNC_MESSAGES_THROUGHOUT = 1000000;
     for (int i = 0; node[i]; ++i) {
         if (strncmp(node[i]->element, XML_DB_SYNC_MAX_EPS, XML_DB_SYNC_MAX_EPS_SIZE) == 0) {
             char * end;
             const long value = strtol(node[i]->content, &end, 10);
 
-            if (value < 0 || value > 1000000 || *end) {
+            if (value < MIN_SYNC_MESSAGES_THROUGHOUT || value > MAX_SYNC_MESSAGES_THROUGHOUT || *end) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 syscollector->sync.sync_max_eps = value;

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -37,7 +37,7 @@ public:
     MOCK_METHOD(nlohmann::json, ports, (), (override));
 };
 
-void reportFunction(const std::string& payload)
+void reportFunction(const std::string& /*payload*/)
 {
     // std::cout << payload << std::endl;
 }

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -36,10 +36,10 @@ syscollector_start_func syscollector_start_ptr = NULL;
 syscollector_stop_func syscollector_stop_ptr = NULL;
 syscollector_sync_message_func syscollector_sync_message_ptr = NULL;
 
-
-int queue_fd = 0;                                   // Output queue file descriptor
-bool in_shutdown = false;
-static pthread_mutex_t shutdown_mutex;
+long syscollector_sync_max_eps = 10;    // Database syncrhonization number of events per seconds
+int queue_fd = 0;                       // Output queue file descriptor
+bool in_shutdown = false;               // In shutdown state
+static pthread_mutex_t shutdown_mutex;  // Output queue file descriptor
 
 
 static bool is_shutdown() {
@@ -49,19 +49,19 @@ static bool is_shutdown() {
     return in_shutdown_process;
 }
 
-static void wm_sys_send_diff_message(const void* data) {
-    const int eps = 1000000/wm_max_eps;
+static void wm_sys_send_diff_message(/*const void* data*/) {
+    // const int eps = 1000000/syscollector_sync_max_eps;
     // Sending deltas is disabled due to issue: 7322 - https://github.com/wazuh/wazuh/issues/7322
     // if (!is_shutdown()) {
-    //     wm_sendmsg(eps,queue_fd, data, WM_SYS_LOCATION, SYSCOLLECTOR_MQ);
+    //     wm_sendmsg(eps, queue_fd, data, WM_SYS_LOCATION, SYSCOLLECTOR_MQ);
     // }
  }
 
 static void wm_sys_send_dbsync_message(const void* data) {
-    const int eps = 1000000/wm_max_eps;
+    const int eps = 1000000/syscollector_sync_max_eps;
 
     if (!is_shutdown()) {
-        wm_sendmsg(eps,queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ);
+        wm_sendmsg(eps, queue_fd, data, WM_SYS_LOCATION, DBSYNC_MQ);
     }
 }
 
@@ -69,9 +69,7 @@ static void wm_sys_log_error(const char* log) {
     mterror(WM_SYS_LOGTAG, "%s", log);
 }
 
-
-void* wm_sys_main(wm_sys_t *sys) 
-{
+void* wm_sys_main(wm_sys_t *sys) {
     pthread_mutex_init(&shutdown_mutex, NULL);
     if (!sys->flags.enabled) {
         mtinfo(WM_SYS_LOGTAG, "Module disabled. Exiting...");
@@ -99,6 +97,8 @@ void* wm_sys_main(wm_sys_t *sys)
     }
     if (syscollector_start_ptr) {
         mtinfo(WM_SYS_LOGTAG, "Starting Syscollector.");
+        syscollector_sync_max_eps = sys->sync.sync_max_eps;
+        mtinfo(WM_SYS_LOGTAG, "MNB: sync_max_eps vale: %ld", syscollector_sync_max_eps);
         syscollector_start_ptr(sys->interval,
                                wm_sys_send_diff_message,
                                wm_sys_send_dbsync_message,
@@ -122,8 +122,7 @@ void* wm_sys_main(wm_sys_t *sys)
     return 0;
 }
 
-void wm_sys_destroy(wm_sys_t *data) 
-{
+void wm_sys_destroy(wm_sys_t *data) {
     mtinfo(WM_SYS_LOGTAG, "Destroy received for Syscollector.");
     pthread_mutex_lock(&shutdown_mutex);
     in_shutdown = true;
@@ -148,11 +147,11 @@ void wm_sys_destroy(wm_sys_t *data)
     pthread_mutex_destroy(&shutdown_mutex);
 }
 
-cJSON *wm_sys_dump(const wm_sys_t *sys) 
-{
+cJSON *wm_sys_dump(const wm_sys_t *sys) {
     cJSON *root = cJSON_CreateObject();
     cJSON *wm_sys = cJSON_CreateObject();
 
+    // System provider values
     if (sys->flags.enabled) cJSON_AddStringToObject(wm_sys,"disabled","no"); else cJSON_AddStringToObject(wm_sys,"disabled","yes");
     if (sys->flags.scan_on_start) cJSON_AddStringToObject(wm_sys,"scan-on-start","yes"); else cJSON_AddStringToObject(wm_sys,"scan-on-start","no");
     cJSON_AddNumberToObject(wm_sys,"interval",sys->interval);
@@ -166,6 +165,8 @@ cJSON *wm_sys_dump(const wm_sys_t *sys)
 #ifdef WIN32
     if (sys->flags.hotfixinfo) cJSON_AddStringToObject(wm_sys,"hotfixes","yes"); else cJSON_AddStringToObject(wm_sys,"hotfixes","no");
 #endif
+    // Database synchronization values
+    cJSON_AddNumberToObject(wm_sys,"sync_max_eps",sys->sync.sync_max_eps);
 
     cJSON_AddItemToObject(root,"syscollector",wm_sys);
 

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -1,7 +1,7 @@
 /*
  * Wazuh SYSCOLLECTOR
  * Copyright (C) 2015-2020, Wazuh Inc.
- * November 11, 2020.
+ * November 11, 2021.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -98,7 +98,6 @@ void* wm_sys_main(wm_sys_t *sys) {
     if (syscollector_start_ptr) {
         mtinfo(WM_SYS_LOGTAG, "Starting Syscollector.");
         syscollector_sync_max_eps = sys->sync.sync_max_eps;
-        mtinfo(WM_SYS_LOGTAG, "MNB: sync_max_eps vale: %ld", syscollector_sync_max_eps);
         syscollector_start_ptr(sys->interval,
                                wm_sys_send_diff_message,
                                wm_sys_send_dbsync_message,

--- a/src/wazuh_modules/wm_syscollector.h
+++ b/src/wazuh_modules/wm_syscollector.h
@@ -36,13 +36,18 @@ typedef struct wm_sys_state_t {
     time_t next_time;                       // Absolute time for next scan
 } wm_sys_state_t;
 
+typedef struct wm_sys_db_sync_flags_t {
+    long sync_max_eps;                      // Maximum events per second for synchronization messages.
+} wm_sys_db_sync_flags_t;
+
 typedef struct wm_sys_t {
     unsigned int interval;                  // Time interval between cycles (seconds)
     wm_sys_flags_t flags;                   // Flag bitfield
     wm_sys_state_t state;                   // Running state
+    wm_sys_db_sync_flags_t sync;            // Database synchronization value
 } wm_sys_t;
 
 // Parse XML configuration
-int wm_sys_read(XML_NODE node, wmodule *module);
+int wm_sys_read(const OS_XML *xml, XML_NODE node, wmodule *module);
 
 #endif

--- a/src/win32/ossec-pre6.conf
+++ b/src/win32/ossec-pre6.conf
@@ -147,6 +147,11 @@
     <packages>yes</packages>
     <ports all="no">yes</ports>
     <processes>yes</processes>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <max_eps>10</max_eps>
+    </synchronization>
   </wodle>
 
   <!-- CIS policies evaluation -->

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -166,6 +166,11 @@
     <packages>yes</packages>
     <ports all="no">yes</ports>
     <processes>yes</processes>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <max_eps>10</max_eps>
+    </synchronization>
   </wodle>
 
   <!-- CIS policies evaluation -->


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7323 |

## **Description**
This issue aims to add a new configuration under a synchronization tag, in which the number of messages to send in a period of 1 second is established.

for them, you must look for an approach equal to the one that fim (syscheckd) currently has in its configuration.

https://documentation.wazuh.com/4.0/user-manual/reference/ossec-conf/syscheck.html#synchronization

## **Expected default configuration**
```
    <synchronization>
      <max_eps>10</max_eps>
    </synchronization>
```

## **DoD**
- [X] Implement the e2e configuration flow.
- [X] Add/modify default configuration to 10
- [x] PR CI Pass
