### PR TITLE
Allow OS Regex match empty strings

### DIFF
--- a/ruleset/decoders/0063-pix_decoders.xml
+++ b/ruleset/decoders/0063-pix_decoders.xml
@@ -38,7 +38,7 @@
   - %PIX-6-302015: Built outbound UDP connection 156 for outside:192.168.2.10/1514 (192.168.2.10/1514) to inside:192.168.1.2/1026 (192.168.2.14/1163)
   -->
 <decoder name="pix">
-  <prematch>^%PIX-|^\w\w\w \d\d \d\d\d\d \d\d:\d\d:\d\d: %PIX-|</prematch>
+  <prematch>^%PIX-|^\w\w\w \d\d \d\d\d\d \d\d:\d\d:\d\d: %PIX-</prematch>
 </decoder>
 
 <decoder name="pix-fw1">

--- a/ruleset/decoders/0470-panda-paps_decoders.xml
+++ b/ruleset/decoders/0470-panda-paps_decoders.xml
@@ -24,481 +24,481 @@ LEEF:1.0|Panda Security|paps|02.47.00.0000|exec|sev=4	devTime=2019-05-09 22:00:5
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>devTime=(\.*)\t|(\.*)$</regex>
+  <regex>devTime=(\.*)\t|devTime=(\.*)$</regex>
   <order>devTime</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>devTimeFormat=(\.*)\t|(\.*)$</regex>
+  <regex>devTimeFormat=(\.*)\t|devTimeFormat=(\.*)$</regex>
   <order>devTimeFormat</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>usrName=(\.*)\t|(\.*)$</regex>
+  <regex>usrName=(\.*)\t|usrName=(\.*)$</regex>
   <order>usrName</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>domain=(\.*)\t|(\.*)$</regex>
+  <regex>domain=(\.*)\t|domain=(\.*)$</regex>
   <order>domain</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>src=(\.*)\t|(\.*)$</regex>
+  <regex>src=(\.*)\t|src=(\.*)$</regex>
   <order>src</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>identSrc=(\.*)\t|(\.*)$</regex>
+  <regex>identSrc=(\.*)\t|identSrc=(\.*)$</regex>
   <order>identSrc</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>identHostName=(\.*)\t|(\.*)$</regex>
+  <regex>identHostName=(\.*)\t|identHostName=(\.*)$</regex>
   <order>identHostName</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>1NFI=(\.*)\t|(\.*)$</regex>
+  <regex>1NFI=(\.*)\t|1NFI=(\.*)$</regex>
   <order>1NFI</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>1NMW=(\.*)\t|(\.*)$</regex>
+  <regex>1NMW=(\.*)\t|1NMW=(\.*)$</regex>
   <order>1NMW</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>AVDets=(\.*)\t|(\.*)$</regex>
+  <regex>AVDets=(\.*)\t|AVDets=(\.*)$</regex>
   <order>AVDets</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Action=(\.*)\t|(\.*)$</regex>
+  <regex>Action=(\.*)\t|Action=(\.*)$</regex>
   <order>Action</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Broken=(\.*)\t|(\.*)$</regex>
+  <regex>Broken=(\.*)\t|Broken=(\.*)$</regex>
   <order>Broken</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>BytesReceived=(\.*)\t|(\.*)$</regex>
+  <regex>BytesReceived=(\.*)\t|BytesReceived=(\.*)$</regex>
   <order>BytesReceived</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>BytesSent=(\.*)\t|(\.*)$</regex>
+  <regex>BytesSent=(\.*)\t|BytesSent=(\.*)$</regex>
   <order>BytesSent</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Cat=(\.*)\t|(\.*)$</regex>
+  <regex>Cat=(\.*)\t|Cat=(\.*)$</regex>
   <order>Cat</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>CfgSvcLevel=(\.*)\t|(\.*)$</regex>
+  <regex>CfgSvcLevel=(\.*)\t|CfgSvcLevel=(\.*)$</regex>
   <order>CfgSvcLevel</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Parent1NFI=(\.*)\t|(\.*)$</regex>
+  <regex>Parent1NFI=(\.*)\t|Parent1NFI=(\.*)$</regex>
   <order>Parent1NFI</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Parent1NMW=(\.*)\t|(\.*)$</regex>
+  <regex>Parent1NMW=(\.*)\t|Parent1NMW=(\.*)$</regex>
   <order>Parent1NMW</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentAVDets=(\.*)\t|(\.*)$</regex>
+  <regex>ParentAVDets=(\.*)\t|ParentAVDets=(\.*)$</regex>
   <order>ParentAVDets</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentBroken=(\.*)\t|(\.*)$</regex>
+  <regex>ParentBroken=(\.*)\t|ParentBroken=(\.*)$</regex>
   <order>ParentBroken</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentCat=(\.*)\t|(\.*)$</regex>
+  <regex>ParentCat=(\.*)\t|ParentCat=(\.*)$</regex>
   <order>ParentCat</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentClass=(\.*)\t|(\.*)$</regex>
+  <regex>ParentClass=(\.*)\t|ParentClass=(\.*)$</regex>
   <order>ParentClass</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentCompany=(\.*)\t|(\.*)$</regex>
+  <regex>ParentCompany=(\.*)\t|ParentCompany=(\.*)$</regex>
   <order>ParentCompany</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentDriveType=(\.*)\t|(\.*)$</regex>
+  <regex>ParentDriveType=(\.*)\t|ParentDriveType=(\.*)$</regex>
   <order>ParentDriveType</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentExeType=(\.*)\t|(\.*)$</regex>
+  <regex>ParentExeType=(\.*)\t|ParentExeType=(\.*)$</regex>
   <order>ParentExeType</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentFlags=(\.*)\t|(\.*)$</regex>
+  <regex>ParentFlags=(\.*)\t|ParentFlags=(\.*)$</regex>
   <order>ParentFlags</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentHash=(\.*)\t|(\.*)$</regex>
+  <regex>ParentHash=(\.*)\t|ParentHash=(\.*)$</regex>
   <order>ParentHash</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentHeurFI=(\.*)\t|(\.*)$</regex>
+  <regex>ParentHeurFI=(\.*)\t|ParentHeurFI=(\.*)$</regex>
   <order>ParentHeurFI</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentImageType=(\.*)\t|(\.*)$</regex>
+  <regex>ParentImageType=(\.*)\t|ParentImageType=(\.*)$</regex>
   <order>ParentImageType</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentJIDFI=(\.*)\t|(\.*)$</regex>
+  <regex>ParentJIDFI=(\.*)\t|ParentJIDFI=(\.*)$</regex>
   <order>ParentJIDFI</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentJIDMW=(\.*)\t|(\.*)$</regex>
+  <regex>ParentJIDMW=(\.*)\t|ParentJIDMW=(\.*)$</regex>
   <order>ParentJIDMW</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentMWName=(\.*)\t|(\.*)$</regex>
+  <regex>ParentMWName=(\.*)\t|ParentMWName=(\.*)$</regex>
   <order>ParentMWName</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentPID=(\.*)\t|(\.*)$</regex>
+  <regex>ParentPID=(\.*)\t|ParentPID=(\.*)$</regex>
   <order>ParentPID</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentPath=(\.*)\t|(\.*)$</regex>
+  <regex>ParentPath=(\.*)\t|ParentPath=(\.*)$</regex>
   <order>ParentPath</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentPrevLastDay=(\.*)\t|(\.*)$</regex>
+  <regex>ParentPrevLastDay=(\.*)\t|ParentPrevLastDay=(\.*)$</regex>
   <order>ParentPrevLastDay</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentPrevalence=(\.*)\t|(\.*)$</regex>
+  <regex>ParentPrevalence=(\.*)\t|ParentPrevalence=(\.*)$</regex>
   <order>ParentPrevalence</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentSkeptic=(\.*)\t|(\.*)$</regex>
+  <regex>ParentSkeptic=(\.*)\t|ParentSkeptic=(\.*)$</regex>
   <order>ParentSkeptic</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentStatus=(\.*)\t|(\.*)$</regex>
+  <regex>ParentStatus=(\.*)\t|ParentStatus=(\.*)$</regex>
   <order>ParentStatus</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ParentValidSig=(\.*)\t|(\.*)$</regex>
+  <regex>ParentValidSig=(\.*)\t|ParentValidSig=(\.*)$</regex>
   <order>ParentValidSig</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Child1NFI=(\.*)\t|(\.*)$</regex>
+  <regex>Child1NFI=(\.*)\t|Child1NFI=(\.*)$</regex>
   <order>Child1NFI</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Child1NMW=(\.*)\t|(\.*)$</regex>
+  <regex>Child1NMW=(\.*)\t|Child1NMW=(\.*)$</regex>
   <order>Child1NMW</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildAVDets=(\.*)\t|(\.*)$</regex>
+  <regex>ChildAVDets=(\.*)\t|ChildAVDets=(\.*)$</regex>
   <order>ChildAVDets</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildBroken=(\.*)\t|(\.*)$</regex>
+  <regex>ChildBroken=(\.*)\t|ChildBroken=(\.*)$</regex>
   <order>ChildBroken</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildCat=(\.*)\t|(\.*)$</regex>
+  <regex>ChildCat=(\.*)\t|ChildCat=(\.*)$</regex>
   <order>ChildCat</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildClass=(\.*)\t|(\.*)$</regex>
+  <regex>ChildClass=(\.*)\t|ChildClass=(\.*)$</regex>
   <order>ChildClass</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildCompany=(\.*)\t|(\.*)$</regex>
+  <regex>ChildCompany=(\.*)\t|ChildCompany=(\.*)$</regex>
   <order>ChildCompany</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildDriveType=(\.*)\t|(\.*)$</regex>
+  <regex>ChildDriveType=(\.*)\t|ChildDriveType=(\.*)$</regex>
   <order>ChildDriveType</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildExeType=(\.*)\t|(\.*)$</regex>
+  <regex>ChildExeType=(\.*)\t|ChildExeType=(\.*)$</regex>
   <order>ChildExeType</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildFlags=(\.*)\t|(\.*)$</regex>
+  <regex>ChildFlags=(\.*)\t|ChildFlags=(\.*)$</regex>
   <order>ChildFlags</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildHash=(\.*)\t|(\.*)$</regex>
+  <regex>ChildHash=(\.*)\t|ChildHash=(\.*)$</regex>
   <order>ChildHash</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildHeurFI=(\.*)\t|(\.*)$</regex>
+  <regex>ChildHeurFI=(\.*)\t|ChildHeurFI=(\.*)$</regex>
   <order>ChildHeurFI</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildImageType=(\.*)\t|(\.*)$</regex>
+  <regex>ChildImageType=(\.*)\t|ChildImageType=(\.*)$</regex>
   <order>ChildImageType</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildJIDFI=(\.*)\t|(\.*)$</regex>
+  <regex>ChildJIDFI=(\.*)\t|ChildJIDFI=(\.*)$</regex>
   <order>ChildJIDFI</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildJIDMW=(\.*)\t|(\.*)$</regex>
+  <regex>ChildJIDMW=(\.*)\t|ChildJIDMW=(\.*)$</regex>
   <order>ChildJIDMW</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildMWName=(\.*)\t|(\.*)$</regex>
+  <regex>ChildMWName=(\.*)\t|ChildMWName=(\.*)$</regex>
   <order>ChildMWName</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildPath=(\.*)\t|(\.*)$</regex>
+  <regex>ChildPath=(\.*)\t|ChildPath=(\.*)$</regex>
   <order>ChildPath</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildPrevLastDay=(\.*)\t|(\.*)$</regex>
+  <regex>ChildPrevLastDay=(\.*)\t|ChildPrevLastDay=(\.*)$</regex>
   <order>ChildPrevLastDay</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildPrevalence=(\.*)\t|(\.*)$</regex>
+  <regex>ChildPrevalence=(\.*)\t|ChildPrevalence=(\.*)$</regex>
   <order>ChildPrevalence</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildSkeptic=(\.*)\t|(\.*)$</regex>
+  <regex>ChildSkeptic=(\.*)\t|ChildSkeptic=(\.*)$</regex>
   <order>ChildSkeptic</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildStatus=(\.*)\t|(\.*)$</regex>
+  <regex>ChildStatus=(\.*)\t|ChildStatus=(\.*)$</regex>
   <order>ChildStatus</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ChildValidSig=(\.*)\t|(\.*)$</regex>
+  <regex>ChildValidSig=(\.*)\t|ChildValidSig=(\.*)$</regex>
   <order>ChildValidSig</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Class=(\.*)\t|(\.*)$</regex>
+  <regex>Class=(\.*)\t|Class=(\.*)$</regex>
   <order>Class</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ClientCat=(\.*)\t|(\.*)$</regex>
+  <regex>ClientCat=(\.*)\t|ClientCat=(\.*)$</regex>
   <order>ClientCat</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Company=(\.*)\t|(\.*)$</regex>
+  <regex>Company=(\.*)\t|Company=(\.*)$</regex>
   <order>Company</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>DetId=(\.*)\t|(\.*)$</regex>
+  <regex>DetId=(\.*)\t|DetId=(\.*)$</regex>
   <order>DetId</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Direction=(\.*)\t|(\.*)$</regex>
+  <regex>Direction=(\.*)\t|Direction=(\.*)$</regex>
   <order>Direction</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>DriveType=(\.*)\t|(\.*)$</regex>
+  <regex>DriveType=(\.*)\t|DriveType=(\.*)$</regex>
   <order>DriveType</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ExeType=(\.*)\t|(\.*)$</regex>
+  <regex>ExeType=(\.*)\t|ExeType=(\.*)$</regex>
   <order>ExeType</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Hash=(\.*)\t|(\.*)$</regex>
+  <regex>Hash=(\.*)\t|Hash=(\.*)$</regex>
   <order>Hash</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>HeurFI=(\.*)\t|(\.*)$</regex>
+  <regex>HeurFI=(\.*)\t|HeurFI=(\.*)$</regex>
   <order>HeurFI</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>HostName=(\.*)\t|(\.*)$</regex>
+  <regex>HostName=(\.*)\t|HostName=(\.*)$</regex>
   <order>HostName</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>IP=(\.*)\t|(\.*)$</regex>
+  <regex>IP=(\.*)\t|IP=(\.*)$</regex>
   <order>IP</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ImageType=(\.*)\t|(\.*)$</regex>
+  <regex>ImageType=(\.*)\t|ImageType=(\.*)$</regex>
   <order>ImageType</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>JIDFI=(\.*)\t|(\.*)$</regex>
+  <regex>JIDFI=(\.*)\t|JIDFI=(\.*)$</regex>
   <order>JIDFI</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>JIDMW=(\.*)\t|(\.*)$</regex>
+  <regex>JIDMW=(\.*)\t|JIDMW=(\.*)$</regex>
   <order>JIDMW</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Key=(\.*)\t|(\.*)$</regex>
+  <regex>Key=(\.*)\t|Key=(\.*)$</regex>
   <order>Key</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>LocalIp=(\.*)\t|(\.*)$</regex>
+  <regex>LocalIp=(\.*)\t|LocalIp=(\.*)$</regex>
   <order>LocalIp</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>LocalPort=(\.*)\t|(\.*)$</regex>
+  <regex>LocalPort=(\.*)\t|LocalPort=(\.*)$</regex>
   <order>LocalPort</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>LoggedUser=(\.*)\t|(\.*)$</regex>
+  <regex>LoggedUser=(\.*)\t|LoggedUser=(\.*)$</regex>
   <order>LoggedUser</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>MUID=(\.*)\t|(\.*)$</regex>
+  <regex>MUID=(\.*)\t|MUID=(\.*)$</regex>
   <order>MUID</order>
 </decoder>
 
@@ -510,180 +510,180 @@ LEEF:1.0|Panda Security|paps|02.47.00.0000|exec|sev=4	devTime=2019-05-09 22:00:5
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>RegKey=(\.*)\t|(\.*)$</regex>
+  <regex>RegKey=(\.*)\t|RegKey=(\.*)$</regex>
   <order>RegKey</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>NumCacheClassifiedElements=(\.*)\t|(\.*)$</regex>
+  <regex>NumCacheClassifiedElements=(\.*)\t|NumCacheClassifiedElements=(\.*)$</regex>
   <order>NumCacheClassifiedElements</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>OCS_Exec=(\.*)\t|(\.*)$</regex>
+  <regex>OCS_Exec=(\.*)\t|OCS_Exec=(\.*)$</regex>
   <order>OCS_Exec</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>OCS_Name=(\.*)\t|(\.*)$</regex>
+  <regex>OCS_Name=(\.*)\t|OCS_Name=(\.*)$</regex>
   <order>OCS_Name</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>OCS_Version=(\.*)\t|(\.*)$</regex>
+  <regex>OCS_Version=(\.*)\t|OCS_Version=(\.*)$</regex>
   <order>OCS_Version</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Op=(\.*)\t|(\.*)$</regex>
+  <regex>Op=(\.*)\t|Op=(\.*)$</regex>
   <order>Op</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>OperationFlags=(\.*)\t|(\.*)$</regex>
+  <regex>OperationFlags=(\.*)\t|OperationFlags=(\.*)$</regex>
   <order>OperationFlags</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>PECreationSource=(\.*)\t|(\.*)$</regex>
+  <regex>PECreationSource=(\.*)\t|PECreationSource=(\.*)$</regex>
   <order>PECreationSource</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>PID=(\.*)\t|(\.*)$</regex>
+  <regex>PID=(\.*)\t|PID=(\.*)$</regex>
   <order>PID</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Params=(\.*)\t|(\.*)$</regex>
+  <regex>Params=(\.*)\t|Params=(\.*)$</regex>
   <order>Params</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Path=(\.*)\t|(\.*)$</regex>
+  <regex>Path=(\.*)\t|Path=(\.*)$</regex>
   <order>Path</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Port=(\.*)\t|(\.*)$</regex>
+  <regex>Port=(\.*)\t|Port=(\.*)$</regex>
   <order>Port</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>PrevLastDay=(\.*)\t|(\.*)$</regex>
+  <regex>PrevLastDay=(\.*)\t|PrevLastDay=(\.*)$</regex>
   <order>PrevLastDay</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Prevalence=(\.*)\t|(\.*)$</regex>
+  <regex>Prevalence=(\.*)\t|Prevalence=(\.*)$</regex>
   <order>Prevalence</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Protocol=(\.*)\t|(\.*)$</regex>
+  <regex>Protocol=(\.*)\t|Protocol=(\.*)$</regex>
   <order>Protocol</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>RealSvcLevel=(\.*)\t|(\.*)$</regex>
+  <regex>RealSvcLevel=(\.*)\t|RealSvcLevel=(\.*)$</regex>
   <order>RealSvcLevel</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>RegAction=(\.*)\t|(\.*)$</regex>
+  <regex>RegAction=(\.*)\t|RegAction=(\.*)$</regex>
   <order>RegAction</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ResolutionTime=(\.*)\t|(\.*)$</regex>
+  <regex>ResolutionTime=(\.*)\t|ResolutionTime=(\.*)$</regex>
   <order>ResolutionTime</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ResponseCat=(\.*)\t|(\.*)$</regex>
+  <regex>ResponseCat=(\.*)\t|ResponseCat=(\.*)$</regex>
   <order>ResponseCat</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ResponseError=(\.*)\t|(\.*)$</regex>
+  <regex>ResponseError=(\.*)\t|ResponseError=(\.*)$</regex>
   <order>ResponseError</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ServiceLevel=(\.*)\t|(\.*)$</regex>
+  <regex>ServiceLevel=(\.*)\t|ServiceLevel=(\.*)$</regex>
   <order>ServiceLevel</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Skeptic=(\.*)\t|(\.*)$</regex>
+  <regex>Skeptic=(\.*)\t|Skeptic=(\.*)$</regex>
   <order>Skeptic</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>TargetPath=(\.*)\t|(\.*)$</regex>
+  <regex>TargetPath=(\.*)\t|TargetPath=(\.*)$</regex>
   <order>TargetPath</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Timeout=(\.*)\t|(\.*)$</regex>
+  <regex>Timeout=(\.*)\t|Timeout=(\.*)$</regex>
   <order>Timeout</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ToastResult=(\.*)\t|(\.*)$</regex>
+  <regex>ToastResult=(\.*)\t|ToastResult=(\.*)$</regex>
   <order>ToastResult</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>URL=(\.*)\t|(\.*)$</regex>
+  <regex>URL=(\.*)\t|URL=(\.*)$</regex>
   <order>URL</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ValidSig=(\.*)\t|(\.*)$</regex>
+  <regex>ValidSig=(\.*)\t|ValidSig=(\.*)$</regex>
   <order>ValidSig</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>Value=(\.*)\t|(\.*)$</regex>
+  <regex>Value=(\.*)\t|Value=(\.*)$</regex>
   <order>Value</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>ValueData=(\.*)\t|(\.*)$</regex>
+  <regex>ValueData=(\.*)\t|ValueData=(\.*)$</regex>
   <order>ValueData</order>
 </decoder>
 
 <decoder name="paps">
   <parent>paps</parent>
-  <regex>WinningTech=(\.*)\t|(\.*)$</regex>
+  <regex>WinningTech=(\.*)\t|WinningTech=(\.*)$</regex>
   <order>WinningTech</order>
 </decoder>

--- a/src/os_regex/os_regex_execute.c
+++ b/src/os_regex/os_regex_execute.c
@@ -170,7 +170,7 @@ const char *OSRegex_Execute_ex(const char *str, OSRegex *reg, regex_matching *re
 static const char *_OS_Regex(const char *pattern, const char *str, const char **prts_closure,
                              const char **prts_str, int flags)
 {
-    const char *r_code = NULL;
+    const char *r_code = str;
 
     int ok_here;
     int _regex_matched = 0;

--- a/src/tests/tap_os_regex.c
+++ b/src/tests/tap_os_regex.c
@@ -84,11 +84,18 @@ int test_success_regex() {
      * Please note that all strings are \ escaped
      */
     const char *tests[][3] = {
+        {"", "", ""},
+        {"", "a", ""},
         {"abc", "abcd", ""},
         {"abcd", "abcd", ""},
         {"a", "a", ""},
         {"a", "aa", ""},
         {"^a", "ab", ""},
+        {"^$", "", ""},
+        {"^", "", ""},
+        {"$", "", ""},
+        {"\\.*", "", ""},
+        {"(\\.*)", "", ""},
         {"test", "testa", ""},
         {"test", "testest", ""},
         {"lalaila", "lalalalaila", ""},
@@ -157,6 +164,8 @@ int test_fail_regex() {
     const char *tests[][3] = {
         {"abc", "abb", ""},
         {"^ab", " ab", ""},
+        {"^$", "a", ""},
+        {"$", "a", ""},
         {"test", "tes", ""},
         {"abcd", "abc", ""},
         {"abbb", "abb", ""},


### PR DESCRIPTION
|Related issues|
|---|
|#7386 and #3583|

As explained at https://github.com/wazuh/wazuh/issues/7386#issuecomment-777754563, the basic OS Regex algorithm iterates over the input string to validate the regular expression. Then it validates the empty condition (the regex pattern must be fully consumed).

According to this procedure, if the input string is empty, nothing happens, and hence `_OS_Regex` returns the default value (null). Mind that an empty regex does validate anything, and `^$` (or simply `$`) must only match an empty string.

## Proposed fix

As empty strings are valid, we propose to set the initial result of the regex execution to the input string (valid) instead of `null`).

### New TAP tests

In addition to the currently defined tests, we add the following checks:

|Regex|Input|Result|
|---|---|---|
|`""`|`""`|Match|
|`""`|`"a"`|Match|
|`"^$"`|`""`|Match|
|`"^"`|`""`|Match|
|`"$"`|`""`|Match|
|`"\.*"`|`""`|Match|
|`"(\.*)"`|`""`|Match|
|`"^$"`|`"a"`|Do not match|
|`"$"`|`"a"`|Do not match|

## Tests

- [X] Build manager on Linux.
- [X] Run TAP tests with the new checks.
- [x] Run the ruleset test suite.
- [ ] Run the SCA validator.