### PR TITLE
Fix RBAC CDB lists tests.

### DIFF
--- a/api/test/integration/env/configurations/rbac/cdb/black_config.yaml
+++ b/api/test/integration/env/configurations/rbac/cdb/black_config.yaml
@@ -1,9 +1,14 @@
 ---
 - actions:
   - lists:read
-  - lists:update
   - lists:delete
   resources:
   - list:file:aws-eventnames
   - list:file:audit-keys
+  effect: deny
+
+- actions:
+  - lists:update
+  resources:
+  - "*:*:*"
   effect: deny

--- a/api/test/integration/env/configurations/rbac/cdb/white_config.yaml
+++ b/api/test/integration/env/configurations/rbac/cdb/white_config.yaml
@@ -1,10 +1,15 @@
 ---
 - actions:
   - lists:read
-  - lists:update
   - lists:delete
   resources:
   - list:file:aws-eventnames
   - list:file:audit-keys
-  - '*:*:*'
+  effect: allow
+
+- actions:
+  - lists:update
+  resources:
+  - "*:*:*"
+  - list:file:dummy
   effect: allow

--- a/api/test/integration/test_rbac_black_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cdb_list_endpoints.tavern.yaml
@@ -128,7 +128,18 @@ stages:
 test_name: PUT /lists/files/{filename}
 
 stages:
-  - name: Try to update audit-keys list (indirectly denied deletion)
+  - name: Try to update audit-keys list, overwrite=False (deny)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/lists/files/audit-keys"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      data: "{new_cdb_list:s}"
+    response:
+      <<: *permission_denied
+
+  - name: Try to update audit-keys list, overwrite=True (deny)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/lists/files/audit-keys"
@@ -139,36 +150,7 @@ stages:
       params:
         overwrite: True
     response:
-      status_code: 200
-      json:
-        error: 1
-        data:
-          failed_items:
-            - error:
-                code: 4000
-              id:
-                - 'etc/lists/audit-keys'
-          total_affected_items: 0
-          total_failed_items: 1
-
-  - name: Updload new list file (allow)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/new_cdb_list"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-      data: "{new_cdb_list:s}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - 'etc/lists/new_cdb_list'
-          failed_items: [ ]
-          total_affected_items: 1
-          total_failed_items: 0
+      <<: *permission_denied
 
 ---
 test_name: DELETE /lists/files/{filename}
@@ -187,7 +169,7 @@ stages:
   - name: Delete a CDB list (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/new_cdb_list"
+      url: "{protocol:s}://{host:s}:{port:d}/lists/files/security-eventchannel"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -197,7 +179,7 @@ stages:
         error: 0
         data:
           affected_items:
-            - 'etc/lists/new_cdb_list'
+            - 'etc/lists/security-eventchannel'
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0

--- a/api/test/integration/test_rbac_white_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cdb_list_endpoints.tavern.yaml
@@ -132,7 +132,7 @@ stages:
 test_name: PUT /lists/files/{filename}
 
 stages:
-  - name: Try to overwrite security-eventchannel (deny)
+  - name: Try to overwrite security-eventchannel (indirectly denied deletion)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/lists/files/security-eventchannel"

--- a/framework/wazuh/rbac/default/policies.yaml
+++ b/framework/wazuh/rbac/default/policies.yaml
@@ -153,7 +153,7 @@ default_policies:
   lists_read:
     description: Allow reading all lists paths in the system.
     policies:
-      rules:
+      lists:
         actions:
           - lists:read
         resources:
@@ -163,7 +163,7 @@ default_policies:
   lists_all:
     description: Allow managing all CDB lists files in the system.
     policies:
-      rules:
+      files:
         actions:
           - lists:read
           - lists:delete


### PR DESCRIPTION
|Related issue|
|---|
| Closes #7543 |

## Description

Hi team!

This PR updates the RBAC CDB lists tests as requested in #7543. Both white and black policies have been changed, and their tests needed to be updated too.

## Output
```
pytest -vv test_rbac_black_cdb_list_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-65-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 5 items                                                                                                                                                                                            

test_rbac_black_cdb_list_endpoints.tavern.yaml::GET LISTS RBAC PASSED                                                                                                                                  [ 20%]
test_rbac_black_cdb_list_endpoints.tavern.yaml::GET LISTS FILES RBAC PASSED                                                                                                                            [ 40%]
test_rbac_black_cdb_list_endpoints.tavern.yaml::GET /lists/files/{filename} PASSED                                                                                                                     [ 60%]
test_rbac_black_cdb_list_endpoints.tavern.yaml::PUT /lists/files/{filename} PASSED                                                                                                                     [ 80%]
test_rbac_black_cdb_list_endpoints.tavern.yaml::DELETE /lists/files/{filename} PASSED                                                                                                                  [100%]

================================================================================= 5 passed, 7 warnings in 102.35s (0:01:42) ==================================================================================
```

```
pytest -vv test_rbac_white_cdb_list_endpoints.tavern.yaml
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.4.0-65-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '5.4.3', 'py': '1.8.2', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.10.0', 'testinfra': '5.0.0', 'tavern': '1.2.2', 'cov': '2.10.0', 'asyncio': '0.14.0', 'html': '2.0.1'}}
rootdir: /home/selu/Git/wazuh/api/test/integration, inifile: pytest.ini
plugins: metadata-1.10.0, testinfra-5.0.0, tavern-1.2.2, cov-2.10.0, asyncio-0.14.0, html-2.0.1
collected 5 items                                                                                                                                                                                            

test_rbac_white_cdb_list_endpoints.tavern.yaml::GET LISTS RBAC PASSED                                                                                                                                  [ 20%]
test_rbac_white_cdb_list_endpoints.tavern.yaml::GET LISTS FILES RBAC PASSED                                                                                                                            [ 40%]
test_rbac_white_cdb_list_endpoints.tavern.yaml::GET /lists/files/{filename} PASSED                                                                                                                     [ 60%]
test_rbac_white_cdb_list_endpoints.tavern.yaml::PUT /lists/files/{filename} PASSED                                                                                                                     [ 80%]
test_rbac_white_cdb_list_endpoints.tavern.yaml::DELETE /lists/files/{filename} PASSED                                                                                                                  [100%]

================================================================================= 5 passed, 7 warnings in 102.41s (0:01:42) ==================================================================================
```


Regards,
Selu.