### PR TITLE
[7546] Network gateway issue fix

### DIFF
--- a/src/data_provider/include/sysInfo.h
+++ b/src/data_provider/include/sysInfo.h
@@ -1,6 +1,6 @@
 /*
  * Wazuh SysInfo
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * November 11, 2020.
  *
  * This program is free software; you can redistribute it

--- a/src/data_provider/include/sysInfo.h
+++ b/src/data_provider/include/sysInfo.h
@@ -31,15 +31,68 @@
 extern "C" {
 #endif
 
-EXPORTED void sysinfo_hardware(cJSON** js_result);
-EXPORTED void sysinfo_packages(cJSON** js_result);
-EXPORTED void sysinfo_os(cJSON** js_result);
-EXPORTED void sysinfo_processes(cJSON** js_result);
-EXPORTED void sysinfo_networks(cJSON** js_result);
-EXPORTED void sysinfo_ports(cJSON** js_result);
+/**
+ * @brief Obtains the hardware information from the current OS being analyzed.
+ *
+ * @param js_result Resulting json where the specific information will be stored.
+ *
+ * @return 0 on success, -1 otherwise.
+ */
+EXPORTED int sysinfo_hardware(cJSON** js_result);
+
+/**
+ * @brief Obtains the installed packages information from the current OS being analyzed.
+ *
+ * @param js_result Resulting json where the specific information will be stored.
+ *
+ * @return 0 on success, -1 otherwise.
+ */
+EXPORTED int sysinfo_packages(cJSON** js_result);
+
+/**
+ * @brief Obtains the Operating System information from the current OS being analyzed.
+ *
+ * @param js_result Resulting json where the specific information will be stored.
+ *
+ * @return 0 on success, -1 otherwise.
+ */
+EXPORTED int sysinfo_os(cJSON** js_result);
+
+/**
+ * @brief Obtains the processes information from the current OS being analyzed.
+ *
+ * @param js_result Resulting json where the specific information will be stored.
+ *
+ * @return 0 on success, -1 otherwise.
+ */
+EXPORTED int sysinfo_processes(cJSON** js_result);
+
+/**
+ * @brief Obtains the network information from the current OS being analyzed.
+ *
+ * @param js_result Resulting json where the specific information will be stored.
+ *
+ * @return 0 on success, -1 otherwise.
+ */
+EXPORTED int sysinfo_networks(cJSON** js_result);
+
+/**
+ * @brief Obtains the ports information from the current OS being analyzed.
+ *
+ * @param js_result Resulting json where the specific information will be stored.
+ *
+ * @return 0 on success, -1 otherwise.
+ */
+EXPORTED int sysinfo_ports(cJSON** js_result);
+
+/**
+ * @brief Frees the \p js_data information.
+ *
+ * @param js_data Information to be freed.
+ */
 EXPORTED void sysinfo_free_result(cJSON** js_data);
 
-typedef void(*sysinfo_networks_func)(cJSON** jsresult);
+typedef int(*sysinfo_networks_func)(cJSON** jsresult);
 typedef void(*sysinfo_free_result_func)(cJSON** jsresult);
 
 #ifdef __cplusplus

--- a/src/data_provider/src/network/networkLinuxWrapper.h
+++ b/src/data_provider/src/network/networkLinuxWrapper.h
@@ -250,7 +250,7 @@ public:
                     if (GatewayFileFields::Size == fields.size() &&
                         fields.at(GatewayFileFields::Iface).compare(ifName) == 0)
                     {
-                        const auto address { static_cast<uint32_t>(std::stoi(fields.at(GatewayFileFields::Gateway), 0, 16)) };
+                        const auto address { static_cast<uint32_t>(std::stol(fields.at(GatewayFileFields::Gateway), 0, 16)) };
                         m_metrics = fields.at(GatewayFileFields::Metric);
 
                         if (address)

--- a/src/data_provider/src/packages/packagesLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packagesLinuxParserHelper.h
@@ -110,7 +110,7 @@ namespace PackageLinuxHelper
             it = info.find("Installed-Size");
             if (it != info.end())
             {
-                size = stoi(it->second);
+                size = stol(it->second);
             }
             it = info.find("Multi-Arch");
             if (it != info.end())

--- a/src/data_provider/src/packages/packagesLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packagesLinuxParserHelper.h
@@ -56,7 +56,7 @@ namespace PackageLinuxHelper
                 }
 
                 ret["name"]         = name;
-                ret["size"]         = size.empty() || size.compare(DEFAULT_VALUE) == 0 ? 0 : stoi(size);
+                ret["size"]         = size.empty() || size.compare(DEFAULT_VALUE) == 0 ? 0 : stol(size);
                 ret["install_time"] = install_time.empty() || install_time.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : install_time;
                 ret["groups"]       = groups.empty() || groups.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : groups;
                 ret["version"]      = version.empty() || version.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : version;

--- a/src/data_provider/src/sysInfo.cpp
+++ b/src/data_provider/src/sysInfo.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh SysInfo
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * October 7, 2020.
  *
  * This program is free software; you can redistribute it

--- a/src/data_provider/src/sysInfo.cpp
+++ b/src/data_provider/src/sysInfo.cpp
@@ -50,41 +50,101 @@ nlohmann::json SysInfo::ports()
 #ifdef __cplusplus
 extern "C" {
 #endif
-void sysinfo_hardware(cJSON** js_result)
+int sysinfo_hardware(cJSON** js_result)
 {
-    SysInfo info;
-    const auto& hw          {info.hardware()};
-    *js_result = cJSON_Parse(hw.dump().c_str());
+    auto retVal { -1 };
+    try
+    {
+        SysInfo info;
+        const auto& hw          {info.hardware()};
+        *js_result = cJSON_Parse(hw.dump().c_str());
+        retVal = 0;
+    }
+    // LCOV_EXCL_START
+    catch(...)
+    {}
+    // LCOV_EXCL_STOP
+    return retVal;
 }
-void sysinfo_packages(cJSON** js_result)
+int sysinfo_packages(cJSON** js_result)
 {
-    SysInfo info;
-    const auto& packages    {info.packages()};
-    *js_result = cJSON_Parse(packages.dump().c_str());
+    auto retVal { -1 };
+    try
+    {
+        SysInfo info;
+        const auto& packages    {info.packages()};
+        *js_result = cJSON_Parse(packages.dump().c_str());
+        retVal = 0;
+    }
+    // LCOV_EXCL_START
+    catch(...)
+    {}
+    // LCOV_EXCL_STOP
+    return retVal;
 }
-void sysinfo_os(cJSON** js_result)
+int sysinfo_os(cJSON** js_result)
 {
-    SysInfo info;
-    const auto& os          {info.os()};
-    *js_result = cJSON_Parse(os.dump().c_str());
+    auto retVal { -1 };
+    try
+    {
+        SysInfo info;
+        const auto& os          {info.os()};
+        *js_result = cJSON_Parse(os.dump().c_str());
+        retVal = 0;
+    }
+    // LCOV_EXCL_START
+    catch(...)
+    {}
+    // LCOV_EXCL_STOP
+    return retVal;
 }
-void sysinfo_processes(cJSON** js_result)
+int sysinfo_processes(cJSON** js_result)
 {
-    SysInfo info;
-    const auto& processes   {info.processes()};
-    *js_result = cJSON_Parse(processes.dump().c_str());
+    auto retVal { -1 };
+    try
+    {
+        SysInfo info;
+        const auto& processes   {info.processes()};
+        *js_result = cJSON_Parse(processes.dump().c_str());
+        retVal = 0;
+    }
+    // LCOV_EXCL_START
+    catch(...)
+    {}
+    // LCOV_EXCL_STOP
+    return retVal;
 }
-void sysinfo_networks(cJSON** js_result)
+int sysinfo_networks(cJSON** js_result)
 {
-    SysInfo info;
-    const auto& networks    {info.networks()};
-    *js_result = cJSON_Parse(networks.dump().c_str());
+    auto retVal { -1 };
+    try
+    {
+        SysInfo info;
+        const auto& networks    {info.networks()};
+        *js_result = cJSON_Parse(networks.dump().c_str());
+        retVal = 0;
+    }
+    // LCOV_EXCL_START
+    catch(...)
+    {}
+    // LCOV_EXCL_STOP
+    return retVal;
 }
-void sysinfo_ports(cJSON** js_result)
+int sysinfo_ports(cJSON** js_result)
 {
-    SysInfo info;
-    const auto& ports       {info.ports()};
-    *js_result = cJSON_Parse(ports.dump().c_str());
+    auto retVal { -1 };
+    try
+    {
+        SysInfo info;
+        const auto& ports       {info.ports()};
+        *js_result = cJSON_Parse(ports.dump().c_str());
+        retVal = 0;
+    }
+    // LCOV_EXCL_START
+    catch(...)
+    {}
+    // LCOV_EXCL_STOP
+    return retVal;
 }
 void sysinfo_free_result(cJSON** js_data)
 {

--- a/src/data_provider/src/sysInfo.cpp
+++ b/src/data_provider/src/sysInfo.cpp
@@ -55,10 +55,13 @@ int sysinfo_hardware(cJSON** js_result)
     auto retVal { -1 };
     try
     {
-        SysInfo info;
-        const auto& hw          {info.hardware()};
-        *js_result = cJSON_Parse(hw.dump().c_str());
-        retVal = 0;
+        if (js_result)
+        {
+            SysInfo info;
+            const auto& hw          {info.hardware()};
+            *js_result = cJSON_Parse(hw.dump().c_str());
+            retVal = 0;
+        }
     }
     // LCOV_EXCL_START
     catch(...)
@@ -71,10 +74,13 @@ int sysinfo_packages(cJSON** js_result)
     auto retVal { -1 };
     try
     {
-        SysInfo info;
-        const auto& packages    {info.packages()};
-        *js_result = cJSON_Parse(packages.dump().c_str());
-        retVal = 0;
+        if (js_result)
+        {
+            SysInfo info;
+            const auto& packages    {info.packages()};
+            *js_result = cJSON_Parse(packages.dump().c_str());
+            retVal = 0;
+        }
     }
     // LCOV_EXCL_START
     catch(...)
@@ -87,10 +93,13 @@ int sysinfo_os(cJSON** js_result)
     auto retVal { -1 };
     try
     {
-        SysInfo info;
-        const auto& os          {info.os()};
-        *js_result = cJSON_Parse(os.dump().c_str());
-        retVal = 0;
+        if (js_result)
+        {
+            SysInfo info;
+            const auto& os          {info.os()};
+            *js_result = cJSON_Parse(os.dump().c_str());
+            retVal = 0;
+        }
     }
     // LCOV_EXCL_START
     catch(...)
@@ -103,10 +112,13 @@ int sysinfo_processes(cJSON** js_result)
     auto retVal { -1 };
     try
     {
-        SysInfo info;
-        const auto& processes   {info.processes()};
-        *js_result = cJSON_Parse(processes.dump().c_str());
-        retVal = 0;
+        if (js_result)
+        {
+            SysInfo info;
+            const auto& processes   {info.processes()};
+            *js_result = cJSON_Parse(processes.dump().c_str());
+            retVal = 0;
+        }
     }
     // LCOV_EXCL_START
     catch(...)
@@ -119,10 +131,13 @@ int sysinfo_networks(cJSON** js_result)
     auto retVal { -1 };
     try
     {
-        SysInfo info;
-        const auto& networks    {info.networks()};
-        *js_result = cJSON_Parse(networks.dump().c_str());
-        retVal = 0;
+        if (js_result)
+        {
+            SysInfo info;
+            const auto& networks    {info.networks()};
+            *js_result = cJSON_Parse(networks.dump().c_str());
+            retVal = 0;
+        }
     }
     // LCOV_EXCL_START
     catch(...)
@@ -135,10 +150,13 @@ int sysinfo_ports(cJSON** js_result)
     auto retVal { -1 };
     try
     {
-        SysInfo info;
-        const auto& ports       {info.ports()};
-        *js_result = cJSON_Parse(ports.dump().c_str());
-        retVal = 0;
+        if (js_result)
+        {
+            SysInfo info;
+            const auto& ports       {info.ports()};
+            *js_result = cJSON_Parse(ports.dump().c_str());
+            retVal = 0;
+        }
     }
     // LCOV_EXCL_START
     catch(...)

--- a/src/data_provider/tests/sysInfo/sysInfo_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfo_test.cpp
@@ -148,3 +148,12 @@ TEST_F(SysInfoTest, os_c_interface)
     EXPECT_TRUE(object);
     EXPECT_NO_THROW(sysinfo_free_result(&object));
 }
+
+TEST_F(SysInfoTest, c_interfaces_bad_params)
+{
+    EXPECT_EQ(-1, sysinfo_hardware(NULL));
+    EXPECT_EQ(-1, sysinfo_packages(NULL));
+    EXPECT_EQ(-1, sysinfo_processes(NULL));
+    EXPECT_EQ(-1, sysinfo_ports(NULL));
+    EXPECT_EQ(-1, sysinfo_os(NULL));
+}

--- a/src/data_provider/tests/sysInfo/sysInfo_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfo_test.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh SysInfo
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * October 19, 2020.
  *
  * This program is free software; you can redistribute it
@@ -104,7 +104,7 @@ TEST_F(SysInfoTest, os)
 TEST_F(SysInfoTest, hardware_c_interface)
 {
     cJSON *object = NULL;
-    sysinfo_hardware(&object);
+    EXPECT_EQ(0, sysinfo_hardware(&object));
     EXPECT_TRUE(object);
     EXPECT_NO_THROW(sysinfo_free_result(&object));
 }
@@ -112,7 +112,7 @@ TEST_F(SysInfoTest, hardware_c_interface)
 TEST_F(SysInfoTest, packages_c_interface)
 {
     cJSON *object = NULL;
-    sysinfo_packages(&object);
+    EXPECT_EQ(0, sysinfo_packages(&object));
     EXPECT_TRUE(object);
     EXPECT_NO_THROW(sysinfo_free_result(&object));
 }
@@ -120,7 +120,7 @@ TEST_F(SysInfoTest, packages_c_interface)
 TEST_F(SysInfoTest, processes_c_interface)
 {
     cJSON *object = NULL;
-    sysinfo_processes(&object);
+    EXPECT_EQ(0, sysinfo_processes(&object));
     EXPECT_TRUE(object);
     EXPECT_NO_THROW(sysinfo_free_result(&object));
 }
@@ -128,7 +128,7 @@ TEST_F(SysInfoTest, processes_c_interface)
 TEST_F(SysInfoTest, network_c_interface)
 {
     cJSON *object = NULL;
-    sysinfo_networks(&object);
+    EXPECT_EQ(0, sysinfo_networks(&object));
     EXPECT_TRUE(object);
     EXPECT_NO_THROW(sysinfo_free_result(&object));
 }
@@ -136,7 +136,7 @@ TEST_F(SysInfoTest, network_c_interface)
 TEST_F(SysInfoTest, ports_c_interface)
 {
     cJSON *object = NULL;
-    sysinfo_ports(&object);
+    EXPECT_EQ(0, sysinfo_ports(&object));
     EXPECT_TRUE(object);
     EXPECT_NO_THROW(sysinfo_free_result(&object));
 }
@@ -144,7 +144,7 @@ TEST_F(SysInfoTest, ports_c_interface)
 TEST_F(SysInfoTest, os_c_interface)
 {
     cJSON *object = NULL;
-    sysinfo_os(&object);
+    EXPECT_EQ(0, sysinfo_os(&object));
     EXPECT_TRUE(object);
     EXPECT_NO_THROW(sysinfo_free_result(&object));
 }

--- a/src/data_provider/tests/sysInfo/sysInfo_test.h
+++ b/src/data_provider/tests/sysInfo/sysInfo_test.h
@@ -1,6 +1,6 @@
 /*
  * Wazuh SysInfo
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * October 19, 2020.
  *
  * This program is free software; you can redistribute it
@@ -10,10 +10,12 @@
  */
 #ifndef _SYSINFO_TEST_H
 #define _SYSINFO_TEST_H
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
-class SysInfoTest : public ::testing::Test {
+class SysInfoTest : public ::testing::Test
+{
 
 protected:
 

--- a/src/data_provider/tests/sysInfoNetworkLinux/sysInfoNetworkLinux_test.cpp
+++ b/src/data_provider/tests/sysInfoNetworkLinux/sysInfoNetworkLinux_test.cpp
@@ -1,6 +1,6 @@
 /*
  * Wazuh SysInfo
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * October 19, 2020.
  *
  * This program is free software; you can redistribute it
@@ -72,7 +72,6 @@ TEST_F(SysInfoNetworkLinuxTest, Test_AF_INET)
     EXPECT_EQ("192.168.0.255",ifaddr.at("IPv4").at("broadcast").get_ref<const std::string&>());
     EXPECT_EQ("8.8.8.8",ifaddr.at("IPv4").at("dhcp").get_ref<const std::string&>());
     EXPECT_EQ("100",ifaddr.at("IPv4").at("metric").get_ref<const std::string&>());
-    
 }
 
 TEST_F(SysInfoNetworkLinuxTest, Test_AF_INET6_THROW)
@@ -124,7 +123,7 @@ TEST_F(SysInfoNetworkLinuxTest, Test_AF_PACKET)
     EXPECT_EQ("ethernet",ifaddr.at("type").get_ref<const std::string&>());
     EXPECT_EQ("up",ifaddr.at("state").get_ref<const std::string&>());
     EXPECT_EQ("00:A0:C9:14:C8:29",ifaddr.at("mac").get_ref<const std::string&>());
-    
+
     EXPECT_EQ(1,ifaddr.at("tx_packets").get<int32_t>());
     EXPECT_EQ(0,ifaddr.at("rx_packets").get<int32_t>());
     EXPECT_EQ(3,ifaddr.at("tx_bytes").get<int32_t>());
@@ -150,4 +149,39 @@ TEST_F(SysInfoNetworkLinuxTest, Test_AF_UNSPEC_THROW_NULLPTR)
 {
     nlohmann::json ifaddr {};
     EXPECT_ANY_THROW(FactoryNetworkFamilyCreator<OSType::LINUX>::create(nullptr)->buildNetworkData(ifaddr));
+}
+
+TEST_F(SysInfoNetworkLinuxTest, Test_Gateway_7546)
+{
+    auto mock { std::make_shared<SysInfoNetworkLinuxWrapperMock>() };
+    nlohmann::json ifaddr {};
+    EXPECT_CALL(*mock, family()).Times(1).WillOnce(Return(AF_PACKET));
+    EXPECT_CALL(*mock, name()).Times(1).WillOnce(Return("eth01"));
+    EXPECT_CALL(*mock, adapter()).Times(1).WillOnce(Return("adapter"));
+    EXPECT_CALL(*mock, type()).Times(1).WillOnce(Return("ethernet"));
+    EXPECT_CALL(*mock, state()).Times(1).WillOnce(Return("up"));
+    EXPECT_CALL(*mock, MAC()).Times(1).WillOnce(Return("00:A0:C9:14:C8:29"));
+    EXPECT_CALL(*mock, stats()).Times(1).WillOnce(Return(LinkStats{0,1,2,3,4,5,6,7}));
+    EXPECT_CALL(*mock, mtu()).Times(1).WillOnce(Return("1500"));
+    EXPECT_CALL(*mock, gateway()).Times(1).WillOnce(Return("A12BA8C0")); // Gateway value in hexa: A12BA8C0
+
+    EXPECT_NO_THROW(FactoryNetworkFamilyCreator<OSType::LINUX>::create(mock)->buildNetworkData(ifaddr));
+
+    EXPECT_EQ("eth01",ifaddr.at("name").get_ref<const std::string&>());
+    EXPECT_EQ("adapter",ifaddr.at("adapter").get_ref<const std::string&>());
+    EXPECT_EQ("ethernet",ifaddr.at("type").get_ref<const std::string&>());
+    EXPECT_EQ("up",ifaddr.at("state").get_ref<const std::string&>());
+    EXPECT_EQ("00:A0:C9:14:C8:29",ifaddr.at("mac").get_ref<const std::string&>());
+
+    EXPECT_EQ(1,ifaddr.at("tx_packets").get<int32_t>());
+    EXPECT_EQ(0,ifaddr.at("rx_packets").get<int32_t>());
+    EXPECT_EQ(3,ifaddr.at("tx_bytes").get<int32_t>());
+    EXPECT_EQ(2,ifaddr.at("rx_bytes").get<int32_t>());
+    EXPECT_EQ(5,ifaddr.at("tx_errors").get<int32_t>());
+    EXPECT_EQ(4,ifaddr.at("rx_errors").get<int32_t>());
+    EXPECT_EQ(7,ifaddr.at("tx_dropped").get<int32_t>());
+    EXPECT_EQ(6,ifaddr.at("rx_dropped").get<int32_t>());
+
+    EXPECT_EQ("1500",ifaddr.at("mtu").get_ref<const std::string&>());
+    EXPECT_EQ("A12BA8C0",ifaddr.at("gateway").get_ref<const std::string&>());
 }

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -80,32 +80,36 @@ char* getPrimaryIP(){
 #if defined __linux__ || defined __MACH__
     cJSON *object;
     if (sysinfo_network_ptr && sysinfo_free_result_ptr) {
-        sysinfo_network_ptr(&object);
-        if (object) {
-            const cJSON *iface = cJSON_GetObjectItem(object, "iface");
-            if (iface) {
-                const int size_ids = cJSON_GetArraySize(iface);
-                for (int i = 0; i < size_ids; i++){
-                    const cJSON *element = cJSON_GetArrayItem(iface, i);
-                    if(!element) {
-                        continue;
-                    }
-                    cJSON *gateway = cJSON_GetObjectItem(element, "gateway");
-                    if(gateway && cJSON_GetStringValue(gateway) && 0 != strcmp(gateway->valuestring,"unkwown")) {
-                        const cJSON *ipv4 = cJSON_GetObjectItem(element, "IPv4");
-                        if (!ipv4) {
+        if (sysinfo_network_ptr(&object) != -1) {
+            if (object) {
+                const cJSON *iface = cJSON_GetObjectItem(object, "iface");
+                if (iface) {
+                    const int size_ids = cJSON_GetArraySize(iface);
+                    for (int i = 0; i < size_ids; i++){
+                        const cJSON *element = cJSON_GetArrayItem(iface, i);
+                        if(!element) {
                             continue;
                         }
-                        cJSON *address = cJSON_GetObjectItem(ipv4, "address");
-                        if (address && cJSON_GetStringValue(address))
-                        {
-                            os_strdup(address->valuestring, agent_ip);
-                            break;
+                        cJSON *gateway = cJSON_GetObjectItem(element, "gateway");
+                        if(gateway && cJSON_GetStringValue(gateway) && 0 != strcmp(gateway->valuestring,"unkwown")) {
+                            const cJSON *ipv4 = cJSON_GetObjectItem(element, "IPv4");
+                            if (!ipv4) {
+                                continue;
+                            }
+                            cJSON *address = cJSON_GetObjectItem(ipv4, "address");
+                            if (address && cJSON_GetStringValue(address))
+                            {
+                                os_strdup(address->valuestring, agent_ip);
+                                break;
+                            }
                         }
                     }
                 }
+                sysinfo_free_result_ptr(&object);
             }
-            sysinfo_free_result_ptr(&object);
+        }
+        else {
+            mterror(WM_CONTROL_LOGTAG, "Unable to get system network information (%d) %s.", errno, strerror(errno));
         }
     }
 #elif defined sun
@@ -186,7 +190,7 @@ void *wm_control_main(){
         sysinfo_free_result_ptr = so_get_function_sym(sysinfo_module, "sysinfo_free_result");
         sysinfo_network_ptr = so_get_function_sym(sysinfo_module, "sysinfo_networks");
     }
-    
+
     send_ip();
 
     return NULL;

--- a/src/wazuh_modules/wm_control.c
+++ b/src/wazuh_modules/wm_control.c
@@ -80,7 +80,8 @@ char* getPrimaryIP(){
 #if defined __linux__ || defined __MACH__
     cJSON *object;
     if (sysinfo_network_ptr && sysinfo_free_result_ptr) {
-        if (sysinfo_network_ptr(&object) != -1) {
+        const int error_code = sysinfo_network_ptr(&object);
+        if (error_code == 0) {
             if (object) {
                 const cJSON *iface = cJSON_GetObjectItem(object, "iface");
                 if (iface) {
@@ -109,7 +110,7 @@ char* getPrimaryIP(){
             }
         }
         else {
-            mterror(WM_CONTROL_LOGTAG, "Unable to get system network information (%d) %s.", errno, strerror(errno));
+            mterror(WM_CONTROL_LOGTAG, "Unable to get system network information. Error code: %d.", error_code);
         }
     }
 #elif defined sun

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -356,32 +356,36 @@ char *get_agent_ip()
 
     cJSON *object;
     if (sysinfo_network_ptr && sysinfo_free_result_ptr) {
-        sysinfo_network_ptr(&object);
-        if (object) {
-            const cJSON *iface = cJSON_GetObjectItem(object, "iface");
-            if (iface) {
-                const int size_ids = cJSON_GetArraySize(iface);
-                for (int i = 0; i < size_ids; i++){
-                    const cJSON *element = cJSON_GetArrayItem(iface, i);
-                    if(!element) {
-                        continue;
-                    }
-                    cJSON *gateway = cJSON_GetObjectItem(element, "gateway");
-                    if(gateway && cJSON_GetStringValue(gateway) && 0 != strcmp(gateway->valuestring,"unkwown")) {
-                        const cJSON *ipv4 = cJSON_GetObjectItem(element, "IPv4");
-                        if (!ipv4) {
+        if (sysinfo_network_ptr(&object) != -1) {
+            if (object) {
+                const cJSON *iface = cJSON_GetObjectItem(object, "iface");
+                if (iface) {
+                    const int size_ids = cJSON_GetArraySize(iface);
+                    for (int i = 0; i < size_ids; i++){
+                        const cJSON *element = cJSON_GetArrayItem(iface, i);
+                        if(!element) {
                             continue;
                         }
-                        cJSON *address = cJSON_GetObjectItem(ipv4, "address");
-                        if (address && cJSON_GetStringValue(address))
-                        {
-                            os_strdup(address->valuestring, agent_ip);
-                            break;
+                        cJSON *gateway = cJSON_GetObjectItem(element, "gateway");
+                        if(gateway && cJSON_GetStringValue(gateway) && 0 != strcmp(gateway->valuestring,"unkwown")) {
+                            const cJSON *ipv4 = cJSON_GetObjectItem(element, "IPv4");
+                            if (!ipv4) {
+                                continue;
+                            }
+                            cJSON *address = cJSON_GetObjectItem(ipv4, "address");
+                            if (address && cJSON_GetStringValue(address))
+                            {
+                                os_strdup(address->valuestring, agent_ip);
+                                break;
+                            }
                         }
                     }
                 }
+                sysinfo_free_result_ptr(&object);
             }
-            sysinfo_free_result_ptr(&object);
+        }
+        else {
+            merror("Unable to get system network information.");
         }
     }
     return agent_ip;

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -356,7 +356,8 @@ char *get_agent_ip()
 
     cJSON *object;
     if (sysinfo_network_ptr && sysinfo_free_result_ptr) {
-        if (sysinfo_network_ptr(&object) != -1) {
+        const int error_code = sysinfo_network_ptr(&object);
+        if (error_code == 0) {
             if (object) {
                 const cJSON *iface = cJSON_GetObjectItem(object, "iface");
                 if (iface) {
@@ -385,7 +386,7 @@ char *get_agent_ip()
             }
         }
         else {
-            merror("Unable to get system network information.");
+            merror("Unable to get system network information. Error code: %d.", error_code);
         }
     }
     return agent_ip;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7546 |

## Description

```
(gdb) bt
#0  0x00007ffff675770f in raise () from /lib64/libc.so.6
#1  0x00007ffff6741b25 in abort () from /lib64/libc.so.6
#2  0x00007fffecd2d9fe in __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] () from /var/ossec/bin/../lib/libdbsync.so
#3  0x00007fffece3b6ac in __cxxabiv1::__terminate(void (*)()) () from /var/ossec/bin/../lib/libdbsync.so
#4  0x00007fffece3b707 in std::terminate() () from /var/ossec/bin/../lib/libdbsync.so
#5  0x00007fffece39ad8 in __cxa_throw () from /var/ossec/bin/../lib/libdbsync.so
#6  0x00007fffecd2d3e8 in std::__throw_out_of_range(char const*) [clone .cold.4] () from /var/ossec/bin/../lib/libdbsync.so
#7  0x00007fffecd811ef in __gnu_cxx::__stoa<long, int, char, int> (__convf=0x7ffff675bde0 <strtoq>, __name=0x7fffeceefa41 "stoi",
    __str=0x7fffc4001250 "A12BA8C0", __idx=0x0) at /usr/include/c++/8/ext/string_conversions.h:86
#8  0x00007fffecd802a5 in std::__cxx11::stoi (__str=..., __idx=0x0, __base=16) at /usr/include/c++/8/bits/basic_string.h:6411
#9  0x00007fffec236ce1 in NetworkLinuxInterface::NetworkLinuxInterface (this=0x7fffc40011a0, addrs=0x7fffc40023a0)
    at /root/wazuh/src/data_provider/src/network/networkLinuxWrapper.h:253
#10 0x00007fffec24c3dd in __gnu_cxx::new_allocator<NetworkLinuxInterface>::construct<NetworkLinuxInterface, ifaddrs*&> (
    this=0x7fffd9ffaadf, __p=0x7fffc40011a0) at /usr/include/c++/8/ext/new_allocator.h:136
#11 0x00007fffec24b450 in std::allocator_traits<std::allocator<NetworkLinuxInterface> >::construct<NetworkLinuxInterface, ifaddrs*&> (
    __a=..., __p=0x7fffc40011a0) at /usr/include/c++/8/bits/alloc_traits.h:475
#12 0x00007fffec249f77 in std::_Sp_counted_ptr_inplace<NetworkLinuxInterface, std::allocator<NetworkLinuxInterface>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<ifaddrs*&> (this=0x7fffc4001190, __a=...) at /usr/include/c++/8/bits/shared_ptr_base.h:545
#13 0x00007fffec248497 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<NetworkLinuxInterface, std::allocator<NetworkLinuxInterface>, ifaddrs*&> (this=0x7fffd9ffacc8, __p=@0x7fffd9ffacc0: 0x0, __a=...) at /usr/include/c++/8/bits/shared_ptr_base.h:677
#14 0x00007fffec2463c4 in std::__shared_ptr<NetworkLinuxInterface, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<NetworkLinuxInterface>, ifaddrs*&> (this=0x7fffd9ffacc0, __tag=...) at /usr/include/c++/8/bits/shared_ptr_base.h:1342
#15 0x00007fffec2431ef in std::shared_ptr<NetworkLinuxInterface>::shared_ptr<std::allocator<NetworkLinuxInterface>, ifaddrs*&> (
    this=0x7fffd9ffacc0, __tag=...) at /usr/include/c++/8/bits/shared_ptr.h:359
#16 0x00007fffec2403c9 in std::allocate_shared<NetworkLinuxInterface, std::allocator<NetworkLinuxInterface>, ifaddrs*&> (__a=...)
    at /usr/include/c++/8/bits/shared_ptr.h:706
#17 0x00007fffec23d6af in std::make_shared<NetworkLinuxInterface, ifaddrs*&> () at /usr/include/c++/8/bits/shared_ptr.h:722
#18 0x00007fffec234546 in SysInfo::getNetworks[abi:cxx11]() const (this=0x7fffd9ffad58)
    at /root/wazuh/src/data_provider/src/sysInfoLinux.cpp:378
#19 0x00007fffec24ee46 in SysInfo::networks[abi:cxx11]() (this=0x7fffd9ffad58) at /root/wazuh/src/data_provider/src/sysInfo.cpp:42
#20 0x00007fffec24f241 in sysinfo_networks (js_result=0x7fffd9ffadb8) at /root/wazuh/src/data_provider/src/sysInfo.cpp:80
#21 0x000000000045cf0e in getPrimaryIP () at wazuh_modules/wm_control.c:83
#22 0x000000000045d546 in send_ip () at wazuh_modules/wm_control.c:275
#23 0x000000000045d123 in wm_control_main () at wazuh_modules/wm_control.c:190
#24 0x00007ffff6aea2de in start_thread () from /lib64/libpthread.so.0
#25 0x00007ffff681be83 in clone () from /lib64/libc.so.6
```

Input data to reproduce this issue.
```
# cat /proc/net/route
Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
ens34	00000000	A12BA8C0	0003	0	0	100	00000000	0	0	0
ens34	002BA8C0	00000000	0001	0	0	100	00FFFFFF	0	0	0
```

Expected: No exception
Actual: std::stoi out of range exception


- Change to stol
![imagen](https://user-images.githubusercontent.com/14300208/108370041-fb6d8500-71da-11eb-8a33-a4d537113d98.png)
- Add try-catch block in all c interface functions.


## **DoD**
- [x] Replace stoi to stol.
- [x] Add try catch blocks for sysinfo provider in c interface.
- [x] Add unit test to process /proc/net/route example in the botton.
- [x] RTR
![image](https://user-images.githubusercontent.com/22640902/108401223-e274cc00-71fa-11eb-83e4-cc80aa22e8e0.png)

- [x] PR - CI Pass.