### PR TITLE
Refactor test_sort_response to make it a more efficient function

### DIFF
--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -71,17 +71,24 @@ def test_select_key_affected_items_with_agent_id(response, select_key):
         assert set(response.json()["data"]["affected_items"][0].keys()) == expected_keys
 
 
-def test_sort_response(response, affected_items):
+def test_sort_response(response, key, reverse=True):
+    """Check that the response's affected items are sorted by the specified key.
+
+    Parameters
+    ----------
+    response : Request response
+    key : str
+        Key expected to sort by.
+    reverse : bool
+        Indicate if the expected order is ascending (False) or descending (True). Default: True
+
+    Returns
+    -------
+    bool
+        True if the response's items are sorted by the key.
     """
-    :param response: Request response
-    :param affected_items: List of agent
-    :return: True if request response have this items
-    """
-    affected_items = affected_items.replace("'", '"')
-    affected_items = json.loads(affected_items)
-    reverse_index = len(affected_items) - 1
-    for index, item_response in enumerate(response.json()['data']['affected_items']):
-        assert item_response == affected_items[reverse_index - index]
+    affected_items = response.json()['data']['affected_items']
+    assert affected_items == sorted(affected_items, key=lambda item: item[key], reverse=reverse)
 
 
 def test_validate_data_dict_field(response, fields_dict):
@@ -186,10 +193,10 @@ def test_validate_syscollector_hotfix(response, hotfix_filter=None, experimental
 
 def test_validate_group_configuration(response, expected_field, expected_value):
     response_json = response.json()
-    assert len(response_json['data']['affected_items']) > 0 and\
+    assert len(response_json['data']['affected_items']) > 0 and \
            'config' in response_json['data']['affected_items'][0] and \
-           'localfile' in response_json['data']['affected_items'][0]['config'],\
-           'No config or localfile fields were found in the affected_items. Response: {}'.format(response_json)
+           'localfile' in response_json['data']['affected_items'][0]['config'], \
+        'No config or localfile fields were found in the affected_items. Response: {}'.format(response_json)
 
     response_config = response_json['data']['affected_items'][0]['config']['localfile'][0]
     assert expected_field in set(response_config.keys()), \

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -88,6 +88,7 @@ def test_sort_response(response, key=None, reverse=True):
         True if the response's items are sorted by the key.
     """
     affected_items = response.json()['data']['affected_items']
+    # If affected_items is a list of strings instead of dictionaries, key will be None
     assert affected_items == sorted(affected_items, key=(lambda item: item[key]) if key else None, reverse=reverse)
 
 

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -71,7 +71,7 @@ def test_select_key_affected_items_with_agent_id(response, select_key):
         assert set(response.json()["data"]["affected_items"][0].keys()) == expected_keys
 
 
-def test_sort_response(response, key, reverse=True):
+def test_sort_response(response, key=None, reverse=True):
     """Check that the response's affected items are sorted by the specified key.
 
     Parameters
@@ -88,7 +88,7 @@ def test_sort_response(response, key, reverse=True):
         True if the response's items are sorted by the key.
     """
     affected_items = response.json()['data']['affected_items']
-    assert affected_items == sorted(affected_items, key=lambda item: item[key], reverse=reverse)
+    assert affected_items == sorted(affected_items, key=(lambda item: item[key]) if key else None, reverse=reverse)
 
 
 def test_validate_data_dict_field(response, fields_dict):

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -291,7 +291,7 @@ stages:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            affected_items: "{select_id_items}"
+            key: "{id}"
 
   # GET /mitre?limit=50
   - name: Verify no more than 10 elements are shown when json is included

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -17,7 +17,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: &full_items_array
             - phase_name: !anylist
@@ -35,7 +35,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array
@@ -63,14 +63,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array
             - <<: *full_items_array
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
       # Save second item to check offset in next stage
       save:
         json:
@@ -87,7 +87,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
               # Check offset matches with previous request
@@ -97,7 +97,7 @@ stages:
               platform_name: !force_format_include "{offset_item.platform_name}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
 
   # GET /mitre?id=ID
@@ -111,7 +111,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: "{returned_id}"
@@ -120,7 +120,7 @@ stages:
               platform_name: !force_format_include "{returned_platform}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   # GET /mitre?search=ID
   - name: Try to get MITRE attacks using search parameter
@@ -132,7 +132,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: "{returned_id}"
@@ -141,7 +141,7 @@ stages:
               platform_name: !force_format_include "{returned_platform}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   # GET /mitre?search=random_search
   - name: Try to get MITRE attacks searching something that does not exist.
@@ -153,12 +153,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
           total_affected_items: 0
-          total_failed_items: !anyint
+          total_failed_items: 0
 
     # GET /mitre?phase_name=phase
   - name: Try to get MITRE attacks using phase_name parameter
@@ -234,9 +234,6 @@ stages:
         - function: tavern_utils:test_select_key_affected_items
           extra_kwargs:
             select_key: "id"
-      save:
-        json:
-          select_id_items: data.affected_items
 
   # GET /mitre?select=json
   - name: Try to get MITRE attacks using select parameter
@@ -291,7 +288,7 @@ stages:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            key: "{id}"
+            key: "id"
 
   # GET /mitre?limit=50
   - name: Verify no more than 10 elements are shown when json is included
@@ -347,12 +344,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
           total_affected_items: 0
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   # GET /mitre?q=phase_name=Privilege%20Escalation,phase_name=Persistence;platform_name=Windows
   - name: Verify that query parameter work as expected when using multiple values

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -18,7 +18,7 @@ stages:
       status_code: 200
       json:
         # We get totalItems number of arrays in items, using !anything to check items key is in the response
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -36,7 +36,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           # We define this items answer as a common one array full answer
           affected_items: &full_items_array
@@ -61,7 +61,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array
@@ -85,7 +85,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - status: "{offset_item.status}"
@@ -107,7 +107,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -124,7 +124,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - status: "outstanding"
@@ -156,7 +156,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - status: "{returned_status}"
@@ -178,7 +178,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - status: "{returned_status}"
@@ -201,7 +201,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array
@@ -222,7 +222,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -254,7 +254,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -271,7 +271,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -318,7 +318,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -340,7 +340,7 @@ stages:
           select_key: 'log'
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           failed_items: []
@@ -361,7 +361,7 @@ stages:
           select_key: 'log,status,date_last'
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           failed_items: []
@@ -378,7 +378,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - cis: "1.4 Debian Linux"
@@ -398,7 +398,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - status: "outstanding"
@@ -416,15 +416,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
-      save:
-        json:
-          affected_items: data.affected_items
 
   # GET /rootcheck/001?sort=-log
   - name: Sort response (descending)
@@ -437,7 +434,7 @@ stages:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            key: "{log}"
+            key: "log"
 
 
 ---
@@ -456,7 +453,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - end: !anything
@@ -484,7 +481,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - "001"
@@ -541,7 +538,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - "000"
@@ -599,7 +596,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - "001"
@@ -618,7 +615,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 2
         data:
           affected_items:
             - "000"

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -437,7 +437,7 @@ stages:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            affected_items: "{affected_items}"
+            key: "{log}"
 
 
 ---

--- a/api/test/integration/test_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rule_endpoints.tavern.yaml
@@ -834,7 +834,7 @@ stages:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            affected_items: "{affected_items}"
+            key: "{id}"
 
   - name: Filter search
     request:
@@ -944,7 +944,7 @@ stages:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            affected_items: "{affected_items}"
+            key: "{id}"
 
   - name: Filter search
     request:
@@ -1064,7 +1064,7 @@ stages:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            affected_items: "{affected_items}"
+            key: "{id}"
 
   - name: Filter search
     request:
@@ -1597,7 +1597,7 @@ stages:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            affected_items: "{affected_items}"
+            key: "{filename}"
 
   - name: Invalid filter
     request:

--- a/api/test/integration/test_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rule_endpoints.tavern.yaml
@@ -19,7 +19,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: &rules_response
             - description: !anystr
@@ -39,7 +39,7 @@ stages:
               mitre: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Try to show the rules of the system, offset = 0
     request:
@@ -51,7 +51,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *rules_response
@@ -77,7 +77,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - description: "{second_rule_description}"
@@ -86,7 +86,7 @@ stages:
             - <<: *rules_response
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Try to show the rules of the system, without limit
     request:
@@ -95,7 +95,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -109,14 +109,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *rules_response
             - <<: *rules_response
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Try to get all rules with limit = 0
     request:
@@ -134,14 +134,18 @@ stages:
       params:
         sort: -filename
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "filename"
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Show rules of the system using valid select
     request:
@@ -158,7 +162,7 @@ stages:
           select_key: 'id,filename,details.noalert' # required_fields={'id'}
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           failed_items: []
@@ -196,7 +200,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -216,14 +220,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *rules_response
             - <<: *rules_response
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
       save:
         json:
           rule_id: data.affected_items[1].id
@@ -239,13 +243,13 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - id: !int "{rule_id}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Invalid parameter
     request:
@@ -285,14 +289,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *rules_response
             - <<: *rules_response
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter status without limit
     request:
@@ -303,7 +307,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -328,14 +332,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *rules_response
               id: 200
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Test complex q
     request:
@@ -346,7 +350,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *rules_response
@@ -356,7 +360,7 @@ stages:
                   'squid'
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
 ---
 test_name: GET /rules filters
@@ -373,12 +377,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: *rules_response
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter group without limit
     request:
@@ -389,7 +393,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -403,14 +407,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *rules_response
             - <<: *rules_response
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter levels without limit
     request:
@@ -421,7 +425,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -434,7 +438,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -457,14 +461,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *rules_response
             - <<: *rules_response
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter relative_dirname without limit
     request:
@@ -475,7 +479,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -489,7 +493,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *rules_response
@@ -499,7 +503,7 @@ stages:
             - <<: *rules_response
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
       save:
         json:
           pci_dss_value: data.affected_items[1].pci_dss[0]
@@ -521,14 +525,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - pci_dss:
               - "{pci_dss_value}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter pci_dss
     request:
@@ -540,14 +544,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - pci_dss:
               - "{pci_dss_value}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter pci_dss without limit
     request:
@@ -558,7 +562,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -572,14 +576,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - gdpr:
               - "{gdpr_value}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter gdpr without limit
     request:
@@ -590,7 +594,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -604,14 +608,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - gpg13:
               - "{gpg13_value}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter gpg13 without limit
     request:
@@ -622,7 +626,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -636,14 +640,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - hipaa:
               - "{hipaa_value}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter hipaa without limit
     request:
@@ -654,7 +658,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -668,14 +672,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - nist_800_53:
               - "{nist-800-53_value}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter nist-800-53 without limit
     request:
@@ -686,7 +690,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -700,14 +704,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - tsc:
                 - "{tsc_value}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter tsc without limit
     request:
@@ -718,7 +722,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -731,14 +735,14 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - mitre:
               - "{mitre_value}"
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter mitre without limit
     request:
@@ -748,7 +752,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -769,7 +773,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - !anystr
@@ -788,7 +792,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - !anystr
@@ -814,15 +818,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
-      save:
-        json:
-          affected_items: data.affected_items
 
   - name: Filter sort
     request:
@@ -833,8 +834,14 @@ stages:
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "{id}"
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: [ ]
+          total_affected_items: !anyint
+          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -845,12 +852,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Invalid filter
     request:
@@ -878,7 +885,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - !anystr
@@ -897,7 +904,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - !anystr
@@ -923,15 +930,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
-      save:
-        json:
-          affected_items: data.affected_items
 
   - name: Filter reverse sort
     request:
@@ -943,8 +947,14 @@ stages:
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "{id}"
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: [ ]
+          total_affected_items: !anyint
+          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -955,12 +965,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Invalid filter
     request:
@@ -986,7 +996,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
 
@@ -1000,7 +1010,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - !anystr
@@ -1025,15 +1035,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
-      save:
-        json:
-          affected_items: data.affected_items
+          total_failed_items: 0
 
   - name: Filter sort
     request:
@@ -1044,15 +1051,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
-      save:
-        json:
-          affected_items: data.affected_items
 
   - name: Filter reverse sort
     request:
@@ -1063,8 +1067,14 @@ stages:
     response:
       verify_response_with:
         - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "{id}"
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: [ ]
+          total_affected_items: !anyint
+          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1075,12 +1085,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Invalid filter
     request:
@@ -1106,12 +1116,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Try to show the rules by requirement hipaa, limit and offset
     request:
@@ -1123,7 +1133,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -1146,14 +1156,16 @@ stages:
       params:
         sort: "-"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1164,12 +1176,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Invalid filter
     request:
@@ -1195,12 +1207,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Try to show the rules by requirement nist-800-53, limit and offset
     request:
@@ -1212,12 +1224,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Try to show the rules by requirement nist-800-53, limit = 0
     request:
@@ -1235,14 +1247,16 @@ stages:
       params:
         sort: "-"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1253,12 +1267,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Invalid filter
     request:
@@ -1284,12 +1298,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Try to show the rules by requirement tsc, limit and offset
     request:
@@ -1301,12 +1315,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Try to show the rules by requirement tsc, limit = 0
     request:
@@ -1324,14 +1338,16 @@ stages:
       params:
         sort: "-"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1342,12 +1358,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Invalid filter
     request:
@@ -1373,12 +1389,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Try to show the rules by requirement mitre, limit and offset
     request:
@@ -1390,12 +1406,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Try to show the rules by requirement mitre, limit = 0
     request:
@@ -1413,14 +1429,16 @@ stages:
       params:
         sort: "-"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1431,12 +1449,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Invalid filter
     request:
@@ -1462,12 +1480,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Try to show the groups of rules, limit and offset
     request:
@@ -1479,12 +1497,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Try to show the groups of rules, limit = 0
     request:
@@ -1502,14 +1520,16 @@ stages:
       params:
         sort: "-"
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Filter search
     request:
@@ -1520,12 +1540,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Invalid filter
     request:
@@ -1551,15 +1571,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
-      save:
-        json:
-          affected_items: data.affected_items
+          total_failed_items: 0
 
   - name: Get the rules files, limit = 1, offset = 0
     request:
@@ -1571,12 +1588,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
   - name: Get the rules files, limit = 0
     request:
@@ -1597,7 +1614,15 @@ stages:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            key: "{filename}"
+            key: "filename"
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: [ ]
+          total_affected_items: !anyint
+          total_failed_items: 0
 
   - name: Invalid filter
     request:
@@ -1627,12 +1652,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
           total_affected_items: !anyint
-          total_failed_items: !anyint
+          total_failed_items: 0
 
 ---
 test_name: GET /rules/files/{filename}/download
@@ -1667,7 +1692,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *rules_response
@@ -1684,7 +1709,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *rules_response
@@ -1702,7 +1727,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 2
         data:
           affected_items:
             - <<: *rules_response
@@ -1724,7 +1749,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -1749,9 +1774,13 @@ stages:
         sort: -filename
         rule_ids: 1
     response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "filename"
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *rules_response
@@ -1769,7 +1798,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -1798,7 +1827,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:

--- a/api/test/integration/test_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_task_endpoints.tavern.yaml
@@ -184,7 +184,7 @@ stages:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            affected_items: "{select_id_items}"
+            key: "{task_id}"
 
   - name: Verify that query parameter works as expected
     request:

--- a/api/test/integration/test_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_task_endpoints.tavern.yaml
@@ -137,9 +137,6 @@ stages:
         - function: tavern_utils:test_select_key_affected_items
           extra_kwargs:
             select_key: "task_id"
-      save:
-        json:
-          select_id_items: data.affected_items
 
   - name: Try to get tasks using select parameter with more than a field
     request:
@@ -184,7 +181,7 @@ stages:
       verify_response_with:
         - function: tavern_utils:test_sort_response
           extra_kwargs:
-            key: "{task_id}"
+            key: "task_id"
 
   - name: Verify that query parameter works as expected
     request:


### PR DESCRIPTION
|Related issue|
|---|
| #7432 |

Hi team,

This pull request closes #7432.

In this PR, I have updated the `test_sort_response` function. 

Now it is using `sorted(...)` to test if the response's affected items are sorted. I have added the parameters `key` and `reverse`. `key` indicates the key to sort by and `reverse` indicates the order the affected items are expected to have. `reverse` is `True` by default as all the sort tests are sorting descending. I have also updated the docstring.

I have updated tests using this function.

### Test results:

```
test_mitre_endpoints.tavern.yaml 
	 1 passed, 3 warnings
	 
test_rootcheck_endpoints.tavern.yaml 
	 4 passed, 6 warnings
	 
test_task_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rule_endpoints.tavern.yaml 
	 13 passed, 15 warnings
```

Regards,
Manuel.
