### PR TITLE
Fix memory leak when parsing version and assigner from the NVD

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -1661,6 +1661,8 @@ void wm_vuldet_free_nvd_node(nvd_vulnerability *data) {
     wm_vuldet_free_cv_scoring_system(data->cvss3);
     os_free(data->published);
     os_free(data->last_modified);
+    os_free(data->assigner);
+    os_free(data->version);
     os_free(data);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7558 |

## Description

This pull request fixes a memory leak when indexing vulnerabilities from the NVD feed. Variables `version` and `assigner` were not freed as needed after storing them into the vulnerabilities database.

**Valgrind output**
```
==587710== LEAK SUMMARY:
==587710==    definitely lost: 0 bytes in 0 blocks
==587710==    indirectly lost: 0 bytes in 0 blocks
==587710==      possibly lost: 3,808 bytes in 14 blocks
==587710==    still reachable: 136,366 bytes in 51 blocks
==587710==         suppressed: 0 bytes in 0 blocks
==587710== Reachable blocks (those to which a pointer was found) are not shown.
==587710== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Check the memory doesn't grow when parsing NVD feeds

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- [x] Stress test for affected components
