### PR TITLE
Add raw parameter to get configuration endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 - **External dependencies:**
   - Added cython (0.29.21) library to Python dependencies. ([#7451](https://github.com/wazuh/wazuh/pull/7451))  
   - Added xmltodict (0.12.0) library to Python dependencies. ([#7303](https://github.com/wazuh/wazuh/pull/7303))
+ 
+- **API:**
+  - Added new endpoints to manage rules files. ([#7178](https://github.com/wazuh/wazuh/issues/7178))
+  - Added new endpoints to manage CDB lists files. ([#7180](https://github.com/wazuh/wazuh/issues/7180))
+  - Added new endpoints to manage decoder files. ([#7179](https://github.com/wazuh/wazuh/issues/7179))
+  - Added new manager and cluster endpoints to update Wazuh configuration (ossec.conf). ([#7181](https://github.com/wazuh/wazuh/issues/7181))
   
 ### Changed
 
@@ -15,13 +21,10 @@ All notable changes to this project will be documented in this file.
   - Upgraded Python version from 3.8.2 to 3.8.6. ([#7451](https://github.com/wazuh/wazuh/pull/7451))
   - Upgraded Cryptography python library from 3.2.1 to 3.3.2. ([#7451](https://github.com/wazuh/wazuh/pull/7451))
   - Upgraded cffi python library from 1.14.0 to 1.14.4. ([#7451](https://github.com/wazuh/wazuh/pull/7451))
-
-- **API:**
-  - Added new endpoints to manage rules files. ([#7178](https://github.com/wazuh/wazuh/issues/7178))
-  - Added new endpoints to manage CDB lists files. ([#7180](https://github.com/wazuh/wazuh/issues/7180))
-  - Added new endpoints to manage decoder files. ([#7179](https://github.com/wazuh/wazuh/issues/7179))
-  - Added new manager and cluster endpoints to update Wazuh configuration (ossec.conf). ([#7181](https://github.com/wazuh/wazuh/issues/7181))
   
+- **API:**
+  - Added raw parameter to GET /manager/configuration and GET cluster/{node_id}/configuration to load ossec.conf in xml format. ([#7565](https://github.com/wazuh/wazuh/issues/7565))
+
 ### Fixed
 
 - **API:**

--- a/api/api/controllers/manager_controller.py
+++ b/api/api/controllers/manager_controller.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 
 from aiohttp import web
+from connexion.lifecycle import ConnexionResponse
 
 import wazuh.manager as manager
 import wazuh.stats as stats
@@ -14,6 +15,7 @@ from api.models.base_model_ import Body
 from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deserialize_date
 from wazuh.core import common
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
+from wazuh.core.results import AffectedItemsWazuhResult
 
 logger = logging.getLogger('wazuh-api')
 
@@ -60,16 +62,34 @@ async def get_info(request, pretty=False, wait_for_complete=False):
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def get_configuration(request, pretty=False, wait_for_complete=False, section=None, field=None):
+async def get_configuration(request, pretty=False, wait_for_complete=False, section=None, field=None,
+                            raw: bool = False):
     """Get manager's or local_node's configuration (ossec.conf)
 
-    :param pretty: Show results in human-readable format
-    :param wait_for_complete: Disable timeout response
-    :param section: Indicates the wazuh configuration section
-    :param field: Indicates a section child, e.g, fields for rule section are include, decoder_dir, etc.
+    Parameters
+    ----------
+    pretty : bool, optional
+        Show results in human-readable format. It only works when `raw` is False (JSON format). Default `True`
+    wait_for_complete : bool, optional
+        Disable response timeout or not. Default `False`
+    section : str
+        Indicates the wazuh configuration section
+    field : str
+        Indicates a section child, e.g, fields for rule section are include, decoder_dir, etc.
+    raw : bool, optional
+        Whether to return the file content in raw or JSON format. Default `True`
+
+    Returns
+    -------
+    web.json_response or ConnexionResponse
+        Depending on the `raw` parameter, it will return an object or other:
+            raw=True            -> ConnexionResponse (application/xml)
+            raw=False (default) -> web.json_response (application/json)
+        If any exception was raised, it will return a web.json_response with details.
     """
     f_kwargs = {'section': section,
-                'field': field}
+                'field': field,
+                'raw': raw}
 
     dapi = DistributedAPI(f=manager.read_ossec_conf,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -81,7 +101,11 @@ async def get_configuration(request, pretty=False, wait_for_complete=False, sect
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
-    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+    if isinstance(data, AffectedItemsWazuhResult):
+        response = web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+    else:
+        response = ConnexionResponse(body=data["message"], mimetype='application/xml', content_type='application/xml')
+    return response
 
 
 async def get_stats(request, pretty=False, wait_for_complete=False, date=None):

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -4127,6 +4127,13 @@ components:
       required: False
       schema:
         type: boolean
+    raw_conf:
+      in: query
+      name: raw
+      description: "Format response in plain text"
+      required: False
+      schema:
+        type: boolean
     registry:
       in: query
       name: registry
@@ -7955,7 +7962,7 @@ paths:
       tags:
       - Cluster
       summary: "Get node config"
-      description: "Return wazuh configuration used in node {node_id}"
+      description: "Return wazuh configuration used in node {node_id}. The 'section' and 'field' parameters will be ignored if 'raw' parameter is provided."
       operationId: api.controllers.cluster_controller.get_configuration_node
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
@@ -7963,7 +7970,7 @@ paths:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/node_id'
-        - $ref: '#/components/parameters/raw'
+        - $ref: '#/components/parameters/raw_conf'
         - $ref: '#/components/parameters/section'
         - $ref: '#/components/parameters/field'
       responses:
@@ -9385,14 +9392,14 @@ paths:
       tags:
       - Manager
       summary: "Get configuration"
-      description: "Return wazuh configuration used"
+      description: "Return wazuh configuration used. The 'section' and 'field' parameters will be ignored if 'raw' parameter is provided."
       operationId: api.controllers.manager_controller.get_configuration
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/manager:read'
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
-        - $ref: '#/components/parameters/raw'
+        - $ref: '#/components/parameters/raw_conf'
         - $ref: '#/components/parameters/section'
         - $ref: '#/components/parameters/field'
       responses:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -7963,6 +7963,7 @@ paths:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
         - $ref: '#/components/parameters/node_id'
+        - $ref: '#/components/parameters/raw'
         - $ref: '#/components/parameters/section'
         - $ref: '#/components/parameters/field'
       responses:
@@ -9391,6 +9392,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/raw'
         - $ref: '#/components/parameters/section'
         - $ref: '#/components/parameters/field'
       responses:

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -116,6 +116,21 @@ stages:
         extra_kwargs:
           select_key: "{section:s}"
 
+  # GET /manager/configuration
+  - name: Request all sections in raw format
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        raw: True
+    response:
+      status_code: 200
+      headers:
+        content-type: "application/xml; charset=utf-8"
+
 ---
 test_name: GET /manager/configuration
 

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -231,7 +231,7 @@ def get_config(component=None, config=None):
 
 @expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:read"],
                   resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'])
-def read_ossec_conf(section=None, field=None):
+def read_ossec_conf(section=None, field=None, raw=False):
     """ Wrapper for get_ossec_conf
 
     :param section: Filters by section (i.e. rules).
@@ -246,6 +246,9 @@ def read_ossec_conf(section=None, field=None):
                                       )
 
     try:
+        if raw:
+            with open(common.ossec_path) as f:
+                return f.read()
         result.affected_items.append(get_ossec_conf(section=section, field=field))
     except WazuhError as e:
         result.add_failed_item(id_=node_id, error=e)

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -247,7 +247,7 @@ def read_ossec_conf(section=None, field=None, raw=False):
 
     try:
         if raw:
-            with open(common.ossec_path) as f:
+            with open(common.ossec_conf) as f:
                 return f.read()
         result.affected_items.append(get_ossec_conf(section=section, field=field))
     except WazuhError as e:

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -293,12 +293,16 @@ def test_get_config_ko():
     assert result.render()['data']['failed_items'][0]['error']['code'] == 1307
 
 
-def test_read_ossec_conf():
+@pytest.mark.parametrize('raw', [True, False])
+def test_read_ossec_conf(raw):
     """Tests read_ossec_conf() function works as expected"""
-    result = read_ossec_conf()
+    result = read_ossec_conf(raw=raw)
 
-    assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
-    assert result.render()['data']['total_failed_items'] == 0
+    if raw:
+        assert isinstance(result, str), 'No expected result type'
+    else:
+        assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
+        assert result.render()['data']['total_failed_items'] == 0
 
 
 def test_read_ossec_con_ko():


### PR DESCRIPTION
Hello team,

This PR adds the `raw` parameter to the `/manager/configuration` and `/cluster/{node_id}/configuration` endpoints. It will return the `ossec.conf` in xml format.

## Test results

```
================================ test session starts ================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/wazuh/framework
plugins: metadata-1.11.0, tavern-1.0.0, html-3.1.1, testinfra-5.0.0
collected 33 items                                                                  

framework/wazuh/tests/test_manager.py .................................       [100%]

============================= 33 passed in 0.21 seconds =============================
```

```
test_cluster_endpoints.tavern.yaml
	 44 passed, 1 xpassed, 58 warnings
test_manager_endpoints.tavern.yaml
	 31 passed, 34 warnings
```