### PR TITLE
Switch noisy error message to debug in Syslog output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ All notable changes to this project will be documented in this file.
 - **Core:**
   - Fixed a bug in Windows agent that did not honor the buffer's EPS limit. ([#7333](https://github.com/wazuh/wazuh/pull/7333))
   - Fixed a bug in Integratord that might lose alerts from Analysisd due to a race condition. ([#7338](https://github.com/wazuh/wazuh/pull/7338))
-  
+  - Silence the error message when the Syslog forwarder reads an alert with no rule object. ([#7539](https://github.com/wazuh/wazuh/pull/7539))
+
 ### Removed
 
 - **API:**

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -326,7 +326,7 @@ int OS_Alert_SendSyslog_JSON(cJSON *json_data, const SyslogConfig *syslog_config
     mdebug2("OS_Alert_SendSyslog_JSON()");
 
     if (rule = cJSON_GetObjectItem(json_data, "rule"), !rule) {
-        merror("Alert with no rule field.");
+        mdebug2("Alert with no rule field.");
         return 0;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/4254 |

## Description

This pull request silences the error showed when forwarding alerts by Syslog and the forwarder reads an alert with no rule object.

```
ossec-csyslogd: ERROR: Alert with no rule field
```

This is an expected situation since there exist stat alerts that don't include that object.

Related to this change, it was recently added the fix https://github.com/wazuh/wazuh/pull/7338 to retry reading an alert in case of failure.

## Logs/Alerts example

**Before**
```
ossec-csyslogd: ERROR: Alert with no rule field
```

**After**
```
ossec-csyslogd: DEBUG: Alert with no rule field
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Review logs syntax and correct language
