### PR TITLE
HPUX shared modules compilation skip

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -673,28 +673,36 @@ ifeq (${MAKECMDGOALS},server)
 $(error Do not use 'server' directly, use 'TARGET=server')
 endif
 server: external
+ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
+endif
 	${MAKE} ${BUILD_SERVER}
 
 ifeq (${MAKECMDGOALS},local)
 $(error Do not use 'local' directly, use 'TARGET=local')
 endif
 local: external
+ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
+endif
 	${MAKE} ${BUILD_SERVER}
 
 ifeq (${MAKECMDGOALS},hybrid)
 $(error Do not use 'hybrid' directly, use 'TARGET=hybrid')
 endif
 hybrid: external
+ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
+endif
 	${MAKE} ${BUILD_SERVER}
 
 ifeq (${MAKECMDGOALS},agent)
 $(error Do not use 'agent' directly, use 'TARGET=agent')
 endif
 agent: external
+ifneq (${uname_S},HP-UX)
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
+endif
 	${MAKE} ${BUILD_AGENT}
 
 ifneq (,$(filter ${USE_SELINUX},YES yes y Y 1))

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -92,7 +92,11 @@ void* wm_sys_main(wm_sys_t *sys) {
         syscollector_stop_ptr = so_get_function_sym(syscollector_module, "syscollector_stop");
         syscollector_sync_message_ptr = so_get_function_sym(syscollector_module, "syscollector_sync_message");
     } else {
+#ifdef __hpux
+        mtinfo(WM_SYS_LOGTAG, "Not supported in HP-UX.");
+#else
         mterror(WM_SYS_LOGTAG, "Can't load syscollector.");
+#endif
         pthread_exit(NULL);
     }
     if (syscollector_start_ptr) {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7320 |

## Description
This issue aims to test the functionality and compilation in 11.31 IT64, if necessary you have to change the makefile to avoid cmake compilation of all modules.

## DoD
- [x] Test makefile
- [x] Install product and test functionality.
- [ ] PR and CI PASS
