### PR TITLE
Python upgrade to 3.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.1.1]
 
+### Added
+
+- **External dependencies:**
+  - Added cython (0.29.21) library to Python dependencies. ([#7451](https://github.com/wazuh/wazuh/pull/7451))  
+  - Added xmltodict (0.12.0) library to Python dependencies. ([#7303](https://github.com/wazuh/wazuh/pull/7303))
+  
+### Changed
+
+- **External dependencies:**
+  - Upgraded Python version from 3.8.2 to 3.8.6. ([#7451](https://github.com/wazuh/wazuh/pull/7451))
+  - Upgraded Cryptography python library from 3.2.1 to 3.3.2. ([#7451](https://github.com/wazuh/wazuh/pull/7451))
+  - Upgraded cffi python library from 1.14.0 to 1.14.4. ([#7451](https://github.com/wazuh/wazuh/pull/7451))
+
 ### Fixed
 
 - **API:**

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -1,3 +1,5 @@
+pip==20.3.3
+wheel==0.34.2
 aiohttp-cache==2.0.2
 aiohttp-cors==0.7.0
 aiohttp-jinja2==1.2.0
@@ -11,12 +13,13 @@ boto3==1.13.1
 botocore==1.16.1
 cachetools==4.1.0
 certifi==2020.4.5.1
-cffi==1.14.0
+cffi==1.14.4
 chardet==3.0.4
 Click==7.0
 clickclick==1.2.2
 connexion==2.6.0
-cryptography==3.2.1
+cryptography==3.3.2
+cython==0.29.21
 defusedxml==0.6.0
 docker-pycreds==0.4.0
 docker==4.2.0
@@ -59,4 +62,4 @@ urllib3==1.25.9
 uvloop==0.14.0
 websocket-client==0.57.0
 Werkzeug==1.0.1
-wheel==0.34.2
+xmltodict==0.12.0

--- a/install.sh
+++ b/install.sh
@@ -111,7 +111,7 @@ Install()
     # Binary install will use the previous generated code.
     if [ "X${USER_BINARYINSTALL}" = "X" ]; then
         # Download external libraries if missing
-        find external/* > /dev/null 2>&1 || ${MAKEBIN} deps PREFIX=${INSTALLDIR}
+        find external/* > /dev/null 2>&1 || ${MAKEBIN} deps PREFIX=${INSTALLDIR} TARGET=${INSTYPE}
 
         if [ "X${OPTIMIZE_CPYTHON}" = "Xy" ]; then
             CPYTHON_FLAGS="OPTIMIZE_CPYTHON=yes"

--- a/src/Makefile
+++ b/src/Makefile
@@ -889,8 +889,8 @@ endif
 TAR := tar -xf
 GUNZIP := gunzip
 CURL := curl -so
-VERSION = $(subst $() $(),.,$(wordlist 1,2,$(subst ., ,$(patsubst v%,%,$(shell cat VERSION)))))
-RESOURCES_URL := https://packages.wazuh.com/deps/$(VERSION)
+DEPS_VERSION = 10
+RESOURCES_URL := https://packages.wazuh.com/deps/$(DEPS_VERSION)
 CPYTHON := cpython
 ifeq (${PREFIX},/var/ossec)
 	# Download the Python sources if we are building for any other OS.
@@ -918,7 +918,14 @@ endif
 endif
 
 
-EXTERNAL_RES := cJSON $(CPYTHON) curl libdb libffi libyaml openssl procps sqlite zlib audit-userspace msgpack bzip2 libpcre2 libplist
+# Agent dependencies
+EXTERNAL_RES := cJSON curl libdb libffi libyaml openssl procps sqlite zlib audit-userspace msgpack bzip2 libpcre2 libplist
+ifneq (${TARGET},agent)
+ifneq (${TARGET},winagent)
+	# Manager extra dependency
+	EXTERNAL_RES += $(CPYTHON)
+endif
+endif
 EXTERNAL_DIR :=  $(EXTERNAL_RES:%=external/%)
 EXTERNAL_TAR := $(EXTERNAL_RES:%=external/%.tar.gz)
 


### PR DESCRIPTION
|Related issue|
|---|
|#7416|

Hi team,

This PR closes #7416. In this PR we have changed the Python version to 3.8.6. We have added a new dependency and updated the cryptography version to fix a vulnerability detected in the previous version.

We have generated and uploaded the necessary packages to install Wazuh 4.1 on aarch64 and x86_64.

Regards