### PR TITLE
Fix inclusion of the rule description in archives when the rule level is low

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -2070,10 +2070,10 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
                 AddtoIGnore(lf, t_id);
             }
 
+            lf->comment = ParseRuleComment(lf);
+
             /* Log the alert if configured to */
             if (t_currently_rule->alert_opts & DO_LOGALERT) {
-                lf->comment = ParseRuleComment(lf);
-
                 os_calloc(1, sizeof(Eventinfo), lf_cpy);
                 w_copy_event_for_log(lf, lf_cpy);
                 if (queue_push_ex_block(writer_queue_log, lf_cpy) < 0) {


### PR DESCRIPTION
This PR aims to fix the behavior of Analysisd when printing archives that matched a rule with a level below the alert threshold.

For instance, this level-2 rule:

```xml
<group name="local,test,">
  <rule id="100001" level="2">
    <regex>Hello world</regex>
    <description>Salute.</description>
  </rule>
</group>
```

### Currently logged archive

```json
{
  "timestamp": "2021-02-12T18:47:17.380+0100",
  "rule": {
    "level": 2,
    "id": "100001",
    "firedtimes": 1,
    "mail": false,
    "groups": [
      "local",
      "test"
    ]
  },
  "agent": {
    "id": "000",
    "name": "groovy"
  },
  "manager": {
    "name": "groovy"
  },
  "id": "1613152037.526429",
  "full_log": "Hello world",
  "decoder": {},
  "location": "/log/test.log"
}
```

As stated at #4906, we expect archives to include the full rule data when the input event matched a rule, no matter if that produced an alert. As we saw in the code, the rule matched ignored the description member (`lf->comment`) when that should not trigger an alert.

## Proposed fix

Fill in the event's rule description whenever that matched a rule.

### Fixed archive

```json
{
  "timestamp": "2021-02-12T18:49:11.922+0100",
  "rule": {
    "level": 2,
    "description": "Salute.",
    "id": "100001",
    "firedtimes": 1,
    "mail": false,
    "groups": [
      "local",
      "test"
    ]
  },
  "agent": {
    "id": "000",
    "name": "groovy"
  },
  "manager": {
    "name": "groovy"
  },
  "id": "1613152151.0",
  "full_log": "Hello world",
  "decoder": {},
  "location": "/log/test.log"
}
```

## Tests

- [X] Build manager on Linux.
- [X] Check rules and archives on Valgrind.
- [X] Check logtest while running Analysisd on Valgrind.