### PR TITLE
7356 agent upgrade tables issue

### DIFF
--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -1103,6 +1103,7 @@ int wdb_syscollector_processes_save2(wdb_t * wdb, const cJSON * attributes)
     const int tty = cJSON_GetObjectItem(attributes, "tty") ? cJSON_GetObjectItem(attributes, "tty")->valueint : 0;
     const int processor = cJSON_GetObjectItem(attributes, "processor") ? cJSON_GetObjectItem(attributes, "processor")->valueint : 0;
     const char * checksum = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "checksum"));
+    //this is needed to remove old entries in the db with a scan_id != 0: https://github.com/wazuh/wazuh/issues/7356
     wdb_process_delete(wdb, scan_id);
     return wdb_process_save(wdb, scan_id, scan_time, pid, name, state, ppid, utime, stime, cmd, argvs, euser, ruser, suser, egroup, rgroup, sgroup, fgroup, priority, nice, size, vm_size, resident, share, start_time, pgrp, session, nlwp, tgid, tty, processor, checksum, TRUE);
 }
@@ -1127,6 +1128,7 @@ int wdb_syscollector_package_save2(wdb_t * wdb, const cJSON * attributes)
     const char * location = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "location"));
     const char * checksum = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "checksum"));
     const char * item_id = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "item_id"));
+    //this is needed to remove old entries in the db with a scan_id != 0: https://github.com/wazuh/wazuh/issues/7356
     wdb_package_delete(wdb, scan_id);
     return wdb_package_save(wdb, scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, architecture, multiarch, source, description, location, checksum, item_id, TRUE);
 }
@@ -1137,6 +1139,7 @@ int wdb_syscollector_hotfix_save2(wdb_t * wdb, const cJSON * attributes)
     const char * scan_time = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "scan_time"));
     const char * hotfix = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "hotfix"));
     const char * checksum = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "checksum"));
+    //this is needed to remove old entries in the db with a scan_id != 0: https://github.com/wazuh/wazuh/issues/7356
     wdb_hotfix_delete(wdb, scan_id);
     return wdb_hotfix_save(wdb, scan_id, scan_time, hotfix, checksum, TRUE);
 }
@@ -1207,6 +1210,7 @@ int wdb_syscollector_netinfo_save2(wdb_t * wdb, const cJSON * attributes)
     const long rx_dropped = cJSON_GetObjectItem(attributes, "rx_dropped") ? cJSON_GetObjectItem(attributes, "rx_dropped")->valueint : 0;
     const char * checksum = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "checksum"));
     const char * item_id = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "item_id"));
+    //this is needed to remove old entries in the db with a scan_id != 0: https://github.com/wazuh/wazuh/issues/7356
     wdb_netinfo_delete(wdb, scan_id);
     return wdb_netinfo_save(wdb, scan_id, scan_time, name, adapter, type, state, mtu, mac, tx_packets, rx_packets, tx_bytes, rx_bytes, tx_errors, rx_errors, tx_dropped, rx_dropped, checksum, item_id, TRUE);
 }

--- a/src/wazuh_db/wdb_syscollector.c
+++ b/src/wazuh_db/wdb_syscollector.c
@@ -1103,6 +1103,7 @@ int wdb_syscollector_processes_save2(wdb_t * wdb, const cJSON * attributes)
     const int tty = cJSON_GetObjectItem(attributes, "tty") ? cJSON_GetObjectItem(attributes, "tty")->valueint : 0;
     const int processor = cJSON_GetObjectItem(attributes, "processor") ? cJSON_GetObjectItem(attributes, "processor")->valueint : 0;
     const char * checksum = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "checksum"));
+    wdb_process_delete(wdb, scan_id);
     return wdb_process_save(wdb, scan_id, scan_time, pid, name, state, ppid, utime, stime, cmd, argvs, euser, ruser, suser, egroup, rgroup, sgroup, fgroup, priority, nice, size, vm_size, resident, share, start_time, pgrp, session, nlwp, tgid, tty, processor, checksum, TRUE);
 }
 
@@ -1126,6 +1127,7 @@ int wdb_syscollector_package_save2(wdb_t * wdb, const cJSON * attributes)
     const char * location = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "location"));
     const char * checksum = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "checksum"));
     const char * item_id = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "item_id"));
+    wdb_package_delete(wdb, scan_id);
     return wdb_package_save(wdb, scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, architecture, multiarch, source, description, location, checksum, item_id, TRUE);
 }
 
@@ -1135,6 +1137,7 @@ int wdb_syscollector_hotfix_save2(wdb_t * wdb, const cJSON * attributes)
     const char * scan_time = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "scan_time"));
     const char * hotfix = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "hotfix"));
     const char * checksum = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "checksum"));
+    wdb_hotfix_delete(wdb, scan_id);
     return wdb_hotfix_save(wdb, scan_id, scan_time, hotfix, checksum, TRUE);
 }
 
@@ -1204,6 +1207,7 @@ int wdb_syscollector_netinfo_save2(wdb_t * wdb, const cJSON * attributes)
     const long rx_dropped = cJSON_GetObjectItem(attributes, "rx_dropped") ? cJSON_GetObjectItem(attributes, "rx_dropped")->valueint : 0;
     const char * checksum = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "checksum"));
     const char * item_id = cJSON_GetStringValue(cJSON_GetObjectItem(attributes, "item_id"));
+    wdb_netinfo_delete(wdb, scan_id);
     return wdb_netinfo_save(wdb, scan_id, scan_time, name, adapter, type, state, mtu, mac, tx_packets, rx_packets, tx_bytes, rx_bytes, tx_errors, rx_errors, tx_dropped, rx_dropped, checksum, item_id, TRUE);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7356  |

## **Description**
This issue aims to fix the issue related to agent upgrade and its tables in the server.
RCA: after agent upgrade scan_id is no longer used for synchronization and old data is not deleted in the server side dbs.
