### PR TITLE
Add new active configuration combinations in spec

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3682,6 +3682,11 @@ components:
         </tr>
         <tr>
         <td>monitor</td>
+        <td>global</td>
+        <td><code>&lt;global&gt;</code></td>
+        </tr>
+        <tr>
+        <td>monitor</td>
         <td>internal</td>
         <td><code>&lt;monitord&gt;</code></td>
         </tr>
@@ -3689,6 +3694,11 @@ components:
         <td>monitor</td>
         <td>internal</td>
         <td><code>&lt;reports&gt;</code></td>
+        </tr>
+        <tr>
+        <td>request</td>
+        <td>global</td>
+        <td><code>&lt;global&gt;</code></td>
         </tr>
         <tr>
         <td>request</td>


### PR DESCRIPTION
|Related issue|
|---|
| Closes #6591 |

## Description

Hi team! 

The new configuration values requested in #6591 are already allowed since all components (monitor, request and global) can be used, so no changes are required:

https://github.com/wazuh/wazuh/blob/c67953504c34ccbb5ab4f73b76004af8aff8532f/api/api/spec/spec.yaml#L3526-L3527
https://github.com/wazuh/wazuh/blob/c67953504c34ccbb5ab4f73b76004af8aff8532f/api/api/spec/spec.yaml#L3721

> GET /agents/000/config/monitor/global
```JSON
{
  "data": {
    "monitord": {
      "agents_disconnection_time": 20,
      "agents_disconnection_alert_time": 100
    }
  },
  "error": 0
}
```

> GET /agents/000/config/request/global
```JSON
{
  "data": {
    "global": {
      "remoted": {
        "agents_disconnection_alert_time": 100,
        "agents_disconnection_time": 20
      }
    }
  },
  "error": 0
}
```

Therefore, only html example needed to be updated:
https://github.com/wazuh/wazuh/blob/c67953504c34ccbb5ab4f73b76004af8aff8532f/api/api/spec/spec.yaml#L3530-L3533

Regards,
Selu.