### PR TITLE
Remoted: adapt the remoted and keyentry structures to support TCP & UDP simultaneously

### DIFF
--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -279,12 +279,6 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         return OS_INVALID;
     }
 
-    /* Only secure connections support TCP and UDP at the same time */
-    if (logr->conn[pl] != SECURE_CONN && (logr->proto[pl] == (REMOTED_PROTO_TCP | REMOTED_PROTO_UDP))) {
-        mwarn(REMOTED_PROTO_ONLY_SECURE);
-        logr->proto[pl] = REMOTED_PROTO_DEFAULT;
-    }
-
     return (0);
 }
 

--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -279,6 +279,12 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         return OS_INVALID;
     }
 
+    /* Only secure connections support TCP and UDP at the same time */
+    if (logr->conn[pl] != SECURE_CONN && (logr->proto[pl] == (REMOTED_PROTO_TCP | REMOTED_PROTO_UDP))) {
+        mwarn(REMOTED_PROTO_ONLY_SECURE);
+        logr->proto[pl] = REMOTED_PROTO_DEFAULT;
+    }
+
     return (0);
 }
 

--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -23,6 +23,11 @@
 #define REMOTED_PROTO_DEFAULT_STR  (REMOTED_PROTO_DEFAULT == REMOTED_PROTO_TCP \
                               ? REMOTED_PROTO_TCP_STR : REMOTED_PROTO_UDP_STR) ///< String to represent default protocol
 
+#define REMOTED_PROTO_TCP_STR "TCP"
+#define REMOTED_PROTO_UDP_STR "UDP"
+#define REMOTED_PROTO_DEFAULT_STR  (REMOTED_PROTO_DEFAULT == REMOTED_PROTO_TCP \
+                                   ? REMOTED_PROTO_TCP_STR : REMOTED_PROTO_UDP_STR)
+
 #include "shared.h"
 #include "global-config.h"
 

--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -43,7 +43,9 @@ typedef struct _remoted {
     os_ip **denyips;
 
     int m_queue;
-    int sock;
+    int tcp_sock;
+    int udp_sock;
+    int syslog_sock;
     int position;
     int nocmerged;
     socklen_t peer_size;

--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -51,6 +51,6 @@ typedef struct _remoted {
     bool worker_node;
     int rids_closing_time;
     _Config global;
-                                   } remoted;
+} remoted;
 
 #endif /* CLOGREMOTE_H */

--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -26,7 +26,7 @@
 #define REMOTED_PROTO_TCP_STR "TCP"
 #define REMOTED_PROTO_UDP_STR "UDP"
 #define REMOTED_PROTO_DEFAULT_STR  (REMOTED_PROTO_DEFAULT == REMOTED_PROTO_TCP \
-                                   ? REMOTED_PROTO_TCP_STR : REMOTED_PROTO_UDP_STR)
+                              ? REMOTED_PROTO_TCP_STR : REMOTED_PROTO_UDP_STR) ///< String to represent default protocol
 
 #include "shared.h"
 #include "global-config.h"
@@ -51,6 +51,6 @@ typedef struct _remoted {
     bool worker_node;
     int rids_closing_time;
     _Config global;
-} remoted;
+                                   } remoted;
 
 #endif /* CLOGREMOTE_H */

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -39,8 +39,8 @@ typedef struct _keyentry {
     ino_t inode;
 
     os_ip *ip;
-    int sock; ///< File descriptor of client's TCP socket 
-    int net_protocol; ///< Client current protocol
+    int sock;                           ///< File descriptor of client's TCP socket 
+    int net_protocol;                   ///< Client current protocol
     pthread_mutex_t mutex;
     struct sockaddr_in peer_info;
     FILE *fp;

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -39,7 +39,8 @@ typedef struct _keyentry {
     ino_t inode;
 
     os_ip *ip;
-    int sock;
+    int sock; ///< File descriptor of client's TCP socket 
+    int net_protocol; ///< Client current protocol
     pthread_mutex_t mutex;
     struct sockaddr_in peer_info;
     FILE *fp;

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -76,7 +76,7 @@ void HandleRemote(int uid)
             merror_exit(BIND_ERROR, logr.port[position], errno, strerror(errno));
         } else if (logr.conn[position] == SECURE_CONN) {
 
-            if (OS_SetKeepalive(logr.tcp_sock) < 0){
+            if (OS_SetKeepalive(logr.tcp_sock) < 0) {
                 merror("OS_SetKeepalive failed with error '%s'", strerror(errno));
             }
 #ifndef CLIENT
@@ -84,10 +84,10 @@ void HandleRemote(int uid)
                 OS_SetKeepalive_Options(logr.tcp_sock, tcp_keepidle, tcp_keepintvl, tcp_keepcnt);
             }
 #endif
-            if (OS_SetRecvTimeout(logr.tcp_sock, recv_timeout, 0) < 0){
+            if (OS_SetRecvTimeout(logr.tcp_sock, recv_timeout, 0) < 0) {
                 merror("OS_SetRecvTimeout failed with error '%s'", strerror(errno));
             }
-            if (OS_SetSendTimeout(logr.tcp_sock, send_timeout) < 0){
+            if (OS_SetSendTimeout(logr.tcp_sock, send_timeout) < 0) {
                 merror("OS_SetSendTimeout failed with error '%s'", strerror(errno));
             }
         }

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -102,8 +102,8 @@ void HandleRemote(int uid)
         }
     }
 
-    if ( logr.conn[position] == SYSLOG_CONN ) {
-        logr.syslog_sock = ( logr.proto[position] == REMOTED_PROTO_TCP ? logr.tcp_sock : logr.udp_sock );
+    if (logr.conn[position] == SYSLOG_CONN) {
+        logr.syslog_sock = (logr.proto[position] == REMOTED_PROTO_TCP ? logr.tcp_sock : logr.udp_sock);
     }
 
     /* Revoke privileges */

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -159,8 +159,8 @@ void HandleSecure()
             merror_exit("wnotify_init(): %s (%d)", strerror(errno), errno);
         }
 
-        if (wnotify_add(notify, logr.sock) < 0) {
-            merror_exit("wnotify_add(%d): %s (%d)", logr.sock, strerror(errno), errno);
+        if (wnotify_add(notify, logr.tcp_sock) < 0) {
+            merror_exit("wnotify_add(%d): %s (%d)", logr.tcp_sock, strerror(errno), errno);
         }
     }
 
@@ -180,8 +180,8 @@ void HandleSecure()
             for (i = 0; i < n_events; i++) {
                 int fd = wnotify_get(notify, i);
 
-                if (fd == logr.sock) {
-                    sock_client = accept(logr.sock, (struct sockaddr *)&peer_info, &logr.peer_size);
+                if (fd == logr.tcp_sock) {
+                    sock_client = accept(logr.tcp_sock, (struct sockaddr *)&peer_info, &logr.peer_size);
                     if (sock_client < 0) {
                         switch (errno) {
                         case ECONNABORTED:
@@ -238,7 +238,7 @@ void HandleSecure()
                 }
             }
         } else {
-            recv_b = recvfrom(logr.sock, buffer, OS_MAXSTR, 0, (struct sockaddr *)&peer_info, &logr.peer_size);
+            recv_b = recvfrom(logr.udp_sock, buffer, OS_MAXSTR, 0, (struct sockaddr *)&peer_info, &logr.peer_size);
 
             /* Nothing received */
             if (recv_b <= 0) {
@@ -412,7 +412,7 @@ static void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_in *pe
             ssize_t msg_size = strlen(msg);
 
             if (protocol == REMOTED_PROTO_UDP) {
-                retval = sendto(logr.sock, msg, msg_size, 0, (struct sockaddr *)peer_info, logr.peer_size) == msg_size ? 0 : -1;
+                retval = sendto(logr.udp_sock, msg, msg_size, 0, (struct sockaddr *)peer_info, logr.peer_size) == msg_size ? 0 : -1;
             } else {
                 retval = OS_SendSecureTCP(sock_client, msg_size, msg);
             }

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -337,7 +337,7 @@ STATIC void * close_fp_main(void * args) {
 
 static void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_in *peer_info, int sock_client, int *wdb_sock) {
     int agentid;
-    int protocol = logr.proto[logr.position];
+    int protocol = (sock_client == -1) ? REMOTED_PROTO_UDP : REMOTED_PROTO_TCP;
     char cleartext_msg[OS_MAXSTR + 1];
     char srcmsg[OS_FLSIZE + 1];
     char srcip[IPSIZE + 1] = {0};
@@ -467,6 +467,8 @@ static void HandleSecureMessage(char *buffer, int recv_b, struct sockaddr_in *pe
     if (IsValidHeader(tmp_msg)) {
 
         /* We need to save the peerinfo if it is a control msg */
+
+        keys.keyentries[agentid]->net_protocol = protocol;
 
         memcpy(&keys.keyentries[agentid]->peer_info, peer_info, logr.peer_size);
         keyentry * key = OS_DupKeyEntry(keys.keyentries[agentid]);

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -99,7 +99,7 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
     }
 
     /* Send initial message */
-    if (logr.proto[logr.position] == REMOTED_PROTO_UDP) {
+    if (keys.keyentries[key_id]->net_protocol == REMOTED_PROTO_UDP) {
         retval = sendto(logr.udp_sock, crypt_msg, msg_size, 0, (struct sockaddr *)&keys.keyentries[key_id]->peer_info, logr.peer_size) == msg_size ? 0 : -1;
         error = errno;
     } else if (keys.keyentries[key_id]->sock >= 0) {

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -100,7 +100,7 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
 
     /* Send initial message */
     if (logr.proto[logr.position] == REMOTED_PROTO_UDP) {
-        retval = sendto(logr.sock, crypt_msg, msg_size, 0, (struct sockaddr *)&keys.keyentries[key_id]->peer_info, logr.peer_size) == msg_size ? 0 : -1;
+        retval = sendto(logr.udp_sock, crypt_msg, msg_size, 0, (struct sockaddr *)&keys.keyentries[key_id]->peer_info, logr.peer_size) == msg_size ? 0 : -1;
         error = errno;
     } else if (keys.keyentries[key_id]->sock >= 0) {
         w_mutex_lock(&keys.keyentries[key_id]->mutex);

--- a/src/remoted/syslog.c
+++ b/src/remoted/syslog.c
@@ -59,8 +59,7 @@ void HandleSyslog()
     /* Infinite loop */
     while (1) {
         /* Receive message */
-        recv_b = recvfrom(logr.sock, buffer, OS_MAXSTR, 0,
-                          (struct sockaddr *)&peer_info, &peer_size);
+        recv_b = recvfrom(logr.syslog_sock, buffer, OS_MAXSTR, 0, (struct sockaddr *)&peer_info, &peer_size);
 
         /* Nothing received */
         if (recv_b <= 0) {

--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -133,7 +133,7 @@ void HandleSyslogTCP()
         }
 
         /* Accept new connections */
-        int client_socket = OS_AcceptTCP(logr.sock, srcip, IPSIZE);
+        int client_socket = OS_AcceptTCP(logr.syslog_sock, srcip, IPSIZE);
         if (client_socket < 0) {
             mwarn("Accepting TCP connection from client failed: %s (%d)", strerror(errno), errno);
             continue;


### PR DESCRIPTION
|Related issue|
|---|
| Closes #7370 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

Hi Team!

We continue working on **Support TCP and UDP for remoted at the same time** #1838.

## Description

The _**remoted** structure_  and the _**keyentry** structure_ (which has the information of an individual client) were modified in order to support working simultaneously with TCP & UDP, when required, in a secure connection.

To be able to test a stable functioning version, the code was slightly modified to embrace the changes on the structures previously mentioned. Additionally, comments and defines where added to improve the readability and for better understanding of the code.

<!--
Add a clear description of how the problem has been solved.
-->

## Feature Tests

### Feature Tests: With TCP protocol 

`<protocol>tcp</protocol>`

- [x] `#Ping`  `#Pong` (i.e. `go run ./wazuh_sock.go -s 192.168.0.35:1514 -p tcp `)
- [x] Agent connect and send logs
- [ ] Active Response 
- [x] Remote API requeset (i.e.  `go run ./wazuh_sock.go -f /var/ossec/queue/ossec/request -m "019 logcollector getstate"`)
- [ ] Shared files
- [ ] Centralized configuration (Agents can be configured remotely by using the **agent.conf** file.)
- [x]  Get configuration in JSON format (`go run ./wazuh_sock.go -f /var/ossec/queue/ossec/request -m "getconfig remote"`)
- [ ] Send WPK commands

### Feature Tests: With UDP protocol 

`<protocol>udp</protocol>`

- [x] `#Ping`  `#Pong`
- [x] Agent connect and send logs
- [ ] Active Response 
- [x] Remote API requeset (i.e.  `./secure_tcp.go -f /var/ossec/queue/ossec/request -m "019 agent getstate"`)
- [ ] Shared files
- [ ] Centralized configuration (Agents can be configured remotely by using the **agent.conf** file.)
- [x]  Get configuration in JSON format (`go run ./secure_tcp.go -f /var/ossec/queue/ossec/request -m "getconfig remote")
- [ ] Send WPK commands


## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

---

Regards,

Mariano