### PR TITLE
Change behavior when configuring multiple audit keys

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -2069,7 +2069,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 
                     while (key) {
                         if (*key) {
-                            syscheck->audit_key[keyit] = check_ascci_hex(key);
+                            os_strdup(key, syscheck->audit_key[keyit]);
                             os_realloc(syscheck->audit_key, (keyit + 2) * sizeof(char *), syscheck->audit_key);
                             syscheck->audit_key[keyit + 1] = NULL;
                             key = strtok_r(NULL, delim, &saveptr);
@@ -2416,29 +2416,6 @@ void Free_Syscheck(syscheck_config * config) {
 
         free_strarray(config->audit_key);
     }
-}
-
-char* check_ascci_hex (char *input) {
-    unsigned int j = 0;
-    int hex = 0;
-    char outhex[OS_SIZE_256];
-
-    for (j = 0; j < strlen(input); j++) {
-        snprintf(outhex + j*2, OS_SIZE_256 - j * 2, "%hhX", input[j]);
-        if ((unsigned int)input[j] > 126 ||
-                (unsigned int)input[j] == 32 ||
-                (unsigned int)input[j] == 34) {
-            hex = 1;
-        }
-    }
-
-    char *output;
-    if (hex) {
-        os_strdup(outhex, output);
-    } else {
-        os_strdup(input, output);
-    }
-    return output;
 }
 
 static char **get_paths_from_env_variable (char *environment_variable) {

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -506,14 +506,6 @@ char *syscheck_opts2str(char *buf, int buflen, int opts);
 void Free_Syscheck(syscheck_config *config);
 
 /**
- * @brief Transforms an ASCII text to HEX
- *
- * @param input The input text to transform
- * @return The HEX string on success, the original string on failure
- */
-char *check_ascci_hex(char *input);
-
-/**
  * @brief Logs the real time engine status
  *
  */

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -547,13 +547,6 @@ int audit_health_check(int audit_socket);
  */
 void clean_rules(void);
 
-/**
- * @brief
- *
- * @param buffer
- * @return 0 if no key is found, 1 if AUDIT_KEY is found, 2 if an existing key is found, 3 if AUDIT_HEALTHCHECK_KEY is found
- */
-int filterkey_audit_events(char *buffer);
 extern W_Vector *audit_added_dirs;
 extern volatile int audit_thread_active;
 extern volatile int whodata_alerts;

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -87,6 +87,105 @@ static regex_t regexCompiled_dir_hex;
 static regex_t regexCompiled_syscall;
 static regex_t regexCompiled_dev;
 
+typedef enum audit_key_type {
+    FIM_AUDIT_UNKNOWN_KEY = 0,
+    FIM_AUDIT_KEY,
+    FIM_AUDIT_HC_KEY,
+    FIM_AUDIT_CUSTOM_KEY
+} audit_key_type;
+
+/**
+ * @brief Looks for a specific field in an audit event.
+ *
+ * @param buffer Audit message.
+ * @param key Audit field to look for
+ * @return Value of the field specified in key.
+ */
+static char *get_audit_field(const char *buffer, const char *key) {
+    char *value = NULL;
+    char *start = NULL;
+    char *ascii_value = NULL;
+    int end = 0;
+
+    // Find the key
+    if (start = strstr(buffer, key), start == NULL) {
+        return NULL;
+    }
+
+    start += strlen(key);
+
+    if (*start == '"') {
+        start++;
+    }
+
+    // The key can be limited by one of these three characters
+    if (end = strcspn(start, "\n \""), end == 0) {
+        return NULL;
+    }
+
+    os_calloc(end + 1, sizeof(char), value);
+    strncpy(value, start, end);
+
+    if (ascii_value = decode_hex_buffer_2_ascii_buffer(value, end), ascii_value == NULL) {
+        return value;
+    }
+
+    free(value);
+    return ascii_value;
+}
+
+/**
+ * @brief Looks if the buffer contains a valid audit key (AUDIT_KEY, AUDIT_HC_KEY or a specified key)
+ *
+ * @param buffer Audit message to look for.
+ * @return Type of key.
+ * @retval FIM_AUDIT_UNKNOWN_KEY if the key is unknown.
+ * @retval FIM_AUDIT_KEY if the key of the event is AUDIT_KEY.
+ * @retval FIM_AUDIT_HC_KEY if the key of the event is AUDIT_HEALTHCHECK_KEY.
+ * @retval FIM_AUDIT_CUSTOM_KEY if the key of the event is configured using audit_key option.
+ */
+static audit_key_type filterkey_audit_events(char *buffer) {
+    char *save_ptr = NULL;
+    char *full_key = NULL;
+    char *key = NULL;
+    audit_key_type retval = FIM_AUDIT_UNKNOWN_KEY;
+    int i;
+
+    // Find the key
+    if (full_key = get_audit_field(buffer, "key="), full_key == NULL) {
+        return retval;
+    }
+
+    if (strcmp(full_key, AUDIT_KEY) == 0) {
+        mdebug2(FIM_AUDIT_MATCH_KEY, full_key);
+        retval = FIM_AUDIT_KEY;
+        goto end;
+    }
+
+    if (strcmp(full_key, AUDIT_HEALTHCHECK_KEY) == 0) {
+        mdebug2(FIM_AUDIT_MATCH_KEY, full_key);
+        retval = FIM_AUDIT_HC_KEY;
+        goto end;
+    }
+
+    key = strtok_r(full_key, "\001", &save_ptr);
+    while (key != NULL) {
+        if (*key == '\0') {
+            continue;
+        }
+        for (i = 0; syscheck.audit_key[i]; i++) {
+            if (strcmp(key, syscheck.audit_key[i]) == 0) {
+                mdebug2(FIM_AUDIT_MATCH_KEY, key);
+                retval = FIM_AUDIT_CUSTOM_KEY;
+                goto end;
+            }
+        }
+        key = strtok_r(NULL, "\001", &save_ptr);
+    }
+end:
+    free(full_key);
+    return retval;
+}
 
 int check_auditd_enabled(void) {
     PROCTAB *proc = openproc(PROC_FILLSTAT | PROC_FILLSTATUS | PROC_FILLCOM );
@@ -668,13 +767,13 @@ void audit_parse(char *buffer) {
     char *dev = NULL;
     whodata_evt *w_evt;
     unsigned int items = 0;
-    unsigned int filter_key;
+    audit_key_type filter_key;
 
     // Checks if the key obtained is one of those configured to monitor
     filter_key = filterkey_audit_events(buffer);
 
     switch (filter_key) {
-    case 1: // "wazuh_fim"
+    case FIM_AUDIT_KEY: // "wazuh_fim"
         if ((pconfig = strstr(buffer,"type=CONFIG_CHANGE"), pconfig)
             && ((pdelete = strstr(buffer,"op=remove_rule"), pdelete) ||
             (pdelete = strstr(buffer,"op=\"remove_rule\""), pdelete))) { // Detect rules modification.
@@ -733,7 +832,7 @@ void audit_parse(char *buffer) {
             free(p_dir);
         }
         // Fallthrough
-    case 2:
+    case FIM_AUDIT_CUSTOM_KEY:
         if (psuccess = strstr(buffer,"success=yes"), psuccess) {
 
             os_calloc(1, sizeof(whodata_evt), w_evt);
@@ -1135,7 +1234,7 @@ void audit_parse(char *buffer) {
             free_whodata_event(w_evt);
         }
         break;
-    case 3:
+    case FIM_AUDIT_HC_KEY:
         if(regexec(&regexCompiled_syscall, buffer, 2, match, 0) == 0) {
             match_size = match[1].rm_eo - match[1].rm_so;
             char *syscall = NULL;
@@ -1161,6 +1260,8 @@ void audit_parse(char *buffer) {
             }
             os_free(syscall);
         }
+    default:
+        break;
     }
 }
 
@@ -1452,37 +1553,6 @@ void clean_rules(void) {
 
     w_mutex_unlock(&audit_mutex);
 }
-
-
-int filterkey_audit_events(char *buffer) {
-    int i = 0;
-    char logkey1[OS_SIZE_256] = {0};
-    char logkey2[OS_SIZE_256] = {0};
-
-    snprintf(logkey1, OS_SIZE_256, "key=\"%s\"", AUDIT_KEY);
-    if (strstr(buffer, logkey1)) {
-        mdebug2(FIM_AUDIT_MATCH_KEY, logkey1);
-        return 1;
-    }
-
-    snprintf(logkey1, OS_SIZE_256, "key=\"%s\"", AUDIT_HEALTHCHECK_KEY);
-    if (strstr(buffer, logkey1)) {
-        mdebug2(FIM_AUDIT_MATCH_KEY, logkey1);
-        return 3;
-    }
-
-    while (syscheck.audit_key[i]) {
-        snprintf(logkey1, OS_SIZE_256, "key=\"%s\"", syscheck.audit_key[i]);
-        snprintf(logkey2, OS_SIZE_256, "key=%s", syscheck.audit_key[i]);
-        if (strstr(buffer, logkey1) || strstr(buffer, logkey2)) {
-            mdebug2(FIM_AUDIT_MATCH_KEY, logkey1);
-            return 2;
-        }
-        i++;
-    }
-    return 0;
-}
-
 
 // Audit healthcheck before starting the main thread
 int audit_health_check(int audit_socket) {


### PR DESCRIPTION
|Related issue|
|---|
|#6520|


## Description
Hi team!

This PR aims to fix the problem described in #6520. Now, if the key of the audit event doesn't match the `wazuh_fim` or `fim_hc` keys, the key is decoded from hexadecimal to ASCII and the result is compared with all the configured keys.

Closes #6520 

## Configuration options
***ossec.conf***
```xml
    <directories whodata="yes">/test</directories>
    <whodata>
        <audit_key>key 1,key2,key3</audit_key>
    </whodata>
```
***audit rules***
```root@ubuntu1:/var/ossec/etc# auditctl -l
-w /testdir -p wa -k key 1 -k key2 -k key3
-w /home/vagrant -p wa -k key2 -k key3
-w /test -p wa -k wazuh_fim
```
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
```
2021/02/16 10:21:56 wazuh-syscheckd[71667] syscheck_audit.c:178 at filterkey_audit_events(): DEBUG: (6251): Match audit_key: 'key 1'
2021/02/16 10:21:56 wazuh-syscheckd[71667] syscheck_audit.c:1039 at audit_parse(): DEBUG: (6247): audit_event: uid=root, auid=vagrant, euid=root, gid=root, pid=71693, ppid=16752, inode=3932163, path=/testdir/asdfasdfasdf, pname=/usr/bin/touch
.......
021/02/16 10:23:12 wazuh-syscheckd[71703] syscheck_audit.c:1018 at audit_parse(): DEBUG: (6247): audit_event: uid=root, auid=vagrant, euid=root, gid=ossec, pid=71703, ppid=1473, inode=393217, path=/test, pname=/var/ossec/bin/wazuh-syscheckd
2021/02/16 10:23:16 wazuh-syscheckd[71703] syscheck_audit.c:178 at filterkey_audit_events(): DEBUG: (6251): Match audit_key: 'key2'
2021/02/16 10:23:16 wazuh-syscheckd[71703] syscheck_audit.c:1039 at audit_parse(): DEBUG: (6247): audit_event: uid=root, auid=vagrant, euid=root, gid=root, pid=71715, ppid=16752, inode=2891732, path=/home/vagrant/asdf, pname=/usr/bin/touch
.....
2021/02/16 10:23:42 wazuh-syscheckd[71703] syscheck_audit.c:160 at filterkey_audit_events(): DEBUG: (6251): Match audit_key: 'wazuh_fim'
2021/02/16 10:23:42 wazuh-syscheckd[71703] syscheck_audit.c:1039 at audit_parse(): DEBUG: (6247): audit_event: uid=root, auid=vagrant, euid=root, gid=root, pid=71716, ppid=16752, inode=393220, path=/test/adsfasdf, pname=/usr/bin/touch
2021/02/16 10:23:42 wazuh-syscheckd[71703] fim_db.c:381 at fim_db_check_transaction(): DEBUG: Database transaction completed.

```

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
- [X] Source installation
- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [ ] Coverity
  - [X] Valgrind (memcheck and descriptor leaks check)
