### PR TITLE
Update API messages when upgrading agents and getting upgrade results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ All notable changes to this project will be documented in this file.
   - Fixed Windows agent compilation with GCC 10. ([#7359](https://github.com/wazuh/wazuh/pull/7359))
   - Fixed a bug in FIM that caused to wrogly expand environment variables. ([#7332](https://github.com/wazuh/wazuh/pull/7332))
 
+- **API:**
+  - Fixed wrong API messages returned when getting agents' upgrade results. ([#7587](https://github.com/wazuh/wazuh/pull/7587))
+
 ### Removed
 
 - **Core:**

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -721,9 +721,9 @@ def upgrade_agents(agent_list=None, wpk_repo=None, version=None, force=False, us
     -------
     ID of created tasks
     """
-    result = AffectedItemsWazuhResult(all_msg='All upgrade tasks have been created',
-                                      some_msg='Some upgrade tasks have been created',
-                                      none_msg='No upgrade task has been created',
+    result = AffectedItemsWazuhResult(all_msg='All upgrade tasks were created',
+                                      some_msg='Some upgrade tasks were not created',
+                                      none_msg='No upgrade task was created',
                                       sort_fields=['agent'], sort_ascending='True')
 
     agent_list = list(map(int, agents_padding(result=result, agent_list=agent_list)))
@@ -771,9 +771,9 @@ def get_upgrade_result(agent_list=None):
     -------
     Upgrade result.
     """
-    result = AffectedItemsWazuhResult(all_msg='All agents have been updated',
-                                      some_msg='Some agents have not been updated',
-                                      none_msg='No agent has been updated')
+    result = AffectedItemsWazuhResult(all_msg='All upgrade tasks were returned',
+                                      some_msg='Some upgrade tasks were not returned',
+                                      none_msg='No upgrade task was returned')
 
     agent_list = list(map(int, agents_padding(result=result, agent_list=agent_list)))
     agents_result_chunks = [agent_list[x:x + 100] for x in range(0, len(agent_list), 100)]


### PR DESCRIPTION
|Related issue|
|---|
| #7313 |

In this PR I have modified the API messages returned when upgrading agents and getting their upgrade results:

```
{
  "data": {
    "affected_items": [
      {
        "message": "Success",
        "agent": "001",
        "task_id": 4,
        "node": "master-node",
        "module": "upgrade_module",
        "command": "upgrade",
        "status": "Error",
        "error_msg": "The version of the WPK does not exist in the repository",
        "create_time": "2021/02/23 09:05:05",
        "update_time": "2021/02/23 09:05:05"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All upgrade tasks were returned",
  "error": 0
}
```

```
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 1813,
          "message": "No task in DB",
          "remediation": null
        },
        "id": [
          "010"
        ]
      }
    ]
  },
  "message": "No upgrade task was returned",
  "error": 1
}
```
```
{
  "data": {
    "affected_items": [
      {
        "message": "Success",
        "agent": "001",
        "task_id": 4,
        "node": "master-node",
        "module": "upgrade_module",
        "command": "upgrade",
        "status": "Error",
        "error_msg": "The version of the WPK does not exist in the repository",
        "create_time": "2021/02/23 09:05:05",
        "update_time": "2021/02/23 09:05:05"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 1813,
          "message": "No task in DB",
          "remediation": null
        },
        "id": [
          "010"
        ]
      }
    ]
  },
  "message": "Some upgrade tasks were not returned",
  "error": 2
}
```

Regards,
Manuel.