### PR TITLE
Add a default path for runtests.py

### DIFF
--- a/ruleset/testing/runtests.py
+++ b/ruleset/testing/runtests.py
@@ -159,8 +159,8 @@ def cleanup(*args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='This script tests Wazuh rules.')
-    parser.add_argument('--path', '-p', required=True, dest='wazuh_home',
-                        help='Use -p or --path to specify Wazuh installation path (required)')
+    parser.add_argument('--path', '-p', default='/var/ossec', dest='wazuh_home',
+                        help='Use -p or --path to specify Wazuh installation path')
     parser.add_argument('--geoip', '-g', action='store_true', dest='geoip',
                         help='Use -g or --geoip to enable geoip tests (default: False)')
     parser.add_argument('--testfile', '-t', action='store', type=str, dest='testfile',


### PR DESCRIPTION
|Related issue|
|---|
|7482|

**runtests.py** script is used to lunch the ruleset testing. As this script is used in **Jenkins** tests, a default path to the default Wazuh installation is added to the script to simplify the execution of these automated tests. 

- [X] Linux
- [X] Windows
- [X] MAC OS X
- [X] Package installation
- [X] Package upgrade
