### PR TITLE
Prevent FIM from raising false positives about group name changes due to a thread unsafe function

### DIFF
--- a/src/headers/syscheck_op.h
+++ b/src/headers/syscheck_op.h
@@ -278,7 +278,7 @@ char *get_user(int uid);
  * @param gid The group ID
  * @return The group name on success, an empty string on failure
  */
-const char *get_group(int gid);
+char *get_group(int gid);
 
 
 #else
@@ -356,7 +356,7 @@ int w_get_file_permissions(const char *file_path, char *permissions, int perm_si
  *
  * @return The group name on success, an empty string on failure
  */
-const char *get_group(__attribute__((unused)) int gid);
+char *get_group(__attribute__((unused)) int gid);
 
 /**
  * @brief Retrieves the group name and gid of a registry key.

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -593,9 +593,35 @@ char *get_user(int uid) {
     return user_name;
 }
 
-const char *get_group(int gid) {
-    struct group *group = getgrgid(gid);
-    return group ? group->gr_name : "";
+char *get_group(int gid) {
+    struct group grp;
+    struct group *result;
+    char *group_name = NULL;
+    char *buf;
+    int bufsize;
+
+    bufsize = sysconf(_SC_GETGR_R_SIZE_MAX);
+    if (bufsize == -1) {
+        bufsize = 16384;
+    }
+
+    os_calloc(bufsize, sizeof(char), buf);
+
+    result = w_getgrgid(gid, &grp, buf, bufsize);
+
+    if (result == NULL) {
+        if (errno == 0) {
+            mdebug2("Group with gid '%d' not found.\n", gid);
+        } else {
+            mdebug2("Failed getting group_name (%d): '%s'\n", errno, strerror(errno));
+        }
+    } else {
+        os_strdup(grp.gr_name, group_name);
+    }
+
+    os_free(buf);
+
+    return group_name;
 }
 
 /* Send a one-way message to Syscheck */
@@ -921,8 +947,11 @@ unsigned int w_get_file_attrs(const char *file_path) {
     return attrs;
 }
 
-const char *get_group(__attribute__((unused)) int gid) {
-    return "";
+char *get_group(__attribute__((unused)) int gid) {
+    char *result;
+
+    os_strdup("", result);
+    return result;
 }
 
 char *get_registry_group(char **sid, HANDLE hndl) {

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -169,6 +169,7 @@ void free_whodata_event(whodata_evt *w_evt) {
     if (w_evt->effective_name) free(w_evt->effective_name);
     if (w_evt->effective_uid) free(w_evt->effective_uid);
     if (w_evt->group_id) free(w_evt->group_id);
+    if (w_evt->group_name) free(w_evt->group_name);
     if (w_evt->parent_name) free(w_evt->parent_name);
     if (w_evt->parent_cwd) free(w_evt->parent_cwd);
     if (w_evt->inode) free(w_evt->inode);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -712,7 +712,7 @@ fim_file_data * fim_get_data(const char *file, fim_element *item) {
         snprintf(aux, OS_SIZE_64, "%u", item->statbuf.st_gid);
         os_strdup(aux, data->gid);
 
-        os_strdup((char*)get_group(item->statbuf.st_gid), data->group_name);
+        data->group_name = get_group(item->statbuf.st_gid);
     }
 #endif
 
@@ -1129,24 +1129,13 @@ void free_file_data(fim_file_data * data) {
     if (!data) {
         return;
     }
-    if (data->perm) {
-        os_free(data->perm);
-    }
-    if (data->attributes) {
-        os_free(data->attributes);
-    }
-    if (data->uid) {
-        os_free(data->uid);
-    }
-    if (data->gid) {
-        os_free(data->gid);
-    }
-    if (data->user_name) {
-        os_free(data->user_name);
-    }
-    if (data->group_name) {
-        os_free(data->group_name);
-    }
+
+    os_free(data->perm);
+    os_free(data->attributes);
+    os_free(data->uid);
+    os_free(data->gid);
+    os_free(data->user_name);
+    os_free(data->group_name);
 
     os_free(data);
 }

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -743,7 +743,7 @@ void audit_parse(char *buffer) {
                 match_size = match[1].rm_eo - match[1].rm_so;
                 os_malloc(match_size + 1, w_evt->group_id);
                 snprintf (w_evt->group_id, match_size + 1, "%.*s", match_size, buffer + match[1].rm_so);
-                w_evt->group_name = (char*)get_group(atoi(w_evt->group_id));
+                w_evt->group_name = get_group(atoi(w_evt->group_id));
             }
             // process_id
             if(regexec(&regexCompiled_pid, buffer, 2, match, 0) == 0) {

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -77,7 +77,7 @@ endif()
 
 list(APPEND shared_tests_names "test_syscheck_op")
 set(SYSCHECK_OP_BASE_FLAGS "-Wl,--wrap,rmdir_ex -Wl,--wrap,wreaddir -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 \
-                            -Wl,--wrap,_mwarn -Wl,--wrap,_merror -Wl,--wrap,getpwuid_r -Wl,--wrap,getgrgid \
+                            -Wl,--wrap,_mwarn -Wl,--wrap,_merror -Wl,--wrap,getpwuid_r -Wl,--wrap,w_getgrgid \
                             -Wl,--wrap,wstr_split -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP \
                             -Wl,--wrap,sysconf -Wl,--wrap,getpid")
 if(${TARGET} STREQUAL "winagent")

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -88,7 +88,7 @@ static int setup_fim_data(void **state) {
     fim_data->w_evt->path = strdup("./test/test.file");
 #ifndef TEST_WINAGENT
     fim_data->w_evt->group_id = strdup("1000");
-    fim_data->w_evt->group_name = "testing";
+    fim_data->w_evt->group_name = strdup("testing");
     fim_data->w_evt->audit_uid = strdup("99");
     fim_data->w_evt->audit_name = strdup("audit_user");
     fim_data->w_evt->effective_uid = strdup("999");
@@ -469,7 +469,7 @@ void prepare_win_double_scan_success (char *test_file_path, char *dir_file_path,
     // fim_file
     {
         // fim_get_data
-        expect_get_data(strdup("user"), "group", test_file_path, 0);
+        expect_get_data(strdup("user"), strdup("group"), test_file_path, 0);
 
         expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
         expect_string(__wrap_fim_db_get_path, file_path, test_file_path);
@@ -1274,7 +1274,7 @@ static void test_fim_file_add(void **state) {
 #ifdef TEST_WINAGENT
     expect_function_call(__wrap_pthread_mutex_lock);
 #endif
-    expect_get_data(strdup("user"), "group", file_path, 1);
+    expect_get_data(strdup("user"), strdup("group"), file_path, 1);
 
     expect_value(__wrap_fim_db_get_path, fim_sql, syscheck.database);
     expect_string(__wrap_fim_db_get_path, file_path, file_path);
@@ -1483,7 +1483,7 @@ static void test_fim_file_error_on_insert(void **state) {
     // Inside fim_get_data
 #ifndef TEST_WINAGENT
     expect_get_user(0, strdup("user"));
-    expect_get_group(0, "group");
+    expect_get_group(0, strdup("group"));
 #else
     expect_get_file_user("file", "0", strdup("user"));
     expect_w_get_file_permissions("file", "permissions", 0);
@@ -1712,7 +1712,7 @@ static void test_fim_checker_fim_regular(void **state) {
     will_return(__wrap_get_user, strdup("user"));
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "group");
+    will_return(__wrap_get_group, strdup("group"));
 
     expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 999, 1, NULL);
 
@@ -1758,7 +1758,7 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     will_return(__wrap_get_user, strdup("user"));
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "group");
+    will_return(__wrap_get_group, strdup("group"));
 
     expect_wrapper_fim_db_get_paths_from_inode(syscheck.database, 999, 1, NULL);
 
@@ -1936,7 +1936,7 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
     will_return(__wrap_get_user, strdup("user"));
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "group");
+    will_return(__wrap_get_group, strdup("group"));
 
     expect_value(__wrap_fim_db_get_paths_from_inode, fim_sql, syscheck.database);
     expect_any(__wrap_fim_db_get_paths_from_inode, inode);
@@ -3601,7 +3601,7 @@ static void test_fim_get_data(void **state) {
                                     CHECK_SHA1SUM |
                                     CHECK_SHA256SUM;
 
-    expect_get_data(strdup("user"), "group", "test", 1);
+    expect_get_data(strdup("user"), strdup("group"), "test", 1);
     fim_data->local_data = fim_get_data("test", fim_data->item);
 
 #ifndef TEST_WINAGENT
@@ -3634,7 +3634,7 @@ static void test_fim_get_data_no_hashes(void **state) {
                                     CHECK_OWNER |
                                     CHECK_GROUP;
 
-    expect_get_data(strdup("user"), "group", "test", 0);
+    expect_get_data(strdup("user"), strdup("group"), "test", 0);
 
 
     fim_data->local_data = fim_get_data("test", fim_data->item);
@@ -3662,7 +3662,7 @@ static void test_fim_get_data_hash_error(void **state) {
     buf.st_gid = 0;
     fim_data->item->statbuf = buf;
 
-    expect_get_data(strdup("user"), "group", "test", 0);
+    expect_get_data(strdup("user"), strdup("group"), "test", 0);
 
     expect_string(__wrap_OS_MD5_SHA1_SHA256_File, fname, "test");
 #ifndef TEST_WINAGENT

--- a/src/unit_tests/syscheckd/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/test_syscheck_audit.c
@@ -1293,7 +1293,7 @@ void test_audit_parse(void **state) {
     expect_string(__wrap__mdebug1, formatted_msg, "(6334): Audit: Invalid 'auid' value read. Check Audit configuration (PAM).");
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "root");
+    will_return(__wrap_get_group, strdup("root"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -1338,7 +1338,7 @@ void test_audit_parse3(void **state) {
     will_return(__wrap_get_user, strdup("root"));
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "root");
+    will_return(__wrap_get_group, strdup("root"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -1382,7 +1382,7 @@ void test_audit_parse4(void **state) {
     will_return(__wrap_get_user, strdup("root"));
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "root");
+    will_return(__wrap_get_group, strdup("root"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -1439,7 +1439,7 @@ void test_audit_parse_hex(void **state) {
     will_return(__wrap_get_user, strdup("root"));
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "root");
+    will_return(__wrap_get_group, strdup("root"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -1632,7 +1632,7 @@ void test_audit_parse_mv(void **state) {
     will_return(__wrap_get_user, strdup("user50"));
 
     expect_value(__wrap_get_group, gid, 40);
-    will_return(__wrap_get_group, "src");
+    will_return(__wrap_get_group, strdup("src"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -1678,7 +1678,7 @@ void test_audit_parse_mv_hex(void **state) {
     will_return(__wrap_get_user, strdup("user50"));
 
     expect_value(__wrap_get_group, gid, 40);
-    will_return(__wrap_get_group, "src");
+    will_return(__wrap_get_group, strdup("src"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -1722,7 +1722,7 @@ void test_audit_parse_rm(void **state) {
     will_return(__wrap_get_user, strdup("daemon"));
 
     expect_value(__wrap_get_group, gid, 5);
-    will_return(__wrap_get_group, "tty");
+    will_return(__wrap_get_group, strdup("tty"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -1764,7 +1764,7 @@ void test_audit_parse_chmod(void **state) {
     will_return(__wrap_get_user, strdup("user29"));
 
     expect_value(__wrap_get_group, gid, 78);
-    will_return(__wrap_get_group, "");
+    will_return(__wrap_get_group, NULL);
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -1867,7 +1867,7 @@ void test_audit_parse_delete_folder(void **state) {
     will_return(__wrap_get_user, strdup("root"));
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "root");
+    will_return(__wrap_get_group, strdup("root"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -1920,7 +1920,7 @@ void test_audit_parse_delete_folder_hex(void **state) {
     will_return(__wrap_get_user, strdup("root"));
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "root");
+    will_return(__wrap_get_group, strdup("root"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -1977,7 +1977,7 @@ void test_audit_parse_delete_folder_hex3_error(void **state) {
     will_return(__wrap_get_user, strdup("root"));
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "root");
+    will_return(__wrap_get_group, strdup("root"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -2029,7 +2029,7 @@ void test_audit_parse_delete_folder_hex4_error(void **state) {
     will_return(__wrap_get_user, strdup("root"));
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "root");
+    will_return(__wrap_get_group, strdup("root"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -2083,7 +2083,7 @@ void test_audit_parse_delete_folder_hex5_error(void **state) {
     will_return(__wrap_get_user, strdup("root"));
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "root");
+    will_return(__wrap_get_group, strdup("root"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -2285,7 +2285,7 @@ void test_audit_read_events_select_case_0(void **state) {
     will_return(__wrap_get_user, strdup("root"));
 
     expect_value(__wrap_get_group, gid, 0);
-    will_return(__wrap_get_group, "root");
+    will_return(__wrap_get_group, strdup("root"));
 
     will_return(__wrap_readlink, 0);
     will_return(__wrap_readlink, 0);
@@ -2446,7 +2446,7 @@ void test_audit_read_events_select_success_recv_success(void **state) {
         will_return(__wrap_get_user, strdup("root"));
 
         expect_value(__wrap_get_group, gid, 0);
-        will_return(__wrap_get_group, "root");
+        will_return(__wrap_get_group, strdup("root"));
 
         will_return(__wrap_readlink, 0);
         will_return(__wrap_readlink, 0);

--- a/src/unit_tests/wrappers/wazuh/shared/privsep_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/privsep_op_wrappers.c
@@ -13,6 +13,33 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
+#include <string.h>
+
+#ifndef WIN32
+struct group *__wrap_w_getgrgid(gid_t gid, struct group *grp, char *buf, int buflen) {
+    struct group *mock_grp;
+    char *mock_buf;
+    check_expected(gid);
+
+    mock_grp = mock_type(struct group *);
+
+    if (mock_grp && grp) {
+        memcpy(grp, mock_grp, sizeof(char **) + 2 * sizeof(char *) + sizeof(gid_t));
+    }
+
+    mock_buf = mock_type(char *);
+    if (mock_buf && buf) {
+        strncpy(buf, mock_buf, buflen);
+    }
+
+    if (mock()) {
+        return grp;
+    } else {
+        return NULL;
+    }
+}
+#endif
+
 int __wrap_Privsep_GetUser(const char *name) {
     check_expected(name);
 

--- a/src/unit_tests/wrappers/wazuh/shared/privsep_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/privsep_op_wrappers.h
@@ -11,6 +11,12 @@
 #ifndef PRIVSEP_OP_WRAPPERS_H
 #define PRIVSEP_OP_WRAPPERS_H
 
+#ifndef WIN32
+#include <pwd.h>
+
+struct group *__wrap_w_getgrgid(gid_t gid, struct group *grp,  char *buf, int buflen);
+#endif
+
 int __wrap_Privsep_GetUser(const char *name);
 
 int __wrap_Privsep_GetGroup(const char *name);

--- a/src/unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.c
@@ -25,9 +25,9 @@ int __wrap_delete_target_file(const char *path) {
     return mock();
 }
 
-const char *__wrap_get_group(int gid) {
+char *__wrap_get_group(int gid) {
     check_expected(gid);
-    return mock_type(const char*);
+    return mock_type(char*);
 }
 
 #ifndef WIN32

--- a/src/unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/syscheck_op_wrappers.h
@@ -20,7 +20,7 @@ char *__wrap_decode_win_permissions(char *raw_perm);
 
 int __wrap_delete_target_file(const char *path);
 
-const char *__wrap_get_group(int gid);
+char *__wrap_get_group(int gid);
 
 #ifndef WIN32
 char *__wrap_get_user(int uid);


### PR DESCRIPTION
|Related issue|
|---|
|#6592|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #6592 by making calls to `get_group` thread safe. We achieve this by replacing the inner call to `getgrgid` with a call to `w_getgrgid` which uses `getgrgid_r` and adapts it so that the call is the same whether we are in Linux or Solaris.
<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Source upgrade
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
