### PR TITLE
Network name encoding exception - UTF 8

### DIFF
--- a/src/data_provider/src/network/networkWindowsWrapper.h
+++ b/src/data_provider/src/network/networkWindowsWrapper.h
@@ -172,7 +172,7 @@ public:
 
     std::string gateway() const override
     {
-        std::string retVal { "unknown" };
+        std::string retVal;
         constexpr auto GATEWAY_SEPARATOR { "," };
         if (Utils::isVistaOrLater())
         {
@@ -222,7 +222,11 @@ public:
                 currentAdapterInfo = currentAdapterInfo->Next;
             }
         }
-        if (retVal != "unknown")
+        if (retVal.empty())
+        {
+            retVal = "unknown";
+        }
+        else
         {
             // Remove last GATEWAY_SEPARATOR (,)
             retVal = retVal.substr(0, retVal.size()-1);

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -216,7 +216,11 @@ namespace Utils
             const std::wstring wfriendlyName(adapterName);
             if (!wfriendlyName.empty())
             {
-                retVal.assign(wfriendlyName.begin(), wfriendlyName.end());
+                const auto wSize{static_cast<int>(wfriendlyName.size())};
+                const auto sizeNeeded {WideCharToMultiByte(CP_UTF8, 0, wfriendlyName.data(), wSize, nullptr, 0, nullptr, nullptr)};
+                const auto buffer{std::make_unique<char[]>(sizeNeeded)};
+                WideCharToMultiByte(CP_UTF8, 0, wfriendlyName.data(), wSize, buffer.get(), sizeNeeded, nullptr, nullptr);
+                retVal.assign(buffer.get(), sizeNeeded);
             }
             return retVal;
         }

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -219,8 +219,10 @@ namespace Utils
                 const auto wSize{static_cast<int>(wfriendlyName.size())};
                 const auto sizeNeeded {WideCharToMultiByte(CP_UTF8, 0, wfriendlyName.data(), wSize, nullptr, 0, nullptr, nullptr)};
                 const auto buffer{std::make_unique<char[]>(sizeNeeded)};
-                WideCharToMultiByte(CP_UTF8, 0, wfriendlyName.data(), wSize, buffer.get(), sizeNeeded, nullptr, nullptr);
-                retVal.assign(buffer.get(), sizeNeeded);
+                if (WideCharToMultiByte(CP_UTF8, 0, wfriendlyName.data(), wSize, buffer.get(), sizeNeeded, nullptr, nullptr) > 0)
+                {
+                    retVal.assign(buffer.get(), sizeNeeded);
+                }
             }
             return retVal;
         }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7474 |

## Description

This issue aims to solve a detected problem, based on the localization of the various Windows operating systems that may be in use.

The problem here is the use of a wide string to populate the data return json in the sysinfo module (this module is the data provider)

Actual result:
![imagen](https://user-images.githubusercontent.com/14300208/107958257-869f0e80-6f80-11eb-8f35-4ca443c6c975.png)

Expected result:
No exception.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer