### PR TITLE
Fix Windows agent compilation with GCC 10

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1178,7 +1178,7 @@ wazuh_modules/%.o: wazuh_modules/%.c
 
 ifeq (${TARGET},winagent)
 wazuh_modules/syscollector/syscollector_win_ext.dll: wazuh_modules/syscollector/syscollector_win_ext.o
-	${OSSEC_SHARED} ${OSSEC_LDFLAGS} $^ -o $@ $(OSSEC_LIBS) $(JSON_LIB) -liphlpapi -lws2_32
+	${OSSEC_SHARED} ${OSSEC_LDFLAGS} $^ -o $@ $(OSSEC_LIBS) $(JSON_LIB) -liphlpapi -lws2_32 -static-libgcc
 endif # DLL for Windows
 
 ifeq (,$(filter ${DISABLE_SYSC},YES yes y Y 1))

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -30,7 +30,7 @@
 #ifdef WIN32
 #define PATH_SEP '\\'
 typedef uint64_t wino_t;
-int isVista;
+extern int isVista;
 #else
 #define PATH_SEP '/'
 typedef ino_t wino_t;

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -387,6 +387,10 @@
 #define mkdir(x, y) mkdir(x)
 #endif /* WIN32 */
 
+#ifdef WIN32
+int isVista;
+#endif
+
 const char *__local_name = "unset";
 
 /* Set the name of the starting program */

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -37,6 +37,10 @@ typedef struct request_dump_t {
     int first_scan;
 } request_dump_t;
 
+#ifdef WIN32
+static HKEY wm_sca_sub_tree;
+#endif
+
 static const int RETURN_NOT_FOUND = 0;
 static const int RETURN_FOUND = 1;
 static const int RETURN_INVALID = 2;

--- a/src/wazuh_modules/wm_sca.h
+++ b/src/wazuh_modules/wm_sca.h
@@ -29,10 +29,6 @@
 #define WM_SCA_STAMP          "sca"
 #define WM_CONFIGURATION_ASSESSMENT_DB_DUMP                   "sca-dump"
 
-#ifdef WIN32
-HKEY wm_sca_sub_tree;
-#endif
-
 typedef struct wm_sca_policy_t {
     unsigned int enabled:1;
     unsigned int remote:1;

--- a/src/win32/ui/common.c
+++ b/src/win32/ui/common.c
@@ -15,6 +15,8 @@
 #include "os_net/os_net.h"
 #include "validate_op.h"
 
+/* Agent status */
+char ui_server_info[2048 + 1];
 
 /* Generate server info (for the main status) */
 int gen_server_info(HWND hwnd)

--- a/src/win32/ui/os_win32ui.c
+++ b/src/win32/ui/os_win32ui.c
@@ -13,6 +13,8 @@
 #include "os_win32ui.h"
 #include "../os_win.h"
 
+ossec_config config_inst;
+HWND hStatus;
 
 /* Dialog -- About OSSEC */
 BOOL CALLBACK AboutDlgProc(HWND hwnd, UINT Message,

--- a/src/win32/ui/os_win32ui.h
+++ b/src/win32/ui/os_win32ui.h
@@ -69,14 +69,11 @@ typedef struct _ossec_config {
 
 /** Global variables **/
 
-/* Agent status */
-char ui_server_info[2048 + 1];
-
 /* Configuration */
-ossec_config config_inst;
+extern ossec_config config_inst;
 
 /* Status bar */
-HWND hStatus;
+extern HWND hStatus;
 
 /* Ossec icon */
 #define IDI_OSSECICON  201


### PR DESCRIPTION
|Related issue|
|---|
|#6783|

## Description

This PR closes #6783 by replacing definitions of some global variables from header files with declarations to them and placing the definition in an adequate source file.

Compilation of the `syscollector_win_ext.dll` shared library was also causing some trouble due to it not being statically linked to libgcc, so an extra flag was added to its makefile recipe

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- Memory tests for Windows
  - [x] Scan-build report
