### PR TITLE
7360 solaris cicd failure

### DIFF
--- a/src/wazuh_modules/wmcom.c
+++ b/src/wazuh_modules/wmcom.c
@@ -97,11 +97,11 @@ void wmcom_send(char * message)
     if (sock = OS_ConnectUnixDomain(DEFAULTDIR WM_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
         switch (errno) {
             case ECONNREFUSED:
-                merror("At wmcom_send(): Target wmodules refused connection. The component might be disabled");
+                mwarn("At wmcom_send(): Target wmodules refused connection. The component might be disabled");
                 break;
 
             default:
-                merror("At wmcom_send(): Could not connect to socket wmodules: %s (%d).", strerror(errno), errno);
+                mwarn("At wmcom_send(): Could not connect to socket wmodules: %s (%d).", strerror(errno), errno);
         }
     }
     else


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7360 |

This PR aims to fix the solaris failure in cicd related to wrong log levels on wmcom_send function.

## DoD
- [x] cicid green
