### PR TITLE
7411 skip messages output on shutdown syscollector

### DIFF
--- a/src/wazuh_modules/syscollector/cppcheckSuppress.txt
+++ b/src/wazuh_modules/syscollector/cppcheckSuppress.txt
@@ -1,3 +1,3 @@
 *:*.c
 *:*syscollector.h
-*:*src/syscollectorImp.cpp:914
+*:*src/syscollectorImp.cpp:917


### PR DESCRIPTION
|Related issue|
| #7411  |
| closes #7411  |

## Description
This PR aims to fix the shutdown related to the output of sync/deltas messages in syscollector during shutdown.

## DoD
- [X] Modify code.
- [X] Manual tests.
- [X] RTR
 
![image](https://user-images.githubusercontent.com/54002291/107302537-4ad5e780-6a5c-11eb-9985-3f9828457c0a.png)
