### PR TITLE
7529 hotfixes empty kb value

### DIFF
--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -421,7 +421,10 @@ static void getHotFixFromReg(const HKEY key, const std::string& subKey, nlohmann
                         value = value.substr(start);
                         const auto end{value.find("-")};
                         value = value.substr(0, end);
-                        hotfixes.insert(value);
+                        if (value > "KB")
+                        {
+                            hotfixes.insert(value);
+                        }
                     }
                 }
             }

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -415,7 +415,7 @@ static void getHotFixFromReg(const HKEY key, const std::string& subKey, nlohmann
                 if (packageReg.string("InstallLocation", value))
                 {
                     value = Utils::toUpperCase(value);
-                    const auto start{value.find("KB")};
+                    const auto start{ value.find("KB") };
                     if (start != std::string::npos)
                     {
                         value = value.substr(start);


### PR DESCRIPTION
|Related issue|
| #7529 |
| Closes #7529 |

## Description
This PR aims to fix the issue found in hotfixes listed in kibana dashboard. Data provider was not checking the existence of a KB number when reading the items from te registry.

# DoD
- [X] Code changes.
- [X] Manual tests
![image](https://user-images.githubusercontent.com/54002291/108281698-fbc83a80-715e-11eb-96e8-b738b6d14c8a.png)
