### PR TITLE
Add <type> to wazuh decoders

### DIFF
--- a/ruleset/decoders/0005-wazuh_decoders.xml
+++ b/ruleset/decoders/0005-wazuh_decoders.xml
@@ -55,6 +55,7 @@
 
 <decoder name="agent-buffer">
   <parent>wazuh</parent>
+  <type>wazuh</type>
   <prematch offset="after_parent">^Agent buffer:</prematch>
   <regex offset="after_prematch">^ '(\S+)'.</regex>
   <order>level</order>
@@ -62,6 +63,7 @@
 
 <decoder name="agent-upgrade">
   <parent>wazuh</parent>
+  <type>wazuh</type>
   <prematch offset="after_parent">^Upgrade procedure |^Custom installation </prematch>
   <regex offset="after_prematch">on agent (\d\d\d)\s\((\S+)\):\s(\w+)</regex>
   <order>agent.id, agent.name, status</order>
@@ -69,24 +71,28 @@
 
 <decoder name="agent-upgrade">
   <parent>wazuh</parent>
+  <type>wazuh</type>
   <regex>aborted:\s(\.+)$|failed:\s(\.+)$|lost:\s(\.+)$</regex>
   <order>error</order>
 </decoder>
 
 <decoder name="agent-upgrade">
   <parent>wazuh</parent>
+  <type>wazuh</type>
   <regex>started.\sCurrent\sversion:\sWazuh\s(\.+)$</regex>
   <order>agent.cur_version</order>
 </decoder>
 
 <decoder name="agent-upgrade">
   <parent>wazuh</parent>
+  <type>wazuh</type>
   <regex>succeeded.\sNew\sversion:\sWazuh\s(\.+)$</regex>
   <order>agent.new_version</order>
 </decoder>
 
 <decoder name="agent-restart">
   <parent>wazuh</parent>
+  <type>wazuh</type>
   <prematch offset="after_parent">^Invalid remote configuration:</prematch>
   <regex offset="after_prematch">^ '(\S+)'.</regex>
   <order>module</order>
@@ -94,6 +100,7 @@
 
 <decoder name="fim-state">
   <parent>wazuh</parent>
+  <type>wazuh</type>
   <prematch offset="after_parent">^FIM DB: </prematch>
   <plugin_decoder offset="after_prematch">JSON_Decoder</plugin_decoder>
 </decoder>

--- a/ruleset/testing/tests/wazuh.ini
+++ b/ruleset/testing/tests/wazuh.ini
@@ -192,3 +192,95 @@ log 1 pass = wazuh: Alert Level: 3; Rule: 502 - Comment; Location: test_location
 rule = 502
 alert = 3
 decoder = wazuh
+
+# Wazuh Agent Buffer
+
+[wazuh: Agent buffer percent]
+log 1 pass = wazuh: Agent buffer: '90%'.
+
+rule = 202
+alert = 7
+decoder = wazuh
+
+[wazuh: Agent buffer full]
+log 1 pass = wazuh: Agent buffer: 'full'.
+
+rule = 203
+alert = 9
+decoder = wazuh
+
+[wazuh: Agent buffer flooded]
+log 1 pass = wazuh: Agent buffer: 'flooded'.
+
+rule = 204
+alert = 12
+decoder = wazuh
+
+[wazuh: Agent buffer normal]
+log 1 pass = wazuh: Agent buffer: 'normal'.
+
+rule = 205
+alert = 3
+decoder = wazuh
+
+# Wazuh Remote Upgrading
+
+[wazuh: Remote upgrading started]
+log 1 pass = wazuh: Upgrade procedure on agent 001 (TestAgent): started. Current version: v3.0.0
+
+rule = 212
+alert = 3
+decoder = wazuh
+
+[wazuh: Remote upgrading aborted]
+log 1 pass = wazuh: Upgrade procedure on agent 001 (TestAgent): aborted: Cannot execute installer
+
+rule = 213
+alert = 7
+decoder = wazuh
+
+[wazuh: Remote upgrading succeeded]
+log 1 pass = wazuh: Upgrade procedure on agent 001 (TestAgent): succeeded. New version: v3.1.0
+
+rule = 214
+alert = 3
+decoder = wazuh
+
+[wazuh: Remote upgrading failed]
+log 1 pass = wazuh: Upgrade procedure on agent 001 (TestAgent): failed: Restored to previous version
+
+rule = 215
+alert = 6
+decoder = wazuh
+
+[wazuh: Remote upgrading disconnected]
+log 1 pass = wazuh: Upgrade procedure on agent 001 (TestAgent): lost: Maximum attempts exceeded
+
+rule = 216
+alert = 7
+decoder = wazuh
+
+# Wazuh Custom Installation
+
+[wazuh: Custom installation started]
+log 1 pass = wazuh: Custom installation on agent 001 (TestAgent): started.
+
+rule = 217
+alert = 3
+decoder = wazuh
+
+[wazuh:  Custom installation error]
+log 1 pass = wazuh: Custom installation on agent 001 (TestAgent): aborted: Could not verify signature
+
+rule = 218
+alert = 7
+decoder = wazuh
+
+# Wazuh Shared File
+
+[wazuh:  Shared file unmerge error]
+log 1 pass = wazuh: Could not unmerge shared file.
+
+rule = 222
+alert = 7
+decoder = wazuh

--- a/ruleset/testing/tests/wazuh.ini
+++ b/ruleset/testing/tests/wazuh.ini
@@ -269,16 +269,25 @@ rule = 217
 alert = 3
 decoder = wazuh
 
-[wazuh:  Custom installation error]
+[wazuh: Custom installation error]
 log 1 pass = wazuh: Custom installation on agent 001 (TestAgent): aborted: Could not verify signature
 
 rule = 218
 alert = 7
 decoder = wazuh
 
+# Wazuh Invalid Remote Configuration
+
+[wazuh: Invalid remote configuration]
+log 1 pass = wazuh: Invalid remote configuration: 'syscheck'
+
+rule = 220
+alert = 7
+decoder = wazuh
+
 # Wazuh Shared File
 
-[wazuh:  Shared file unmerge error]
+[wazuh: Shared file unmerge error]
 log 1 pass = wazuh: Could not unmerge shared file.
 
 rule = 222


### PR DESCRIPTION
|Related issue|
|---|
|7483|

## Description
This PR fixes the **type** of Wazuh decoders that wasn't triggering the expected rules.
After the standardization of the ruleset with Wazuh naming convention, the **wazuh** and **ossec** groups were unified, leading to every Wazuh rule being in a group name with the category **wazuh**. In order to work, the corresponding decoders should have a **wazuh** type to trigger these rules.

## Tests
- [X] Check that wazuh rules are being triggered as expected
- [X] Check that runstests.py execute successfully