### PR TITLE
Let agents running on Solaris get their IP to the manager

### DIFF
--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -43,7 +43,7 @@ char *getsharedfiles()
 char *get_agent_ip()
 {
     char *agent_ip = NULL;
-#if defined (__linux__) || defined (__MACH__)
+#if defined (__linux__) || defined (__MACH__) || defined (sun)
     int sock;
     int i;
     os_calloc(IPSIZE + 1,sizeof(char),agent_ip);


### PR DESCRIPTION
This PR aims to enable agent's IP reporting on periodical hear-beat (driven by `<notify_time>`). That makes the agent's IP available in the API call `/agents`.

The actual implementation of the agent's IP detection on Solaris was developed in #4380, but we enabled it in Logcollector only, while Agentd skipped such detection via `#ifdef`. In this PR we're adding Solaris to that condition, the rest of the implementation remains.

## Log by Agentd

```
2021/02/08 14:54:08 wazuh-agentd[14212] notify.c:173 at run_notify(): DEBUG: Sending keep alive: #!-SunOS |solaris11 |5.11 |11.3 |i86pc [SunOS|sunos: 11.3] - Wazuh v4.1.0 / ab73af41699f13fdd81903b5f23d8d00
2c45c95db2954d2c7d0ea533f09e81a5 merged.mg
#"_agent_ip":10.0.2.15
```

## API call /agents

```json
{
  "os": {
    "arch": "i86pc",
    "major": "11",
    "minor": "3",
    "name": "SunOS",
    "platform": "sunos",
    "uname": "SunOS |solaris11 |5.11 |11.3 |i86pc",
    "version": "11.3"
  },
  "version": "Wazuh v4.1.0",
  "group": [
    "default"
  ],
  "mergedSum": "2c45c95db2954d2c7d0ea533f09e81a5",
  "ip": "10.0.2.15",
  "id": "001",
  "dateAdd": "1970-01-01T00:00:00Z",
  "registerIP": "any",
  "manager": "groovy",
  "node_name": "node01",
  "lastKeepAlive": "2021-02-08T12:49:56Z",
  "name": "solaris11",
  "status": "active",
  "configSum": "ab73af41699f13fdd81903b5f23d8d00"
}
```