### PR TITLE
7511 centos rpm package release field missing

### DIFF
--- a/src/data_provider/src/packages/packagesLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packagesLinuxParserHelper.h
@@ -40,15 +40,28 @@ namespace PackageLinuxHelper
                 std::string vendor       { fields.at(RPMFields::RPM_FIELDS_VENDOR) };
                 std::string description  { fields.at(RPMFields::RPM_FIELDS_SUMMARY) };
 
+                std::string release      { fields.at(RPMFields::RPM_FIELDS_RELEASE) };
+                std::string epoch        { fields.at(RPMFields::RPM_FIELDS_EPOCH) };
+
+                if (!epoch.empty() && epoch.compare("(none)") != 0)
+                {
+                    version = epoch + ":" + version;
+                }
+
+                if (!release.empty() && release.compare("(none)") != 0)
+                {
+                    version += "-" + release;
+                }
+
                 ret["name"]         = name;
-                ret["size"]         = size.empty() ? 0 : stoi(size);
-                ret["install_time"] = install_time.empty() ? UNKNOWN_VALUE : install_time;
-                ret["groups"]       = groups.empty() ? UNKNOWN_VALUE : groups;
-                ret["version"]      = version.empty() ? UNKNOWN_VALUE : version;
-                ret["architecture"] = architecture.empty() ? UNKNOWN_VALUE : architecture;
+                ret["size"]         = size.empty() || size.compare("(none)") == 0 ? 0 : stoi(size);
+                ret["install_time"] = install_time.empty() || install_time.compare("(none)") == 0 ? UNKNOWN_VALUE : install_time;
+                ret["groups"]       = groups.empty() || groups.compare("(none)") == 0 ? UNKNOWN_VALUE : groups;
+                ret["version"]      = version.empty() || version.compare("(none)") == 0 ? UNKNOWN_VALUE : version;
+                ret["architecture"] = architecture.empty() || architecture.compare("(none)") == 0 ? UNKNOWN_VALUE : architecture;
                 ret["format"]       = "rpm";
-                ret["vendor"]       = vendor.empty() ? UNKNOWN_VALUE : vendor;
-                ret["description"]  = description.empty() ? UNKNOWN_VALUE : description;
+                ret["vendor"]       = vendor.empty() || vendor.compare("(none)") == 0 ? UNKNOWN_VALUE : vendor;
+                ret["description"]  = description.empty() || description.compare("(none)") == 0 ? UNKNOWN_VALUE : description;
             }
         }
         return ret;

--- a/src/data_provider/src/packages/packagesLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packagesLinuxParserHelper.h
@@ -27,6 +27,8 @@ namespace PackageLinuxHelper
     {
         nlohmann::json ret;
         const auto fields { Utils::split(packageInfo,'\t') };
+        constexpr auto DEFAULT_VALUE { "(none)" };
+
         if (RPMFields::RPM_FIELDS_SIZE <= fields.size())
         {
             std::string name             { fields.at(RPMFields::RPM_FIELDS_NAME) };
@@ -43,25 +45,25 @@ namespace PackageLinuxHelper
                 std::string release      { fields.at(RPMFields::RPM_FIELDS_RELEASE) };
                 std::string epoch        { fields.at(RPMFields::RPM_FIELDS_EPOCH) };
 
-                if (!epoch.empty() && epoch.compare("(none)") != 0)
+                if (!epoch.empty() && epoch.compare(DEFAULT_VALUE) != 0)
                 {
                     version = epoch + ":" + version;
                 }
 
-                if (!release.empty() && release.compare("(none)") != 0)
+                if (!release.empty() && release.compare(DEFAULT_VALUE) != 0)
                 {
                     version += "-" + release;
                 }
 
                 ret["name"]         = name;
-                ret["size"]         = size.empty() || size.compare("(none)") == 0 ? 0 : stoi(size);
-                ret["install_time"] = install_time.empty() || install_time.compare("(none)") == 0 ? UNKNOWN_VALUE : install_time;
-                ret["groups"]       = groups.empty() || groups.compare("(none)") == 0 ? UNKNOWN_VALUE : groups;
-                ret["version"]      = version.empty() || version.compare("(none)") == 0 ? UNKNOWN_VALUE : version;
-                ret["architecture"] = architecture.empty() || architecture.compare("(none)") == 0 ? UNKNOWN_VALUE : architecture;
+                ret["size"]         = size.empty() || size.compare(DEFAULT_VALUE) == 0 ? 0 : stoi(size);
+                ret["install_time"] = install_time.empty() || install_time.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : install_time;
+                ret["groups"]       = groups.empty() || groups.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : groups;
+                ret["version"]      = version.empty() || version.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : version;
+                ret["architecture"] = architecture.empty() || architecture.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : architecture;
                 ret["format"]       = "rpm";
-                ret["vendor"]       = vendor.empty() || vendor.compare("(none)") == 0 ? UNKNOWN_VALUE : vendor;
-                ret["description"]  = description.empty() || description.compare("(none)") == 0 ? UNKNOWN_VALUE : description;
+                ret["vendor"]       = vendor.empty() || vendor.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : vendor;
+                ret["description"]  = description.empty() || description.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : description;
             }
         }
         return ret;

--- a/src/data_provider/tests/sysInfo/CMakeLists.txt
+++ b/src/data_provider/tests/sysInfo/CMakeLists.txt
@@ -11,7 +11,7 @@ file(GLOB SYSINFO_SRC
     "${CMAKE_SOURCE_DIR}/src/sysInfo.cpp"
     "${CMAKE_SOURCE_DIR}/src/osinfo/sysOsParsers.cpp")
 
-add_executable(sysinfo_unit_test 
+add_executable(sysinfo_unit_test
     ${sysinfo_UNIT_TEST_SRC}
     ${SYSINFO_SRC})
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.h
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.h
@@ -7,7 +7,7 @@
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
- */ 
+ */
 #ifndef _SYSINFO_PARSERS_TEST_H
 #define _SYSINFO_PARSERS_TEST_H
 #include "gtest/gtest.h"

--- a/src/data_provider/tests/sysInfo/sysInfo_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfo_test.cpp
@@ -74,7 +74,7 @@ TEST_F(SysInfoTest, processes)
     SysInfoWrapper info;
     EXPECT_CALL(info, getProcessesInfo()).WillOnce(Return("processes"));
     const auto result {info.processes()};
-    EXPECT_FALSE(result.empty());    
+    EXPECT_FALSE(result.empty());
 }
 
 TEST_F(SysInfoTest, network)
@@ -82,7 +82,7 @@ TEST_F(SysInfoTest, network)
     SysInfoWrapper info;
     EXPECT_CALL(info, getNetworks()).WillOnce(Return("networks"));
     const auto result {info.networks()};
-    EXPECT_FALSE(result.empty());    
+    EXPECT_FALSE(result.empty());
 }
 
 TEST_F(SysInfoTest, ports)
@@ -102,7 +102,7 @@ TEST_F(SysInfoTest, os)
 }
 
 TEST_F(SysInfoTest, hardware_c_interface)
-{   
+{
     cJSON *object = NULL;
     sysinfo_hardware(&object);
     EXPECT_TRUE(object);
@@ -122,7 +122,7 @@ TEST_F(SysInfoTest, processes_c_interface)
     cJSON *object = NULL;
     sysinfo_processes(&object);
     EXPECT_TRUE(object);
-    EXPECT_NO_THROW(sysinfo_free_result(&object));  
+    EXPECT_NO_THROW(sysinfo_free_result(&object));
 }
 
 TEST_F(SysInfoTest, network_c_interface)

--- a/src/data_provider/tests/sysInfo/sysInfo_test.h
+++ b/src/data_provider/tests/sysInfo/sysInfo_test.h
@@ -7,7 +7,7 @@
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
- */ 
+ */
 #ifndef _SYSINFO_TEST_H
 #define _SYSINFO_TEST_H
 #include "gtest/gtest.h"

--- a/src/data_provider/tests/sysInfo/sysOsInfo_test.h
+++ b/src/data_provider/tests/sysInfo/sysOsInfo_test.h
@@ -7,7 +7,7 @@
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
- */ 
+ */
 #ifndef _SYSINFO_OS_TEST_H
 #define _SYSINFO_OS_TEST_H
 #include "gtest/gtest.h"

--- a/src/data_provider/tests/sysInfoNetworkWindows/sysInfoNetworkWindows_test.cpp
+++ b/src/data_provider/tests/sysInfoNetworkWindows/sysInfoNetworkWindows_test.cpp
@@ -28,7 +28,7 @@ public:
     virtual ~SysInfoNetworkWindowsWrapperMock() = default;
     MOCK_METHOD(int, family, (), (const override));
     MOCK_METHOD(std::string, name, (), (const override));
-    MOCK_METHOD(std::string, adapter, (), (const override)); 
+    MOCK_METHOD(std::string, adapter, (), (const override));
     MOCK_METHOD(std::string, address, (), (const override));
     MOCK_METHOD(std::string, netmask, (), (const override));
     MOCK_METHOD(std::string, broadcast, (), (const override));
@@ -92,13 +92,13 @@ TEST_F(SysInfoNetworkWindowsTest, Test_IPV4)
     EXPECT_CALL(*mock, netmask()).Times(1).WillOnce(Return(netmask));
     EXPECT_CALL(*mock, broadcast()).Times(1).WillOnce(Return(broadcast));
     EXPECT_CALL(*mock, dhcp()).Times(1).WillOnce(Return(dhcp));
-    EXPECT_CALL(*mock, metrics()).Times(1).WillOnce(Return(metrics));   
+    EXPECT_CALL(*mock, metrics()).Times(1).WillOnce(Return(metrics));
     EXPECT_NO_THROW(FactoryNetworkFamilyCreator<OSType::WINDOWS>::create(mock)->buildNetworkData(networkInfo));
     EXPECT_EQ(address, networkInfo.at("IPv4").at("address").get_ref<const std::string&>());
     EXPECT_EQ(netmask, networkInfo.at("IPv4").at("netmask").get_ref<const std::string&>());
     EXPECT_EQ(broadcast, networkInfo.at("IPv4").at("broadcast").get_ref<const std::string&>());
     EXPECT_EQ(dhcp, networkInfo.at("IPv4").at("dhcp").get_ref<const std::string&>());
-    EXPECT_EQ(metrics, networkInfo.at("IPv4").at("metric").get_ref<const std::string&>()); 
+    EXPECT_EQ(metrics, networkInfo.at("IPv4").at("metric").get_ref<const std::string&>());
 }
 
 TEST_F(SysInfoNetworkWindowsTest, Test_IPV6)
@@ -149,7 +149,7 @@ TEST_F(SysInfoNetworkWindowsTest, Test_COMMON_DATA)
     EXPECT_EQ(type, networkInfo.at("type").get_ref<const std::string&>());
     EXPECT_EQ(state, networkInfo.at("state").get_ref<const std::string&>());
     EXPECT_EQ(MAC, networkInfo.at("mac").get_ref<const std::string&>());
-    
+
     EXPECT_EQ(1, networkInfo.at("tx_packets").get<int32_t>());
     EXPECT_EQ(0, networkInfo.at("rx_packets").get<int32_t>());
     EXPECT_EQ(3, networkInfo.at("tx_bytes").get<int32_t>());

--- a/src/data_provider/tests/sysInfoNetworkWindows/sysInfoNetworkWindows_test.h
+++ b/src/data_provider/tests/sysInfoNetworkWindows/sysInfoNetworkWindows_test.h
@@ -15,7 +15,7 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
-class SysInfoNetworkWindowsTest : public ::testing::Test 
+class SysInfoNetworkWindowsTest : public ::testing::Test
 {
 protected:
 

--- a/src/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
@@ -31,7 +31,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformation)
     EXPECT_EQ(15432, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
-    EXPECT_EQ("1.5", jsPackageInfo["version"]);
+    EXPECT_EQ("3:1.5-24.el5", jsPackageInfo["version"]);
     EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
     EXPECT_EQ("rpm", jsPackageInfo["format"]);
     EXPECT_EQ("CentOS", jsPackageInfo["vendor"]);
@@ -67,6 +67,126 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationUnknownInEmpty)
     EXPECT_EQ("rpm", jsPackageInfo["format"]);
     EXPECT_EQ(UNKNOWN_VALUE, jsPackageInfo["vendor"]);
     EXPECT_EQ(UNKNOWN_VALUE, jsPackageInfo["description"]);
+}
+
+TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpoch)
+{
+    constexpr auto RPM_PACKAGE_CENTOS
+    {
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+    };
+
+    const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
+    EXPECT_FALSE(jsPackageInfo.empty());
+    EXPECT_EQ("mktemp", jsPackageInfo["name"]);
+    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
+    EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
+    EXPECT_EQ("1.5-24.el5", jsPackageInfo["version"]);
+    EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
+    EXPECT_EQ("rpm", jsPackageInfo["format"]);
+    EXPECT_EQ("CentOS", jsPackageInfo["vendor"]);
+    EXPECT_EQ("A small utility for safely making /tmp files.", jsPackageInfo["description"]);
+}
+
+TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpochNonRelease)
+{
+    constexpr auto RPM_PACKAGE_CENTOS
+    {
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t\t\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+    };
+
+    const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
+    EXPECT_FALSE(jsPackageInfo.empty());
+    EXPECT_EQ("mktemp", jsPackageInfo["name"]);
+    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
+    EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
+    EXPECT_EQ("1.5", jsPackageInfo["version"]);
+    EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
+    EXPECT_EQ("rpm", jsPackageInfo["format"]);
+    EXPECT_EQ("CentOS", jsPackageInfo["vendor"]);
+    EXPECT_EQ("A small utility for safely making /tmp files.", jsPackageInfo["description"]);
+}
+
+TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonRelease)
+{
+    constexpr auto RPM_PACKAGE_CENTOS
+    {
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t3\t\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+    };
+
+    const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
+    EXPECT_FALSE(jsPackageInfo.empty());
+    EXPECT_EQ("mktemp", jsPackageInfo["name"]);
+    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
+    EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
+    EXPECT_EQ("3:1.5", jsPackageInfo["version"]);
+    EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
+    EXPECT_EQ("rpm", jsPackageInfo["format"]);
+    EXPECT_EQ("CentOS", jsPackageInfo["vendor"]);
+    EXPECT_EQ("A small utility for safely making /tmp files.", jsPackageInfo["description"]);
+}
+
+TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpochWithNone)
+{
+    constexpr auto RPM_PACKAGE_CENTOS
+    {
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t(none)\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+    };
+
+    const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
+    EXPECT_FALSE(jsPackageInfo.empty());
+    EXPECT_EQ("mktemp", jsPackageInfo["name"]);
+    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
+    EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
+    EXPECT_EQ("1.5-24.el5", jsPackageInfo["version"]);
+    EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
+    EXPECT_EQ("rpm", jsPackageInfo["format"]);
+    EXPECT_EQ("CentOS", jsPackageInfo["vendor"]);
+    EXPECT_EQ("A small utility for safely making /tmp files.", jsPackageInfo["description"]);
+}
+
+TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonReleaseWithNone)
+{
+    constexpr auto RPM_PACKAGE_CENTOS
+    {
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t3\t(none)\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+    };
+
+    const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
+    EXPECT_FALSE(jsPackageInfo.empty());
+    EXPECT_EQ("mktemp", jsPackageInfo["name"]);
+    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
+    EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
+    EXPECT_EQ("3:1.5", jsPackageInfo["version"]);
+    EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
+    EXPECT_EQ("rpm", jsPackageInfo["format"]);
+    EXPECT_EQ("CentOS", jsPackageInfo["vendor"]);
+    EXPECT_EQ("A small utility for safely making /tmp files.", jsPackageInfo["description"]);
+}
+
+TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpochNonReleaseWithNone)
+{
+    constexpr auto RPM_PACKAGE_CENTOS
+    {
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t(none)\t(none)\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+    };
+
+    const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
+    EXPECT_FALSE(jsPackageInfo.empty());
+    EXPECT_EQ("mktemp", jsPackageInfo["name"]);
+    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
+    EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
+    EXPECT_EQ("1.5", jsPackageInfo["version"]);
+    EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
+    EXPECT_EQ("rpm", jsPackageInfo["format"]);
+    EXPECT_EQ("CentOS", jsPackageInfo["vendor"]);
+    EXPECT_EQ("A small utility for safely making /tmp files.", jsPackageInfo["description"]);
 }
 
 TEST_F(SysInfoPackagesLinuxHelperTest, parseDpkgInformation)

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2312,6 +2312,28 @@ void test_wm_checks_package_vulnerability_lt_no_epoch(void **state)
     assert_int_equal(VU_VULNERABLE, ret);
 }
 
+void test_wm_checks_package_vulnerability_no_revision_rpm(void **state)
+{
+    char *version_a = "5.3.2";
+    char *version_b = "6.1.1-23";
+    char *operation = "less than";
+
+    int ret = wm_checks_package_vulnerability(version_a, operation, version_b, VER_TYPE_RPM);
+
+    assert_int_equal(VU_ERROR_CMP, ret);
+}
+
+void test_wm_checks_package_vulnerability_no_revision_rpm_centos(void **state)
+{
+    char *version_a = "5.3.2";
+    char *version_b = "6.1.1-23";
+    char *operation = "less than";
+
+    int ret = wm_checks_package_vulnerability(version_a, operation, version_b, VER_TYPE_RPM_CENTOS);
+
+    assert_int_equal(VU_ERROR_CMP, ret);
+}
+
 void test_wm_checks_package_vulnerability_lt_no_revision(void **state)
 {
     char *version_a = "1:5.3.2";

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -675,6 +675,13 @@ int wm_checks_package_vulnerability(char *version_a, const char *operation, cons
             goto clean;
         }
 
+        // This sanity is included since you cannot always expect a revision to come,
+        // since it is a data provided by the agent.
+        if (NULL == package_version->version || NULL == package_version->revision) {
+            ret = VU_ERROR_CMP;
+            goto clean;
+        }
+
         if(pkg_version_relate(package_version, feed_condition, package_feed_version, vertype)) {
             ret = VU_VULNERABLE;
         } else {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -677,7 +677,7 @@ int wm_checks_package_vulnerability(char *version_a, const char *operation, cons
 
         // This sanity is included since you cannot always expect a revision to come,
         // since it is a data provided by the agent.
-        if (NULL == package_version->version || NULL == package_version->revision) {
+        if ((vertype == VER_TYPE_RPM_CENTOS || vertype == VER_TYPE_RPM) && (NULL == package_version->version || NULL == package_version->revision)) {
             ret = VU_ERROR_CMP;
             goto clean;
         }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7511|

## Description

It was found if the "release" field concatenated to the version was not being sent, this is an error, but a sanitizing check must be added in vuln detector, to avoid a segfault caused by not being able to retrieve the data.

![imagen](https://user-images.githubusercontent.com/14300208/108125557-5db57100-7087-11eb-936f-327a3fc6dedf.png)


## DoD
- [x] Concatenate release to veresion in agent sysinfo code.
- [x] Add sanity to vulndetector code.
- [ ] PR - CI Pass.
