### PR TITLE
Changes to testing environment: add g++ and cmake and update healthchecks

### DIFF
--- a/api/test/integration/env/base/agent/Dockerfile
+++ b/api/test/integration/env/base/agent/Dockerfile
@@ -5,7 +5,12 @@ FROM ubuntu:16.04 as base_agent
 ARG agent_branch
 
 # install dependencies
-RUN apt-get update && apt-get install tree python python3 git gnupg2 gcc make vim libc6-dev curl policycoreutils automake autoconf libtool apt-transport-https lsb-release python-cryptography sqlite3 build-essential openjdk-8-jre -y && curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add - && echo "deb https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/staging/apt/ unstable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+RUN apt-get update && apt-get install wget tree python python3 git gnupg2 gcc g++ make vim libc6-dev curl policycoreutils automake autoconf libtool apt-transport-https lsb-release python-cryptography sqlite3 build-essential openjdk-8-jre -y && curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add - && echo "deb https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/staging/apt/ unstable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+
+# Install cmake version 3.12.4
+RUN wget http://www.cmake.org/files/v3.12/cmake-3.12.4.tar.gz
+RUN tar xf cmake-3.12.4.tar.gz
+RUN cd cmake-3.12.4 && ./configure && make install
 
 ## install Wazuh
 RUN git clone https://github.com/wazuh/wazuh && cd /wazuh && git checkout $agent_branch

--- a/api/test/integration/env/base/manager/manager.Dockerfile
+++ b/api/test/integration/env/base/manager/manager.Dockerfile
@@ -6,12 +6,12 @@ ARG manager_branch
 RUN apt-get update && apt-get install -y supervisor
 ADD base/manager/supervisord.conf /etc/supervisor/conf.d/
 
-RUN apt-get update && apt-get install wget python python3 git gnupg2 gcc make vim libc6-dev curl policycoreutils automake autoconf libtool apt-transport-https lsb-release python-cryptography sqlite3 -y && curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add - && echo "deb https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/staging/apt/ unstable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+RUN apt-get update && apt-get install wget python python3 git gnupg2 gcc g++ make vim libc6-dev curl policycoreutils automake autoconf libtool apt-transport-https lsb-release python-cryptography sqlite3 -y && curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add - && echo "deb https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/staging/apt/ unstable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
-# Install cmake version 3.12.4 and g++
+# Install cmake version 3.12.4
 RUN wget http://www.cmake.org/files/v3.12/cmake-3.12.4.tar.gz
 RUN tar xf cmake-3.12.4.tar.gz
-RUN apt-get install g++ -y && cd cmake-3.12.4 && ./configure && make install
+RUN cd cmake-3.12.4 && ./configure && make install
 
 RUN git clone https://github.com/wazuh/wazuh && cd /wazuh && git checkout $manager_branch
 COPY base/manager/preloaded-vars.conf /wazuh/etc/preloaded-vars.conf

--- a/api/test/integration/env/configurations/base/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/base/agent/healthcheck/healthcheck.py
@@ -1,12 +1,5 @@
-import os
-
 def get_health():
-    output = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
-
-    if output == 0:
-        return 0
-    else:
-        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/api/test/integration/env/configurations/base/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/base/agent/healthcheck/healthcheck.py
@@ -1,5 +1,42 @@
+import os
+import re
+from datetime import datetime
+
+
+def get_timestamp(log):
+    # Get timestamp from log
+    # Log example:
+    # 2021/02/15 12:37:04 wazuh-agentd: INFO: Agent is restarting due to shared configuration changes.
+    timestamp = re.search(r'^[0-9]{4}-1[0-2]|0[1-9]-3[01]|0[1-9]|[12][0-9][tT]2[0-3]|[01][0-9]:[0-5][0-9]:[0-5][0-9]\.['
+                          r'0-9]+?[zZ]|[+-]?:2[0-3]|[01][0-9]:[0-5][0-9]', log).group(0)
+
+    t = datetime.strptime(timestamp, "%Y/%m/%d %H:%M:%S")
+
+    return t
+
+
 def get_health():
-    return 0
+    # Get agent health. The agent will be healthy if it has been connected to the manager after been
+    # restarted due to a shared configuration changes
+
+    shared_conf_restart = os.system(
+        "grep -q 'wazuh-agentd: INFO: Agent is restarting due to shared configuration changes.' "
+        "/var/ossec/logs/ossec.log")
+    agent_connection = os.system(
+        "grep -q 'wazuh-agentd: INFO: (4102): Connected to the server' /var/ossec/logs/ossec.log")
+
+    if shared_conf_restart == 0 and agent_connection == 0:
+        output_agent_restart = os.popen(
+            "grep -q 'wazuh-agentd: INFO: Agent is restarting due to shared configuration changes.' "
+            "/var/ossec/logs/ossec.log").read().split()
+        output_agent_connection = os.popen(
+            "grep -q 'wazuh-agentd: INFO: (4102): Connected to the server' /var/ossec/logs/ossec.log").read().split()
+
+        t1 = get_timestamp(output_agent_restart[len(output_agent_restart) - 1])
+        t2 = get_timestamp(output_agent_connection[len(output_agent_connection) - 1])
+
+        return 0 if t2 > t1 else 1
+    return 1
 
 
 if __name__ == "__main__":

--- a/api/test/integration/env/configurations/base/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/base/agent/healthcheck/healthcheck.py
@@ -18,7 +18,7 @@ def get_health():
     # Get agent health. The agent will be healthy if it has been connected to the manager after been
     # restarted due to shared configuration changes.
     # Using agentd when using grep as the module name can vary between ossec-agentd and wazuh-agentd,
-    # depending on the agent version
+    # depending on the agent version.
 
     shared_conf_restart = os.system(
         "grep -q 'agentd: INFO: Agent is restarting due to shared configuration changes.' "

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -1,0 +1,14 @@
+import os
+
+
+def get_health():
+    output = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+
+    if output == 0:
+        return 0
+    else:
+        return 1
+
+
+if __name__ == "__main__":
+    exit(get_health())

--- a/api/test/integration/env/configurations/manager/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/manager/agent/healthcheck/healthcheck.py
@@ -1,1 +1,2 @@
+# No checks are needed as manager tests don't depend on agents
 exit(0)

--- a/api/test/integration/env/configurations/security/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/security/agent/healthcheck/healthcheck.py
@@ -1,0 +1,2 @@
+# No checks are needed as security tests don't depend on agents
+exit(0)


### PR DESCRIPTION
Hi team, 
In this PR I have added the `g++` and `cmake` dependencies to the agent and manager dockerfiles of our testing environment.

I have also updated the base agent healthcheck, as it was checking if syscollector had finished (syscollector shouldn't be checked if it isn't used).
For this healthcheck, I have checked if the agent was connected to the manager after been restarted due to shared configuration changes.

The testing environmnet works, most tests are passing:

```
test_agent_GET_endpoints.tavern.yaml 
	 91 passed, 98 warnings
	 
test_ciscat_endpoints.tavern.yaml 
	 1 passed, 3 warnings
	 
test_cdb_list_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_active_response_endpoints.tavern.yaml 
	 2 passed, 4 warnings
```

	 
I have also tested the new dependencies in jenkins. I got the following results:
- https://ci.wazuh.info/job/test_integration_api_endpoints/294/ (agent_GET passed with new deps)
- https://ci.wazuh.info/job/test_integration_api_endpoints/296/ (more tests with deps+healthcheck)
	 
Tests like experimental and syscollector will result in errors, as a fix regarding syscollector healthchecks needs to be added. This happens beause logs from syscollector and its behaviour changed.

Regards,
Manuel.