### PR TITLE
Keep processing permissions after finding a duplicate user in Windows events

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1385,7 +1385,7 @@ cJSON *win_perm_to_json(char *perms) {
             }
         }
         if (next_it) {
-            break;
+            continue;
         }
 
         if (!user_obj) {


### PR DESCRIPTION
|Related issue|
|---|
|#6750|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Break statement changed to continue in the condition that checks if next_it is true or false.


Tests passed in local, some unknown problems arise in jenkins (bento/ubuntu-20.04): [analysisd_test_6750.zip](https://github.com/wazuh/wazuh/files/6147629/analysisd_test_6750.zip)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows


<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory


