### PR TITLE
Fix Active Response message creation

### DIFF
--- a/framework/wazuh/core/active_response.py
+++ b/framework/wazuh/core/active_response.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import json
 
 from wazuh.core import common
 from wazuh.core.agent import Agent
@@ -50,7 +51,7 @@ def create_message(command: str = '', custom: bool = False, arguments: list = No
     return msg_queue
 
 
-def create_json_message(command: str = '', arguments: list = None, alert: dict = None) -> dict:
+def create_json_message(command: str = '', arguments: list = None, alert: dict = None) -> str:
     """Create the JSON message that will be sent. Function used when Wazuh agent version is >= 4.2.0.
 
     Parameters
@@ -70,8 +71,8 @@ def create_json_message(command: str = '', arguments: list = None, alert: dict =
 
     Returns
     -------
-    dict
-        Dict with the message that will be sent to the socket.
+    str
+        Message that will be sent to the socket.
     """
     if not command:
         raise WazuhError(1650)
@@ -79,9 +80,10 @@ def create_json_message(command: str = '', arguments: list = None, alert: dict =
     cluster_enabled = not read_cluster_config()['disabled']
     node_name = get_node().get('node') if cluster_enabled else None
 
-    msg_queue = create_wazuh_socket_message(origin={'name': node_name, 'module': 'api/framework'}, command=command,
-                                            parameters={'extra_args': arguments if arguments else [],
-                                                        'alert': alert if alert else {}})
+    msg_queue = json.dumps(
+        create_wazuh_socket_message(origin={'name': node_name, 'module': 'api/framework'}, command=command,
+                                    parameters={'extra_args': arguments if arguments else [],
+                                                'alert': alert if alert else {}}))
 
     return msg_queue
 

--- a/framework/wazuh/core/tests/test_active_response.py
+++ b/framework/wazuh/core/tests/test_active_response.py
@@ -2,9 +2,9 @@
 # Copyright (C) 2015-2020, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-
+import json
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -136,7 +136,7 @@ def test_create_json_message(expected_exception, command, arguments, alert):
         with pytest.raises(WazuhError, match=f'.* {expected_exception} .*'):
             active_response.create_json_message(command=command, arguments=arguments, alert=alert)
     else:
-        ret = active_response.create_json_message(command=command, arguments=arguments, alert=alert)
+        ret = json.loads(active_response.create_json_message(command=command, arguments=arguments, alert=alert))
         assert ret["version"] == 1, f'Wrong message version'
         assert command in ret["command"], f'Command not being returned'
         if arguments:


### PR DESCRIPTION
Hi team,

In this PR I have fixed an error when creating Active Response messages sent to the socket. Related issue: #7210 

The message created in json format was being pasted in the AR message as a dictionary. That was happening because there was a `json.dumps` missing and the message was being returned as a dictionary.

I have tested that the agents are being restarted manually. I have tested all the endpoints too, as we are testing in our tests the sending of messages.

I have also updated the active response core tests.


```
framework/wazuh/core/tests/test_active_response.py
====================== 14 passed in 0.08s =======================


framework/wazuh/tests/test_active_response.py
====================== 12 passed in 0.10s =======================
```



```
test_active_response_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rbac_black_active_response_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rbac_white_active_response_endpoints.tavern.yaml 
	 2 passed, 4 warnings
```
