### PR TITLE
Change the behavior when changing from realtime to scheduled

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -63,7 +63,7 @@ void fim_delete_file_event(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mu
         return;
     }
     /* Don't send alert if received mode and mode in configuration aren't the same.
-       Scheduled mode events must always be processed to preserver the state of the agent's DB.
+       Scheduled mode events must always be processed to preserve the state of the agent's DB.
     */
     switch (mode) {
     case FIM_REALTIME:
@@ -90,8 +90,8 @@ void fim_delete_file_event(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mu
 
     if (send_alert && state == FIMDB_OK) {
         whodata_evt *whodata_event = (whodata_evt *) w_evt;
-        cJSON * json_event      = NULL;
-        char * json_formatted    = NULL;
+        cJSON *json_event = NULL;
+        char *json_formatted = NULL;
 
         w_mutex_lock(mutex);
         json_event = fim_json_event(entry->file_entry.path, NULL, entry->file_entry.data, pos, FIM_DELETE, mode,

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -47,10 +47,74 @@ static const char *FIM_EVENT_MODE[] = {
     "whodata"
 };
 
-// static const char *FIM_ENTRY_TYPE[] = {
-//     "file",
-//     "registry"
-// };
+void fim_delete_file_event(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex,
+                           __attribute__((unused))void *alert,
+                           __attribute__((unused))void *fim_ev_mode,
+                           __attribute__((unused))void *w_evt) {
+    int *send_alert = (int *) alert;
+    fim_event_mode mode = (fim_event_mode) fim_ev_mode;
+    int rows = 0;
+    int pos = -1;
+
+    if(entry->type == FIM_TYPE_FILE) {
+        pos = fim_configuration_directory(entry->file_entry.path, "file");
+        if(pos == -1) {
+            mdebug2(FIM_DELETE_EVENT_PATH_NOCONF, entry->file_entry.path);
+            return;
+        } else {
+            switch (mode) {
+            /* Don't send alert if received mode and mode in configuration aren't the same unless the the received
+               mode is scheduled. That could mean that the realtime or whodata buffer overflowed and the events must
+               be triggered in the next scan.
+             */
+            case FIM_REALTIME:
+                if (!(syscheck.opts[pos] & REALTIME_ACTIVE)) {
+                    return;     // LCOV_EXCL_LINE
+                }
+                break;
+
+            case FIM_WHODATA:
+                if (!(syscheck.opts[pos] & WHODATA_ACTIVE)) {
+                    return;     // LCOV_EXCL_LINE
+                }
+                break;
+
+            default:
+            // In case that the event's mode is scheduled, we have to process it.
+                break;
+            }
+        }
+    }
+    // Remove the path from the DB.
+    w_mutex_lock(mutex);
+    rows = fim_db_remove_path(fim_sql, entry->file_entry.path);
+    w_mutex_unlock(mutex);
+
+    if (send_alert && rows >= 1) {
+        whodata_evt *whodata_event = (whodata_evt *) w_evt;
+        cJSON * json_event      = NULL;
+        char * json_formatted    = NULL;
+
+        w_mutex_lock(mutex);
+        json_event = fim_json_event(entry->file_entry.path, NULL, entry->file_entry.data, pos, FIM_DELETE, mode,
+                                    whodata_event, NULL);
+        w_mutex_unlock(mutex);
+
+        if (syscheck.opts[pos] & CHECK_SEECHANGES) {
+            fim_diff_process_delete_file(entry->file_entry.path);
+        }
+
+        if (json_event) {
+            mdebug2(FIM_FILE_MSG_DELETE, entry->file_entry.path);
+            json_formatted = cJSON_PrintUnformatted(json_event);
+            send_syscheck_msg(json_formatted);
+
+            os_free(json_formatted);
+            cJSON_Delete(json_event);
+        }
+    }
+}
+
 
 void fim_scan() {
     int it = 0;
@@ -217,8 +281,8 @@ void fim_checker(const char *path, fim_element *item, whodata_evt *w_evt, int re
         w_mutex_unlock(&syscheck.fim_entry_mutex);
 
         if (saved_entry) {
-            fim_db_remove_path(syscheck.database, saved_entry, &syscheck.fim_entry_mutex, (void *) (int) true,
-                                (void *) (fim_event_mode) item->mode, (void *) w_evt);
+            fim_delete_file_event(syscheck.database, saved_entry, &syscheck.fim_entry_mutex, (void *) (int) true,
+                                 (void *) (fim_event_mode) item->mode, (void *) w_evt);
             free_entry(saved_entry);
             saved_entry = NULL;
         }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -69,13 +69,13 @@ void fim_delete_file_event(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mu
              */
             case FIM_REALTIME:
                 if (!(syscheck.opts[pos] & REALTIME_ACTIVE)) {
-                    return;     // LCOV_EXCL_LINE
+                    return;
                 }
                 break;
 
             case FIM_WHODATA:
                 if (!(syscheck.opts[pos] & WHODATA_ACTIVE)) {
-                    return;     // LCOV_EXCL_LINE
+                    return;
                 }
                 break;
 

--- a/src/syscheckd/db/fim_db_files.c
+++ b/src/syscheckd/db/fim_db_files.c
@@ -108,7 +108,7 @@ void fim_db_bind_get_path_inode(fdb_t *fim_sql, const char *file_path);
 void fim_db_bind_get_path_from_pattern(fdb_t *fim_sql, const char *pattern);
 
 /**
- * @brief Removes paths from the FIM DB if its configuration chemats with the one provided
+ * @brief Removes paths from the FIM DB if its configuration matches with the one provided
  *
  * @param fim_sql FIM database structure.
  * @param entry Entry data to be removed.
@@ -456,9 +456,9 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_file_data *new, fim
     return res_data || res_path;
 }
 
-unsigned int fim_db_remove_path(fdb_t *fim_sql, const char *path) {
-    unsigned int rows = 0;
-
+int fim_db_remove_path(fdb_t *fim_sql, const char *path) {
+    int state = FIMDB_ERR;
+    int rows = 0;
     // Clean and bind statements
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_PATH_COUNT);
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_DELETE_DATA);
@@ -490,12 +490,12 @@ unsigned int fim_db_remove_path(fdb_t *fim_sql, const char *path) {
             fim_sql->full = false;
             break;
         }
+        state = FIMDB_OK;
     }
-
 
 end:
     fim_db_check_transaction(fim_sql);
-    return rows;
+    return state;
 }
 
 void fim_db_remove_validated_path(fdb_t *fim_sql,

--- a/src/syscheckd/db/fim_db_files.c
+++ b/src/syscheckd/db/fim_db_files.c
@@ -108,7 +108,7 @@ void fim_db_bind_get_path_inode(fdb_t *fim_sql, const char *file_path);
 void fim_db_bind_get_path_from_pattern(fdb_t *fim_sql, const char *pattern);
 
 /**
- * @brief Removes paths from the FIM DB if its configuration matches with the one provided
+ * @brief Removes paths from the FIM DB if its configuration chemats with the one provided
  *
  * @param fim_sql FIM database structure.
  * @param entry Entry data to be removed.
@@ -143,7 +143,7 @@ int fim_db_get_not_scanned(fdb_t * fim_sql, fim_tmp_file **file, int storage) {
 
 // LCOV_EXCL_START
 int fim_db_delete_not_scanned(fdb_t * fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage) {
-    return fim_db_process_read_file(fim_sql, file, FIM_TYPE_FILE, mutex, fim_db_remove_path, storage,
+    return fim_db_process_read_file(fim_sql, file, FIM_TYPE_FILE, mutex, fim_delete_file_event, storage,
                                     (void *) true, (void *) FIM_SCHEDULED, NULL);
 }
 
@@ -154,7 +154,7 @@ int fim_db_delete_range(fdb_t * fim_sql, fim_tmp_file *file, pthread_mutex_t *mu
 
 int fim_db_process_missing_entry(fdb_t *fim_sql, fim_tmp_file *file, pthread_mutex_t *mutex, int storage,
                                  fim_event_mode mode, whodata_evt * w_evt) {
-    return fim_db_process_read_file(fim_sql, file, FIM_TYPE_FILE, mutex, fim_db_remove_path, storage,
+    return fim_db_process_read_file(fim_sql, file, FIM_TYPE_FILE, mutex, fim_delete_file_event, storage,
                                     (void *) true, (void *) (fim_event_mode) mode, (void *) w_evt);
 }
 // LCOV_EXCL_STOP
@@ -456,55 +456,14 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_file_data *new, fim
     return res_data || res_path;
 }
 
-void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex,
-     __attribute__((unused))void *alert,
-     __attribute__((unused))void *fim_ev_mode,
-     __attribute__((unused))void *w_evt) {
-
-    int *send_alert = (int *) alert;
-    fim_event_mode mode = (fim_event_mode) fim_ev_mode;
-    int rows = 0;
-    int conf;
-
-    if(entry->type == FIM_TYPE_FILE) {
-
-        conf = fim_configuration_directory(entry->file_entry.path, "file");
-
-        if(conf > -1) {
-            switch (mode) {
-            /* Don't send alert if received mode and mode in configuration aren't the same */
-            case FIM_REALTIME:
-                if (!(syscheck.opts[conf] & REALTIME_ACTIVE)) {
-                    return;     // LCOV_EXCL_LINE
-                }
-                break;
-
-            case FIM_WHODATA:
-                if (!(syscheck.opts[conf] & WHODATA_ACTIVE)) {
-                    return;     // LCOV_EXCL_LINE
-                }
-                break;
-
-            case FIM_SCHEDULED:
-                if (!(syscheck.opts[conf] & SCHEDULED_ACTIVE)) {
-                    return;     // LCOV_EXCL_LINE
-                }
-                break;
-
-            }
-        } else {
-            mdebug2(FIM_DELETE_EVENT_PATH_NOCONF, entry->file_entry.path);
-            return;
-        }
-    }
-
-    w_mutex_lock(mutex);
+unsigned int fim_db_remove_path(fdb_t *fim_sql, const char *path) {
+    unsigned int rows = 0;
 
     // Clean and bind statements
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_GET_PATH_COUNT);
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_DELETE_DATA);
     fim_db_clean_stmt(fim_sql, FIMDB_STMT_DELETE_PATH);
-    fim_db_bind_path(fim_sql, FIMDB_STMT_GET_PATH_COUNT, entry->file_entry.path);
+    fim_db_bind_path(fim_sql, FIMDB_STMT_GET_PATH_COUNT, path);
 
     if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_GET_PATH_COUNT]) == SQLITE_ROW) {
         rows = sqlite3_column_int(fim_sql->stmt[FIMDB_STMT_GET_PATH_COUNT], 0);
@@ -518,15 +477,13 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
             // The inode has only one entry, delete the entry data.
             fim_db_bind_delete_data_id(fim_sql, rowid);
             if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_DATA]) != SQLITE_DONE) {
-                w_mutex_unlock(mutex);
                 goto end;
             }
             //Fallthrough
         default:
             // The inode has more entries, delete only this path.
-            fim_db_bind_path(fim_sql, FIMDB_STMT_DELETE_PATH, entry->file_entry.path);
+            fim_db_bind_path(fim_sql, FIMDB_STMT_DELETE_PATH, path);
             if (sqlite3_step(fim_sql->stmt[FIMDB_STMT_DELETE_PATH]) != SQLITE_DONE) {
-                w_mutex_unlock(mutex);
                 goto end;
             }
 
@@ -535,45 +492,10 @@ void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex
         }
     }
 
-    w_mutex_unlock(mutex);
-
-
-    if (send_alert && rows >= 1) {
-        whodata_evt *whodata_event = (whodata_evt *) w_evt;
-        cJSON * json_event      = NULL;
-        char * json_formatted    = NULL;
-        int pos = 0;
-        const char *FIM_ENTRY_TYPE[] = {"file", "registry"};
-
-        // Obtaining the position of the directory, in @syscheck.dir, where @entry belongs
-        if (pos = fim_configuration_directory(entry->file_entry.path,
-            FIM_ENTRY_TYPE[entry->type]), pos < 0) {
-            goto end;
-        }
-
-        w_mutex_lock(mutex);
-        json_event = fim_json_event(entry->file_entry.path, NULL, entry->file_entry.data, pos, FIM_DELETE, mode,
-                                    whodata_event, NULL);
-        w_mutex_unlock(mutex);
-
-        if (!strcmp(FIM_ENTRY_TYPE[entry->type], "file") && syscheck.opts[pos] & CHECK_SEECHANGES) {
-            fim_diff_process_delete_file(entry->file_entry.path);
-        }
-
-        if (json_event) {
-            mdebug2(FIM_FILE_MSG_DELETE, entry->file_entry.path);
-            json_formatted = cJSON_PrintUnformatted(json_event);
-            send_syscheck_msg(json_formatted);
-
-            os_free(json_formatted);
-            cJSON_Delete(json_event);
-        }
-    }
 
 end:
-    w_mutex_lock(mutex);
     fim_db_check_transaction(fim_sql);
-    w_mutex_unlock(mutex);
+    return rows;
 }
 
 void fim_db_remove_validated_path(fdb_t *fim_sql,
@@ -586,7 +508,7 @@ void fim_db_remove_validated_path(fdb_t *fim_sql,
     int validated_configuration = fim_configuration_directory(entry->file_entry.path, "file");
 
     if (validated_configuration == *original_configuration) {
-        fim_db_remove_path(fim_sql, entry, mutex, alert, fim_ev_mode, NULL);
+        fim_delete_file_event(fim_sql, entry, mutex, alert, fim_ev_mode, NULL);
     }
 }
 

--- a/src/syscheckd/db/fim_db_files.h
+++ b/src/syscheckd/db/fim_db_files.h
@@ -79,14 +79,14 @@ int fim_db_insert_path(fdb_t *fim_sql, const char *file_path, fim_file_data *ent
 int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_file_data *new, fim_file_data *saved);
 
 /**
- * @brief Delete entry from the BD using file path.
+ * @brief Delete entry from the DB using file path.
  *
  * @param fim_sql FIM database struct.
  * @param path Path of the entry to be removed.
  *
- * @return Number of entries that has been deleted .
+ * @return FIMDB_OK on success, FIMDB_ERR otherwise.
  */
-unsigned int fim_db_remove_path(fdb_t *fim_sql, const char *path);
+int fim_db_remove_path(fdb_t *fim_sql, const char *path);
 
 /**
  * @brief Set all entries from database to unscanned.

--- a/src/syscheckd/db/fim_db_files.h
+++ b/src/syscheckd/db/fim_db_files.h
@@ -82,18 +82,11 @@ int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_file_data *new, fim
  * @brief Delete entry from the BD using file path.
  *
  * @param fim_sql FIM database struct.
- * @param entry Entry data to be removed.
- * @param mutex FIM database's mutex for thread synchronization.
- * @param alert False don't send alert, True send delete alert.
- * @param fim_ev_mode FIM Mode (scheduled/realtime/whodata)
- * @param w_evt Whodata information.
+ * @param path Path of the entry to be removed.
  *
- * @return FIMDB_OK on success, FIMDB_ERR otherwise.
+ * @return Number of entries that has been deleted .
  */
-void fim_db_remove_path(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex,
-                        __attribute__((unused))void *alert,
-                        __attribute__((unused))void *fim_ev_mode,
-                        __attribute__((unused))void *w_evt);
+unsigned int fim_db_remove_path(fdb_t *fim_sql, const char *path);
 
 /**
  * @brief Set all entries from database to unscanned.

--- a/src/syscheckd/db/fim_db_files.h
+++ b/src/syscheckd/db/fim_db_files.h
@@ -79,7 +79,7 @@ int fim_db_insert_path(fdb_t *fim_sql, const char *file_path, fim_file_data *ent
 int fim_db_insert(fdb_t *fim_sql, const char *file_path, fim_file_data *new, fim_file_data *saved);
 
 /**
- * @brief Delete entry using file path.
+ * @brief Delete entry from the BD using file path.
  *
  * @param fim_sql FIM database struct.
  * @param entry Entry data to be removed.

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -245,6 +245,8 @@ int main(int argc, char **argv)
                 minfo(FIM_REALTIME_MONITORING_DIRECTORY, syscheck.dir[r]);
 #else
                 mwarn(FIM_WARN_REALTIME_DISABLED, syscheck.dir[r]);
+                syscheck.opts[r] &= ~ REALTIME_ACTIVE;
+                syscheck.opts[r] |= SCHEDULED_ACTIVE;
 #endif
             }
 

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -920,7 +920,7 @@ void fim_diff_folder_size();
 const char *fim_get_real_path(int position);
 
 /**
- * @brief Create the delete event and removes the entry from the database.
+ * @brief Create a delete event and removes the entry from the database.
  *
  * @param fim_sql FIM database struct.
  * @param entry Entry data to be removed.

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -919,4 +919,19 @@ void fim_diff_folder_size();
  */
 const char *fim_get_real_path(int position);
 
+/**
+ * @brief Create the delete event and removes the entry from the database.
+ *
+ * @param fim_sql FIM database struct.
+ * @param entry Entry data to be removed.
+ * @param mutex FIM database's mutex for thread synchronization.
+ * @param alert False don't send alert, True send delete alert.
+ * @param fim_ev_mode FIM Mode (scheduled/realtime/whodata)
+ * @param w_evt Whodata information.
+ *
+ */
+void fim_delete_file_event(fdb_t *fim_sql, fim_entry *entry, pthread_mutex_t *mutex,
+                           __attribute__((unused))void *alert,
+                           __attribute__((unused))void *fim_ev_mode,
+                           __attribute__((unused))void *w_evt);
 #endif /* SYSCHECK_H */

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1654,7 +1654,7 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
     expect_string(__wrap_fim_db_get_path, file_path, "/media/test.file");
     will_return(__wrap_fim_db_get_path, fim_data->fentry);
 
-    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 0);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_ERR);
 
 
     fim_checker(path, fim_data->item, NULL, 1);
@@ -2364,7 +2364,7 @@ static void test_fim_scan_no_limit(void **state) {
 }
 
 /**** delete_file_event ****/
-void test_fim_delete_file_event_success_no_entries(void **state) {
+void test_fim_delete_file_event_delete_error(void **state) {
     fim_data_t *fim_data = *state;
 
     fim_data->fentry->file_entry.path = strdup("/media/test");
@@ -2389,13 +2389,13 @@ void test_fim_delete_file_event_success_no_entries(void **state) {
     fim_data->local_data->options = 511;
     strcpy(fim_data->local_data->checksum, "");
 
-    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 0);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_ERR);
 
 
     fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *)true, NULL, NULL);
 }
 
-void test_fim_delete_file_event_success_multiple_entries(void **state) {
+void test_fim_delete_file_event_remove_success(void **state) {
     fim_data_t *fim_data = *state;
 
     fim_data->fentry->file_entry.path = strdup("/media/test");
@@ -2421,7 +2421,7 @@ void test_fim_delete_file_event_success_multiple_entries(void **state) {
     strcpy(fim_data->local_data->checksum, "");
 
     char buffer[OS_SIZE_128] = {0};
-    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 4);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_OK);
     // inside fim_json_event
     expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606060, 12345678, NULL);
     snprintf(buffer, OS_SIZE_128, FIM_FILE_MSG_DELETE, fim_data->fentry->file_entry.path);
@@ -2496,7 +2496,7 @@ void test_fim_delete_file_event_different_mode_scheduled(void **state) {
     strcpy(fim_data->local_data->checksum, "");
 
     char buffer[OS_SIZE_128] = {0};
-    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 4);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_OK);
     // inside fim_json_event
     expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606060, 12345678, NULL);
     snprintf(buffer, OS_SIZE_128, FIM_FILE_MSG_DELETE, fim_data->fentry->file_entry.path);
@@ -2600,7 +2600,7 @@ void test_fim_delete_file_event_report_changes(void **state) {
     syscheck.opts[pos] |= CHECK_SEECHANGES;
 
     char buffer[OS_SIZE_128] = {0};
-    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 4);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_OK);
     // inside fim_json_event
     expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606060, 12345678, NULL);
     expect_fim_diff_process_delete_file(fim_data->fentry->file_entry.path, 0);
@@ -2739,7 +2739,7 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
     expect_function_call(__wrap_pthread_mutex_unlock);
 
     expect_function_call(__wrap_pthread_mutex_lock);
-    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 0);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_ERR);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
     fim_checker(expanded_path, fim_data->item, NULL, 1);
@@ -3272,7 +3272,7 @@ static void test_fim_scan_no_limit(void **state) {
     fim_scan();
 }
 
-void test_fim_delete_file_event_success_no_entries(void **state) {
+void test_fim_delete_file_event_delete_error(void **state) {
     fim_data_t *fim_data = *state;
 
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
@@ -3306,13 +3306,13 @@ void test_fim_delete_file_event_success_no_entries(void **state) {
     strcpy(fim_data->local_data->checksum, "");
 
     expect_function_call(__wrap_pthread_mutex_lock);
-    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 0);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_ERR);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
     fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *)true, NULL, NULL);
 }
 
-void test_fim_delete_file_event_success_multiple_entries(void **state) {
+void test_fim_delete_file_event_remove_success(void **state) {
     fim_data_t *fim_data = *state;
 
     char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
@@ -3346,7 +3346,7 @@ void test_fim_delete_file_event_success_multiple_entries(void **state) {
     strcpy(fim_data->local_data->checksum, "");
 
     expect_function_call(__wrap_pthread_mutex_lock);
-    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 4);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_OK);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
     expect_function_call(__wrap_pthread_mutex_lock);
@@ -3438,7 +3438,7 @@ void test_fim_delete_file_event_different_mode_scheduled(void **state) {
     strcpy(fim_data->local_data->checksum, "");
 
     expect_function_call(__wrap_pthread_mutex_lock);
-    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 4);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, FIMDB_OK);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
     expect_function_call(__wrap_pthread_mutex_lock);
@@ -4753,8 +4753,8 @@ int main(void) {
         cmocka_unit_test(test_fim_diff_folder_size),
 
         /* test_fim_delete_file_event */
-        cmocka_unit_test_setup(test_fim_delete_file_event_success_no_entries, setup_fim_entry),
-        cmocka_unit_test_setup(test_fim_delete_file_event_success_multiple_entries, setup_fim_entry),
+        cmocka_unit_test_setup(test_fim_delete_file_event_delete_error, setup_fim_entry),
+        cmocka_unit_test_setup(test_fim_delete_file_event_remove_success, setup_fim_entry),
         cmocka_unit_test_setup(test_fim_delete_file_event_no_conf, setup_fim_entry),
 #ifndef TEST_WINAGENT
         cmocka_unit_test_setup(test_fim_delete_file_event_report_changes, setup_fim_entry),

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1619,7 +1619,7 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
     fim_data->item->index = 3;
     syscheck.opts[3] |= CHECK_SEECHANGES;
 
-    fim_data->fentry->file_entry.path = strdup("file");
+    fim_data->fentry->file_entry.path = strdup("/media/test.file");
     fim_data->fentry->file_entry.data = fim_data->local_data;
 
     fim_data->local_data->size = 1500;
@@ -1654,8 +1654,8 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
     expect_string(__wrap_fim_db_get_path, file_path, "/media/test.file");
     will_return(__wrap_fim_db_get_path, fim_data->fentry);
 
-    expect_value(__wrap_fim_db_remove_path, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_remove_path, entry, fim_data->fentry);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 0);
+
 
     fim_checker(path, fim_data->item, NULL, 1);
 
@@ -2363,6 +2363,254 @@ static void test_fim_scan_no_limit(void **state) {
     fim_scan();
 }
 
+/**** delete_file_event ****/
+void test_fim_delete_file_event_success_no_entries(void **state) {
+    fim_data_t *fim_data = *state;
+
+    fim_data->fentry->file_entry.path = strdup("/media/test");
+    fim_data->fentry->file_entry.data = fim_data->local_data;
+
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 0);
+
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *)true, NULL, NULL);
+}
+
+void test_fim_delete_file_event_success_multiple_entries(void **state) {
+    fim_data_t *fim_data = *state;
+
+    fim_data->fentry->file_entry.path = strdup("/media/test");
+    fim_data->fentry->file_entry.data = fim_data->local_data;
+
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+
+    char buffer[OS_SIZE_128] = {0};
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 4);
+    // inside fim_json_event
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606060, 12345678, NULL);
+    snprintf(buffer, OS_SIZE_128, FIM_FILE_MSG_DELETE, fim_data->fentry->file_entry.path);
+    expect_string(__wrap__mdebug2, formatted_msg, buffer);
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true, NULL, NULL);
+}
+
+
+void test_fim_delete_file_event_no_conf(void **state) {
+    fim_data_t *fim_data = *state;
+
+    fim_data->fentry->file_entry.path = strdup("/a/random/path");
+    fim_data->fentry->file_entry.data = fim_data->local_data;
+
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+
+    char buffer_msg[OS_SIZE_128] = {0};
+    char buffer_config[OS_SIZE_128] = {0};
+
+    snprintf(buffer_msg, OS_SIZE_128, FIM_DELETE_EVENT_PATH_NOCONF, fim_data->fentry->file_entry.path);
+    snprintf(buffer_config, OS_SIZE_128, FIM_CONFIGURATION_NOTFOUND, "file", fim_data->fentry->file_entry.path);
+
+    // Inside fim_configuration_directory
+    expect_string(__wrap__mdebug2, formatted_msg, buffer_config);
+
+    expect_string(__wrap__mdebug2, formatted_msg, buffer_msg);
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true, NULL, NULL);
+}
+
+void test_fim_delete_file_event_different_mode_scheduled(void **state) {
+    fim_data_t *fim_data = *state;
+
+    fim_data->fentry->file_entry.path = strdup("/media/test");
+    fim_data->fentry->file_entry.data = fim_data->local_data;
+
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+
+    char buffer[OS_SIZE_128] = {0};
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 4);
+    // inside fim_json_event
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606060, 12345678, NULL);
+    snprintf(buffer, OS_SIZE_128, FIM_FILE_MSG_DELETE, fim_data->fentry->file_entry.path);
+    expect_string(__wrap__mdebug2, formatted_msg, buffer);
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true,
+                          (void *) FIM_SCHEDULED, NULL);
+}
+
+void test_fim_delete_file_event_different_mode_abort_realtime(void **state) {
+    fim_data_t *fim_data = *state;
+
+    fim_data->fentry->file_entry.path = strdup("/media/test");
+    fim_data->fentry->file_entry.data = fim_data->local_data;
+
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true,
+                          (void *) FIM_WHODATA, NULL);
+}
+
+void test_fim_delete_file_event_different_mode_abort_whodata(void **state) {
+    fim_data_t *fim_data = *state;
+
+    fim_data->fentry->file_entry.path = strdup("/media/test");
+    fim_data->fentry->file_entry.data = fim_data->local_data;
+
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_WHODATA;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+
+    int pos = fim_configuration_directory(fim_data->fentry->file_entry.path, "file");
+    syscheck.opts[pos] |= WHODATA_ACTIVE;
+    syscheck.opts[pos] &= ~REALTIME_ACTIVE;
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true,
+                          (void *) FIM_REALTIME, NULL);
+
+    syscheck.opts[pos] &= ~WHODATA_ACTIVE;
+    syscheck.opts[pos] |= REALTIME_ACTIVE;
+}
+
+void test_fim_delete_file_event_report_changes(void **state) {
+    fim_data_t *fim_data = *state;
+
+    fim_data->fentry->file_entry.path = strdup("/media/test");
+    fim_data->fentry->file_entry.data = fim_data->local_data;
+
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+    int pos = fim_configuration_directory(fim_data->fentry->file_entry.path, "file");
+    syscheck.opts[pos] |= CHECK_SEECHANGES;
+
+    char buffer[OS_SIZE_128] = {0};
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 4);
+    // inside fim_json_event
+    expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 606060, 12345678, NULL);
+    expect_fim_diff_process_delete_file(fim_data->fentry->file_entry.path, 0);
+
+    snprintf(buffer, OS_SIZE_128, FIM_FILE_MSG_DELETE, fim_data->fentry->file_entry.path);
+    expect_string(__wrap__mdebug2, formatted_msg, buffer);
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true, NULL, NULL);
+    syscheck.opts[pos] &= ~CHECK_SEECHANGES;
+}
 #else
 static void test_fim_checker_invalid_fim_mode(void **state) {
     fim_data_t *fim_data = *state;
@@ -2452,9 +2700,9 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
 
     str_lowercase(expanded_path);
 
-    //fim_data->fentry->file_entry.path = strdup("file");
     //fim_data->fentry->file_entry.data = fim_data->local_data;
 
+    fim_data->fentry->file_entry.path = strdup(expanded_path);
     fim_data->local_data->size = 1500;
     fim_data->local_data->perm = strdup("0664");
     fim_data->local_data->attributes = strdup("r--r--r--");
@@ -2484,17 +2732,15 @@ static void test_fim_checker_deleted_file_enoent(void **state) {
 
     expect_fim_diff_process_delete_file(expanded_path, 0);
 
-#ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
-#endif
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, expanded_path);
     will_return(__wrap_fim_db_get_path, fim_data->fentry);
-#ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_unlock);
-#endif
-    expect_value(__wrap_fim_db_remove_path, fim_sql, syscheck.database);
-    expect_value(__wrap_fim_db_remove_path, entry, fim_data->fentry);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 0);
+    expect_function_call(__wrap_pthread_mutex_unlock);
 
     fim_checker(expanded_path, fim_data->item, NULL, 1);
 
@@ -3025,6 +3271,268 @@ static void test_fim_scan_no_limit(void **state) {
 
     fim_scan();
 }
+
+void test_fim_delete_file_event_success_no_entries(void **state) {
+    fim_data_t *fim_data = *state;
+
+    char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
+    char expanded_path[OS_MAXSTR];
+    fim_data->item->index = 7;
+    syscheck.opts[7] |= CHECK_SEECHANGES;
+
+    if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
+        fail();
+
+    str_lowercase(expanded_path);
+
+    fim_data->fentry->file_entry.path = strdup(expanded_path);
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 0);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *)true, NULL, NULL);
+}
+
+void test_fim_delete_file_event_success_multiple_entries(void **state) {
+    fim_data_t *fim_data = *state;
+
+    char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
+    char expanded_path[OS_MAXSTR];
+    fim_data->item->index = 7;
+    syscheck.opts[7] |= CHECK_SEECHANGES;
+    char buffer[OS_SIZE_128] = {0};
+    if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
+        fail();
+
+    str_lowercase(expanded_path);
+
+    fim_data->fentry->file_entry.path = strdup(expanded_path);
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 4);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_fim_diff_process_delete_file(expanded_path, 0);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    snprintf(buffer, OS_SIZE_128, FIM_FILE_MSG_DELETE, fim_data->fentry->file_entry.path);
+    expect_string(__wrap__mdebug2, formatted_msg, buffer);
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true, NULL, NULL);
+}
+
+void test_fim_delete_file_event_no_conf(void **state) {
+    fim_data_t *fim_data = *state;
+
+    char *path = "C:\\A\\random\\path";
+    char expanded_path[OS_MAXSTR];
+    fim_data->item->index = 7;
+    syscheck.opts[7] |= CHECK_SEECHANGES;
+    char buffer[OS_SIZE_128] = {0};
+    if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
+        fail();
+
+    str_lowercase(expanded_path);
+
+    fim_data->fentry->file_entry.path = strdup(expanded_path);
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+    char buffer_msg[OS_SIZE_128] = {0};
+    char buffer_config[OS_SIZE_128] = {0};
+
+    snprintf(buffer_msg, OS_SIZE_128, FIM_DELETE_EVENT_PATH_NOCONF, fim_data->fentry->file_entry.path);
+    snprintf(buffer_config, OS_SIZE_128, FIM_CONFIGURATION_NOTFOUND, "file", fim_data->fentry->file_entry.path);
+
+    // Inside fim_configuration_directory
+    expect_string(__wrap__mdebug2, formatted_msg, buffer_config);
+    expect_string(__wrap__mdebug2, formatted_msg, buffer_msg);
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true, NULL, NULL);
+}
+
+void test_fim_delete_file_event_different_mode_scheduled(void **state) {
+    fim_data_t *fim_data = *state;
+
+    char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
+    char expanded_path[OS_MAXSTR];
+    fim_data->item->index = 7;
+    syscheck.opts[7] |= CHECK_SEECHANGES;
+    char buffer[OS_SIZE_128] = {0};
+    if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
+        fail();
+
+    str_lowercase(expanded_path);
+
+    fim_data->fentry->file_entry.path = strdup(expanded_path);
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_fim_db_remove_path(syscheck.database, fim_data->fentry->file_entry.path, 4);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_fim_diff_process_delete_file(expanded_path, 0);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    snprintf(buffer, OS_SIZE_128, FIM_FILE_MSG_DELETE, fim_data->fentry->file_entry.path);
+    expect_string(__wrap__mdebug2, formatted_msg, buffer);
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true,
+                          (void *) FIM_SCHEDULED, NULL);
+}
+
+void test_fim_delete_file_event_different_mode_abort_realtime(void **state) {
+    fim_data_t *fim_data = *state;
+
+    char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
+    char expanded_path[OS_MAXSTR];
+    fim_data->item->index = 7;
+    syscheck.opts[7] |= CHECK_SEECHANGES;
+    char buffer[OS_SIZE_128] = {0};
+    if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
+        fail();
+
+    str_lowercase(expanded_path);
+
+    fim_data->fentry->file_entry.path = strdup(expanded_path);
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true,
+                          (void *) FIM_WHODATA, NULL);
+}
+
+void test_fim_delete_file_event_different_mode_abort_whodata(void **state) {
+    fim_data_t *fim_data = *state;
+
+    char *path = "%WINDIR%\\System32\\drivers\\etc\\test.exe";
+    char expanded_path[OS_MAXSTR];
+    fim_data->item->index = 7;
+    syscheck.opts[7] |= CHECK_SEECHANGES;
+    char buffer[OS_SIZE_128] = {0};
+    if(!ExpandEnvironmentStrings(path, expanded_path, OS_MAXSTR))
+        fail();
+
+    str_lowercase(expanded_path);
+
+    fim_data->fentry->file_entry.path = strdup(expanded_path);
+    fim_data->local_data->size = 1500;
+    fim_data->local_data->perm = strdup("0664");
+    fim_data->local_data->attributes = strdup("r--r--r--");
+    fim_data->local_data->uid = strdup("100");
+    fim_data->local_data->gid = strdup("1000");
+    fim_data->local_data->user_name = strdup("test");
+    fim_data->local_data->group_name = strdup("testing");
+    fim_data->local_data->mtime = 1570184223;
+    fim_data->local_data->inode = 606060;
+    strcpy(fim_data->local_data->hash_md5, "3691689a513ace7e508297b583d7050d");
+    strcpy(fim_data->local_data->hash_sha1, "07f05add1049244e7e71ad0f54f24d8094cd8f8b");
+    strcpy(fim_data->local_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e99f9643c6262667b61fbe57694df224d40");
+    fim_data->local_data->mode = FIM_REALTIME;
+    fim_data->local_data->last_event = 1570184220;
+    fim_data->local_data->dev = 12345678;
+    fim_data->local_data->scanned = 123456;
+    fim_data->local_data->options = 511;
+    strcpy(fim_data->local_data->checksum, "");
+
+    int pos = fim_configuration_directory(fim_data->fentry->file_entry.path, "file");
+    syscheck.opts[pos] |= WHODATA_ACTIVE;
+    syscheck.opts[pos] &= ~REALTIME_ACTIVE;
+
+    fim_delete_file_event(syscheck.database, fim_data->fentry, &syscheck.fim_entry_mutex, (void *) true,
+                          (void *) FIM_REALTIME, NULL);
+
+    syscheck.opts[pos] &= ~WHODATA_ACTIVE;
+    syscheck.opts[pos] |= REALTIME_ACTIVE;
+}
+
 #endif
 
 /* fim_check_db_state */
@@ -4244,6 +4752,16 @@ int main(void) {
         /* fim_diff_folder_size */
         cmocka_unit_test(test_fim_diff_folder_size),
 
+        /* test_fim_delete_file_event */
+        cmocka_unit_test_setup(test_fim_delete_file_event_success_no_entries, setup_fim_entry),
+        cmocka_unit_test_setup(test_fim_delete_file_event_success_multiple_entries, setup_fim_entry),
+        cmocka_unit_test_setup(test_fim_delete_file_event_no_conf, setup_fim_entry),
+#ifndef TEST_WINAGENT
+        cmocka_unit_test_setup(test_fim_delete_file_event_report_changes, setup_fim_entry),
+#endif
+        cmocka_unit_test_setup(test_fim_delete_file_event_different_mode_scheduled, setup_fim_entry),
+        cmocka_unit_test_setup(test_fim_delete_file_event_different_mode_abort_realtime, setup_fim_entry),
+        cmocka_unit_test_setup(test_fim_delete_file_event_different_mode_abort_whodata, setup_fim_entry),
     };
     const struct CMUnitTest root_monitor_tests[] = {
         cmocka_unit_test(test_fim_checker_root_ignore_file_under_recursion_level),

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -196,10 +196,10 @@ int __wrap_fim_db_process_missing_entry(fdb_t *fim_sql,
     return mock();
 }
 
-unsigned int __wrap_fim_db_remove_path(fdb_t *fim_sql, char *path) {
+int __wrap_fim_db_remove_path(fdb_t *fim_sql, char *path) {
     check_expected_ptr(fim_sql);
     check_expected(path);
-    return mock_type(unsigned int);
+    return mock_type(int);
 }
 
 int __wrap_fim_db_set_all_unscanned(fdb_t *fim_sql) {
@@ -326,7 +326,7 @@ void expect_fim_db_get_path_from_pattern(fdb_t *fim_sql,
     will_return(__wrap_fim_db_get_path_from_pattern, ret);
 }
 
-void expect_fim_db_remove_path(fdb_t *fim_sql, char *path, unsigned int ret_val) {
+void expect_fim_db_remove_path(fdb_t *fim_sql, char *path, int ret_val) {
     expect_value(__wrap_fim_db_remove_path, fim_sql, fim_sql);
     expect_string(__wrap_fim_db_remove_path, path, path);
     will_return(__wrap_fim_db_remove_path, ret_val);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -196,11 +196,10 @@ int __wrap_fim_db_process_missing_entry(fdb_t *fim_sql,
     return mock();
 }
 
-void __wrap_fim_db_remove_path(fdb_t *fim_sql,
-                               fim_entry *entry,
-                               __attribute__((unused)) void *arg) {
+unsigned int __wrap_fim_db_remove_path(fdb_t *fim_sql, char *path) {
     check_expected_ptr(fim_sql);
-    check_expected_ptr(entry);
+    check_expected(path);
+    return mock_type(unsigned int);
 }
 
 int __wrap_fim_db_set_all_unscanned(fdb_t *fim_sql) {
@@ -325,4 +324,10 @@ void expect_fim_db_get_path_from_pattern(fdb_t *fim_sql,
 
     will_return(__wrap_fim_db_get_path_from_pattern, file);
     will_return(__wrap_fim_db_get_path_from_pattern, ret);
+}
+
+void expect_fim_db_remove_path(fdb_t *fim_sql, char *path, unsigned int ret_val) {
+    expect_value(__wrap_fim_db_remove_path, fim_sql, fim_sql);
+    expect_string(__wrap_fim_db_remove_path, path, path);
+    will_return(__wrap_fim_db_remove_path, ret_val);
 }

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -85,7 +85,7 @@ int __wrap_fim_db_process_missing_entry(fdb_t *fim_sql,
                                         fim_event_mode mode,
                                         whodata_evt * w_evt);
 
-unsigned int __wrap_fim_db_remove_path(fdb_t *fim_sql, char *path);
+int __wrap_fim_db_remove_path(fdb_t *fim_sql, char *path);
 
 int __wrap_fim_db_set_all_unscanned(fdb_t *fim_sql);
 
@@ -159,6 +159,6 @@ void expect_fim_db_get_path_from_pattern(fdb_t *fim_sql,
 /**
  * @brief This function loads the expect and will_return calls for the wrapper of fim_db_remove_path
  */
-void expect_fim_db_remove_path(fdb_t *fim_sql, char *path, unsigned int ret_val);
+void expect_fim_db_remove_path(fdb_t *fim_sql, char *path, int ret_val);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -85,9 +85,7 @@ int __wrap_fim_db_process_missing_entry(fdb_t *fim_sql,
                                         fim_event_mode mode,
                                         whodata_evt * w_evt);
 
-void __wrap_fim_db_remove_path(fdb_t *fim_sql,
-                               fim_entry *entry,
-                               void *arg);
+unsigned int __wrap_fim_db_remove_path(fdb_t *fim_sql, char *path);
 
 int __wrap_fim_db_set_all_unscanned(fdb_t *fim_sql);
 
@@ -157,4 +155,10 @@ void expect_fim_db_get_path_from_pattern(fdb_t *fim_sql,
                                          fim_tmp_file *file,
                                          int storage,
                                          int ret);
+
+/**
+ * @brief This function loads the expect and will_return calls for the wrapper of fim_db_remove_path
+ */
+void expect_fim_db_remove_path(fdb_t *fim_sql, char *path, unsigned int ret_val);
+
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|#7263|

## Description
This PR aims to fix issue #7263 by changing the behavior when changing from `realtime` to `scheduled` when the system is not compatible with `realtime`.

This PR also changes the function `fim_db_remove_path` to only remove paths from the DB instead of triggering the alerts.
Closes #7263 
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
```xml
<directories realtime="yes">/test</directories>
```

## Logs/Alerts example

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
- [x] Source installation
- [x] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
