### PR TITLE
Adapt binaries to work under relative paths

### DIFF
--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -13,11 +13,7 @@ void write_debug_file (const char *ar_name, const char *msg) {
     char path[PATH_MAX];
     char *timestamp = w_get_timestamp(time(NULL));
 
-#ifndef WIN32
-    snprintf(path, PATH_MAX, "%s%s", isChroot() ? "" : HOMEDIR, LOG_FILE);
-#else
     snprintf(path, PATH_MAX, "%s", LOG_FILE);
-#endif
 
     FILE *ar_log_file = fopen(path, "a");
 

--- a/src/active-response/active_responses.h
+++ b/src/active-response/active_responses.h
@@ -10,7 +10,7 @@
 #include "shared.h"
 
 #ifndef WIN32
-#define LOG_FILE "/logs/active-responses.log"
+#define LOG_FILE "logs/active-responses.log"
 #else
 #define LOG_FILE "active-response\\active-responses.log"
 #endif

--- a/src/active-response/firewalld-drop.c
+++ b/src/active-response/firewalld-drop.c
@@ -9,8 +9,8 @@
 
 #include "active_responses.h"
 
-#define LOCK_PATH "/active-response/bin/fw-drop"
-#define LOCK_FILE "/active-response/bin/fw-drop/pid"
+#define LOCK_PATH "active-response/bin/fw-drop"
+#define LOCK_FILE "active-response/bin/fw-drop/pid"
 #define DEFAULT_FW_CMD "/bin/firewall-cmd"
 
 int main (int argc, char **argv) {
@@ -113,8 +113,8 @@ int main (int argc, char **argv) {
 
         memset(lock_path, '\0', PATH_MAX);
         memset(lock_pid_path, '\0', PATH_MAX);
-        snprintf(lock_path, PATH_MAX - 1, "%s%s", HOMEDIR, LOCK_PATH);
-        snprintf(lock_pid_path, PATH_MAX - 1, "%s%s", HOMEDIR, LOCK_FILE);
+        snprintf(lock_path, PATH_MAX - 1, "%s", LOCK_PATH);
+        snprintf(lock_pid_path, PATH_MAX - 1, "%s", LOCK_FILE);
 
         // Taking lock
         if (lock(lock_path, lock_pid_path, argv[0], basename(argv[0])) == OS_INVALID) {

--- a/src/active-response/firewalls/default-firewall-drop.c
+++ b/src/active-response/firewalls/default-firewall-drop.c
@@ -9,8 +9,8 @@
 
 #include "../active_responses.h"
 
-#define LOCK_PATH "/active-response/bin/fw-drop"
-#define LOCK_FILE "/active-response/bin/fw-drop/pid"
+#define LOCK_PATH "active-response/bin/fw-drop"
+#define LOCK_FILE "active-response/bin/fw-drop/pid"
 #define IP4TABLES "/sbin/iptables"
 #define IP6TABLES "/sbin/ip6tables"
 
@@ -114,8 +114,8 @@ int main (int argc, char **argv) {
 
         memset(lock_path, '\0', PATH_MAX);
         memset(lock_pid_path, '\0', PATH_MAX);
-        snprintf(lock_path, PATH_MAX - 1, "%s%s", HOMEDIR, LOCK_PATH);
-        snprintf(lock_pid_path, PATH_MAX - 1, "%s%s", HOMEDIR, LOCK_FILE);
+        snprintf(lock_path, PATH_MAX - 1, "%s", LOCK_PATH);
+        snprintf(lock_pid_path, PATH_MAX - 1, "%s", LOCK_FILE);
 
         // Taking lock
         if (lock(lock_path, lock_pid_path, argv[0], basename(argv[0])) == OS_INVALID) {

--- a/src/active-response/host-deny.c
+++ b/src/active-response/host-deny.c
@@ -9,8 +9,8 @@
 
 #include "active_responses.h"
 
-#define LOCK_PATH "/active-response/bin/host-deny-lock"
-#define LOCK_FILE "/active-response/bin/host-deny-lock/pid"
+#define LOCK_PATH "active-response/bin/host-deny-lock"
+#define LOCK_FILE "active-response/bin/host-deny-lock/pid"
 #define DEFAULT_HOSTS_DENY_PATH "/etc/hosts.deny"
 #define FREEBSD_HOSTS_DENY_PATH "/etc/hosts.allow"
 
@@ -92,8 +92,8 @@ int main (int argc, char **argv) {
 
     memset(lock_path, '\0', PATH_MAX);
     memset(lock_pid_path, '\0', PATH_MAX);
-    snprintf(lock_path, PATH_MAX - 1, "%s%s", HOMEDIR, LOCK_PATH);
-    snprintf(lock_pid_path, PATH_MAX - 1, "%s%s", HOMEDIR, LOCK_FILE);
+    snprintf(lock_path, PATH_MAX - 1, "%s", LOCK_PATH);
+    snprintf(lock_pid_path, PATH_MAX - 1, "%s", LOCK_FILE);
 
     if (!strcmp("add", action)) {
         // Taking lock
@@ -155,7 +155,7 @@ int main (int argc, char **argv) {
         char temp_hosts_deny_path[PATH_MAX];
 
         memset(temp_hosts_deny_path, '\0', PATH_MAX);
-        snprintf(temp_hosts_deny_path, PATH_MAX - 1, "%s%s", HOMEDIR, "/active-response/bin/temp-hosts-deny");
+        snprintf(temp_hosts_deny_path, PATH_MAX - 1, "%s", "active-response/bin/temp-hosts-deny");
 
         // Taking lock
         if (lock(lock_path, lock_pid_path, argv[0], basename(argv[0])) == OS_INVALID) {

--- a/src/active-response/kaspersky.c
+++ b/src/active-response/kaspersky.c
@@ -11,7 +11,7 @@
 
 #define PYTHON2             "/usr/bin/python"
 #define PYTHON3             "/usr/bin/python3"
-#define PATH_TO_KASPERSKY   BUILDDIR(HOMEDIR,"/active-response/bin/kaspersky.py")
+#define PATH_TO_KASPERSKY   "active-response/bin/kaspersky.py"
 
 int main (int argc, char **argv) {
     (void)argc;

--- a/src/active-response/restart-wazuh.c
+++ b/src/active-response/restart-wazuh.c
@@ -50,10 +50,6 @@ int main (int argc, char **argv) {
 		char *exec_cmd[3] = { "bin/wazuh-control", "restart", NULL};
         wfd_t *wfd = NULL;
 
-		if (isChroot()) {
-			strcpy(exec_cmd[0], "/bin/wazuh-control");
-		}
-
         if (wfd = wpopenv(*exec_cmd, exec_cmd, W_BIND_STDERR), !wfd) {
             memset(log_msg, '\0', LOGSIZE);
 			snprintf(log_msg, LOGSIZE -1, "Error executing '%s': %s", *exec_cmd, strerror(errno));

--- a/src/active-response/restart-wazuh.c
+++ b/src/active-response/restart-wazuh.c
@@ -47,7 +47,7 @@ int main (int argc, char **argv) {
 	if (strcmp("add", action) == 0) {
 #ifndef WIN32
 	    char log_msg[LOGSIZE];
-		char *exec_cmd[3] = { BUILDDIR(HOMEDIR,"/bin/wazuh-control"), "restart", NULL};
+		char *exec_cmd[3] = { "bin/wazuh-control", "restart", NULL};
         wfd_t *wfd = NULL;
 
 		if (isChroot()) {

--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -97,9 +97,6 @@ int main(int argc, char **argv)
     OS_SetName(ARGV0);
 #ifndef WIN32
     char * home_path = w_homedir(argv[0]);
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
     mdebug1(WAZUH_HOMEDIR, home_path);
 #endif
 

--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -113,18 +113,18 @@ int add_agent(int json_output)
     if (sock = auth_connect(), sock < 0) {
         authd_running = 0;
         /* Check if we can open the auth_file */
-        fp = fopen(AUTH_FILE, "a");
+        fp = fopen(KEYS_FILE, "a");
         if (!fp) {
             if (json_output) {
                 char buffer[1024];
                 cJSON *json_root = cJSON_CreateObject();
-                snprintf(buffer, 1023, "Could not open file '%s' due to [(%d)-(%s)]", AUTH_FILE, errno, strerror(errno));
+                snprintf(buffer, 1023, "Could not open file '%s' due to [(%d)-(%s)]", KEYS_FILE, errno, strerror(errno));
                 cJSON_AddNumberToObject(json_root, "error", 71);
                 cJSON_AddStringToObject(json_root, "message", buffer);
                 printf("%s", cJSON_PrintUnformatted(json_root));
                 exit(1);
             } else
-                merror_exit(FOPEN_ERROR, AUTH_FILE, errno, strerror(errno));
+                merror_exit(FOPEN_ERROR, KEYS_FILE, errno, strerror(errno));
         }
         fclose(fp);
 
@@ -314,7 +314,7 @@ int add_agent(int json_output)
                 time3 = time(0);
                 rand2 = os_random();
 
-                if (TempFile(&file, AUTH_FILE, 1) < 0 ) {
+                if (TempFile(&file, KEYS_FILE, 1) < 0 ) {
                     if (json_output) {
                         char buffer[1024];
                         cJSON *json_root = cJSON_CreateObject();
@@ -348,17 +348,17 @@ int add_agent(int json_output)
                 fprintf(file.fp, "%s %s %s %s\n", id, name, c_ip.ip, key);
                 fclose(file.fp);
 
-                if (OS_MoveFile(file.name, AUTH_FILE) < 0) {
+                if (OS_MoveFile(file.name, KEYS_FILE) < 0) {
                     if (json_output) {
                         char buffer[1024];
                         cJSON *json_root = cJSON_CreateObject();
-                        snprintf(buffer, 1023, "Could not write file '%s'", AUTH_FILE);
+                        snprintf(buffer, 1023, "Could not write file '%s'", KEYS_FILE);
                         cJSON_AddNumberToObject(json_root, "error", 71);
                         cJSON_AddStringToObject(json_root, "message", buffer);
                         printf("%s", cJSON_PrintUnformatted(json_root));
                         exit(1);
                     } else
-                        merror_exit("Could not write file '%s'", AUTH_FILE);
+                        merror_exit("Could not write file '%s'", KEYS_FILE);
                 }
 
                 free(file.name);
@@ -511,13 +511,13 @@ int remove_agent(int json_output)
                     if (json_output) {
                         char buffer[1024];
                         cJSON *json_root = cJSON_CreateObject();
-                        snprintf(buffer, 1023, "Could not open object '%s' due to [(%d)-(%s)]", AUTH_FILE, errno, strerror(errno));
+                        snprintf(buffer, 1023, "Could not open object '%s' due to [(%d)-(%s)]", KEYS_FILE, errno, strerror(errno));
                         cJSON_AddNumberToObject(json_root, "error", 71);
                         cJSON_AddStringToObject(json_root, "message", buffer);
                         printf("%s", cJSON_PrintUnformatted(json_root));
                         exit(1);
                     } else
-                        merror_exit(FOPEN_ERROR, AUTH_FILE, errno, strerror(errno));
+                        merror_exit(FOPEN_ERROR, KEYS_FILE, errno, strerror(errno));
                 }
 
                 free(full_name);

--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -578,7 +578,7 @@ int list_agents(int cmdlist)
 
 int limitReached() {
     FILE *fp;
-    const char *keys_file = isChroot() ? KEYS_FILE : KEYSFILE_PATH;
+    const char *keys_file = KEYS_FILE;
     char buffer[OS_BUFFER_SIZE + 1];
     int counter = 0;
 

--- a/src/addagent/manage_keys.c
+++ b/src/addagent/manage_keys.c
@@ -56,7 +56,7 @@ int k_import(const char *cmdimport)
 {
     FILE *fp;
     const char *user_input;
-    char auth_file[] = AUTH_FILE;
+    char auth_file[] = KEYS_FILE;
     char *keys_file = basename_ex(auth_file);
     char *b64_dec;
 
@@ -241,17 +241,17 @@ int k_extract(const char *cmdextract, int json_output)
     }
 
     /* Try to open the auth file */
-    fp = fopen(AUTH_FILE, "r");
+    fp = fopen(KEYS_FILE, "r");
     if (!fp) {
         if (json_output) {
             char buffer[1024];
-            snprintf(buffer, 1023, "Could not open file '%s' due to [(%d)-(%s)]", AUTH_FILE, errno, strerror(errno));
+            snprintf(buffer, 1023, "Could not open file '%s' due to [(%d)-(%s)]", KEYS_FILE, errno, strerror(errno));
             cJSON_AddNumberToObject(json_root, "error", 71);
             cJSON_AddStringToObject(json_root, "message", buffer);
             printf("%s", cJSON_PrintUnformatted(json_root));
             exit(1);
         } else
-            merror_exit(FOPEN_ERROR, AUTH_FILE, errno, strerror(errno));
+            merror_exit(FOPEN_ERROR, KEYS_FILE, errno, strerror(errno));
     }
 
     if (fsetpos(fp, &fp_pos)) {
@@ -342,9 +342,9 @@ int k_bulkload(const char *cmdbulk)
     }
 
     /* Check if we can open the auth_file */
-    fp = fopen(AUTH_FILE, "a");
+    fp = fopen(KEYS_FILE, "a");
     if (!fp) {
-        merror_exit(FOPEN_ERROR, AUTH_FILE, errno, strerror(errno));
+        merror_exit(FOPEN_ERROR, KEYS_FILE, errno, strerror(errno));
     }
     fclose(fp);
 
@@ -369,8 +369,8 @@ int k_bulkload(const char *cmdbulk)
         strncpy(name, trimwhitespace(token), FILE_SIZE - 1);
 
 #ifndef WIN32
-        if (chmod(AUTH_FILE, 0640) == -1) {
-            merror_exit(CHMOD_ERROR, AUTH_FILE, errno, strerror(errno));
+        if (chmod(KEYS_FILE, 0640) == -1) {
+            merror_exit(CHMOD_ERROR, KEYS_FILE, errno, strerror(errno));
         }
 #endif
 
@@ -440,13 +440,13 @@ int k_bulkload(const char *cmdbulk)
             time3 = time(0);
             rand2 = os_random();
 
-            fp = fopen(AUTH_FILE, "a");
+            fp = fopen(KEYS_FILE, "a");
             if (!fp) {
                 merror_exit(FOPEN_ERROR, KEYS_FILE, errno, strerror(errno));
             }
 #ifndef WIN32
-            if (chmod(AUTH_FILE, 0640) == -1) {
-                merror_exit(CHMOD_ERROR, AUTH_FILE, errno, strerror(errno));
+            if (chmod(KEYS_FILE, 0640) == -1) {
+                merror_exit(CHMOD_ERROR, KEYS_FILE, errno, strerror(errno));
             }
 #endif
 

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -144,7 +144,7 @@ int OS_RemoveAgent(const char *u_id) {
 
     fclose(fp);
 
-    if (TempFile(&file, isChroot() ? KEYS_FILE : KEYSFILE_PATH, 0) < 0) {
+    if (TempFile(&file, KEYS_FILE, 0) < 0) {
         free(buffer);
         return 0;
     }
@@ -153,7 +153,7 @@ int OS_RemoveAgent(const char *u_id) {
     fclose(file.fp);
     full_name = getFullnameById(u_id);
 
-    if (OS_MoveFile(file.name, isChroot() ? KEYS_FILE : KEYSFILE_PATH) < 0) {
+    if (OS_MoveFile(file.name, KEYS_FILE) < 0) {
         free(file.name);
         free(buffer);
         free(full_name);
@@ -306,11 +306,7 @@ int IDExist(const char *id, int discard_removed)
         return (0);
     }
 
-    if (isChroot()) {
-        fp = fopen(KEYS_FILE, "r");
-    } else {
-        fp = fopen(KEYSFILE_PATH, "r");
-    }
+    fp = fopen(KEYS_FILE, "r");
 
     if (!fp) {
         return (0);
@@ -394,11 +390,7 @@ int NameExist(const char *u_name)
         return (0);
     }
 
-    if (isChroot()) {
-        fp = fopen(KEYS_FILE, "r");
-    } else {
-        fp = fopen(KEYSFILE_PATH, "r");
-    }
+    fp = fopen(KEYS_FILE, "r");
 
     if (!fp) {
         return (0);
@@ -450,10 +442,7 @@ char *IPExist(const char *u_ip)
     if (!(u_ip && strncmp(u_ip, "any", 3)) || strchr(u_ip, '/'))
         return NULL;
 
-    if (isChroot())
-        fp = fopen(KEYS_FILE, "r");
-    else
-        fp = fopen(KEYSFILE_PATH, "r");
+    fp = fopen(KEYS_FILE, "r");
 
     if (!fp)
         return NULL;
@@ -519,7 +508,7 @@ double OS_AgentAntiquity_ID(const char *id) {
 
 /**
  * @brief Returns the number of seconds since last agent connection
- * 
+ *
  * @param name The name of the agent
  * @param ip The IP address of the agent (unused). Kept only for compatibility
  * @retval On success, it returns the difference between the current time and the last keepalive

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -86,7 +86,7 @@ int OS_RemoveAgent(const char *u_id) {
     if (!id_exist)
         return 0;
 
-    fp = fopen(AUTH_FILE, "r");
+    fp = fopen(KEYS_FILE, "r");
 
     if (!fp)
         return 0;
@@ -144,7 +144,7 @@ int OS_RemoveAgent(const char *u_id) {
 
     fclose(fp);
 
-    if (TempFile(&file, isChroot() ? AUTH_FILE : KEYSFILE_PATH, 0) < 0) {
+    if (TempFile(&file, isChroot() ? KEYS_FILE : KEYSFILE_PATH, 0) < 0) {
         free(buffer);
         return 0;
     }
@@ -153,7 +153,7 @@ int OS_RemoveAgent(const char *u_id) {
     fclose(file.fp);
     full_name = getFullnameById(u_id);
 
-    if (OS_MoveFile(file.name, isChroot() ? AUTH_FILE : KEYSFILE_PATH) < 0) {
+    if (OS_MoveFile(file.name, isChroot() ? KEYS_FILE : KEYSFILE_PATH) < 0) {
         free(file.name);
         free(buffer);
         free(full_name);
@@ -235,7 +235,7 @@ char *getFullnameById(const char *id)
         return (NULL);
     }
 
-    fp = fopen(AUTH_FILE, "r");
+    fp = fopen(KEYS_FILE, "r");
     if (!fp) {
         return (NULL);
     }
@@ -307,7 +307,7 @@ int IDExist(const char *id, int discard_removed)
     }
 
     if (isChroot()) {
-        fp = fopen(AUTH_FILE, "r");
+        fp = fopen(KEYS_FILE, "r");
     } else {
         fp = fopen(KEYSFILE_PATH, "r");
     }
@@ -395,7 +395,7 @@ int NameExist(const char *u_name)
     }
 
     if (isChroot()) {
-        fp = fopen(AUTH_FILE, "r");
+        fp = fopen(KEYS_FILE, "r");
     } else {
         fp = fopen(KEYSFILE_PATH, "r");
     }
@@ -451,7 +451,7 @@ char *IPExist(const char *u_ip)
         return NULL;
 
     if (isChroot())
-        fp = fopen(AUTH_FILE, "r");
+        fp = fopen(KEYS_FILE, "r");
     else
         fp = fopen(KEYSFILE_PATH, "r");
 
@@ -544,7 +544,7 @@ int print_agents(int print_status, int active_only, int inactive_only, int csv_o
     char line_read[FILE_SIZE + 1];
     line_read[FILE_SIZE] = '\0';
 
-    fp = fopen(AUTH_FILE, "r");
+    fp = fopen(KEYS_FILE, "r");
     if (!fp) {
         return (0);
     }

--- a/src/agentlessd/agentlessd.c
+++ b/src/agentlessd/agentlessd.c
@@ -36,7 +36,7 @@ static int save_agentless_entry(const char *host, const char *script, const char
 
     sys_location[1024] = '\0';
     snprintf(sys_location, 1024, "%s/(%s) %s",
-             AGENTLESS_ENTRYDIRPATH, script, host);
+             AGENTLESS_ENTRYDIR, script, host);
 
     fp = fopen(sys_location, "w");
     if (fp) {
@@ -60,8 +60,10 @@ static int send_intcheck_msg(const char *script, const char *host, const char *m
     if (SendMSG(lessdc.queue, msg, sys_location, SYSCHECK_MQ) < 0) {
         merror(QUEUE_SEND);
 
-        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
-            merror_exit(QUEUE_FATAL, DEFAULTQPATH);
+        if ((lessdc.queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
+            char buffer[PATH_MAX] = {'\0'};
+            abspath(DEFAULTQUEUE, buffer, PATH_MAX);
+            merror_exit(QUEUE_FATAL, buffer);
         }
 
         /* If we reach here, we can try to send it again */
@@ -81,8 +83,10 @@ static int send_log_msg(const char *script, const char *host, const char *msg)
 
     if (SendMSG(lessdc.queue, msg, sys_location, LOCALFILE_MQ) < 0) {
         merror(QUEUE_SEND);
-        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
-            merror_exit(QUEUE_FATAL, DEFAULTQPATH);
+        if ((lessdc.queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
+            char buffer[PATH_MAX] = {'\0'};
+            abspath(DEFAULTQUEUE, buffer, PATH_MAX);
+            merror_exit(QUEUE_FATAL, buffer);
         }
 
         /* If we reach here, we can try to send it again */
@@ -103,7 +107,7 @@ static int gen_diff_alert(const char *host, const char *script, time_t alert_dif
     diff_alert[OS_MAXSTR - OS_LOG_HEADER] = '\0';
 
     snprintf(buf, 2048, "%s/%s->%s/diff.%d",
-             DIFF_DIR_PATH, host, script, (int)alert_diff_time);
+             DIFF_DIR, host, script, (int)alert_diff_time);
 
     fp = fopen(buf, "r");
     if (!fp) {
@@ -137,8 +141,10 @@ static int gen_diff_alert(const char *host, const char *script, time_t alert_dif
     if (SendMSG(lessdc.queue, diff_alert, buf, LOCALFILE_MQ) < 0) {
         merror(QUEUE_SEND);
 
-        if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
-            merror_exit(QUEUE_FATAL, DEFAULTQPATH);
+        if ((lessdc.queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
+            char buffer[PATH_MAX] = {'\0'};
+            abspath(DEFAULTQUEUE, buffer, PATH_MAX);
+            merror_exit(QUEUE_FATAL, buffer);
         }
 
         /* If we reach here, we can try to send it again */
@@ -172,9 +178,9 @@ static int check_diff_file(const char *host, const char *script)
     tmp_location[1024] = '\0';
     diff_location[1024] = '\0';
 
-    snprintf(new_location, 1024, "%s/%s->%s/%s", DIFF_DIR_PATH, host, script,
+    snprintf(new_location, 1024, "%s/%s->%s/%s", DIFF_DIR, host, script,
              DIFF_NEW_FILE);
-    snprintf(old_location, 1024, "%s/%s->%s/%s", DIFF_DIR_PATH, host, script,
+    snprintf(old_location, 1024, "%s/%s->%s/%s", DIFF_DIR, host, script,
              DIFF_LAST_FILE);
 
     /* If the file is not there, rename new location to last location */
@@ -199,7 +205,7 @@ static int check_diff_file(const char *host, const char *script)
 
     /* Save the old file at timestamp and rename new to last */
     date_of_change = File_DateofChange(old_location);
-    snprintf(tmp_location, 1024, "%s/%s->%s/state.%d", DIFF_DIR_PATH, host, script,
+    snprintf(tmp_location, 1024, "%s/%s->%s/state.%d", DIFF_DIR, host, script,
              (int)date_of_change);
 
     if (rename(old_location, tmp_location) != 0) {
@@ -219,7 +225,7 @@ static int check_diff_file(const char *host, const char *script)
         return 0;
     }
 
-    snprintf(diff_location, sizeof(diff_location), BUILDDIR(HOMEDIR,DIFF_DIR "/%s->%s/diff.%d"), host, script, (int)date_of_change);
+    snprintf(diff_location, sizeof(diff_location), DIFF_DIR "/%s->%s/diff.%d", host, script, (int)date_of_change);
 
     if (fp = fopen(diff_location, "wb"), !fp) {
         merror("Unable to open diff file '%s': %s (%d)", diff_location, strerror(errno), errno);
@@ -255,14 +261,14 @@ static FILE *open_diff_file(const char *host, const char *script)
     char sys_location[1024 + 1];
 
     sys_location[1024] = '\0';
-    snprintf(sys_location, 1024, "%s/%s->%s/%s", DIFF_DIR_PATH, host, script,
+    snprintf(sys_location, 1024, "%s/%s->%s/%s", DIFF_DIR, host, script,
              DIFF_NEW_FILE);
 
     fp = fopen(sys_location, "w");
 
     /* If we can't open, try creating the directory */
     if (!fp) {
-        snprintf(sys_location, 1024, "%s/%s->%s", DIFF_DIR_PATH, host, script);
+        snprintf(sys_location, 1024, "%s/%s->%s", DIFF_DIR, host, script);
         if (IsDir(sys_location) == -1) {
             if (mkdir(sys_location, 0770) == -1) {
                 merror(MKDIR_ERROR, sys_location, errno, strerror(errno));
@@ -270,7 +276,7 @@ static FILE *open_diff_file(const char *host, const char *script)
             }
         }
 
-        snprintf(sys_location, 1024, "%s/%s->%s/%s", DIFF_DIR_PATH, host,
+        snprintf(sys_location, 1024, "%s/%s->%s/%s", DIFF_DIR, host,
                  script, DIFF_NEW_FILE);
         fp = fopen(sys_location, "w");
         if (!fp) {
@@ -290,7 +296,7 @@ static char ** command_args(const char * type, const char * server, const char *
     char * save_ptr = NULL;
     int i = 1;
 
-    snprintf(command, sizeof(command), BUILDDIR(HOMEDIR,AGENTLESSDIR "/%s"), type);
+    snprintf(command, sizeof(command), AGENTLESSDIR "/%s", type);
 
     os_malloc(4 * sizeof(char *), argv);
     os_strdup(command, argv[0]);
@@ -342,7 +348,7 @@ static int run_periodic_cmd(agentlessd_entries *entry, int test_it)
         /* We only test for the first server entry */
         else if (test_it) {
             int ret_code = 0;
-            snprintf(command, OS_SIZE_1024, "%s/%s", AGENTLESSDIRPATH, entry->type);
+            snprintf(command, OS_SIZE_1024, "%s/%s", AGENTLESSDIR, entry->type);
 
             if (wfd = wpopenl(command, W_CHECK_WRITE, command, "test", "test", NULL), wfd) {
                 ret_code = wpclose(wfd);
@@ -452,8 +458,10 @@ void Agentlessd()
     today = tm_result.tm_mday;
 
     /* Connect to the message queue. Exit if it fails. */
-    if ((lessdc.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
-        merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
+    if ((lessdc.queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(DEFAULTQUEUE, buffer, PATH_MAX);
+        merror_exit(QUEUE_FATAL, buffer);
     }
 
     // Start com request thread

--- a/src/agentlessd/lessdcom.c
+++ b/src/agentlessd/lessdcom.c
@@ -76,8 +76,10 @@ void * lessdcom_main(__attribute__((unused)) void * arg) {
 
     mdebug1("Local requests thread ready");
 
-    if (sock = OS_BindUnixDomain(BUILDDIR(HOMEDIR,LESSD_LOCAL_SOCK), SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s': (%d) %s.", LESSD_LOCAL_SOCK, errno, strerror(errno));
+    if (sock = OS_BindUnixDomain(LESSD_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(LESSD_LOCAL_SOCK, buffer, PATH_MAX);
+        merror("Unable to bind to socket '%s': (%d) %s.", buffer, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/agentlessd/main.c
+++ b/src/agentlessd/main.c
@@ -133,10 +133,6 @@ int main(int argc, char **argv)
         goDaemonLight();
     }
 
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
-
     /* Exit if not configured */
     if (!lessdc.entries) {
         minfo("Not configured. Exiting.");

--- a/src/agentlessd/main.c
+++ b/src/agentlessd/main.c
@@ -30,9 +30,10 @@ static void help_agentlessd(char * home_path)
     print_out("    -f          Run in foreground");
     print_out("    -u <user>   User to run as (default: %s)", USER);
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
-    print_out("    -c <config> Configuration file to use (default: %s)", OSSECCONF);
-    print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
+    print_out("    -c <config> Configuration file to use (default: %s/%s)", home_path, OSSECCONF);
+    print_out("    -D <dir>    Directory to chdir and chroot into (default: %s)", home_path);
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -42,18 +43,13 @@ int main(int argc, char **argv)
     uid_t uid;
     gid_t gid;
 
+    char * home_path = w_homedir(argv[0]);
     const char *user = USER;
     const char *group = GROUPGLOBAL;
     const char *cfg = OSSECCONF;
 
     /* Set the name */
     OS_SetName(ARGV0);
-
-    char * home_path = w_homedir(argv[0]);
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
-    mdebug1(WAZUH_HOMEDIR, home_path);
 
     while ((c = getopt(argc, argv, "Vdhtfu:g:D:c:")) != -1) {
         switch (c) {
@@ -85,7 +81,8 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-D needs an argument.");
                 }
-                home_path = optarg;
+                os_free(home_path);
+                os_strdup(optarg, home_path);
                 break;
             case 'c':
                 if (!optarg) {
@@ -101,6 +98,12 @@ int main(int argc, char **argv)
                 break;
         }
     }
+
+    /* chdir to working directory */
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* Check if the user/group given are valid */
     uid = Privsep_GetUser(user);

--- a/src/analysisd/active-response.c
+++ b/src/analysisd/active-response.c
@@ -43,9 +43,11 @@ int AR_ReadConfig(const char *cfgfile)
     modules |= CAR;
 
     /* Clean ar file */
-    fp = fopen(DEFAULTARPATH, "w");
+    fp = fopen(DEFAULTAR, "w");
     if (!fp) {
-        merror(FOPEN_ERROR, DEFAULTARPATH, errno, strerror(errno));
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(DEFAULTAR, buffer, PATH_MAX);
+        merror(FOPEN_ERROR, buffer, errno, strerror(errno));
         return (OS_INVALID);
     }
     fprintf(fp, "restart-ossec0 - restart-ossec.sh - 0\nrestart-ossec0 - restart-ossec.cmd - 0\n"
@@ -60,15 +62,17 @@ int AR_ReadConfig(const char *cfgfile)
         return (OS_INVALID);
     }
 
-    if ((chown(DEFAULTARPATH, (uid_t) - 1, gr_gid)) == -1) {
+    if ((chown(DEFAULTAR, (uid_t) - 1, gr_gid)) == -1) {
         merror("Could not change the group to '%s': %d", GROUPGLOBAL, errno);
         return (OS_INVALID);
     }
 #endif
 
     /* Set right permission */
-    if (chmod(DEFAULTARPATH, 0640) == -1) {
-        merror(CHMOD_ERROR, DEFAULTARPATH, errno, strerror(errno));
+    if (chmod(DEFAULTAR, 0640) == -1) {
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(DEFAULTAR, buffer, PATH_MAX);
+        merror(CHMOD_ERROR, buffer, errno, strerror(errno));
         return (OS_INVALID);
     }
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -281,11 +281,12 @@ int main(int argc, char **argv)
     gid_t gid;
 
     const char *cfg = OSSECCONF;
-    char * home_path = w_homedir(argv[0]);
-    mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* Set the name */
     OS_SetName(ARGV0);
+
+    // Define current working directory
+    char * home_path = w_homedir(argv[0]);
 
     thishour = 0;
     today = 0;
@@ -295,7 +296,6 @@ int main(int argc, char **argv)
     hourly_events = 0;
     hourly_syscheck = 0;
     hourly_firewall = 0;
-    sys_debug_level = getDefine_Int("analysisd", "debug", 0, 2);
 
 #ifdef LIBGEOIP_ENABLED
     geoipdb = NULL;
@@ -350,6 +350,14 @@ int main(int argc, char **argv)
         }
 
     }
+
+    /* Change working directory */
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
+
+    sys_debug_level = getDefine_Int("analysisd", "debug", 0, 2);
 
     /* Check current debug_level
      * Command line setting takes precedence

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -248,7 +248,7 @@ static int cpu_cores;
 
 /* Print help statement */
 __attribute__((noreturn))
-static void help_analysisd(void)
+static void help_analysisd(const char * home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtf] [-u user] [-g group] [-c config] [-D dir]", ARGV0);
@@ -261,9 +261,10 @@ static void help_analysisd(void)
     print_out("    -f          Run in foreground");
     print_out("    -u <user>   User to run as (default: %s)", USER);
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
-    print_out("    -c <config> Configuration file to use (default: %s)", DEFAULTCPATH);
-    print_out("    -D <dir>    Directory to chroot into (default: %s)", HOMEDIR);
+    print_out("    -c <config> Configuration file to use (default: %s)", OSSECCONF);
+    print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -274,17 +275,22 @@ int main(int argc, char **argv)
 {
     int c = 0, m_queue = 0, test_config = 0, run_foreground = 0;
     int debug_level = 0;
-    home_path = w_homedir(argv[0]);
-    const char *dir = HOMEDIR;
     const char *user = USER;
     const char *group = GROUPGLOBAL;
     uid_t uid;
     gid_t gid;
 
-    const char *cfg = DEFAULTCPATH;
+    const char *cfg = OSSECCONF;
 
     /* Set the name */
     OS_SetName(ARGV0);
+
+    // Define current working directory
+    char * home_path = w_homedir(argv[0]);
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     thishour = 0;
     today = 0;
@@ -307,7 +313,7 @@ int main(int argc, char **argv)
                 print_version();
                 break;
             case 'h':
-                help_analysisd();
+                help_analysisd(home_path);
                 break;
             case 'd':
                 nowDebug();
@@ -332,7 +338,7 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-D needs an argument");
                 }
-                dir = optarg;
+                snprintf(home_path, PATH_MAX, "%s", optarg);
                 break;
             case 'c':
                 if (!optarg) {
@@ -344,7 +350,7 @@ int main(int argc, char **argv)
                 test_config = 1;
                 break;
             default:
-                help_analysisd();
+                help_analysisd(home_path);
                 break;
         }
 
@@ -363,8 +369,6 @@ int main(int argc, char **argv)
     }
 
     /* Start daemon */
-    mdebug1(STARTED_MSG);
-    mdebug1(WAZUH_HOMEDIR, home_path);
     DEBUG_MSG("%s: DEBUG: Starting on debug mode - %d ", ARGV0, (int)time(0));
 
     srandom_init();
@@ -483,8 +487,8 @@ int main(int argc, char **argv)
     }
 
     /* Chroot */
-    if (Privsep_Chroot(dir) < 0) {
-        merror_exit(CHROOT_ERROR, dir, errno, strerror(errno));
+    if (Privsep_Chroot(home_path) < 0) {
+        merror_exit(CHROOT_ERROR, home_path, errno, strerror(errno));
     }
     nowChroot();
 
@@ -737,7 +741,8 @@ int main(int argc, char **argv)
     }
 
     /* Verbose message */
-    mdebug1(PRIVSEP_MSG, dir, user);
+    mdebug1(PRIVSEP_MSG, home_path, user);
+    os_free(home_path);
 
     /* Signal manipulation */
     StartSIG(ARGV0);
@@ -809,7 +814,6 @@ int main(int argc, char **argv)
     /* Going to main loop */
     OS_ReadMSG(m_queue);
 
-    os_free(home_path);
     exit(0);
 }
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -261,8 +261,8 @@ static void help_analysisd(const char * home_path)
     print_out("    -f          Run in foreground");
     print_out("    -u <user>   User to run as (default: %s)", USER);
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
-    print_out("    -c <config> Configuration file to use (default: %s)", OSSECCONF);
-    print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
+    print_out("    -c <config> Configuration file to use (default: %s/%s)", home_path, OSSECCONF);
+    print_out("    -D <dir>    Directory to chroot and chdir into (default: %s)", home_path);
     print_out(" ");
     os_free(home_path);
     exit(1);
@@ -281,17 +281,12 @@ int main(int argc, char **argv)
     gid_t gid;
 
     const char *cfg = OSSECCONF;
+    char * home_path = w_homedir(argv[0]);
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* Set the name */
     OS_SetName(ARGV0);
-
-    // Define current working directory
-    char * home_path = w_homedir(argv[0]);
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
-    mdebug1(WAZUH_HOMEDIR, home_path);
-
+ 
     thishour = 0;
     today = 0;
     prev_year = 0;

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -248,7 +248,7 @@ static int cpu_cores;
 
 /* Print help statement */
 __attribute__((noreturn))
-static void help_analysisd(const char * home_path)
+static void help_analysisd(char * home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtf] [-u user] [-g group] [-c config] [-D dir]", ARGV0);
@@ -286,7 +286,7 @@ int main(int argc, char **argv)
 
     /* Set the name */
     OS_SetName(ARGV0);
- 
+
     thishour = 0;
     today = 0;
     prev_year = 0;
@@ -514,7 +514,7 @@ int main(int argc, char **argv)
             OSList_SetMaxSize(list_msg, ERRORLIST_MAXSIZE);
             OSListNode * node_log_msg;
             int error_exit = 0;
-            
+
 
             /* Initialize the decoders list */
             OS_CreateOSDecoderList();
@@ -534,9 +534,9 @@ int main(int argc, char **argv)
                     if (!test_config) {
                         mdebug1("Reading decoder file %s.", *decodersfiles);
                     }
-                    if (!ReadDecodeXML(*decodersfiles, &os_analysisd_decoderlist_pn, 
+                    if (!ReadDecodeXML(*decodersfiles, &os_analysisd_decoderlist_pn,
                                         &os_analysisd_decoderlist_nopn, &os_analysisd_decoder_store, list_msg)) {
-                        error_exit = 1; 
+                        error_exit = 1;
                     }
                     node_log_msg = OSList_GetFirstNode(list_msg);
 
@@ -1363,7 +1363,7 @@ void * ad_input_main(void * args) {
                         reported_dbsync = TRUE;
                     }
                 }
-            } else if (msg[0] == UPGRADE_MQ) { 
+            } else if (msg[0] == UPGRADE_MQ) {
                 result = -1;
 
                 if (!queue_full(upgrade_module_input)) {
@@ -1384,7 +1384,7 @@ void * ad_input_main(void * args) {
                         reported_upgrade_module = TRUE;
                     }
                 }
-                
+
             } else {
 
                 os_strdup(buffer, copy);

--- a/src/analysisd/ar_json.c
+++ b/src/analysisd/ar_json.c
@@ -88,7 +88,7 @@ char *get_node_name()
     OS_XML xml;
 
     const char *(xml_node[]) = {"ossec_config", "cluster", "node_name", NULL};
-    if (OS_ReadXML(DEFAULTCPATH, &xml) >= 0) {
+    if (OS_ReadXML(OSSECCONF, &xml) >= 0) {
         node_name = OS_GetOneContentforElement(&xml, xml_node);
     }
     OS_ClearXML(&xml);

--- a/src/analysisd/fts.h
+++ b/src/analysisd/fts.h
@@ -14,8 +14,8 @@
 #include "eventinfo.h"
 
 /* FTS queues */
-#define FTS_QUEUE "/queue/fts/fts-queue"
-#define IG_QUEUE  "/queue/fts/ig-queue"
+#define FTS_QUEUE "queue/fts/fts-queue"
+#define IG_QUEUE  "queue/fts/ig-queue"
 
 /**
  * @brief Structure to save previous fts events

--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -105,7 +105,7 @@ int w_analysisd_write_state(){
 
     mdebug2("Updating state file.");
 
-    snprintf(path, sizeof(path), "%s" OS_PIDFILE "/%s.state", isChroot() ? "" : HOMEDIR, __local_name);
+    snprintf(path, sizeof(path), OS_PIDFILE "/%s.state", __local_name);
     snprintf(path_temp, sizeof(path_temp), "%s.temp", path);
 
     if (fp = fopen(path_temp, "w"), !fp) {

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -80,8 +80,10 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     os_setwait();
 
     /* Create the queue and read from it. Exit if fails. */
-    if ((agt->m_queue = StartMQ(DEFAULTQPATH, READ, 0)) < 0) {
-        merror_exit(QUEUE_ERROR, DEFAULTQPATH, strerror(errno));
+    if ((agt->m_queue = StartMQ(DEFAULTQUEUE, READ, 0)) < 0) {
+		char absPath[PATH_MAX] = {'\0'};
+		abspath(DEFAULTQUEUE, absPath, PATH_MAX);
+        merror_exit(QUEUE_ERROR, absPath, strerror(errno));
     }
 
 #ifdef HPUX
@@ -141,7 +143,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
 
     /* Connect to the execd queue */
     if (agt->execdq == 0) {
-        if ((agt->execdq = StartMQ(EXECQUEUEPATH, WRITE, 1)) < 0) {
+        if ((agt->execdq = StartMQ(EXECQUEUE, WRITE, 1)) < 0) {
             minfo("Unable to connect to the active response "
                    "queue (disabled).");
             agt->execdq = -1;

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -49,7 +49,6 @@ int main(int argc, char **argv)
     int test_config = 0;
     int debug_level = 0;
     char *home_path = w_homedir(argv[0]);
-    agent_debug_level = getDefine_Int("agent", "debug", 0, 2);
 
     const char *user = USER;
     const char *group = GROUPGLOBAL;
@@ -70,6 +69,8 @@ int main(int argc, char **argv)
         exit(1);
     }
     mdebug1(WAZUH_HOMEDIR, home_path);
+
+    agent_debug_level = getDefine_Int("agent", "debug", 0, 2);
 
     while ((c = getopt(argc, argv, "Vtdfhu:g:D:c:")) != -1) {
         switch (c) {

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -19,11 +19,11 @@
 
 
 /* Prototypes */
-static void help_agentd(const char *home_path) __attribute((noreturn));
+static void help_agentd(char *home_path) __attribute((noreturn));
 
 
 /* Print help statement */
-static void help_agentd(const char *home_path)
+static void help_agentd(char *home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtf] [-u user] [-g group] [-c config]", ARGV0);
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
     int c = 0;
     int test_config = 0;
     int debug_level = 0;
-    const char *home_path = w_homedir(argv[0]);
+    char *home_path = w_homedir(argv[0]);
     agent_debug_level = getDefine_Int("agent", "debug", 0, 2);
 
     const char *user = USER;

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
                 break;
         }
     }
-
+	os_free(home_path);
     mdebug1(STARTUP_MSG, (int)getpid());
 
     agt = (agent *)calloc(1, sizeof(agent));
@@ -180,6 +180,5 @@ int main(int argc, char **argv)
     /* Agentd Start */
     AgentdStart(uid, gid, user, group);
 
-    os_free(home_path);
     return (0);
 }

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
                 break;
         }
     }
-	os_free(home_path);
+    os_free(home_path);
     mdebug1(STARTUP_MSG, (int)getpid());
 
     agt = (agent *)calloc(1, sizeof(agent));

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -19,11 +19,11 @@
 
 
 /* Prototypes */
-static void help_agentd(char *home_path) __attribute((noreturn));
+static void help_agentd(const char *home_path) __attribute((noreturn));
 
 
 /* Print help statement */
-static void help_agentd(char *home_path)
+static void help_agentd(const char *home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtf] [-u user] [-g group] [-c config]", ARGV0);

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -38,6 +38,7 @@ static void help_agentd(const char *home_path)
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
     print_out("    -c <config> Configuration file to use (default: %s/%s)", home_path, OSSECCONF);
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -68,6 +69,7 @@ int main(int argc, char **argv)
         os_free(home_path);
         exit(1);
     }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     while ((c = getopt(argc, argv, "Vtdfhu:g:D:c:")) != -1) {
         switch (c) {

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -143,9 +143,9 @@ void run_notify()
     agent_ip = get_agent_ip();
 
     /* Create message */
-	char absPath[PATH_MAX] = {'\0'};
-	abspath(AGENTCONFIG, absPath, PATH_MAX);
-	
+    char absPath[PATH_MAX] = {'\0'};
+    abspath(AGENTCONFIG, absPath, PATH_MAX);
+
     if(agent_ip && strcmp(agent_ip, "Err")) {
         char label_ip[60];
         snprintf(label_ip, sizeof label_ip, "#\"_agent_ip\":%s", agent_ip);

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -143,11 +143,14 @@ void run_notify()
     agent_ip = get_agent_ip();
 
     /* Create message */
+	char absPath[PATH_MAX] = {'\0'};
+	abspath(AGENTCONFIG, absPath, PATH_MAX);
+	
     if(agent_ip && strcmp(agent_ip, "Err")) {
         char label_ip[60];
         snprintf(label_ip, sizeof label_ip, "#\"_agent_ip\":%s", agent_ip);
-        if ((File_DateofChange(AGENTCONFIG) > 0 ) &&
-                (OS_MD5_File(AGENTCONFIG, md5sum, OS_TEXT) == 0)) {
+        if ((File_DateofChange(absPath) > 0 ) &&
+                (OS_MD5_File(absPath, md5sum, OS_TEXT) == 0)) {
             snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s / %s\n%s%s%s\n",
                     getuname(), md5sum, tmp_labels, shared_files, label_ip);
         } else {
@@ -156,8 +159,8 @@ void run_notify()
         }
     }
     else {
-        if ((File_DateofChange(AGENTCONFIG) > 0 ) &&
-                (OS_MD5_File(AGENTCONFIG, md5sum, OS_TEXT) == 0)) {
+        if ((File_DateofChange(absPath) > 0 ) &&
+                (OS_MD5_File(absPath, md5sum, OS_TEXT) == 0)) {
             snprintf(tmp_msg, OS_MAXSTR - OS_HEADER_SIZE, "#!-%s / %s\n%s%s\n",
                     getuname(), md5sum, tmp_labels, shared_files);
         } else {

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -22,7 +22,7 @@ char *getsharedfiles()
     char *ret;
     os_md5 md5sum;
 
-    if (OS_MD5_File(SHAREDCFG_FILEPATH, md5sum, OS_TEXT) != 0) {
+    if (OS_MD5_File(SHAREDCFG_FILE, md5sum, OS_TEXT) != 0) {
         md5sum[0] = 'x';
         md5sum[1] = '\0';
     }

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -159,7 +159,7 @@ int receive_msg()
                         mwarn("Error communicating with Security configuration assessment");
                         close(agt->cfgadq);
 
-                        if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE, 1)) < 0) {
+                        if ((agt->cfgadq = StartMQ(CFGAQUEUE, WRITE, 1)) < 0) {
                             mwarn("Unable to connect to the Security configuration assessment "
                                     "queue (disabled).");
                             agt->cfgadq = -1;
@@ -170,7 +170,7 @@ int receive_msg()
                         }
                     }
                 } else {
-                    if ((agt->cfgadq = StartMQ(CFGASSESSMENTQUEUEPATH, WRITE, 1)) < 0) {
+                    if ((agt->cfgadq = StartMQ(CFGAQUEUE, WRITE, 1)) < 0) {
                         mwarn("Unable to connect to the Security configuration assessment "
                             "queue (disabled).");
                         agt->cfgadq = -1;
@@ -229,7 +229,7 @@ int receive_msg()
                 }
 
                 snprintf(file, OS_SIZE_1024, "%s/%s",
-                         SHAREDCFG_DIRPATH,
+                         SHAREDCFG_DIR,
                          tmp_msg);
 
                 fp = fopen(file, "w");
@@ -269,11 +269,11 @@ int receive_msg()
                         final_file = strrchr(file, '/');
                         if (final_file) {
                             if (strcmp(final_file + 1, SHAREDCFG_FILENAME) == 0) {
-                                if (cldir_ex_ignore(SHAREDCFG_DIRPATH, IGNORE_LIST)) {
+                                if (cldir_ex_ignore(SHAREDCFG_DIR, IGNORE_LIST)) {
                                     mwarn("Could not clean up shared directory.");
                                 }
 
-                                if(!UnmergeFiles(file, SHAREDCFG_DIRPATH, OS_TEXT)){
+                                if(!UnmergeFiles(file, SHAREDCFG_DIR, OS_TEXT)){
                                     char msg_output[OS_MAXSTR];
 
                                     snprintf(msg_output, OS_MAXSTR, "%c:%s:%s",  LOCALFILE_MQ, "wazuh-agent", AG_IN_UNMERGE);

--- a/src/client-agent/request.c
+++ b/src/client-agent/request.c
@@ -149,7 +149,7 @@ int req_push(char * buffer, size_t length) {
 
         if (strcmp(target, "agent")) {
             char sockname[PATH_MAX];
-            snprintf(sockname, PATH_MAX, BUILDDIR(HOMEDIR,"/queue/ossec/%s"), target);
+            snprintf(sockname, PATH_MAX, "/queue/ossec/%s", target);
 
             if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock < 0) {
                 switch (errno) {

--- a/src/client-agent/restart_agent.c
+++ b/src/client-agent/restart_agent.c
@@ -33,11 +33,7 @@ void * restartAgent() {
 	int sock = -1;
 	char sockname[PATH_MAX + 1];
 
-	if (isChroot()) {
-		strcpy(sockname, COM_LOCAL_SOCK);
-	} else {
-		strcpy(sockname, BUILDDIR(HOMEDIR,COM_LOCAL_SOCK));
-	}
+	strcpy(sockname, COM_LOCAL_SOCK);
 
 	if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock < 0) {
 		switch (errno) {
@@ -71,12 +67,7 @@ int verifyRemoteConf(){
 	const char *configPath;
  	char msg_output[OS_MAXSTR];
 
-	if (isChroot()) {
-		configPath = AGENTCONFIGINT;
-
-	} else {
-		configPath = AGENTCONFIG;
-	}
+	configPath = AGENTCONFIG;
 
 	if (Test_Syscheck(configPath) < 0) {
 		snprintf(msg_output, OS_MAXSTR, "%c:%s:%s: '%s'. ",  LOCALFILE_MQ, "wazuh-agent", AG_IN_RCON, "syscheck");

--- a/src/client-agent/rotate_log.c
+++ b/src/client-agent/rotate_log.c
@@ -49,9 +49,9 @@ void * w_rotate_log_thread(__attribute__((unused)) void * arg) {
     snprintf(path_json, PATH_MAX, "%s", LOGJSONFILE);
 #else
     // /var/ossec/logs/ossec.log
-    snprintf(path, PATH_MAX, "%s", isChroot() ? LOGFILE : BUILDDIR(HOMEDIR,LOGFILE));
+    snprintf(path, PATH_MAX, "%s", LOGFILE);
     // /var/ossec/logs/ossec.json
-    snprintf(path_json, PATH_MAX, "%s", isChroot() ? LOGJSONFILE : BUILDDIR(HOMEDIR,LOGJSONFILE));
+    snprintf(path_json, PATH_MAX, "%s", LOGJSONFILE);
 #endif
 
     while (1) {

--- a/src/client-agent/state.c
+++ b/src/client-agent/state.c
@@ -77,7 +77,7 @@ int write_state() {
     }
 #else
     char path_temp[PATH_MAX + 1];
-    snprintf(path, sizeof(path), "%s" OS_PIDFILE "/%s.state", isChroot() ? "" : HOMEDIR, __local_name);
+    snprintf(path, sizeof(path), "%s" OS_PIDFILE "/%s.state", "", __local_name);
     snprintf(path_temp, sizeof(path_temp), "%s.temp", path);
 
     if (fp = fopen(path_temp, "w"), !fp) {

--- a/src/client-agent/state.c
+++ b/src/client-agent/state.c
@@ -77,7 +77,7 @@ int write_state() {
     }
 #else
     char path_temp[PATH_MAX + 1];
-    snprintf(path, sizeof(path), "%s" OS_PIDFILE "/%s.state", "", __local_name);
+    snprintf(path, sizeof(path), OS_PIDFILE "/%s.state", __local_name);
     snprintf(path_temp, sizeof(path_temp), "%s.temp", path);
 
     if (fp = fopen(path_temp, "w"), !fp) {

--- a/src/config/active-response.c
+++ b/src/config/active-response.c
@@ -52,9 +52,11 @@ int ReadActiveResponses(XML_NODE node, void *d1, void *d2)
     active_response *tmp_ar;
 
     /* Open shared ar file */
-    fp = fopen(DEFAULTARPATH, "a");
+    fp = fopen(DEFAULTAR, "a");
     if (!fp) {
-        merror(FOPEN_ERROR, DEFAULTARPATH, errno, strerror(errno));
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(DEFAULTAR, buffer, PATH_MAX);
+        merror(FOPEN_ERROR, buffer, errno, strerror(errno));
         return (-1);
     }
 
@@ -67,7 +69,7 @@ int ReadActiveResponses(XML_NODE node, void *d1, void *d2)
         return OS_INVALID;
     }
 
-    if ((chown(DEFAULTARPATH, (uid_t) - 1, gid)) == -1) {
+    if ((chown(DEFAULTAR, (uid_t) - 1, gid)) == -1) {
         merror("Could not change the group to '%s': %d.", GROUPGLOBAL, errno);
         fclose(fp);
         return OS_INVALID;
@@ -75,7 +77,7 @@ int ReadActiveResponses(XML_NODE node, void *d1, void *d2)
 
 #endif
 
-    if ((chmod(DEFAULTARPATH, 0640)) == -1) {
+    if ((chmod(DEFAULTAR, 0640)) == -1) {
         merror("Could not chmod to 0640: '%d'", errno);
         fclose(fp);
         return (-1);
@@ -282,7 +284,7 @@ int ReadActiveResponses(XML_NODE node, void *d1, void *d2)
              tmp_ar->timeout);
 
     /* Add to shared file */
-    mdebug1("Writing command '%s' to '%s'", tmp_ar->command, DEFAULTARPATH);
+    mdebug1("Writing command '%s' to '%s'", tmp_ar->command, DEFAULTAR);
     fprintf(fp, "%s - %s - %d\n",
             tmp_ar->name,
             tmp_ar->ar_cmd->executable,

--- a/src/config/agentlessd-config.c
+++ b/src/config/agentlessd-config.c
@@ -104,7 +104,7 @@ int Read_CAgentless(XML_NODE node, void *config, __attribute__((unused)) void *c
             char script_path[1024 + 1];
 
             script_path[1024] = '\0';
-            snprintf(script_path, 1024, "%s/%s", AGENTLESSDIRPATH,
+            snprintf(script_path, 1024, "%s/%s", AGENTLESSDIR,
                      node[i]->content);
 
             if (w_ref_parent_folder(script_path)) {
@@ -113,8 +113,10 @@ int Read_CAgentless(XML_NODE node, void *config, __attribute__((unused)) void *c
             }
 
             if (File_DateofChange(script_path) <= 0) {
+                char buffer[PATH_MAX] = {'\0'};
+                abspath(AGENTLESSDIR, buffer, PATH_MAX);
                 merror("Unable to find '%s' at '%s'.",
-                       node[i]->content, AGENTLESSDIRPATH);
+                       node[i]->content, buffer);
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }

--- a/src/config/authd-config.c
+++ b/src/config/authd-config.c
@@ -40,8 +40,8 @@ int Read_Authd(XML_NODE node, void *d1, __attribute__((unused)) void *d2) {
     char manager_cert[OS_SIZE_1024];
     char manager_key[OS_SIZE_1024];
 
-    snprintf(manager_cert, OS_SIZE_1024 - 1, "%s/etc/sslmanager.cert", HOMEDIR);
-    snprintf(manager_key, OS_SIZE_1024 - 1, "%s/etc/sslmanager.key", HOMEDIR);
+    snprintf(manager_cert, OS_SIZE_1024 - 1, "etc/sslmanager.cert");
+    snprintf(manager_key, OS_SIZE_1024 - 1, "etc/sslmanager.key");
 
     // config->flags.disabled = AD_CONF_UNPARSED;
     /* If authd is defined, enable it by default */

--- a/src/config/rules-config.c
+++ b/src/config/rules-config.c
@@ -274,11 +274,7 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
 
     for (i = 0; decoder_dirs[i]; i++) {
         mdebug1("Reading decoders folder: %s", decoder_dirs[i]);
-        if(isChroot()) {
-            snprintf(path, PATH_MAX + 1, "%s", decoder_dirs[i]);
-        } else {
-            snprintf(path, PATH_MAX + 1, "%s/%s", HOMEDIR, decoder_dirs[i]);
-        }
+        snprintf(path, PATH_MAX + 1, "%s", decoder_dirs[i]);
 
         OSRegex_FreePattern(&regex);
         if (!OSRegex_Compile(decoder_dirs_pattern[i], &regex, 0)) {
@@ -331,11 +327,7 @@ int Read_Rules(XML_NODE node, void *configp, __attribute__((unused)) void *mailp
 
     for (i = 0; rules_dirs[i]; i++) {
         mdebug1("Reading rules folder: %s", rules_dirs[i]);
-        if(isChroot()) {
-            snprintf(path, PATH_MAX + 1, "%s", rules_dirs[i]);
-        } else {
-            snprintf(path, PATH_MAX + 1, "%s/%s", HOMEDIR, rules_dirs[i]);
-        }
+        snprintf(path, PATH_MAX + 1, "%s", rules_dirs[i]);
 
         OSRegex_FreePattern(&regex);
         if (!OSRegex_Compile(rules_dirs_pattern[i], &regex, 0)) {

--- a/src/config/wmodules-agent-upgrade.c
+++ b/src/config/wmodules-agent-upgrade.c
@@ -246,8 +246,8 @@ static int wm_agent_upgrade_read_ca_verification_old(unsigned int *verification_
     OS_XML xml2;
 
     /* Read XML file */
-    if (OS_ReadXML(DEFAULTCPATH, &xml2) < 0) {
-        merror_exit(XML_ERROR, DEFAULTCPATH, xml2.err, xml2.err_line);
+    if (OS_ReadXML(OSSECCONF, &xml2) < 0) {
+        merror_exit(XML_ERROR, OSSECCONF, xml2.err, xml2.err_line);
     }
 
     if (ca_verification = OS_GetContents(&xml2, caverify), ca_verification) {

--- a/src/config/wmodules-gcp.c
+++ b/src/config/wmodules-gcp.c
@@ -96,11 +96,7 @@ int wm_gcp_read(xml_node **nodes, wmodule *module) {
             if(nodes[i]->content[0] == '/') {
                 sprintf(realpath_buffer, "%s", nodes[i]->content);
             } else {
-                char relative_path[PATH_MAX] = {0};
-
-                sprintf(relative_path, "%s/", HOMEDIR);
-                strcat(relative_path, nodes[i]->content);
-                const char * const realpath_buffer_ref = realpath(relative_path, realpath_buffer);
+                const char * const realpath_buffer_ref = realpath(nodes[i]->content, realpath_buffer);
                 if (!realpath_buffer_ref) {
                     mwarn("File '%s' from tag '%s' not found.", realpath_buffer, XML_CREDENTIALS_FILE);
                     return OS_INVALID;

--- a/src/config/wmodules-sca.c
+++ b/src/config/wmodules-sca.c
@@ -107,7 +107,7 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
     #ifdef WIN32
     sprintf(ruleset_path, "%s\\", SECURITY_CONFIGURATION_ASSESSMENT_DIR_WIN);
     #else
-    sprintf(ruleset_path, "%s/", BUILDDIR(HOMEDIR,SECURITY_CONFIGURATION_ASSESSMENT_DIR));
+    sprintf(ruleset_path, "%s/", SECURITY_CONFIGURATION_ASSESSMENT_DIR);
     #endif
 
     DIR *ruleset_dir = opendir(ruleset_path);

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -616,7 +616,6 @@
 #define WAZUH_HOMEDIR "Wazuh home directory: %s"
 
 /* Debug Messages */
-#define STARTED_MSG "Starting ..."
 #define FOUND_USER  "Found user/group ..."
 #define ASINIT      "Active response initialized ..."
 #define READ_CONFIG "Read configuration ..."

--- a/src/headers/debug_op.h
+++ b/src/headers/debug_op.h
@@ -27,8 +27,8 @@
 /* For internal logs */
 #ifndef LOGFILE
 #ifndef WIN32
-#define LOGFILE   "/logs/ossec.log"
-#define LOGJSONFILE "/logs/ossec.json"
+#define LOGFILE   "logs/ossec.log"
+#define LOGJSONFILE "logs/ossec.json"
 #define _PRINTF_FORMAT printf
 #else
 #define LOGFILE "ossec.log"

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -116,141 +116,92 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define FALLBACKDIR     "/var/ossec"
 #endif
 
-/* Default directory - Checked at runtime */
-#ifndef WIN32
-#ifndef HOMEDIR
-#ifdef WAZUH_UNIT_TESTING
-#define HOMEDIR FALLBACKDIR
-#else
-#define HOMEDIR ({ \
-    struct stat wazuh_homedir_test; \
-    char * wazuh_homedir = home_path; \
-    if (wazuh_homedir != NULL) { \
-        if (stat(wazuh_homedir, &wazuh_homedir_test) < 0 || !S_ISDIR(wazuh_homedir_test.st_mode)) wazuh_homedir = FALLBACKDIR; \
-    } else { \
-        wazuh_homedir = FALLBACKDIR; \
-    } \
-    wazuh_homedir; \
-})
-#endif
-#endif
-#endif
-
-#ifndef BUILDDIR
-#ifndef WAZUH_UNIT_TESTING
-#define BUILDDIR(x,y) ({ \
-    static char wazuh_fulldir[MAXPATHLEN + 1] = {'\0'}; \
-    char *wazuh_str1 = (x); \
-    char *wazuh_str2 = (y); \
-    if (wazuh_str1 && *wazuh_str1 && wazuh_str2 && *wazuh_str2) snprintf(wazuh_fulldir, MAXPATHLEN, "%s%s", wazuh_str1, wazuh_str2); \
-    wazuh_fulldir; \
-})
-#else
-#define BUILDDIR(x,y)   x y
-#endif
-#endif
-
 /* Default queue */
-#define DEFAULTQUEUE    "/queue/ossec/queue"
+#define DEFAULTQUEUE    "queue/ossec/queue"
 
 // Authd local socket
-#define AUTH_LOCAL_SOCK "/queue/ossec/auth"
-#define AUTH_LOCAL_SOCK_PATH BUILDDIR(HOMEDIR,AUTH_LOCAL_SOCK)
+#define AUTH_LOCAL_SOCK "queue/ossec/auth"
 
 // Remote requests socket
-#define REMOTE_REQ_SOCK "/queue/ossec/request"
+#define REMOTE_REQ_SOCK "queue/ossec/request"
 
 // Local requests socket
-#define COM_LOCAL_SOCK  "/queue/ossec/com"
-#define LC_LOCAL_SOCK  "/queue/ossec/logcollector"
-#define SYS_LOCAL_SOCK  "/queue/ossec/syscheck"
-#define WM_LOCAL_SOCK  "/queue/ossec/wmodules"
-#define ANLSYS_LOCAL_SOCK  "/queue/ossec/analysis"
-#define MAIL_LOCAL_SOCK "/queue/ossec/mail"
-#define LESSD_LOCAL_SOCK "/queue/ossec/agentless"
-#define INTG_LOCAL_SOCK "/queue/ossec/integrator"
-#define CSYS_LOCAL_SOCK  "/queue/ossec/csyslog"
-#define MON_LOCAL_SOCK  "/queue/ossec/monitor"
-#define CLUSTER_SOCK "/queue/cluster/c-internal.sock"
-#define CONTROL_SOCK "/queue/ossec/control"
-#define LOGTEST_SOCK "/queue/ossec/logtest"
-#define AGENT_UPGRADE_SOCK "/queue/ossec/upgrade"
+#define COM_LOCAL_SOCK  "queue/ossec/com"
+#define LC_LOCAL_SOCK  "queue/ossec/logcollector"
+#define SYS_LOCAL_SOCK  "queue/ossec/syscheck"
+#define WM_LOCAL_SOCK  "queue/ossec/wmodules"
+#define ANLSYS_LOCAL_SOCK  "queue/ossec/analysis"
+#define MAIL_LOCAL_SOCK "queue/ossec/mail"
+#define LESSD_LOCAL_SOCK "queue/ossec/agentless"
+#define INTG_LOCAL_SOCK "queue/ossec/integrator"
+#define CSYS_LOCAL_SOCK  "queue/ossec/csyslog"
+#define MON_LOCAL_SOCK  "queue/ossec/monitor"
+#define CLUSTER_SOCK "queue/cluster/c-internal.sock"
+#define CONTROL_SOCK "queue/ossec/control"
+#define LOGTEST_SOCK "queue/ossec/logtest"
+#define AGENT_UPGRADE_SOCK "queue/ossec/upgrade"
 
 
 // Tasks socket
-#define TASK_QUEUE "/queue/tasks/task"
-
-// Absolute path local requests socket
-#define CONTROL_SOCK_PATH BUILDDIR(HOMEDIR,CONTROL_SOCK)
+#define TASK_QUEUE "queue/tasks/task"
 
 // Attempts to check sockets availability
 #define SOCK_ATTEMPTS   10
 
 // Database socket
-#define WDB_LOCAL_SOCK "/queue/db/wdb"
-#ifndef WIN32
-#define WDB_LOCAL_SOCK_PATH BUILDDIR(HOMEDIR,WDB_LOCAL_SOCK)
-#endif
+#define WDB_LOCAL_SOCK "queue/db/wdb"
 
-#define WM_DOWNLOAD_SOCK "/queue/ossec/download"
-#define WM_DOWNLOAD_SOCK_PATH BUILDDIR(HOMEDIR,WM_DOWNLOAD_SOCK)
+#define WM_DOWNLOAD_SOCK "queue/ossec/download"
 
-#define WM_KEY_REQUEST_SOCK "/queue/ossec/krequest"
-#define WM_KEY_REQUEST_SOCK_PATH BUILDDIR(HOMEDIR,WM_KEY_REQUEST_SOCK)
+#define WM_KEY_REQUEST_SOCK "queue/ossec/krequest"
 
 // Tasks socket
-#define WM_UPGRADE_SOCK "/queue/tasks/upgrade"
-#define WM_UPGRADE_SOCK_PATH BUILDDIR(HOMEDIR,WM_UPGRADE_SOCK)
+#define WM_UPGRADE_SOCK "queue/tasks/upgrade"
 
-#define WM_TASK_MODULE_SOCK "/queue/tasks/task"
-#define WM_TASK_MODULE_SOCK_PATH BUILDDIR(HOMEDIR,WM_TASK_MODULE_SOCK)
+#define WM_TASK_MODULE_SOCK "queue/tasks/task"
 
 /* Active Response files */
 #define DEFAULTAR_FILE  "ar.conf"
-
+#define AR_BINDIR       "active-response/bin"
 #ifndef WIN32
-#define DEFAULTAR       "/etc/shared/" DEFAULTAR_FILE
-#define AR_BINDIR       "/active-response/bin"
-#define AGENTCONFIGINT  "/etc/shared/agent.conf"
-#define AGENTCONFIG     BUILDDIR(HOMEDIR,"/etc/shared/agent.conf")
-#define DEF_CA_STORE    BUILDDIR(HOMEDIR,"/etc/wpk_root.pem")
+#define DEFAULTAR       "etc/shared/" DEFAULTAR_FILE
+#define AGENTCONFIG     "etc/shared/agent.conf"
+#define DEF_CA_STORE    "etc/wpk_root.pem"
 #else
 #define DEFAULTAR       "shared/" DEFAULTAR_FILE
-#define AR_BINDIR       "active-response/bin"
 #define AGENTCONFIG     "shared/agent.conf"
-#define AGENTCONFIGINT  "shared/agent.conf"
 #define DEF_CA_STORE    "wpk_root.pem"
 #endif
 
 /* Exec queue */
-#define EXECQUEUE       "/queue/alerts/execq"
+#define EXECQUEUE       "queue/alerts/execq"
 
 /* Security configuration assessment module queue */
-#define CFGAQUEUE       "/queue/alerts/cfgaq"
+#define CFGAQUEUE       "queue/alerts/cfgaq"
 
 /* Security configuration assessment remoted queue */
-#define CFGARQUEUE       "/queue/alerts/cfgarq"
+#define CFGARQUEUE       "queue/alerts/cfgarq"
 
 /* Exec queue api*/
-#define EXECQUEUEA      "/queue/alerts/execa"
+#define EXECQUEUEA      "queue/alerts/execa"
 
 /* Active Response queue */
-#define ARQUEUE         "/queue/alerts/ar"
+#define ARQUEUE         "queue/alerts/ar"
 
 /* Decoder file */
 #define XML_LDECODER    "etc/decoders/local_decoder.xml"
 
 /* Agent groups location */
-#define GROUPS_DIR    "/queue/agent-groups"
+#define GROUPS_DIR    "queue/agent-groups"
 
 /* Default group name */
 #define DEFAULT_GROUP "default"
 
 /* Syscheck directory */
-#define SYSCHECK_DIR    "/queue/syscheck"
+#define SYSCHECK_DIR    "queue/syscheck"
 
 /* Rootcheck directory */
-#define ROOTCHECK_DIR    "/queue/rootcheck"
+#define ROOTCHECK_DIR    "queue/rootcheck"
 
 /* Wazuh Database */
 #define WDB_DIR         "var/db"
@@ -262,13 +213,7 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define WDB_TASK_NAME   "tasks"
 
 /* Diff queue */
-#ifndef WIN32
-#define DIFF_DIR        "/queue/diff"
-#define DIFF_DIR_PATH   BUILDDIR(HOMEDIR,DIFF_DIR)
-#else
 #define DIFF_DIR        "queue/diff"
-#define DIFF_DIR_PATH   DIFF_DIR
-#endif
 #define DIFF_NEW_FILE   "new-entry"
 #define DIFF_LAST_FILE  "last-entry"
 #define DIFF_GZ_FILE    "last-entry.gz"
@@ -279,172 +224,110 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define SYSCHECK_REG    "syscheck-registry"
 
 /* Rule path */
-#define RULEPATH        "/rules"
+#define RULEPATH        "rules"
 
 /* Wait file */
 #ifndef WIN32
-#define WAIT_FILE       "/queue/ossec/.wait"
+#define WAIT_FILE       "queue/ossec/.wait"
 #else
 #define WAIT_FILE       ".wait"
 #endif
 
 /* Agent information file */
 #ifndef WIN32
-#define AGENT_INFO_FILE "/queue/ossec/.agent_info"
-#define AGENT_INFO_FILEP BUILDDIR(HOMEDIR,AGENT_INFO_FILE)
+#define AGENT_INFO_FILE "queue/ossec/.agent_info"
 #else
 #define AGENT_INFO_FILE ".agent_info"
-#define AGENT_INFO_FILEP AGENT_INFO_FILE
-#endif
-
-/* Syscheck restart */
-#ifndef WIN32
-#define SYSCHECK_RESTART        "/var/run/.syscheck_run"
-#define SYSCHECK_RESTART_PATH   BUILDDIR(HOMEDIR,SYSCHECK_RESTART)
-#else
-#define SYSCHECK_RESTART        "syscheck/.syscheck_run"
-#define SYSCHECK_RESTART_PATH   "syscheck/.syscheck_run"
 #endif
 
 /* Agentless directories */
-#define AGENTLESSDIR        "/agentless"
-#define AGENTLESSPASS       "/agentless/.passlist"
-#define AGENTLESS_ENTRYDIR  "/queue/agentless"
+#define AGENTLESSDIR        "agentless"
+#define AGENTLESS_ENTRYDIR  "queue/agentless"
 
 /* Integration directory. */
-#define INTEGRATORDIR "/integrations"
-#define INTEGRATORDIRPATH    BUILDDIR(HOMEDIR,INTEGRATORDIR)
+#define INTEGRATORDIR "integrations"
 
 
 /* Internal definitions files */
 #ifndef WIN32
-#define OSSEC_DEFINES   "/etc/internal_options.conf"
-#define OSSEC_LDEFINES   "/etc/local_internal_options.conf"
-#define OSSEC_DEFINES_PATH BUILDDIR(HOMEDIR,OSSEC_DEFINES)
+#define OSSEC_DEFINES   "etc/internal_options.conf"
+#define OSSEC_LDEFINES   "etc/local_internal_options.conf"
 #else
 #define OSSEC_DEFINES   "internal_options.conf"
 #define OSSEC_LDEFINES   "local_internal_options.conf"
 #endif
 
 /* Log directories */
-#define EVENTS            "/logs/archives"
-#define EVENTS_DAILY      "/logs/archives/archives.log"
-#define ALERTS            "/logs/alerts"
-#define ALERTS_PATH       BUILDDIR(HOMEDIR,ALERTS)
-#define ALERTS_DAILY      "/logs/alerts/alerts.log"
-#define ALERTSJSON_DAILY  "/logs/alerts/alerts.json"
-#define FWLOGS            "/logs/firewall"
-#define FWLOGS_DAILY      "/logs/firewall/firewall.log"
-#define EVENTSJSON_DAILY  "/logs/archives/archives.json"
+#define EVENTS            "logs/archives"
+#define EVENTS_DAILY      "logs/archives/archives.log"
+#define ALERTS            "logs/alerts"
+#define ALERTS_DAILY      "logs/alerts/alerts.log"
+#define ALERTSJSON_DAILY  "logs/alerts/alerts.json"
+#define FWLOGS            "logs/firewall"
+#define FWLOGS_DAILY      "logs/firewall/firewall.log"
+#define EVENTSJSON_DAILY  "logs/archives/archives.json"
 
 /* Stats directories */
-#define STATWQUEUE  "/stats/weekly-average"
-#define STATQUEUE   "/stats/hourly-average"
-#define STATSAVED   "/stats/totals"
+#define STATWQUEUE  "stats/weekly-average"
+#define STATQUEUE   "stats/hourly-average"
+#define STATSAVED   "stats/totals"
 
 /* Authentication keys file */
 #ifndef WIN32
-#define KEYS_FILE       "/etc/client.keys"
-#define AUTHD_PASS      "/etc/authd.pass"
-#define KEYSFILE_PATH   BUILDDIR(HOMEDIR,KEYS_FILE)
-#define AUTHDPASS_PATH  BUILDDIR(HOMEDIR,AUTHD_PASS)
+#define KEYS_FILE       "etc/client.keys"
+#define AUTHD_PASS      "etc/authd.pass"
 #else
 #define KEYS_FILE       "client.keys"
-#define KEYSFILE_PATH   KEYS_FILE
 #define AUTHD_PASS      "authd.pass"
-#define AUTHDPASS_PATH  AUTHD_PASS
-#endif
-
-#ifndef AUTH_FILE
-#define AUTH_FILE       KEYS_FILE
 #endif
 
 /* Timestamp file */
-#define TIMESTAMP_FILE  "/queue/agents-timestamp"
+#define TIMESTAMP_FILE  "queue/agents-timestamp"
 
 /* Shared config directory */
 #ifndef WIN32
-#define SHAREDCFG_DIR   "/etc/shared"
+#define SHAREDCFG_DIR   "etc/shared"
 #else
 #define SHAREDCFG_DIR   "shared"
 #endif
 
 /* Multi-groups directory */
-#define MULTIGROUPS_DIR   "/var/multigroups"
+#define MULTIGROUPS_DIR   "var/multigroups"
 #define MAX_GROUP_NAME 255
 #define MULTIGROUP_SEPARATOR ','
 #define MAX_GROUPS_PER_MULTIGROUP 256
 
 // Incoming directory
 #ifndef WIN32
-#define INCOMING_DIR   "/var/incoming"
+#define INCOMING_DIR   "var/incoming"
 #else
 #define INCOMING_DIR   "incoming"
 #endif
 
 // Upgrade directory
 #ifndef WIN32
-#define UPGRADE_DIR   "/var/upgrade"
+#define UPGRADE_DIR   "var/upgrade"
 #else
 #define UPGRADE_DIR   "upgrade"
 #endif
 
 // Download directory
-#define DOWNLOAD_DIR  "/var/download"
+#define DOWNLOAD_DIR  "var/download"
 
 /* Built-in defines */
-#ifdef WIN32
-#define DEFAULTQPATH    DEFAULTQUEUE
-#else
-#define DEFAULTQPATH    BUILDDIR(HOMEDIR,DEFAULTQUEUE)
-#endif
 
 #ifndef WIN32
-#define OSSECCONF       "/etc/ossec.conf"
-#define DEFAULTCPATH    BUILDDIR(HOMEDIR,OSSECCONF)
+#define OSSECCONF       "etc/ossec.conf"
 #else
 #define OSSECCONF       "ossec.conf"
-#define DEFAULTCPATH    "ossec.conf"
-#endif
-
-#ifndef WIN32
-#define DEFAULTARPATH           BUILDDIR(HOMEDIR,DEFAULTAR)
-#define AR_BINDIRPATH           BUILDDIR(HOMEDIR,AR_BINDIR)
-#define AGENTLESSDIRPATH        BUILDDIR(HOMEDIR,AGENTLESSDIR)
-#define AGENTLESSPASSPATH       BUILDDIR(HOMEDIR,AGENTLESSPASS)
-#define AGENTLESS_ENTRYDIRPATH  BUILDDIR(HOMEDIR,AGENTLESS_ENTRYDIR)
-#else
-#define DEFAULTARPATH           "shared/ar.conf"
-#define AR_BINDIRPATH           "active-response/bin"
-#define AGENTLESSDIRPATH        AGENTLESSDIR
-#define AGENTLESSPASSPATH       AGENTLESSPASS
-#define AGENTLESS_ENTRYDIRPATH  AGENTLESS_ENTRYDIR
-#endif
-#define EXECQUEUEPATH           BUILDDIR(HOMEDIR,EXECQUEUE)
-#define CFGASSESSMENTQUEUEPATH  BUILDDIR(HOMEDIR,CFGAQUEUE)
-
-#define EXECQUEUEPATHAPI        BUILDDIR(HOMEDIR,EXECQUEUEA)
-
-#ifdef WIN32
-#define SHAREDCFG_DIRPATH   SHAREDCFG_DIR
-#else
-#define SHAREDCFG_DIRPATH   BUILDDIR(HOMEDIR,SHAREDCFG_DIR)
 #endif
 
 #define SHAREDCFG_FILE      SHAREDCFG_DIR "/merged.mg"
-#ifdef WIN32
-#define SHAREDCFG_FILEPATH  SHAREDCFG_DIRPATH "/merged.mg"
-#else
-#define SHAREDCFG_FILEPATH  BUILDDIR(HOMEDIR,SHAREDCFG_DIR "/merged.mg")
-#endif
 #define SHAREDCFG_FILENAME  "merged.mg"
-
-#define WAIT_FILE_PATH  BUILDDIR(HOMEDIR,WAIT_FILE)
 
 #define MAX_QUEUED_EVENTS_PATH "/proc/sys/fs/inotify/max_queued_events"
 
 #define TMP_DIR "tmp"
-#define TMP_PATH BUILDDIR(HOMEDIR,TMP_DIR)
 
 /* Windows COMSPEC */
 #define COMSPEC "C:\\Windows\\System32\\cmd.exe"
@@ -509,7 +392,7 @@ https://www.gnu.org/licenses/gpl.html\n"
 
 #define CLOCK_LENGTH 256
 
-#define SECURITY_CONFIGURATION_ASSESSMENT_DIR   "/ruleset/sca"
+#define SECURITY_CONFIGURATION_ASSESSMENT_DIR       "ruleset/sca"
 
 #define SECURITY_CONFIGURATION_ASSESSMENT_DIR_WIN   "ruleset\\sca"
 

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -51,7 +51,7 @@ typedef struct _enrollment_target_cfg {
  */
 typedef struct _enrollment_cert_cfg {
     char *ciphers;              /**> chipers string (default DEFAULT_CIPHERS) */
-    char *authpass_file;        /**> password file (default AUTHDPASS_PATH) */
+    char *authpass_file;        /**> password file (default AUTHD_PASS) */
     char *authpass;             /**> override password file for password verification */
     char *agent_cert;           /**> Agent Certificate (null if not used) */
     char *agent_key;            /**> Agent Key (null if not used) */

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -27,7 +27,7 @@
 #include <libproc.h>
 #endif
 
-#define OS_PIDFILE  "/var/run"
+#define OS_PIDFILE  "var/run"
 #define UCS2_LE 1
 #define UCS2_BE 2
 

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -163,11 +163,9 @@ void os_set_agent_crypto_method(keystore * keys,const int method);
 
 /** Remote IDs directories and internal definitions */
 #ifndef WIN32
-#define RIDS_DIR        "/queue/rids"
-#define RIDS_DIR_PATH   BUILDDIR(HOMEDIR,RIDS_DIR)
+#define RIDS_DIR        "queue/rids"
 #else
 #define RIDS_DIR        "rids"
-#define RIDS_DIR_PATH   RIDS_DIR
 #endif
 
 #define SENDER_COUNTER  "sender_counter"

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -273,7 +273,4 @@ extern const char *__local_name;
 #include "bzip2_op.h"
 #include "enrollment_op.h"
 
-// Global Wazuh home directory
-extern char *home_path;
-
 #endif /* SHARED_H */

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -119,7 +119,7 @@ void * lccom_main(__attribute__((unused)) void * arg) {
 
     mdebug1("Local requests thread ready");
 
-    if (sock = OS_BindUnixDomain(BUILDDIR(HOMEDIR,LC_LOCAL_SOCK), SOCK_STREAM, OS_MAXSTR), sock < 0) {
+    if (sock = OS_BindUnixDomain(LC_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
         merror("Unable to bind to socket '%s': (%d) %s.", LC_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1951,24 +1951,24 @@ void * w_output_thread(void * args){
             if (result != 0) {
                 if (result != 1) {
 #ifdef CLIENT
-                    merror("Unable to send message to '%s' (wazuh-agentd might be down). Attempting to reconnect.", DEFAULTQPATH);
+                    merror("Unable to send message to '%s' (wazuh-agentd might be down). Attempting to reconnect.", DEFAULTQUEUE);
 #else
-                    merror("Unable to send message to '%s' (wazuh-analysisd might be down). Attempting to reconnect.", DEFAULTQPATH);
+                    merror("Unable to send message to '%s' (wazuh-analysisd might be down). Attempting to reconnect.", DEFAULTQUEUE);
 #endif
                 }
                 // Retry to connect infinitely.
-                logr_queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
+                logr_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
-                minfo("Successfully reconnected to '%s'", DEFAULTQPATH);
+                minfo("Successfully reconnected to '%s'", DEFAULTQUEUE);
 
                 if (result = SendMSGtoSCK(logr_queue, message->buffer, message->file, message->queue_mq, message->log_target),
                     result != 0) {
                     // We reconnected but are still unable to send the message, notify it and go on.
                     if (result != 1) {
 #ifdef CLIENT
-                        merror("Unable to send message to '%s' after a successfull reconnection...", DEFAULTQPATH);
+                        merror("Unable to send message to '%s' after a successfull reconnection...", DEFAULTQUEUE);
 #else
-                        merror("Unable to send message to '%s' after a successfull reconnection...", DEFAULTQPATH);
+                        merror("Unable to send message to '%s' after a successfull reconnection...", DEFAULTQUEUE);
 #endif
                     }
                     result = 1;
@@ -2610,11 +2610,11 @@ STATIC void w_initialize_file_status() {
     /* Read json file to load last read positions */
     FILE * fd = NULL;
 
-    if (fd = fopen(LOCALFILE_STATUS_PATH, "r"), fd != NULL) {
+    if (fd = fopen(LOCALFILE_STATUS, "r"), fd != NULL) {
         char str[OS_MAXSTR] = {0};
 
         if (fread(str, 1, OS_MAXSTR - 1, fd) < 1) {
-            merror(FREAD_ERROR, LOCALFILE_STATUS_PATH, errno, strerror(errno));
+            merror(FREAD_ERROR, LOCALFILE_STATUS, errno, strerror(errno));
             clearerr(fd);
         } else {
             cJSON * global_json = cJSON_Parse(str);
@@ -2624,7 +2624,7 @@ STATIC void w_initialize_file_status() {
 
         fclose(fd);
     } else if (errno != ENOENT) {
-        merror_exit(FOPEN_ERROR, LOCALFILE_STATUS_PATH, errno, strerror(errno));
+        merror_exit(FOPEN_ERROR, LOCALFILE_STATUS, errno, strerror(errno));
     }
 }
 
@@ -2638,14 +2638,14 @@ STATIC void w_save_file_status() {
     FILE * fd = NULL;
     size_t size_str = strlen(str);
 
-    if (fd = wfopen(LOCALFILE_STATUS_PATH, "w"), fd != NULL) {
+    if (fd = wfopen(LOCALFILE_STATUS, "w"), fd != NULL) {
         if (fwrite(str, 1, size_str, fd) == 0) {
-            merror(FWRITE_ERROR, LOCALFILE_STATUS_PATH, errno, strerror(errno));
+            merror(FWRITE_ERROR, LOCALFILE_STATUS, errno, strerror(errno));
             clearerr(fd);
         }
         fclose(fd);
     } else {
-        merror_exit(FOPEN_ERROR, LOCALFILE_STATUS_PATH, errno, strerror(errno));
+        merror_exit(FOPEN_ERROR, LOCALFILE_STATUS, errno, strerror(errno));
     }
 
     os_free(str);

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -25,10 +25,9 @@
 
 ///< JSON path wich contains the files position of last read
 #ifdef WIN32
-#define LOCALFILE_STATUS_PATH   "queue\\logcollector\\file_status.json"
+#define LOCALFILE_STATUS   "queue\\logcollector\\file_status.json"
 #else
-#define LOCALFILE_STATUS        "/queue/logcollector/file_status.json"
-#define LOCALFILE_STATUS_PATH   BUILDDIR(HOMEDIR,LOCALFILE_STATUS)
+#define LOCALFILE_STATUS        "queue/logcollector/file_status.json"
 #endif
 
 ///< JSON fields for file_status

--- a/src/logcollector/main.c
+++ b/src/logcollector/main.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
                 print_version();
                 break;
             case 'h':
-                help_logcollector();
+                help_logcollector(home_path);
                 break;
             case 'd':
                 nowDebug();

--- a/src/logcollector/main.c
+++ b/src/logcollector/main.c
@@ -40,7 +40,7 @@ static void help_logcollector()
     print_out("                to increase the debug level.");
     print_out("    -t          Test configuration");
     print_out("    -f          Run in foreground");
-    print_out("    -c <config> Configuration file to use (default: %s)", DEFAULTCPATH);
+    print_out("    -c <config> Configuration file to use (default: %s)", OSSECCONF);
     print_out(" ");
     exit(1);
 }
@@ -51,7 +51,10 @@ int main(int argc, char **argv)
     int debug_level = 0;
     int test_config = 0, run_foreground = 0;
     home_path = w_homedir(argv[0]);
-    const char *cfg = DEFAULTCPATH;
+    if (chdir(home_path) != 0) {
+        merror(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    const char *cfg = OSSECCONF;
     gid_t gid;
     const char *group = GROUPGLOBAL;
     lc_debug_level = getDefine_Int("logcollector", "debug", 0, 2);
@@ -179,8 +182,8 @@ int main(int argc, char **argv)
     mdebug1(STARTED_MSG);
 
     /* Start the queue */
-    if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
-        merror_exit(QUEUE_FATAL, DEFAULTQPATH);
+    if ((logr_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
+        merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 
     /* Main loop */

--- a/src/logcollector/main.c
+++ b/src/logcollector/main.c
@@ -42,6 +42,7 @@ static void help_logcollector(char * home_path)
     print_out("    -f          Run in foreground");
     print_out("    -c <config> Configuration file to use (default: %s/%s)", home_path, OSSECCONF);
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -100,6 +101,8 @@ int main(int argc, char **argv)
 
     }
 
+    os_free(home_path);
+    
     /* Check if the group given is valid */
     gid = Privsep_GetGroup(group);
     if (gid == (gid_t) - 1) {
@@ -193,6 +196,5 @@ int main(int argc, char **argv)
     /* Main loop */
     LogCollectorStart();
 
-    os_free(home_path);
     return (0);
 }

--- a/src/logcollector/main.c
+++ b/src/logcollector/main.c
@@ -25,11 +25,11 @@
 #include "logcollector.h"
 
 /* Prototypes */
-static void help_logcollector(void) __attribute__((noreturn));
+static void help_logcollector(char * home_path) __attribute__((noreturn));
 
 
 /* Print help statement */
-static void help_logcollector()
+static void help_logcollector(char * home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtf] [-c config]", ARGV0);
@@ -40,7 +40,7 @@ static void help_logcollector()
     print_out("                to increase the debug level.");
     print_out("    -t          Test configuration");
     print_out("    -f          Run in foreground");
-    print_out("    -c <config> Configuration file to use (default: %s)", OSSECCONF);
+    print_out("    -c <config> Configuration file to use (default: %s/%s)", home_path, OSSECCONF);
     print_out(" ");
     exit(1);
 }
@@ -50,10 +50,17 @@ int main(int argc, char **argv)
     int c;
     int debug_level = 0;
     int test_config = 0, run_foreground = 0;
-    home_path = w_homedir(argv[0]);
-    if (chdir(home_path) != 0) {
-        merror(CHDIR_ERROR, home_path, errno, strerror(errno));
+
+    /* Set the name */
+    OS_SetName(ARGV0);
+
+    // Define current working directory
+    char * home_path = w_homedir(argv[0]);
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
     }
+    mdebug1(WAZUH_HOMEDIR, home_path);
+
     const char *cfg = OSSECCONF;
     gid_t gid;
     const char *group = GROUPGLOBAL;
@@ -61,9 +68,6 @@ int main(int argc, char **argv)
 
     /* Setup random */
     srandom_init();
-
-    /* Set the name */
-    OS_SetName(ARGV0);
 
     while ((c = getopt(argc, argv, "Vtdhfc:")) != -1) {
         switch (c) {
@@ -90,7 +94,7 @@ int main(int argc, char **argv)
                 test_config = 1;
                 break;
             default:
-                help_logcollector();
+                help_logcollector(home_path);
                 break;
         }
 
@@ -179,7 +183,7 @@ int main(int argc, char **argv)
         merror_exit(PID_ERROR);
     }
 
-    mdebug1(STARTED_MSG);
+    minfo(STARTUP_MSG, (int)getpid());
 
     /* Start the queue */
     if ((logr_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {

--- a/src/logcollector/state.c
+++ b/src/logcollector/state.c
@@ -108,13 +108,13 @@ STATIC void w_logcollector_state_dump() {
 
     FILE * lc_state_file = NULL;
 
-    if (lc_state_file = fopen(LOGCOLLECTOR_STATE_PATH, "w"), lc_state_file != NULL) {
+    if (lc_state_file = fopen(LOGCOLLECTOR_STATE, "w"), lc_state_file != NULL) {
         if (fwrite(lc_state_str, sizeof(char), len + 1, lc_state_file) < 1) {
-            merror(FWRITE_ERROR, LOGCOLLECTOR_STATE_PATH, errno, strerror(errno));
+            merror(FWRITE_ERROR, LOGCOLLECTOR_STATE, errno, strerror(errno));
         }
         fclose(lc_state_file);
     } else {
-        merror(FOPEN_ERROR, LOGCOLLECTOR_STATE_PATH, errno, strerror(errno));
+        merror(FOPEN_ERROR, LOGCOLLECTOR_STATE, errno, strerror(errno));
     }
 
     os_free(lc_state_str);

--- a/src/logcollector/state.h
+++ b/src/logcollector/state.h
@@ -13,10 +13,9 @@
 #include "shared.h"
 
 #ifdef WIN32
-#define LOGCOLLECTOR_STATE_PATH "wazuh-logcollector.state"
+#define LOGCOLLECTOR_STATE      "wazuh-logcollector.state"
 #else
-#define LOGCOLLECTOR_STATE      "/var/run/wazuh-logcollector.state"
-#define LOGCOLLECTOR_STATE_PATH BUILDDIR(HOMEDIR,LOGCOLLECTOR_STATE)
+#define LOGCOLLECTOR_STATE      "var/run/wazuh-logcollector.state"
 #endif
 
 // Double of max value of logcollector.queue_size

--- a/src/monitord/main.c
+++ b/src/monitord/main.c
@@ -14,11 +14,11 @@
 #include "os_net/os_net.h"
 
 /* Prototypes */
-static void help_monitord(void) __attribute__((noreturn));
+static void help_monitord(char * home_path) __attribute__((noreturn));
 
 
 /* Print help statement */
-static void help_monitord()
+static void help_monitord(char * home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtf] [-u user] [-g group] [-c config] [-D dir]", ARGV0);
@@ -31,8 +31,8 @@ static void help_monitord()
     print_out("    -f          Run in foreground");
     print_out("    -u <user>   User to run as (default: %s)", USER);
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
-    print_out("    -c <config> Configuration file to use (default: %s)", DEFAULTCPATH);
-    print_out("    -D <dir>    Directory to chroot into (default: %s)", HOMEDIR);
+    print_out("    -c <config> Configuration file to use (default: %s)", OSSECCONF);
+    print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
     print_out("    -n          Disable agent monitoring.");
     print_out("    -w <sec>    Time (sec.) to wait before rotating logs and alerts.");
     print_out(" ");
@@ -45,11 +45,9 @@ int main(int argc, char **argv)
     int no_agents = 0;
     uid_t uid;
     gid_t gid;
-    home_path = w_homedir(argv[0]);
-    const char *dir = HOMEDIR;
     const char *user = USER;
     const char *group = GROUPGLOBAL;
-    const char *cfg = DEFAULTCPATH;
+    const char *cfg = OSSECCONF;
     short day_wait = -1;
     char * end;
     int debug_level = 0;
@@ -60,13 +58,19 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
+    char * home_path = w_homedir(argv[0]);
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
+
     while ((c = getopt(argc, argv, "Vdhtfu:g:D:c:nw:")) != -1) {
         switch (c) {
             case 'V':
                 print_version();
                 break;
             case 'h':
-                help_monitord();
+                help_monitord(home_path);
                 break;
             case 'd':
                 nowDebug();
@@ -91,7 +95,7 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-D needs an argument");
                 }
-                dir = optarg;
+                home_path = optarg;
                 break;
             case 'c':
                 if (!optarg) {
@@ -116,7 +120,7 @@ int main(int argc, char **argv)
 
                 break;
             default:
-                help_monitord();
+                help_monitord(home_path);
                 break;
         }
 
@@ -130,10 +134,6 @@ int main(int argc, char **argv)
             debug_level--;
         }
     }
-
-    /* Start daemon */
-    mdebug1(STARTED_MSG);
-    mdebug1(WAZUH_HOMEDIR, home_path);
 
     /*Check if the user/group given are valid */
     uid = Privsep_GetUser(user);
@@ -226,8 +226,8 @@ int main(int argc, char **argv)
     }
 
     /* chroot */
-    if (Privsep_Chroot(dir) < 0) {
-        merror_exit(CHROOT_ERROR, dir, errno, strerror(errno));
+    if (Privsep_Chroot(home_path) < 0) {
+        merror_exit(CHROOT_ERROR, home_path, errno, strerror(errno));
     }
 
     nowChroot();
@@ -237,7 +237,7 @@ int main(int argc, char **argv)
         merror_exit(SETUID_ERROR, user, errno, strerror(errno));
     }
 
-    mdebug1(PRIVSEP_MSG, dir, user);
+    mdebug1(PRIVSEP_MSG, home_path, user);
 
     /* Signal manipulation */
     StartSIG(ARGV0);

--- a/src/monitord/main.c
+++ b/src/monitord/main.c
@@ -31,11 +31,12 @@ static void help_monitord(char * home_path)
     print_out("    -f          Run in foreground");
     print_out("    -u <user>   User to run as (default: %s)", USER);
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
-    print_out("    -c <config> Configuration file to use (default: %s)", OSSECCONF);
-    print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
+    print_out("    -c <config> Configuration file to use (default: %s/%s)", home_path, OSSECCONF);
+    print_out("    -D <dir>    Directory to chroot and chdir into (default: %s)", home_path);
     print_out("    -n          Disable agent monitoring.");
     print_out("    -w <sec>    Time (sec.) to wait before rotating logs and alerts.");
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -59,9 +60,6 @@ int main(int argc, char **argv)
     OS_SetName(ARGV0);
 
     char * home_path = w_homedir(argv[0]);
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
     mdebug1(WAZUH_HOMEDIR, home_path);
 
     while ((c = getopt(argc, argv, "Vdhtfu:g:D:c:nw:")) != -1) {
@@ -95,7 +93,8 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-D needs an argument");
                 }
-                home_path = optarg;
+                os_free(home_path);
+                os_strdup(optarg, home_path);
                 break;
             case 'c':
                 if (!optarg) {

--- a/src/monitord/main.c
+++ b/src/monitord/main.c
@@ -59,8 +59,8 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
+    // Define current working directory
     char * home_path = w_homedir(argv[0]);
-    mdebug1(WAZUH_HOMEDIR, home_path);
 
     while ((c = getopt(argc, argv, "Vdhtfu:g:D:c:nw:")) != -1) {
         switch (c) {
@@ -124,6 +124,12 @@ int main(int argc, char **argv)
         }
 
     }
+
+    /* Change working directory */
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     if (debug_level == 0) {
         /* Get debug level */

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -41,9 +41,9 @@ void Monitord()
     snprintf(path_json, PATH_MAX, "%s", LOGJSONFILE);
 #else
     /* /var/ossec/logs/ossec.log */
-    snprintf(path, PATH_MAX, "%s", isChroot() ? LOGFILE : BUILDDIR(HOMEDIR,LOGFILE));
+    snprintf(path, PATH_MAX, "%s", LOGFILE);
     /* /var/ossec/logs/ossec.json */
-    snprintf(path_json, PATH_MAX, "%s", isChroot() ? LOGJSONFILE : BUILDDIR(HOMEDIR,LOGJSONFILE));
+    snprintf(path_json, PATH_MAX, "%s", LOGJSONFILE);
 #endif
 
     /* Connect to the message queue or exit */

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -75,11 +75,11 @@ void w_rotate_log(int compress, int keep_log_days, int new_day, int rotate_json,
     strcpy(base_dir, "logs");
 #else
     // /var/ossec/logs/ossec.log
-    snprintf(old_path, PATH_MAX, "%s", isChroot() ? LOGFILE : BUILDDIR(HOMEDIR,LOGFILE));
+    snprintf(old_path, PATH_MAX, "%s", LOGFILE);
     // /var/ossec/logs/ossec.json
-    snprintf(old_path_json, PATH_MAX, "%s", isChroot() ? LOGJSONFILE : BUILDDIR(HOMEDIR,LOGJSONFILE));
+    snprintf(old_path_json, PATH_MAX, "%s", LOGJSONFILE);
     // /var/ossec/logs/ossec
-    snprintf(base_dir, PATH_MAX, "%s/logs/ossec", isChroot() ? "" : HOMEDIR);
+    snprintf(base_dir, PATH_MAX, "%s/logs/ossec", "");
 #endif
 
     os_snprintf(year_dir, PATH_MAX, "%s/%d", base_dir, tm.tm_year + 1900);

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -242,7 +242,7 @@ w_err_t w_auth_add_agent(char *response, const char *ip, const char *agentname, 
     /* Add the agent to the centralized configuration group */
     if(groups) {
         char path[PATH_MAX];
-        if (snprintf(path, PATH_MAX, isChroot() ? GROUPS_DIR "/%s" : BUILDDIR(HOMEDIR,GROUPS_DIR "/%s"), keys.keyentries[index]->id) >= PATH_MAX) {
+        if (snprintf(path, PATH_MAX, GROUPS_DIR "/%s", keys.keyentries[index]->id) >= PATH_MAX) {
             merror("At set_agent_group(): file path too large for agent '%s'.", keys.keyentries[index]->id);
             OS_RemoveAgent(keys.keyentries[index]->id);
             merror("Unable to set agent centralized group: %s (internal error)", groups);
@@ -281,7 +281,7 @@ w_err_t w_auth_validate_groups(const char *groups, char *response) {
             break;
         }
 
-        snprintf(dir, PATH_MAX + 1, isChroot() ? SHAREDCFG_DIR"/%s" : BUILDDIR(HOMEDIR,SHAREDCFG_DIR"/%s"), group);
+        snprintf(dir, PATH_MAX + 1, SHAREDCFG_DIR "/%s", group);
         dp = opendir(dir);
         if (!dp) {
             merror("Invalid group: %.255s",group);

--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -39,8 +39,8 @@
 #include <openssl/bio.h>
 
 extern BIO *bio_err;
-#define KEYFILE  "/etc/sslmanager.key"
-#define CERTFILE "/etc/sslmanager.cert"
+#define KEYFILE  "etc/sslmanager.key"
+#define CERTFILE "etc/sslmanager.cert"
 #define DEFAULT_CIPHERS "HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH"
 #define DEFAULT_PORT 1515
 #define DEFAULT_CENTRALIZED_GROUP "default"

--- a/src/os_auth/local-server.c
+++ b/src/os_auth/local-server.c
@@ -88,7 +88,9 @@ void* run_local_server(__attribute__((unused)) void *arg) {
     mdebug1("Local server thread ready.");
 
     if (sock = OS_BindUnixDomain(AUTH_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s': '%s'. Closing local server.", AUTH_LOCAL_SOCK, strerror(errno));
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(OSSECCONF, buffer, PATH_MAX);
+        merror("Unable to bind to socket '%s': '%s'. Closing local server.", buffer, strerror(errno));
         return NULL;
     }
 
@@ -362,7 +364,6 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
         }
     }
 
-
     if (index = OS_AddNewAgent(&keys, id, name, ip, key), index < 0) {
         ierror = EKEY;
         goto fail;
@@ -371,7 +372,7 @@ cJSON* local_add(const char *id, const char *name, const char *ip, char *groups,
 
     if(groups) {
         char path[PATH_MAX];
-        if (snprintf(path, PATH_MAX, isChroot() ? GROUPS_DIR "/%s" : BUILDDIR(HOMEDIR,GROUPS_DIR "/%s"), keys.keyentries[index]->id) >= PATH_MAX) {
+        if (snprintf(path, PATH_MAX, GROUPS_DIR "/%s", keys.keyentries[index]->id) >= PATH_MAX) {
             ierror = EINVGROUP;
             goto fail;
         }

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -120,9 +120,9 @@ int main(int argc, char **argv)
                 break;
             case 'D':
                 if (!optarg) {
-                    merror_exit("-g needs an argument");
+                    merror_exit("-%c needs an argument", c);
                 }
-                mwarn(DEPRECATED_OPTION_WARN, "-D", DEFAULTCPATH);
+                mwarn(DEPRECATED_OPTION_WARN, "-D", home_path);
                 break;
 #endif
             case 't':

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -45,7 +45,7 @@ static void help_agent_auth(const char * home_path)
     print_out("    -t          Test configuration.");
 #ifndef WIN32
     print_out("    -g <group>  Group to run as (default: %s).", GROUPGLOBAL);
-    print_out("    -D <dir>    Directory to chroot into (default: %s).", home_path);
+    print_out("    -D <dir>    Directory to chroot and chdir into (default: %s).", home_path);
     os_free(home_path);
 #endif
     print_out("    -m <addr>   Manager IP address.");

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -30,10 +30,10 @@
 #undef ARGV0
 #define ARGV0 "agent-auth"
 
-static void help_agent_auth(void) __attribute__((noreturn));
+static void help_agent_auth(const char * home_path) __attribute__((noreturn));
 
 /* Print help statement */
-static void help_agent_auth()
+static void help_agent_auth(const char * home_path)
 {
     print_header();
     print_out("  %s: -[Vhdti] [-g group] [-D dir] [-m IP address] [-p port] [-A name] [-c ciphers] [-v path] [-x path] [-k path] [-P pass] [-G group] [-I IP address]", ARGV0);
@@ -45,7 +45,8 @@ static void help_agent_auth()
     print_out("    -t          Test configuration.");
 #ifndef WIN32
     print_out("    -g <group>  Group to run as (default: %s).", GROUPGLOBAL);
-    print_out("    -D <dir>    Directory to chroot into (default: %s).", FALLBACKDIR);
+    print_out("    -D <dir>    Directory to chroot into (default: %s).", home_path);
+    os_free(home_path);
 #endif
     print_out("    -m <addr>   Manager IP address.");
     print_out("    -p <port>   Manager port (default: %d).", DEFAULT_PORT);
@@ -92,7 +93,6 @@ int main(int argc, char **argv)
         merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
     }
     mdebug1(WAZUH_HOMEDIR, home_path);
-    os_free(home_path);
 #endif
 
     while ((c = getopt(argc, argv, "VdhtG:m:p:A:c:v:x:k:D:P:aI:i"
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
                 print_version();
                 break;
             case 'h':
-                help_agent_auth();
+                help_agent_auth(home_path);
                 break;
             case 'd':
                 debug_level = 1;
@@ -198,10 +198,12 @@ int main(int argc, char **argv)
                 target_cfg->use_src_ip = 1;
                 break;
             default:
-                help_agent_auth();
+                help_agent_auth(home_path);
                 break;
         }
     }
+
+    os_free(home_path);
 
     if (optind < argc) {
         mwarn("Extra arguments detected. They will be ignored.");

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -30,10 +30,10 @@
 #undef ARGV0
 #define ARGV0 "agent-auth"
 
-static void help_agent_auth(const char * home_path) __attribute__((noreturn));
+static void help_agent_auth(char * home_path) __attribute__((noreturn));
 
 /* Print help statement */
-static void help_agent_auth(const char * home_path)
+static void help_agent_auth(char * home_path)
 {
     print_header();
     print_out("  %s: -[Vhdti] [-g group] [-D dir] [-m IP address] [-p port] [-A name] [-c ciphers] [-v path] [-x path] [-k path] [-P pass] [-G group] [-I IP address]", ARGV0);
@@ -46,7 +46,6 @@ static void help_agent_auth(const char * home_path)
 #ifndef WIN32
     print_out("    -g <group>  Group to run as (default: %s).", GROUPGLOBAL);
     print_out("    -D <dir>    Directory to chroot and chdir into (default: %s).", home_path);
-    os_free(home_path);
 #endif
     print_out("    -m <addr>   Manager IP address.");
     print_out("    -p <port>   Manager port (default: %d).", DEFAULT_PORT);
@@ -61,6 +60,7 @@ static void help_agent_auth(const char * home_path)
     print_out("    -I <IP>     Set the agent IP address.");
     print_out("    -i          Let the agent IP address be set by the manager connection.");
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -105,7 +105,11 @@ int main(int argc, char **argv)
                 print_version();
                 break;
             case 'h':
+#ifndef WIN32
                 help_agent_auth(home_path);
+#else
+                help_agent_auth(NULL);
+#endif
                 break;
             case 'd':
                 debug_level = 1;
@@ -198,12 +202,18 @@ int main(int argc, char **argv)
                 target_cfg->use_src_ip = 1;
                 break;
             default:
+#ifndef WIN32
                 help_agent_auth(home_path);
+#else
+                help_agent_auth(NULL);
+#endif
                 break;
         }
     }
 
+#ifndef WIN32
     os_free(home_path);
+#endif
 
     if (optind < argc) {
         mwarn("Extra arguments detected. They will be ignored.");
@@ -265,11 +275,11 @@ int main(int argc, char **argv)
     }
 
     w_enrollment_ctx *cfg = w_enrollment_init(target_cfg, cert_cfg);
-    int ret = w_enrollment_request_key(cfg, server_address); 
-    
+    int ret = w_enrollment_request_key(cfg, server_address);
+
     w_enrollment_target_destroy(target_cfg);
     w_enrollment_cert_destroy(cert_cfg);
     w_enrollment_destroy(cfg);
-    
+
     exit((ret == 0) ? 0 : 1);
 }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -70,7 +70,7 @@ pthread_cond_t cond_pending = PTHREAD_COND_INITIALIZER;
 
 
 /* Print help statement */
-static void help_authd()
+static void help_authd(const char * home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtfi] [-g group] [-D dir] [-p port] [-P] [-c ciphers] [-v path [-s]] [-x path] [-k path]", ARGV0);
@@ -80,7 +80,7 @@ static void help_authd()
     print_out("    -t          Test configuration.");
     print_out("    -f          Run in foreground.");
     print_out("    -g <group>  Group to run as. Default: %s.", GROUPGLOBAL);
-    print_out("    -D <dir>    Directory to chroot into. Default: %s.", FALLBACKDIR);
+    print_out("    -D <dir>    Directory to chroot into. Default: %s.", home_path);
     print_out("    -p <port>   Manager port. Default: %d.", DEFAULT_PORT);
     print_out("    -P          Enable shared password authentication, at %s or random.", AUTHD_PASS);
     print_out("    -c          SSL cipher list (default: %s)", DEFAULT_CIPHERS);
@@ -91,6 +91,7 @@ static void help_authd()
     print_out("    -a          Auto select SSL/TLS method. Default: TLS v1.2 only.");
     print_out("    -L          Force insertion though agent limit reached.");
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -164,6 +165,9 @@ int main(int argc, char **argv)
     pthread_t thread_local_server = 0;
     fd_set fdset;
 
+    /* Set the name */
+    OS_SetName(ARGV0);
+
     // Define current working directory
     char * home_path = w_homedir(argv[0]);
     if (chdir(home_path) == -1) {
@@ -173,9 +177,6 @@ int main(int argc, char **argv)
 
     /* Initialize some variables */
     bio_err = 0;
-
-    /* Set the name */
-    OS_SetName(ARGV0);
 
     // Get options
 
@@ -197,7 +198,7 @@ int main(int argc, char **argv)
                     break;
 
                 case 'h':
-                    help_authd();
+                    help_authd(home_path);
                     break;
 
                 case 'd':
@@ -294,7 +295,7 @@ int main(int argc, char **argv)
                     break;
 
                 default:
-                    help_authd();
+                    help_authd(home_path);
                     break;
             }
         }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -34,7 +34,7 @@
 #include "os_err.h"
 
 /* Prototypes */
-static void help_authd(void) __attribute((noreturn));
+static void help_authd(const char * home_path) __attribute((noreturn));
 static int ssl_error(const SSL *ssl, int ret);
 
 /* Thread for dispatching connection pool */

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -207,7 +207,7 @@ int main(int argc, char **argv)
                     break;
 
                 case 'i':
-                    mwarn(DEPRECATED_OPTION_WARN, "-i", DEFAULTCPATH);
+                    mwarn(DEPRECATED_OPTION_WARN, "-i", OSSECCONF);
                     break;
 
                 case 'g':
@@ -221,7 +221,7 @@ int main(int argc, char **argv)
                     if (!optarg) {
                         merror_exit("-D needs an argument");
                     }
-                    dir = optarg;
+                    snprintf(home_path, PATH_MAX, "%s", optarg);
                     break;
 
                 case 't':
@@ -279,11 +279,11 @@ int main(int argc, char **argv)
                     break;
 
                 case 'F':
-                    mwarn(DEPRECATED_OPTION_WARN, "-F", DEFAULTCPATH);
+                    mwarn(DEPRECATED_OPTION_WARN, "-F", OSSECCONF);
                     break;
 
                 case 'r':
-                    mwarn(DEPRECATED_OPTION_WARN, "-r", DEFAULTCPATH);
+                    mwarn(DEPRECATED_OPTION_WARN, "-r", OSSECCONF);
                     break;
 
                 case 'a':
@@ -301,8 +301,10 @@ int main(int argc, char **argv)
         }
 
         // Return -1 if not configured
-        if (authd_read_config(DEFAULTCPATH) < 0) {
-            merror_exit(CONFIG_ERROR, DEFAULTCPATH);
+        if (authd_read_config(OSSECCONF) < 0) {
+            char buffer[PATH_MAX] = {'\0'};
+            abspath(OSSECCONF, buffer, PATH_MAX);
+            merror_exit(CONFIG_ERROR, buffer);
         }
 
         // Overwrite arguments

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -82,12 +82,12 @@ static void help_authd(const char * home_path)
     print_out("    -g <group>  Group to run as. Default: %s.", GROUPGLOBAL);
     print_out("    -D <dir>    Directory to chroot into. Default: %s.", home_path);
     print_out("    -p <port>   Manager port. Default: %d.", DEFAULT_PORT);
-    print_out("    -P          Enable shared password authentication, at %s or random.", AUTHD_PASS);
+    print_out("    -P          Enable shared password authentication, at %s/%s or random.", home_path, AUTHD_PASS);
     print_out("    -c          SSL cipher list (default: %s)", DEFAULT_CIPHERS);
     print_out("    -v <path>   Full path to CA certificate used to verify clients.");
     print_out("    -s          Used with -v, enable source host verification.");
-    print_out("    -x <path>   Full path to server certificate. Default: %s.", CERTFILE);
-    print_out("    -k <path>   Full path to server key. Default: %s.", KEYFILE);
+    print_out("    -x <path>   Full path to server certificate. Default: %s/%s.", home_path, CERTFILE);
+    print_out("    -k <path>   Full path to server key. Default: %s/%s.", home_path, KEYFILE);
     print_out("    -a          Auto select SSL/TLS method. Default: TLS v1.2 only.");
     print_out("    -L          Force insertion though agent limit reached.");
     print_out(" ");
@@ -170,9 +170,6 @@ int main(int argc, char **argv)
 
     // Define current working directory
     char * home_path = w_homedir(argv[0]);
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
     mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* Initialize some variables */

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -170,7 +170,6 @@ int main(int argc, char **argv)
 
     // Define current working directory
     char * home_path = w_homedir(argv[0]);
-    mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* Initialize some variables */
     bio_err = 0;
@@ -296,6 +295,12 @@ int main(int argc, char **argv)
                     break;
             }
         }
+
+        /* Change working directory */
+        if (chdir(home_path) == -1) {
+            merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+        }
+        mdebug1(WAZUH_HOMEDIR, home_path);
 
         // Return -1 if not configured
         if (authd_read_config(OSSECCONF) < 0) {

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -34,7 +34,7 @@
 #include "os_err.h"
 
 /* Prototypes */
-static void help_authd(const char * home_path) __attribute((noreturn));
+static void help_authd(char * home_path) __attribute((noreturn));
 static int ssl_error(const SSL *ssl, int ret);
 
 /* Thread for dispatching connection pool */
@@ -70,7 +70,7 @@ pthread_cond_t cond_pending = PTHREAD_COND_INITIALIZER;
 
 
 /* Print help statement */
-static void help_authd(const char * home_path)
+static void help_authd(char * home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtfi] [-g group] [-D dir] [-p port] [-P] [-c ciphers] [-v path [-s]] [-x path] [-k path]", ARGV0);

--- a/src/os_auth/ssl.c
+++ b/src/os_auth/ssl.c
@@ -59,12 +59,12 @@ SSL_CTX *os_ssl_keys(int is_server, const char *os_dir, const char *ciphers, con
         char default_key[PATH_MAX + 1];
 
         if (!cert) {
-            snprintf(default_cert, PATH_MAX + 1, "%s%s", os_dir, CERTFILE);
+            snprintf(default_cert, PATH_MAX + 1, "%s/%s", os_dir, CERTFILE);
             cert = default_cert;
         }
 
         if (!key) {
-            snprintf(default_key, PATH_MAX + 1, "%s%s", os_dir, KEYFILE);
+            snprintf(default_key, PATH_MAX + 1, "%s/%s", os_dir, KEYFILE);
             key = default_key;
         }
 

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -144,17 +144,21 @@ int OS_CheckKeys()
 {
     FILE *fp;
 
-    if (File_DateofChange(KEYSFILE_PATH) < 0) {
-        merror(NO_AUTHFILE, KEYSFILE_PATH);
+    if (File_DateofChange(KEYS_FILE) < 0) {
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(KEYS_FILE, buffer, PATH_MAX);
+        merror(NO_AUTHFILE, buffer);
         merror(NO_CLIENT_KEYS);
         return (0);
     }
 
-    fp = fopen(KEYSFILE_PATH, "r");
+    fp = fopen(KEYS_FILE, "r");
     if (!fp) {
         /* We can leave from here */
-        merror(FOPEN_ERROR, KEYSFILE_PATH, errno, strerror(errno));
-        merror(NO_AUTHFILE, KEYSFILE_PATH);
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(KEYS_FILE, buffer, PATH_MAX);
+        merror(FOPEN_ERROR, buffer, errno, strerror(errno));
+        merror(NO_AUTHFILE, buffer);
         merror(NO_CLIENT_KEYS);
         return (0);
     }
@@ -170,7 +174,7 @@ void OS_ReadKeys(keystore *keys, int rehash_keys, int save_removed)
 {
     FILE *fp;
 
-    const char *keys_file = isChroot() ? KEYS_FILE : KEYSFILE_PATH;
+    const char *keys_file = KEYS_FILE;
     char buffer[OS_BUFFER_SIZE + 1];
     char name[KEYSIZE + 1];
     char ip[KEYSIZE + 1];
@@ -557,7 +561,7 @@ int OS_WriteKeys(const keystore *keys) {
     File file;
     char cidr[20];
 
-    if (TempFile(&file, isChroot() ? AUTH_FILE : KEYSFILE_PATH, 0) < 0)
+    if (TempFile(&file, KEYS_FILE, 0) < 0)
         return -1;
 
     for (i = 0; i < keys->keysize; i++) {
@@ -573,7 +577,7 @@ int OS_WriteKeys(const keystore *keys) {
 
     fclose(file.fp);
 
-    if (OS_MoveFile(file.name, isChroot() ? AUTH_FILE : KEYSFILE_PATH) < 0) {
+    if (OS_MoveFile(file.name, KEYS_FILE) < 0) {
         free(file.name);
         return -1;
     }

--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -86,13 +86,9 @@ void OS_StartCounter(keystore *keys)
     for (i = 0; i <= keys->keysize; i++) {
         /* On i == keysize, we deal with the sender counter */
         if (i == keys->keysize) {
-            snprintf(rids_file, OS_FLSIZE, "%s/%s",
-                     isChroot() ? RIDS_DIR : RIDS_DIR_PATH,
-                     SENDER_COUNTER);
+            snprintf(rids_file, OS_FLSIZE, "%s/%s", RIDS_DIR, SENDER_COUNTER);
         } else {
-            snprintf(rids_file, OS_FLSIZE, "%s/%s",
-                     isChroot() ? RIDS_DIR : RIDS_DIR_PATH,
-                     keys->keyentries[i]->id);
+            snprintf(rids_file, OS_FLSIZE, "%s/%s", RIDS_DIR, keys->keyentries[i]->id);
         }
 
         keys->keyentries[i]->fp = fopen(rids_file, "r+");
@@ -184,7 +180,7 @@ static void StoreCounter(const keystore *keys, int id, unsigned int global, unsi
 {
     if (!keys->keyentries[id]->fp) {
         char rids_file[OS_FLSIZE + 1];
-        snprintf(rids_file, OS_FLSIZE, "%s/%s", isChroot() ? RIDS_DIR : RIDS_DIR_PATH, keys->keyentries[id]->id);
+        snprintf(rids_file, OS_FLSIZE, "%s/%s", RIDS_DIR, keys->keyentries[id]->id);
         keys->keyentries[id]->fp = fopen(rids_file, "r+");
         if (!keys->keyentries[id]->fp) {
             keys->keyentries[id]->fp = fopen(rids_file, "w");
@@ -219,7 +215,7 @@ static void ReloadCounter(const keystore *keys, unsigned int id, const char * ci
     ino_t new_inode;
     char rids_file[OS_FLSIZE + 1];
 
-    snprintf(rids_file, OS_FLSIZE, "%s/%s", isChroot() ? RIDS_DIR : RIDS_DIR_PATH, cid);
+    snprintf(rids_file, OS_FLSIZE, "%s/%s", RIDS_DIR, cid);
     new_inode = File_Inode(rids_file);
 
     if (keys->keyentries[id]->inode != new_inode) {

--- a/src/os_csyslogd/main.c
+++ b/src/os_csyslogd/main.c
@@ -49,8 +49,8 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
+    // Define current working directory
     char * home_path = w_homedir(argv[0]);
-    mdebug1(WAZUH_HOMEDIR, home_path);
 
     while ((c = getopt(argc, argv, "Vdhtfu:g:D:c:")) != -1) {
         switch (c) {
@@ -99,6 +99,12 @@ int main(int argc, char **argv)
                 break;
         }
     }
+
+    /* Change working directory */
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* Check if the user/group given are valid */
     uid = Privsep_GetUser(user);

--- a/src/os_csyslogd/main.c
+++ b/src/os_csyslogd/main.c
@@ -11,11 +11,11 @@
 #include "csyslogd.h"
 
 /* Prototypes */
-static void help_csyslogd(void) __attribute__((noreturn));
+static void help_csyslogd(char * home_path) __attribute__((noreturn));
 
 
 /* Print help statement */
-static void help_csyslogd()
+static void help_csyslogd(char * home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtf] [-u user] [-g group] [-c config] [-D dir]", ARGV0);
@@ -28,8 +28,8 @@ static void help_csyslogd()
     print_out("    -f          Run in foreground");
     print_out("    -u <user>   User to run as (default: %s)", MAILUSER);
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
-    print_out("    -c <config> Configuration file to use (default: %s)", DEFAULTCPATH);
-    print_out("    -D <dir>    Directory to chroot into (default: %s)", HOMEDIR);
+    print_out("    -c <config> Configuration file to use (default: %s)", OSSECCONF);
+    print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
     print_out(" ");
     exit(1);
 }
@@ -41,15 +41,19 @@ int main(int argc, char **argv)
     gid_t gid;
 
     /* Use MAILUSER (read only) */
-    home_path = w_homedir(argv[0]);
-    const char *dir = HOMEDIR;
-
     const char *user = MAILUSER;
     const char *group = GROUPGLOBAL;
-    const char *cfg = DEFAULTCPATH;
+    const char *cfg = OSSECCONF;
 
     /* Set the name */
     OS_SetName(ARGV0);
+
+    // Define current working directory
+    char * home_path = w_homedir(argv[0]);
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     while ((c = getopt(argc, argv, "Vdhtfu:g:D:c:")) != -1) {
         switch (c) {
@@ -57,7 +61,7 @@ int main(int argc, char **argv)
                 print_version();
                 break;
             case 'h':
-                help_csyslogd();
+                help_csyslogd(home_path);
                 break;
             case 'd':
                 nowDebug();
@@ -81,7 +85,7 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-D needs an argument");
                 }
-                dir = optarg;
+                home_path = optarg;
                 break;
             case 'c':
                 if (!optarg) {
@@ -93,14 +97,10 @@ int main(int argc, char **argv)
                 test_config = 1;
                 break;
             default:
-                help_csyslogd();
+                help_csyslogd(home_path);
                 break;
         }
     }
-
-    /* Start daemon */
-    mdebug1(STARTED_MSG);
-    mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* Check if the user/group given are valid */
     uid = Privsep_GetUser(user);
@@ -153,8 +153,8 @@ int main(int argc, char **argv)
     }
 
     /* chroot */
-    if (Privsep_Chroot(dir) < 0) {
-        merror_exit(CHROOT_ERROR, dir, errno, strerror(errno));
+    if (Privsep_Chroot(home_path) < 0) {
+        merror_exit(CHROOT_ERROR, home_path, errno, strerror(errno));
     }
 
     /* Now in chroot */
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
     w_create_thread(csyscom_main, NULL);
 
     /* Basic start up completed */
-    mdebug1(PRIVSEP_MSG, dir, user);
+    mdebug1(PRIVSEP_MSG, home_path, user);
 
     /* Signal manipulation */
     StartSIG(ARGV0);

--- a/src/os_csyslogd/main.c
+++ b/src/os_csyslogd/main.c
@@ -28,9 +28,10 @@ static void help_csyslogd(char * home_path)
     print_out("    -f          Run in foreground");
     print_out("    -u <user>   User to run as (default: %s)", MAILUSER);
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
-    print_out("    -c <config> Configuration file to use (default: %s)", OSSECCONF);
-    print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
+    print_out("    -c <config> Configuration file to use (default: %s/%s)", home_path, OSSECCONF);
+    print_out("    -D <dir>    Directory to chroot and chdir into (default: %s)", home_path);
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -48,11 +49,7 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
-    // Define current working directory
     char * home_path = w_homedir(argv[0]);
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
     mdebug1(WAZUH_HOMEDIR, home_path);
 
     while ((c = getopt(argc, argv, "Vdhtfu:g:D:c:")) != -1) {
@@ -85,7 +82,8 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-D needs an argument");
                 }
-                home_path = optarg;
+                os_free(home_path);
+                os_strdup(optarg, home_path);
                 break;
             case 'c':
                 if (!optarg) {

--- a/src/os_dbd/main.c
+++ b/src/os_dbd/main.c
@@ -19,7 +19,7 @@
 static void print_db_info(void);
 static void cleanup();
 static void handler(int signum);
-static void help_dbd(const char *home_path) __attribute__((noreturn));
+static void help_dbd(char *home_path) __attribute__((noreturn));
 
 
 /* Print information regarding enabled databases */
@@ -39,7 +39,7 @@ static void print_db_info()
 }
 
 /* Print help statement */
-static void help_dbd(const char *home_path)
+static void help_dbd(char *home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtfv] [-u user] [-g group] [-c config] [-D dir]", ARGV0);
@@ -73,8 +73,8 @@ int main(int argc, char **argv)
     const char *user = MAILUSER;
     const char *group = GROUPGLOBAL;
     const char *cfg = OSSECCONF;
-    const char *home_path = w_homedir(argv[0]);
-	
+    char *home_path = w_homedir(argv[0]);
+
     /* Database Structure */
     DBConfig db_config;
     db_config.error_count = 0;

--- a/src/os_dbd/main.c
+++ b/src/os_dbd/main.c
@@ -266,7 +266,7 @@ int main(int argc, char **argv)
 
     /* Basic start up completed */
     mdebug1(PRIVSEP_MSG, home_path, user);
-	os_free(home_path);
+    os_free(home_path);
 
     /* Signal manipulation */
     StartSIG(ARGV0);

--- a/src/os_dbd/main.c
+++ b/src/os_dbd/main.c
@@ -19,7 +19,7 @@
 static void print_db_info(void);
 static void cleanup();
 static void handler(int signum);
-static void help_dbd(char *home_path) __attribute__((noreturn));
+static void help_dbd(const char *home_path) __attribute__((noreturn));
 
 
 /* Print information regarding enabled databases */
@@ -39,7 +39,7 @@ static void print_db_info()
 }
 
 /* Print help statement */
-static void help_dbd(char *home_path)
+static void help_dbd(const char *home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtfv] [-u user] [-g group] [-c config] [-D dir]", ARGV0);

--- a/src/os_dbd/main.c
+++ b/src/os_dbd/main.c
@@ -140,9 +140,6 @@ int main(int argc, char **argv)
     char absPath[PATH_MAX] = {'\0'};
     abspath(OSSECCONF, absPath, PATH_MAX);
 
-    /* Start daemon */
-    mdebug1(WAZUH_HOMEDIR, home_path);
-
     /* Setup random */
     srandom_init();
 
@@ -269,6 +266,7 @@ int main(int argc, char **argv)
 
     /* Basic start up completed */
     mdebug1(PRIVSEP_MSG, home_path, user);
+	os_free(home_path);
 
     /* Signal manipulation */
     StartSIG(ARGV0);
@@ -279,7 +277,6 @@ int main(int argc, char **argv)
     /* The real daemon now */
     OS_DBD(&db_config);
 
-    os_free(home_path);
     return (0);
 }
 

--- a/src/os_dbd/main.c
+++ b/src/os_dbd/main.c
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
                 print_version();
                 break;
             case 'h':
-                help_dbd();
+                help_dbd(home_path);
                 break;
             case 'd':
                 nowDebug();

--- a/src/os_dbd/main.c
+++ b/src/os_dbd/main.c
@@ -53,11 +53,12 @@ static void help_dbd(const char *home_path)
     print_out("    -u <user>   User to run as (default: %s)", MAILUSER);
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
     print_out("    -c <config> Configuration file to use (default: %s/%s)", home_path, OSSECCONF);
-    print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
+    print_out("    -D <dir>    Directory to chroot and chdir into (default: %s)", home_path);
     print_out(" ");
     print_out("  Database Support:");
     print_db_info();
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -69,10 +70,10 @@ int main(int argc, char **argv)
     unsigned int d;
 
     /* Use MAILUSER (read only) */
-    const char *home_path = w_homedir(argv[0]);
     const char *user = MAILUSER;
     const char *group = GROUPGLOBAL;
     const char *cfg = OSSECCONF;
+    const char *home_path = w_homedir(argv[0]);
 	
     /* Database Structure */
     DBConfig db_config;
@@ -80,13 +81,6 @@ int main(int argc, char **argv)
 
     /* Set the name */
     OS_SetName(ARGV0);
-
-    /* Change working directory */
-    if (chdir(home_path) == -1) {
-        merror(CHDIR_ERROR, home_path, errno, strerror(errno));
-        os_free(home_path);
-        exit(1);
-    }
 
     while ((c = getopt(argc, argv, "Vdhtfu:g:D:c:")) != -1) {
         switch (c) {
@@ -134,6 +128,13 @@ int main(int argc, char **argv)
                 help_dbd(home_path);
                 break;
         }
+    }
+
+    /* Change working directory */
+    if (chdir(home_path) == -1) {
+        merror(CHDIR_ERROR, home_path, errno, strerror(errno));
+        os_free(home_path);
+        exit(1);
     }
 
     /* Get absolute path */

--- a/src/os_execd/config.c
+++ b/src/os_execd/config.c
@@ -210,11 +210,7 @@ cJSON *getClusterConfig(void) {
 
     cJSON *cluster_config_cJSON;
 
-    if (isChroot()) {
-        strcpy(sockname, CLUSTER_SOCK);
-    } else {
-        strcpy(sockname, BUILDDIR(HOMEDIR,CLUSTER_SOCK));
-    }
+    strcpy(sockname, CLUSTER_SOCK);
 
     if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock < 0) {
         switch (errno) {

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -92,7 +92,7 @@ int ReadExecConfig()
             /* Write the full command path */
             snprintf(exec_cmd[exec_size], OS_FLSIZE,
                      "%s/%s",
-                     AR_BINDIRPATH,
+                     AR_BINDIR,
                      str_pt);
             process_file = fopen(exec_cmd[exec_size], "r");
             if (!process_file) {
@@ -161,7 +161,7 @@ char *GetCommandbyName(const char *name, int *timeout)
     if (name[0] == '!') {
         static char command[OS_FLSIZE];
 
-        if (snprintf(command, sizeof(command), "%s/%s", AR_BINDIRPATH, name + 1) >= (int)sizeof(command)) {
+        if (snprintf(command, sizeof(command), "%s/%s", AR_BINDIR, name + 1) >= (int)sizeof(command)) {
             mwarn("Cannot execute command '%32s...': path too long.", name + 1);
             return NULL;
         }

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -39,9 +39,9 @@ int ReadExecConfig()
     exec_size = 0;
 
     /* Open file */
-    fp = fopen(DEFAULTARPATH, "r");
+    fp = fopen(DEFAULTAR, "r");
     if (!fp) {
-        merror(FOPEN_ERROR, DEFAULTARPATH, errno, strerror(errno));
+        merror(FOPEN_ERROR, DEFAULTAR, errno, strerror(errno));
         return (0);
     }
 
@@ -55,14 +55,14 @@ int ReadExecConfig()
         // The command name must not start with '!'
 
         if (buffer[0] == '!') {
-            merror(EXEC_INV_CONF, DEFAULTARPATH);
+            merror(EXEC_INV_CONF, DEFAULTAR);
             continue;
         }
 
         /* Clean up the buffer */
         tmp_str = strstr(buffer, " - ");
         if (!tmp_str) {
-            merror(EXEC_INV_CONF, DEFAULTARPATH);
+            merror(EXEC_INV_CONF, DEFAULTAR);
             continue;
         }
         *tmp_str = '\0';
@@ -77,7 +77,7 @@ int ReadExecConfig()
         /* Search for ' ' and - */
         tmp_str = strstr(tmp_str, " - ");
         if (!tmp_str) {
-            merror(EXEC_INV_CONF, DEFAULTARPATH);
+            merror(EXEC_INV_CONF, DEFAULTAR);
             continue;
         }
         *tmp_str = '\0';

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -59,6 +59,7 @@ static void help_execd(char * home_path)
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
     print_out("    -c <config> Configuration file to use (default: %s/%s)", home_path, OSSECCONF);
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -156,6 +157,8 @@ int main(int argc, char **argv)
         }
     }
 
+    os_free(home_path);
+
     if (debug_level == 0) {
         /* Get debug level */
         debug_level = getDefine_Int("execd", "debug", 0, 2);
@@ -227,7 +230,6 @@ int main(int argc, char **argv)
     /* The real daemon Now */
     ExecdStart(m_queue);
 
-    os_free(home_path);
     exit(0);
 }
 

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -126,7 +126,7 @@ int main(int argc, char **argv)
                 print_version();
                 break;
             case 'h':
-                help_execd();
+                help_execd(home_path);
                 break;
             case 'd':
                 debug_level = 1;
@@ -151,7 +151,7 @@ int main(int argc, char **argv)
                 test_config = 1;
                 break;
             default:
-                help_execd();
+                help_execd(home_path);
                 break;
         }
     }

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -117,11 +117,7 @@ size_t wcom_unmerge(const char *file_path, char ** output){
         return strlen(*output);
     }
 
-#ifndef WIN32
-    if (UnmergeFiles(final_path, isChroot() ? INCOMING_DIR : BUILDDIR(HOMEDIR,INCOMING_DIR), OS_BINARY) == 0) {
-#else
     if (UnmergeFiles(final_path, INCOMING_DIR, OS_BINARY) == 0) {
-#endif
         merror("At WCOM unmerge: Error unmerging file '%s.'", final_path);
         os_strdup("err Cannot unmerge file", *output);
         return strlen(*output);
@@ -193,10 +189,7 @@ size_t wcom_restart(char ** output) {
     if (lock <= 0) {
 #ifndef WIN32
 
-        char *exec_cmd[3] = { BUILDDIR(HOMEDIR,"/bin/wazuh-control"), "restart", NULL};
-        if (isChroot()) {
-            strcpy(exec_cmd[0], "/bin/wazuh-control");
-        }
+        char *exec_cmd[3] = { "bin/wazuh-control", "restart", NULL};
 
         switch (fork()) {
             case -1:
@@ -281,11 +274,7 @@ size_t wcom_getconfig(const char * section, char ** output) {
         int sock = -1;
         char sockname[PATH_MAX + 1] = {0};
 
-        if (isChroot()) {
-            strcpy(sockname, CLUSTER_SOCK);
-        } else {
-            strcpy(sockname, BUILDDIR(HOMEDIR,CLUSTER_SOCK));
-        }
+        strcpy(sockname, CLUSTER_SOCK);
 
         if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock < 0) {
             os_strdup("err Unable to connect with socket. The component might be disabled", *output);
@@ -326,7 +315,7 @@ void * wcom_main(__attribute__((unused)) void * arg) {
 
     mdebug1("Local requests thread ready");
 
-    if (sock = OS_BindUnixDomain(BUILDDIR(HOMEDIR,COM_LOCAL_SOCK), SOCK_STREAM, OS_MAXSTR), sock < 0) {
+    if (sock = OS_BindUnixDomain(COM_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
         merror("Unable to bind to socket '%s': (%d) %s.", COM_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }
@@ -401,7 +390,7 @@ int _jailfile(char finalpath[PATH_MAX + 1], const char * basedir, const char * f
     }
 
 #ifndef WIN32
-    return snprintf(finalpath, PATH_MAX + 1, "%s/%s/%s", isChroot() ? "" : HOMEDIR, basedir, filename) > PATH_MAX ? -1 : 0;
+    return snprintf(finalpath, PATH_MAX + 1, "%s/%s", basedir, filename) > PATH_MAX ? -1 : 0;
 #else
     return snprintf(finalpath, PATH_MAX + 1, "%s\\%s", basedir, filename) > PATH_MAX ? -1 : 0;
 #endif

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -216,7 +216,7 @@ size_t wcom_restart(char ** output) {
         }
 #else
         static char command[OS_FLSIZE];
-        snprintf(command, sizeof(command), "%s/%s", AR_BINDIRPATH, "restart-wazuh.exe");
+        snprintf(command, sizeof(command), "%s/%s", AR_BINDIR, "restart-wazuh.exe");
         char *cmd[2] = { command, NULL };
         char *cmd_parameters = "{\"version\":1,\"origin\":{\"name\":\"\",\"module\":\"wazuh-execd\"},\"command\":\"add\",\"parameters\":{\"extra_args\":[],\"alert\":{},\"program\":\"restart-wazuh.exe\"}}";
         wfd_t *wfd = wpopenv(cmd[0], cmd, W_BIND_STDIN);

--- a/src/os_execd/win_execd.c
+++ b/src/os_execd/win_execd.c
@@ -63,7 +63,7 @@ static void WinExecd_Shutdown()
 int WinExecd_Start()
 {
     int c;
-    char *cfg = DEFAULTCPATH;
+    char *cfg = OSSECCONF;
     winexec_queue = queue_init(OS_SIZE_128);
 
     /* Read config */

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -389,7 +389,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
             if(temp_file_created == 1)
             {
                 int dbg_lvl = isDebug();
-                snprintf(exec_full_cmd, 4095, "%s %s %s %s %s", absPath, exec_tmp_file, integrator_config[s]->apikey == NULL ? "" : integrator_config[s]->apikey, integrator_config[s]->hookurl == NULL ? "" : integrator_config[s]->hookurl, dbg_lvl <= 0 ? "" : "debug");
+                os_snprintf(exec_full_cmd, 4095, "%s %s %s %s %s", absPath, exec_tmp_file, integrator_config[s]->apikey == NULL ? "" : integrator_config[s]->apikey, integrator_config[s]->hookurl == NULL ? "" : integrator_config[s]->hookurl, dbg_lvl <= 0 ? "" : "debug");
                 if (dbg_lvl <= 0) strcat(exec_full_cmd, " > /dev/null 2>&1");
 
                 mdebug1("Running: %s", exec_full_cmd);
@@ -419,7 +419,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                         } else {
                             merror("Command (%s) execution exited abnormally.", exec_full_cmd);
                         }
-                        
+
                     } else {
                         merror("Could not launch command %s (%d)", strerror(errno), errno);
                     }

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -51,12 +51,16 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
         mdebug1("JSON file queue connected.");
     }
 
+    /* Get absolulte path */
+    char absPath[PATH_MAX] = {'\0'};
+    abspath(INTEGRATORDIR, absPath, PATH_MAX);
+
     /* Connecting to syslog. */
     while(integrator_config[s])
     {
         integrator_config[s]->enabled = 1;
 
-        snprintf(integration_path, 2048 -1, "%s/%s", INTEGRATORDIRPATH, integrator_config[s]->name);
+        snprintf(integration_path, 2048 -1, "%s/%s", INTEGRATORDIR, integrator_config[s]->name);
         if(File_DateofChange(integration_path) > 0)
         {
             os_strdup(integration_path, integrator_config[s]->path);
@@ -64,7 +68,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
         else
         {
             integrator_config[s]->enabled = 0;
-            merror("Unable to enable integration for: '%s'. File not found inside '%s'.", integrator_config[s]->name, INTEGRATORDIRPATH);
+            merror("Unable to enable integration for: '%s'. File not found inside '%s'.", integrator_config[s]->name, absPath);
             s++;
             continue;
         }
@@ -385,7 +389,7 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
             if(temp_file_created == 1)
             {
                 int dbg_lvl = isDebug();
-                snprintf(exec_full_cmd, 4095, "%s %s %s %s %s", integrator_config[s]->path, exec_tmp_file, integrator_config[s]->apikey == NULL ? "" : integrator_config[s]->apikey, integrator_config[s]->hookurl == NULL ? "" : integrator_config[s]->hookurl, dbg_lvl <= 0 ? "" : "debug");
+                snprintf(exec_full_cmd, 4095, "%s %s %s %s %s", absPath, exec_tmp_file, integrator_config[s]->apikey == NULL ? "" : integrator_config[s]->apikey, integrator_config[s]->hookurl == NULL ? "" : integrator_config[s]->hookurl, dbg_lvl <= 0 ? "" : "debug");
                 if (dbg_lvl <= 0) strcat(exec_full_cmd, " > /dev/null 2>&1");
 
                 mdebug1("Running: %s", exec_full_cmd);
@@ -406,8 +410,8 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
                                 // 127 means error in exec
                                 merror("Couldn't execute command (%s). Check file and permissions.", exec_full_cmd);
                             } else if(wstatus != 0){
-                                merror("Unable to run integration for %s -> %s",  integrator_config[s]->name, integrator_config[s]->path);
-                                merror("While running %s -> %s. Output: %s ",  integrator_config[s]->name, integrator_config[s]->path, buffer);
+                                merror("Unable to run integration for %s -> %s",  integrator_config[s]->name, absPath);
+                                merror("While running %s -> %s. Output: %s ",  integrator_config[s]->name, absPath, buffer);
                                 merror("Exit status was: %d", wstatus);
                             } else {
                                 mdebug1("Command ran successfully");

--- a/src/os_integrator/intgcom.c
+++ b/src/os_integrator/intgcom.c
@@ -75,8 +75,10 @@ void * intgcom_main(__attribute__((unused)) void * arg) {
 
     mdebug1("Local requests thread ready");
 
-    if (sock = OS_BindUnixDomain(BUILDDIR(HOMEDIR,INTG_LOCAL_SOCK), SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s': (%d) %s.", INTG_LOCAL_SOCK, errno, strerror(errno));
+    if (sock = OS_BindUnixDomain(INTG_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
+		char absPath[PATH_MAX] = {'\0'};
+		abspath(INTG_LOCAL_SOCK, absPath, PATH_MAX);
+        merror("Unable to bind to socket '%s': (%d) %s.", absPath, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/os_integrator/main.c
+++ b/src/os_integrator/main.c
@@ -105,9 +105,6 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Starting daemon */
-    mdebug1(WAZUH_HOMEDIR, home_path);
-
     /* Check if the user/group given are valid */
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);
@@ -166,6 +163,7 @@ int main(int argc, char **argv)
 
     /* Basic start up completed. */
     mdebug1(PRIVSEP_MSG, home_path, user);
+	os_free(home_path);
 
     /* Signal manipulation */
     StartSIG(ARGV0);
@@ -180,6 +178,5 @@ int main(int argc, char **argv)
     /* the real daemon now */
     OS_IntegratorD(integrator_config);
 
-    os_free(home_path);
     exit(0);
 }

--- a/src/os_integrator/main.c
+++ b/src/os_integrator/main.c
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
 
     /* Basic start up completed. */
     mdebug1(PRIVSEP_MSG, home_path, user);
-	os_free(home_path);
+    os_free(home_path);
 
     /* Signal manipulation */
     StartSIG(ARGV0);

--- a/src/os_integrator/main.c
+++ b/src/os_integrator/main.c
@@ -45,16 +45,22 @@ int main(int argc, char **argv)
 
     /* Highly recommended not to run as root. However, some integrations
      * may require it. */
-    home_path = w_homedir(argv[0]);
-    char *dir = HOMEDIR;
+    const char *home_path = w_homedir(argv[0]);
     char *user = MAILUSER;
     char *group = GROUPGLOBAL;
-    char *cfg = DEFAULTCPATH;
+    char *cfg = OSSECCONF;
 
     integrator_config = NULL;
 
     /* Setting the name */
     OS_SetName(ARGV0);
+
+	/* Change working directory */
+    if (chdir(home_path) == -1) {
+        merror(CHDIR_ERROR, home_path, errno, strerror(errno));
+        os_free(home_path);
+        exit(1);
+    }
 
     while((c = getopt(argc, argv, "Vdhtfu:g:")) != -1){
         switch(c){
@@ -100,7 +106,6 @@ int main(int argc, char **argv)
     }
 
     /* Starting daemon */
-    mdebug1(STARTED_MSG);
     mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* Check if the user/group given are valid */
@@ -160,7 +165,7 @@ int main(int argc, char **argv)
     w_create_thread(intgcom_main, NULL);
 
     /* Basic start up completed. */
-    mdebug1(PRIVSEP_MSG ,dir,user);
+    mdebug1(PRIVSEP_MSG, home_path, user);
 
     /* Signal manipulation */
     StartSIG(ARGV0);

--- a/src/os_integrator/main.c
+++ b/src/os_integrator/main.c
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
 
     /* Highly recommended not to run as root. However, some integrations
      * may require it. */
-    const char *home_path = w_homedir(argv[0]);
+    char *home_path = w_homedir(argv[0]);
     char *user = MAILUSER;
     char *group = GROUPGLOBAL;
     char *cfg = OSSECCONF;

--- a/src/os_maild/mailcom.c
+++ b/src/os_maild/mailcom.c
@@ -102,8 +102,8 @@ void * mailcom_main(__attribute__((unused)) void * arg) {
     mdebug1("Local requests thread ready");
 
     if (sock = OS_BindUnixDomain(socket_path, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-		char absPath[PATH_MAX] = {'\0'};
-		abspath(MAIL_LOCAL_SOCK, absPath, PATH_MAX);
+        char absPath[PATH_MAX] = {'\0'};
+        abspath(MAIL_LOCAL_SOCK, absPath, PATH_MAX);
         merror("Unable to bind to socket '%s': (%d) %s.", absPath, errno, strerror(errno));
         return NULL;
     }

--- a/src/os_maild/mailcom.c
+++ b/src/os_maild/mailcom.c
@@ -97,16 +97,14 @@ void * mailcom_main(__attribute__((unused)) void * arg) {
     fd_set fdset;
     char socket_path[PATH_MAX + 1] = {0};
 
-    snprintf(socket_path,PATH_MAX,"%s",BUILDDIR(HOMEDIR,MAIL_LOCAL_SOCK));
-
-    if(isChroot()){
-        snprintf(socket_path,PATH_MAX,"%s",MAIL_LOCAL_SOCK);
-    }
+    snprintf(socket_path,PATH_MAX,"%s", MAIL_LOCAL_SOCK);
 
     mdebug1("Local requests thread ready");
 
     if (sock = OS_BindUnixDomain(socket_path, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror("Unable to bind to socket '%s': (%d) %s.", MAIL_LOCAL_SOCK, errno, strerror(errno));
+		char absPath[PATH_MAX] = {'\0'};
+		abspath(MAIL_LOCAL_SOCK, absPath, PATH_MAX);
+        merror("Unable to bind to socket '%s': (%d) %s.", absPath, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -126,8 +126,8 @@ int main(int argc, char **argv)
 
     /* Read configuration */
     if (MailConf(test_config, cfg, &mail) < 0) {
-		char absPath[PATH_MAX] = {'\0'};
-		abspath(OSSECCONF, absPath, PATH_MAX);
+        char absPath[PATH_MAX] = {'\0'};
+        abspath(OSSECCONF, absPath, PATH_MAX);
         merror_exit(CONFIG_ERROR, absPath);
     }
 
@@ -203,6 +203,7 @@ int main(int argc, char **argv)
     }
 
     mdebug1(PRIVSEP_MSG, home_path, user);
+	os_free(home_path);
 
     // Start com request thread
     w_create_thread(mailcom_main, NULL);
@@ -221,7 +222,6 @@ int main(int argc, char **argv)
     /* The real daemon now */
     OS_Run(&mail);
 
-    os_free(home_path);
     return (0);
 }
 

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -44,8 +44,9 @@ static void help_maild(const char *home_path)
     print_out("    -u <user>   User to run as (default: %s)", MAILUSER);
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
     print_out("    -c <config> Configuration file to use (default: %s/%s)", home_path, OSSECCONF);
-    print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
+    print_out("    -D <dir>    Directory to chroot and chdir into (default: %s)", home_path);
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -61,13 +62,6 @@ int main(int argc, char **argv)
 
     /* Set the name */
     OS_SetName(ARGV0);
-
-	/* Change working directory */
-    if (chdir(home_path) == -1) {
-        merror(CHDIR_ERROR, home_path, errno, strerror(errno));
-        os_free(home_path);
-        exit(1);
-    }
 
     while ((c = getopt(argc, argv, "Vdhtfu:g:D:c:")) != -1) {
         switch (c) {
@@ -115,6 +109,13 @@ int main(int argc, char **argv)
                 help_maild(home_path);
                 break;
         }
+    }
+
+    /* Change working directory */
+    if (chdir(home_path) == -1) {
+        merror(CHDIR_ERROR, home_path, errno, strerror(errno));
+        os_free(home_path);
+        exit(1);
     }
 
     /* Check if the user/group given are valid */

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -24,13 +24,13 @@ char _g_subject[SUBJECT_SIZE + 2];
 
 /* Prototypes */
 static void OS_Run(MailConfig *mail) __attribute__((nonnull)) __attribute__((noreturn));
-static void help_maild(const char *home_path) __attribute__((noreturn));
+static void help_maild(char *home_path) __attribute__((noreturn));
 
 /* Mail Structure */
 MailConfig mail;
 
 /* Print help statement */
-static void help_maild(const char *home_path)
+static void help_maild(char *home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtf] [-u user] [-g group] [-c config] [-D dir]", ARGV0);
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
     int c, test_config = 0, run_foreground = 0;
     uid_t uid;
     gid_t gid;
-    const char *home_path = w_homedir(argv[0]);
+    char *home_path = w_homedir(argv[0]);
     const char *user = MAILUSER;
     const char *group = GROUPGLOBAL;
     const char *cfg = OSSECCONF;

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -203,7 +203,7 @@ int main(int argc, char **argv)
     }
 
     mdebug1(PRIVSEP_MSG, home_path, user);
-	os_free(home_path);
+    os_free(home_path);
 
     // Start com request thread
     w_create_thread(mailcom_main, NULL);

--- a/src/remoted/ar-forward.c
+++ b/src/remoted/ar-forward.c
@@ -20,7 +20,7 @@ void *AR_Forward(__attribute__((unused)) void *arg)
 {
     int arq = 0;
     int ar_location = 0;
-    const char * path = isChroot() ? ARQUEUE : BUILDDIR(HOMEDIR,ARQUEUE);
+    const char * path = ARQUEUE;
     char *msg_to_send;
     os_calloc(OS_MAXSTR, sizeof(char), msg_to_send);
     char *msg;

--- a/src/remoted/cfga-forward.c
+++ b/src/remoted/cfga-forward.c
@@ -20,7 +20,7 @@ void *SCFGA_Forward(__attribute__((unused)) void *arg)
 {
     int cfgarq = 0;
     char *agent_id;
-    const char * path = isChroot() ? CFGARQUEUE : BUILDDIR(HOMEDIR,CFGARQUEUE);
+    const char * path = CFGARQUEUE;
 
     char msg[OS_SIZE_4096 + 1];
 

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
                 print_version();
                 break;
             case 'h':
-                help_remoted();
+                help_remoted(home_path);
                 break;
             case 'd':
                 nowDebug();
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
                 nocmerged = 1;
                 break;
             default:
-                help_remoted();
+                help_remoted(home_path);
                 break;
         }
     }

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -51,8 +51,8 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
+    // Define current working directory
     char * home_path = w_homedir(argv[0]);
-    mdebug1(WAZUH_HOMEDIR, home_path);
 
     const char *cfg = OSSECCONF;
     const char *user = REMUSER;
@@ -109,6 +109,12 @@ int main(int argc, char **argv)
                 break;
         }
     }
+
+    /* Change working directory */
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* Check current debug_level
      * Command line setting takes precedence

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -35,6 +35,7 @@ static void help_remoted(char *home_path)
     print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
     print_out("    -m          Avoid creating shared merged file (read only)");
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -50,11 +51,7 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
-    // Define current working directory
     char * home_path = w_homedir(argv[0]);
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
     mdebug1(WAZUH_HOMEDIR, home_path);
 
     const char *cfg = OSSECCONF;
@@ -101,7 +98,8 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-D needs an argument");
                 }
-                home_path = optarg;
+                os_free(home_path);
+                os_strdup(optarg, home_path);
                 break;
             case 'm':
                 nocmerged = 1;
@@ -191,6 +189,7 @@ int main(int argc, char **argv)
         merror_exit(CHROOT_ERROR, home_path, errno, strerror(errno));
     }
     nowChroot();
+    os_free(home_path);
 
     /* Start the signal manipulation */
     StartSIG(ARGV0);
@@ -221,6 +220,5 @@ int main(int argc, char **argv)
         }
     }
 
-    os_free(home_path);
     return (0);
 }

--- a/src/remoted/request.c
+++ b/src/remoted/request.c
@@ -50,7 +50,7 @@ void * req_main(__attribute__((unused)) void * arg) {
     unsigned int counter = (unsigned int)os_random();
     char counter_s[COUNTER_LENGTH];
     req_node_t * node;
-    const char * path = isChroot() ? REMOTE_REQ_SOCK : BUILDDIR(HOMEDIR,REMOTE_REQ_SOCK);
+    const char * path = REMOTE_REQ_SOCK;
 
     mdebug1("Running request listener thread.");
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -543,7 +543,7 @@ int _close_sock(keystore * keys, int sock) {
 
 int key_request_connect() {
 #ifndef WIN32
-    return OS_ConnectUnixDomain(isChroot() ? WM_KEY_REQUEST_SOCK : WM_KEY_REQUEST_SOCK_PATH, SOCK_DGRAM, OS_MAXSTR);
+    return OS_ConnectUnixDomain(WM_KEY_REQUEST_SOCK, SOCK_DGRAM, OS_MAXSTR);
 #else
     return -1;
 #endif

--- a/src/remoted/shared_download.c
+++ b/src/remoted/shared_download.c
@@ -532,7 +532,7 @@ void w_create_group(char *group){
 
     char group_path[PATH_MAX] = {0};
 
-    if(snprintf(group_path,PATH_MAX,isChroot() ? "/etc/shared/%s" : BUILDDIR(HOMEDIR,"/etc/shared/%s"), group) >= PATH_MAX){
+    if(snprintf(group_path,PATH_MAX, "/etc/shared/%s", group) >= PATH_MAX){
         mwarn(W_PARSER_GROUP_TOO_LARGE,PATH_MAX);
     }
     else{
@@ -622,7 +622,7 @@ int w_init_shared_download()
         return OS_INVALID;
     }
 
-    snprintf(yaml_file, OS_SIZE_1024, "%s%s/%s", isChroot() ? "" : HOMEDIR, SHAREDCFG_DIR, W_SHARED_YAML_FILE);
+    snprintf(yaml_file, OS_SIZE_1024, "%s/%s", isChroot() ? "" : SHAREDCFG_DIR, W_SHARED_YAML_FILE);
 
     if (w_prepare_parsing() == 1) {
         /* Check download module connection */

--- a/src/remoted/shared_download.c
+++ b/src/remoted/shared_download.c
@@ -622,7 +622,7 @@ int w_init_shared_download()
         return OS_INVALID;
     }
 
-    snprintf(yaml_file, OS_SIZE_1024, "%s/%s", isChroot() ? "" : SHAREDCFG_DIR, W_SHARED_YAML_FILE);
+    snprintf(yaml_file, OS_SIZE_1024, "%s/%s", SHAREDCFG_DIR, W_SHARED_YAML_FILE);
 
     if (w_prepare_parsing() == 1) {
         /* Check download module connection */

--- a/src/remoted/state.c
+++ b/src/remoted/state.c
@@ -58,7 +58,7 @@ int rem_write_state() {
 
     mdebug2("Updating state file.");
 
-    snprintf(path, sizeof(path), OS_PIDFILE "/%s.state", isChroot() ? "" : __local_name);
+    snprintf(path, sizeof(path), OS_PIDFILE "/%s.state", __local_name);
     snprintf(path_temp, sizeof(path_temp), "%s.temp", path);
 
     if (fp = fopen(path_temp, "w"), !fp) {

--- a/src/remoted/state.c
+++ b/src/remoted/state.c
@@ -58,7 +58,7 @@ int rem_write_state() {
 
     mdebug2("Updating state file.");
 
-    snprintf(path, sizeof(path), "%s" OS_PIDFILE "/%s.state", isChroot() ? "" : HOMEDIR, __local_name);
+    snprintf(path, sizeof(path), OS_PIDFILE "/%s.state", isChroot() ? "" : __local_name);
     snprintf(path_temp, sizeof(path_temp), "%s.temp", path);
 
     if (fp = fopen(path_temp, "w"), !fp) {

--- a/src/reportd/report.c
+++ b/src/reportd/report.c
@@ -30,7 +30,7 @@ static void help_reportd(char * home_path)
     print_out("    -s          Show the alert dump");
     print_out("    -u <user>   User to run as (default: %s)", USER);
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
-    print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
+    print_out("    -D <dir>    Directory to chroot and chdir into (default: %s)", home_path);
     print_out("    -f <filter> <value> Filter the results");
     print_out("    -r <filter> <value> Show related entries");
     print_out("    Filters allowed: group, rule, level, location,");
@@ -40,6 +40,7 @@ static void help_reportd(char * home_path)
     print_out("     -f level 10 (to filter on level >= 10)");
     print_out("     -f group authentication -r user srcip (to show srcip for all users)");
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -62,9 +63,6 @@ int main(int argc, char **argv)
     OS_SetName(ARGV0);
 
     char * home_path = w_homedir(argv[0]);
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
     mdebug1(WAZUH_HOMEDIR, home_path);
 
     r_filter.group = NULL;
@@ -146,7 +144,8 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-D needs an argument");
                 }
-                home_path = optarg;
+                os_free(home_path);
+                os_strdup(optarg, home_path);
                 break;
             case 't':
                 test_config = 1;

--- a/src/reportd/report.c
+++ b/src/reportd/report.c
@@ -11,11 +11,11 @@
 #include "shared.h"
 
 /* Prototypes */
-static void help_reportd(void) __attribute__((noreturn));
+static void help_reportd(char * home_path) __attribute__((noreturn));
 
 
 /* Print help statement */
-static void help_reportd()
+static void help_reportd(char * home_path)
 {
     print_header();
     print_out("  Generate reports (via stdin)");
@@ -30,7 +30,7 @@ static void help_reportd()
     print_out("    -s          Show the alert dump");
     print_out("    -u <user>   User to run as (default: %s)", USER);
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
-    print_out("    -D <dir>    Directory to chroot into (default: %s)", HOMEDIR);
+    print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
     print_out("    -f <filter> <value> Filter the results");
     print_out("    -r <filter> <value> Show related entries");
     print_out("    Filters allowed: group, rule, level, location,");
@@ -48,8 +48,6 @@ int main(int argc, char **argv)
     int c, test_config = 0;
     uid_t uid;
     gid_t gid;
-    home_path = w_homedir(argv[0]);
-    const char *dir  = HOMEDIR;
     const char *user = USER;
     const char *group = GROUPGLOBAL;
 
@@ -62,6 +60,12 @@ int main(int argc, char **argv)
 
     /* Set the name */
     OS_SetName(ARGV0);
+
+    char * home_path = w_homedir(argv[0]);
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     r_filter.group = NULL;
     r_filter.rule = NULL;
@@ -89,7 +93,7 @@ int main(int argc, char **argv)
                 print_version();
                 break;
             case 'h':
-                help_reportd();
+                help_reportd(home_path);
                 break;
             case 'd':
                 nowDebug();
@@ -142,7 +146,7 @@ int main(int argc, char **argv)
                 if (!optarg) {
                     merror_exit("-D needs an argument");
                 }
-                dir = optarg;
+                home_path = optarg;
                 break;
             case 't':
                 test_config = 1;
@@ -151,15 +155,11 @@ int main(int argc, char **argv)
                 r_filter.show_alerts = 1;
                 break;
             default:
-                help_reportd();
+                help_reportd(home_path);
                 break;
         }
 
     }
-
-    /* Start daemon */
-    mdebug1(STARTED_MSG);
-    mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* Check if the user/group given are valid */
     uid = Privsep_GetUser(user);
@@ -179,8 +179,8 @@ int main(int argc, char **argv)
     }
 
     /* chroot */
-    if (Privsep_Chroot(dir) < 0) {
-        merror_exit(CHROOT_ERROR, dir, errno, strerror(errno));
+    if (Privsep_Chroot(home_path) < 0) {
+        merror_exit(CHROOT_ERROR, home_path, errno, strerror(errno));
     }
     nowChroot();
 
@@ -189,7 +189,9 @@ int main(int argc, char **argv)
         merror_exit(SETUID_ERROR, user, errno, strerror(errno));
     }
 
-    mdebug1(PRIVSEP_MSG, dir, user);
+    mdebug1(PRIVSEP_MSG, home_path, user);
+
+    os_free(home_path);
 
     /* Signal manipulation */
     StartSIG(ARGV0);
@@ -205,6 +207,5 @@ int main(int argc, char **argv)
     /* The real stuff now */
     os_ReportdStart(&r_filter);
 
-    os_free(home_path);
     exit(0);
 }

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -219,9 +219,6 @@ int rootcheck_init(int test_config, char * home_path)
     if (rootcheck.workdir == NULL) {
         rootcheck.workdir = home_path;
     }
-#ifndef OSSECHIDS
-    os_free(home_path);
-#endif
 #endif
 
 #ifdef OSSECHIDS

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -201,7 +201,6 @@ int rootcheck_init(int test_config)
         mtinfo(ARGV0, "Rootcheck disabled.");
         return (1);
     }
-    mtdebug1(ARGV0, STARTED_MSG);
 
 #ifndef WIN32
     /* Check if Unix audit file is configured */

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -219,7 +219,9 @@ int rootcheck_init(int test_config, char * home_path)
     if (rootcheck.workdir == NULL) {
         rootcheck.workdir = home_path;
     }
+#ifndef OSSECHIDS
     os_free(home_path);
+#endif
 #endif
 
 #ifdef OSSECHIDS

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -47,6 +47,7 @@ void help_rootcheck(char * home_path)
     print_out("    -c <config> Configuration file to use");
     print_out("    -D <dir>    Directory to chroot into (default: %s)", home_path);
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -72,6 +72,8 @@ int rootcheck_init(int test_config, char * home_path)
         merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
     }
     mdebug1(WAZUH_HOMEDIR, home_path);
+#else
+    os_free(home_path);
 #endif
 
     /* Zero the structure, initialize default values */

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -55,10 +55,11 @@ int main(int argc, char **argv)
 {
     int test_config = 0;
     const char *cfg = "./rootcheck.conf";
+    char * home_path = w_homedir(argv[0]);
 
 #else
 
-int rootcheck_init(int test_config)
+int rootcheck_init(int test_config, char * home_path)
 {
     const char *cfg = OSSECCONF;
 
@@ -66,11 +67,12 @@ int rootcheck_init(int test_config)
 
     int c;
 
-    char * home_path = w_homedir(argv[0]);
+#ifndef WIN32
     if (chdir(home_path) == -1) {
         merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
     }
     mdebug1(WAZUH_HOMEDIR, home_path);
+#endif
 
     /* Zero the structure, initialize default values */
     rootcheck.workdir = NULL;
@@ -215,8 +217,8 @@ int rootcheck_init(int test_config)
     if (rootcheck.workdir == NULL) {
         rootcheck.workdir = home_path;
     }
-#endif
     os_free(home_path);
+#endif
 
 #ifdef OSSECHIDS
     /* Start up message */

--- a/src/rootcheck/rootcheck.h
+++ b/src/rootcheck/rootcheck.h
@@ -95,7 +95,7 @@ int del_plist(OSList *p_list);
 int notify_rk(int rk_type, const char *msg);
 
 /* Start the rootcheck externally */
-int rootcheck_init(int test_config);
+int rootcheck_init(int test_config, char * home_path);
 
 /* Connect Rootcheck queue */
 void rootcheck_connect();

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -43,12 +43,16 @@ int notify_rk(int rk_type, const char *msg)
     if (SendMSG(rootcheck.queue, msg, ROOTCHECK, ROOTCHECK_MQ) < 0) {
         mterror(ARGV0, QUEUE_SEND);
 
-        if ((rootcheck.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
-            mterror_exit(ARGV0, QUEUE_FATAL, DEFAULTQPATH);
+        if ((rootcheck.queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
+            char buffer[PATH_MAX] = {'\0'};
+            abspath(DEFAULTQUEUE, buffer, PATH_MAX);
+            mterror_exit(ARGV0, QUEUE_FATAL, buffer);
         }
 
         if (SendMSG(rootcheck.queue, msg, ROOTCHECK, ROOTCHECK_MQ) < 0) {
-            mterror_exit(ARGV0, QUEUE_FATAL, DEFAULTQPATH);
+            char buffer[PATH_MAX] = {'\0'};
+            abspath(DEFAULTQUEUE, buffer, PATH_MAX);
+            mterror_exit(ARGV0, QUEUE_FATAL, buffer);
         }
     }
 #endif

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -76,25 +76,18 @@ char *os_read_agent_name()
 
     mdebug2("Calling os_read_agent_name().");
 
-    if (isChroot()) {
-        fp = fopen(AGENT_INFO_FILE, "r");
-    } else {
-        fp = fopen(AGENT_INFO_FILEP, "r");
-    }
+    fp = fopen(AGENT_INFO_FILE, "r");
 
     /* We give 1 second for the file to be created */
     if (!fp) {
         sleep(1);
-
-        if (isChroot()) {
-            fp = fopen(AGENT_INFO_FILE, "r");
-        } else {
-            fp = fopen(AGENT_INFO_FILEP, "r");
-        }
+        fp = fopen(AGENT_INFO_FILE, "r");
     }
 
     if (!fp) {
-        mdebug1(FOPEN_ERROR, AGENT_INFO_FILE, errno, strerror(errno));
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(AGENT_INFO_FILE, buffer, PATH_MAX);
+        mdebug1(FOPEN_ERROR, buffer, errno, strerror(errno));
         return (NULL);
     }
 
@@ -200,16 +193,12 @@ char *os_read_agent_profile()
     FILE *fp;
 
     mdebug2("Calling os_read_agent_profile().");
-
-    if (isChroot()) {
-        fp = fopen(AGENT_INFO_FILE, "r");
-    } else {
-        fp = fopen(AGENT_INFO_FILEP, "r");
-    }
+    fp = fopen(AGENT_INFO_FILE, "r");
 
     if (!fp) {
-        mdebug2("Failed to open file. Errno=%d.", errno);
-        merror(FOPEN_ERROR, AGENT_INFO_FILE, errno, strerror(errno));
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(AGENT_INFO_FILE, buffer, PATH_MAX);
+        merror(FOPEN_ERROR, buffer, errno, strerror(errno));
         return (NULL);
     }
 
@@ -243,9 +232,9 @@ int os_write_agent_info(const char *agent_name, __attribute__((unused)) const ch
 {
     FILE *fp;
 
-    fp = fopen(isChroot() ? AGENT_INFO_FILE : AGENT_INFO_FILEP, "w");
+    fp = fopen(AGENT_INFO_FILE, "w");
     if (!fp) {
-        merror(FOPEN_ERROR, isChroot() ? AGENT_INFO_FILE : AGENT_INFO_FILEP, errno, strerror(errno));
+        merror(FOPEN_ERROR, AGENT_INFO_FILE, errno, strerror(errno));
         return (0);
     }
 
@@ -267,7 +256,7 @@ int get_agent_group(const char *id, char *group, size_t size) {
     int result = 0;
     FILE *fp;
 
-    if (snprintf(path, PATH_MAX, isChroot() ? GROUPS_DIR "/%s" : BUILDDIR(HOMEDIR,GROUPS_DIR "/%s"), id) >= PATH_MAX) {
+    if (snprintf(path, PATH_MAX, GROUPS_DIR "/%s", id) >= PATH_MAX) {
         merror("At get_agent_group(): file path too large for agent '%s'.", id);
         return -1;
     }
@@ -298,7 +287,7 @@ int set_agent_group(const char * id, const char * group) {
     FILE *fp;
     mode_t oldmask;
 
-    if (snprintf(path, PATH_MAX, isChroot() ? GROUPS_DIR "/%s" : BUILDDIR(HOMEDIR,GROUPS_DIR "/%s"), id) >= PATH_MAX) {
+    if (snprintf(path, PATH_MAX, GROUPS_DIR "/%s", id) >= PATH_MAX) {
         merror("At set_agent_group(): file path too large for agent '%s'.", id);
         return -1;
     }
@@ -348,7 +337,7 @@ int set_agent_multigroup(char * group){
     char _hash[9] = {0};
 
     strncpy(_hash,multi_group_hash,8);
-    snprintf(multigroup_path,PATH_MAX,"%s/%s",isChroot() ?  MULTIGROUPS_DIR :  BUILDDIR(HOMEDIR,MULTIGROUPS_DIR),_hash);
+    snprintf(multigroup_path, PATH_MAX, "%s/%s" , MULTIGROUPS_DIR, _hash);
     DIR *dp;
     dp = opendir(multigroup_path);
 
@@ -383,7 +372,7 @@ int create_multigroup_dir(const char * multigroup) {
     }
     mdebug1("Attempting to create multigroup dir: '%s'",multigroup);
 
-    if (snprintf(path, PATH_MAX, isChroot() ? MULTIGROUPS_DIR "/%s" : BUILDDIR(HOMEDIR,MULTIGROUPS_DIR "/%s"), multigroup) >= PATH_MAX) {
+    if (snprintf(path, PATH_MAX, MULTIGROUPS_DIR "/%s", multigroup) >= PATH_MAX) {
         merror("At create_multigroup_dir(): path too large for multigroup '%s'.", multigroup);
         return -1;
     }
@@ -604,7 +593,7 @@ void w_remove_multigroup(const char *group){
     char path[PATH_MAX + 1] = {0};
 
     if(multigroup){
-        sprintf(path,"%s",isChroot() ? GROUPS_DIR : BUILDDIR(HOMEDIR,GROUPS_DIR));
+        sprintf(path, "%s", GROUPS_DIR);
 
         if(wstr_find_in_folder(path,group,1) < 0){
             /* Remove the DIR */
@@ -617,7 +606,7 @@ void w_remove_multigroup(const char *group){
 
             strncpy(_hash,multi_group_hash,8);
 
-            sprintf(path,"%s/%s",isChroot() ? MULTIGROUPS_DIR : BUILDDIR(HOMEDIR,MULTIGROUPS_DIR), _hash);
+            sprintf(path, "%s/%s", MULTIGROUPS_DIR, _hash);
 
             if (rmdir_ex(path) != 0) {
                 mdebug1("At w_remove_multigroup(): Directory '%s' couldn't be deleted. ('%s')",path, strerror(errno));
@@ -630,7 +619,7 @@ void w_remove_multigroup(const char *group){
 // Connect to Agentd. Returns socket or -1 on error.
 int auth_connect() {
 #ifndef WIN32
-    return OS_ConnectUnixDomain(isChroot() ? AUTH_LOCAL_SOCK : AUTH_LOCAL_SOCK_PATH, SOCK_STREAM, OS_MAXSTR);
+    return OS_ConnectUnixDomain(AUTH_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR);
 #else
     return -1;
 #endif
@@ -840,11 +829,7 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
     int result = 0;
     int response_length = 0;
 
-    if (isChroot()) {
-        strcpy(sockname, CLUSTER_SOCK);
-    } else {
-        strcpy(sockname, BUILDDIR(HOMEDIR,CLUSTER_SOCK));
-    }
+    strcpy(sockname, CLUSTER_SOCK);
 
     if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock >= 0) {
         if (OS_SendSecureTCPCluster(sock, command, payload, strlen(payload)) >= 0) {
@@ -985,12 +970,14 @@ char * get_agent_id_from_name(const char *agent_name) {
     os_calloc(PATH_MAX,sizeof(char),path);
     os_calloc(OS_SIZE_65536 + 1,sizeof(char),buffer);
 
-    snprintf(path,PATH_MAX,"%s",isChroot() ? KEYS_FILE : KEYSFILE_PATH);
+    snprintf(path,PATH_MAX,"%s", KEYS_FILE);
 
-    fp = fopen(path,"r");
+    fp = fopen(path, "r");
 
     if(!fp) {
-        mdebug1("Couldnt open file '%s'",path);
+        char keys_path[PATH_MAX] = {'\0'};
+        abspath(KEYS_FILE, keys_path, PATH_MAX);
+        mdebug1("Couldnt open file '%s'", keys_path);
         os_free(path);
         os_free(buffer);
         return NULL;
@@ -1043,7 +1030,7 @@ char * get_agent_id_from_name(const char *agent_name) {
 /* Connect to the control socket if available */
 #if defined (__linux__) || defined (__MACH__) || defined(sun)
 int control_check_connection() {
-    int sock = OS_ConnectUnixDomain(CONTROL_SOCK_PATH, SOCK_STREAM, OS_SIZE_128);
+    int sock = OS_ConnectUnixDomain(CONTROL_SOCK, SOCK_STREAM, OS_SIZE_128);
 
     if (sock < 0) {
         return -1;

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -20,7 +20,7 @@ int w_is_worker(void) {
     const char * xmlf[] = {"ossec_config", "cluster", NULL};
     const char * xmlf2[] = {"ossec_config", "cluster", "node_type", NULL};
     const char * xmlf3[] = {"ossec_config", "cluster", "disabled", NULL};
-    const char *cfgfile = DEFAULTCPATH;
+    const char *cfgfile = OSSECCONF;
     int modules = 0;
     int is_worker = 0;
     _Config cfg;
@@ -76,7 +76,7 @@ char *get_master_node(void) {
 
     OS_XML xml;
     const char * xmlf[] = {"ossec_config", "cluster", "nodes", "node", NULL};
-    const char *cfgfile = DEFAULTCPATH;
+    const char *cfgfile = OSSECCONF;
     _Config cfg;
     int modules = 0;
     char *master_node = NULL;

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -79,7 +79,7 @@ static void _log(int level, const char *tag, const char * file, int line, const 
 #ifndef WIN32
         int oldmask;
 
-        strncpy(logfile, isChroot() ? LOGJSONFILE : BUILDDIR(HOMEDIR,LOGJSONFILE), sizeof(logfile) - 1);
+        strncpy(logfile, LOGJSONFILE, sizeof(logfile) - 1);
         logfile[sizeof(logfile) - 1] = '\0';
 
         if (!IsFile(logfile)) {
@@ -145,7 +145,7 @@ static void _log(int level, const char *tag, const char * file, int line, const 
 #ifndef WIN32
         int oldmask;
 
-        strncpy(logfile, isChroot() ? LOGFILE : BUILDDIR(HOMEDIR,LOGFILE), sizeof(logfile) - 1);
+        strncpy(logfile, LOGFILE, sizeof(logfile) - 1);
         logfile[sizeof(logfile) - 1] = '\0';
 
         if (!IsFile(logfile)) {

--- a/src/shared/debug_op.c
+++ b/src/shared/debug_op.c
@@ -235,11 +235,13 @@ void os_logging_config(){
 
   pid = (int)getpid();
 
-  if (OS_ReadXML(chroot_flag ? OSSECCONF : DEFAULTCPATH, &xml) < 0){
+  if (OS_ReadXML(OSSECCONF, &xml) < 0){
     flags.log_plain = 1;
     flags.log_json = 0;
     OS_ClearXML(&xml);
-    merror_exit(XML_ERROR, chroot_flag ? OSSECCONF : DEFAULTCPATH, xml.err, xml.err_line);
+    char buffer[PATH_MAX] = {'\0'};
+    abspath(OSSECCONF, buffer, PATH_MAX);
+    merror_exit(XML_ERROR, buffer, xml.err, xml.err_line);
   }
 
   logformat = OS_GetOneContentforElement(&xml, xmlf);

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -73,7 +73,7 @@ w_enrollment_cert *w_enrollment_cert_init(){
     w_enrollment_cert *cert_cfg;
     os_malloc(sizeof(w_enrollment_cert), cert_cfg);
     cert_cfg->ciphers = strdup(DEFAULT_CIPHERS);
-    cert_cfg->authpass_file = strdup(AUTHDPASS_PATH);
+    cert_cfg->authpass_file = strdup(AUTHD_PASS_PATH);
     cert_cfg->authpass = NULL;
     cert_cfg->agent_cert = NULL;
     cert_cfg->agent_key = NULL;
@@ -373,10 +373,12 @@ static int w_enrollment_store_key_entry(const char* keys) {
 
 #ifdef WIN32
     FILE *fp;
-    fp = fopen(KEYSFILE_PATH, "w");
+    fp = fopen(KEYS_FILE, "w");
 
     if (!fp) {
-        merror(FOPEN_ERROR, KEYSFILE_PATH, errno, strerror(errno));
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(KEYS_FILE, buffer, PATH_MAX);
+        merror(FOPEN_ERROR, buffer, errno, strerror(errno));
         return -1;
     }
     fprintf(fp, "%s\n", keys);
@@ -385,8 +387,10 @@ static int w_enrollment_store_key_entry(const char* keys) {
 #else /* !WIN32 */
     File file;
 
-    if (TempFile(&file, isChroot() ? AUTH_FILE : KEYSFILE_PATH, 0) < 0) {
-        merror(FOPEN_ERROR, isChroot() ? AUTH_FILE : KEYSFILE_PATH, errno, strerror(errno));
+    if (TempFile(&file, KEYS_FILE, 0) < 0) {
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(KEYS_FILE, buffer, PATH_MAX);
+        merror(FOPEN_ERROR, buffer, errno, strerror(errno));
         return -1;
     }
 
@@ -400,7 +404,7 @@ static int w_enrollment_store_key_entry(const char* keys) {
     fprintf(file.fp, "%s\n", keys);
     fclose(file.fp);
 
-    if (OS_MoveFile(file.name, isChroot() ? AUTH_FILE : KEYSFILE_PATH) < 0) {
+    if (OS_MoveFile(file.name, KEYS_FILE) < 0) {
         free(file.name);
         return -1;
     }

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -73,7 +73,7 @@ w_enrollment_cert *w_enrollment_cert_init(){
     w_enrollment_cert *cert_cfg;
     os_malloc(sizeof(w_enrollment_cert), cert_cfg);
     cert_cfg->ciphers = strdup(DEFAULT_CIPHERS);
-    cert_cfg->authpass_file = strdup(AUTHD_PASS_PATH);
+    cert_cfg->authpass_file = strdup(AUTHD_PASS);
     cert_cfg->authpass = NULL;
     cert_cfg->agent_cert = NULL;
     cert_cfg->agent_key = NULL;

--- a/src/shared/file-queue.c
+++ b/src/shared/file-queue.c
@@ -44,7 +44,7 @@ static void GetFile_Queue(file_queue *fileq)
     fileq->file_name[0] = '\0';
     fileq->file_name[MAX_FQUEUE] = '\0';
 
-    snprintf(fileq->file_name, MAX_FQUEUE, "%s", fileq->flags & CRALERT_FP_SET ? "<stdin>" : isChroot() ? ALERTS_DAILY : BUILDDIR(HOMEDIR,ALERTS_DAILY));
+    snprintf(fileq->file_name, MAX_FQUEUE, "%s", fileq->flags & CRALERT_FP_SET ? "<stdin>" : ALERTS_DAILY);
 }
 
 /* Re Handle the file queue */

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -3361,6 +3361,7 @@ int w_uncompress_bz2_gz_file(const char * path, const char * dest) {
 #ifndef WIN32
 char *w_homedir(char *arg) {
     char *buff = NULL;
+    struct stat buff_stat;
     char * delim = "/bin";
     os_malloc(PATH_MAX, buff);
 #ifdef __MACH__
@@ -3393,6 +3394,10 @@ char *w_homedir(char *arg) {
 
         dirname(buff);
         buff = w_strtok_r_str_delim(delim, &buff);
+    }
+
+    if (stat(buff, &buff_stat) < 0 || !S_ISDIR(buff_stat.st_mode)) {
+        snprintf(buff, PATH_MAX, "%s", FALLBACKDIR);
     }
 
     return buff;

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1162,11 +1162,6 @@ void goDaemonLight()
 
     dup2(1, 2);
 
-    /* Go to / */
-    if (chdir("/") == -1) {
-        merror(CHDIR_ERROR, "/", errno, strerror(errno));
-    }
-
     nowDaemon();
 }
 
@@ -1206,11 +1201,6 @@ void goDaemon()
         dup2(fd, 2);
 
         close(fd);
-    }
-
-    /* Go to / */
-    if (chdir("/") == -1) {
-        merror(CHDIR_ERROR, "/", errno, strerror(errno));
     }
 
     nowDaemon();

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -539,12 +539,7 @@ int CreatePID(const char *name, int pid)
     char file[256];
     FILE *fp;
 
-    if (isChroot()) {
-        snprintf(file, 255, "%s/%s-%d.pid", OS_PIDFILE, name, pid);
-    } else {
-        snprintf(file, 255, "%s%s/%s-%d.pid", HOMEDIR,
-                 OS_PIDFILE, name, pid);
-    }
+    snprintf(file, 255, "%s/%s-%d.pid", OS_PIDFILE, name, pid);
 
     fp = fopen(file, "a");
     if (!fp) {
@@ -595,12 +590,7 @@ int DeletePID(const char *name)
 {
     char file[256];
 
-    if (isChroot()) {
-        snprintf(file, 255, "%s/%s-%d.pid", OS_PIDFILE, name, (int)getpid());
-    } else {
-        snprintf(file, 255, "%s%s/%s-%d.pid", HOMEDIR,
-                 OS_PIDFILE, name, (int)getpid());
-    }
+    snprintf(file, 255, "%s/%s-%d.pid", OS_PIDFILE, name, (int)getpid());
 
     if (File_DateofChange(file) < 0) {
         return (-1);
@@ -622,7 +612,7 @@ void DeleteState() {
 #ifdef WIN32
         snprintf(path, sizeof(path), "%s.state", __local_name);
 #else
-        snprintf(path, sizeof(path), "%s" OS_PIDFILE "/%s.state", isChroot() ? "" : HOMEDIR, __local_name);
+        snprintf(path, sizeof(path), OS_PIDFILE "/%s.state", __local_name);
 #endif
         unlink(path);
     } else {

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -392,7 +392,6 @@ int isVista;
 #endif
 
 const char *__local_name = "unset";
-char *home_path = NULL;
 
 /* Set the name of the starting program */
 void OS_SetName(const char *name)

--- a/src/shared/json-queue.c
+++ b/src/shared/json-queue.c
@@ -20,11 +20,7 @@ void jqueue_init(file_queue * queue) {
  */
 int jqueue_open(file_queue * queue, int tail) {
 
-#ifndef WIN32
-    strncpy(queue->file_name, isChroot() ? ALERTSJSON_DAILY : BUILDDIR(HOMEDIR,ALERTSJSON_DAILY), MAX_FQUEUE);
-#else
     strncpy(queue->file_name, ALERTSJSON_DAILY, MAX_FQUEUE);
-#endif
 
     if (queue->fp) {
         fclose(queue->fp);

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -825,13 +825,13 @@ void delete_sqlite(const char *id, const char *name)
     char path[512] = { '\0' };
 
     /* Delete related files */
-    snprintf(path, 511, "%s%s/agents/%s-%s.db", isChroot() ? "/" : "", WDB_DIR, id, name);
+    snprintf(path, 511, "%s/agents/%s-%s.db", WDB_DIR, id, name);
     unlink(path);
 
-    snprintf(path, 511, "%s%s/agents/%s-%s.db-wal", isChroot() ? "/" : "", WDB_DIR, id, name);
+    snprintf(path, 511, "%s/agents/%s-%s.db-wal", WDB_DIR, id, name);
     unlink(path);
 
-    snprintf(path, 511, "%s%s/agents/%s-%s.db-shm", isChroot() ? "/" : "", WDB_DIR, id, name);
+    snprintf(path, 511, "%s/agents/%s-%s.db-shm", WDB_DIR, id, name);
     unlink(path);
 }
 

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -63,7 +63,7 @@ void normalize_path(char * path) {
 int remove_empty_folders(const char *path) {
     assert(path != NULL);
 
-    char * DIFF_PATH = DIFF_DIR_PATH;
+    char * DIFF_PATH = DIFF_DIR;
     const char *c;
     char parent[PATH_MAX] = "\0";
     char ** subdir;
@@ -79,7 +79,7 @@ int remove_empty_folders(const char *path) {
             subdir = wreaddir(parent);
             if (!(subdir && *subdir)) {
                 // Remove empty folder
-                mdebug1("Removing empty directory '%s'.", parent);
+                mdebug1("Removing empty directory '%s'", parent);
                 if (rmdir_ex(parent) != 0) {
                     mwarn("Empty directory '%s' couldn't be deleted. ('%s')", parent, strerror(errno));
                     retval = -1;
@@ -600,7 +600,7 @@ const char *get_group(int gid) {
 
 /* Send a one-way message to Syscheck */
 void ag_send_syscheck(char * message) {
-    int sock = OS_ConnectUnixDomain(BUILDDIR(HOMEDIR,SYS_LOCAL_SOCK), SOCK_STREAM, OS_MAXSTR);
+    int sock = OS_ConnectUnixDomain(SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR);
 
     if (sock < 0) {
         mwarn("dbsync: cannot connect to syscheck: %s (%d)", strerror(errno), errno);

--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -147,8 +147,10 @@ int wurl_request(const char * url, const char * dest, const char *header, const 
 
     // Connect to downlod module
 
-    if (sock = OS_ConnectUnixDomain(isChroot() ? WM_DOWNLOAD_SOCK : WM_DOWNLOAD_SOCK_PATH, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        mwarn("Couldn't connect to download module socket '%s'", WM_DOWNLOAD_SOCK_PATH);
+    if (sock = OS_ConnectUnixDomain(WM_DOWNLOAD_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(WM_DOWNLOAD_SOCK, buffer, PATH_MAX);
+        mwarn("Couldn't connect to download module socket '%s'", buffer);
         goto end;
     }
 
@@ -231,7 +233,7 @@ int wurl_request_gz(const char * url, const char * dest, const char * header, co
 
 /* Check download module availability */
 int wurl_check_connection() {
-    int sock = OS_ConnectUnixDomain(isChroot() ? WM_DOWNLOAD_SOCK : WM_DOWNLOAD_SOCK_PATH, SOCK_STREAM, OS_MAXSTR);
+    int sock = OS_ConnectUnixDomain(WM_DOWNLOAD_SOCK, SOCK_STREAM, OS_MAXSTR);
 
     if (sock < 0) {
         return -1;

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -49,15 +49,7 @@ static char *_read_file(const char *high_name, const char *low_name, char *defin
     char *ret;
     int i;
 
-#ifndef WIN32
-    if (isChroot()) {
-        snprintf(def_file, OS_FLSIZE, "%s", defines_file);
-    } else {
-        snprintf(def_file, OS_FLSIZE, "%s%s", HOMEDIR, defines_file);
-    }
-#else
     snprintf(def_file, OS_FLSIZE, "%s", defines_file);
-#endif
 
     fp = fopen(def_file, "r");
     if (!fp) {

--- a/src/shared/wait_op.c
+++ b/src/shared/wait_op.c
@@ -22,12 +22,7 @@ void os_setwait()
 
     /* For same threads */
     __wait_lock = 1;
-
-#ifndef WIN32
-    fp = fopen(isChroot() ? WAIT_FILE : WAIT_FILE_PATH, "w");
-#else
     fp = fopen(WAIT_FILE, "w");
-#endif
 
     if (fp) {
         fprintf(fp, "l");
@@ -41,12 +36,7 @@ void os_setwait()
 void os_delwait()
 {
     __wait_lock = 0;
-
-#ifndef WIN32
-    unlink(isChroot() ? WAIT_FILE : WAIT_FILE_PATH);
-#else
     unlink(WAIT_FILE);
-#endif
 
     return;
 }
@@ -101,16 +91,9 @@ void os_wait()
     static int just_unlocked = 0;
 
     /* If the wait file is not present, keep going */
-    if (isChroot()) {
-        if (stat(WAIT_FILE, &file_status) == -1) {
-            just_unlocked = 1;
-            return;
-        }
-    } else {
-        if (stat(WAIT_FILE_PATH, &file_status) == -1) {
-            just_unlocked = 1;
-            return;
-        }
+    if (stat(WAIT_FILE, &file_status) == -1) {
+        just_unlocked = 1;
+        return;
     }
 
     /* Wait until the lock is gone */
@@ -121,14 +104,8 @@ void os_wait()
     }
 
     while (1) {
-        if (isChroot()) {
-            if (stat(WAIT_FILE, &file_status) == -1) {
-                break;
-            }
-        } else {
-            if (stat(WAIT_FILE_PATH, &file_status) == -1) {
-                break;
-            }
+        if (stat(WAIT_FILE, &file_status) == -1) {
+            break;
         }
 
         /* Sleep LOCK_LOOP seconds and check if lock is gone */
@@ -152,7 +129,7 @@ void os_wait()
 
 bool os_iswait() {
 #ifndef WIN32
-    return IsFile(isChroot() ? WAIT_FILE : WAIT_FILE_PATH) == 0;
+    return IsFile(WAIT_FILE) == 0;
 #else
     return __wait_lock;
 #endif

--- a/src/shared/wazuhdb_op.c
+++ b/src/shared/wazuhdb_op.c
@@ -23,11 +23,8 @@ int wdbc_connect() {
     int wdb_socket = -1;
     char sockname[PATH_MAX + 1];
 
-    if (isChroot()) {
-        strcpy(sockname, WDB_LOCAL_SOCK);
-    } else {
-        strcpy(sockname, BUILDDIR(HOMEDIR,WDB_LOCAL_SOCK));
-    }
+    strcpy(sockname, WDB_LOCAL_SOCK);
+
 
     for (attempts = 1; attempts <= 3 && (wdb_socket = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_SIZE_6144)) < 0; attempts++) {
         switch (errno) {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -69,7 +69,7 @@ void fim_scan() {
     fim_diff_folder_size();
     syscheck.disk_quota_full_msg = true;
 
-    mdebug2(FIM_DIFF_FOLDER_SIZE, DIFF_DIR_PATH, syscheck.diff_folder_size);
+    mdebug2(FIM_DIFF_FOLDER_SIZE, DIFF_DIR, syscheck.diff_folder_size);
 
     w_mutex_lock(&syscheck.fim_scan_mutex);
 
@@ -1191,9 +1191,9 @@ void free_inode_data(fim_inode_data **data) {
 void fim_diff_folder_size(){
     char *diff_local;
 
-    os_malloc(strlen(DIFF_DIR_PATH) + strlen("/local") + 1, diff_local);
+    os_malloc(strlen(DIFF_DIR) + strlen("/local") + 1, diff_local);
 
-    snprintf(diff_local, strlen(DIFF_DIR_PATH) + strlen("/local") + 1, "%s/local", DIFF_DIR_PATH);
+    snprintf(diff_local, strlen(DIFF_DIR) + strlen("/local") + 1, "%s/local", DIFF_DIR);
 
     if (IsDir(diff_local) == 0) {
         syscheck.diff_folder_size = DirSize(diff_local) / 1024;

--- a/src/syscheckd/db/fim_db.h
+++ b/src/syscheckd/db/fim_db.h
@@ -23,8 +23,8 @@
 
 #ifndef WAZUH_UNIT_TESTING
 #ifndef WIN32
-#define FIM_DB_DISK_PATH    BUILDDIR(HOMEDIR,"/queue/fim/db/fim.db")
-#define FIM_DB_TMPDIR       BUILDDIR(HOMEDIR,"/tmp/")
+#define FIM_DB_DISK_PATH    "queue/fim/db/fim.db"
+#define FIM_DB_TMPDIR       "tmp/"
 #else
 #define FIM_DB_DISK_PATH    "queue/fim/db/fim.db"
 #define FIM_DB_TMPDIR       "tmp/"

--- a/src/syscheckd/fim_diff_changes.c
+++ b/src/syscheckd/fim_diff_changes.c
@@ -495,7 +495,9 @@ diff_data *initialize_file_diff_data(const char *filename){
 
     // Get cwd for Windows
     if (abspath(DIFF_DIR, abs_diff_dir_path, sizeof(abs_diff_dir_path)) == NULL) {
-        merror(FIM_ERROR_GET_ABSOLUTE_PATH, DIFF_DIR, strerror(errno), errno);
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(DIFF_DIR, buffer, PATH_MAX);
+        merror(FIM_ERROR_GET_ABSOLUTE_PATH, buffer, strerror(errno), errno);
         os_free(path_filtered);
         goto error;
     }

--- a/src/syscheckd/fim_diff_changes.c
+++ b/src/syscheckd/fim_diff_changes.c
@@ -298,16 +298,16 @@ diff_data *initialize_registry_diff_data(const char *key_name, const char *value
     OS_SHA1_Str(value_name, -1, encoded_value);
 
     if (configuration->arch){
-        snprintf(buffer, PATH_MAX, "%s/registry/[x64] %s/%s", DIFF_DIR_PATH, encoded_key, encoded_value);
+        snprintf(buffer, PATH_MAX, "%s/registry/[x64] %s/%s", DIFF_DIR, encoded_key, encoded_value);
     } else {
-        snprintf(buffer, PATH_MAX, "%s/registry/[x32] %s/%s", DIFF_DIR_PATH, encoded_key, encoded_value);
+        snprintf(buffer, PATH_MAX, "%s/registry/[x32] %s/%s", DIFF_DIR, encoded_key, encoded_value);
     }
     os_strdup(buffer, diff->compress_folder);
 
     snprintf(buffer, PATH_MAX, "%s/last-entry.gz", diff->compress_folder);
     os_strdup(buffer, diff->compress_file);
 
-    snprintf(buffer, PATH_MAX, "%s/tmp", DIFF_DIR_PATH);
+    snprintf(buffer, PATH_MAX, "%s/tmp", DIFF_DIR);
     os_strdup(buffer, diff->tmp_folder);
 
     if (configuration->arch){
@@ -494,8 +494,8 @@ diff_data *initialize_file_diff_data(const char *filename){
     }
 
     // Get cwd for Windows
-    if (abspath(DIFF_DIR_PATH, abs_diff_dir_path, sizeof(abs_diff_dir_path)) == NULL) {
-        merror(FIM_ERROR_GET_ABSOLUTE_PATH, DIFF_DIR_PATH, strerror(errno), errno);
+    if (abspath(DIFF_DIR, abs_diff_dir_path, sizeof(abs_diff_dir_path)) == NULL) {
+        merror(FIM_ERROR_GET_ABSOLUTE_PATH, DIFF_DIR, strerror(errno), errno);
         os_free(path_filtered);
         goto error;
     }
@@ -503,10 +503,10 @@ diff_data *initialize_file_diff_data(const char *filename){
     snprintf(buffer, PATH_MAX, "%s/local/%s", abs_diff_dir_path, path_filtered);
     os_free(path_filtered);
 #else
-    strcpy(abs_diff_dir_path, DIFF_DIR_PATH);
+    strcpy(abs_diff_dir_path, DIFF_DIR);
 
     // This snprintf is duplicated to avoid a double slash ('/') in UNIX systems
-    snprintf(buffer, PATH_MAX, "%s/local%s", DIFF_DIR_PATH, diff->file_origin);
+    snprintf(buffer, PATH_MAX, "%s/local%s", DIFF_DIR, diff->file_origin);
 #endif
 
     // Check if the full_diff_path for filename, is too long
@@ -949,10 +949,10 @@ next_it:
 int fim_diff_process_delete_file(const char *filename){
     char *full_path;
     int ret;
-    os_malloc(sizeof(char) * (strlen(DIFF_DIR_PATH) + strlen(filename) + 8), full_path);
+    os_malloc(sizeof(char) * (strlen(DIFF_DIR) + strlen(filename) + 8), full_path);
 
 #ifdef WIN32
-    snprintf(full_path, PATH_MAX, "%s/local/", DIFF_DIR_PATH);
+    snprintf(full_path, PATH_MAX, "%s/local/", DIFF_DIR);
     // Remove ":" from filename
     char *buffer = NULL;
     buffer = os_strip_char(filename, ':');
@@ -964,7 +964,7 @@ int fim_diff_process_delete_file(const char *filename){
     strcat(full_path, buffer);
     os_free(buffer);
 #else
-    snprintf(full_path, PATH_MAX, "%s/local", DIFF_DIR_PATH);
+    snprintf(full_path, PATH_MAX, "%s/local", DIFF_DIR);
     strcat(full_path, filename);
 #endif
 
@@ -991,9 +991,9 @@ int fim_diff_process_delete_registry(const char *key_name, int arch){
     OS_SHA1_Str(key_name, strlen(key_name), encoded_key);
 
     if (arch){
-        snprintf(full_path, PATH_MAX, "%s/registry/[x64] %s", DIFF_DIR_PATH, encoded_key);
+        snprintf(full_path, PATH_MAX, "%s/registry/[x64] %s", DIFF_DIR, encoded_key);
     } else {
-        snprintf(full_path, PATH_MAX, "%s/registry/[x32] %s", DIFF_DIR_PATH, encoded_key);
+        snprintf(full_path, PATH_MAX, "%s/registry/[x32] %s", DIFF_DIR, encoded_key);
     }
 
     if(fim_diff_delete_compress_folder(full_path) == -1){
@@ -1012,9 +1012,9 @@ int fim_diff_process_delete_value(const char *key_name, const char *value_name, 
     OS_SHA1_Str(value_name, strlen(value_name), encoded_value);
 
     if (arch){
-        snprintf(full_path, PATH_MAX, "%s/registry/[x64] %s/%s", DIFF_DIR_PATH, encoded_key, encoded_value);
+        snprintf(full_path, PATH_MAX, "%s/registry/[x64] %s/%s", DIFF_DIR, encoded_key, encoded_value);
     } else {
-        snprintf(full_path, PATH_MAX, "%s/registry/[x32] %s/%s", DIFF_DIR_PATH, encoded_key, encoded_value);
+        snprintf(full_path, PATH_MAX, "%s/registry/[x32] %s/%s", DIFF_DIR, encoded_key, encoded_value);
     }
 
     if(fim_diff_delete_compress_folder(full_path) == -1){

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -90,6 +90,8 @@ int main(int argc, char **argv)
         }
     }
 
+    os_free(home_path);
+
     /* Check if the group given is valid */
     gid = Privsep_GetGroup(group);
     if (gid == (gid_t) - 1) {
@@ -158,13 +160,7 @@ int main(int argc, char **argv)
     if (!run_foreground) {
         nowDaemon();
         goDaemon();
-    } else {
-        if (chdir(home_path) == -1) {
-            merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-        }
     }
-
-    os_free(home_path);
 
     /* Start signal handling */
     StartSIG(ARGV0);

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -139,7 +139,7 @@ int main(int argc, char **argv)
     }
 
     /* Rootcheck config */
-    if (rootcheck_init(test_config) == 0) {
+    if (rootcheck_init(test_config, home_path) == 0) {
         syscheck.rootcheck = 1;
     } else {
         syscheck.rootcheck = 0;

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -20,7 +20,7 @@
 // LCOV_EXCL_START
 
 /* Print help statement */
-__attribute__((noreturn)) static void help_syscheckd(const char *home_path)
+__attribute__((noreturn)) static void help_syscheckd(char *home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtf] [-c config]", ARGV0);

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -90,8 +90,6 @@ int main(int argc, char **argv)
         }
     }
 
-    os_free(home_path);
-
     /* Check if the group given is valid */
     gid = Privsep_GetGroup(group);
     if (gid == (gid_t) - 1) {
@@ -146,6 +144,8 @@ int main(int argc, char **argv)
     } else {
         syscheck.rootcheck = 0;
     }
+
+    os_free(home_path);
 
     /* Exit if testing config */
     if (test_config) {

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -20,7 +20,7 @@
 // LCOV_EXCL_START
 
 /* Print help statement */
-__attribute__((noreturn)) static void help_syscheckd()
+__attribute__((noreturn)) static void help_syscheckd(const char *home_path)
 {
     print_header();
     print_out("  %s: -[Vhdtf] [-c config]", ARGV0);
@@ -31,8 +31,9 @@ __attribute__((noreturn)) static void help_syscheckd()
     print_out("                to increase the debug level.");
     print_out("    -t          Test configuration");
     print_out("    -f          Run in foreground");
-    print_out("    -c <config> Configuration file to use (default: %s)", OSSECCONF);
+    print_out("    -c <config> Configuration file to use (default: %s/%s)", home_path, OSSECCONF);
     print_out(" ");
+    os_free(home_path);
     exit(1);
 }
 
@@ -65,7 +66,7 @@ int main(int argc, char **argv)
                 print_version();
                 break;
             case 'h':
-                help_syscheckd();
+                help_syscheckd(home_path);
                 break;
             case 'd':
                 nowDebug();
@@ -84,7 +85,7 @@ int main(int argc, char **argv)
                 test_config = 1;
                 break;
             default:
-                help_syscheckd();
+                help_syscheckd(home_path);
                 break;
         }
     }

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -64,8 +64,8 @@ STATIC void fim_send_msg(char mq, const char * location, const char * msg) {
     if (SendMSG(syscheck.queue, msg, location, mq) < 0) {
         merror(QUEUE_SEND);
 
-        if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
-            merror_exit(QUEUE_FATAL, DEFAULTQPATH);
+        if ((syscheck.queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
+            merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
         }
 
         // Try to send it again
@@ -172,7 +172,7 @@ void start_daemon()
     // Deleting content local/diff directory
     char diff_dir[PATH_MAX];
 
-    snprintf(diff_dir, PATH_MAX, "%s/local/", DIFF_DIR_PATH);
+    snprintf(diff_dir, PATH_MAX, "%s/local/", DIFF_DIR);
 
     if (cldir_ex(diff_dir) == -1 && errno != ENOENT) {
         merror("Unable to clear directory '%s': %s (%d)", diff_dir, strerror(errno), errno);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -65,7 +65,9 @@ STATIC void fim_send_msg(char mq, const char * location, const char * msg) {
         merror(QUEUE_SEND);
 
         if ((syscheck.queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
-            merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
+            char buffer[PATH_MAX] = {'\0'};
+            abspath(DEFAULTQUEUE, buffer, PATH_MAX);
+            merror_exit(QUEUE_FATAL, buffer);
         }
 
         // Try to send it again

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -97,7 +97,7 @@ int Start_win32_Syscheck()
 {
     int debug_level = 0;
     int r = 0;
-    char *cfg = DEFAULTCPATH;
+    char *cfg = OSSECCONF;
     /* Read internal options */
     read_internal(debug_level);
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -101,8 +101,6 @@ int Start_win32_Syscheck()
     /* Read internal options */
     read_internal(debug_level);
 
-    mdebug1(STARTED_MSG);
-
     /* Check if the configuration is present */
     if (File_DateofChange(cfg) < 0) {
         merror_exit(NO_CONFIG, cfg);

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -136,7 +136,7 @@ int Start_win32_Syscheck()
     }
 
     /* Rootcheck config */
-    if (rootcheck_init(0) == 0) {
+    if (rootcheck_init(0, NULL) == 0) {
         syscheck.rootcheck = 1;
     } else {
         syscheck.rootcheck = 0;

--- a/src/syscheckd/syscom.c
+++ b/src/syscheckd/syscom.c
@@ -123,7 +123,9 @@ void * syscom_main(__attribute__((unused)) void * arg) {
     mdebug1(FIM_SYSCOM_REQUEST_READY);
 
     if (sock = OS_BindUnixDomain(SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-        merror(FIM_ERROR_SYSCOM_BIND_SOCKET, SYS_LOCAL_SOCK, errno, strerror(errno));
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(SYS_LOCAL_SOCK, buffer, PATH_MAX);
+        merror(FIM_ERROR_SYSCOM_BIND_SOCKET, buffer, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/syscheckd/syscom.c
+++ b/src/syscheckd/syscom.c
@@ -122,7 +122,7 @@ void * syscom_main(__attribute__((unused)) void * arg) {
 
     mdebug1(FIM_SYSCOM_REQUEST_READY);
 
-    if (sock = OS_BindUnixDomain(BUILDDIR(HOMEDIR,SYS_LOCAL_SOCK), SOCK_STREAM, OS_MAXSTR), sock < 0) {
+    if (sock = OS_BindUnixDomain(SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
         merror(FIM_ERROR_SYSCOM_BIND_SOCKET, SYS_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -19,20 +19,20 @@
 #include "audit_op.h"
 #include "string_op.h"
 
-#define AUDIT_CONF_FILE BUILDDIR(HOMEDIR,"/etc/af_wazuh.conf")
+#define AUDIT_CONF_FILE "etc/af_wazuh.conf"
 #define PLUGINS_DIR_AUDIT_2 "/etc/audisp/plugins.d"
 #define PLUGINS_DIR_AUDIT_3 "/etc/audit/plugins.d"
 #define AUDIT_CONF_LINK "af_wazuh.conf"
-#define AUDIT_SOCKET BUILDDIR(HOMEDIR,"/queue/ossec/audit")
+#define AUDIT_SOCKET "queue/ossec/audit"
 #define BUF_SIZE OS_MAXSTR
 #define AUDIT_KEY "wazuh_fim"
 #define AUDIT_LOAD_RETRIES 5 // Max retries to reload Audit rules
 #define MAX_CONN_RETRIES 5 // Max retries to reconnect to Audit socket
 #define RELOAD_RULES_INTERVAL 30 // Seconds to re-add Audit rules
 
-#define AUDIT_HEALTHCHECK_DIR BUILDDIR(HOMEDIR,"/tmp")
+#define AUDIT_HEALTHCHECK_DIR "tmp"
 #define AUDIT_HEALTHCHECK_KEY "wazuh_hc"
-#define AUDIT_HEALTHCHECK_FILE BUILDDIR(HOMEDIR,"/tmp/audit_hc")
+#define AUDIT_HEALTHCHECK_FILE "tmp/audit_hc"
 
 #ifndef WAZUH_UNIT_TESTING
 #define audit_thread_status() ((mode == READING_MODE && audit_thread_active) || \
@@ -151,7 +151,9 @@ int set_auditd_config(void) {
 
     fp = fopen(AUDIT_CONF_FILE, "w");
     if (!fp) {
-        merror(FOPEN_ERROR, AUDIT_CONF_FILE, errno, strerror(errno));
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(AUDIT_CONF_FILE, buffer, PATH_MAX);
+        merror(FOPEN_ERROR, buffer, errno, strerror(errno));
         return -1;
     }
 
@@ -163,7 +165,9 @@ int set_auditd_config(void) {
     fprintf(fp, "format = string\n");
 
     if (fclose(fp)) {
-        merror(FCLOSE_ERROR, AUDIT_CONF_FILE, errno, strerror(errno));
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(AUDIT_CONF_FILE, buffer, PATH_MAX);
+        merror(FCLOSE_ERROR, buffer, errno, strerror(errno));
         return -1;
     }
 
@@ -181,7 +185,9 @@ int set_auditd_config(void) {
 
         // Fallthrough
         default:
-            merror(LINK_ERROR, audit_path, AUDIT_CONF_FILE, errno, strerror(errno));
+            char buffer[PATH_MAX] = {'\0'};
+            abspath(AUDIT_CONF_FILE, buffer, PATH_MAX);
+            merror(LINK_ERROR, audit_path, buffer, errno, strerror(errno));
             return -1;
         }
     }
@@ -201,7 +207,9 @@ int init_auditd_socket(void) {
     int sfd;
 
     if (sfd = OS_ConnectUnixDomain(AUDIT_SOCKET, SOCK_STREAM, OS_MAXSTR), sfd < 0) {
-        merror(FIM_ERROR_WHODATA_SOCKET_CONNECT, AUDIT_SOCKET);
+        char buffer[PATH_MAX] = {'\0'};
+        abspath(AUDIT_SOCKET, buffer, PATH_MAX);
+        merror(FIM_ERROR_WHODATA_SOCKET_CONNECT, buffer);
         return (-1);
     }
 

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -117,6 +117,7 @@ int set_auditd_config(void) {
 
     FILE *fp;
     char audit_path[50] = {0};
+    char buffer[PATH_MAX] = {'\0'};
 
     // Check audisp version
     if (IsDir(PLUGINS_DIR_AUDIT_3) == 0) {
@@ -151,7 +152,6 @@ int set_auditd_config(void) {
 
     fp = fopen(AUDIT_CONF_FILE, "w");
     if (!fp) {
-        char buffer[PATH_MAX] = {'\0'};
         abspath(AUDIT_CONF_FILE, buffer, PATH_MAX);
         merror(FOPEN_ERROR, buffer, errno, strerror(errno));
         return -1;
@@ -165,7 +165,6 @@ int set_auditd_config(void) {
     fprintf(fp, "format = string\n");
 
     if (fclose(fp)) {
-        char buffer[PATH_MAX] = {'\0'};
         abspath(AUDIT_CONF_FILE, buffer, PATH_MAX);
         merror(FCLOSE_ERROR, buffer, errno, strerror(errno));
         return -1;
@@ -185,7 +184,6 @@ int set_auditd_config(void) {
 
         // Fallthrough
         default:
-            char buffer[PATH_MAX] = {'\0'};
             abspath(AUDIT_CONF_FILE, buffer, PATH_MAX);
             merror(LINK_ERROR, audit_path, buffer, errno, strerror(errno));
             return -1;

--- a/src/unit_tests/logcollector/test_logcollector.c
+++ b/src/unit_tests/logcollector/test_logcollector.c
@@ -916,7 +916,7 @@ void test_w_initialize_file_status_OSHash_Create_fail(void ** state) {
     expect_function_call(__wrap_OSHash_SetFreeDataPointer);
     will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
-    expect_string(__wrap_fopen, path, LOCALFILE_STATUS_PATH);
+    expect_string(__wrap_fopen, path, LOCALFILE_STATUS);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, NULL);
 
@@ -939,7 +939,7 @@ void test_w_initialize_file_status_OSHash_setSize_fail(void ** state) {
     expect_function_call(__wrap_OSHash_SetFreeDataPointer);
     will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
-    expect_string(__wrap_fopen, path, LOCALFILE_STATUS_PATH);
+    expect_string(__wrap_fopen, path, LOCALFILE_STATUS);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, NULL);
 
@@ -960,7 +960,7 @@ void test_w_initialize_file_status_fopen_fail(void ** state) {
     expect_function_call(__wrap_OSHash_SetFreeDataPointer);
     will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
-    expect_string(__wrap_fopen, path, LOCALFILE_STATUS_PATH);
+    expect_string(__wrap_fopen, path, LOCALFILE_STATUS);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, NULL);
 
@@ -981,7 +981,7 @@ void test_w_initialize_file_status_fread_fail(void ** state) {
     expect_function_call(__wrap_OSHash_SetFreeDataPointer);
     will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
-    expect_string(__wrap_fopen, path, LOCALFILE_STATUS_PATH);
+    expect_string(__wrap_fopen, path, LOCALFILE_STATUS);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, "test");
 
@@ -1013,7 +1013,7 @@ void test_w_initialize_file_status_OK(void ** state) {
     expect_function_call(__wrap_OSHash_SetFreeDataPointer);
     will_return(__wrap_OSHash_SetFreeDataPointer, 1);
 
-    expect_string(__wrap_fopen, path, LOCALFILE_STATUS_PATH);
+    expect_string(__wrap_fopen, path, LOCALFILE_STATUS);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, "test");
 

--- a/src/unit_tests/logcollector/test_state.c
+++ b/src/unit_tests/logcollector/test_state.c
@@ -836,7 +836,7 @@ void test_w_logcollector_state_dump_fail_open(void ** state) {
     will_return(__wrap_cJSON_Print, strdup("Test 123"));
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_fopen, path, LOGCOLLECTOR_STATE_PATH);
+    expect_string(__wrap_fopen, path, LOGCOLLECTOR_STATE);
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, NULL);
 
@@ -855,7 +855,7 @@ void test_w_logcollector_state_dump_fail_write(void ** state) {
     will_return(__wrap_cJSON_Print, strdup("Test 123"));
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_fopen, path, LOGCOLLECTOR_STATE_PATH);
+    expect_string(__wrap_fopen, path, LOGCOLLECTOR_STATE);
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, (FILE *) 100);
     will_return(__wrap_fwrite, 0);
@@ -878,7 +878,7 @@ void test_w_logcollector_state_dump_ok(void ** state) {
     will_return(__wrap_cJSON_Print, strdup("Test 123"));
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_fopen, path, LOGCOLLECTOR_STATE_PATH);
+    expect_string(__wrap_fopen, path, LOGCOLLECTOR_STATE);
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, (FILE *) 100);
     will_return(__wrap_fwrite, 1);
@@ -1026,7 +1026,7 @@ void test_w_logcollector_state_main_ok(void ** state) {
     will_return(__wrap_cJSON_Print, strdup("Test 123"));
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_fopen, path, LOGCOLLECTOR_STATE_PATH);
+    expect_string(__wrap_fopen, path, LOGCOLLECTOR_STATE);
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, (FILE *) 100);
     will_return(__wrap_fwrite, 1);

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -603,17 +603,17 @@ void test_w_enrollment_store_key_entry_cannot_open(void **state) {
     const char* key_string = "KEY EXAMPLE STRING";
     char key_file[1024];
 #ifdef WIN32
-    expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
+    expect_string(__wrap_fopen, filename, KEYS_FILE);
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 0);
 #else
-    expect_string(__wrap_TempFile, source, KEYSFILE_PATH);
+    expect_string(__wrap_TempFile, source, KEYS_FILE);
     expect_value(__wrap_TempFile, copy, 0);
     will_return(__wrap_TempFile, NULL);
     will_return(__wrap_TempFile, NULL);
     will_return(__wrap_TempFile, -1);
 #endif
-    snprintf(key_file, 1024, "(1103): Could not open file '%s' due to [(2)-(No such file or directory)].", KEYSFILE_PATH);
+    snprintf(key_file, 1024, "(1103): Could not open file '%s' due to [(2)-(No such file or directory)].", KEYS_FILE);
     expect_string(__wrap__merror, formatted_msg, key_file);
     int ret = w_enrollment_store_key_entry(key_string);
     assert_int_equal(ret, -1);
@@ -625,7 +625,7 @@ void test_w_enrollment_store_key_entry_chmod_fail(void **state) {
     const char* key_string = "KEY EXAMPLE STRING";
     char key_file[1024];
 
-    expect_string(__wrap_TempFile, source, KEYSFILE_PATH);
+    expect_string(__wrap_TempFile, source, KEYS_FILE);
     expect_value(__wrap_TempFile, copy, 0);
     will_return(__wrap_TempFile, strdup("client.keys.temp"));
     will_return(__wrap_TempFile, 6);
@@ -646,7 +646,7 @@ void test_w_enrollment_store_key_entry_success(void **state) {
     FILE file;
     const char* key_string = "KEY EXAMPLE STRING";
 #ifdef WIN32
-    expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
+    expect_string(__wrap_fopen, filename, KEYS_FILE);
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, &file);
 
@@ -654,7 +654,7 @@ void test_w_enrollment_store_key_entry_success(void **state) {
     expect_string(wrap_fprintf, formatted_msg, "KEY EXAMPLE STRING\n");
     will_return(wrap_fprintf, 0);
 #else
-    expect_string(__wrap_TempFile, source, KEYSFILE_PATH);
+    expect_string(__wrap_TempFile, source, KEYS_FILE);
     expect_value(__wrap_TempFile, copy, 0);
     will_return(__wrap_TempFile, strdup("client.keys.temp"));
     will_return(__wrap_TempFile, 6);
@@ -667,7 +667,7 @@ void test_w_enrollment_store_key_entry_success(void **state) {
     expect_string(__wrap_fprintf, formatted_msg, "KEY EXAMPLE STRING\n");
 
     expect_string(__wrap_OS_MoveFile, src, "client.keys.temp");
-    expect_string(__wrap_OS_MoveFile, dst, KEYSFILE_PATH);
+    expect_string(__wrap_OS_MoveFile, dst, KEYS_FILE);
     will_return(__wrap_OS_MoveFile, 0);
 #endif
     int ret = w_enrollment_store_key_entry(key_string);
@@ -705,7 +705,7 @@ void test_w_enrollment_process_agent_key_valid_key(void **state) {
     expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
     will_return(__wrap_OS_IsValidIP, 1);
 #ifdef WIN32
-    expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
+    expect_string(__wrap_fopen, filename, KEYS_FILE);
     expect_string(__wrap_fopen, mode, "w");
     will_return(__wrap_fopen, 4);
 
@@ -713,7 +713,7 @@ void test_w_enrollment_process_agent_key_valid_key(void **state) {
     expect_string(wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
     will_return(wrap_fprintf, 0);
 #else
-    expect_string(__wrap_TempFile, source, KEYSFILE_PATH);
+    expect_string(__wrap_TempFile, source, KEYS_FILE);
     expect_value(__wrap_TempFile, copy, 0);
     will_return(__wrap_TempFile, strdup("client.keys.temp"));
     will_return(__wrap_TempFile, 4);
@@ -726,7 +726,7 @@ void test_w_enrollment_process_agent_key_valid_key(void **state) {
     expect_string(__wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
 
     expect_string(__wrap_OS_MoveFile, src, "client.keys.temp");
-    expect_string(__wrap_OS_MoveFile, dst, KEYSFILE_PATH);
+    expect_string(__wrap_OS_MoveFile, dst, KEYS_FILE);
     will_return(__wrap_OS_MoveFile, 0);
 #endif
     expect_string(__wrap__minfo, formatted_msg, "Valid key received");
@@ -802,7 +802,7 @@ void test_w_enrollment_process_response_success(void **state) {
         expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
         will_return(__wrap_OS_IsValidIP, 1);
 #ifdef WIN32
-        expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
+        expect_string(__wrap_fopen, filename, KEYS_FILE);
         expect_string(__wrap_fopen, mode, "w");
         will_return(__wrap_fopen, 4);
 
@@ -810,7 +810,7 @@ void test_w_enrollment_process_response_success(void **state) {
         expect_string(wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
         will_return(wrap_fprintf, 0);
 #else
-        expect_string(__wrap_TempFile, source, KEYSFILE_PATH);
+        expect_string(__wrap_TempFile, source, KEYS_FILE);
         expect_value(__wrap_TempFile, copy, 0);
         will_return(__wrap_TempFile, strdup("client.keys.temp"));
         will_return(__wrap_TempFile, 4);
@@ -823,7 +823,7 @@ void test_w_enrollment_process_response_success(void **state) {
         expect_string(__wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
 
         expect_string(__wrap_OS_MoveFile, src, "client.keys.temp");
-        expect_string(__wrap_OS_MoveFile, dst, KEYSFILE_PATH);
+        expect_string(__wrap_OS_MoveFile, dst, KEYS_FILE);
         will_return(__wrap_OS_MoveFile, 0);
 #endif
         expect_string(__wrap__minfo, formatted_msg, "Valid key received");
@@ -908,7 +908,7 @@ void test_w_enrollment_request_key(void **state) {
             expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
             will_return(__wrap_OS_IsValidIP, 1);
 #ifdef WIN32
-            expect_string(__wrap_fopen, filename, KEYSFILE_PATH);
+            expect_string(__wrap_fopen, filename, KEYS_FILE);
             expect_string(__wrap_fopen, mode, "w");
             will_return(__wrap_fopen, 4);
 
@@ -916,7 +916,7 @@ void test_w_enrollment_request_key(void **state) {
             expect_string(wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
             will_return(wrap_fprintf, 0);
 #else
-            expect_string(__wrap_TempFile, source, KEYSFILE_PATH);
+            expect_string(__wrap_TempFile, source, KEYS_FILE);
             expect_value(__wrap_TempFile, copy, 0);
             will_return(__wrap_TempFile, strdup("client.keys.temp"));
             will_return(__wrap_TempFile, 4);
@@ -929,7 +929,7 @@ void test_w_enrollment_request_key(void **state) {
             expect_string(__wrap_fprintf, formatted_msg, "006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f\n");
 
             expect_string(__wrap_OS_MoveFile, src, "client.keys.temp");
-            expect_string(__wrap_OS_MoveFile, dst, KEYSFILE_PATH);
+            expect_string(__wrap_OS_MoveFile, dst, KEYS_FILE);
             will_return(__wrap_OS_MoveFile, 0);
 #endif
             expect_string(__wrap__minfo, formatted_msg, "Valid key received");
@@ -982,7 +982,7 @@ void test_w_enrollment_load_pass_null_cert(void **state) {
 void test_w_enrollment_load_pass_empty_file(void **state) {
     w_enrollment_cert *cert = *state;
 
-    expect_string(__wrap_fopen, filename, AUTHDPASS_PATH);
+    expect_string(__wrap_fopen, filename, AUTHD_PASS_PATH);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 4);
 #ifdef WIN32
@@ -995,7 +995,7 @@ void test_w_enrollment_load_pass_empty_file(void **state) {
     will_return(__wrap_fgets, NULL);
 #endif
     char buff[1024];
-    snprintf(buff, 1024, "Using password specified on file: %s", AUTHDPASS_PATH);
+    snprintf(buff, 1024, "Using password specified on file: %s", AUTHD_PASS_PATH);
     expect_string(__wrap__minfo, formatted_msg, buff);
     expect_string(__wrap__minfo, formatted_msg, "No authentication password provided");
 
@@ -1006,7 +1006,7 @@ void test_w_enrollment_load_pass_empty_file(void **state) {
 void test_w_enrollment_load_pass_file_with_content(void **state) {
     w_enrollment_cert *cert = *state;
 
-    expect_string(__wrap_fopen, filename, AUTHDPASS_PATH);
+    expect_string(__wrap_fopen, filename, AUTHD_PASS_PATH);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 4);
 #ifdef WIN32
@@ -1019,7 +1019,7 @@ void test_w_enrollment_load_pass_file_with_content(void **state) {
     will_return(__wrap_fgets, "content_password");
 #endif
     char buff[1024];
-    snprintf(buff, 1024, "Using password specified on file: %s", AUTHDPASS_PATH);
+    snprintf(buff, 1024, "Using password specified on file: %s", AUTHD_PASS_PATH);
     expect_string(__wrap__minfo, formatted_msg, buff);
 
     w_enrollment_load_pass(cert);

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -982,7 +982,7 @@ void test_w_enrollment_load_pass_null_cert(void **state) {
 void test_w_enrollment_load_pass_empty_file(void **state) {
     w_enrollment_cert *cert = *state;
 
-    expect_string(__wrap_fopen, filename, AUTHD_PASS_PATH);
+    expect_string(__wrap_fopen, filename, AUTHD_PASS);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 4);
 #ifdef WIN32
@@ -995,7 +995,7 @@ void test_w_enrollment_load_pass_empty_file(void **state) {
     will_return(__wrap_fgets, NULL);
 #endif
     char buff[1024];
-    snprintf(buff, 1024, "Using password specified on file: %s", AUTHD_PASS_PATH);
+    snprintf(buff, 1024, "Using password specified on file: %s", AUTHD_PASS);
     expect_string(__wrap__minfo, formatted_msg, buff);
     expect_string(__wrap__minfo, formatted_msg, "No authentication password provided");
 
@@ -1006,7 +1006,7 @@ void test_w_enrollment_load_pass_empty_file(void **state) {
 void test_w_enrollment_load_pass_file_with_content(void **state) {
     w_enrollment_cert *cert = *state;
 
-    expect_string(__wrap_fopen, filename, AUTHD_PASS_PATH);
+    expect_string(__wrap_fopen, filename, AUTHD_PASS);
     expect_string(__wrap_fopen, mode, "r");
     will_return(__wrap_fopen, 4);
 #ifdef WIN32
@@ -1019,7 +1019,7 @@ void test_w_enrollment_load_pass_file_with_content(void **state) {
     will_return(__wrap_fgets, "content_password");
 #endif
     char buff[1024];
-    snprintf(buff, 1024, "Using password specified on file: %s", AUTHD_PASS_PATH);
+    snprintf(buff, 1024, "Using password specified on file: %s", AUTHD_PASS);
     expect_string(__wrap__minfo, formatted_msg, buff);
 
     w_enrollment_load_pass(cert);

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -2077,7 +2077,7 @@ static void test_get_group(void **state) {
 static void test_ag_send_syscheck_success(void **state) {
     char *input = "This is a mock message, it wont be sent anywhere";
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR SYS_LOCAL_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, SYS_LOCAL_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
 
@@ -2095,7 +2095,7 @@ static void test_ag_send_syscheck_success(void **state) {
 static void test_ag_send_syscheck_unable_to_connect(void **state) {
     char *input = "This is a mock message, it wont be sent anywhere";
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR SYS_LOCAL_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, SYS_LOCAL_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
 
@@ -2112,7 +2112,7 @@ static void test_ag_send_syscheck_unable_to_connect(void **state) {
 static void test_ag_send_syscheck_error_sending_message(void **state) {
     char *input = "This is a mock message, it wont be sent anywhere";
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR SYS_LOCAL_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, SYS_LOCAL_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
 

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -4072,9 +4072,9 @@ void test_fim_diff_folder_size(void **state) {
     (void) state;
     char *diff_local;
 
-    diff_local = (char *)calloc(strlen(DIFF_DIR_PATH) + strlen("/local") + 1, sizeof(char));
+    diff_local = (char *)calloc(strlen(DIFF_DIR) + strlen("/local") + 1, sizeof(char));
 
-    snprintf(diff_local, strlen(DIFF_DIR_PATH) + strlen("/local") + 1, "%s/local", DIFF_DIR_PATH);
+    snprintf(diff_local, strlen(DIFF_DIR) + strlen("/local") + 1, "%s/local", DIFF_DIR);
 
     expect_string(__wrap_IsDir, file, diff_local);
     will_return(__wrap_IsDir, 0);

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -279,7 +279,7 @@ void test_fim_send_msg_retry(void **state) {
 
     expect_string(__wrap__merror, formatted_msg, QUEUE_SEND);
 
-    expect_StartMQ_call(DEFAULTQPATH, WRITE, 0);
+    expect_StartMQ_call(DEFAULTQUEUE, WRITE, 0);
 
     expect_w_send_sync_msg("test", SYSCHECK, SYSCHECK_MQ, -1);
 
@@ -292,7 +292,7 @@ void test_fim_send_msg_retry_error(void **state) {
     expect_w_send_sync_msg("test", SYSCHECK, SYSCHECK_MQ, -1);
     expect_string(__wrap__merror, formatted_msg, QUEUE_SEND);
 
-    expect_StartMQ_call(DEFAULTQPATH, WRITE, -1);
+    expect_StartMQ_call(DEFAULTQUEUE, WRITE, -1);
 
     expect_string(__wrap__merror_exit, formatted_msg, "(1211): Unable to access queue: '/var/ossec/queue/ossec/queue'. Giving up.");
 

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -92,7 +92,7 @@ int __wrap_Read_Syscheck_Config(const char * file)
     return mock();
 }
 
-int __wrap_rootcheck_init(int value)
+int __wrap_rootcheck_init(int value, char * home_path)
 {
     return mock();
 }

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -3931,7 +3931,7 @@ void test_wdb_update_groups_error_json(void **state) {
 
     expect_string(__wrap__merror, formatted_msg, "Error querying Wazuh DB to update groups.");
 
-    ret = wdb_update_groups(HOMEDIR SHAREDCFG_DIR, NULL);
+    ret = wdb_update_groups(SHAREDCFG_DIR, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }

--- a/src/unit_tests/wazuh_db/test_wdb_agent.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agent.c
@@ -3992,7 +3992,7 @@ void test_wdb_update_groups_error_max_path(void **state) {
     // Handling result
     expect_string(__wrap__merror, formatted_msg, "At wdb_remove_group_from_belongs_db(): couldn't delete 'test_group' from 'belongs' table.");
 
-    ret = wdb_update_groups(HOMEDIR SHAREDCFG_DIR, NULL);
+    ret = wdb_update_groups(SHAREDCFG_DIR, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 
@@ -4042,7 +4042,7 @@ void test_wdb_update_groups_error_removing_group_db(void **state) {
     // Handling result
     expect_string(__wrap__merror, formatted_msg, "At wdb_remove_group_from_belongs_db(): couldn't delete 'test_group' from 'belongs' table.");
 
-    ret = wdb_update_groups(HOMEDIR SHAREDCFG_DIR, NULL);
+    ret = wdb_update_groups(SHAREDCFG_DIR, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 
@@ -4078,7 +4078,7 @@ void test_wdb_update_groups_error_adding_new_groups(void **state) {
     will_return(__wrap_strerror, "error");
     expect_string(__wrap__merror, formatted_msg, "Couldn't open directory '/var/ossec/etc/shared': error.");
 
-    ret = wdb_update_groups(HOMEDIR SHAREDCFG_DIR, NULL);
+    ret = wdb_update_groups(SHAREDCFG_DIR, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 
@@ -4143,7 +4143,7 @@ void test_wdb_update_groups_success(void **state) {
 
     will_return(__wrap_readdir, NULL);
 
-    ret = wdb_update_groups(HOMEDIR SHAREDCFG_DIR, NULL);
+    ret = wdb_update_groups(SHAREDCFG_DIR, NULL);
 
     assert_int_equal(OS_SUCCESS, ret);
 

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_agent.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_agent.c
@@ -150,7 +150,7 @@ void test_wm_upgrade_agent_send_ack_message_error(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mterror, formatted_msg, "(1210): Queue '/queue/ossec/queue' not accessible: 'Success'");
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 1);
 
@@ -187,7 +187,7 @@ void test_wm_upgrade_agent_send_ack_message_error_exit(void **state)
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mterror, formatted_msg, "(1210): Queue '/queue/ossec/queue' not accessible: 'Success'");
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, -1);
 
@@ -356,7 +356,7 @@ void test_wm_agent_upgrade_check_status_successful(void **state)
 
     allow_upgrades = false;
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, queue);
 
@@ -427,7 +427,7 @@ void test_wm_agent_upgrade_check_status_time_limit(void **state)
 
     allow_upgrades = false;
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, queue);
 
@@ -615,7 +615,7 @@ void test_wm_agent_upgrade_check_status_queue_error(void **state)
 
     allow_upgrades = false;
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, queue);
 
@@ -710,7 +710,7 @@ void test_wm_agent_upgrade_listen_messages_receive_empty(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR AGENT_UPGRADE_SOCK);
+    expect_string(__wrap_OS_BindUnixDomain, path, AGENT_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -738,7 +738,7 @@ void test_wm_agent_upgrade_listen_messages_receive_error(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR AGENT_UPGRADE_SOCK);
+    expect_string(__wrap_OS_BindUnixDomain, path, AGENT_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -766,7 +766,7 @@ void test_wm_agent_upgrade_listen_messages_receive_sock_error(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR AGENT_UPGRADE_SOCK);
+    expect_string(__wrap_OS_BindUnixDomain, path, AGENT_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -795,7 +795,7 @@ void test_wm_agent_upgrade_listen_messages_accept_error_eintr(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR AGENT_UPGRADE_SOCK);
+    expect_string(__wrap_OS_BindUnixDomain, path, AGENT_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -828,7 +828,7 @@ void test_wm_agent_upgrade_listen_messages_accept_error(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR AGENT_UPGRADE_SOCK);
+    expect_string(__wrap_OS_BindUnixDomain, path, AGENT_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -863,7 +863,7 @@ void test_wm_agent_upgrade_listen_messages_select_zero(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR AGENT_UPGRADE_SOCK);
+    expect_string(__wrap_OS_BindUnixDomain, path, AGENT_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -894,7 +894,7 @@ void test_wm_agent_upgrade_listen_messages_select_error_eintr(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR AGENT_UPGRADE_SOCK);
+    expect_string(__wrap_OS_BindUnixDomain, path, AGENT_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -923,7 +923,7 @@ void test_wm_agent_upgrade_listen_messages_select_error(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR AGENT_UPGRADE_SOCK);
+    expect_string(__wrap_OS_BindUnixDomain, path, AGENT_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -940,7 +940,7 @@ void test_wm_agent_upgrade_listen_messages_bind_error(void **state)
 {
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR AGENT_UPGRADE_SOCK);
+    expect_string(__wrap_OS_BindUnixDomain, path, AGENT_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, -1);
@@ -973,7 +973,7 @@ void test_wm_agent_upgrade_start_agent_module_enabled(void **state)
     expect_memory(__wrap_CreateThread, function_pointer, wm_agent_upgrade_listen_messages, sizeof(wm_agent_upgrade_listen_messages));
 #endif
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, queue);
 

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c
@@ -71,11 +71,7 @@ int setup_jailfile_long_name(void **state) {
 
 int setup_jailfile_long_name2(void **state) {
     char *filename = malloc(sizeof(char) * OS_MAXSTR);
-    #ifdef TEST_WINAGENT
     const unsigned int length = PATH_MAX - strlen(TMP_DIR) - 2;
-    #else
-    const unsigned int length = PATH_MAX - strlen(HOMEDIR) - strlen(TMP_DIR) - 2;
-    #endif
     for(int i=0; i < length; i++) {
         sprintf(&filename[i], "a");
     }

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_manager.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_manager.c
@@ -88,7 +88,7 @@ void test_wm_agent_upgrade_listen_messages_upgrade_command(void **state)
                       "    \"message\":\"Success\""
                       "}");
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -186,7 +186,7 @@ void test_wm_agent_upgrade_listen_messages_upgrade_custom_command(void **state)
                       "    \"message\":\"Success\""
                       "}");
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -285,7 +285,7 @@ void test_wm_agent_upgrade_listen_messages_agent_update_status_command(void **st
                       "    \"message\":\"Success\""
                       "}");
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -386,7 +386,7 @@ void test_wm_agent_upgrade_listen_messages_upgrade_result_command(void **state)
                       "    \"message\":\"Success\""
                       "}");
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -462,7 +462,7 @@ void test_wm_agent_upgrade_listen_messages_parse_error(void **state)
 
     char *response = "{\"error\":25,\"message\":\"Upgrade procedure could not start\",\"data\":[{\"error\":25,\"message\":\"Upgrade procedure could not start\"}]}";
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -516,7 +516,7 @@ void test_wm_agent_upgrade_listen_messages_parse_error_with_message(void **state
 
     sprintf(response, "{\"error\":1,\"data\":[{\"error\":1,\"message\":\"Could not parse message JSON\"}],\"message\":\"Could not parse message JSON\"}");
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -561,7 +561,7 @@ void test_wm_agent_upgrade_listen_messages_receive_empty(void **state)
     int peer = 1111;
     char *input = "Bad JSON";
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -592,7 +592,7 @@ void test_wm_agent_upgrade_listen_messages_receive_error(void **state)
     int peer = 1111;
     char *input = "Bad JSON";
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -623,7 +623,7 @@ void test_wm_agent_upgrade_listen_messages_receive_sock_error(void **state)
     int peer = 1111;
     char *input = "Bad JSON";
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -655,7 +655,7 @@ void test_wm_agent_upgrade_listen_messages_accept_error_eintr(void **state)
     char *input = "Bad JSON";
     errno = EINTR;
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -691,7 +691,7 @@ void test_wm_agent_upgrade_listen_messages_accept_error(void **state)
     char *input = "Bad JSON";
     errno = 1;
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -729,7 +729,7 @@ void test_wm_agent_upgrade_listen_messages_select_zero(void **state)
     int peer = 1111;
     char *input = "Bad JSON";
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -763,7 +763,7 @@ void test_wm_agent_upgrade_listen_messages_select_error_eintr(void **state)
     char *input = "Bad JSON";
     errno = EINTR;
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -795,7 +795,7 @@ void test_wm_agent_upgrade_listen_messages_select_error(void **state)
     int socket = 0;
     errno = 1;
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, socket);
@@ -816,7 +816,7 @@ void test_wm_agent_upgrade_listen_messages_bind_error(void **state)
 {
     wm_manager_configs *config = *state;
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, -1);
@@ -834,7 +834,7 @@ void test_wm_agent_upgrade_start_manager_module_enabled(void **state)
     expect_string(__wrap__mtinfo, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mtinfo, formatted_msg, "(8153): Module Agent Upgrade started.");
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, -1);
@@ -857,7 +857,7 @@ void test_wm_agent_upgrade_start_manager_module_disabled(void **state)
     expect_string(__wrap__mtinfo, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mtinfo, formatted_msg, "(8153): Module Agent Upgrade started.");
 
-    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK_PATH);
+    expect_string(__wrap_OS_BindUnixDomain, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, -1);

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_tasks.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_tasks.c
@@ -253,7 +253,7 @@ void test_wm_agent_send_task_information_master_ok(void **state)
                       "\"command\":\"upgrade\","
                       "\"agent\":10}]";
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -323,7 +323,7 @@ void test_wm_agent_send_task_information_master_json_err(void **state)
                       "\"command\":\"upgrade\","
                       "\"agent\":10}]";
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -393,7 +393,7 @@ void test_wm_agent_send_task_information_master_recv_error(void **state)
                       "\"command\":\"upgrade\","
                       "\"agent\":10}]";
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -463,7 +463,7 @@ void test_wm_agent_send_task_information_master_sockterr_error(void **state)
                       "\"command\":\"upgrade\","
                       "\"agent\":10}]";
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -517,7 +517,7 @@ void test_wm_agent_send_task_information_master_connect_error(void **state)
     cJSON_AddItemToArray(input, task_request1);
     cJSON_AddItemToArray(input, task_request2);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, OS_SOCKTERR);
@@ -647,7 +647,7 @@ void test_wm_agent_upgrade_send_tasks_information_master(void **state)
 
     will_return(__wrap_w_is_worker, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
@@ -193,7 +193,7 @@ void test_wm_agent_upgrade_send_command_to_agent_ok(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -327,7 +327,7 @@ void test_wm_agent_upgrade_send_lock_restart_ok(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -367,7 +367,7 @@ void test_wm_agent_upgrade_send_lock_restart_err(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -409,7 +409,7 @@ void test_wm_agent_upgrade_send_open_ok(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -451,7 +451,7 @@ void test_wm_agent_upgrade_send_open_ok_new(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -494,7 +494,7 @@ void test_wm_agent_upgrade_send_open_retry_ok(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -520,7 +520,7 @@ void test_wm_agent_upgrade_send_open_retry_ok(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -562,7 +562,7 @@ void test_wm_agent_upgrade_send_open_retry_err(void **state)
 
     will_return_count(__wrap_isChroot, 0, 10);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 10);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 10);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 10);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 10);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 10);
@@ -648,7 +648,7 @@ void test_wm_agent_upgrade_send_write_ok(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -677,7 +677,7 @@ void test_wm_agent_upgrade_send_write_ok(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -735,7 +735,7 @@ void test_wm_agent_upgrade_send_write_ok_new(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -764,7 +764,7 @@ void test_wm_agent_upgrade_send_write_ok_new(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -823,7 +823,7 @@ void test_wm_agent_upgrade_send_write_err(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -852,7 +852,7 @@ void test_wm_agent_upgrade_send_write_err(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -916,7 +916,7 @@ void test_wm_agent_upgrade_send_close_ok(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -958,7 +958,7 @@ void test_wm_agent_upgrade_send_close_ok_new(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -1000,7 +1000,7 @@ void test_wm_agent_upgrade_send_close_err(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -1043,7 +1043,7 @@ void test_wm_agent_upgrade_send_sha1_ok(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -1086,7 +1086,7 @@ void test_wm_agent_upgrade_send_sha1_ok_new(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -1130,7 +1130,7 @@ void test_wm_agent_upgrade_send_sha1_err(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -1173,7 +1173,7 @@ void test_wm_agent_upgrade_send_sha1_invalid_sha1(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -1219,7 +1219,7 @@ void test_wm_agent_upgrade_send_upgrade_ok(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -1262,7 +1262,7 @@ void test_wm_agent_upgrade_send_upgrade_ok_new(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -1306,7 +1306,7 @@ void test_wm_agent_upgrade_send_upgrade_err(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -1349,7 +1349,7 @@ void test_wm_agent_upgrade_send_upgrade_script_err(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -1424,7 +1424,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_linux_ok(void **state)
 
     will_return_count(__wrap_isChroot, 0, 6);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 6);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 6);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 6);
@@ -1590,7 +1590,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_windows_ok(void **state)
 
     will_return_count(__wrap_isChroot, 0, 6);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 6);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 6);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 6);
@@ -1756,7 +1756,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_custom_custom_installer_ok(
 
     will_return_count(__wrap_isChroot, 0, 6);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 6);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 6);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 6);
@@ -1921,7 +1921,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_custom_default_installer_ok
 
     will_return_count(__wrap_isChroot, 0, 6);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 6);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 6);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 6);
@@ -2087,7 +2087,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_run_upgrade_err(void **stat
 
     will_return_count(__wrap_isChroot, 0, 6);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 6);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 6);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 6);
@@ -2252,7 +2252,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_send_sha1_err(void **state)
 
     will_return_count(__wrap_isChroot, 0, 5);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 5);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 5);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 5);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 5);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 5);
@@ -2403,7 +2403,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_close_file_err(void **state
 
     will_return_count(__wrap_isChroot, 0, 4);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 4);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 4);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 4);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 4);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 4);
@@ -2536,7 +2536,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_write_file_err(void **state
 
     will_return_count(__wrap_isChroot, 0, 3);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 3);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 3);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 3);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 3);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 3);
@@ -2650,7 +2650,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_open_file_err(void **state)
 
     will_return_count(__wrap_isChroot, 0, 11);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 11);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 11);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 11);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 11);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 11);
@@ -2800,7 +2800,7 @@ void test_wm_agent_upgrade_send_wpk_to_agent_upgrade_lock_restart_err(void **sta
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);
@@ -3007,7 +3007,7 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_ok(void **state)
 
     will_return_count(__wrap_isChroot, 0, 6);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 6);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 6);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 6);
@@ -3239,7 +3239,7 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_legacy_ok(void **state)
 
     will_return_count(__wrap_isChroot, 0, 6);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 6);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 6);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 6);
@@ -3472,7 +3472,7 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_custom_ok(void **state)
 
     will_return_count(__wrap_isChroot, 0, 6);
 
-    expect_string_count(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK, 6);
+    expect_string_count(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM, 6);
     expect_value_count(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR, 6);
     will_return_count(__wrap_OS_ConnectUnixDomain, socket, 6);
@@ -3703,7 +3703,7 @@ void test_wm_agent_upgrade_start_upgrade_upgrade_err(void **state)
 
     will_return(__wrap_isChroot, 0);
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, HOMEDIR REMOTE_REQ_SOCK);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, REMOTE_REQ_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_ConnectUnixDomain, socket);

--- a/src/unit_tests/wazuh_modules/aws/test_wm_aws.c
+++ b/src/unit_tests/wazuh_modules/aws/test_wm_aws.c
@@ -124,7 +124,7 @@ void test_interval_execution(void **state) {
     will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
     will_return(__wrap_FOREVER, 0);
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 0);
 

--- a/src/unit_tests/wazuh_modules/azure/test_wm_azure.c
+++ b/src/unit_tests/wazuh_modules/azure/test_wm_azure.c
@@ -135,7 +135,7 @@ void test_interval_execution(void **state) {
 
     will_return_always(__wrap_wm_exec, 0);
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 0);
 

--- a/src/unit_tests/wazuh_modules/command/test_wm_command.c
+++ b/src/unit_tests/wazuh_modules/command/test_wm_command.c
@@ -116,7 +116,7 @@ void test_interval_execution(void **state) {
     module_data->scan_config.interval = 60; // 1min
     module_data->scan_config.month_interval = false;
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 0);
 

--- a/src/unit_tests/wazuh_modules/oscap/test_wm_oscap.c
+++ b/src/unit_tests/wazuh_modules/oscap/test_wm_oscap.c
@@ -148,7 +148,7 @@ void test_interval_execution(void **state) {
         will_return(__wrap_wm_sendmsg, 0);
     }
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 0);
 

--- a/src/unit_tests/wazuh_modules/sca/test_wm_sca.c
+++ b/src/unit_tests/wazuh_modules/sca/test_wm_sca.c
@@ -151,7 +151,7 @@ void test_interval_execution(void **state) {
     module_data->scan_config.interval = 60; // 1min
     module_data->scan_config.month_interval = false;
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 0);
 

--- a/src/unit_tests/wazuh_modules/task_manager/test_wm_task_manager.c
+++ b/src/unit_tests/wazuh_modules/task_manager/test_wm_task_manager.c
@@ -123,7 +123,7 @@ void test_wm_task_manager_init_ok(void **state)
 
     config->enabled = 1;
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_BindUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, sock);
@@ -139,7 +139,7 @@ void test_wm_task_manager_init_bind_err(void **state)
 
     config->enabled = 1;
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_BindUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, OS_INVALID);
@@ -166,7 +166,7 @@ void test_wm_task_manager_init_disabled(void **state)
 
     will_return(__wrap_pthread_exit, OS_INVALID);
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_BindUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, sock);
@@ -623,7 +623,7 @@ void test_wm_task_manager_main_ok(void **state)
 
     // wm_task_manager_init
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_BindUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, sock);
@@ -695,7 +695,7 @@ void test_wm_task_manager_main_recv_max_err(void **state)
 
     // wm_task_manager_init
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_BindUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, sock);
@@ -741,7 +741,7 @@ void test_wm_task_manager_main_recv_empty_err(void **state)
 
     // wm_task_manager_init
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_BindUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, sock);
@@ -787,7 +787,7 @@ void test_wm_task_manager_main_recv_err(void **state)
 
     // wm_task_manager_init
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_BindUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, sock);
@@ -833,7 +833,7 @@ void test_wm_task_manager_main_sockterr_err(void **state)
 
     // wm_task_manager_init
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_BindUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, sock);
@@ -879,7 +879,7 @@ void test_wm_task_manager_main_accept_err(void **state)
 
     // wm_task_manager_init
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_BindUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, sock);
@@ -932,7 +932,7 @@ void test_wm_task_manager_main_select_empty_err(void **state)
 
     // wm_task_manager_init
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_BindUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, sock);
@@ -980,7 +980,7 @@ void test_wm_task_manager_main_select_err(void **state)
 
     // wm_task_manager_init
 
-    expect_string(__wrap_OS_BindUnixDomain, path, HOMEDIR TASK_QUEUE);
+    expect_string(__wrap_OS_BindUnixDomain, path, TASK_QUEUE);
     expect_value(__wrap_OS_BindUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_BindUnixDomain, max_msg_size, OS_MAXSTR);
     will_return(__wrap_OS_BindUnixDomain, sock);

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -318,7 +318,7 @@ static int setup_cve_report(void **state) {
     vuldet->flags.enabled = 1;
     vuldet->flags.run_on_start = 1;
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 1);
 
@@ -603,7 +603,7 @@ void test_wm_vuldet_get_os_unix_info (void **state)
     char *response = "ok [{\"os_major\":\"10.0\",\"os_minor\":\"1\",\"release\":\"4.5.1\"}]";
     size_t response_size = strlen(response) + 1;
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, WDB_LOCAL_SOCK_PATH);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, WDB_LOCAL_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_SIZE_6144);
     will_return(__wrap_OS_ConnectUnixDomain, 11111);
@@ -775,7 +775,7 @@ void test_wm_vuldet_get_os_unix_info_request_error(void **state)
     const char *query = "agent 000 sql SELECT OS_MAJOR, OS_MINOR, OS_PATCH, RELEASE FROM SYS_OSINFO;";
     size_t query_size = strlen(query) + 1;
 
-    expect_string(__wrap_OS_ConnectUnixDomain, path, WDB_LOCAL_SOCK_PATH);
+    expect_string(__wrap_OS_ConnectUnixDomain, path, WDB_LOCAL_SOCK);
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_SIZE_6144);
     will_return(__wrap_OS_ConnectUnixDomain, 11111);
@@ -5289,7 +5289,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
     vuldet->flags.enabled = 1;
     vuldet->flags.run_on_start = 1;
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 1);
 
@@ -5616,7 +5616,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **
     vuldet->flags.enabled = 1;
     vuldet->flags.run_on_start = 1;
 
-    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 1);
 

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -43,8 +43,6 @@ static void helpmsg()
 
 int main(int argc, char **argv)
 {
-    home_path = w_homedir(argv[0]);
-    const char *dir = HOMEDIR;
     const char *group = GROUPGLOBAL;
     const char *user = USER;
     const char *agent_id = NULL;
@@ -76,6 +74,13 @@ int main(int argc, char **argv)
 
     /* Set the name */
     OS_SetName(ARGV0);
+
+    /* Define current working directory */
+    char * home_path = w_homedir(argv[0]);
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     int is_worker = w_is_worker();
     char *master;
@@ -194,9 +199,11 @@ int main(int argc, char **argv)
     }
 
     /* Chroot to the default directory */
-    if (Privsep_Chroot(dir) < 0) {
-        merror_exit(CHROOT_ERROR, dir, errno, strerror(errno));
+    if (Privsep_Chroot(home_path) < 0) {
+        merror_exit(CHROOT_ERROR, home_path, errno, strerror(errno));
     }
+
+    os_free(home_path);
 
     /* Inside chroot now */
     nowChroot();
@@ -679,6 +686,5 @@ int main(int argc, char **argv)
     printf("\n** Invalid argument combination.\n");
     helpmsg();
 
-    os_free(home_path);
     return (0);
 }

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -75,11 +75,7 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
-    /* Define current working directory */
     char * home_path = w_homedir(argv[0]);
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
     mdebug1(WAZUH_HOMEDIR, home_path);
 
     int is_worker = w_is_worker();

--- a/src/util/clear_stats.c
+++ b/src/util/clear_stats.c
@@ -35,8 +35,6 @@ int main(int argc, char **argv)
     int clear_daily = 0;
     int clear_weekly = 0;
 
-    home_path = w_homedir(argv[0]);
-    const char *dir = HOMEDIR;
     const char *group = GROUPGLOBAL;
     const char *user = USER;
     gid_t gid;
@@ -44,6 +42,13 @@ int main(int argc, char **argv)
 
     /* Set the name */
     OS_SetName(ARGV0);
+
+    /* Define current working directory */
+    char * home_path = w_homedir(argv[0]);
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* user arguments */
     if (argc != 2) {
@@ -63,9 +68,11 @@ int main(int argc, char **argv)
     }
 
     /* Chroot to the default directory */
-    if (Privsep_Chroot(dir) < 0) {
-        merror_exit(CHROOT_ERROR, dir, errno, strerror(errno));
+    if (Privsep_Chroot(home_path) < 0) {
+        merror_exit(CHROOT_ERROR, home_path, errno, strerror(errno));
     }
+
+    os_free(home_path);
 
     /* Inside chroot now */
     nowChroot();
@@ -157,6 +164,5 @@ int main(int argc, char **argv)
 
     printf("\n** Internal stats clear.\n\n");
 
-	os_free(home_path);
     return (0);
 }

--- a/src/util/list_agents.c
+++ b/src/util/list_agents.c
@@ -43,11 +43,7 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
-    /* Define current working directory */
     char * home_path = w_homedir(argv[0]);
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
     mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* User arguments */

--- a/src/util/list_agents.c
+++ b/src/util/list_agents.c
@@ -31,8 +31,6 @@ static void helpmsg()
 
 int main(int argc, char **argv)
 {
-    home_path = w_homedir(argv[0]);
-    const char *dir = HOMEDIR;
     const char *group = GROUPGLOBAL;
     const char *user = USER;
 
@@ -44,6 +42,13 @@ int main(int argc, char **argv)
 
     /* Set the name */
     OS_SetName(ARGV0);
+
+    /* Define current working directory */
+    char * home_path = w_homedir(argv[0]);
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* User arguments */
     if (argc < 2) {
@@ -63,9 +68,11 @@ int main(int argc, char **argv)
     }
 
     /* Chroot to the default directory */
-    if (Privsep_Chroot(dir) < 0) {
-        merror_exit(CHROOT_ERROR, dir, errno, strerror(errno));
+    if (Privsep_Chroot(home_path) < 0) {
+        merror_exit(CHROOT_ERROR, home_path, errno, strerror(errno));
     }
+
+    os_free(home_path);
 
     /* Inside chroot now */
     nowChroot();
@@ -106,6 +113,5 @@ int main(int argc, char **argv)
         printf("** No agent available.\n");
     }
 
-    os_free(home_path);
     return (0);
 }

--- a/src/util/verify-agent-conf.c
+++ b/src/util/verify-agent-conf.c
@@ -37,8 +37,7 @@ static void helpmsg()
 
 int main(int argc, char **argv)
 {
-    home_path = w_homedir(argv[0]);
-    const char *ar = BUILDDIR(HOMEDIR,SHAREDCFG_DIR);
+    const char *ar = SHAREDCFG_DIR;
     char path[PATH_MAX + 1];
     char path_f[PATH_MAX + 1];
     DIR *gdir, *subdir;
@@ -48,6 +47,13 @@ int main(int argc, char **argv)
 
     /* Set the name */
     OS_SetName(ARGV0);
+
+    /* Define current working directory */
+    char * home_path = w_homedir(argv[0]);
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     /* User arguments */
     if (argc > 1) {

--- a/src/util/verify-agent-conf.c
+++ b/src/util/verify-agent-conf.c
@@ -54,6 +54,7 @@ int main(int argc, char **argv)
         merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
     }
     mdebug1(WAZUH_HOMEDIR, home_path);
+    os_free(home_path);
 
     /* User arguments */
     if (argc > 1) {
@@ -146,7 +147,6 @@ int main(int argc, char **argv)
     }
     printf("\n");
 
-    os_free(home_path);
     return (error);
 }
 

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -42,7 +42,11 @@ int main(int argc, char ** argv)
 
     OS_SetName(ARGV0);
 
+    // Define current working directory
     char * home_path = w_homedir(argv[0]);
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
     mdebug1(WAZUH_HOMEDIR, home_path);
 
     // Get options

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -43,9 +43,6 @@ int main(int argc, char ** argv)
     OS_SetName(ARGV0);
 
     char * home_path = w_homedir(argv[0]);
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
     mdebug1(WAZUH_HOMEDIR, home_path);
 
     // Get options

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -34,11 +34,6 @@ int main(int argc, char ** argv)
     int run_foreground = 0;
     int i;
     int status;
-    home_path = w_homedir(argv[0]);
-
-    if (chdir(home_path) == -1) {
-        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
-    }
 
     pthread_t thread_dealer;
     pthread_t * worker_pool = NULL;
@@ -46,6 +41,12 @@ int main(int argc, char ** argv)
     pthread_t thread_up;
 
     OS_SetName(ARGV0);
+
+    char * home_path = w_homedir(argv[0]);
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
 
     // Get options
 
@@ -106,9 +107,6 @@ int main(int argc, char ** argv)
     open_dbs = OSHash_Create();
     if (!open_dbs) merror_exit("wazuh_db: OSHash_Create() failed");
 
-    mdebug1(STARTED_MSG);
-    mdebug1(WAZUH_HOMEDIR, home_path);
-
     if (!run_foreground) {
         goDaemon();
         nowDaemon();
@@ -152,6 +150,8 @@ int main(int argc, char ** argv)
             merror_exit(SETUID_ERROR, USER, errno, strerror(errno));
         }
     }
+
+    os_free(home_path);
 
     // Signal manipulation
 
@@ -228,12 +228,10 @@ int main(int argc, char ** argv)
     unlink(path_template);
     mdebug1("Template file removed again: %s", path_template);
 
-    os_free(home_path);
     return EXIT_SUCCESS;
 
 failure:
     os_free(worker_pool);
-    os_free(home_path);
     return EXIT_FAILURE;
 }
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -267,7 +267,7 @@ sqlite3* wdb_open_agent(int id_agent, const char *name) {
     char dir[OS_FLSIZE + 1];
     sqlite3 *db;
 
-    snprintf(dir, OS_FLSIZE, "%s%s/agents/%03d-%s.db", isChroot() ? "/" : "", WDB_DIR, id_agent, name);
+    snprintf(dir, OS_FLSIZE, "%s/agents/%03d-%s.db", WDB_DIR, id_agent, name);
 
     if (sqlite3_open_v2(dir, &db, SQLITE_OPEN_READWRITE, NULL)) {
         mdebug1("No SQLite database found for agent '%s', creating.", name);
@@ -1074,7 +1074,7 @@ int wdb_sql_exec(wdb_t *wdb, const char *sql_exec) {
 int wdb_remove_database(const char * agent_id) {
     char path[PATH_MAX];
 
-    snprintf(path, PATH_MAX, "%s%s/%s.db", isChroot() ? "/" : "", WDB2_DIR, agent_id);
+    snprintf(path, PATH_MAX, "%s/%s.db", WDB2_DIR, agent_id);
     int result = unlink(path);
 
     if (result == -1) {

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -1374,11 +1374,7 @@ time_t get_agent_date_added(int agent_id) {
     struct tm t;
     time_t t_of_sec;
 
-#ifndef WIN32   // Useless condition since Wazuh DB will never run in Windows agents. Best solution is not to compile Wazuh DB for Windows
-    snprintf(path, PATH_MAX, "%s", isChroot() ? TIMESTAMP_FILE : BUILDDIR(HOMEDIR,TIMESTAMP_FILE));
-#else
     snprintf(path, PATH_MAX, "%s", TIMESTAMP_FILE);
-#endif
 
     fp = fopen(path, "r");
 

--- a/src/wazuh_db/wdb_agent.c
+++ b/src/wazuh_db/wdb_agent.c
@@ -1214,7 +1214,7 @@ int wdb_create_agent_db(int id, const char *name) {
         }
     }
 
-    snprintf(path, OS_FLSIZE, "%s%s/agents/%03d-%s.db", isChroot() ? "/" : "", WDB_DIR, id, name);
+    snprintf(path, OS_FLSIZE, "%s/agents/%03d-%s.db", WDB_DIR, id, name);
 
     if (!(dest = fopen(path, "w"))) {
         fclose(source);
@@ -1260,14 +1260,14 @@ int wdb_remove_agent_db(int id, const char * name) {
     char path[PATH_MAX];
     char path_aux[PATH_MAX];
 
-    snprintf(path, PATH_MAX, "%s%s/agents/%03d-%s.db", isChroot() ? "/" : "", WDB_DIR, id, name);
+    snprintf(path, PATH_MAX, "%s/agents/%03d-%s.db", WDB_DIR, id, name);
 
     if (!remove(path)) {
-        snprintf(path_aux, PATH_MAX, "%s%s/agents/%03d-%s.db-shm", isChroot() ? "/" : "", WDB_DIR, id, name);
+        snprintf(path_aux, PATH_MAX, "%s/agents/%03d-%s.db-shm", WDB_DIR, id, name);
         if (remove(path_aux) < 0) {
             mdebug2(DELETE_ERROR, path_aux, errno, strerror(errno));
         }
-        snprintf(path_aux, PATH_MAX, "%s%s/agents/%03d-%s.db-wal", isChroot() ? "/" : "", WDB_DIR, id, name);
+        snprintf(path_aux, PATH_MAX, "%s/agents/%03d-%s.db-wal", WDB_DIR, id, name);
         if (remove(path_aux) < 0) {
             mdebug2(DELETE_ERROR, path_aux, errno, strerror(errno));
         }

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.c
@@ -110,11 +110,8 @@ void wm_agent_upgrade_start_agent_module(const wm_agent_configs* agent_config, c
 STATIC void* wm_agent_upgrade_listen_messages(__attribute__((unused)) void *arg) {
     // Initialize socket
     char sockname[PATH_MAX + 1];
-    if (isChroot()) {
-		strcpy(sockname, AGENT_UPGRADE_SOCK);
-	} else {
-		strcpy(sockname, BUILDDIR(HOMEDIR,AGENT_UPGRADE_SOCK));
-	}
+
+	strcpy(sockname, AGENT_UPGRADE_SOCK);
 
     int sock = OS_BindUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR);
     if (sock < 0) {
@@ -195,7 +192,7 @@ STATIC void wm_agent_upgrade_check_status(const wm_agent_configs* agent_config) 
      *  StartMQ will wait until agent connection which is when the pkg_install.sh will write
      *  the upgrade result
     */
-    int queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
+    int queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     // Wait until pkg_installer script verifies the agent was connected and writes the upgrade_result file
     sleep(WM_AGENT_UPGRADE_RESULT_WAIT_TIME);
@@ -274,7 +271,7 @@ STATIC void wm_upgrade_agent_send_ack_message(int *queue_fd, wm_upgrade_agent_st
         if(*queue_fd >= 0){
             close(*queue_fd);
         }
-        *queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
+        *queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
         if (*queue_fd < 0) {
             mterror_exit(WM_AGENT_UPGRADE_LOGTAG, QUEUE_FATAL, DEFAULTQUEUE);
         }

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.h
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_agent.h
@@ -15,7 +15,7 @@
 #ifdef WIN32
     #define WM_AGENT_UPGRADE_RESULT_FILE UPGRADE_DIR "\\upgrade_result"
 #else
-    #define WM_AGENT_UPGRADE_RESULT_FILE BUILDDIR(HOMEDIR,UPGRADE_DIR "/upgrade_result")
+    #define WM_AGENT_UPGRADE_RESULT_FILE UPGRADE_DIR "/upgrade_result"
 #endif
 
 #define WM_AGENT_UPGRADE_RESULT_WAIT_TIME 30

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -405,7 +405,7 @@ STATIC int _jailfile(char finalpath[PATH_MAX + 1], const char * basedir, const c
     }
 
 #ifndef WIN32
-    return snprintf(finalpath, PATH_MAX + 1, "%s/%s", isChroot() ? "" : basedir, filename) > PATH_MAX ? -1 : 0;
+    return snprintf(finalpath, PATH_MAX + 1, "%s/%s", basedir, filename) > PATH_MAX ? -1 : 0;
 #else
     return snprintf(finalpath, PATH_MAX + 1, "%s\\%s", basedir, filename) > PATH_MAX ? -1 : 0;
 #endif

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -347,21 +347,13 @@ STATIC char * wm_agent_upgrade_com_upgrade(const cJSON* json_object) {
     }
 
     // Clean up upgrade folder
-#ifndef WIN32
-    if (cldir_ex(isChroot() ? UPGRADE_DIR : BUILDDIR(HOMEDIR,UPGRADE_DIR))) {
-#else
     if (cldir_ex(UPGRADE_DIR)) {
-#endif
         mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_GERENIC_ERROR, "upgrade", error_messages[ERROR_CLEAN_DIRECTORY]);
         return wm_agent_upgrade_command_ack(ERROR_CLEAN_DIRECTORY, error_messages[ERROR_CLEAN_DIRECTORY]);
     }
 
     //Unmerge
-#ifndef WIN32
-    if (UnmergeFiles(merged, isChroot() ? UPGRADE_DIR : BUILDDIR(HOMEDIR,UPGRADE_DIR), OS_BINARY) == 0) {
-#else
     if (UnmergeFiles(merged, UPGRADE_DIR, OS_BINARY) == 0) {
-#endif
         unlink(merged);
         mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_UNMERGING_FILE_ERROR, "upgrade", merged);
         return wm_agent_upgrade_command_ack(ERROR_UNMERGE, error_messages[ERROR_UNMERGE]);
@@ -396,11 +388,7 @@ STATIC char * wm_agent_upgrade_com_upgrade(const cJSON* json_object) {
 }
 
 STATIC char * wm_agent_upgrade_com_clear_result() {
-#ifndef WIN32
-    const char * PATH = isChroot() ? UPGRADE_DIR "/upgrade_result" : WM_AGENT_UPGRADE_RESULT_FILE;
-#else
-    const char * PATH = UPGRADE_DIR "\\upgrade_result";
-#endif
+    const char * PATH = WM_AGENT_UPGRADE_RESULT_FILE;
     if (remove(PATH) == 0) {
         allow_upgrades = true;
         return wm_agent_upgrade_command_ack(ERROR_OK, error_messages[ERROR_OK]);
@@ -417,7 +405,7 @@ STATIC int _jailfile(char finalpath[PATH_MAX + 1], const char * basedir, const c
     }
 
 #ifndef WIN32
-    return snprintf(finalpath, PATH_MAX + 1, "%s/%s/%s", isChroot() ? "" : HOMEDIR, basedir, filename) > PATH_MAX ? -1 : 0;
+    return snprintf(finalpath, PATH_MAX + 1, "%s/%s", isChroot() ? "" : basedir, filename) > PATH_MAX ? -1 : 0;
 #else
     return snprintf(finalpath, PATH_MAX + 1, "%s\\%s", basedir, filename) > PATH_MAX ? -1 : 0;
 #endif

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.c
@@ -87,9 +87,9 @@ void wm_agent_upgrade_start_manager_module(const wm_manager_configs* manager_con
 STATIC void wm_agent_upgrade_listen_messages(const wm_manager_configs* manager_configs) {
 
     // Initialize socket
-    int sock = OS_BindUnixDomain(WM_UPGRADE_SOCK_PATH, SOCK_STREAM, OS_MAXSTR);
+    int sock = OS_BindUnixDomain(WM_UPGRADE_SOCK, SOCK_STREAM, OS_MAXSTR);
     if (sock < 0) {
-        mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_BIND_SOCK_ERROR, WM_UPGRADE_SOCK_PATH, strerror(errno));
+        mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_BIND_SOCK_ERROR, WM_UPGRADE_SOCK, strerror(errno));
         return;
     }
 

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_parsing.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_parsing.c
@@ -412,7 +412,7 @@ cJSON* wm_agent_upgrade_parse_task_module_request(wm_upgrade_command command, cJ
 
     const char *(xml_node[]) = {"ossec_config", "cluster", "node_name", NULL};
 
-    if (OS_ReadXML(DEFAULTCPATH, &xml) >= 0) {
+    if (OS_ReadXML(OSSECCONF, &xml) >= 0) {
         node_name = OS_GetOneContentforElement(&xml, xml_node);
     }
 

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_tasks.c
@@ -200,10 +200,10 @@ cJSON* wm_agent_upgrade_send_tasks_information(const cJSON *message_object) {
 STATIC cJSON *wm_agent_send_task_information_master(const cJSON *message_object) {
     cJSON* response = NULL;
 
-    int sock = OS_ConnectUnixDomain(WM_TASK_MODULE_SOCK_PATH, SOCK_STREAM, OS_MAXSTR);
+    int sock = OS_ConnectUnixDomain(WM_TASK_MODULE_SOCK, SOCK_STREAM, OS_MAXSTR);
 
     if (sock == OS_SOCKTERR) {
-        mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_UNREACHEABLE_TASK_MANAGER, WM_TASK_MODULE_SOCK_PATH);
+        mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_UNREACHEABLE_TASK_MANAGER, WM_TASK_MODULE_SOCK);
     } else {
         char *buffer = NULL;
         int length;

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_upgrades.c
@@ -602,7 +602,7 @@ char* wm_agent_upgrade_send_command_to_agent(const char *command, const size_t c
     char *response = NULL;
     int length = 0;
 
-    const char *path = isChroot() ? REMOTE_REQ_SOCK : BUILDDIR(HOMEDIR,REMOTE_REQ_SOCK);
+    const char *path = REMOTE_REQ_SOCK;
 
     int sock = OS_ConnectUnixDomain(path, SOCK_STREAM, OS_MAXSTR);
 

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -25,12 +25,19 @@ int main(int argc, char **argv)
     int c;
     int wm_debug = 0;
     int test_config = 0;
-    home_path = w_homedir(argv[0]);
-    wmodule *cur_module;
-    wm_debug_level = getDefine_Int("wazuh_modules", "debug", 0, 2);
-
+    
     /* Set the name */
     OS_SetName(ARGV0);
+    
+    // Define current working directory
+    char * home_path = w_homedir(argv[0]);
+    if (chdir(home_path) == -1) {
+        merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
+    }
+    mdebug1(WAZUH_HOMEDIR, home_path);
+
+    wmodule *cur_module;
+    wm_debug_level = getDefine_Int("wazuh_modules", "debug", 0, 2);
 
     // Get command line options
 
@@ -146,7 +153,7 @@ void wm_setup()
 
     // Change working directory
 
-    if (chdir(HOMEDIR) < 0) {
+    if (chdir(home_path) < 0) {
         merror_exit("chdir(): %s", strerror(errno));
     }
 

--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -35,6 +35,7 @@ int main(int argc, char **argv)
         merror_exit(CHDIR_ERROR, home_path, errno, strerror(errno));
     }
     mdebug1(WAZUH_HOMEDIR, home_path);
+    os_free(home_path);
 
     wmodule *cur_module;
     wm_debug_level = getDefine_Int("wazuh_modules", "debug", 0, 2);
@@ -101,7 +102,6 @@ int main(int argc, char **argv)
         pthread_join(cur_module->thread, NULL);
     }
 
-    os_free(home_path);
     return EXIT_SUCCESS;
 }
 
@@ -149,12 +149,6 @@ void wm_setup()
 
     if (Privsep_SetGroup(gid) < 0) {
         merror_exit(SETGID_ERROR, GROUPGLOBAL, errno, strerror(errno));
-    }
-
-    // Change working directory
-
-    if (chdir(home_path) < 0) {
-        merror_exit("chdir(): %s", strerror(errno));
     }
 
     if (wm_check() < 0) {

--- a/src/wazuh_modules/syscollector/syscollector_common.c
+++ b/src/wazuh_modules/syscollector/syscollector_common.c
@@ -200,7 +200,7 @@ static void wm_sys_setup(wm_sys_t *_sys) {
     #ifndef WIN32
 
     // Connect to socket
-    queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
+    queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (queue_fd < 0) {
         mterror(WM_SYS_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/task_manager/wm_task_manager.c
+++ b/src/wazuh_modules/task_manager/wm_task_manager.c
@@ -105,7 +105,7 @@ STATIC int wm_task_manager_init(wm_task_manager *task_config) {
     w_create_thread(wm_task_manager_clean_tasks, task_config);
 
     /* Set the queue */
-    if (sock = OS_BindUnixDomain(BUILDDIR(HOMEDIR,TASK_QUEUE), SOCK_STREAM, OS_MAXSTR), sock < 0) {
+    if (sock = OS_BindUnixDomain(TASK_QUEUE, SOCK_STREAM, OS_MAXSTR), sock < 0) {
         mterror(WM_TASK_MANAGER_LOGTAG, MOD_TASK_CREATE_SOCK_ERROR, TASK_QUEUE, strerror(errno)); // LCOV_EXCL_LINE
         pthread_exit(NULL);
     }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -7104,7 +7104,7 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
         pthread_exit(NULL);
     }
 
-    vuldet->queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
+    vuldet->queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (vuldet->queue_fd < 0) {
         mterror(WM_VULNDETECTOR_LOGTAG, "Can't connect to queue.");
@@ -7208,11 +7208,11 @@ void wm_vuldet_update_last_scan(char *agent_id) {
 int wm_vuldet_get_wdb_socket() {
     if (wdb_vuldet_sock < 0) {
         int i;
-        for (i = 0; i < VU_MAX_WAZUH_DB_ATTEMPS && (wdb_vuldet_sock = OS_ConnectUnixDomain(WDB_LOCAL_SOCK_PATH, SOCK_STREAM, OS_SIZE_6144)) < 0; i++) {
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_SOCKET_RETRY, WDB_LOCAL_SOCK_PATH, i);
+        for (i = 0; i < VU_MAX_WAZUH_DB_ATTEMPS && (wdb_vuldet_sock = OS_ConnectUnixDomain(WDB_LOCAL_SOCK, SOCK_STREAM, OS_SIZE_6144)) < 0; i++) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_SOCKET_RETRY, WDB_LOCAL_SOCK, i);
             sleep(i * i);
             if (i == VU_MAX_WAZUH_DB_ATTEMPS) {
-                mterror(WM_VULNDETECTOR_LOGTAG, VU_SOCKET_RETRY_ERROR, WDB_LOCAL_SOCK_PATH);
+                mterror(WM_VULNDETECTOR_LOGTAG, VU_SOCKET_RETRY_ERROR, WDB_LOCAL_SOCK);
                 i = -1;
             }
         }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -34,9 +34,9 @@
 #define VU_FIT_TEMP_FILE VU_TEMP_FILE "-fitted"
 #define VU_TEMP_METADATA_FILE VU_TEMP_FILE "-metadata"
 #define VU_DEB_TEMP_FILE VU_TEMP_FILE "-deb"
-#define VU_DICTIONARIES BUILDDIR(HOMEDIR,"/queue/vulnerabilities/dictionaries")
-#define VU_CPE_HELPER_FILE BUILDDIR(HOMEDIR,"/queue/vulnerabilities/dictionaries/cpe_helper.json")
-#define VU_MSU_FILE BUILDDIR(HOMEDIR,"/queue/vulnerabilities/dictionaries/msu.json")
+#define VU_DICTIONARIES "queue/vulnerabilities/dictionaries"
+#define VU_CPE_HELPER_FILE "queue/vulnerabilities/dictionaries/cpe_helper.json"
+#define VU_MSU_FILE "queue/vulnerabilities/dictionaries/msu.json"
 #define VU_CPEHELPER_FORMAT_VERSION 1
 #define CANONICAL_REPO "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.%s.cve.oval.xml.bz2"
 #define DEBIAN_REPO "https://www.debian.org/security/oval/oval-definitions-%s.xml"

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -251,7 +251,7 @@ void wm_aws_setup(wm_aws *_aws_config) {
 
     // Connect to socket
 
-    aws_config->queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
+    aws_config->queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (aws_config->queue_fd < 0) {
         mterror(WM_AWS_LOGTAG, "Can't connect to queue.");
@@ -302,11 +302,9 @@ void wm_aws_run_s3(wm_aws *aws_config, wm_aws_bucket *exec_bucket) {
     // script path
     char * script = NULL;
     os_calloc(PATH_MAX, sizeof(char), script);
-#ifndef WIN32
-    snprintf(script, PATH_MAX, "%s", BUILDDIR(HOMEDIR,WM_AWS_SCRIPT_PATH));
-#else
+
     snprintf(script, PATH_MAX, "%s", WM_AWS_SCRIPT_PATH);
-#endif
+
     wm_strcat(&command, script, '\0');
     os_free(script);
 
@@ -459,11 +457,9 @@ void wm_aws_run_service(wm_aws *aws_config, wm_aws_service *exec_service) {
     // script path
     char * script = NULL;
     os_calloc(PATH_MAX, sizeof(char), script);
-#ifndef WIN32
-    snprintf(script, PATH_MAX, "%s", BUILDDIR(HOMEDIR,WM_AWS_SCRIPT_PATH));
-#else
+
     snprintf(script, PATH_MAX, "%s", WM_AWS_SCRIPT_PATH);
-#endif
+
     wm_strcat(&command, script, '\0');
     os_free(script);
 

--- a/src/wazuh_modules/wm_aws.h
+++ b/src/wazuh_modules/wm_aws.h
@@ -16,7 +16,7 @@
 
 #define WM_AWS_LOGTAG ARGV0 ":aws-s3"
 #define WM_AWS_DEFAULT_INTERVAL 5
-#define WM_AWS_SCRIPT_PATH "/wodles/aws/aws-s3"
+#define WM_AWS_SCRIPT_PATH "wodles/aws/aws-s3"
 
 typedef struct wm_aws_state_t {
     time_t next_time;               // Absolute time for next scan

--- a/src/wazuh_modules/wm_azure.c
+++ b/src/wazuh_modules/wm_azure.c
@@ -119,7 +119,7 @@ void wm_azure_log_analytics(wm_azure_api_t *log_analytics) {
 
         char * script = NULL;
         os_calloc(PATH_MAX, sizeof(char), script);
-        snprintf(script, PATH_MAX, "%s", BUILDDIR(HOMEDIR,WM_AZURE_SCRIPT_PATH));
+        snprintf(script, PATH_MAX, "%s", WM_AZURE_SCRIPT_PATH);
         wm_strcat(&command, script, '\0');
         os_free(script);
         wm_strcat(&command, "--log_analytics", ' ');
@@ -198,7 +198,7 @@ void wm_azure_graphs(wm_azure_api_t *graph) {
 
         char * script = NULL;
         os_calloc(PATH_MAX, sizeof(char), script);
-        snprintf(script, PATH_MAX, "%s", BUILDDIR(HOMEDIR,WM_AZURE_SCRIPT_PATH));
+        snprintf(script, PATH_MAX, "%s", WM_AZURE_SCRIPT_PATH);
         wm_strcat(&command, script, '\0');
         os_free(script);
         wm_strcat(&command, "--graph", ' ');
@@ -275,7 +275,7 @@ void wm_azure_storage(wm_azure_storage_t *storage) {
 
         char * script = NULL;
         os_calloc(PATH_MAX, sizeof(char), script);
-        snprintf(script, PATH_MAX, "%s", BUILDDIR(HOMEDIR,WM_AZURE_SCRIPT_PATH));
+        snprintf(script, PATH_MAX, "%s", WM_AZURE_SCRIPT_PATH);
         wm_strcat(&command, script, '\0');
         os_free(script);
         wm_strcat(&command, "--storage", ' ');
@@ -355,7 +355,7 @@ void wm_azure_setup(wm_azure_t *_azure_config) {
 
     // Connect to socket
 
-    queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
+    queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (queue_fd < 0) {
         mterror(WM_AZURE_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/wm_azure.h
+++ b/src/wazuh_modules/wm_azure.h
@@ -14,7 +14,7 @@
 #define WM_AZURE
 
 #define WM_AZURE_LOGTAG ARGV0 ":" AZ_WM_NAME
-#define WM_AZURE_SCRIPT_PATH "/wodles/azure/azure-logs"
+#define WM_AZURE_SCRIPT_PATH "wodles/azure/azure-logs"
 
 #define LOG_ANALYTICS   0
 #define GRAPHS          1

--- a/src/wazuh_modules/wm_ciscat.c
+++ b/src/wazuh_modules/wm_ciscat.c
@@ -92,7 +92,7 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
                     skip_java = 1;
                 }
             #else
-                snprintf(java_fullpath, OS_MAXSTR - 1, "%s/%s", HOMEDIR, ciscat->java_path);
+                snprintf(java_fullpath, OS_MAXSTR - 1, "%s", ciscat->java_path);
             #endif
                 break;
             default:
@@ -126,7 +126,7 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
                     snprintf(cis_path, OS_MAXSTR - 1, "%s\\%s", current, ciscat->ciscat_path);
                 }
             #else
-                snprintf(cis_path, OS_MAXSTR - 1, "%s/%s", HOMEDIR, ciscat->ciscat_path);
+                snprintf(cis_path, OS_MAXSTR - 1, "%s", ciscat->ciscat_path);
             #endif
                 break;
             default:
@@ -138,7 +138,7 @@ void* wm_ciscat_main(wm_ciscat *ciscat) {
         if (*current)
             snprintf(cis_path, OS_MAXSTR - 1, "%s\\%s", current, WM_CISCAT_DEFAULT_DIR_WIN);
     #else
-        snprintf(cis_path, OS_MAXSTR - 1, "%s", BUILDDIR(HOMEDIR,WM_CISCAT_DEFAULT_DIR));
+        snprintf(cis_path, OS_MAXSTR - 1, "%s", WM_CISCAT_DEFAULT_DIR);
     #endif
     }
 
@@ -230,7 +230,7 @@ void wm_ciscat_setup(wm_ciscat *_ciscat) {
 
 #ifndef WIN32
 
-    queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
+    queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (queue_fd < 0) {
         mterror(WM_CISCAT_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/wm_ciscat.h
+++ b/src/wazuh_modules/wm_ciscat.h
@@ -16,9 +16,9 @@
 #define MAX_RESULT          64              // Maximum result length
 
 #define WM_CISCAT_LOGTAG ARGV0 ":ciscat"
-#define WM_CISCAT_DEFAULT_DIR     "/wodles/ciscat"
+#define WM_CISCAT_DEFAULT_DIR     "wodles/ciscat"
 #define WM_CISCAT_DEFAULT_DIR_WIN "wodles\\ciscat"
-#define WM_CISCAT_REPORTS BUILDDIR(HOMEDIR,"/tmp")
+#define WM_CISCAT_REPORTS "tmp"
 
 #define WM_CISCAT_PROFILE       "<Profile id="
 #define WM_CISCAT_PROFILE2      "<xccdf:Profile id="

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -153,7 +153,7 @@ void * wm_command_main(wm_command_t * command) {
 #ifndef WIN32
     if (!command->ignore_output) {
 
-        command->queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
+        command->queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
         if (command->queue_fd < 0) {
             mterror(WM_COMMAND_LOGTAG, "Can't connect to queue.");

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -287,7 +287,7 @@ void *send_ip(){
     ssize_t length;
     fd_set fdset;
 
-    if (sock = OS_BindUnixDomain(BUILDDIR(HOMEDIR,CONTROL_SOCK), SOCK_STREAM, OS_MAXSTR), sock < 0) {
+    if (sock = OS_BindUnixDomain(CONTROL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
         mterror(WM_CONTROL_LOGTAG, "Unable to bind to socket '%s': (%d) %s.", CONTROL_SOCK, errno, strerror(errno));
         return NULL;
     }

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -331,7 +331,7 @@ void wm_clean_dangling_db() {
     struct dirent * dirent = NULL;
     DIR * dir;
 
-    snprintf(dirname, sizeof(dirname), "%s%s/agents", isChroot() ? "/" : "", WDB_DIR);
+    snprintf(dirname, sizeof(dirname), "%s/agents", WDB_DIR);
     mtdebug1(WM_DATABASE_LOGTAG, "Cleaning directory '%s'.", dirname);
 
     if (!(dir = opendir(dirname))) {

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -616,7 +616,7 @@ void wm_inotify_setup(wm_database * data) {
 
 #ifndef LOCAL
 
-    char * keysfile_path = KEYS_FILE;
+    char keysfile_path[PATH_MAX] = KEYS_FILE;
     char * keysfile_dir = dirname(keysfile_path);
 
     if (data->sync_agents) {
@@ -646,7 +646,7 @@ void wm_inotify_setup(wm_database * data) {
 // Real time inotify reader thread
 static void * wm_inotify_start(__attribute__((unused)) void * args) {
     char buffer[IN_BUFFER_SIZE];
-    char * keysfile_dir = KEYS_FILE;
+    char keysfile_dir[PATH_MAX] = KEYS_FILE;
     char * keysfile;
     struct inotify_event *event;
     char * dirname = NULL;

--- a/src/wazuh_modules/wm_docker.c
+++ b/src/wazuh_modules/wm_docker.c
@@ -35,7 +35,7 @@ const wm_context WM_DOCKER_CONTEXT = {
 
 void* wm_docker_main(wm_docker_t *docker_conf) {
     int status = 0;
-    char * command = BUILDDIR(HOMEDIR,WM_DOCKER_SCRIPT_PATH);
+    char * command = WM_DOCKER_SCRIPT_PATH;
     char * timestamp = NULL;
     int attempts = 0;
 

--- a/src/wazuh_modules/wm_docker.h
+++ b/src/wazuh_modules/wm_docker.h
@@ -14,7 +14,7 @@
 #ifndef WIN32
 
 #define WM_DOCKER_LOGTAG ARGV0 ":docker-listener"
-#define WM_DOCKER_SCRIPT_PATH  "/wodles/docker/DockerListener"
+#define WM_DOCKER_SCRIPT_PATH  "wodles/docker/DockerListener"
 
 #define WM_DOCKER_DEF_INTERVAL 60
 

--- a/src/wazuh_modules/wm_download.c
+++ b/src/wazuh_modules/wm_download.c
@@ -62,8 +62,8 @@ void * wm_download_main(wm_download_t * data) {
     do {
         static unsigned int seconds = 60;
 
-        if (sock = OS_BindUnixDomain(WM_DOWNLOAD_SOCK_PATH, SOCK_STREAM, OS_MAXSTR), sock < 0) {
-            mwarn("Unable to bind to socket '%s', retrying in %u secs.", WM_DOWNLOAD_SOCK_PATH, seconds);
+        if (sock = OS_BindUnixDomain(WM_DOWNLOAD_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
+            mwarn("Unable to bind to socket '%s', retrying in %u secs.", WM_DOWNLOAD_SOCK, seconds);
             sleep(seconds);
             seconds += seconds < 600 ? 60 : 0;
         }
@@ -212,7 +212,7 @@ unsc:
 
     // Jail path
 
-    if (snprintf(jpath, sizeof(jpath), "%s/%s", HOMEDIR, unsc_fpath) >= (int)sizeof(jpath)) {
+    if (snprintf(jpath, sizeof(jpath), "%s", unsc_fpath) >= (int)sizeof(jpath)) {
         mdebug1("Path too long: '%s'", buffer_cpy);
         snprintf(buffer, OS_MAXSTR, "err path too long");
         goto end;

--- a/src/wazuh_modules/wm_gcp.c
+++ b/src/wazuh_modules/wm_gcp.c
@@ -86,11 +86,9 @@ void wm_gcp_run(const wm_gcp *data) {
 
     char * script = NULL;
     os_calloc(PATH_MAX, sizeof(char), script);
-#ifndef WIN32
-    snprintf(script, PATH_MAX, "%s", BUILDDIR(HOMEDIR,WM_GCP_SCRIPT_PATH));
-#else
+
     snprintf(script, PATH_MAX, "%s", WM_GCP_SCRIPT_PATH);
-#endif
+
     wm_strcat(&command, script, '\0');
     os_free(script);
 

--- a/src/wazuh_modules/wm_gcp.h
+++ b/src/wazuh_modules/wm_gcp.h
@@ -13,7 +13,7 @@
 #define WM_GCP_H
 
 #define WM_GCP_LOGTAG ARGV0 ":gcp-pubsub"
-#define WM_GCP_SCRIPT_PATH "/wodles/gcloud/gcloud"
+#define WM_GCP_SCRIPT_PATH "wodles/gcloud/gcloud"
 
 #define WM_GCP_DEF_INTERVAL 3600
 

--- a/src/wazuh_modules/wm_keyrequest.c
+++ b/src/wazuh_modules/wm_keyrequest.c
@@ -86,8 +86,8 @@ void * wm_key_request_main(wm_krequest_t * data) {
     /* Init the queue input */
     request_queue = queue_init(data->queue_size);
 
-    if ((sock = StartMQ(WM_KEY_REQUEST_SOCK_PATH, READ, 0)) < 0) {
-        merror(QUEUE_ERROR, WM_KEY_REQUEST_SOCK_PATH, strerror(errno));
+    if ((sock = StartMQ(WM_KEY_REQUEST_SOCK, READ, 0)) < 0) {
+        merror(QUEUE_ERROR, WM_KEY_REQUEST_SOCK, strerror(errno));
         pthread_exit(NULL);
     }
 

--- a/src/wazuh_modules/wm_oscap.c
+++ b/src/wazuh_modules/wm_oscap.c
@@ -97,7 +97,7 @@ void wm_oscap_setup(wm_oscap *_oscap) {
 
     // Connect to socket
 
-    queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
+    queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (queue_fd < 0) {
         mterror(WM_OSCAP_LOGTAG, "Can't connect to queue.");
@@ -131,7 +131,7 @@ void wm_oscap_run(wm_oscap_eval *eval) {
 
     char * script = NULL;
     os_calloc(PATH_MAX, sizeof(char), script);
-    snprintf(script, PATH_MAX, "%s", BUILDDIR(HOMEDIR,WM_OSCAP_SCRIPT_PATH));
+    snprintf(script, PATH_MAX, "%s", WM_OSCAP_SCRIPT_PATH);
     wm_strcat(&command, script, '\0');
     os_free(script);
 

--- a/src/wazuh_modules/wm_oscap.h
+++ b/src/wazuh_modules/wm_oscap.h
@@ -15,7 +15,7 @@
 #define WM_OSCAP_DEF_TIMEOUT    1800    // Default runtime limit (30 minutes)
 
 #define WM_OSCAP_LOGTAG ARGV0 ":oscap"
-#define WM_OSCAP_SCRIPT_PATH "/wodles/oscap/oscap.py"
+#define WM_OSCAP_SCRIPT_PATH "wodles/oscap/oscap.py"
 
 typedef enum wm_oscap_eval_t { WM_OSCAP_XCCDF = 1, WM_OSCAP_OVAL } wm_oscap_eval_t;
 

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -17,11 +17,7 @@
 #include <signal.h>
 #include <stdio.h>
 
-#ifdef WIN32
 #define TMP_CONFIG_PATH "tmp/osquery.conf.tmp"
-#else
-#define TMP_CONFIG_PATH "/tmp/osquery.conf.tmp"
-#endif
 
 #ifdef WIN32
 #define OSQUERYD_BIN "osqueryd.exe"
@@ -422,7 +418,7 @@ int wm_osquery_decorators(wm_osquery_monitor_t * osquery)
 
     os_calloc(1, sizeof(wlabel_t), labels);
 
-    if (ReadConfig(CLABELS, DEFAULTCPATH, &labels, NULL) < 0)
+    if (ReadConfig(CLABELS, OSSECCONF, &labels, NULL) < 0)
         goto end;
 
 #ifdef CLIENT
@@ -484,11 +480,7 @@ int wm_osquery_decorators(wm_osquery_monitor_t * osquery)
 
     free(osquery->config_path);
 
-#ifdef WIN32
     os_strdup(TMP_CONFIG_PATH, osquery->config_path);
-#else
-    os_strdup(BUILDDIR(HOMEDIR,TMP_CONFIG_PATH), osquery->config_path);
-#endif
 
     // Write new configuration
 
@@ -558,11 +550,7 @@ int wm_osquery_packs(wm_osquery_monitor_t *osquery)
 
     free(osquery->config_path);
 
-#ifdef WIN32
     os_strdup(TMP_CONFIG_PATH, osquery->config_path);
-#else
-    os_strdup(BUILDDIR(HOMEDIR,TMP_CONFIG_PATH), osquery->config_path);
-#endif
 
     // Write new configuration
 
@@ -591,7 +579,7 @@ void *wm_osquery_monitor_main(wm_osquery_monitor_t *osquery)
 #ifndef WIN32
     // Connect to queue
 
-    osquery->queue_fd = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
+    osquery->queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
     if (osquery->queue_fd < 0) {
         mterror(WM_OSQUERYMONITOR_LOGTAG, "Can't connect to queue. Closing module.");
         return NULL;

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -212,7 +212,7 @@ void * wm_sca_main(wm_sca_t * data) {
 
 #ifndef WIN32
 
-    data->queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS);
+    data->queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (data->queue < 0) {
         merror("Can't connect to queue.");
@@ -260,7 +260,7 @@ static int wm_sca_send_alert(wm_sca_t * data,cJSON *json_alert)
             close(data->queue);
         }
 
-        if ((data->queue = StartMQ(DEFAULTQPATH, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
+        if ((data->queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
             mwarn("Can't connect to queue.");
         } else {
             if(wm_sendmsg(data->msg_delay, data->queue, msg,WM_SCA_STAMP, SCA_MQ) < 0) {
@@ -2959,8 +2959,8 @@ static void * wm_sca_request_thread(wm_sca_t * data) {
 
     /* Create request socket */
     int cfga_queue;
-    if ((cfga_queue = StartMQ(CFGASSESSMENTQUEUEPATH, READ, 0)) < 0) {
-        merror(QUEUE_ERROR, CFGASSESSMENTQUEUEPATH, strerror(errno));
+    if ((cfga_queue = StartMQ(CFGAQUEUE, READ, 0)) < 0) {
+        merror(QUEUE_ERROR, CFGAQUEUE, strerror(errno));
         pthread_exit(NULL);
     }
 

--- a/src/wazuh_modules/wmcom.c
+++ b/src/wazuh_modules/wmcom.c
@@ -86,7 +86,7 @@ void * wmcom_main(__attribute__((unused)) void * arg) {
 
     mdebug1("Local requests thread ready");
 
-    if (sock = OS_BindUnixDomain(BUILDDIR(HOMEDIR,WM_LOCAL_SOCK), SOCK_STREAM, OS_MAXSTR), sock < 0) {
+    if (sock = OS_BindUnixDomain(WM_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
         merror("Unable to bind to socket '%s': (%d) %s.", WM_LOCAL_SOCK, errno, strerror(errno));
         return NULL;
     }

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -62,7 +62,7 @@ int wm_config() {
 
     // Read configuration: ossec.conf
 
-    if (ReadConfig(CWMODULE, DEFAULTCPATH, &wmodules, &agent_cfg) < 0) {
+    if (ReadConfig(CWMODULE, OSSECCONF, &wmodules, &agent_cfg) < 0) {
         return -1;
     }
 

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -20,8 +20,8 @@
 #include <pthread.h>
 #include "config/config.h"
 
-#define WM_DEFAULT_DIR  BUILDDIR(HOMEDIR,"/wodles")       // Default modules directory.
-#define WM_STATE_DIR    BUILDDIR(HOMEDIR,"/var/wodles")   // Default directory for states.
+#define WM_DEFAULT_DIR  "wodles"                   // Default modules directory.
+#define WM_STATE_DIR    "var/wodles"               // Default directory for states.
 #define WM_DIR_WIN      "wodles"                    // Default directory for states (Windows)
 #define WM_STRING_MAX   67108864                    // Max. dynamic string size (64 MB).
 #define WM_BUFFER_MAX   1024                        // Max. static buffer size.

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -313,10 +313,14 @@ void InstallAuthKeys(char *msg)
             !OS_IsValidName(entry[2]) || !OS_IsValidName(entry[3]))
             merror_exit("Invalid key received (2). Closing connection.");
 
-        fp = fopen(KEYSFILE_PATH, "w");
+        fp = fopen(KEYS_FILE, "w");
 
-        if (!fp)
-            merror_exit("Unable to open key file: %s", KEYSFILE_PATH);
+        if (!fp) {
+            char buffer[PATH_MAX] = {'\0'};
+            abspath(KEYS_FILE, buffer, PATH_MAX);
+            merror_exit("Unable to open key file: %s", buffer);
+        }
+            
 
         fprintf(fp, "%s\n", key);
         fclose(fp);
@@ -446,7 +450,7 @@ int main(int argc, char **argv)
     /* Checking if there is a custom password file */
     if (authpass == NULL) {
         FILE *fp;
-        fp = fopen(AUTHDPASS_PATH, "r");
+        fp = fopen(AUTHD_PASS, "r");
         buf[0] = '\0';
 
         if (fp) {
@@ -458,7 +462,10 @@ int main(int argc, char **argv)
             }
 
             fclose(fp);
-            printf("INFO: Using password specified on file: %s\n", AUTHDPASS_PATH);
+
+            char buffer[PATH_MAX] = {'\0'};
+            abspath(AUTHD_PASS, buffer, PATH_MAX);
+            printf("INFO: Using password specified on file: %s\n", buffer);
         }
     }
     if (!authpass) {

--- a/src/win32/ui/common.c
+++ b/src/win32/ui/common.c
@@ -232,7 +232,7 @@ int config_read(__attribute__((unused)) HWND hwnd)
     }
 
     /* Get agent ID, name and IP */
-    tmp_str = cat_file(AUTH_FILE, NULL);
+    tmp_str = cat_file(KEYS_FILE, NULL);
     if (tmp_str) {
         char *to_free = tmp_str;
         /* Get base 64 */
@@ -485,7 +485,7 @@ int set_ossec_key(char *key, HWND hwnd)
 {
     FILE *fp;
 
-    char auth_file_tmp[] = AUTH_FILE;
+    char auth_file_tmp[] = KEYS_FILE;
     char *keys_file = basename_ex(auth_file_tmp);
 
     char tmp_path[strlen(TMP_DIR) + 1 + strlen(keys_file) + 6 + 1];
@@ -515,7 +515,7 @@ int set_ossec_key(char *key, HWND hwnd)
         return (0);
     }
 
-    if (rename_ex(tmp_path, AUTH_FILE)) {
+    if (rename_ex(tmp_path, KEYS_FILE)) {
         MessageBox(hwnd, "Unable to rename temporary file.",
                    "Error -- Failure Renaming Temporary File", MB_OK);
 

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -34,7 +34,7 @@ void *skthread()
 int local_start()
 {
     int rc;
-    char *cfg = DEFAULTCPATH;
+    char *cfg = OSSECCONF;
     WSADATA wsaData;
     DWORD  threadID;
     DWORD  threadID2;


### PR DESCRIPTION
|Related issue|
|---|
|#7430|

## Description

Hi team,

This pull request aims to include several changes to adapt Wazuh's binaries to work under relative paths, thus making the compiling process independent of any predefined installation path. Several changes have been introduced to achieve this:

- Each binary has first to move with `chdir()` its working directory to the one in which it is installed.
- From now on, binaries use relative paths to navigate or use Wazuh-related resources.
- When outputting path-related data, there have to be a way to print the absolute path, generally using `abspath()`.

## Configuration options


## Logs/Alerts example


## Tests

- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities


- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
