### PR TITLE
Fix API integration tests failing in master

### DIFF
--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -157,8 +157,14 @@ def healthcheck_procedure(module: str):
     # Avoid race condition
     time.sleep(2)
     if os.path.exists(manager_folder):
+        # Rename the base healthcheck and copy the specific one
+        os.popen(f'cp -rf {os.path.join(master_base_folder, "healthcheck.py")} '
+                 f'{os.path.join(tmp_content, "manager", "healthcheck", "base_healthcheck.py")}')
         os.popen(f'cp -rf {manager_folder} {os.path.join(tmp_content, "manager")}')
     if os.path.exists(agent_folder):
+        # Rename the base healthcheck and copy the specific one
+        os.popen(f'cp -rf {os.path.join(agent_base_folder, "healthcheck.py")} '
+                 f'{os.path.join(tmp_content, "agent", "healthcheck", "base_healthcheck.py")}')
         os.popen(f'cp -rf {agent_folder} {os.path.join(tmp_content, "agent")}')
 
 

--- a/api/test/integration/env/configurations/base/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/base/agent/healthcheck/healthcheck.py
@@ -14,7 +14,7 @@ def get_timestamp(log):
     return t
 
 
-def get_health():
+def get_agent_health_base():
     # Get agent health. The agent will be healthy if it has been connected to the manager after been
     # restarted due to shared configuration changes.
     # Using agentd when using grep as the module name can vary between ossec-agentd and wazuh-agentd,
@@ -42,4 +42,4 @@ def get_health():
 
 
 if __name__ == "__main__":
-    exit(get_health())
+    exit(get_agent_health_base())

--- a/api/test/integration/env/configurations/base/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/base/manager/healthcheck/healthcheck.py
@@ -25,5 +25,9 @@ def get_worker_health():
     return check0 or check1
 
 
+def get_manager_health_base():
+    return get_master_health() if socket.gethostname() == 'wazuh-master' else get_worker_health()
+
+
 if __name__ == "__main__":
-    exit(get_master_health()) if socket.gethostname() == 'wazuh-master' else exit(get_worker_health())
+    exit(get_manager_health_base())

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -1,5 +1,7 @@
 import os
 
+from base_healthcheck import get_agent_health_base
+
 
 def get_health():
     output = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
@@ -11,4 +13,4 @@ def get_health():
 
 
 if __name__ == "__main__":
-    exit(get_health())
+    exit(get_health() or get_agent_health_base())

--- a/api/test/integration/env/configurations/experimental/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/manager/healthcheck/healthcheck.py
@@ -1,22 +1,9 @@
 import os
 import socket
 
-
-def check(result):
-    if result == 0:
-        return 0
-    else:
-        return 1
-
-
-def get_master_health():
-    os.system("/var/ossec/bin/agent_control -ls > /tmp/output.txt")
-    check0 = check(os.system("diff -q /tmp/output.txt /configuration_files/healthcheck/agent_control_check.txt"))
-    check1 = check(os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log"))
-    check2 = check(os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log"))
-    return check0 or check1 or check2
-
+from base_healthcheck import get_manager_health_base
 
 if __name__ == "__main__":
     # Workers are not needed in this test, so the exit code is set to 0 (healthy).
-    exit(get_master_health()) if socket.gethostname() == 'wazuh-master' else exit(0)
+    exit(os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+         or get_manager_health_base()) if socket.gethostname() == 'wazuh-master' else exit(0)

--- a/api/test/integration/env/configurations/sca/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/sca/agent/healthcheck/healthcheck.py
@@ -1,8 +1,8 @@
 import os
 
-output = os.system("grep -q 'sca: INFO: Security Configuration Assessment scan finished.' /var/ossec/logs/ossec.log")
+from base_healthcheck import get_agent_health_base
 
-if output == 0:
-    exit(0)
-else:
-    exit(1)
+if __name__ == "__main__":
+    exit(os.system(
+        "grep -q 'sca: INFO: Security Configuration Assessment scan finished.' /var/ossec/logs/ossec.log")
+         or get_agent_health_base())

--- a/api/test/integration/env/configurations/security/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/security/manager/healthcheck/healthcheck.py
@@ -1,0 +1,21 @@
+import os
+import socket
+
+
+def check(result):
+    if result == 0:
+        return 0
+    else:
+        return 1
+
+
+def get_master_health():
+    os.system("/var/ossec/bin/wazuh-control status > /tmp/daemons.txt")
+    check0 = check(os.system("diff -q /tmp/daemons.txt /configuration_files/healthcheck/daemons_check.txt"))
+    check1 = check(os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log"))
+    return check0 or check1
+
+
+if __name__ == "__main__":
+    # Workers are not needed in this test, so the exit code is set to 0 (healthy).
+    exit(get_master_health()) if socket.gethostname() == 'wazuh-master' else exit(0)

--- a/api/test/integration/env/configurations/syscheck/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscheck/agent/healthcheck/healthcheck.py
@@ -1,8 +1,11 @@
 import os
 
+from base_healthcheck import get_agent_health_base
+
 
 def get_health():
-    output = os.system("grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
+    output = os.system(
+        "grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
 
     if output == 0:
         return 0
@@ -11,4 +14,4 @@ def get_health():
 
 
 if __name__ == "__main__":
-    exit(get_health())
+    exit(get_health() or get_agent_health_base())

--- a/api/test/integration/env/configurations/syscheck/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscheck/manager/healthcheck/healthcheck.py
@@ -1,22 +1,10 @@
 import os
 import socket
 
-
-def check(result):
-    if result == 0:
-        return 0
-    else:
-        return 1
-
-
-def get_master_health():
-    os.system("/var/ossec/bin/agent_control -ls > /tmp/output.txt")
-    check0 = check(os.system("diff -q /tmp/output.txt /configuration_files/healthcheck/agent_control_check.txt"))
-    check1 = check(os.system("grep -q 'wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log"))
-    check2 = check(os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log"))
-    return check0 or check1 or check2
-
+from base_healthcheck import get_manager_health_base
 
 if __name__ == "__main__":
     # Workers are not needed in this test, so the exit code is set to 0 (healthy).
-    exit(get_master_health()) if socket.gethostname() == 'wazuh-master' else exit(0)
+    exit(os.system(
+        "grep -q 'wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
+         or get_manager_health_base()) if socket.gethostname() == 'wazuh-master' else exit(0)

--- a/api/test/integration/env/configurations/syscollector/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscollector/agent/healthcheck/healthcheck.py
@@ -1,5 +1,7 @@
 import os
 
+from base_healthcheck import get_agent_health_base
+
 
 def get_health():
     output = os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
@@ -11,4 +13,4 @@ def get_health():
 
 
 if __name__ == "__main__":
-    exit(get_health())
+    exit(get_health() or get_agent_health_base())

--- a/api/test/integration/env/configurations/syscollector/manager/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscollector/manager/healthcheck/healthcheck.py
@@ -1,22 +1,10 @@
 import os
 import socket
 
-
-def check(result):
-    if result == 0:
-        return 0
-    else:
-        return 1
-
-
-def get_master_health():
-    os.system("/var/ossec/bin/agent_control -ls > /tmp/output.txt")
-    check0 = check(os.system("diff -q /tmp/output.txt /configuration_files/healthcheck/agent_control_check.txt"))
-    check1 = check(os.system("grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log"))
-    check2 = check(os.system("grep -qs 'Listening on ' /var/ossec/logs/api.log"))
-    return check0 or check1 or check2
-
+from base_healthcheck import get_manager_health_base
 
 if __name__ == "__main__":
     # Workers are not needed in this test, so the exit code is set to 0 (healthy).
-    exit(get_master_health()) if socket.gethostname() == 'wazuh-master' else exit(0)
+    exit(os.system(
+        "grep -q 'wazuh-modulesd:syscollector: INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+         or get_manager_health_base()) if socket.gethostname() == 'wazuh-master' else exit(0)

--- a/api/test/integration/test_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_active_response_endpoints.tavern.yaml
@@ -15,8 +15,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "restart-wazuh0"
-        arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+        command: "custom"
+        custom: True
       params:
         agents_list: '001'
     response:
@@ -39,8 +39,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "restart-wazuh0"
-        arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+        command: "custom"
+        custom: True
       params:
         agents_list: '006'
     response:
@@ -53,7 +53,6 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: !float "{restart_delay}"
 
   - name: Send a message to a list of agents (Status=Active)
     request:
@@ -64,8 +63,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "restart-wazuh0"
-        arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+        command: "custom"
+        custom: True
       params:
         agents_list: 002,004,005,007,010,012
     response:
@@ -86,7 +85,6 @@ stages:
                 - '012'
           total_affected_items: 4
           total_failed_items: 2
-    delay_after: !float "{restart_delay}"
 
   - name: Try to send a message to an agent (status=disconnected/never_connected)
     request:

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1404,7 +1404,6 @@ stages:
               type: !anystr
               max_agents: !anystr
               openssl_support: !anystr
-              ruleset_version: !anystr
               tz_offset: !anystr
               tz_name: !anystr
           failed_items: []
@@ -1560,12 +1559,12 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Read logs with filters -> tag=ossec-analysisd, limit=1 {node_id}
+  - name: Read logs with filters -> tag=wazuh-analysisd, limit=1 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
       params:
-        tag: ossec-analysisd
+        tag: wazuh-analysisd
         limit: 1
     response:
       status_code: 200
@@ -1578,12 +1577,12 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Read logs with filters -> tag=ossec-syscheckd, limit=2 {node_id}
+  - name: Read logs with filters -> tag=wazuh-syscheckd, limit=2 {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
       params:
-        tag: ossec-syscheckd
+        tag: wazuh-syscheckd
         limit: 2
     response:
       status_code: 200
@@ -1592,9 +1591,9 @@ stages:
         data:
           affected_items:
             - <<: *cluster_log
-              tag: ossec-syscheckd
+              tag: wazuh-syscheckd
             - <<: *cluster_log
-              tag: ossec-syscheckd
+              tag: wazuh-syscheckd
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -1618,19 +1617,19 @@ stages:
           total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Read logs with filters by query (tag=ossec-syscheckd, level=info) {node_id}
+  - name: Read logs with filters by query (tag=wazuh-syscheckd, level=info) {node_id}
     request:
       verify: False
       <<: *get_cluster_logs
       params:
-        q: tag=ossec-syscheckd;level=info
+        q: tag=wazuh-syscheckd;level=info
     response:
       status_code: 200
       verify_response_with:
         - function: tavern_utils:test_expected_value
           extra_kwargs:
             key: "tag"
-            expected_values: "ossec-syscheckd"
+            expected_values: "wazuh-syscheckd"
         - function: tavern_utils:test_expected_value
           extra_kwargs:
             key: "level"
@@ -1726,7 +1725,7 @@ stages:
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
-    response: &unexisting_node
+    response:
       status_code: 200
       json:
         error: 1

--- a/api/test/integration/test_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoder_endpoints.tavern.yaml
@@ -17,7 +17,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           total_affected_items: !anyint
@@ -32,7 +32,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: &full_items_array
             - details: !anything
@@ -64,7 +64,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array
@@ -88,7 +88,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
               # Check offset matches with previous request
@@ -113,7 +113,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array
@@ -132,7 +132,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - filename: "{tavern.request_vars.params.filename}"
@@ -151,7 +151,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - relative_dirname: "{tavern.request_vars.params.relative_dirname}"
@@ -170,7 +170,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - status: "{tavern.request_vars.params.status}"
@@ -218,7 +218,7 @@ stages:
           select_key: 'filename,position,name,details.parent' # required_fields={'filename', 'position'}
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           failed_items: []
@@ -256,7 +256,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -273,7 +273,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array
@@ -293,7 +293,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array
@@ -312,7 +312,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -345,7 +345,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: *full_items_array
           failed_items: []
@@ -363,7 +363,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: *full_items_array
           failed_items: []
@@ -391,7 +391,7 @@ stages:
       status_code: 200
       json:
         # We get totalItems number of arrays in items, using !anything to check items key is in the response
-        error: !anyint
+        error: 0
         data: &decoder_name_response
           affected_items:
             - details: !anything
@@ -416,7 +416,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array
@@ -440,7 +440,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
               # Check offset matches with previous request
@@ -465,7 +465,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array
@@ -522,7 +522,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -542,7 +542,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -566,7 +566,7 @@ stages:
       status_code: 200
       json:
         # We get totalItems number of arrays in items, using !anything to check items key is in the response
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -583,7 +583,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: &full_items_array_files
             - filename: !anystr
@@ -611,7 +611,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array_files
@@ -635,7 +635,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
               # Check offset matches with previous request
@@ -657,7 +657,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array_files
@@ -676,7 +676,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - filename: "{tavern.request_vars.params.filename}"
@@ -695,7 +695,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - relative_dirname: "{tavern.request_vars.params.relative_dirname}"
@@ -714,7 +714,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - status: "{returned_files_status:s}"
@@ -770,7 +770,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: *full_items_array_files
           failed_items: []
@@ -788,7 +788,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: *full_items_array_files
           failed_items: []
@@ -812,7 +812,7 @@ stages:
       status_code: 200
       json:
         # We get totalItems number of arrays in items, using !anything to check items key is in the response
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []
@@ -829,7 +829,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: &full_items_array_parents
             - details: !anything
@@ -852,7 +852,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array_parents
@@ -874,7 +874,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
               # Check offset matches with previous request
@@ -897,7 +897,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - <<: *full_items_array_parents
@@ -953,7 +953,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: *full_items_array_parents
           total_affected_items: !anyint
@@ -969,7 +969,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: *full_items_array_parents
           total_affected_items: !anyint

--- a/api/test/integration/test_rbac_black_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_active_response_endpoints.tavern.yaml
@@ -33,8 +33,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "restart-wazuh0"
-        arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+        command: "custom"
+        custom: True
       params:
         agents_list: '002'
     response:
@@ -47,7 +47,6 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: !float "{restart_delay}"
 
   - name: Send a message to a list of agents
     request:
@@ -58,8 +57,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "restart-wazuh0"
-        arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+        command: "custom"
+        custom: True
       params:
         agents_list: 002,004,005,007,010,011
     response:
@@ -83,8 +82,7 @@ stages:
                 - '011'
           total_affected_items: 2
           total_failed_items: 4
-    delay_after: !float "{restart_delay}"
-    
+
   - name: Try to send a message to an agent (status=disconnected/never_connected) (Allow)
     request:
       verify: False

--- a/api/test/integration/test_rbac_black_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_decoder_endpoints.tavern.yaml
@@ -23,7 +23,7 @@ stages:
           affected_items:
             - &full_item_decoders
               details: !anything
-              filename: 0005-wazuh_decoders.xml
+              filename: 0006-json_decoders.xml
               name: !anystr
               relative_dirname: !anystr
               position: !anyint
@@ -264,9 +264,9 @@ stages:
             - <<: *full_item_decoders_parent
               filename: 0010-active-response_decoders.xml
             - <<: *full_item_decoders_parent
-              filename: 0015-aix-ipsec_decoders.xml
+              filename: 0010-active-response_decoders.xml
             - <<: *full_item_decoders_parent
-              filename: 0025-apache_decoders.xml
+              filename: 0015-aix-ipsec_decoders.xml
             - <<: *full_item_decoders_parent
               filename: 0025-apache_decoders.xml
           failed_items: []

--- a/api/test/integration/test_rbac_black_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_decoder_endpoints.tavern.yaml
@@ -18,12 +18,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - &full_item_decoders
               details: !anything
-              filename: 0006-json_decoders.xml
+              filename: 0005-wazuh_decoders.xml
               name: !anystr
               relative_dirname: !anystr
               position: !anyint
@@ -35,7 +35,7 @@ stages:
             - <<: *full_item_decoders
               filename: 0010-active-response_decoders.xml
             - <<: *full_item_decoders
-              filename: 0015-aix-ipsec_decoders.xml
+              filename: 0010-active-response_decoders.xml
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -52,7 +52,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -71,7 +71,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -103,7 +103,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - filename: 0006-json_decoders.xml
@@ -137,7 +137,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 2
         data:
           affected_items:
             - filename: 0006-json_decoders.xml
@@ -251,7 +251,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - &full_item_decoders_parent

--- a/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
@@ -36,7 +36,7 @@ stages:
           total_failed_items: 0
 
 ---
-test_name: GET /syscheck/000/last_scan
+test_name: GET /syscheck/{agent_id}/last_scan
 
 stages:
 
@@ -143,7 +143,7 @@ test_name: DELETE /syscheck
 
 stages:
 
-  - name: Try to delete syscheck scans in agent 000
+  - name: Try to delete syscheck scans in agent 002 (Allow)
     request:
       verify: False
       method: DELETE
@@ -160,7 +160,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to check the answer is empty after deleting the scans for agent 000
+  - name: Try to delete syscheck scans in agent 001 (Deny)
     request:
       verify: False
       method: DELETE

--- a/api/test/integration/test_rbac_white_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_active_response_endpoints.tavern.yaml
@@ -15,8 +15,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "restart-wazuh0"
-        arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+        command: "custom"
+        custom: True
       params:
         agents_list: '001'
     response:
@@ -29,7 +29,6 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: !float "{restart_delay}"
 
   - name: Send a message to an agent (Status=Active) (Deny)
     request:
@@ -61,8 +60,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: application/json
       json:
-        command: "restart-wazuh0"
-        arguments: ["-", "null", "(from_the_server)", "(no_rule_id)"]
+        command: "custom"
+        custom: True
       params:
         agents_list: 002,004,005,007,010,011
     response:
@@ -86,7 +85,6 @@ stages:
                 - '010'
           total_affected_items: 2
           total_failed_items: 4
-    delay_after: !float "{restart_delay}"
 
   - name: Try to send a message to an agent (status=disconnected/never_connected) (Allow)
     request:

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -1289,7 +1289,7 @@ stages:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/groups"
       method: POST
-      params:
+      json:
         group_id: "group5"
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_decoder_endpoints.tavern.yaml
@@ -18,7 +18,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - &full_item_decoders
@@ -48,7 +48,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: []
           failed_items: []
@@ -67,7 +67,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 2
         data:
           affected_items:
             - <<: *full_item_decoders
@@ -101,7 +101,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - filename: 0005-wazuh_decoders.xml
@@ -126,7 +126,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - filename: 0005-wazuh_decoders.xml
@@ -259,7 +259,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items: !anything
           failed_items: []

--- a/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
@@ -39,7 +39,7 @@ stages:
             error: !anystr
 
 ---
-test_name: GET /syscheck/000/last_scan
+test_name: GET /syscheck/{agent_id}/last_scan
 
 stages:
 
@@ -135,7 +135,7 @@ test_name: DELETE /syscheck
 
 stages:
 
-  - name: Try to delete syscheck scans in agent 000
+  - name: Try to delete syscheck scans in agent 001 (Allow)
     request:
       verify: False
       method: DELETE
@@ -152,7 +152,7 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Try to check the answer is empty after deleting the scans for agent 000
+  - name: Try to delete syscheck scans in agent 002 (Deny)
     request:
       verify: False
       method: DELETE

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -374,6 +374,7 @@ stages:
       <<: *get_rootcheck_agent
       params:
         select: cis
+        sort: +cis
         distinct: true
     response:
       status_code: 200
@@ -381,11 +382,16 @@ stages:
         error: 0
         data:
           affected_items:
-            - cis: "1.4 Debian Linux"
-            - cis: "5.2 Debian Linux"
+            - cis: !anystr
+            - cis: !anystr
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "cis"
+            reverse: False
 
   # GET /rootcheck/001?select=status,distinct=true
   - name: Filter by select parameter and distinct, selecting status

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -367,8 +367,8 @@ stages:
           failed_items: []
           total_failed_items: 0
 
-  # GET /rootcheck/001?select=cis,distinct=true
-  - name: Filter by select parameter and distinct, selecting cis
+  # GET /rootcheck/001?select=cis&sort=+cis&distinct=true
+  - name: Filter by select parameter and distinct, selecting cis and sorting by cis
     request:
       verify: False
       <<: *get_rootcheck_agent

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -1,4 +1,4 @@
-test_name: GET /sca/001
+test_name: GET /sca/{agent_id}
 
 marks:
   - base_tests
@@ -15,10 +15,10 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data: !anything
 
-  - name: Parameters -> limit=2
+  - name: Parameters -> limit=1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/001"
@@ -26,11 +26,11 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        limit: 2
+        limit: 1
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - &sca_agent_result_001
@@ -46,9 +46,41 @@ stages:
               hash_file: !anystr
               total_checks: !anyint
               invalid: !anyint
-            - <<: *sca_agent_result_001
-          total_affected_items: 2
+          total_affected_items: 1
           failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> limit=2 (Using an agent with 2 sca policies)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 2
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - &sca_agent_result_006
+              name: !anystr
+              pass: !anyint
+              score: !anyint
+              references: !anystr #THIS FIELD IS NOT INCLUDED IN ALL ANSWERS
+              fail: !anyint
+              description: !anystr
+              policy_id: !anystr
+              start_scan: !anystr
+              end_scan: !anystr
+              hash_file: !anystr
+              total_checks: !anyint
+              invalid: !anyint
+            - <<: *sca_agent_result_006
+          total_affected_items: 2
+          failed_items: [ ]
           total_failed_items: 0
 
   - name: Parameters -> offset=1,limit=1
@@ -64,18 +96,17 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_001
+          affected_items: []
           failed_items: []
+          total_affected_items: 1
           total_failed_items: 0
 
   - name: Parameters -> sort=-score,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -85,35 +116,45 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
-            - <<: *sca_agent_result_001
-            - <<: *sca_agent_result_001
+            - <<: *sca_agent_result_006
+            - <<: *sca_agent_result_006
           failed_items: []
+          total_affected_items: 2
           total_failed_items: 0
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "score"
 
-  - name: Parameters -> sort=+score,limit=1
+  - name: Parameters -> sort=+score,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        limit: 1
-        sort: -score
+        limit: 2
+        sort: +score
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
-            - <<: *sca_agent_result_001
+            - <<: *sca_agent_result_006
+            - <<: *sca_agent_result_006
           failed_items: []
+          total_affected_items: 2
           total_failed_items: 0
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "score"
+            reverse: False
 
   - name: Parameters -> search=cis,limit=1
     request:
@@ -128,15 +169,15 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
             - <<: *sca_agent_result_001
           failed_items: []
+          total_affected_items: 1
           total_failed_items: 0
 
-  - name: Parameters -> q=score>50,limit=1
+  - name: Parameters -> q=score>40,limit=1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/001"
@@ -149,12 +190,12 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
             - <<: *sca_agent_result_001
           failed_items: []
+          total_affected_items: 1
           total_failed_items: 0
 
   - name: Parameters -> limit=2500
@@ -169,10 +210,10 @@ stages:
     response:
       status_code: 400
 
-  - name: Parameters -> name=CIS benchmark for Debian/Linux 9 L2,limit=1
+  - name: Parameters -> name=CIS benchmark for Debian/Linux 9 L2, limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -182,16 +223,16 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
-            - <<: *sca_agent_result_001
+            - <<: *sca_agent_result_006
               name: CIS benchmark for Debian/Linux 9 L2
           failed_items: []
+          total_affected_items: 1
           total_failed_items: 0
 
-  - name: Parameters -> references=https://www.cisecurity.org/cis-benchmarks/,limit=1
+  - name: Parameters -> references=https://www.cisecurity.org/cis-benchmarks/, limit=1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/001"
@@ -204,13 +245,13 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
             - <<: *sca_agent_result_001
               references: https://www.cisecurity.org/cis-benchmarks/
           failed_items: []
+          total_affected_items: 1
           total_failed_items: 0
 
   - name: Parameters -> description=This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.,limit=1
@@ -226,37 +267,37 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
             - <<: *sca_agent_result_001
               description: !anystr
           failed_items: []
+          total_affected_items: 1
           total_failed_items: 0
 
 ---
-test_name: GET /sca/001/checks/cis_debian9_L1
+test_name: GET /sca/001/checks/cis_debian9
 
 stages:
 
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data: !anything
 
   - name: Parameters -> limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -265,9 +306,8 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
             - &sca_check_result_001
               remediation: !anystr
@@ -281,12 +321,13 @@ stages:
               rules: !anything
               condition: !anything
           failed_items: []
+          total_affected_items: !anyint
           total_failed_items: 0
 
   - name: Parameters -> limit=4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -295,21 +336,21 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
             - <<: *sca_check_result_001
             - <<: *sca_check_result_001
             - <<: *sca_check_result_001
             - <<: *sca_check_result_001
           failed_items: []
+          total_affected_items: !anyint
           total_failed_items: 0
 
   - name: Parameters -> sort=-id,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -319,19 +360,23 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
             - <<: *sca_check_result_001
             - <<: *sca_check_result_001
           failed_items: []
+          total_affected_items: !anyint
           total_failed_items: 0
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "id"
 
   - name: Parameters -> search=passwd,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -341,39 +386,39 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
             - <<: *sca_check_result_001
           failed_items: []
+          total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Parameters -> q=id=3098
+  - name: Parameters -> q=id=2003
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
-        q: id=3098
+        q: id=2003
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
             - <<: *sca_check_result_001
-              id: 3098
+              id: 2003
           failed_items: []
+          total_affected_items: 1
           total_failed_items: 0
 
   - name: Parameters -> result=failed,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -383,19 +428,19 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
             - <<: *sca_check_result_001
               result: failed
           failed_items: []
+          total_affected_items: !anyint
           total_failed_items: 0
 
   - name: Parameters -> file=/etc/shadow,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -405,13 +450,13 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
             - <<: *sca_check_result_001
               file: /etc/shadow
           failed_items: []
+          total_affected_items: !anyint
           total_failed_items: 0
 
   - name: Parameters -> limit=2500
@@ -426,10 +471,10 @@ stages:
     response:
       status_code: 400
 
-  - name: Parameters -> title="Ensure shadow group is empty,limit=1
+  - name: Parameters -> title="Ensure shadow group is empty",limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -439,19 +484,19 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
           affected_items:
             - <<: *sca_check_result_001
               title: Ensure shadow group is empty
           failed_items: []
+          total_affected_items: !anyint
           total_failed_items: 0
 
-  - name: Parameters -> title="Ensure address space layout randomization (ASLR) is enabled"
+  - name: Parameters -> title="Ensure address space layout randomization (ASLR) is enabled",limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -461,7 +506,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
@@ -472,7 +517,7 @@ stages:
   - name: Parameters -> title="non-existent"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -482,17 +527,17 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: 0
           affected_items: []
           failed_items: []
           total_failed_items: 0
 
-  - name: Parameters -> description="The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
+  - name: Parameters -> description="The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root.",limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -502,7 +547,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
@@ -514,7 +559,7 @@ stages:
   - name: Parameters -> remediation=Remove any legacy + entries from /etc/group if they exist.,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -524,7 +569,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
@@ -536,34 +581,28 @@ stages:
   - name: Parameters -> rationale with apostrophe and parenthesis"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        rationale: >-
-          Having no timeout value associated with a connection could allow an unauthorized user access to
-          another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a
-          timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5
-          minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0.
-          In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages
-          will be sent.
+        rationale: Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent.
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
-            - id: 3081
+            - rationale: Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent.
           failed_items: []
           total_failed_items: 0
 
   - name: Parameters -> rationale with word "count"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -577,7 +616,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
@@ -592,7 +631,7 @@ stages:
   - name: Parameters -> rationale with word "offset"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -602,7 +641,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: 0
           affected_items: []
@@ -612,7 +651,7 @@ stages:
   - name: Parameters -> command="dpkg -s libpam-pwquality"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -622,7 +661,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
@@ -633,7 +672,7 @@ stages:
   - name: Parameters -> status="Not applicable"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -643,7 +682,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
@@ -654,7 +693,7 @@ stages:
   - name: Parameters -> reason="Invalid path or wrong permissions to run command 'ip6tables -L'"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -664,7 +703,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
@@ -687,22 +726,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
-        data: !anything
-
-  - name: Parameters -> limit=2
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2
-    response:
-      status_code: 200
-      json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - &sca_agent_result_002
@@ -718,55 +742,11 @@ stages:
               hash_file: !anystr
               total_checks: !anyint
               invalid: !anyint
-            - <<: *sca_agent_result_002
-          total_affected_items: 2
+          total_affected_items: 1
           failed_items: []
           total_failed_items: 0
 
-  - name: Parameters -> offset=1,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        offset: 1
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_002
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> sort=-score,limit=2
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2
-        sort: -score
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_002
-            - <<: *sca_agent_result_002
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> sort=+score,limit=1
+  - name: Parameters -> name=CIS Benchmark for Debian/Linux 9,limit=1
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/sca/002"
@@ -775,91 +755,16 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        sort: -score
+        name: CIS Benchmark for Debian/Linux 9
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
+          total_affected_items: 1
           affected_items:
             - <<: *sca_agent_result_002
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> search=cis,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        search: cis
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_002
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> q=score>50,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        q: score>40
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_002
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> limit=2500
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2500
-    response:
-      status_code: 400
-
-  - name: Parameters -> name=CIS benchmark for Debian/Linux 9 L2,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        name: CIS benchmark for Debian/Linux 9 L2
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_002
-              name: CIS benchmark for Debian/Linux 9 L2
+              name: CIS Benchmark for Debian/Linux 9
           failed_items: []
           total_failed_items: 0
 
@@ -876,9 +781,9 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
+          total_affected_items: 1
           affected_items:
             - <<: *sca_agent_result_002
               references: https://www.cisecurity.org/cis-benchmarks/
@@ -898,9 +803,9 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
-          total_affected_items: !anyint
+          total_affected_items: 1
           affected_items:
             - <<: *sca_agent_result_002
               description: !anystr
@@ -908,27 +813,27 @@ stages:
           total_failed_items: 0
 
 ---
-test_name: GET /sca/002/checks/cis_debian9_L1
+test_name: GET /sca/006/checks/cis_debian9_L1
 
 stages:
 
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data: !anything
 
   - name: Parameters -> limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -937,11 +842,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
-            - &sca_check_result_002
+            - &sca_check_result_006
               remediation: !anystr
               rationale: !anystr
               title: !anystr
@@ -958,7 +863,7 @@ stages:
   - name: Parameters -> limit=4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -967,21 +872,21 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
-            - <<: *sca_check_result_002
-            - <<: *sca_check_result_002
-            - <<: *sca_check_result_002
-            - <<: *sca_check_result_002
+            - <<: *sca_check_result_006
+            - <<: *sca_check_result_006
+            - <<: *sca_check_result_006
+            - <<: *sca_check_result_006
           failed_items: []
           total_failed_items: 0
 
   - name: Parameters -> sort=-id,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -991,19 +896,19 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
-            - <<: *sca_check_result_002
-            - <<: *sca_check_result_002
+            - <<: *sca_check_result_006
+            - <<: *sca_check_result_006
           failed_items: []
           total_failed_items: 0
 
   - name: Parameters -> search=passwd,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1013,18 +918,18 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
-            - <<: *sca_check_result_002
+            - <<: *sca_check_result_006
           failed_items: []
           total_failed_items: 0
 
   - name: Parameters -> q=id=3098
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1033,11 +938,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
-            - <<: *sca_check_result_002
+            - <<: *sca_check_result_006
               id: 3098
           failed_items: []
           total_failed_items: 0
@@ -1045,7 +950,7 @@ stages:
   - name: Parameters -> result=failed,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1055,11 +960,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
-            - <<: *sca_check_result_002
+            - <<: *sca_check_result_006
               result: failed
           failed_items: []
           total_failed_items: 0
@@ -1067,7 +972,7 @@ stages:
   - name: Parameters -> file=/etc/shadow,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1077,11 +982,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
-            - <<: *sca_check_result_002
+            - <<: *sca_check_result_006
               file: /etc/shadow
           failed_items: []
           total_failed_items: 0
@@ -1089,7 +994,7 @@ stages:
   - name: Parameters -> limit=2500
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1101,7 +1006,7 @@ stages:
   - name: Parameters -> title="Ensure shadow group is empty,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1111,11 +1016,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
-            - <<: *sca_check_result_002
+            - <<: *sca_check_result_006
               title: Ensure shadow group is empty
           failed_items: []
           total_failed_items: 0
@@ -1123,7 +1028,7 @@ stages:
   - name: Parameters -> remediation=Remove any legacy + entries from /etc/group if they exist.,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1133,11 +1038,11 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
-            - <<: *sca_check_result_002
+            - <<: *sca_check_result_006
               remediation: Remove any legacy + entries from /etc/group if they exist.
           failed_items: []
           total_failed_items: 0
@@ -1145,7 +1050,7 @@ stages:
   - name: Parameters -> rationale with apostrophe"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1155,7 +1060,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
@@ -1166,7 +1071,7 @@ stages:
   - name: Parameters -> command="systemctl is-enabled autofs"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1176,7 +1081,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
@@ -1187,7 +1092,7 @@ stages:
   - name: Parameters -> status="Not applicable"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1197,7 +1102,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
@@ -1208,7 +1113,7 @@ stages:
   - name: Parameters -> reason="Invalid path or wrong permissions to run command '/sbin/modprobe -n -v freevxfs'"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1218,611 +1123,10 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           total_affected_items: !anyint
           affected_items:
             - reason: Invalid path or wrong permissions to run command '/sbin/modprobe -n -v freevxfs'
-          failed_items: []
-          total_failed_items: 0
-
----
-test_name: GET /sca/003
-
-stages:
-
-  - name: Request
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data: !anything
-
-  - name: Parameters -> limit=2
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          affected_items:
-            - &sca_agent_result_003
-              name: !anystr
-              pass: !anyint
-              score: !anyint
-              references: !anystr #THIS FIELD IS NOT INCLUDED IN ALL ANSWERS
-              fail: !anyint
-              description: !anystr
-              policy_id: !anystr
-              start_scan: !anystr
-              end_scan: !anystr
-              hash_file: !anystr
-              total_checks: !anyint
-              invalid: !anyint
-            - <<: *sca_agent_result_003
-          total_affected_items: 2
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> offset=1,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        offset: 1
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_003
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> sort=-score,limit=2
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2
-        sort: -score
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_003
-            - <<: *sca_agent_result_003
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> sort=+score,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        sort: -score
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_003
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> search=cis,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        search: cis
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_003
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> q=score>50,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        q: score>40
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_003
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> q=policy_id~cis_;total_checks>20;total_checks<50
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        q: policy_id~cis_;total_checks>20;total_checks<50
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: 1
-          affected_items:
-            - <<: *sca_agent_result_003
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> limit=2500
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2500
-    response:
-      status_code: 400
-
-  - name: Parameters -> name=CIS benchmark for Debian/Linux 9 L2,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        name: CIS benchmark for Debian/Linux 9 L2
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_003
-              name: CIS benchmark for Debian/Linux 9 L2
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> references=https://www.cisecurity.org/cis-benchmarks/,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        references: https://www.cisecurity.org/cis-benchmarks/
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_003
-              references: https://www.cisecurity.org/cis-benchmarks/
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> description=This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        description: This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_agent_result_003
-              description: !anystr
-          failed_items: []
-          total_failed_items: 0
-
----
-test_name: GET /sca/003/checks/cis_debian9_L1
-
-stages:
-
-  - name: Request
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data: !anything
-
-  - name: Parameters -> limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - &sca_check_result_003
-              remediation: !anystr
-              rationale: !anystr
-              title: !anystr
-              policy_id: !anystr
-              description: !anystr
-              id: !anyint
-              result: !anystr
-              compliance: !anything
-              rules: !anything
-              condition: !anything
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> limit=4
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 4
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_003
-            - <<: *sca_check_result_003
-            - <<: *sca_check_result_003
-            - <<: *sca_check_result_003
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> sort=-id,limit=2
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2
-        sort: -id
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_003
-            - <<: *sca_check_result_003
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> search=passwd,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        search: passwd
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_003
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> q=id=3098
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        q: id=3098
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_003
-              id: 3098
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> q=result=passed;file~/etc/pass;compliance.value=5.4.3;id<5000
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        q: result=passed;file~/etc/pass;compliance.value=5.4.3;id<5000
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_003
-              id: 3091
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> result=failed,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        result: failed
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_003
-              result: failed
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> file=/etc/shadow,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        file: /etc/shadow
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_003
-              file: /etc/shadow
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> limit=2500
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2500
-    response:
-      status_code: 400
-
-  - name: Parameters -> title="Ensure shadow group is empty,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        title: Ensure shadow group is empty
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_003
-              title: Ensure shadow group is empty
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> remediation=Remove any legacy + entries from /etc/group if they exist.,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        remediation: Remove any legacy + entries from /etc/group if they exist.
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - <<: *sca_check_result_003
-              remediation: Remove any legacy + entries from /etc/group if they exist.
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> rationale with apostrophe and parenthesis"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        rationale: >-
-          Having no timeout value associated with a connection could allow an unauthorized user access to
-          another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a
-          timeout value at least reduces the risk of this happening. While the recommended setting is 300 seconds (5
-          minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0.
-          In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages
-          will be sent.
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - id: 3081
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> command="dpkg -s libpam-pwquality"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        command: dpkg -s libpam-pwquality
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - command: dpkg -s libpam-pwquality
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> status="Not applicable"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        status: Not applicable
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - status: Not applicable
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> reason="Invalid path or wrong permissions to run command 'ip6tables -L'"
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003/checks/cis_debian9_L1"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        reason: Invalid path or wrong permissions to run command 'ip6tables -L'
-    response:
-      status_code: 200
-      json:
-        error: !anyint
-        data:
-          total_affected_items: !anyint
-          affected_items:
-            - reason: Invalid path or wrong permissions to run command 'ip6tables -L'
           failed_items: []
           total_failed_items: 0

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -1,10 +1,11 @@
-test_name: GET /sca/{agent_id}
+test_name: GET /sca/{agent_id} for agents with Wazuh version >=4.2.0 (001) and <4.2.0 (006)
 
 marks:
   - base_tests
 
 stages:
 
+  # Testing GET /sca/001
   - name: Request
     request:
       verify: False
@@ -50,39 +51,6 @@ stages:
           failed_items: []
           total_failed_items: 0
 
-  - name: Parameters -> limit=2 (Using an agent with 2 sca policies)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - &sca_agent_result_006
-              name: !anystr
-              pass: !anyint
-              score: !anyint
-              references: !anystr #THIS FIELD IS NOT INCLUDED IN ALL ANSWERS
-              fail: !anyint
-              description: !anystr
-              policy_id: !anystr
-              start_scan: !anystr
-              end_scan: !anystr
-              hash_file: !anystr
-              total_checks: !anyint
-              invalid: !anyint
-            - <<: *sca_agent_result_006
-          total_affected_items: 2
-          failed_items: [ ]
-          total_failed_items: 0
-
   - name: Parameters -> offset=1,limit=1
     request:
       verify: False
@@ -102,59 +70,6 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-
-  - name: Parameters -> sort=-score,limit=2
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2
-        sort: -score
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *sca_agent_result_006
-            - <<: *sca_agent_result_006
-          failed_items: []
-          total_affected_items: 2
-          total_failed_items: 0
-      verify_response_with:
-        - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "score"
-
-  - name: Parameters -> sort=+score,limit=2
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2
-        sort: +score
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *sca_agent_result_006
-            - <<: *sca_agent_result_006
-          failed_items: []
-          total_affected_items: 2
-          total_failed_items: 0
-      verify_response_with:
-        - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "score"
-            reverse: False
 
   - name: Parameters -> search=cis,limit=1
     request:
@@ -210,28 +125,6 @@ stages:
     response:
       status_code: 400
 
-  - name: Parameters -> name=CIS benchmark for Debian/Linux 9 L2, limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        name: CIS benchmark for Debian/Linux 9 L2
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *sca_agent_result_006
-              name: CIS benchmark for Debian/Linux 9 L2
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
-
   - name: Parameters -> references=https://www.cisecurity.org/cis-benchmarks/, limit=1
     request:
       verify: False
@@ -276,8 +169,287 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
+  - name: Parameters -> name=CIS Benchmark for Debian/Linux 9, limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        name: CIS Benchmark for Debian/Linux 9
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *sca_agent_result_001
+              name: CIS Benchmark for Debian/Linux 9
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Parameters -> sort=-score,limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        sort: -score
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *sca_agent_result_001
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "score"
+
+  - name: Parameters -> sort=+score,limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        sort: +score
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *sca_agent_result_001
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "score"
+            reverse: False
+
+  # Testing GET /sca/006
+  - name: Parameters -> limit=2
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 2
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - &sca_agent_result_006
+              name: !anystr
+              pass: !anyint
+              score: !anyint
+              references: !anystr #THIS FIELD IS NOT INCLUDED IN ALL ANSWERS
+              fail: !anyint
+              description: !anystr
+              policy_id: !anystr
+              start_scan: !anystr
+              end_scan: !anystr
+              hash_file: !anystr
+              total_checks: !anyint
+              invalid: !anyint
+            - <<: *sca_agent_result_006
+          total_affected_items: 2
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> offset=1,limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        offset: 1
+        limit: 1
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *sca_agent_result_006
+          failed_items: []
+          total_affected_items: 2
+          total_failed_items: 0
+
+  - name: Parameters -> search=cis,limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        search: cis
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *sca_agent_result_006
+          failed_items: []
+          total_affected_items: 2
+          total_failed_items: 0
+
+  - name: Parameters -> q=score>40,limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        q: score>40
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *sca_agent_result_006
+          failed_items: []
+          total_affected_items: 1
+          total_failed_items: 0
+
+  - name: Parameters -> limit=2500
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 2500
+    response:
+      status_code: 400
+
+  - name: Parameters -> references=https://www.cisecurity.org/cis-benchmarks/, limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        references: https://www.cisecurity.org/cis-benchmarks/
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *sca_agent_result_006
+              references: https://www.cisecurity.org/cis-benchmarks/
+          failed_items: []
+          total_affected_items: 2
+          total_failed_items: 0
+
+  - name: Parameters -> description=This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.,limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        description: This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.
+        limit: 1
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *sca_agent_result_006
+              description: !anystr
+          failed_items: []
+          total_affected_items: 2
+          total_failed_items: 0
+
+  - name: Parameters -> sort=-score,limit=2
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 2
+        sort: -score
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *sca_agent_result_006
+            - <<: *sca_agent_result_006
+          failed_items: [ ]
+          total_affected_items: 2
+          total_failed_items: 0
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "score"
+
+  - name: Parameters -> sort=+score,limit=2
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 2
+        sort: +score
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *sca_agent_result_006
+            - <<: *sca_agent_result_006
+          failed_items: [ ]
+          total_affected_items: 2
+          total_failed_items: 0
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "score"
+            reverse: False
+
 ---
-test_name: GET /sca/001/checks/cis_debian9
+test_name: GET /sca/001/checks/cis_debian9 (001 is an agent with version >=4.2.0)
 
 stages:
 
@@ -462,7 +634,7 @@ stages:
   - name: Parameters -> limit=2500
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -711,109 +883,30 @@ stages:
           failed_items: []
           total_failed_items: 0
 
----
-test_name: GET /sca/002
-
-stages:
-
-  - name: Request
+  - name: Parameters -> command="systemctl is-enabled autofs"
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - &sca_agent_result_002
-              name: !anystr
-              pass: !anyint
-              score: !anyint
-              references: !anystr #THIS FIELD IS NOT INCLUDED IN ALL ANSWERS
-              fail: !anyint
-              description: !anystr
-              policy_id: !anystr
-              start_scan: !anystr
-              end_scan: !anystr
-              hash_file: !anystr
-              total_checks: !anyint
-              invalid: !anyint
-          total_affected_items: 1
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> name=CIS Benchmark for Debian/Linux 9,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         limit: 1
-        name: CIS Benchmark for Debian/Linux 9
+        command: systemctl is-enabled autofs
     response:
       status_code: 200
       json:
         error: 0
         data:
-          total_affected_items: 1
+          total_affected_items: !anyint
           affected_items:
-            - <<: *sca_agent_result_002
-              name: CIS Benchmark for Debian/Linux 9
-          failed_items: []
+            - command: systemctl is-enabled autofs
+          failed_items: [ ]
           total_failed_items: 0
 
-  - name: Parameters -> references=https://www.cisecurity.org/cis-benchmarks/,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 1
-        references: https://www.cisecurity.org/cis-benchmarks/
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: 1
-          affected_items:
-            - <<: *sca_agent_result_002
-              references: https://www.cisecurity.org/cis-benchmarks/
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Parameters -> description=This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.,limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        description: This document provides prescriptive guidance for establishing a secure configuration posture for Debian Linux 9.
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: 1
-          affected_items:
-            - <<: *sca_agent_result_002
-              description: !anystr
-          failed_items: []
-          total_failed_items: 0
 
 ---
-test_name: GET /sca/006/checks/cis_debian9_L1
+test_name: GET /sca/006/checks/cis_debian9_L1 (006 is an agent with version <4.2.0)
 
 stages:
 
@@ -1128,5 +1221,96 @@ stages:
           total_affected_items: !anyint
           affected_items:
             - reason: Invalid path or wrong permissions to run command '/sbin/modprobe -n -v freevxfs'
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> rationale with word "count"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        rationale: >-
+          Any users assigned to the shadow group would be granted read access to the /etc/shadow file.
+          If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking
+          program against the hashed passwords to break them. Other security information that is stored in
+          the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts.
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - rationale: >-
+                Any users assigned to the shadow group would be granted read access to the /etc/shadow file.
+                If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking
+                program against the hashed passwords to break them. Other security information that is stored in
+                the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts.
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> rationale with word "offset"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        rationale: offset
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          total_affected_items: 0
+          affected_items: []
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> command="dpkg -s libpam-pwquality"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        command: dpkg -s libpam-pwquality
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - command: dpkg -s libpam-pwquality
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Parameters -> reason="Invalid path or wrong permissions to run command 'ip6tables -L'"
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 1
+        reason: Invalid path or wrong permissions to run command 'ip6tables -L'
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          total_affected_items: !anyint
+          affected_items:
+            - reason: Invalid path or wrong permissions to run command 'ip6tables -L'
           failed_items: []
           total_failed_items: 0

--- a/api/test/integration/test_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscheck_endpoints.tavern.yaml
@@ -495,7 +495,7 @@ stages:
           total_failed_items: 0
 
 ---
-test_name: PUT /syscheck/000
+test_name: PUT /syscheck
 
 stages:
 
@@ -1003,7 +1003,7 @@ test_name: DELETE /syscheck
 
 stages:
 
-  - name: Try to delete syscheck scans in agent 000
+  - name: Try to delete syscheck scans in agent 001
     request:
       verify: False
       method: DELETE

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -122,8 +122,8 @@ wdb_path = os.path.join(ossec_path, 'queue', 'db')
 api_config_path = os.path.join(ossec_path, 'api', 'configuration', 'api.yaml')
 database_path_agents = os.path.join(database_path, 'agents')
 os_pidfile = os.path.join('var', 'run')
-analysisd_stats = os.path.join(ossec_path, 'var', 'run', 'ossec-analysisd.state')
-remoted_stats = os.path.join(ossec_path, 'var', 'run', 'ossec-remoted.state')
+analysisd_stats = os.path.join(ossec_path, 'var', 'run', 'wazuh-analysisd.state')
+remoted_stats = os.path.join(ossec_path, 'var', 'run', 'wazuh-remoted.state')
 ar_conf_path = os.path.join(ossec_path, 'etc', 'shared', 'ar.conf')
 
 # Ruleset

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -930,7 +930,7 @@ def filter_array_by_query(q: str, input_array: typing.List) -> typing.List:
                 match_candidates = list()
                 if field_subnames and field_name in elem and \
                         get_match_candidates(deepcopy(elem[field_name]), field_subnames.split('.'), match_candidates):
-                    if any([check_clause(candidate, op, value) for candidate in match_candidates]):
+                    if any([check_clause(candidate, op, value) for candidate in match_candidates if candidate]):
                         continue
                 else:
                     if field_name in elem and check_clause(elem[field_name], op, value):


### PR DESCRIPTION
|Related issue|
|---|
| #7502 |

Hi team,

This PR closes #7502.

I have updated a lot of API integration tests and healthchecks to avoid random fails in the nightly results in MASTER.

**DECODERS TESTS:**

`q: 'details.prematch.pattern~wazuh'` is failing

After debugging, I have realized the API call returns Wazuh internal error when iterating on an affected item with `prematch.pattern = None`. I have included a condition in the `utils.py` function  `filter_array_by_query` to avoid errors like this one.

**SYSCHECK TESTS:**

The specific healthchecks (in this case syscheck) also need the base healthcheck as the race condition can still appear (and it appears in this specific failed test). I have updated our testing environment to use it.

https://ci.wazuh.info/blue/organizations/jenkins/test_integration_api_endpoints/detail/test_integration_api_endpoints/304/pipeline/5750


With this PR, we will be adding the base healthcheck to the `tmp` folder when we have a specific healthcheck. The base healthcheck will be named `base_healthcheck.py` and we will need to import the `get_manager_health_base` or `get_agent_health_base` functions in the specific module healthcheck in order to use it.

If there is no specific healthcheck, the base healthcheck will be `healthcheck.py`. When the specific module test we are running doesn't need an agents healthcheck, the `base_healthcheck.py` function will be copied into the `tmp` folder but we won't use it.


**ACTIVE RESPONSE TESTS:**

I have changed the `restart-wazuh0` command. We don't need to test always with a restart command as we are only testing the endpoint responses. In this case using `restart-wazuh0` was causing race conditions and failed tests sometimes. I have used `custom` as command.

**SCA TESTS:**

Agents with Wazuh version 4.2.0 have only 1 cis benchamark (they don't have L1 and L2). I have changed all our tests. I have also deleted redundant ones.


**SECURITY_PUT TESTS:**

Fixed with fix to api entrypoint (merged in 4.1)

All security tests passed in jenkins:
https://ci.wazuh.info/job/test_integration_api_endpoints/315/



**ROOTCHECK TESTS:** (failing in 4.1)

https://ci.wazuh.info/blue/organizations/jenkins/test_integration_api_endpoints/detail/test_integration_api_endpoints/310/pipeline

I have added `sort=cis` to avoid this error. By default the endpoint response is sorted by the last scan time, so the position of the cis result in the response could vary.


## TESTS RESULTS:

```
test_active_response_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rbac_black_active_response_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rbac_white_active_response_endpoints.tavern.yaml 
	 2 passed, 4 warnings

```
```
test_rbac_black_syscheck_endpoints.tavern.yaml 
	 4 passed, 6 warnings

test_rbac_white_syscheck_endpoints.tavern.yaml 
	 4 passed, 6 warnings

test_syscheck_endpoints.tavern.yaml 
	 35 passed, 39 warnings
```

```
test_decoder_endpoints.tavern.yaml 
	 23 passed, 29 warnings

test_rbac_black_decoder_endpoints.tavern.yaml 
	 4 passed, 6 warnings

test_rbac_white_decoder_endpoints.tavern.yaml 
	 4 passed, 6 warnings
```

```
test_rbac_black_sca_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_rbac_white_sca_endpoints.tavern.yaml 
	 2 passed, 4 warnings

test_sca_endpoints.tavern.yaml 
	 4 passed, 6 warnings
```

```
test_rbac_black_rootcheck_endpoints.tavern.yaml 
	 4 passed, 6 warnings

test_rbac_white_rootcheck_endpoints.tavern.yaml 
	 4 passed, 6 warnings

test_rootcheck_endpoints.tavern.yaml 
	 4 passed, 6 warnings
```


```
test_manager_endpoints.tavern.yaml 
	 33 passed, 36 warnings

test_rbac_black_manager_endpoints.tavern.yaml 
	 17 passed, 19 warnings

test_rbac_white_manager_endpoints.tavern.yaml 
	 17 passed, 19 warnings
```

Regards,
Manuel.

