### PR TITLE
Fix API integration tests errors in 4.1

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -22,6 +22,7 @@ variables:
   upgrade_delay: 45
   global_db_delay: 20
   active_reponse_delay: 5
+  rootcheck_delay: 40
 
   custom_wpk_path: "/var/ossec/test_custom_upgrade_3.12.2.wpk"
 

--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -22,7 +22,6 @@ variables:
   upgrade_delay: 45
   global_db_delay: 20
   active_reponse_delay: 5
-  rootcheck_delay: 40
 
   custom_wpk_path: "/var/ossec/test_custom_upgrade_3.12.2.wpk"
 

--- a/api/test/integration/test_rbac_black_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rootcheck_endpoints.tavern.yaml
@@ -28,7 +28,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -36,7 +36,7 @@ stages:
           total_failed_items: 0
 
 ---
-test_name: GET /rootcheck/001/last_scan
+test_name: GET /rootcheck/{agent_id}/last_scan
 
 stages:
 
@@ -60,7 +60,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - end: !anything
@@ -84,7 +84,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 2
         data:
           affected_items: !anything
           failed_items:
@@ -113,7 +113,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 2
         data:
           affected_items: !anything
           failed_items:
@@ -143,7 +143,7 @@ test_name: DELETE /rootcheck
 
 stages:
 
-  - name: Try to delete rootcheck scans in agent 002
+  - name: Try to delete rootcheck scans in agent 002 (Allow)
     request:
       verify: False
       method: DELETE
@@ -155,14 +155,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to delete rootcheck scans in agent 001
+  - name: Try to delete rootcheck scans in agent 001 (Deny)
     request:
       verify: False
       method: DELETE

--- a/api/test/integration/test_rbac_white_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_rootcheck_endpoints.tavern.yaml
@@ -39,7 +39,7 @@ stages:
             error: !anystr
 
 ---
-test_name: GET /rootcheck/001/last_scan
+test_name: GET /rootcheck/{agent_id}/last_scan
 
 stages:
 

--- a/api/test/integration/test_rbac_white_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_rootcheck_endpoints.tavern.yaml
@@ -16,7 +16,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -53,7 +53,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - end: !anything
@@ -87,7 +87,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -106,7 +106,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 2
         data:
           affected_items: !anything
           failed_items:
@@ -135,7 +135,7 @@ test_name: DELETE /rootcheck
 
 stages:
 
-  - name: Try to delete rootcheck scans in agent 001
+  - name: Try to delete rootcheck scans in agent 001 (Allow)
     request:
       verify: False
       method: DELETE
@@ -147,14 +147,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to delete rootcheck scans in agent 002
+  - name: Try to delete rootcheck scans in agent 002 (Deny)
     request:
       verify: False
       method: DELETE

--- a/api/test/integration/test_rbac_white_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_task_endpoints.tavern.yaml
@@ -16,7 +16,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -37,25 +37,20 @@ stages:
     response:
       status_code: 200
 
----
-test_name: GET /tasks/status
-
-stages:
-
-  - name: Get all existent tasks, in progress
+  - name: Get all existent tasks (At this point there is a task created)
     request:
       verify: False
       <<: *get_tasks
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - agent_id: "001"
               create_time: !anyint
               node: !anystr
-              status: "In progress"
+              status: !anystr
               last_update_time: !anyint
               command: "upgrade"
               module: "upgrade_module"

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -51,7 +51,7 @@ stages:
         message: !anystr
 
   # GET /rootcheck/001?limit=2&offset=0
-  - name: Try to get rootcheck scan results for agent 001 using limit and offset parameter
+  - name: Try to get rootcheck scan results for agent 001 using limit 2 and offset 0
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -74,8 +74,8 @@ stages:
         json:
           offset_item: data.affected_items[1]
 
-  # GET /rootcheck/000?limit=1&offset=1
-  - name: Try to get rootcheck scan results for agent 000 using limit and offset parameter
+  # GET /rootcheck/001?limit=1&offset=1
+  - name: Try to get rootcheck scan results for agent 001 using limit 1 and offset 1
     request:
       verify: False
       <<: *get_rootcheck_agent

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -491,12 +491,12 @@ stages:
 
 
 ---
-test_name: DELETE /roothceck
+test_name: DELETE /rootcheck
 
 stages:
 
   # DELETE /rootcheck
-  - name: Try to delete roothceck scans in agent 001
+  - name: Try to delete rootcheck scans in agent 001
     request:
       verify: False
       method: DELETE
@@ -555,7 +555,7 @@ stages:
         message: !anystr
 
   # DELETE /rootcheck
-  - name: Try to delete roothceck scans in all agents
+  - name: Try to delete rootcheck scans in all agents
     request:
       verify: False
       method: DELETE
@@ -606,7 +606,7 @@ stages:
 
 
 ---
-test_name: PUT /roothceck
+test_name: PUT /rootcheck
 
 stages:
 
@@ -630,7 +630,7 @@ stages:
         message: !anystr
 
   # PUT /rootcheck?agents_list=001
-  - name: Run roothceck scan in agent 001
+  - name: Run rootcheck scan in agent 001
     request:
       verify: False
       method: PUT
@@ -649,7 +649,7 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: !float "{global_db_delay}"
+    delay_after: !float "{rootcheck_delay}"
 
   # GET /rootcheck/001
   - name: Check that agent 001 has data again
@@ -671,7 +671,7 @@ stages:
         message: !anystr
 
   # PUT /rootcheck
-  - name: Run roothceck scan in agent 001
+  - name: Run rootcheck scan in agent 001
     request:
       verify: False
       method: PUT
@@ -706,7 +706,7 @@ stages:
                 - "012"
           total_affected_items: 9
           total_failed_items: 4
-    delay_after: !float "{global_db_delay}"
+    delay_after: !float "{rootcheck_delay}"
 
   # GET /rootcheck/001
   - name: Check that agent 002 has data again

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -50,29 +50,6 @@ stages:
           total_failed_items: 0
         message: !anystr
 
-  # GET /rootcheck/002?limit=1
-  - name: Try to get rootcheck scan results for agent 002 with a set limit of 1 answer
-    request:
-      verify: False
-      method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/002"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          # We define this items answer as a common one array full answer
-          affected_items:
-            - <<: *full_items_array
-          failed_items: [ ]
-          total_affected_items: !anyint
-          total_failed_items: 0
-        message: !anystr
-
   # GET /rootcheck/001?limit=2&offset=0
   - name: Try to get rootcheck scan results for agent 001 using limit and offset parameter
     request:
@@ -98,7 +75,7 @@ stages:
           offset_item: data.affected_items[1]
 
   # GET /rootcheck/000?limit=1&offset=1
-  - name: Try to get rootcheck scan results for agent 001 using limit and offset parameter
+  - name: Try to get rootcheck scan results for agent 000 using limit and offset parameter
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -111,7 +88,6 @@ stages:
         error: !anyint
         data:
           affected_items:
-              # Save second item to check offset in next stage
             - status: "{offset_item.status}"
               date_last: "{offset_item.date_last}"
               date_first: "{offset_item.date_first}"
@@ -122,7 +98,7 @@ stages:
           total_failed_items: 0
 
   # GET /rootcheck/001?q=log=5.2 (perfect match)
-  - name: Filters by composed query
+  - name: Filters by composed query with a perfect match, no items returned
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -139,7 +115,7 @@ stages:
           total_failed_items: 0
 
   # GET /rootcheck/001?q=log~5.2 (LIKE ~)
-  - name: Filters by composed query
+  - name: Filters by composed query with a LIKE operator
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -171,7 +147,7 @@ stages:
           returned_total: data.total_affected_items
 
   # GET /rootcheck/001?q=log~5.2;cis=5.2 Debian Linux
-  - name: Filters by composed query
+  - name: Filters by composed query with LIKE and perfect match
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -236,7 +212,7 @@ stages:
           total_failed_items: 0
 
   # GET /rootcheck/001?limit=1&search=random
-  - name: Try to get limited rootcheck scan results for agent 001 using search parameter
+  - name: Try to get limited rootcheck scan results for agent 001 using search parameter, no items returned
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -269,7 +245,7 @@ stages:
             expected_values: "1.4 Debian Linux"
 
   # GET /rootcheck/001?cis=2.0 Debian Linux (does not exist)
-  - name: Filter by CIS parameter
+  - name: Filter by CIS parameter, no items returned
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -286,7 +262,7 @@ stages:
           total_failed_items: 0
 
   # GET /rootcheck/001?pci_dss=2 (does not exist)
-  - name: Filter by PCI_DSS parameter
+  - name: Filter by PCI_DSS parameter, no items returned
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -318,7 +294,7 @@ stages:
             expected_values: "outstanding"
 
   # GET /rootcheck/001?status=all
-  - name: Filter by status parameter
+  - name: Filter by status parameter using the all keyword
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -333,7 +309,7 @@ stages:
             expected_values: "outstanding"
 
   # GET /rootcheck/001?status=solved (does not exist)
-  - name: Filter by status parameter
+  - name: Filter by status parameter, no items returned
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -371,7 +347,7 @@ stages:
           total_failed_items: 0
 
 # GET /rootcheck/001?select=log,status,date_last
-  - name: Filter by select parameter
+  - name: Filter by select parameter with more than a field
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -392,7 +368,7 @@ stages:
           total_failed_items: 0
 
   # GET /rootcheck/001?select=cis,distinct=true
-  - name: Filter by select parameter and distinct
+  - name: Filter by select parameter and distinct, selecting cis
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -412,7 +388,7 @@ stages:
           total_failed_items: 0
 
   # GET /rootcheck/001?select=status,distinct=true
-  - name: Filter by select parameter and distinct
+  - name: Filter by select parameter and distinct, selecting status
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -431,7 +407,7 @@ stages:
           total_failed_items: 0
 
   # GET /rootcheck/001?sort=+log
-  - name: Sort response
+  - name: Sort response (ascending)
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -451,7 +427,7 @@ stages:
           affected_items: data.affected_items
 
   # GET /rootcheck/001?sort=-log
-  - name: Sort response
+  - name: Sort response (descending)
     request:
       verify: False
       <<: *get_rootcheck_agent
@@ -517,7 +493,7 @@ stages:
           total_failed_items: 0
 
   # GET /rootcheck/001
-  - name: Check if data has been deleted in agent 001.
+  - name: Check if data has been deleted in agent 001
     request:
       verify: False
       method: GET
@@ -586,7 +562,7 @@ stages:
           total_failed_items: 0
 
   # GET /rootcheck/002
-  - name: Check if data has been deleted in agent 002.
+  - name: Check if data has been deleted in agent 002
     request:
       verify: False
       method: GET
@@ -610,25 +586,6 @@ test_name: PUT /rootcheck
 
 stages:
 
-  # GET /rootcheck/001
-  - name: Check that agent 001 has no data
-    request:
-      verify: False
-      method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: []
-          failed_items: []
-          total_affected_items: 0
-          total_failed_items: 0
-        message: !anystr
-
   # PUT /rootcheck?agents_list=001
   - name: Run rootcheck scan in agent 001
     request:
@@ -649,29 +606,9 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: !float "{rootcheck_delay}"
-
-  # GET /rootcheck/001
-  - name: Check that agent 001 has data again
-    request:
-      verify: False
-      method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: 5
-          total_failed_items: 0
-        message: !anystr
 
   # PUT /rootcheck
-  - name: Run rootcheck scan in agent 001
+  - name: Run rootcheck scan in all agents
     request:
       verify: False
       method: PUT
@@ -706,23 +643,3 @@ stages:
                 - "012"
           total_affected_items: 9
           total_failed_items: 4
-    delay_after: !float "{rootcheck_delay}"
-
-  # GET /rootcheck/001
-  - name: Check that agent 002 has data again
-    request:
-      verify: False
-      method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/002"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: 5
-          total_failed_items: 0
-        message: !anystr

--- a/api/test/integration/test_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_task_endpoints.tavern.yaml
@@ -16,7 +16,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -90,7 +90,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: &task
             - agent_id: !anystr
@@ -114,7 +114,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - agent_id: !anystr
@@ -131,17 +131,14 @@ stages:
           total_failed_items: 0
     delay_after: !float "{upgrade_delay}"
 
-  - name: Get all existent tasks, completed (Limit 1)
+  - name: Get at least one existant completed task
     request:
       verify: False
       <<: *get_tasks
-      params:
-        limit: 1
-        offset: 1
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *task
@@ -248,26 +245,22 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
           total_affected_items: 0
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Verify that query parameter work as expected when using multiple values
     request:
       verify: False
       <<: *get_tasks
       params:
-        q: "agent_id=004;status=Legacy;module=upgrade_module;command=upgrade"
+        q: "status=Legacy;module=upgrade_module;command=upgrade"
     response:
       status_code: 200
       verify_response_with:
-        - function: tavern_utils:test_expected_value
-          extra_kwargs:
-            key: "agent_id"
-            expected_values: "004"
         - function: tavern_utils:test_expected_value
           extra_kwargs:
             key: "status"
@@ -307,16 +300,16 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *task
-              status: "Legacy"
+              status: !anystr
               last_update_time: !anyint
               agent_id: !anystr
               task_id: 3
             - <<: *task
-              status: "Legacy"
+              status: !anystr
               last_update_time: !anyint
               agent_id: !anystr
               task_id: 4
@@ -336,11 +329,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *task
-              status: "Legacy"
+              status: !anystr
               last_update_time: !anyint
               agent_id: "003"
               task_id: !anyint
@@ -360,7 +353,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -379,7 +372,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - agent_id: "007"
@@ -407,27 +400,27 @@ stages:
     response:
       status_code: 200
       json: &task_module_response
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *task
-              status: "Legacy"
+              status: !anystr
               last_update_time: !anyint
               task_id: 1
             - <<: *task
-              status: "Legacy"
+              status: !anystr
               last_update_time: !anyint
               task_id: 2
             - <<: *task
-              status: "Legacy"
+              status: !anystr
               last_update_time: !anyint
               task_id: 3
             - <<: *task
-              status: "Legacy"
+              status: !anystr
               last_update_time: !anyint
               task_id: 4
             - <<: *task
-              status: "Failed"
+              status: !anystr
               last_update_time: !anyint
               task_id: 5
           failed_items: []
@@ -460,7 +453,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items: !anything

--- a/api/test/integration/test_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_task_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ marks:
 
 stages:
 
-  - name: Get all existent tasks (At this point there is no task created)
+  - name: Get all existent tasks (At this point there are no tasks created)
     request: &get_tasks
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
@@ -23,7 +23,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 0
 
-  - name: Upgrade an agent
+  - name: Upgrade agents to create tasks
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
@@ -52,7 +52,7 @@ stages:
           failed_items: []
         message: !anystr
 
-  - name: Upgrade an agent (Invalid version)
+  - name: Upgrade agents to create tasks (Invalid version)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
@@ -75,12 +75,7 @@ stages:
           failed_items: []
         message: !anystr
 
----
-test_name: GET /tasks/status
-
-stages:
-
-  - name: Get all existent tasks, in progress (Limit 1)
+  - name: Get all existent tasks (Limit 1)
     request:
       verify: False
       <<: *get_tasks
@@ -96,7 +91,7 @@ stages:
             - agent_id: !anystr
               create_time: !anyint
               node: !anystr
-              status: "In progress"
+              status: !anystr
               last_update_time: !anyint
               command: "upgrade"
               module: "upgrade_module"
@@ -105,7 +100,7 @@ stages:
           total_affected_items: 5
           total_failed_items: 0
 
-  - name: Get all existent tasks, in progress (Limit 2)
+  - name: Get all existent tasks (Limit 2)
     request:
       verify: False
       <<: *get_tasks
@@ -120,29 +115,12 @@ stages:
             - agent_id: !anystr
               create_time: !anyint
               node: !anystr
-              status: "In progress"
+              status: !anystr
               last_update_time: !anyint
               command: "upgrade"
               module: "upgrade_module"
               task_id: 1
             - <<: *task
-          failed_items: []
-          total_affected_items: 5
-          total_failed_items: 0
-    delay_after: !float "{upgrade_delay}"
-
-  - name: Get at least one existant completed task
-    request:
-      verify: False
-      <<: *get_tasks
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *task
-              status: "Legacy"
           failed_items: []
           total_affected_items: 5
           total_failed_items: 0
@@ -163,7 +141,7 @@ stages:
         json:
           select_id_items: data.affected_items
 
-  - name: Try to get tasks using select parameter
+  - name: Try to get tasks using select parameter with more than a field
     request:
       verify: False
       <<: *get_tasks
@@ -194,7 +172,7 @@ stages:
     response:
       status_code: 400
 
-  - name: Try to get all tasks using sort parameter and limit parameter
+  - name: Try to get all tasks using sort and select parameter
     request:
       verify: False
       <<: *get_tasks
@@ -257,14 +235,14 @@ stages:
       verify: False
       <<: *get_tasks
       params:
-        q: "status=Legacy;module=upgrade_module;command=upgrade"
+        q: "agent_id=004;module=upgrade_module;command=upgrade"
     response:
       status_code: 200
       verify_response_with:
         - function: tavern_utils:test_expected_value
           extra_kwargs:
-            key: "status"
-            expected_values: "Legacy"
+            key: "agent_id"
+            expected_values: "004"
         - function: tavern_utils:test_expected_value
           extra_kwargs:
             key: "module"
@@ -360,35 +338,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 0
 
-  - name: Get all existent tasks, Failed
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        status: "Failed"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - agent_id: "007"
-              create_time: !anyint
-              node: !anystr
-              status: "Failed"
-              last_update_time: !anyint
-              command: "upgrade"
-              module: "upgrade_module"
-              error_message: !anystr
-              task_id: 5
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
-
-  - name: Get all existent tasks, upgrade_module
+  - name: Get all existent tasks with module=upgrade_module
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
@@ -427,7 +377,7 @@ stages:
           total_affected_items: 5
           total_failed_items: 0
 
-  - name: Get all existent tasks, upgrade command
+  - name: Get all existent tasks with command=upgrade
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
@@ -440,7 +390,7 @@ stages:
       status_code: 200
       json: *task_module_response
 
-  - name: Get all existent tasks, specifing node name (worker2)
+  - name: Get all existent tasks with node=worker2
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/tasks/status"

--- a/api/test/integration/test_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_task_endpoints.tavern.yaml
@@ -186,7 +186,7 @@ stages:
           extra_kwargs:
             affected_items: "{select_id_items}"
 
-  - name: Verify that query parameter work as expected
+  - name: Verify that query parameter works as expected
     request:
       verify: False
       <<: *get_tasks
@@ -200,7 +200,7 @@ stages:
             key: "agent_id"
             expected_values: "004"
 
-  - name: Verify that query parameter work as expected
+  - name: Verify that query parameter works as expected
     request:
       verify: False
       <<: *get_tasks
@@ -214,7 +214,7 @@ stages:
             key: "agent_id"
             expected_values: "005"
 
-  - name: Verify that query parameter work as expected (using non-existent agent_id)
+  - name: Verify that query parameter works as expected (using non-existent agent_id)
     request:
       verify: False
       <<: *get_tasks
@@ -230,7 +230,7 @@ stages:
           total_affected_items: 0
           total_failed_items: 0
 
-  - name: Verify that query parameter work as expected when using multiple values
+  - name: Verify that query parameter works as expected when using multiple values
     request:
       verify: False
       <<: *get_tasks
@@ -252,7 +252,7 @@ stages:
             key: "command"
             expected_values: "upgrade"
 
-  - name: Verify that query parameter work as expected (wrong_field)
+  - name: Verify that query parameter works as expected (wrong_field)
     request:
       verify: False
       <<: *get_tasks
@@ -389,3 +389,37 @@ stages:
     response:
       status_code: 200
       json: *task_module_response
+
+  - name: Get all existent tasks with node=worker2
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        node: "worker2"
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "node"
+            expected_values: "worker2"
+
+  - name: Get all existent tasks with status=In progress
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        status: "In progress"
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "status"
+            expected_values: "In progress"

--- a/api/test/integration/test_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_task_endpoints.tavern.yaml
@@ -389,28 +389,3 @@ stages:
     response:
       status_code: 200
       json: *task_module_response
-
-  - name: Get all existent tasks with node=worker2
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        node: "worker2"
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          affected_items: !anything
-          failed_items: []
-          total_failed_items: 0
-      verify_response_with:
-        function: tavern_utils:test_response_is_different
-        extra_kwargs:
-          response_value: total_affected_items
-          unexpected_value: task_module_response.data.total_affected_items

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -397,7 +397,7 @@ class Agent:
         try:
             data = db_query.run()['items'][0]
         except IndexError:
-            raise WazuhResourceNotFound(1701, extra_message=self.id)
+            raise WazuhResourceNotFound(1701)
 
         list(map(lambda x: setattr(self, x[0], x[1]), data.items()))
 


### PR DESCRIPTION
|Related issue|
|---|
| #7376 |

Hi team,

This PR closes #7376. I have investigated and corrected the errors found in the nightly test results.

### Errors found in 4.1 nightly test results (February 6):



**FAILED test_rbac_black_active_response_endpoints.tavern.yaml::PUT ACTIVE-RESPONSE OVER A LIST OF AGENTS**


I haven't changed the error field (0,1 or 2) as it is changed in master.
Known error, it is fixed in 4.2, I fix it in this PR too.

```
test_active_response_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rbac_black_active_response_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rbac_white_active_response_endpoints.tavern.yaml 
	 2 passed, 4 warnings
```



**FAILED test_rootcheck_endpoints.tavern.yaml::PUT /roothceck**


TODO: fix test_rootcheck




**FAILED test_task_endpoints.tavern.yaml::GET /tasks/status**
**FAILED test_task_endpoints.tavern.yaml::GET /tasks/status (Filters)**


Trying to get a completed task (`status: "Legacy"`) but it still has `status : "In progress"`.
I have removed all the filters corresponding to statuses. The status can vary depending on the execution and may make our tests fail.
I have changed `status:` `"Legacy"` to `!anystr`.
I have also updated the test and the rbac ones. Test_task has now 2 tests.


```
test_rbac_black_task_endpoints.tavern.yaml 
	 1 passed, 3 warnings

test_rbac_white_task_endpoints.tavern.yaml 
	 1 passed, 3 warnings

test_task_endpoints.tavern.yaml 
	 2 passed, 5 warnings
```

TODO:  
- Investigate this random error with the new changes:

```
test_task_endpoints.tavern.yaml [3/3]
Formatting 'select_id_items' will result in it being coerced to a string (it is a <class 'box.box_list.BoxList'>)
Formatting 'select_id_items' will result in it being coerced to a string (it is a <class 'box.box_list.BoxList'>)
Formatting 'select_id_items' will result in it being coerced to a string (it is a <class 'box.box_list.BoxList'>)
Formatting 'select_id_items' will result in it being coerced to a string (it is a <class 'box.box_list.BoxList'>)
	 1 failed, 1 passed, 4 warnings
```

- Last test case in test_task_endpoints can fail if all the tasks are in the same worker node. Investigate and remove or update it.


Regards,
Manuel.
