### PR TITLE
Remove behind_proxy_server API configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ All notable changes to this project will be documented in this file.
   - File /etc/ossec-init.conf does not exist anymore. ([#7175](https://github.com/wazuh/wazuh/pull/7175))
   - Unused files have been removed from the repository, including TAP tests. ([#7398](https://github.com/wazuh/wazuh/issues/7398))
 
+- **API:**
+  - Removed `behind_proxy_server` option from configuration. ([#7006](https://github.com/wazuh/wazuh/issues/7006))
 
 ## [v4.1.1]
 

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -27,7 +27,6 @@ default_security_configuration = {
 default_api_configuration = {
     "host": "0.0.0.0",
     "port": 55000,
-    "behind_proxy_server": False,
     "https": {
         "enabled": True,
         "key": "api/configuration/ssl/server.key",

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -3,9 +3,6 @@
 # host: 0.0.0.0
 # port: 55000
 
-# Set this option to "yes" in case the API is running behind a proxy server. Values: yes, no
-# behind_proxy_server: no
-
 # Advanced configuration
 
 # https:

--- a/api/api/models/configuration_model.py
+++ b/api/api/models/configuration_model.py
@@ -233,10 +233,9 @@ class AccessModel(Model):
 
 class APIConfigurationModel(Body):
     """API configuration model. Deprecated since v4.0.4, we maintain Model"""
-    def __init__(self, behind_proxy_server=None, https=None, logs=None, cors=None,
-                 cache=None, use_only_authd=None, drop_privileges=None, experimental_features=None, access=None):
+    def __init__(self, https=None, logs=None, cors=None, cache=None, use_only_authd=None, drop_privileges=None,
+                 experimental_features=None, access=None):
         self.swagger_types = {
-            'behind_proxy_server': bool,
             'https': HTTPSModel,
             'logs': LogsModel,
             'cors': CORSModel,
@@ -248,7 +247,6 @@ class APIConfigurationModel(Body):
         }
 
         self.attribute_map = {
-            'behind_proxy_server': 'behind_proxy_server',
             'https': 'https',
             'logs': 'logs',
             'cors': 'cors',
@@ -259,7 +257,6 @@ class APIConfigurationModel(Body):
             'access': 'access'
         }
 
-        self._behind_proxy_server = behind_proxy_server
         self._https = https
         self._logs = logs
         self._cors = cors
@@ -268,14 +265,6 @@ class APIConfigurationModel(Body):
         self._drop_privileges = drop_privileges
         self._experimental_features = experimental_features
         self._access = access
-
-    @property
-    def behind_proxy_server(self):
-        return self._behind_proxy_server
-
-    @behind_proxy_server.setter
-    def behind_proxy_server(self, behind_proxy_server):
-        self._behind_proxy_server = behind_proxy_server
 
     @property
     def https(self):

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2546,10 +2546,6 @@ components:
               format: int32
               minimum: 1
               example: 300
-        behind_proxy_server:
-          description: "Set this option to 'yes' in case the API is running behind a proxy server"
-          type: boolean
-          default: false
         logs:
           type: object
           additionalProperties: false
@@ -5552,9 +5548,8 @@ paths:
                     type: string
                     format: names
                   ip:
-                    description: "If this is not included, the API will get the IP automatically. If you are behind a
-                    proxy, you must set the option behind_proxy_server to yes at api.yaml and make sure the proxy is
-                    setting HTTP header 'X-Forwarded-For' with origin IP address. Allowed values: IP, IP/NET, ANY"
+                    description: "If this is not included, the API will get the IP automatically. Allowed values:
+                    IP, IP/NET, ANY"
                     type: string
                     format: alphanumeric
                   force_time:
@@ -6923,9 +6918,8 @@ paths:
                     type: string
                     format: names
                   ip:
-                    description: "If this is not included, the API will get the IP automatically. If you are behind a
-                    proxy, you must set the option behind_proxy_server to yes at api.yaml and make sure the proxy is
-                    setting HTTP header 'X-Forwarded-For' with origin IP address. Allowed values: IP, IP/NET, ANY"
+                    description: "If this is not included, the API will get the IP automatically. Allowed values:
+                    IP, IP/NET, ANY"
                     type: string
                     format: alphanumeric
                   force_time:
@@ -7892,7 +7886,6 @@ paths:
                       node_api_config:
                         host: 0.0.0.0
                         port: 55000
-                        behind_proxy_server: false
                         https:
                           enabled: true
                           key: "/var/ossec/api/configuration/ssl/server.key"
@@ -7921,7 +7914,6 @@ paths:
                       node_api_config:
                         host: 0.0.0.0
                         port: 55000
-                        behind_proxy_server: false
                         https:
                           enabled: true
                           key: "/var/ossec/api/configuration/ssl/server.key"
@@ -10278,7 +10270,6 @@ paths:
                       node_api_config:
                         host: 0.0.0.0
                         port: 55000
-                        behind_proxy_server: false
                         https:
                           enabled: true
                           key: "/var/ossec/api/configuration/ssl/server.key"

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -13,7 +13,6 @@ from wazuh.core import common
 custom_api_configuration = {
     "host": "127.0.1.1",
     "port": 1000,
-    "behind_proxy_server": False,
     "https": {
         "enabled": True,
         "key": "api/configuration/ssl/server.key",

--- a/api/test/integration/env/configurations/base/manager/config/api/configuration/api.yaml
+++ b/api/test/integration/env/configurations/base/manager/config/api/configuration/api.yaml
@@ -1,9 +1,6 @@
 host: 0.0.0.0
 port: 55000
 
-# Set this option to "yes" in case the API is running behind a proxy server. Values: yes, no
-behind_proxy_server: no
-
 # Advanced configuration
 
 https:

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -877,7 +877,6 @@ stages:
               node_api_config: &default_api_config
                 host: !anystr
                 port: !anyint
-                behind_proxy_server: !anybool
                 https:
                   enabled: !anybool
                   key: !anystr

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -736,7 +736,6 @@ stages:
               node_api_config:
                 host: !anystr
                 port: !anyint
-                behind_proxy_server: !anybool
 
                 https:
                   enabled: !anybool

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -83,10 +83,6 @@ class WazuhException(Exception):
         1117: {'message': "Unable to connect with component. The component might be disabled."},
         1118: {'message': "Could not request component configuration"},
         1119: "Directory '/tmp' needs read, write & execution permission for 'ossec' user",
-        1120: {
-            'message': "Error adding agent. HTTP header 'X-Forwarded-For' not present in a behind_proxy_server API configuration",
-            'remediation': "Please, make sure your proxy is setting 'X-Forwarded-For' HTTP header"
-        },
         1121: {'message': "Error connecting with socket"},
         1122: {'message': 'Experimental features are disabled',
                'remediation': 'Experimental features can be enabled in WAZUH_PATH/configuration/api.yaml or '

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -17,7 +17,6 @@ from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.utils import process_array, safe_move, validate_wazuh_xml
 from wazuh.rbac.decorators import expose_resources
 
-allowed_api_fields = {'behind_proxy_server', 'logs', 'cache', 'cors', 'use_only_authd', 'experimental_features'}
 cluster_enabled = not read_cluster_config()['disabled']
 node_id = get_node().get('node') if cluster_enabled else 'manager'
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #7006 |

## Description

Hi team!

This PR definitely removes the `behind_proxy_server` option in the API configuration, which had no effect since this issue https://github.com/wazuh/wazuh/issues/7015.

Spec has been updated and all references to `X-Forwarded-For` too.

## Unittests and Integration tests
Tests were updated and all pass correctly.

Regards,
Selu.