### PR TITLE
Add new endpoint for users' run_as parameter modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 - **API:**
   - Added new endpoint to get agent stats from different components. ([#7128](https://github.com/wazuh/wazuh/issues/7128))
+  - Added new endpoint to modify users' allow_run_as flag. ([#7588](https://github.com/wazuh/wazuh/pull/7588))
 
 - **Ruleset:**
   - Added support for UFW firewall to decoders. ([#7100](https://github.com/wazuh/wazuh/pull/7100))
@@ -67,7 +68,9 @@ All notable changes to this project will be documented in this file.
   - Unused files have been removed from the repository, including TAP tests. ([#7398](https://github.com/wazuh/wazuh/issues/7398))
 
 - **API:**
+  - Removed the `allow_run_as` parameter from endpoints `POST /security/users` and `PUT /security/users/{user_id}`. ([#7588](https://github.com/wazuh/wazuh/pull/7588))
   - Removed `behind_proxy_server` option from configuration. ([#7006](https://github.com/wazuh/wazuh/issues/7006))
+
 
 ## [v4.1.1]
 

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -195,8 +195,8 @@ async def get_users(request, user_ids: list = None, pretty=False, wait_for_compl
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
-async def enable_run_as(request, user_id: str, allow_run_as: bool, pretty=False, wait_for_complete=False):
-    """Modify the specified user' run_as flag.
+async def edit_run_as(request, user_id: str, allow_run_as: bool, pretty=False, wait_for_complete=False):
+    """Modify the specified user' allow_run_as flag.
 
     Parameters
     ----------
@@ -204,7 +204,7 @@ async def enable_run_as(request, user_id: str, allow_run_as: bool, pretty=False,
     user_id : str
         User ID of the user to be updated
     allow_run_as : bool
-        Enable authorization context login method for the new user
+        Enable or disable authorization context login method for the specified user
     pretty : bool, optional
         Show results in human-readable format
     wait_for_complete : bool, optional
@@ -216,7 +216,7 @@ async def enable_run_as(request, user_id: str, allow_run_as: bool, pretty=False,
     """
     f_kwargs = {'user_id': user_id, 'allow_run_as': allow_run_as}
 
-    dapi = DistributedAPI(f=security.enable_run_as,
+    dapi = DistributedAPI(f=security.edit_run_as,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='local_master',
                           is_async=False,

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -195,6 +195,41 @@ async def get_users(request, user_ids: list = None, pretty=False, wait_for_compl
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
+async def enable_run_as(request, user_id: str, allow_run_as: bool, pretty=False, wait_for_complete=False):
+    """Modify the specified user' run_as flag.
+
+    Parameters
+    ----------
+    request : connexion.request
+    user_id : str
+        User ID of the user to be updated
+    allow_run_as : bool
+        Enable authorization context login method for the new user
+    pretty : bool, optional
+        Show results in human-readable format
+    wait_for_complete : bool, optional
+        Disable timeout response
+
+    Returns
+    -------
+    User data
+    """
+    f_kwargs = {'user_id': user_id, 'allow_run_as': allow_run_as}
+
+    dapi = DistributedAPI(f=security.enable_run_as,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='local_master',
+                          is_async=False,
+                          logger=logger,
+                          current_user=request['token_info']['sub'],
+                          rbac_permissions=request['token_info']['rbac_policies'],
+                          wait_for_complete=wait_for_complete
+                          )
+    data = raise_if_exc(await dapi.distribute_function())
+
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+
+
 async def create_user(request, pretty=False, wait_for_complete=False):
     """Create a new user.
 

--- a/api/api/models/security_model.py
+++ b/api/api/models/security_model.py
@@ -7,22 +7,19 @@ from api.models.base_model_ import Body
 
 class CreateUserModel(Body):
     """Create_user model."""
-    def __init__(self, username: str = None, password: str = None, allow_run_as: bool = None):
+    def __init__(self, username: str = None, password: str = None):
         self.swagger_types = {
             'username': str,
-            'password': str,
-            'allow_run_as': bool
+            'password': str
         }
 
         self.attribute_map = {
             'username': 'username',
-            'password': 'password',
-            'allow_run_as': 'allow_run_as'
+            'password': 'password'
         }
 
         self._username = username
         self._password = password
-        self._allow_run_as = allow_run_as
 
     @property
     def username(self):
@@ -39,14 +36,6 @@ class CreateUserModel(Body):
     @password.setter
     def password(self, passw):
         self._password = passw
-
-    @property
-    def allow_run_as(self):
-        return self._allow_run_as
-
-    @allow_run_as.setter
-    def allow_run_as(self, allow_run_as):
-        self._allow_run_as = allow_run_as
 
 
 class UpdateUserModel(CreateUserModel):

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -413,12 +413,12 @@ x-rbac-catalog:
         actions: ['security:read']
         resources: ['policy:id:*', 'role:id:2', 'user:id:5', 'rule:id:3']
         effect: "allow"
-    'security:run_as':
-      description: "Change the value of the run_as flag for a user"
+    'security:edit_run_as':
+      description: "Change the value of the allow_run_as flag for a user"
       resources:
         - $ref: '#/x-rbac-catalog/resources/*:*'
       example:
-        actions: [ 'security:run_as' ]
+        actions: [ 'security:edit_run_as' ]
         resources: [ '*:*:*' ]
         effect: "allow"
     'security:update':
@@ -4426,7 +4426,7 @@ components:
     allow_run_as:
       in: query
       name: allow_run_as
-      description: "Value for the run_as flag"
+      description: "Value for the allow_run_as flag"
       schema:
         type: boolean
         default: false
@@ -14088,10 +14088,10 @@ paths:
       tags:
         - Security
       summary: "Enable/Disable run_as"
-      description: "Modify a user's run_as flag by specifying their ID"
-      operationId: api.controllers.security_controller.enable_run_as
+      description: "Modify a user's allow_run_as flag by specifying their ID"
+      operationId: api.controllers.security_controller.edit_run_as
       x-rbac-actions:
-        - $ref: '#/x-rbac-catalog/actions/security:run_as'
+        - $ref: '#/x-rbac-catalog/actions/security:edit_run_as'
       parameters:
         - $ref: '#/components/parameters/user_id_required'
         - $ref: '#/components/parameters/allow_run_as'
@@ -14120,7 +14120,7 @@ paths:
                     total_affected_items: 1
                     total_failed_items: 0
                     failed_items: [ ]
-                  message: Parameter run_as has been enabled for the user
+                  message: Parameter allow_run_as has been enabled for the user
                   error: 0
         '400':
           $ref: '#/components/responses/ResponseError'

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -413,6 +413,14 @@ x-rbac-catalog:
         actions: ['security:read']
         resources: ['policy:id:*', 'role:id:2', 'user:id:5', 'rule:id:3']
         effect: "allow"
+    'security:run_as':
+      description: "Change the value of the run_as flag for a user"
+      resources:
+        - $ref: '#/x-rbac-catalog/resources/*:*'
+      example:
+        actions: [ 'security:run_as' ]
+        resources: [ '*:*:*' ]
+        effect: "allow"
     'security:update':
       description: "Update the information of system security resources"
       resources:
@@ -4415,6 +4423,13 @@ components:
       description: "Type of file"
       schema:
         type: string
+    allow_run_as:
+      in: query
+      name: allow_run_as
+      description: "Value for the run_as flag"
+      schema:
+        type: boolean
+        default: false
     user_ids:
       in: query
       name: 'user_ids'
@@ -14068,6 +14083,56 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
+  /security/users/{user_id}/run_as:
+    put:
+      tags:
+        - Security
+      summary: "Enable/Disable run_as"
+      description: "Modify a user's run_as flag by specifying their ID"
+      operationId: api.controllers.security_controller.enable_run_as
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/security:run_as'
+      parameters:
+        - $ref: '#/components/parameters/user_id_required'
+        - $ref: '#/components/parameters/allow_run_as'
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+      responses:
+        '200':
+          description: "User's flag changed successfully"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseUsers'
+                example:
+                  data:
+                    affected_items:
+                      - id: 1
+                        username: wazuh
+                        allow_run_as: true
+                        roles:
+                          - 1
+                    total_affected_items: 1
+                    total_failed_items: 0
+                    failed_items: [ ]
+                  message: Parameter run_as has been enabled for the user
+                  error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '406':
+          $ref: '#/components/responses/WrongContentTypeResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
   /security/actions:
     get:
       tags:
@@ -14293,9 +14358,6 @@ paths:
                 password:
                   type: string
                   format: password
-                allow_run_as:
-                  type: boolean
-                  default: False
               required:
                 - username
                 - password
@@ -14406,9 +14468,6 @@ paths:
                 password:
                   type: string
                   format: password
-                allow_run_as:
-                  type: boolean
-                  default: False
       responses:
         '200':
           description: "User updated successful"

--- a/api/test/integration/env/configurations/rbac/security/black_config.txt
+++ b/api/test/integration/env/configurations/rbac/security/black_config.txt
@@ -30,3 +30,4 @@
 | security:revoke       | *         | *     |                 |
 | security:read_config  | *         |       | *               |
 | security:update_config| *         |       | *               |
+| security:run_as       | *         |       | *               |

--- a/api/test/integration/env/configurations/rbac/security/black_config.txt
+++ b/api/test/integration/env/configurations/rbac/security/black_config.txt
@@ -30,4 +30,4 @@
 | security:revoke       | *         | *     |                 |
 | security:read_config  | *         |       | *               |
 | security:update_config| *         |       | *               |
-| security:run_as       | *         |       | *               |
+| security:edit_run_as  | *         |       | *               |

--- a/api/test/integration/env/configurations/rbac/security/black_config.yaml
+++ b/api/test/integration/env/configurations/rbac/security/black_config.yaml
@@ -69,7 +69,7 @@
   - security:create
   - security:read_config
   - security:update_config
-  - security:run_as
+  - security:edit_run_as
   resources:
   - "*:*:*"
   effect: deny

--- a/api/test/integration/env/configurations/rbac/security/black_config.yaml
+++ b/api/test/integration/env/configurations/rbac/security/black_config.yaml
@@ -69,6 +69,7 @@
   - security:create
   - security:read_config
   - security:update_config
+  - security:run_as
   resources:
   - "*:*:*"
   effect: deny

--- a/api/test/integration/env/configurations/rbac/security/white_config.txt
+++ b/api/test/integration/env/configurations/rbac/security/white_config.txt
@@ -30,3 +30,4 @@
 | security:revoke       | *         |                 | *    |
 | security:read_config  | *         | *               |      |
 | security:update_config| *         | *               |      |
+| security:run_as       | *         | *               |      |

--- a/api/test/integration/env/configurations/rbac/security/white_config.txt
+++ b/api/test/integration/env/configurations/rbac/security/white_config.txt
@@ -30,4 +30,4 @@
 | security:revoke       | *         |                 | *    |
 | security:read_config  | *         | *               |      |
 | security:update_config| *         | *               |      |
-| security:run_as       | *         | *               |      |
+| security:edit_run_as  | *         | *               |      |

--- a/api/test/integration/env/configurations/rbac/security/white_config.yaml
+++ b/api/test/integration/env/configurations/rbac/security/white_config.yaml
@@ -67,6 +67,7 @@
   - security:create
   - security:read_config
   - security:update_config
+  - security:run_as
   resources:
   - "*:*:*"
   effect: allow

--- a/api/test/integration/env/configurations/rbac/security/white_config.yaml
+++ b/api/test/integration/env/configurations/rbac/security/white_config.yaml
@@ -67,7 +67,7 @@
   - security:create
   - security:read_config
   - security:update_config
-  - security:run_as
+  - security:edit_run_as
   resources:
   - "*:*:*"
   effect: allow

--- a/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
@@ -424,11 +424,11 @@ stages:
           total_failed_items: 0
 
 ---
-test_name: UPDATE USER'S RUN_AS FLAG
+test_name: UPDATE USER'S ALLOW_RUN_AS FLAG
 
 stages:
 
-  - name: Update one specified user's run_as flag (Denied)
+  - name: Update one specified user's allow_run_as flag (Denied)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/users/104/run_as"

--- a/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
@@ -424,6 +424,23 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: UPDATE USER'S RUN_AS FLAG
+
+stages:
+
+  - name: Update one specified user's run_as flag (Denied)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/104/run_as"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      params:
+        allow_run_as: false
+    response:
+      <<: *permission_denied
+
+---
 test_name: UPDATE ROLES RBAC
 
 stages:
@@ -709,7 +726,6 @@ stages:
       json:
         username: newUser
         password: stringA1!
-        allow_run_as: true
     response:
       status_code: 200
       json:
@@ -718,7 +734,7 @@ stages:
           affected_items:
             - id: 106
               username: newUser
-              allow_run_as: true
+              allow_run_as: false
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -993,7 +1009,7 @@ stages:
               roles: []
             - id: 106
               username: newUser
-              allow_run_as: true
+              allow_run_as: false
               roles: []
           total_affected_items: 4
           total_failed_items: 0

--- a/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
@@ -425,6 +425,31 @@ stages:
       <<: *permission_denied
 
 ---
+test_name: UPDATE USER'S RUN_AS FLAG
+
+stages:
+
+  - name: Update one specified user's run_as flag (Allowed)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/103/run_as"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      params:
+        allow_run_as: true
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: 103
+              username: python
+              allow_run_as: true
+          total_affected_items: 1
+
+---
 test_name: UPDATE ROLES RBAC
 
 stages:
@@ -956,7 +981,6 @@ stages:
       json:
         username: newUser
         password: stringA1!
-        allow_run_as: true
     response:
       <<: *permission_denied
 

--- a/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
@@ -425,11 +425,11 @@ stages:
       <<: *permission_denied
 
 ---
-test_name: UPDATE USER'S RUN_AS FLAG
+test_name: UPDATE USER'S ALLOW_RUN_AS FLAG
 
 stages:
 
-  - name: Update one specified user's run_as flag (Allowed)
+  - name: Update one specified user's allow_run_as flag (Allowed)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/users/103/run_as"

--- a/api/test/integration/test_security_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_POST_endpoints.tavern.yaml
@@ -773,7 +773,6 @@ stages:
       json:
         username: "new_user"
         password: "new_user1A!"
-        allow_run_as: true
       method: POST
     response:
       status_code: 200
@@ -787,7 +786,6 @@ stages:
       json:
         username: "symbols"
         password: "new_user1A!@#~½¬?¿ñàÀ"
-        allow_run_as: true
       method: POST
     response:
       status_code: 200
@@ -801,7 +799,6 @@ stages:
       json:
         username: "test_very_long_user_name_so_the_request_fails_because_of_maximum1"
         password: "new_user1A!@#~½¬?¿ñàÀ"
-        allow_run_as: true
       method: POST
     response:
       status_code: 400
@@ -813,7 +810,6 @@ stages:
       json:
         username: "new_user"
         password: "new_user1B!"
-        allow_run_as: false
     response:
       status_code: 200
       json:
@@ -873,7 +869,6 @@ stages:
       <<: *post_users_request
       json:
         username: "new_user1"
-        allow_run_as: true
     response:
       status_code: 400
 

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -474,7 +474,7 @@ stages:
       status_code: 200
 
 ---
-test_name: PUT /security/users/{username}
+test_name: PUT /security/users/{user_id}
 
 stages:
 
@@ -494,7 +494,6 @@ stages:
       <<: *put_users_request
       json:
         password: "new_user"
-        allow_run_as: true
     response:
       status_code: 400
 
@@ -504,7 +503,6 @@ stages:
       <<: *put_users_request
       json:
         password: "new_user2A!"
-        allow_run_as: true
     response:
       status_code: 200
       json:
@@ -513,7 +511,7 @@ stages:
           affected_items:
             - id: 103
               username: python
-              allow_run_as: true
+              allow_run_as: false
           total_affected_items: 1
 
   - name: Update an non-existent user
@@ -525,7 +523,6 @@ stages:
       method: PUT
       json:
         password: "new_user1A"
-        allow_run_as: false
     response:
       status_code: 200
       json:
@@ -554,7 +551,7 @@ stages:
       verify: False
       <<: *put_users_request
       json:
-        allow_run_as: false
+        password: "new_pa55worD!"
     response:
       status_code: 200
       json:
@@ -564,6 +561,67 @@ stages:
             - username: python
               allow_run_as: false
           total_affected_items: 1
+
+
+---
+test_name: PUT /security/users/{user_id}/run_as
+
+stages:
+
+  - name: Update user's run_as flag
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/103/run_as"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      params:
+        allow_run_as: True
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: 103
+              username: python
+              allow_run_as: true
+          total_affected_items: 1
+
+  - name: Update user's run_as flag (invalid_user)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/INVALID/run_as"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      params:
+        allow_run_as: True
+    response:
+      status_code: 400
+
+  - name: Update user's run_as flag (nonexistent user)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/999/run_as"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      params:
+        allow_run_as: True
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items: [ ]
+          failed_items:
+            - error:
+                code: 5001
+              id:
+                - 999
+          total_affected_items: 0
+          total_failed_items: 1
 
 ---
 test_name: PUT /security/config

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -568,7 +568,7 @@ test_name: PUT /security/users/{user_id}/run_as
 
 stages:
 
-  - name: Update user's run_as flag
+  - name: Update user's allow_run_as flag
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/users/103/run_as"
@@ -588,7 +588,7 @@ stages:
               allow_run_as: true
           total_affected_items: 1
 
-  - name: Update user's run_as flag (invalid_user)
+  - name: Update user's allow_run_as flag (invalid_user)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/users/INVALID/run_as"
@@ -600,7 +600,7 @@ stages:
     response:
       status_code: 400
 
-  - name: Update user's run_as flag (nonexistent user)
+  - name: Update user's allow_run_as flag (nonexistent user)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/users/999/run_as"

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -537,6 +537,8 @@ class WazuhException(Exception):
                               'any other user with the necessary permissions'},
         5009: {'message': 'Insecure user password provided',
                'remediation': 'The password must contain a length between 8 and 64 characters.'},
+        5010: {'message': 'The value of the parameter run_as is invalid',
+               'remediation': 'The value of the run_as parameter must be true (enable authentication through authorization context) or false (disable authentication through authorization context).'},
 
         # Security issues
         6000: {'message': 'Limit of login attempts reached. '

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -537,8 +537,8 @@ class WazuhException(Exception):
                               'any other user with the necessary permissions'},
         5009: {'message': 'Insecure user password provided',
                'remediation': 'The password must contain a length between 8 and 64 characters.'},
-        5010: {'message': 'The value of the parameter run_as is invalid',
-               'remediation': 'The value of the run_as parameter must be true (enable authentication through authorization context) or false (disable authentication through authorization context).'},
+        5010: {'message': 'The value of the parameter allow_run_as is invalid',
+               'remediation': 'The value of the allow_run_as parameter must be true (enabled authentication through authorization context) or false (disabled authentication through authorization context).'},
 
         # Security issues
         6000: {'message': 'Limit of login attempts reached. '

--- a/framework/wazuh/core/tests/test_common.py
+++ b/framework/wazuh/core/tests/test_common.py
@@ -43,7 +43,6 @@ def test_context_cached():
     @context_cached('foobar')
     def foo(arg='bar', **data):
         test_context_cached.calls_to_foo += 1
-        print(data)
         return arg
 
     # The result of function 'foo' is being cached and it has been called once

--- a/framework/wazuh/rbac/default/policies.yaml
+++ b/framework/wazuh/rbac/default/policies.yaml
@@ -69,6 +69,7 @@ default_policies:
           - security:read_config
           - security:update_config
           - security:revoke
+          - security:run_as
         resources:
           - '*:*:*'
         effect: allow
@@ -91,6 +92,7 @@ default_policies:
         actions:
           - security:create_user
           - security:revoke
+          - security:run_as
         resources:
           - '*:*:*'
         effect: allow
@@ -101,6 +103,16 @@ default_policies:
           - security:delete
         resources:
           - user:id:*
+        effect: allow
+
+  users_modify_run_as:
+    description: Allow change the run_as value of the users.
+    policies:
+      flag:
+        actions:
+          - security:run_as
+        resources:
+          - '*:*:*'
         effect: allow
 
   ciscat_read:

--- a/framework/wazuh/rbac/default/policies.yaml
+++ b/framework/wazuh/rbac/default/policies.yaml
@@ -69,7 +69,7 @@ default_policies:
           - security:read_config
           - security:update_config
           - security:revoke
-          - security:run_as
+          - security:edit_run_as
         resources:
           - '*:*:*'
         effect: allow
@@ -92,7 +92,7 @@ default_policies:
         actions:
           - security:create_user
           - security:revoke
-          - security:run_as
+          - security:edit_run_as
         resources:
           - '*:*:*'
         effect: allow
@@ -106,11 +106,11 @@ default_policies:
         effect: allow
 
   users_modify_run_as:
-    description: Allow change the run_as value of the users.
+    description: Allow changing the allow_run_as value of the users.
     policies:
       flag:
         actions:
-          - security:run_as
+          - security:edit_run_as
         resources:
           - '*:*:*'
         effect: allow

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -675,7 +675,35 @@ class AuthenticationManager:
     It manages users and token generation.
     """
 
-    def add_user(self, username: str, password: str, allow_run_as: bool = False, check_default: bool = True):
+    def enable_run_as(self, user_id: int, allow_run_as: bool):
+        """Change the specified user's run_as flag.
+
+        Parameters
+        ----------
+        user_id : int
+            Unique user id
+        allow_run_as : bool
+            Flag that indicates if the user can log into the API throw an authorization context
+
+        Returns
+        -------
+        True if the user's flag has been modified successfully.
+        INVALID if the specified value is not correct. False otherwise.
+        """
+        try:
+            user = self.session.query(User).filter_by(id=user_id).first()
+            if user is not None:
+                if isinstance(allow_run_as, bool):
+                    user.allow_run_as = allow_run_as
+                    self.session.commit()
+                    return True
+                return SecurityError.INVALID
+            return False
+        except IntegrityError:
+            self.session.rollback()
+            return False
+
+    def add_user(self, username: str, password: str, check_default: bool = True):
         """Creates a new user if it does not exist.
 
         Parameters
@@ -684,8 +712,6 @@ class AuthenticationManager:
             Unique user name
         password : str
             Password provided by user. It will be stored hashed
-        allow_run_as : bool
-            Flag that indicates if the user can log into the API throw an authorization context
         check_default : bool
             Flag that indicates if the user ID can be less than max_id_reserved
 
@@ -701,15 +727,14 @@ class AuthenticationManager:
                     user_id = max_id_reserved + 1
             except (TypeError, AttributeError):
                 pass
-            self.session.add(User(username=username, password=generate_password_hash(password),
-                                  allow_run_as=allow_run_as, user_id=user_id))
+            self.session.add(User(username=username, password=generate_password_hash(password), user_id=user_id))
             self.session.commit()
             return True
         except IntegrityError:
             self.session.rollback()
             return False
 
-    def update_user(self, user_id: int, password: str, allow_run_as: bool):
+    def update_user(self, user_id: int, password: str):
         """Update the password an existent user
 
         Parameters
@@ -718,8 +743,6 @@ class AuthenticationManager:
             Unique user id
         password : str
             Password provided by user. It will be stored hashed
-        allow_run_as : bool
-            Enable authorization context login method for the new user
 
         Returns
         -------
@@ -730,9 +753,6 @@ class AuthenticationManager:
             if user is not None:
                 if password:
                     user.password = generate_password_hash(password)
-                if allow_run_as is not None:
-                    user.allow_run_as = allow_run_as
-                if password or allow_run_as is not None:
                     self.session.commit()
                     return True
             return False
@@ -2436,8 +2456,8 @@ with open(os.path.join(default_path, "users.yaml"), 'r') as stream:
 
     with AuthenticationManager() as auth:
         for d_username, payload in default_users[next(iter(default_users))].items():
-            auth.add_user(username=d_username, password=payload['password'],
-                          allow_run_as=payload['allow_run_as'], check_default=False)
+            auth.add_user(username=d_username, password=payload['password'], check_default=False)
+            auth.enable_run_as(user_id=auth.get_user(username=d_username)['id'], allow_run_as=payload['allow_run_as'])
 
 # Create default roles if they don't exist yet
 with open(os.path.join(default_path, "roles.yaml"), 'r') as stream:

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -675,15 +675,15 @@ class AuthenticationManager:
     It manages users and token generation.
     """
 
-    def enable_run_as(self, user_id: int, allow_run_as: bool):
-        """Change the specified user's run_as flag.
+    def edit_run_as(self, user_id: int, allow_run_as: bool):
+        """Change the specified user's allow_run_as flag.
 
         Parameters
         ----------
         user_id : int
             Unique user id
         allow_run_as : bool
-            Flag that indicates if the user can log into the API throw an authorization context
+            Flag that indicates if the user can log into the API through an authorization context
 
         Returns
         -------
@@ -2457,7 +2457,7 @@ with open(os.path.join(default_path, "users.yaml"), 'r') as stream:
     with AuthenticationManager() as auth:
         for d_username, payload in default_users[next(iter(default_users))].items():
             auth.add_user(username=d_username, password=payload['password'], check_default=False)
-            auth.enable_run_as(user_id=auth.get_user(username=d_username)['id'], allow_run_as=payload['allow_run_as'])
+            auth.edit_run_as(user_id=auth.get_user(username=d_username)['id'], allow_run_as=payload['allow_run_as'])
 
 # Create default roles if they don't exist yet
 with open(os.path.join(default_path, "roles.yaml"), 'r') as stream:

--- a/framework/wazuh/rbac/tests/test_orm.py
+++ b/framework/wazuh/rbac/tests/test_orm.py
@@ -306,12 +306,21 @@ def test_delete_all_policies(db_setup):
         assert len_policies == len(pm.get_policies()) + 2
 
 
+def test_enable_run_as(db_setup):
+    """Check update a user's run_as flag in the database"""
+    with db_setup.AuthenticationManager() as am:
+        am.add_user(username='runas', password='testingA6!')
+        assert am.enable_run_as(user_id='106', allow_run_as=True)
+        assert am.enable_run_as(user_id='106', allow_run_as="INVALID") == db_setup.SecurityError.INVALID
+        assert not am.enable_run_as(user_id='999', allow_run_as=False)
+
+
 def test_update_user(db_setup):
     """Check update a user in the database"""
     with db_setup.AuthenticationManager() as am:
         am.add_user(username='toUpdate', password='testingA6!')
-        assert am.update_user(user_id='106', password='testingA0!', allow_run_as=False)
-        assert not am.update_user(user_id='999', password='testingA0!', allow_run_as=True)
+        assert am.update_user(user_id='106', password='testingA0!')
+        assert not am.update_user(user_id='999', password='testingA0!')
 
 
 def test_update_role(db_setup):

--- a/framework/wazuh/rbac/tests/test_orm.py
+++ b/framework/wazuh/rbac/tests/test_orm.py
@@ -306,13 +306,13 @@ def test_delete_all_policies(db_setup):
         assert len_policies == len(pm.get_policies()) + 2
 
 
-def test_enable_run_as(db_setup):
-    """Check update a user's run_as flag in the database"""
+def test_edit_run_as(db_setup):
+    """Check update a user's allow_run_as flag in the database"""
     with db_setup.AuthenticationManager() as am:
         am.add_user(username='runas', password='testingA6!')
-        assert am.enable_run_as(user_id='106', allow_run_as=True)
-        assert am.enable_run_as(user_id='106', allow_run_as="INVALID") == db_setup.SecurityError.INVALID
-        assert not am.enable_run_as(user_id='999', allow_run_as=False)
+        assert am.edit_run_as(user_id='106', allow_run_as=True)
+        assert am.edit_run_as(user_id='106', allow_run_as="INVALID") == db_setup.SecurityError.INVALID
+        assert not am.edit_run_as(user_id='999', allow_run_as=False)
 
 
 def test_update_user(db_setup):

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -113,7 +113,40 @@ def get_users(user_ids: list = None, offset: int = 0, limit: int = common.databa
 
 
 @expose_resources(actions=['security:create_user'], resources=['*:*:*'])
-def create_user(username: str = None, password: str = None, allow_run_as: bool = False):
+def enable_run_as(user_id: str = None, allow_run_as: bool = False):
+    """Enable/Disable the user's run_as flag
+
+    Parameters
+    ----------
+    user_id : str
+        User ID
+    allow_run_as : bool
+        Enable authorization context login method for the new user
+
+    Returns
+    -------
+    result : AffectedItemsWazuhResult
+        Status message
+    """
+    result = AffectedItemsWazuhResult(none_msg='The parameter run_as could not be enabled for the user',
+                                      all_msg='Parameter run_as has been enabled for the user')
+    with AuthenticationManager() as auth:
+        user_id = int(user_id)
+        query = auth.enable_run_as(user_id, allow_run_as)
+        if query is False:
+            result.add_failed_item(id_=user_id, error=WazuhError(5001))
+        elif query is SecurityError.INVALID:
+            result.add_failed_item(id_=user_id, error=WazuhError(5010))
+        else:
+            result.affected_items.append(auth.get_user_id(user_id))
+            result.total_affected_items += 1
+            invalid_users_tokens(users=[user_id])
+
+    return result
+
+
+@expose_resources(actions=['security:create_user'], resources=['*:*:*'])
+def create_user(username: str = None, password: str = None):
     """Create a new user
 
     Parameters
@@ -122,8 +155,6 @@ def create_user(username: str = None, password: str = None, allow_run_as: bool =
         Name for the new user
     password : str
         Password for the new user
-    allow_run_as : bool
-        Enable authorization context login method for the new user
 
     Returns
     -------
@@ -138,7 +169,7 @@ def create_user(username: str = None, password: str = None, allow_run_as: bool =
     result = AffectedItemsWazuhResult(none_msg='User could not be created',
                                       all_msg='User was successfully created')
     with AuthenticationManager() as auth:
-        if auth.add_user(username, password, allow_run_as=allow_run_as):
+        if auth.add_user(username, password):
             operation = auth.get_user(username)
             if operation:
                 result.affected_items.append(operation)
@@ -152,7 +183,7 @@ def create_user(username: str = None, password: str = None, allow_run_as: bool =
 
 
 @expose_resources(actions=['security:update'], resources=['user:id:{user_id}'])
-def update_user(user_id: str = None, password: str = None, allow_run_as: bool = None):
+def update_user(user_id: str = None, password: str = None):
     """Update a specified user
 
     Parameters
@@ -161,14 +192,12 @@ def update_user(user_id: str = None, password: str = None, allow_run_as: bool = 
         User ID
     password : str
         Password for the new user
-    allow_run_as : bool
-        Enable authorization context login method for the new user
 
     Returns
     -------
     Status message
     """
-    if password is None and allow_run_as is None:
+    if password is None:
         raise WazuhError(4001)
     if password:
         if len(password) > 64 or len(password) < 8:
@@ -178,7 +207,7 @@ def update_user(user_id: str = None, password: str = None, allow_run_as: bool = 
     result = AffectedItemsWazuhResult(all_msg='User was successfully updated',
                                       none_msg='User could not be updated')
     with AuthenticationManager() as auth:
-        query = auth.update_user(int(user_id[0]), password, allow_run_as)
+        query = auth.update_user(int(user_id[0]), password)
         if query is False:
             result.add_failed_item(id_=int(user_id[0]), error=WazuhError(5001))
         else:

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -135,7 +135,7 @@ def enable_run_as(user_id: str = None, allow_run_as: bool = False):
         query = auth.enable_run_as(user_id, allow_run_as)
         if query is False:
             result.add_failed_item(id_=user_id, error=WazuhError(5001))
-        elif query is SecurityError.INVALID:
+        elif query == SecurityError.INVALID:
             result.add_failed_item(id_=user_id, error=WazuhError(5010))
         else:
             result.affected_items.append(auth.get_user_id(user_id))

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -112,27 +112,29 @@ def get_users(user_ids: list = None, offset: int = 0, limit: int = common.databa
     return result
 
 
-@expose_resources(actions=['security:run_as'], resources=['*:*:*'])
-def enable_run_as(user_id: str = None, allow_run_as: bool = False):
-    """Enable/Disable the user's run_as flag
+@expose_resources(actions=['security:edit_run_as'], resources=['*:*:*'])
+def edit_run_as(user_id: str = None, allow_run_as: bool = False):
+    """Enable/Disable the user's allow_run_as flag
 
     Parameters
     ----------
     user_id : str
         User ID
     allow_run_as : bool
-        Enable authorization context login method for the new user
+        Enable or disable authorization context login method for the specified user
 
     Returns
     -------
     result : AffectedItemsWazuhResult
         Status message
     """
-    result = AffectedItemsWazuhResult(none_msg='The parameter run_as could not be enabled for the user',
-                                      all_msg='Parameter run_as has been enabled for the user')
+    result = AffectedItemsWazuhResult(none_msg=f"The parameter allow_run_as could not be "
+                                               f"{'enabled' if allow_run_as else 'disabled'} for the user",
+                                      all_msg=f"Parameter allow_run_as has been "
+                                              f"{'enabled' if allow_run_as else 'disabled'} for the user")
     with AuthenticationManager() as auth:
         user_id = int(user_id)
-        query = auth.enable_run_as(user_id, allow_run_as)
+        query = auth.edit_run_as(user_id, allow_run_as)
         if query is False:
             result.add_failed_item(id_=user_id, error=WazuhError(5001))
         elif query == SecurityError.INVALID:

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -112,7 +112,7 @@ def get_users(user_ids: list = None, offset: int = 0, limit: int = common.databa
     return result
 
 
-@expose_resources(actions=['security:create_user'], resources=['*:*:*'])
+@expose_resources(actions=['security:run_as'], resources=['*:*:*'])
 def enable_run_as(user_id: str = None, allow_run_as: bool = False):
     """Enable/Disable the user's run_as flag
 

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -473,6 +473,19 @@ get_rbac_actions:
           effect: deny
         related_endpoints:
           - DELETE /rootcheck
+      rootcheck:run:
+        description: Run agents rootcheck scan
+        resources:
+          - agent:id
+          - agent:group
+        example:
+          actions:
+            - rootcheck:run
+          resources:
+            - agent:id:*
+          effect: allow
+        related_endpoints:
+          - PUT /rootcheck
       rootcheck:read:
         description: Access information from agents rootcheck database
         resources:
@@ -487,19 +500,6 @@ get_rbac_actions:
         related_endpoints:
           - GET /rootcheck/{agent_id}
           - GET /rootcheck/{agent_id}/last_scan
-      rootcheck:run:
-        description: Run agents rootcheck scan
-        resources:
-          - agent:id
-          - agent:group
-        example:
-          actions:
-            - rootcheck:run
-          resources:
-            - agent:id:*
-          effect: allow
-        related_endpoints:
-          - PUT /rootcheck
       rules:read:
         description: Read rules files
         resources:
@@ -667,6 +667,18 @@ get_rbac_actions:
           - GET /syscollector/{agent_id}/packages
           - GET /syscollector/{agent_id}/ports
           - GET /syscollector/{agent_id}/processes
+      security:run_as:
+        description: Change the value of the run_as flag for a user
+        resources:
+          - "*:*"
+        example:
+          actions:
+            - security:run_as
+          resources:
+            - "*:*:*"
+          effect: allow
+        related_endpoints:
+          - PUT /security/users/{user_id}/run_as
       security:read:
         description: Access information about system security resources
         resources:

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -667,13 +667,13 @@ get_rbac_actions:
           - GET /syscollector/{agent_id}/packages
           - GET /syscollector/{agent_id}/ports
           - GET /syscollector/{agent_id}/processes
-      security:run_as:
-        description: Change the value of the run_as flag for a user
+      security:edit_run_as:
+        description: Change the value of the allow_run_as flag for a user
         resources:
           - "*:*"
         example:
           actions:
-            - security:run_as
+            - security:edit_run_as
           resources:
             - "*:*:*"
           effect: allow

--- a/framework/wazuh/tests/data/security/users_test_cases.yml
+++ b/framework/wazuh/tests/data/security/users_test_cases.yml
@@ -1,0 +1,40 @@
+---
+enable_run_as:
+  - params:
+      user_id: 1
+      allow_run_as: False
+    result:
+      affected_items:
+        - id: 1
+          username: wazuh
+          allow_run_as: false
+          roles:
+            - 1
+      failed_items: {}
+  - params:
+      user_id: 2
+      allow_run_as: True
+    result:
+      affected_items:
+        - id: 2
+          username: wazuh-wui
+          allow_run_as: true
+          roles:
+            - 1
+      failed_items: {}
+  - params:
+      user_id: 2
+      allow_run_as: INVALID
+    result:
+      affected_items: []
+      failed_items:
+        "5010":
+          - 2
+  - params:
+      user_id: 999
+      allow_run_as: true
+    result:
+      affected_items: []
+      failed_items:
+        "5001":
+          - 999

--- a/framework/wazuh/tests/data/security/users_test_cases.yml
+++ b/framework/wazuh/tests/data/security/users_test_cases.yml
@@ -1,5 +1,5 @@
 ---
-enable_run_as:
+edit_run_as:
   - params:
       user_id: 1
       allow_run_as: False


### PR DESCRIPTION
|Related issue|
|---|
|#6651|

Hi team,

This PR closes #6651. In this PR we have added a new endpoint to enable/disable the run_as parameter of the users.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

### Unittests
```
adriiiprodri@wazuh pytest -xs  wazuh/tests
=========================================== test session starts ===========================================
platform linux -- Python 3.9.1, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/framework
plugins: metadata-1.11.0, html-3.1.1, tavern-1.13.1
collected 707 items                                                                                       

wazuh/tests/test_active_response.py ............
wazuh/tests/test_agent.py ....................................................................................
wazuh/tests/test_cdb_list.py ...............................................
wazuh/tests/test_ciscat.py .................................
wazuh/tests/test_cluster.py .....ss
wazuh/tests/test_decoders.py ...............................
wazuh/tests/test_group.py ........
wazuh/tests/test_logtest.py ......
wazuh/tests/test_manager.py ......................................
wazuh/tests/test_mitre.py ....................................................................................................................................................................................
wazuh/tests/test_rootcheck.py .................................................
wazuh/tests/test_rule.py ....................................................
wazuh/tests/test_sca.py .......
wazuh/tests/test_security.py .........................................................................
wazuh/tests/test_stats.py ................
wazuh/tests/test_syscheck.py ........................
wazuh/tests/test_syscollector.py ............
wazuh/tests/test_task.py ............................

========================= 705 passed, 2 skipped, 17 warnings in 76.24s (0:01:16) ==========================
```
```
adriiiprodri@wazuh pytest -xs  wazuh/core/tests 
=========================================== test session starts ===========================================
platform linux -- Python 3.9.1, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/framework
plugins: metadata-1.11.0, html-3.1.1, tavern-1.13.1
collected 647 items                                                                                       

wazuh/core/tests/test_active_response.py ..............
wazuh/core/tests/test_agent.py .........................................................................................................................................................
wazuh/core/tests/test_cdb_list.py .................................
wazuh/core/tests/test_common.py ......{}
wazuh/core/tests/test_configuration.py ..................................
wazuh/core/tests/test_decoder.py ................
wazuh/core/tests/test_input_validator.py ...
wazuh/core/tests/test_logtest.py ..
wazuh/core/tests/test_manager.py ...............................
wazuh/core/tests/test_ossec_queue.py ...................
wazuh/core/tests/test_pyDaemonModule.py ......
wazuh/core/tests/test_results.py ........................................
wazuh/core/tests/test_rootcheck.py ..........
wazuh/core/tests/test_rule.py ......................
wazuh/core/tests/test_stats.py ...
wazuh/core/tests/test_syscollector.py ...
wazuh/core/tests/test_utils.py ..................................................................................................................................................................................................................
wazuh/core/tests/test_wazuh_socket.py ....................
wazuh/core/tests/test_wdb.py .....................

==================================== 647 passed, 12 warnings in 2.85s =====================================
```
```
adriiiprodri@wazuh pytest -xs  wazuh/rbac/tests             
=========================================== test session starts ===========================================
platform linux -- Python 3.9.1, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/Desktop/git/wazuh/framework
plugins: metadata-1.11.0, html-3.1.1, tavern-1.13.1
collected 224 items                                                                                       

wazuh/rbac/tests/test_auth_context.py ..
wazuh/rbac/tests/test_decorators.py .........................................................................................................
wazuh/rbac/tests/test_default_configuration.py ....................................................
wazuh/rbac/tests/test_orm.py ......................................................
wazuh/rbac/tests/test_preprocessor.py ...........

=============================== 224 passed, 2 warnings in 248.96s (0:04:08) ===============================
```

### Integration tests
```
adriiiprodri@wazuh python3 run_tests.py -k security -rbac both
Collected tests [6]:
test_rbac_black_security_endpoints.tavern.yaml, test_rbac_white_security_endpoints.tavern.yaml, test_security_DELETE_endpoints.tavern.yaml, test_security_GET_endpoints.tavern.yaml, test_security_POST_endpoints.tavern.yaml, test_security_PUT_endpoints.tavern.yaml


test_rbac_black_security_endpoints.tavern.yaml 
	 25 passed, 27 warnings

test_rbac_white_security_endpoints.tavern.yaml 
	 25 passed, 27 warnings

test_security_DELETE_endpoints.tavern.yaml 
	 15 passed, 17 warnings

test_security_GET_endpoints.tavern.yaml 
	 18 passed, 20 warnings

test_security_POST_endpoints.tavern.yaml 
	 7 passed, 9 warnings

test_security_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings
```