### PR TITLE
Reduce modulesd CPU usage on systems with large routing tables

### DIFF
--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -67,7 +67,7 @@ int ClientConf(const char *cfgfile)
         mwarn("Client buffer throughput too low: set to %d eps", min_eps);
         agt->events_persec = min_eps;
     }
-    
+
     return (1);
 }
 
@@ -85,6 +85,7 @@ cJSON *getClientConfig(void) {
     if (agt->profile) cJSON_AddStringToObject(client,"config-profile",agt->profile);
     cJSON_AddNumberToObject(client,"notify_time",agt->notify_time);
     cJSON_AddNumberToObject(client,"time-reconnect",agt->max_time_reconnect_try);
+    cJSON_AddNumberToObject(client,"ip_update_interval",agt->main_ip_update_interval);
     if (agt->lip) cJSON_AddStringToObject(client,"local_ip",agt->lip);
     if (agt->flags.auto_restart) cJSON_AddStringToObject(client,"auto_restart","yes"); else cJSON_AddStringToObject(client,"auto_restart","no");
     if (agt->flags.remote_conf) cJSON_AddStringToObject(client,"remote_conf","yes"); else cJSON_AddStringToObject(client,"remote_conf","no");
@@ -100,7 +101,7 @@ cJSON *getClientConfig(void) {
             cJSON_AddNumberToObject(server,"port",agt->server[i].port);
             cJSON_AddNumberToObject(server,"max_retries", agt->server[i].max_retries);
             cJSON_AddNumberToObject(server,"retry_interval", agt->server[i].retry_interval);
-    
+
             if (agt->server[i].protocol == IPPROTO_UDP) cJSON_AddStringToObject(server,"protocol","udp"); else cJSON_AddStringToObject(server,"protocol","tcp");
             cJSON_AddItemToArray(servers,server);
         }
@@ -114,25 +115,25 @@ cJSON *getClientConfig(void) {
 
         if (agt->enrollment_cfg->target_cfg->manager_name)
             cJSON_AddStringToObject(enrollment_cfg, "manager_address", agt->enrollment_cfg->target_cfg->manager_name);
-        
+
         cJSON_AddNumberToObject(enrollment_cfg, "port", agt->enrollment_cfg->target_cfg->port);
-        
+
         if (agt->enrollment_cfg->target_cfg->agent_name)
             cJSON_AddStringToObject(enrollment_cfg, "agent_name", agt->enrollment_cfg->target_cfg->agent_name);
-        if (agt->enrollment_cfg->target_cfg->centralized_group)   
+        if (agt->enrollment_cfg->target_cfg->centralized_group)
             cJSON_AddStringToObject(enrollment_cfg, "group", agt->enrollment_cfg->target_cfg->centralized_group);
-        
+
         cJSON_AddStringToObject(enrollment_cfg, "ssl_cipher", agt->enrollment_cfg->cert_cfg->ciphers);
-        
+
         if (agt->enrollment_cfg->cert_cfg->ca_cert)
             cJSON_AddStringToObject(enrollment_cfg, "server_certificate_path", agt->enrollment_cfg->cert_cfg->ca_cert);
         if (agt->enrollment_cfg->cert_cfg->agent_cert)
             cJSON_AddStringToObject(enrollment_cfg, "agent_certificate_path", agt->enrollment_cfg->cert_cfg->agent_cert);
-        if (agt->enrollment_cfg->cert_cfg->agent_key)    
+        if (agt->enrollment_cfg->cert_cfg->agent_key)
             cJSON_AddStringToObject(enrollment_cfg, "agent_key_path", agt->enrollment_cfg->cert_cfg->agent_key);
         if(agt->enrollment_cfg->cert_cfg->authpass)
             cJSON_AddStringToObject(enrollment_cfg, "authorization_pass_path", agt->enrollment_cfg->cert_cfg->authpass_file);
-        
+
         cJSON_AddStringToObject(enrollment_cfg,"auto_method",agt->enrollment_cfg->cert_cfg->auto_method ? "yes": "no");
         cJSON_AddItemToObject(client,"enrollment",enrollment_cfg);
     }

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -42,21 +42,30 @@ char *getsharedfiles()
 #ifndef WIN32
 char *get_agent_ip()
 {
-    char *agent_ip = NULL;
+    static char agent_ip[IPSIZE + 1] = { '\0' };
 #if defined (__linux__) || defined (__MACH__) || defined (sun)
+    static time_t last_update = 0;
+    time_t now = time(NULL);
     int sock;
     int i;
-    os_calloc(IPSIZE + 1,sizeof(char),agent_ip);
+
+    if ((now - last_update) < agt->main_ip_update_interval) {
+        return strdup(agent_ip);
+    }
+
+    last_update = now;
+    *agent_ip = '\0';
 
     for (i = SOCK_ATTEMPTS; i > 0; --i) {
         if (sock = control_check_connection(), sock >= 0) {
             if (OS_SendUnix(sock, agent_ip, IPSIZE) < 0) {
                 mdebug1("Error sending msg to control socket (%d) %s", errno, strerror(errno));
+                last_update = 0;
             }
             else{
                 if (OS_RecvUnix(sock, IPSIZE, agent_ip) <= 0) {
                     mdebug1("Error receiving msg from control socket (%d) %s", errno, strerror(errno));
-                    *agent_ip = '\0';
+                    last_update = 0;
                 }
             }
 
@@ -70,9 +79,10 @@ char *get_agent_ip()
 
     if(sock < 0) {
         mdebug1("Cannot get the agent host's IP because the control module is not available: (%d) %s.", errno, strerror(errno));
+        last_update = 0;
     }
 #endif
-    return agent_ip;
+    return strdup(agent_ip);
 }
 #endif /* !WIN32 */
 
@@ -165,7 +175,7 @@ void run_notify()
                     getuname(), tmp_labels, shared_files);
         }
     }
-    free(agent_ip);
+    os_free(agent_ip);
 
     /* Send status message */
     mdebug2("Sending keep alive: %s", tmp_msg);

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -31,6 +31,7 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     const char *xml_ar_disabled = "disable-active-response";
     const char *xml_notify_time = "notify_time";
     const char *xml_max_time_reconnect_try = "time-reconnect";
+    const char *xml_main_ip_update_interval = "ip_update_interval";
     const char *xml_profile_name = "config-profile";
     const char *xml_auto_restart = "auto_restart";
     const char *xml_crypto_method = "crypto_method";
@@ -45,6 +46,7 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     agent * logr = (agent *)d1;
     logr->notify_time = 0;
     logr->max_time_reconnect_try = 0;
+    logr->main_ip_update_interval = 0;
     logr->rip_id = 0;
     logr->server_count = 0;
 
@@ -140,6 +142,16 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
+        } else if (strcmp(node[i]->element, xml_main_ip_update_interval) == 0) {
+            if (!OS_StrIsNum(node[i]->content)) {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
+            logr->main_ip_update_interval = atoi(node[i]->content);
+            if (logr->main_ip_update_interval < 0) {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
         } else if (strcmp(node[i]->element, xml_ar_disabled) == 0) {
             if (strcmp(node[i]->content, "yes") == 0) {
                 logr->execdq = -1;
@@ -230,7 +242,7 @@ int Read_Client_Server(XML_NODE node, agent * logr)
     /* Default values */
     int port = DEFAULT_SECURE;
     int protocol = IPPROTO_TCP;
-    int max_retries = DEFAULT_MAX_RETRIES; 
+    int max_retries = DEFAULT_MAX_RETRIES;
     int retry_interval = DEFAULT_RETRY_INTERVAL;
 
     /* Get parameters for each configurated server*/
@@ -273,7 +285,7 @@ int Read_Client_Server(XML_NODE node, agent * logr)
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
                 return (OS_INVALID);
             }
-        } else if (strcmp(node[j]->element, xml_max_retries) == 0) { 
+        } else if (strcmp(node[j]->element, xml_max_retries) == 0) {
             if (!OS_StrIsNum(node[j]->content)) {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
                 return (OS_INVALID);
@@ -283,7 +295,7 @@ int Read_Client_Server(XML_NODE node, agent * logr)
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
                 return (OS_INVALID);
             }
-        } else if (strcmp(node[j]->element, xml_retry_interval) == 0) { 
+        } else if (strcmp(node[j]->element, xml_retry_interval) == 0) {
             if (!OS_StrIsNum(node[j]->content)) {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
                 return (OS_INVALID);
@@ -447,7 +459,7 @@ int Read_Client_Enrollment(XML_NODE node, agent * logr){
                 w_enrollment_target_destroy(target_cfg);
                 w_enrollment_cert_destroy(cert_cfg);
                 return (OS_INVALID);
-            } 
+            }
             logr->enrollment_cfg->delay_after_enrollment = delay_after_enrollment;
         } else if (strcmp(node[j]->element, xml_use_source_ip) == 0) {
             if (!strcmp(node[j]->content, "yes")) {

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -38,6 +38,7 @@ typedef struct _agent {
     char *lip;
     int notify_time;
     int max_time_reconnect_try;
+    int main_ip_update_interval;
     char *profile;
     int buffer;
     int buflength;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -837,10 +837,10 @@ void LogCollectorStart()
             w_save_file_status();
 
             f_check = 0;
-        }
 
-        if (mq_log_builder_update() == -1) {
-            mdebug1("Output log pattern data could not be updated.");
+            if (mq_log_builder_update() == -1) {
+                mdebug1("Output log pattern data could not be updated.");
+            }
         }
 
         sleep(1);

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -265,10 +265,6 @@ OSHashNode *__wrap_OSHash_Begin(const OSHash *self, unsigned int *i) {
     return mock_type(OSHashNode *);
 }
 
-time_t __wrap_time(time_t *t) {
-    return mock_type(time_t);
-}
-
 double __wrap_difftime (time_t __time1, time_t __time0) {
     return mock();
 }
@@ -1190,7 +1186,7 @@ void test_w_logtest_register_session_remove_old(void ** state) {
     expect_value(__wrap_OSHash_Add, key, session.token);
     expect_value(__wrap_OSHash_Add, data, &session);
     will_return(__wrap_OSHash_Add, 0);
-    
+
 
     w_logtest_register_session(&connection, &session);
     assert_int_equal(connection.active_client, active_session);
@@ -2778,7 +2774,7 @@ void test_w_logtest_process_request_type_log_processing(void ** state) {
 
     will_return(__wrap_cJSON_CreateObject, (cJSON *) 1);
     will_return(__wrap_cJSON_CreateObject, (cJSON *) 1);
-    
+
     will_return(__wrap_cJSON_ParseWithOpts, (cJSON *) 1);
     will_return(__wrap_cJSON_GetObjectItemCaseSensitive, (cJSON *) 1);
     will_return(__wrap_cJSON_IsObject, (cJSON *) 1);

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -21,7 +21,7 @@ set_target_properties(
 
 target_link_libraries(CLIENT-AGENT ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
-# Generate Analysisd tests
+# Generate agentd tests
 list(APPEND client-agent_names "test_start_agent")
 set(START_AGENT_BASE_FLAGS "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_minfo -Wl,--wrap,_mdebug1 \
                             -Wl,--wrap,w_rotate_log -Wl,--wrap,getDefine_Int -Wl,--wrap,OS_ConnectUDP \
@@ -34,6 +34,11 @@ if(${TARGET} STREQUAL "winagent")
 else()
     list(APPEND client-agent_flags "${START_AGENT_BASE_FLAGS} -Wl,--wrap=close")
 endif()
+
+list(APPEND client-agent_names "test_notify")
+list(APPEND client-agent_flags "-Wl,--wrap,control_check_connection,--wrap,OS_SendUnix,--wrap,OS_RecvUnix,--wrap,close \
+                                -Wl,--wrap,sleep,--wrap,w_rotate_log,--wrap,getpid,--wrap,time,--wrap,_mdebug1 \
+                                -Wl,--wrap,_mdebug2")
 
 list(LENGTH client-agent_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/client-agent/test_notify.c
+++ b/src/unit_tests/client-agent/test_notify.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "../client-agent/agentd.h"
+
+#define TIME_INCREMENT ((time_t)(60))
+
+static time_t base_time = 123456;
+
+static agent global_config = { .main_ip_update_interval = (int)TIME_INCREMENT };
+
+static int setup_group(void **state) {
+    agt = &global_config;
+
+    return 0;
+}
+
+#ifdef TEST_AGENT
+// get_agent_ip
+static void get_agent_ip_fail_to_connect(void **state) {
+    char *retval;
+
+    expect_any_count(__wrap__mdebug2, formatted_msg, SOCK_ATTEMPTS);
+
+    will_return(__wrap_time, base_time);
+
+    for (int i = SOCK_ATTEMPTS; i > 0; i--) {
+        will_return(__wrap_control_check_connection, -1);
+        expect_value(__wrap_sleep, seconds, 1);
+    }
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+
+    retval = get_agent_ip();
+
+    assert_string_equal(retval, "");
+
+    free(retval);
+}
+
+static void get_agent_ip_fail_to_send_request(void **state) {
+    char *retval;
+    static const int socket = 8;
+
+    will_return(__wrap_time, base_time);
+
+    will_return(__wrap_control_check_connection, socket);
+
+    expect_value(__wrap_OS_SendUnix, socket, socket);
+    expect_string(__wrap_OS_SendUnix, msg, "");
+    expect_value(__wrap_OS_SendUnix, size, IPSIZE);
+    will_return(__wrap_OS_SendUnix, OS_SOCKTERR);
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+
+    retval = get_agent_ip();
+
+    assert_string_equal(retval, "");
+
+    free(retval);
+}
+
+static void get_agent_ip_fail_to_receive_response(void **state) {
+    char *retval;
+    static const int socket = 8;
+
+    will_return(__wrap_time, base_time);
+
+    will_return(__wrap_control_check_connection, socket);
+
+    expect_value(__wrap_OS_SendUnix, socket, socket);
+    expect_string(__wrap_OS_SendUnix, msg, "");
+    expect_value(__wrap_OS_SendUnix, size, IPSIZE);
+    will_return(__wrap_OS_SendUnix, OS_SUCCESS);
+
+    expect_value(__wrap_OS_RecvUnix, socket, socket);
+    expect_value(__wrap_OS_RecvUnix, sizet, IPSIZE);
+    will_return(__wrap_OS_RecvUnix, "");
+    will_return(__wrap_OS_RecvUnix, -1);
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+
+    retval = get_agent_ip();
+
+    assert_string_equal(retval, "");
+
+    free(retval);
+}
+
+static void get_agent_ip_updated_successfully(void **state) {
+    char *retval;
+    static const int socket = 8;
+    static const char *const RESPONSE = "10.0.2.15";
+
+    will_return(__wrap_time, base_time);
+
+    will_return(__wrap_control_check_connection, socket);
+
+    expect_value(__wrap_OS_SendUnix, socket, socket);
+    expect_string(__wrap_OS_SendUnix, msg, "");
+    expect_value(__wrap_OS_SendUnix, size, IPSIZE);
+    will_return(__wrap_OS_SendUnix, OS_SUCCESS);
+
+    expect_value(__wrap_OS_RecvUnix, socket, socket);
+    expect_value(__wrap_OS_RecvUnix, sizet, IPSIZE);
+    will_return(__wrap_OS_RecvUnix, RESPONSE);
+    will_return(__wrap_OS_RecvUnix, strlen(RESPONSE));
+
+    retval = get_agent_ip();
+
+    assert_string_equal(retval, RESPONSE);
+
+    free(retval);
+
+    // Check the function uses the cache for the given interval
+    will_return(__wrap_time, base_time + (TIME_INCREMENT / 2));
+
+    retval = get_agent_ip();
+
+    assert_string_equal(retval, RESPONSE);
+
+    free(retval);
+
+    // Check the IP gets refreshed after the interval
+    base_time += TIME_INCREMENT;
+
+    will_return(__wrap_time, base_time + (TIME_INCREMENT / 2));
+
+    will_return(__wrap_control_check_connection, socket);
+
+    expect_value(__wrap_OS_SendUnix, socket, socket);
+    expect_string(__wrap_OS_SendUnix, msg, "");
+    expect_value(__wrap_OS_SendUnix, size, IPSIZE);
+    will_return(__wrap_OS_SendUnix, OS_SUCCESS);
+
+    expect_value(__wrap_OS_RecvUnix, socket, socket);
+    expect_value(__wrap_OS_RecvUnix, sizet, IPSIZE);
+    will_return(__wrap_OS_RecvUnix, RESPONSE);
+    will_return(__wrap_OS_RecvUnix, strlen(RESPONSE));
+
+    retval = get_agent_ip();
+
+    assert_string_equal(retval, RESPONSE);
+
+    free(retval);
+}
+
+#endif // TEST_AGENT
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+#ifdef TEST_AGENT
+        cmocka_unit_test(get_agent_ip_fail_to_connect),
+        cmocka_unit_test(get_agent_ip_fail_to_send_request),
+        cmocka_unit_test(get_agent_ip_fail_to_receive_response),
+        cmocka_unit_test(get_agent_ip_updated_successfully)
+#endif // TEST_AGENT
+    };
+
+    return cmocka_run_group_tests(tests, setup_group, NULL);
+}

--- a/src/unit_tests/logcollector/test_read_multiline_regex.c
+++ b/src/unit_tests/logcollector/test_read_multiline_regex.c
@@ -46,10 +46,6 @@ static int group_teardown(void ** state) {
 }
 
 /* wraps */
-time_t __wrap_time(time_t * t) {
-    return mock_type(time_t);
-}
-
 int __wrap_can_read() {
     return mock_type(int);
 }
@@ -69,7 +65,7 @@ void __wrap_w_get_hash_context(const char * path, SHA_CTX * context, int64_t pos
     return;
 }
 
-int __wrap_w_update_file_status(const char * path, int64_t pos, SHA_CTX * context) { 
+int __wrap_w_update_file_status(const char * path, int64_t pos, SHA_CTX * context) {
     return mock_type(int);
 }
 

--- a/src/unit_tests/logcollector/test_state.c
+++ b/src/unit_tests/logcollector/test_state.c
@@ -53,10 +53,6 @@ static int teardown_group(void ** state) {
 }
 
 /* wraps */
-time_t __wrap_time(time_t * t) {
-    return mock_type(time_t);
-}
-
 size_t __wrap_strftime(char *s, size_t max, const char *format,
                        const struct tm *tm) {
     strncpy(s, mock_type(char *), max);

--- a/src/unit_tests/monitord/test_monitor_actions.c
+++ b/src/unit_tests/monitord/test_monitor_actions.c
@@ -34,11 +34,6 @@
 #include "config/config.h"
 
 /* redefinitons/wrapping */
-
-time_t __wrap_time(__attribute__((unused)) time_t *t) {
-    return mock_type(time_t);
-}
-
 extern monitor_time_control mond_time_control;
 
 /* setup/teardown */

--- a/src/unit_tests/monitord/test_monitord.c
+++ b/src/unit_tests/monitord/test_monitord.c
@@ -31,10 +31,6 @@
 
 /* redefinitons/wrapping */
 
-time_t __wrap_time(__attribute__((unused)) time_t *t) {
-    return mock_type(time_t);
-}
-
 int __wrap_ReadConfig(int modules, const char *cfgfile, __attribute__((unused)) void *d1, __attribute__((unused)) void *d2) {
     check_expected(modules);
     check_expected(cfgfile);

--- a/src/unit_tests/os_execd/test_execd.c
+++ b/src/unit_tests/os_execd/test_execd.c
@@ -59,12 +59,6 @@ static int test_teardown_file(void **state) {
     return 0;
 }
 
-/* Wrappers */
-
-time_t __wrap_time(time_t *t) {
-    return mock_type(time_t);
-}
-
 /* Tests */
 
 static void test_ExecdStart_ok(void **state) {

--- a/src/unit_tests/wazuh_db/test_wdb_task.c
+++ b/src/unit_tests/wazuh_db/test_wdb_task.c
@@ -49,12 +49,6 @@ static int test_teardown(void **state){
     return 0;
 }
 
-// Wrappers
-
-time_t __wrap_time(time_t *__timer) {
-    return mock();
-}
-
 
 void test_wdb_task_delete_old_entries_ok(void **state)
 {

--- a/src/unit_tests/wazuh_modules/task_manager/test_wm_task_manager_commands.c
+++ b/src/unit_tests/wazuh_modules/task_manager/test_wm_task_manager_commands.c
@@ -129,12 +129,6 @@ static int teardown_json_upgrade_cancel_tasks_task(void **state) {
     return 0;
 }
 
-// Wrappers
-
-time_t __wrap_time(time_t *__timer) {
-    return mock();
-}
-
 // Tests
 
 void test_wm_task_manager_send_message_to_wdb_ok(void **state)

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.c
@@ -54,10 +54,6 @@ char * __wrap_w_get_file_content(const char * path, int max_size) {
 
 // wm_vuln_detector_evr mocks
 
-time_t __wrap_time(time_t *t) {
-    return mock_type(time_t);
-}
-
 struct tm *__wrap_localtime(const time_t *t) {
     return mock_type(struct tm *);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.h
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.h
@@ -20,8 +20,6 @@ extern char **d_sub_strings;
 
 /* redefinitons/wrapping */
 
-time_t __wrap_time(time_t *t);
-
 struct tm *__wrap_localtime(const time_t *t);
 
 int __wrap_wurl_request_uncompress_bz2_gz(const char * url, const char * dest, const char * header, const char * data, const long timeout);

--- a/src/unit_tests/wrappers/posix/time_wrappers.c
+++ b/src/unit_tests/wrappers/posix/time_wrappers.c
@@ -1,0 +1,18 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "time_wrappers.h"
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+time_t __wrap_time(__attribute__ ((unused)) time_t *t) {
+    return mock_type(time_t);
+}

--- a/src/unit_tests/wrappers/posix/time_wrappers.h
+++ b/src/unit_tests/wrappers/posix/time_wrappers.h
@@ -1,0 +1,18 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef TIME_WRAPPERS_H
+#define TIME_WRAPPERS_H
+
+#include <time.h>
+
+time_t __wrap_time(time_t *t);
+
+#endif // TIME_WRAPPERS_H

--- a/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.c
@@ -22,3 +22,7 @@ int __wrap_auth_connect() {
 char* __wrap_get_agent_id_from_name(__attribute__((unused)) char *agent_name) {
     return mock_type(char*);
 }
+
+int __wrap_control_check_connection() {
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/agent_op_wrappers.h
@@ -13,5 +13,6 @@
 
 int __wrap_auth_connect();
 char* __wrap_get_agent_id_from_name(__attribute__((unused)) char *agent_name);
+int __wrap_control_check_connection();
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|#7192|

## Description

This PR closes #7192. The high CPU usage of modulesd was due to logcollector and agentd querying the control module for the main IP of the agent quite often, in systems with large routing tables this could cause it to continuously read the routing table located at `/proc/net/route`. In order to solve this issue, logcollector now queries the main IP every `logcollector.vcheck_files` seconds (64 seconds by default) and agentd has a new configuration option (`ip_update_time`) which can be used to further tune how often it queries the control module (by default it will query every time a keep-alive message is sent).

## Configuration options

| Option name | Default value | Possible values|
|---|---|---|
| ip_update_interval | 0 | Positive integers |

Example configuration, update main ip every minute:
```xml
  <client>
    <server>
      <address>192.168.50.20</address>
      <port>1514</port>
      <protocol>udp</protocol>
    </server>
    <config-profile>ubuntu, ubuntu18</config-profile>
    <notify_time>10</notify_time>
    <time-reconnect>60</time-reconnect>
    <ip_update_interval>60</ip_update_interval>
    <auto_restart>yes</auto_restart>
    <crypto_method>aes</crypto_method>
    <local_ip>10.0.2.15</local_ip>
  </client>
```

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Configuration on demand reports new parameters
- [x] Added unit tests (for new features)
