### PR TITLE
Add PUT /manager/configuration and /cluster/{node_id}/configuration endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
   - Added new endpoints to manage rules files. ([#7178](https://github.com/wazuh/wazuh/issues/7178))
   - Added new endpoints to manage CDB lists files. ([#7180](https://github.com/wazuh/wazuh/issues/7180))
   - Added new endpoints to manage decoder files. ([#7179](https://github.com/wazuh/wazuh/issues/7179))
-
+  - Added new manager and cluster endpoints to update Wazuh configuration (ossec.conf). ([#7181](https://github.com/wazuh/wazuh/issues/7181))
+  
 ### Fixed
 
 - **API:**

--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -634,7 +634,8 @@ async def get_node_config(request, node_id, component, wait_for_complete=False, 
 
 
 async def update_configuration(request, node_id, body,  pretty=False, wait_for_complete=False):
-    """Update Wazuh configuration (ossec.conf) in node node_id
+    """Update Wazuh configuration (ossec.conf) in node node_id.
+
     Parameters
     ----------
     pretty : bool, optional

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -422,3 +422,31 @@ async def get_manager_config_ondemand(request, component, pretty=False, wait_for
     data = raise_if_exc(await dapi.distribute_function())
 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+
+
+async def update_configuration(request, body, pretty=False, wait_for_complete=False):
+    """Update manager's or local_node's configuration (ossec.conf)
+    Parameters
+    ----------
+    pretty : bool, optional
+        Show results in human-readable format. It only works when `raw` is False (JSON format). Default `True`
+    wait_for_complete : bool, optional
+        Disable response timeout or not. Default `False`
+    """
+    # Parse body to utf-8
+    Body.validate_content_type(request, expected_content_type='application/octet-stream')
+    parsed_body = Body.decode_body(body, unicode_error=1911, attribute_error=1912)
+
+    f_kwargs = {'new_conf': parsed_body}
+
+    dapi = DistributedAPI(f=manager.update_ossec_conf,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='local_any',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          logger=logger,
+                          rbac_permissions=request['token_info']['rbac_policies']
+                          )
+    data = raise_if_exc(await dapi.distribute_function())
+
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -425,7 +425,8 @@ async def get_manager_config_ondemand(request, component, pretty=False, wait_for
 
 
 async def update_configuration(request, body, pretty=False, wait_for_complete=False):
-    """Update manager's or local_node's configuration (ossec.conf)
+    """Update manager's or local_node's configuration (ossec.conf).
+
     Parameters
     ----------
     pretty : bool, optional

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -200,6 +200,14 @@ x-rbac-catalog:
         actions: ['cluster:read']
         resources: ['node:id:worker1', 'node:id:worker3']
         effect: "deny"
+    'cluster:update_config':
+      description: "Update current Wazuh's node configuration"
+      resources:
+        - $ref: '#/x-rbac-catalog/resources/*:*'
+      example:
+        actions: [ 'cluster:update_config' ]
+        resources: [ '*:*:*' ]
+        effect: "allow"
     'cluster:read_api_config':
       description: "Check Wazuh's cluster nodes API configuration"
       resources:
@@ -257,6 +265,14 @@ x-rbac-catalog:
       example:
         actions: ['manager:read']
         resources: ['*:*:*']
+        effect: "allow"
+    'manager:update_config':
+      description: "Update current Wazuh manager configuration"
+      resources:
+        - $ref: '#/x-rbac-catalog/resources/*:*'
+      example:
+        actions: [ 'manager:update_config' ]
+        resources: [ '*:*:*' ]
         effect: "allow"
     'manager:read_api_config':
       description: "Read Wazuh manager API configuration"
@@ -1987,7 +2003,7 @@ components:
         tz_name:
           type: string
 
-    WazuhMangerConfiguration:
+    WazuhManagerConfiguration:
       type: object
       properties:
         active-response:
@@ -8037,7 +8053,7 @@ paths:
                 - type: object
                   properties:
                     data:
-                      $ref: '#/components/schemas/WazuhMangerConfiguration'
+                      $ref: '#/components/schemas/WazuhManagerConfiguration'
               example:
                 data:
                   affected_items:
@@ -8087,6 +8103,50 @@ paths:
           $ref: '#/components/responses/PermissionDeniedResponse'
         '405':
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+    put:
+      tags:
+      - Cluster
+      summary: "Update node configuration"
+      description: "Replace wazuh configuration for the given node with the data contained in the API request"
+      operationId: api.controllers.cluster_controller.update_configuration
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/cluster:update_config'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/node_id'
+      requestBody:
+        description: "Content of the ossec.conf to be uploaded"
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: "Confirmation message"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: '#/components/schemas/ConfirmationMessage'
+              example:
+                message: "File was uploaded successfully"
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '406':
+          $ref: '#/components/responses/WrongContentTypeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
@@ -9565,7 +9625,7 @@ paths:
                 - type: object
                   properties:
                     data:
-                      $ref: '#/components/schemas/WazuhMangerConfiguration'
+                      $ref: '#/components/schemas/WazuhManagerConfiguration'
               example:
                 data:
                   affected_items:
@@ -9615,6 +9675,49 @@ paths:
           $ref: '#/components/responses/PermissionDeniedResponse'
         '405':
           $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+    put:
+      tags:
+      - Manager
+      summary: "Update wazuh configuration"
+      description: "Replace wazuh configuration with the data contained in the API request"
+      operationId: api.controllers.manager_controller.update_configuration
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/manager:update_config'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+      requestBody:
+        description: "Content of the ossec.conf to be uploaded"
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: "Confirmation message"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: '#/components/schemas/ConfirmationMessage'
+              example:
+                message: "File was uploaded successfully"
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '406':
+          $ref: '#/components/responses/WrongContentTypeResponse'
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
@@ -15842,3 +15945,4 @@ paths:
 externalDocs:
   description: "Find more about Wazuh API usage"
   url: 'https://documentation.wazuh.com/4.1/user-manual/api/index.html'
+

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -201,7 +201,7 @@ x-rbac-catalog:
         resources: ['node:id:worker1', 'node:id:worker3']
         effect: "deny"
     'cluster:update_config':
-      description: "Update current Wazuh's node configuration"
+      description: "Change the Wazuh's cluster node configuration"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8135,7 +8135,7 @@ paths:
                   - $ref: '#/components/schemas/ApiResponse'
                   - $ref: '#/components/schemas/ConfirmationMessage'
               example:
-                message: "File was uploaded successfully"
+                message: "Configuration was successfully updated"
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'
@@ -9706,7 +9706,7 @@ paths:
                   - $ref: '#/components/schemas/ApiResponse'
                   - $ref: '#/components/schemas/ConfirmationMessage'
               example:
-                message: "File was uploaded successfully"
+                message: "Configuration was successfully updated"
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -15945,4 +15945,3 @@ paths:
 externalDocs:
   description: "Find more about Wazuh API usage"
   url: 'https://documentation.wazuh.com/4.1/user-manual/api/index.html'
-

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -9681,7 +9681,7 @@ paths:
       tags:
       - Manager
       summary: "Update Wazuh configuration"
-      description: "Replace wazuh configuration with the data contained in the API request"
+      description: "Replace Wazuh configuration with the data contained in the API request"
       operationId: api.controllers.manager_controller.update_configuration
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/manager:update_config'

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -9680,7 +9680,7 @@ paths:
     put:
       tags:
       - Manager
-      summary: "Update wazuh configuration"
+      summary: "Update Wazuh configuration"
       description: "Replace wazuh configuration with the data contained in the API request"
       operationId: api.controllers.manager_controller.update_configuration
       x-rbac-actions:

--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -152,3 +152,52 @@ variables:
     </query>
     </localfile>
     </agent_config>
+
+  valid_ossec_conf:
+    <ossec_config>
+      <global>
+        <jsonout_output>yes</jsonout_output>
+        <alerts_log>yes</alerts_log>
+        <logall>no</logall>
+        <logall_json>no</logall_json>
+        <email_notification>no</email_notification>
+        <agents_disconnection_time>20s</agents_disconnection_time>
+        <agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
+      </global>
+
+      <logging>
+        <log_format>plain</log_format>
+      </logging>
+
+      <alerts>
+        <log_alert_level>300</log_alert_level>
+        <email_alert_level>12</email_alert_level>
+      </alerts>
+
+      <remote>
+        <connection>secure</connection>
+        <port>1514</port>
+        <protocol>tcp</protocol>
+      </remote>
+
+      <syscheck>
+        <disabled>yes</disabled>
+      </syscheck>
+    </ossec_config>
+
+  invalid_ossec_conf:
+    <ossec_config>
+      <global>
+        <jsonout_output>yes</jsonout_output>
+        <alerts_log>yes</alerts_log>
+        <logall>no</logall>
+        <logall_json>no</logall_json>
+      </global>
+
+      <alerts>
+        <log_alert_level>3</log_alert_level>
+        <email_alert_level>12</email_alert_level>
+      </alerts>
+
+      <remote>
+    </ossec_config>

--- a/api/test/integration/env/configurations/rbac/cluster/black_config.txt
+++ b/api/test/integration/env/configurations/rbac/cluster/black_config.txt
@@ -13,5 +13,5 @@
 | cluster:read_file        | node:id&file:path |                     | master-node,worker2 & etc/ossec.conf,etc/rules/local_rules.xml,ruleset/rules/0350-amazon_rules.xml             |
 | cluster:upload_file      | node:id           |                     | master-node,worker2                                                                                            |
 | cluster:delete_file      | node:id&file:path |                     | master-node,worker2 & etc/decoders/0005-wazuh_decoders.xml, etc/ossec.conf                                     |
-| cluster:upload_config    | node:id           | worker1             | master-node,worker2                                                                                            |
+| cluster:update_config    | node:id           | worker1             | master-node,worker2                                                                                            |
 | cluster:read_api_config  | node:id           | worker1             | master-node,worker2                                                                                            |

--- a/api/test/integration/env/configurations/rbac/cluster/black_config.txt
+++ b/api/test/integration/env/configurations/rbac/cluster/black_config.txt
@@ -13,4 +13,5 @@
 | cluster:read_file        | node:id&file:path |                     | master-node,worker2 & etc/ossec.conf,etc/rules/local_rules.xml,ruleset/rules/0350-amazon_rules.xml             |
 | cluster:upload_file      | node:id           |                     | master-node,worker2                                                                                            |
 | cluster:delete_file      | node:id&file:path |                     | master-node,worker2 & etc/decoders/0005-wazuh_decoders.xml, etc/ossec.conf                                     |
+| cluster:upload_config    | node:id           | worker1             | master-node,worker2                                                                                            |
 | cluster:read_api_config  | node:id           | worker1             | master-node,worker2                                                                                            |

--- a/api/test/integration/env/configurations/rbac/cluster/black_config.yaml
+++ b/api/test/integration/env/configurations/rbac/cluster/black_config.yaml
@@ -31,6 +31,7 @@
 
 - actions:
   - cluster:upload_file
+  - cluster:upload_config
   - cluster:read_api_config
   resources:
   - node:id:master-node

--- a/api/test/integration/env/configurations/rbac/cluster/black_config.yaml
+++ b/api/test/integration/env/configurations/rbac/cluster/black_config.yaml
@@ -31,7 +31,7 @@
 
 - actions:
   - cluster:upload_file
-  - cluster:upload_config
+  - cluster:update_config
   - cluster:read_api_config
   resources:
   - node:id:master-node

--- a/api/test/integration/env/configurations/rbac/cluster/white_config.txt
+++ b/api/test/integration/env/configurations/rbac/cluster/white_config.txt
@@ -13,5 +13,5 @@
 | cluster:read_file        | node:id&file:path | master-node,worker2 | etc/ossec.conf,etc/rules/local_rules.xml,ruleset/rules/0350-amazon_rules.xml                |                     |
 | cluster:upload_file      | node:id           | master-node,worker2                                                                                               |                     |
 | cluster:delete_file      | node:id&file:path | master-node,worker2 | ruleset/decoders/0005-wazuh_decoders.xml                                                    |                     |
-| cluster:upload_config    | node:id           | master-node,worker2                                                                                               | worker1             |
+| cluster:update_config    | node:id           | master-node,worker2                                                                                               | worker1             |
 | cluster:read_api_config  | node:id           | master-node,worker2                                                                                               | worker1             |

--- a/api/test/integration/env/configurations/rbac/cluster/white_config.txt
+++ b/api/test/integration/env/configurations/rbac/cluster/white_config.txt
@@ -13,4 +13,5 @@
 | cluster:read_file        | node:id&file:path | master-node,worker2 | etc/ossec.conf,etc/rules/local_rules.xml,ruleset/rules/0350-amazon_rules.xml                |                     |
 | cluster:upload_file      | node:id           | master-node,worker2                                                                                               |                     |
 | cluster:delete_file      | node:id&file:path | master-node,worker2 | ruleset/decoders/0005-wazuh_decoders.xml                                                    |                     |
+| cluster:upload_config    | node:id           | master-node,worker2                                                                                               | worker1             |
 | cluster:read_api_config  | node:id           | master-node,worker2                                                                                               | worker1             |

--- a/api/test/integration/env/configurations/rbac/cluster/white_config.yaml
+++ b/api/test/integration/env/configurations/rbac/cluster/white_config.yaml
@@ -31,6 +31,7 @@
 
 - actions:
   - cluster:upload_file
+  - cluster:upload_config
   - cluster:read_api_config
   resources:
   - node:id:master-node

--- a/api/test/integration/env/configurations/rbac/cluster/white_config.yaml
+++ b/api/test/integration/env/configurations/rbac/cluster/white_config.yaml
@@ -31,7 +31,7 @@
 
 - actions:
   - cluster:upload_file
-  - cluster:upload_config
+  - cluster:update_config
   - cluster:read_api_config
   resources:
   - node:id:master-node

--- a/api/test/integration/env/configurations/rbac/manager/black_config.txt
+++ b/api/test/integration/env/configurations/rbac/manager/black_config.txt
@@ -6,4 +6,5 @@
 | manager:read_file        | file:path |        | *                            |
 | manager:upload_file      | *         | *      |                              |
 | manager:restart          | *         | *      |                              |
+| manager:upload_config    | *         |        | *                            |
 | manager:read_api_config  | *         |        | *                            |

--- a/api/test/integration/env/configurations/rbac/manager/black_config.txt
+++ b/api/test/integration/env/configurations/rbac/manager/black_config.txt
@@ -6,5 +6,5 @@
 | manager:read_file        | file:path |        | *                            |
 | manager:upload_file      | *         | *      |                              |
 | manager:restart          | *         | *      |                              |
-| manager:upload_config    | *         |        | *                            |
+| manager:update_config    | *         |        | *                            |
 | manager:read_api_config  | *         |        | *                            |

--- a/api/test/integration/env/configurations/rbac/manager/black_config.yaml
+++ b/api/test/integration/env/configurations/rbac/manager/black_config.yaml
@@ -5,7 +5,7 @@
   - file:path:*
   effect: deny
 - actions:
-  - manager:upload_config
+  - manager:update_config
   resources:
   - "*:*:*"
   effect: deny

--- a/api/test/integration/env/configurations/rbac/manager/black_config.yaml
+++ b/api/test/integration/env/configurations/rbac/manager/black_config.yaml
@@ -5,6 +5,11 @@
   - file:path:*
   effect: deny
 - actions:
+  - manager:upload_config
+  resources:
+  - "*:*:*"
+  effect: deny
+- actions:
   - manager:read_api_config
   resources:
   - "*:*:*"

--- a/api/test/integration/env/configurations/rbac/manager/white_config.txt
+++ b/api/test/integration/env/configurations/rbac/manager/white_config.txt
@@ -6,4 +6,5 @@
 | manager:read_file        | file:path | *                         |      |
 | manager:upload_file      | *         |                           | *    |
 | manager:restart          | *         |                           | *    |
+| manager:upload_config    | *         | *                         |      |
 | manager:read_api_config  | *         | *                         |      |

--- a/api/test/integration/env/configurations/rbac/manager/white_config.txt
+++ b/api/test/integration/env/configurations/rbac/manager/white_config.txt
@@ -6,5 +6,5 @@
 | manager:read_file        | file:path | *                         |      |
 | manager:upload_file      | *         |                           | *    |
 | manager:restart          | *         |                           | *    |
-| manager:upload_config    | *         | *                         |      |
+| manager:update_config    | *         | *                         |      |
 | manager:read_api_config  | *         | *                         |      |

--- a/api/test/integration/env/configurations/rbac/manager/white_config.yaml
+++ b/api/test/integration/env/configurations/rbac/manager/white_config.yaml
@@ -5,6 +5,11 @@
   - file:path:*
   effect: allow
 - actions:
+  - manager:upload_config
+  resources:
+  - "*:*:*"
+  effect: allow
+- actions:
   - manager:read_api_config
   resources:
   - "*:*:*"

--- a/api/test/integration/env/configurations/rbac/manager/white_config.yaml
+++ b/api/test/integration/env/configurations/rbac/manager/white_config.yaml
@@ -5,7 +5,7 @@
   - file:path:*
   effect: allow
 - actions:
-  - manager:upload_config
+  - manager:update_config
   resources:
   - "*:*:*"
   effect: allow

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -2979,3 +2979,125 @@ stages:
           failed_items: []
           total_affected_items: 3
           total_failed_items: 0
+    delay_after: !float "{restart_delay_cluster}"
+
+---
+test_name: PUT /cluster/{node_id}/configuration
+
+stages:
+
+  # PUT /cluster/{node_id}/configuration
+  - name: Upload a valid configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      method: PUT
+      data: "{valid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - 'worker1'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+        error: 0
+
+  # GET /cluster/{node_id}/configuration
+  - name: Ensure the new config has been applied by checking a field
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+      params:
+        section: "alerts"
+        field: "log_alert_level"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - alerts:
+                log_alert_level: '300'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+
+  # PUT /cluster/{node_id}/configuration
+  - name: Try to upload an invalid configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      method: PUT
+      data: "{invalid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1113
+              id:
+                - 'worker1'
+          total_affected_items: 0
+          total_failed_items: 1
+
+  # PUT /cluster/{node_id}/configuration
+  - name: Try to upload an empty configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      method: PUT
+      data: "{invalid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1113
+              id:
+                - 'worker1'
+          total_affected_items: 0
+          total_failed_items: 1
+
+  # GET /cluster/{node_id}/configuration
+  - name: Ensure the config didn't change
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+      params:
+        section: "alerts"
+        field: "log_alert_level"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - alerts:
+                log_alert_level: '300'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -239,6 +239,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
+
 ---
 test_name: GET /manager/stats
 
@@ -2338,6 +2339,127 @@ stages:
         data:
           affected_items:
             - !anystr
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+---
+test_name: PUT /manager/configuration
+
+stages:
+
+  # PUT /manager/configuration
+  - name: Upload a valid configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: PUT
+      data: "{valid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - 'manager'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+        error: 0
+
+  # GET /manager/configuration/
+  - name: Ensure the new config has been applied by checking a field
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+      params:
+        section: "alerts"
+        field: "log_alert_level"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - alerts:
+                log_alert_level: '300'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+
+  # PUT /manager/configuration
+  - name: Try to upload an invalid configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: PUT
+      data: "{invalid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1113
+              id:
+                - 'manager'
+          total_affected_items: 0
+          total_failed_items: 1
+
+  # PUT /manager/configuration
+  - name: Try to upload an empty configuration
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: PUT
+      data: "{invalid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items: []
+          failed_items:
+            - error:
+                code: 1113
+              id:
+                - 'manager'
+          total_affected_items: 0
+          total_failed_items: 1
+
+  # GET /manager/configuration/
+  - name: Ensure the config didn't change
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: GET
+      params:
+        section: "alerts"
+        field: "log_alert_level"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - alerts:
+                log_alert_level: '300'
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0

--- a/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
@@ -681,6 +681,43 @@ stages:
           total_failed_items: 1
 
 ---
+test_name: PUT /cluster/{node_id}/configuration
+
+stages:
+
+  - name: Upload a valid configuration (Allow)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      method: PUT
+      data: "{valid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - 'worker1'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+        error: 0
+
+  - name: Try to upload a valid configuration (Deny)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
+      method: PUT
+      data: "{valid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      <<: *permission_denied
+
+---
 test_name: PUT /cluster/restart
 
 stages:

--- a/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
@@ -309,3 +309,20 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       <<: *permission_denied
+
+---
+test_name: PUT /manager/configuration
+
+stages:
+
+  - name: Attempt to upload a valid configuration (Deny)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: PUT
+      data: "{valid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      <<: *permission_denied

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -802,3 +802,40 @@ stages:
         path: etc/ossec.conf
     response:
       status_code: 400
+
+---
+test_name: PUT /cluster/{node_id}/configuration
+
+stages:
+
+  - name: Upload a valid configuration (Allow)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/configuration"
+      method: PUT
+      data: "{valid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+      json:
+        data:
+          affected_items:
+            - 'worker2'
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+        error: 0
+
+  - name: Try to upload a valid configuration (Deny)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      method: PUT
+      data: "{valid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      <<: *permission_denied

--- a/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
@@ -277,6 +277,23 @@ stages:
       status_code: 200
 
 ---
+test_name: PUT /manager/configuration
+
+stages:
+
+  - name: Upload a valid configuration (Allow)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: PUT
+      data: "{valid_ossec_conf:s}"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+        content-type: application/octet-stream
+    response:
+      status_code: 200
+
+---
 test_name: PUT /manager/restart
 
 stages:

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -810,7 +810,7 @@ def get_active_configuration(agent_id, component, configuration):
 
 def write_ossec_conf(new_conf: str):
     """
-    Replaces the current wazuh configuration (ossec.conf) with the provided configuration.
+    Replace the current wazuh configuration (ossec.conf) with the provided configuration.
 
     Parameters
     ----------

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -503,45 +503,6 @@ def get_ossec_conf(section=None, field=None, conf_file=common.ossec_conf):
     return data
 
 
-def get_raw_ossec_conf(section=None, field=None,):
-    """
-    Returns ossec.conf (manager) as dictionary.
-    :param section: Filters by section (i.e. rules).
-    :param field: Filters by field in section (i.e. included).
-    :return: ossec.conf (manager) as dictionary.
-    """
-    try:
-        # Read XML
-        xml_data = load_wazuh_xml(common.ossec_conf)
-
-    except Exception as e:
-        raise WazuhError(1101, extra_message=str(e))
-
-    if section:
-        for xml_group in xml_data[0]:
-            if xml_group.tag.lower() == section:
-                xml_data = xml_group
-                break
-
-    if section and field:
-        try:
-            if isinstance(xml_data, list):
-                xml_data = [ET.tostring(item[field], encoding='unicode', method='xml') for item in xml_data[section]]
-            else:
-                if xml_data.findtext(field):
-                    xml_data = xml_data.findtext(field)
-                else:
-                    xml_data = xml_data.find(field)
-
-                #xml_data = ET.tostring(xml_data[section][field], encoding='unicode', method='xml')
-        except KeyError:
-            raise WazuhError(1103)
-        except Exception as e:
-            print(e)
-
-    return xml_data if isinstance(xml_data, str) else ET.tostring(xml_data, encoding='unicode', method='xml')
-
-
 def get_agent_conf(group_id=None, offset=0, limit=common.database_limit, filename='agent.conf', return_format=None):
     """
     Returns agent.conf as dictionary.

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -847,11 +847,17 @@ def get_active_configuration(agent_id, component, configuration):
                          extra_message='{0}:{1}'.format(component, configuration))
 
 
-def write_ossec_conf(new_conf):
+def write_ossec_conf(new_conf: str):
     """
-    """
-    # Check if the configuration is empty
+    Replaces the current wazuh configuration (ossec.conf) with the provided configuration.
 
-    # Write the new configuration
-    with open(common.ossec_conf, 'w') as f:
-        f.writelines(new_conf)
+    Parameters
+    ----------
+    new_conf: str
+        The new configuration to be applied.
+    """
+    try:
+        with open(common.ossec_conf, 'w') as f:
+            f.writelines(new_conf)
+    except Exception:
+        raise WazuhError(1126)

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -100,6 +100,9 @@ class WazuhException(Exception):
         1125: {'message': 'Invalid ossec configuration',
                'remediation': 'Please, provide a valid ossec configuration'
                },
+        1126: {'message': 'Error updating ossec configuration',
+               'remediation': 'Please, ensure `WAZUH_PATH/etc/ossec.conf` has the proper permissions and ownership.'
+               },
 
         # Rule: 1200 - 1299
         1200: {'message': 'Error reading rules from `WAZUH_HOME/etc/ossec.conf`',

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -97,6 +97,9 @@ class WazuhException(Exception):
         1123: {'message': f"Error communicating with socket. Query too long, maximum allowed size for queries is {MAX_SOCKET_BUFFER_SIZE // 1024} KB"},
         1124: {'message': 'Remote command detected',
                'remediation': f'To solve this issue please enable the remote commands in the API settings or add an exception: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/configuration.html#remote-commands-configuration'},
+        1125: {'message': 'Invalid ossec configuration',
+               'remediation': 'Please, provide a valid ossec configuration'
+               },
 
         # Rule: 1200 - 1299
         1200: {'message': 'Error reading rules from `WAZUH_HOME/etc/ossec.conf`',

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -10,6 +10,8 @@ from unittest.mock import mock_open
 from unittest.mock import patch, MagicMock
 from xml.etree.ElementTree import fromstring
 
+from wazuh.core.common import ossec_conf
+
 import pytest
 
 with patch('wazuh.core.common.ossec_uid'):
@@ -387,3 +389,17 @@ def test_get_active_configuration_fourth_exception(agent_id, component, config, 
             with patch('wazuh.core.configuration.OssecSocket.receive', return_value=b'ok {"a": "2"}'):
                 with patch('wazuh.core.configuration.OssecSocket.close', side_effect=None):
                     assert {"a": "2"} == configuration.get_active_configuration(agent_id, component, config)
+
+
+def test_write_ossec_conf():
+    content = "New config"
+    with patch('wazuh.core.configuration.open', mock_open()) as mocked_file:
+        configuration.write_ossec_conf(new_conf=content)
+        mocked_file.assert_called_once_with(ossec_conf, 'w')
+        mocked_file().writelines.assert_called_once_with(content)
+
+
+def test_write_ossec_conf_exceptions():
+    with patch('wazuh.core.configuration.open', return_value=Exception):
+        with pytest.raises(WazuhError, match=".* 1126 .*"):
+            configuration.write_ossec_conf(new_conf="placeholder")

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -386,7 +386,7 @@ def get_basic_info():
     return result
 
 
-@expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:upload_config"],
+@expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:update_config"],
                   resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'])
 def update_ossec_conf(new_conf=None):
     """

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -424,15 +424,11 @@ def update_ossec_conf(new_conf=None):
             raise WazuhError(1125)
         else:
             result.affected_items.append(node_id)
-
-    except WazuhError as e:
-        exists(backup_file) and safe_move(backup_file, common.ossec_conf)
-        result.add_failed_item(id_=node_id, error=e)
-    except Exception as e:
-        exists(backup_file) and safe_move(backup_file, common.ossec_conf)
-        raise e
-    finally:
         exists(backup_file) and remove(backup_file)
+    except WazuhError as e:
+        result.add_failed_item(id_=node_id, error=e)
+    finally:
+        exists(backup_file) and safe_move(backup_file, common.ossec_conf)
 
     result.total_affected_items = len(result.affected_items)
     return result

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -386,7 +386,7 @@ def get_basic_info():
     return result
 
 
-@expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:read"],
+@expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:upload_config"],
                   resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'])
 def update_ossec_conf(new_conf=None):
     """

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -421,11 +421,15 @@ def update_ossec_conf(new_conf=None):
             raise WazuhError(1125)
         else:
             result.affected_items.append(node_id)
+    except WazuhError as e:
+        if backup_conf:
+            write_ossec_conf(backup_conf)
+        result.add_failed_item(id_=node_id, error=e)
     except Exception as e:
         # Make sure the configuration is always restored regardless of the exception type raised
         if backup_conf:
             write_ossec_conf(backup_conf)
-        result.add_failed_item(id_=node_id, error=e)
+        raise e
 
     result.total_affected_items = len(result.affected_items)
 

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -390,7 +390,7 @@ def get_basic_info():
                   resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'])
 def update_ossec_conf(new_conf=None):
     """
-    Replaces wazuh configuration (ossec.conf) with the provided configuration.
+    Replace wazuh configuration (ossec.conf) with the provided configuration.
 
     Parameters
     ----------

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -414,7 +414,10 @@ def update_ossec_conf(new_conf=None):
         new_conf = prettify_xml(new_conf)
 
         # Create a backup of the current configuration before attempting to replace it
-        copyfile(common.ossec_conf, backup_file)
+        try:
+            copyfile(common.ossec_conf, backup_file)
+        except IOError:
+            raise WazuhError(1019)
 
         # Write the new configuration and validate it
         write_ossec_conf(new_conf)

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -406,7 +406,7 @@ def update_ossec_conf(new_conf=None):
     backup_conf = None
     try:
         # Check a configuration has been provided
-        if new_conf is None or not new_conf or len(new_conf) == 0:
+        if not new_conf:
             raise WazuhError(1125)
 
         # Check if the configuration is valid

--- a/framework/wazuh/rbac/default/policies.yaml
+++ b/framework/wazuh/rbac/default/policies.yaml
@@ -276,6 +276,7 @@ default_policies:
           - cluster:status
           - manager:read
           - manager:read_api_config
+          - manager:upload_config
           - manager:upload_file
           - manager:restart
           - manager:delete_file
@@ -296,6 +297,7 @@ default_policies:
           - cluster:read
           - cluster:restart
           - cluster:upload_file
+          - cluster:upload_config
         resources:
           - node:id:*
         effect: allow

--- a/framework/wazuh/rbac/default/policies.yaml
+++ b/framework/wazuh/rbac/default/policies.yaml
@@ -276,7 +276,7 @@ default_policies:
           - cluster:status
           - manager:read
           - manager:read_api_config
-          - manager:upload_config
+          - manager:update_config
           - manager:upload_file
           - manager:restart
           - manager:delete_file
@@ -297,7 +297,7 @@ default_policies:
           - cluster:read
           - cluster:restart
           - cluster:upload_file
-          - cluster:upload_config
+          - cluster:update_config
         resources:
           - node:id:*
         effect: allow


### PR DESCRIPTION
Hello team,

This PR closes #7181. This PR adds the following:

- Two new endpoints to allow the user to update the wazuh configuration (ossec.conf) using the Wazuh API:
  - `PUT /manager/configuration`
  - `PUT /cluster/{node_id]/configuration`.
- Unit and integration tests for the new endpoints.
- A fix for a typo in the Spec.yaml

## Tests performed
### Unit tests

wazuh/core/tests/
```
================================= test session starts =================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/wazuh/framework
plugins: metadata-1.11.0, tavern-1.0.0, html-3.1.1, testinfra-5.0.0
collected 643 items                                                                   

framework/wazuh/core/tests/test_active_response.py ............                 [  1%]
framework/wazuh/core/tests/test_agent.py ...................................... [  7%]
............................................................................... [ 20%]
..................................                                              [ 25%]
framework/wazuh/core/tests/test_cdb_list.py .................................   [ 30%]
framework/wazuh/core/tests/test_common.py .......                               [ 31%]
framework/wazuh/core/tests/test_configuration.py .............................. [ 36%]
......                                                                          [ 37%]
framework/wazuh/core/tests/test_decoder.py ................                     [ 39%]
framework/wazuh/core/tests/test_input_validator.py ...                          [ 40%]
framework/wazuh/core/tests/test_logtest.py ..                                   [ 40%]
framework/wazuh/core/tests/test_manager.py ................................     [ 45%]
framework/wazuh/core/tests/test_ossec_queue.py ...................              [ 48%]
framework/wazuh/core/tests/test_pyDaemonModule.py ......                        [ 49%]
framework/wazuh/core/tests/test_results.py .................................... [ 54%]
....                                                                            [ 55%]
framework/wazuh/core/tests/test_rootcheck.py ..........                         [ 57%]
framework/wazuh/core/tests/test_rule.py ......................                  [ 60%]
framework/wazuh/core/tests/test_syscollector.py ...                             [ 60%]
framework/wazuh/core/tests/test_utils.py ...................................... [ 66%]
............................................................................... [ 79%]
............................................................................... [ 91%]
..............                                                                  [ 93%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................            [ 96%]
framework/wazuh/core/tests/test_wdb.py .....................                    [100%]

===================== 643 passed, 11 warnings in 2.84 seconds =====================
```
wazuh/core/cluster/tests/
```
================================= test session starts =================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/wazuh/framework
plugins: metadata-1.11.0, tavern-1.0.0, html-3.1.1, testinfra-5.0.0
collected 55 items                                                                    

framework/wazuh/core/cluster/tests/test_cluster.py ...................          [ 34%]
framework/wazuh/core/cluster/tests/test_common.py .......                       [ 47%]
framework/wazuh/core/cluster/tests/test_control.py sssss                        [ 56%]
framework/wazuh/core/cluster/tests/test_local_client.py .                       [ 58%]
framework/wazuh/core/cluster/tests/test_utils.py .......                        [ 70%]
framework/wazuh/core/cluster/tests/test_worker.py ............ss.s              [100%]

================== 47 passed, 8 skipped, 9 warnings in 0.48 seconds ===================
```

core/cluster/dapi/tests/
```
================================= test session starts =================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/wazuh/framework
plugins: metadata-1.11.0, tavern-1.0.0, html-3.1.1, testinfra-5.0.0
collected 22 items                                                                    

framework/wazuh/core/cluster/dapi/tests/test_dapi.py ......................     [100%]

======================= 22 passed, 11 warnings in 0.62 seconds ========================
```

wazuh/tests/
```
================================= test session starts =================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/wazuh/framework
plugins: metadata-1.11.0, tavern-1.0.0, html-3.1.1, testinfra-5.0.0
collected 672 items                                                                   

framework/wazuh/tests/test_active_response.py .........                         [  1%]
framework/wazuh/tests/test_agent.py ........................................... [  7%]
.........................................                                       [ 13%]
framework/wazuh/tests/test_cdb_list.py ........................................ [ 19%]
.......                                                                         [ 20%]
framework/wazuh/tests/test_ciscat.py ..                                         [ 21%]
framework/wazuh/tests/test_cluster.py .....ss                                   [ 22%]
framework/wazuh/tests/test_decoders.py ...............................          [ 26%]
framework/wazuh/tests/test_group.py ........                                    [ 27%]
framework/wazuh/tests/test_logtest.py ......                                    [ 28%]
framework/wazuh/tests/test_manager.py ......................................... [ 34%]
                                                                                [ 34%]
framework/wazuh/tests/test_mitre.py ........................................... [ 41%]
............................................................................... [ 53%]
..........................................................                      [ 61%]
framework/wazuh/tests/test_rootcheck.py ....................................... [ 67%]
..........                                                                      [ 69%]
framework/wazuh/tests/test_rule.py ............................................ [ 75%]
...........                                                                     [ 77%]
framework/wazuh/tests/test_sca.py .......                                       [ 78%]
framework/wazuh/tests/test_security.py ........................................ [ 84%]
.............................                                                   [ 88%]
framework/wazuh/tests/test_stats.py .............                               [ 90%]
framework/wazuh/tests/test_syscheck.py ........................                 [ 94%]
framework/wazuh/tests/test_syscollector.py ............                         [ 95%]
framework/wazuh/tests/test_task.py ............................                 [100%]

=============== 670 passed, 2 skipped, 15 warnings in 72.56 seconds ===============
```

wazuh/rbac/tests/
```
================================= test session starts =================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/wazuh/framework
plugins: metadata-1.11.0, tavern-1.0.0, html-3.1.1, testinfra-5.0.0
collected 224 items                                                                   

framework/wazuh/rbac/tests/test_auth_context.py ..                              [  0%]
framework/wazuh/rbac/tests/test_decorators.py ................................. [ 15%]
........................................................................        [ 47%]
framework/wazuh/rbac/tests/test_default_configuration.py ...................... [ 57%]
...............................                                                 [ 71%]
framework/wazuh/rbac/tests/test_orm.py ........................................ [ 89%]
.............                                                                   [ 95%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                     [100%]

====================== 224 passed, 1 warnings in 230.25 seconds =======================
```

### Integration tests
```
test_cluster_endpoints.tavern.yaml 
         53 passed, 1 xpassed, 1 warnings

test_manager_endpoints.tavern.yaml 
         34 passed, 1 warnings

test_rbac_black_cluster_endpoints.tavern.yaml 
         20 passed, 1 warnings

test_rbac_black_manager_endpoints.tavern.yaml 
         18 passed, 1 warnings

test_rbac_white_cluster_endpoints.tavern.yaml 
         20 passed, 1 warnings

test_rbac_white_manager_endpoints.tavern.yaml 
         18 passed, 1 warnings

test_security_DELETE_endpoints.tavern.yaml 
         15 passed, 1 warnings

test_security_GET_endpoints.tavern.yaml 
         18 passed, 1 warnings

test_security_POST_endpoints.tavern.yaml 
         7 passed, 1 warnings

test_security_PUT_endpoints.tavern.yaml 
         8 passed, 1 warnings

```