### PR TITLE
[7507] Incorrect scan time fix

### DIFF
--- a/src/shared_modules/utils/tests/timeHelper_test.cpp
+++ b/src/shared_modules/utils/tests/timeHelper_test.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh shared modules utils
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * December 28, 2020.
  *
  * This program is free software; you can redistribute it
@@ -27,9 +27,10 @@ TEST_F(TimeUtilsTest, CheckTimestamp)
 
 TEST_F(TimeUtilsTest, CheckTimestampValidFormat)
 {
-    constexpr auto DATE_FORMAT_REGEX_STR { "[0-9]{4}/([1-9]|1[0-2])/([1-9]|[1-2][0-9]|3[0-1]) (2[0-3]|1[0-9]|[0-9]):([0-9]|[1-5][0-9]):([1-5][0-9]|[0-9])" };
+    constexpr auto DATE_FORMAT_REGEX_STR { "[0-9]{4}/([0-9]|1[0-2]){2}/(([0-9]|1[0-2]){2}) (([0-9]|1[0-2]){2}):(([0-9]|1[0-2]){2}):(([0-9]|1[0-2]){2})" };
     const auto currentTimestamp { Utils::getCurrentTimestamp() };
     const auto timestamp { Utils::getTimestamp(std::time(nullptr)) };
+    std::cout << timestamp << std::endl;
     EXPECT_TRUE(std::regex_match(currentTimestamp, std::regex(DATE_FORMAT_REGEX_STR)));
     EXPECT_TRUE(std::regex_match(timestamp, std::regex(DATE_FORMAT_REGEX_STR)));
 }

--- a/src/shared_modules/utils/tests/timeHelper_test.cpp
+++ b/src/shared_modules/utils/tests/timeHelper_test.cpp
@@ -30,7 +30,6 @@ TEST_F(TimeUtilsTest, CheckTimestampValidFormat)
     constexpr auto DATE_FORMAT_REGEX_STR { "[0-9]{4}/([0-9]|1[0-2]){2}/(([0-9]|1[0-2]){2}) (([0-9]|1[0-2]){2}):(([0-9]|1[0-2]){2}):(([0-9]|1[0-2]){2})" };
     const auto currentTimestamp { Utils::getCurrentTimestamp() };
     const auto timestamp { Utils::getTimestamp(std::time(nullptr)) };
-    std::cout << timestamp << std::endl;
     EXPECT_TRUE(std::regex_match(currentTimestamp, std::regex(DATE_FORMAT_REGEX_STR)));
     EXPECT_TRUE(std::regex_match(timestamp, std::regex(DATE_FORMAT_REGEX_STR)));
 }

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <ctime>
+#include <iomanip>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -1,6 +1,6 @@
 /*
  * Wazuh shared modules utils
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * December 28, 2020.
  *
  * This program is free software; you can redistribute it
@@ -22,21 +22,24 @@ namespace Utils
 {
     static std::string getTimestamp(std::time_t time)
     {
-        std::string timestamp;
-        tm* localTime { localtime(&time) };
-        // Final timestamp: "YYYY/MM/DD h:m:s"
-        timestamp  = std::to_string(localTime->tm_year + 1900);
-        timestamp += "/";
-        timestamp += std::to_string(localTime->tm_mon + 1);
-        timestamp += "/";
-        timestamp += std::to_string(localTime->tm_mday);
-        timestamp += " ";
-        timestamp += std::to_string(localTime->tm_hour);
-        timestamp += ":";
-        timestamp += std::to_string(localTime->tm_min);
-        timestamp += ":";
-        timestamp += std::to_string(localTime->tm_sec);
-        return timestamp;
+        std::stringstream ss;
+        // gmtime: result expressed as a UTC time
+        tm* localTime { gmtime(&time) };
+        // Final timestamp: "YYYY/MM/DD hh:mm:ss"
+        // Date
+        ss << std::hex << std::setfill('0') << std::setw(4) << std::to_string(localTime->tm_year + 1900);
+        ss << "/";
+        ss << std::hex << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_mon + 1);
+        ss << "/";
+        ss << std::hex << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_mday);
+        // Time
+        ss << " ";
+        ss << std::hex << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_hour);
+        ss << ":";
+        ss << std::hex << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_min);
+        ss << ":";
+        ss << std::hex << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_sec);
+        return ss.str();
     }
 
     static std::string getCurrentTimestamp()

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -27,18 +27,18 @@ namespace Utils
         tm* localTime { gmtime(&time) };
         // Final timestamp: "YYYY/MM/DD hh:mm:ss"
         // Date
-        ss << std::hex << std::setfill('0') << std::setw(4) << std::to_string(localTime->tm_year + 1900);
+        ss << std::setfill('0') << std::setw(4) << std::to_string(localTime->tm_year + 1900);
         ss << "/";
-        ss << std::hex << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_mon + 1);
+        ss << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_mon + 1);
         ss << "/";
-        ss << std::hex << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_mday);
+        ss << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_mday);
         // Time
         ss << " ";
-        ss << std::hex << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_hour);
+        ss << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_hour);
         ss << ":";
-        ss << std::hex << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_min);
+        ss << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_min);
         ss << ":";
-        ss << std::hex << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_sec);
+        ss << std::setfill('0') << std::setw(2) << std::to_string(localTime->tm_sec);
         return ss.str();
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7507 |

## **Description**

This issue was discovered in the api framework tests, apparently the format is incorrect since when the units are not greater than 10, the leading zero is not being concatenated.

Expected
scan_time:  `2021/02/16 14:00:21`

Actual:
scan_time:  `2021/2/16 14:0:21`

## **DoD**
- [X] RC/Fix
- [X] Update UTs
- [X] RTR PASSED in all affected modules

**Data Provider**
![image](https://user-images.githubusercontent.com/22640902/108088421-3181fc00-7057-11eb-8e7c-691388295d92.png)

**Utils**
![image](https://user-images.githubusercontent.com/22640902/108088493-48c0e980-7057-11eb-90f3-31309326485f.png)

**Syscollector**
![image](https://user-images.githubusercontent.com/22640902/108089270-2c717c80-7058-11eb-87fd-14c93c0eb5ae.png)

- [x] CI PASS
