### PR TITLE
Fixing Wazuh name to avoid errors during the upgrade

### DIFF
--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -322,7 +322,7 @@ getPreinstalledName()
     if [ -f "${OSSEC_INIT}" ]; then
         . ${OSSEC_INIT}
     else
-        NAME="wazuh"
+        NAME="Wazuh"
     fi
 
     echo $NAME


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7528 |

## Description

During the Wazuh upgrades, the name of the product is used to determine whether the upgrade is from an old version of the product. Because the capitalization of the name was wrong, the name comparison resulted in a false result in the function `UpdateOldVersions` and this triggered all the mechanisms to upgrade from old versions, triggering some errors because of missing folders.

The name was fixed and the errors don't happen anymore.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade