### PR TITLE
Add g++ and cmake to integration tests environment

### DIFF
--- a/api/test/integration/env/base/manager/manager.Dockerfile
+++ b/api/test/integration/env/base/manager/manager.Dockerfile
@@ -8,6 +8,11 @@ ADD base/manager/supervisord.conf /etc/supervisor/conf.d/
 
 RUN apt-get update && apt-get install wget python python3 git gnupg2 gcc make vim libc6-dev curl policycoreutils automake autoconf libtool apt-transport-https lsb-release python-cryptography sqlite3 -y && curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add - && echo "deb https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/staging/apt/ unstable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
+# Install cmake version 3.12.4 and g++
+RUN wget http://www.cmake.org/files/v3.12/cmake-3.12.4.tar.gz
+RUN tar xf cmake-3.12.4.tar.gz
+RUN apt-get install g++ -y && cd cmake-3.12.4 && ./configure && make install
+
 RUN git clone https://github.com/wazuh/wazuh && cd /wazuh && git checkout $manager_branch
 COPY base/manager/preloaded-vars.conf /wazuh/etc/preloaded-vars.conf
 RUN /wazuh/install.sh


### PR DESCRIPTION
|Related issue|
|---|
| #7469 |

Hi team,

This pull request closes #7469.

In this PR, I have included `g++` and `cmake` version `3.12.4` to the API testing environment.

Regards,
Manuel.