### PR TITLE
Adding new table to agents' database to store the CVE's id that affect each packages 

### DIFF
--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -340,9 +340,19 @@ CREATE TABLE IF NOT EXISTS sync_info (
     n_completions INTEGER DEFAULT 0
 );
 
+CREATE TABLE IF NOT EXISTS vuln_cves (
+    name TEXT,
+    version TEXT,
+    architecture TEXT,
+    cve TEXT,
+    PRIMARY KEY (name, version, architecture, cve)
+);
+CREATE INDEX IF NOT EXISTS packages_id ON vuln_cves (name);
+CREATE INDEX IF NOT EXISTS cves_id ON vuln_cves (cve);
+
 BEGIN;
 
-INSERT INTO metadata (key, value) VALUES ('db_version', '7');
+INSERT INTO metadata (key, value) VALUES ('db_version', '8');
 INSERT INTO scan_info (module) VALUES ('fim');
 INSERT INTO scan_info (module) VALUES ('syscollector');
 INSERT INTO sync_info (component) VALUES ('fim');

--- a/src/wazuh_db/schema_upgrade_v8.sql
+++ b/src/wazuh_db/schema_upgrade_v8.sql
@@ -1,0 +1,22 @@
+/*
+ * SQL Schema for upgrading databases
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * February 17, 2021.
+ *
+ * This program is a free software, you can redistribute it
+ * and/or modify it under the terms of GPLv2.
+*/
+
+CREATE TABLE IF NOT EXISTS vuln_cves (
+    name TEXT,
+    version TEXT,
+    architecture TEXT,
+    cve TEXT,
+    PRIMARY KEY (name, version, architecture, cve)
+);
+
+CREATE INDEX IF NOT EXISTS packages_id ON vuln_cves (name);
+CREATE INDEX IF NOT EXISTS cves_id ON vuln_cves (cve);
+
+INSERT OR REPLACE INTO metadata (key, value) VALUES ('db_version', 8);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -253,12 +253,12 @@ typedef enum global_db_access {
     WDB_DISCONNECT_AGENTS
 } global_db_access;
 
-struct stmt_cache { 
+struct stmt_cache {
     sqlite3_stmt *stmt;
     char *query;
 };
 
-struct stmt_cache_list { 
+struct stmt_cache_list {
     struct stmt_cache value;
     struct stmt_cache_list *next;
 };
@@ -310,6 +310,7 @@ extern char *schema_upgrade_v4_sql;
 extern char *schema_upgrade_v5_sql;
 extern char *schema_upgrade_v6_sql;
 extern char *schema_upgrade_v7_sql;
+extern char *schema_upgrade_v8_sql;
 extern char *schema_global_upgrade_v1_sql;
 extern char *schema_global_upgrade_v2_sql;
 
@@ -351,7 +352,7 @@ typedef enum {
     FIELD_REAL
 } field_type_t;
 
-struct field { 
+struct field {
     field_type_t type;
     int index;
     bool is_old_implementation;
@@ -359,19 +360,19 @@ struct field {
     char name[OS_SIZE_256];
 };
 
-struct column_list { 
+struct column_list {
     struct field value;
     const struct column_list *next;
 };
 
-struct kv { 
+struct kv {
     char key[OS_SIZE_256];
     char value[OS_SIZE_256];
     bool single_row_table;
     struct column_list const *column_list;
 };
 
-struct kv_list { 
+struct kv_list {
     struct kv current;
     const struct kv_list *next;
 };

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -38,6 +38,7 @@ wdb_t * wdb_upgrade(wdb_t *wdb) {
         schema_upgrade_v5_sql,
         schema_upgrade_v6_sql,
         schema_upgrade_v7_sql,
+        schema_upgrade_v8_sql
     };
 
     char db_version[OS_SIZE_256 + 2];


### PR DESCRIPTION
|Related issue|
|---|
|7512|


## Description

This PR adds a new table in the agents' database to store the CVE's that affected their packages.
Also, the upgrade mechanism was updated to include this new database version.

The UT weren't necessary to update.

Closes #7512 .

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade

