### PR TITLE
Fix lower case issue with API integration tests mapping

### DIFF
--- a/api/test/integration/mapping/_test_mapping.py
+++ b/api/test/integration/mapping/_test_mapping.py
@@ -36,7 +36,7 @@ def calculate_test_mappings():
         test_tag = re.match(test_tag_regex, test).group(1)
         if test_tag.startswith('rbac'):
             # Add RBAC tests
-            test_mapping['rbac'].append(test.lower())
+            test_mapping['rbac'].append(test)
         else:
             # Add every other test
             test_mapping[test_tag.lower()].append(test)
@@ -51,7 +51,7 @@ def calculate_test_mappings():
 def get_file_and_test_info(test_name, test_mapping, module_name):
     try:
         # Get file tag, i.e.: agent.py -> agent
-        test_tag = re.match(file_tag_regex, test_name).group(1)
+        test_tag = re.match(file_tag_regex, test_name.lower()).group(1)
     except AttributeError:
         return None
 
@@ -85,7 +85,7 @@ if __name__ == '__main__':
                 mappings['files'] = list()
                 for file in sorted(files):
                     if file.endswith(allowed_extensions):
-                        test_info = get_file_and_test_info(file.lower(), test_tags, module)
+                        test_info = get_file_and_test_info(file, test_tags, module)
                         if test_info and test_info[2]:
                             mappings['files'].append({'name': test_info[0], 'tag': test_info[1], 'tests': test_info[2]})
 

--- a/api/test/integration/mapping/integration_test_api_endpoints.json
+++ b/api/test/integration/mapping/integration_test_api_endpoints.json
@@ -700,7 +700,7 @@
         "path": "framework/wazuh/core",
         "files": [
             {
-                "name": "inputvalidator.py",
+                "name": "InputValidator.py",
                 "tag": "inputvalidator",
                 "tests": [
                     "test_agent_DELETE_endpoints.tavern.yaml",
@@ -853,7 +853,7 @@
                 ]
             },
             {
-                "name": "pydaemonmodule.py",
+                "name": "pyDaemonModule.py",
                 "tag": "pydaemonmodule",
                 "tests": [
                     "test_agent_DELETE_endpoints.tavern.yaml",
@@ -1777,7 +1777,7 @@
         "path": "framework/wazuh/core",
         "files": [
             {
-                "name": "inputvalidator.py",
+                "name": "InputValidator.py",
                 "tag": "inputvalidator",
                 "tests": [
                     "test_agent_DELETE_endpoints.tavern.yaml",
@@ -1930,7 +1930,7 @@
                 ]
             },
             {
-                "name": "pydaemonmodule.py",
+                "name": "pyDaemonModule.py",
                 "tag": "pydaemonmodule",
                 "tests": [
                     "test_agent_DELETE_endpoints.tavern.yaml",
@@ -2936,31 +2936,31 @@
                 ]
             },
             {
-                "name": "test_agent_delete_endpoints.tavern.yaml",
+                "name": "test_agent_DELETE_endpoints.tavern.yaml",
                 "tag": "test",
                 "tests": [
-                    "test_agent_delete_endpoints.tavern.yaml"
+                    "test_agent_DELETE_endpoints.tavern.yaml"
                 ]
             },
             {
-                "name": "test_agent_get_endpoints.tavern.yaml",
+                "name": "test_agent_GET_endpoints.tavern.yaml",
                 "tag": "test",
                 "tests": [
-                    "test_agent_get_endpoints.tavern.yaml"
+                    "test_agent_GET_endpoints.tavern.yaml"
                 ]
             },
             {
-                "name": "test_agent_post_endpoints.tavern.yaml",
+                "name": "test_agent_POST_endpoints.tavern.yaml",
                 "tag": "test",
                 "tests": [
-                    "test_agent_post_endpoints.tavern.yaml"
+                    "test_agent_POST_endpoints.tavern.yaml"
                 ]
             },
             {
-                "name": "test_agent_put_endpoints.tavern.yaml",
+                "name": "test_agent_PUT_endpoints.tavern.yaml",
                 "tag": "test",
                 "tests": [
-                    "test_agent_put_endpoints.tavern.yaml"
+                    "test_agent_PUT_endpoints.tavern.yaml"
                 ]
             },
             {
@@ -3307,31 +3307,31 @@
                 ]
             },
             {
-                "name": "test_security_delete_endpoints.tavern.yaml",
+                "name": "test_security_DELETE_endpoints.tavern.yaml",
                 "tag": "test",
                 "tests": [
-                    "test_security_delete_endpoints.tavern.yaml"
+                    "test_security_DELETE_endpoints.tavern.yaml"
                 ]
             },
             {
-                "name": "test_security_get_endpoints.tavern.yaml",
+                "name": "test_security_GET_endpoints.tavern.yaml",
                 "tag": "test",
                 "tests": [
-                    "test_security_get_endpoints.tavern.yaml"
+                    "test_security_GET_endpoints.tavern.yaml"
                 ]
             },
             {
-                "name": "test_security_post_endpoints.tavern.yaml",
+                "name": "test_security_POST_endpoints.tavern.yaml",
                 "tag": "test",
                 "tests": [
-                    "test_security_post_endpoints.tavern.yaml"
+                    "test_security_POST_endpoints.tavern.yaml"
                 ]
             },
             {
-                "name": "test_security_put_endpoints.tavern.yaml",
+                "name": "test_security_PUT_endpoints.tavern.yaml",
                 "tag": "test",
                 "tests": [
-                    "test_security_put_endpoints.tavern.yaml"
+                    "test_security_PUT_endpoints.tavern.yaml"
                 ]
             },
             {


### PR DESCRIPTION
Hello team,

We found an issue with the API integration test mapping file. All the filenames within the JSON file were lower case, leading to wrong mappings.

It is now fixed:

### Before
```json
            {
                "name": "test_agent_delete_endpoints.tavern.yaml",
                "tag": "test",
                "tests": [
                    "test_agent_delete_endpoints.tavern.yaml"
                ]
            },
            {
                "name": "test_agent_get_endpoints.tavern.yaml",
                "tag": "test",
                "tests": [
                    "test_agent_get_endpoints.tavern.yaml"
                ]
            },
```

### After
```json
            {
                "name": "test_agent_DELETE_endpoints.tavern.yaml",
                "tag": "test",
                "tests": [
                    "test_agent_DELETE_endpoints.tavern.yaml"
                ]
            },
            {
                "name": "test_agent_GET_endpoints.tavern.yaml",
                "tag": "test",
                "tests": [
                    "test_agent_GET_endpoints.tavern.yaml"
                ]
            },
```

Regards,
Víctor Fernández