### PR TITLE
Fix migration process to overwrite default policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
   - Fixed a bug that caused an error when attempting to use an IAM Role with **CloudWatchLogs** service. ([#7330](https://github.com/wazuh/wazuh/pull/7330))
 - **Framework:**
   - Fixed a race condition bug when using RBAC expand_group function. ([#7353](https://github.com/wazuh/wazuh/pull/7353))
+  - Fix migration process to overwrite default RBAC policies. ([#7594](https://github.com/wazuh/wazuh/pull/7594))  
 - **Core:**
   - Fixed a bug in Windows agent that did not honor the buffer's EPS limit. ([#7333](https://github.com/wazuh/wazuh/pull/7333))
   - Fixed a bug in Integratord that might lose alerts from Analysisd due to a race condition. ([#7338](https://github.com/wazuh/wazuh/pull/7338))

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -26,6 +26,7 @@ from api.constants import SECURITY_PATH
 
 # Max reserved ID value
 max_id_reserved = 99
+cloud_reserved_range = 89
 
 # Start a session and set the default security elements
 _auth_db_file = os.path.join(SECURITY_PATH, 'rbac.db')
@@ -1342,13 +1343,8 @@ class PoliciesManager:
 
                         try:
                             if not check_default:
-                                policies = sorted([p.id for p in self.get_policies()])
-                                for p_id in policies or [0]:
-                                    if policy_id and p_id - policy_id > 1:
-                                        break
-                                    else:
-                                        policy_id = p_id
-                                policy_id += 1
+                                policies = sorted([p.id for p in self.get_policies()]) or [0]
+                                policy_id = max(filter(lambda x: not(x > cloud_reserved_range), policies)) + 1
 
                             elif check_default and \
                                     self.session.query(Policies).order_by(desc(Policies.id)
@@ -1366,7 +1362,6 @@ class PoliciesManager:
                     return SecurityError.INVALID
             else:
                 return SecurityError.INVALID
-            return False
         except IntegrityError:
             self.session.rollback()
             return SecurityError.ALREADY_EXIST

--- a/framework/wazuh/tests/data/security/default/default_cases.yml
+++ b/framework/wazuh/tests/data/security/default/default_cases.yml
@@ -1,0 +1,48 @@
+---
+add_role:
+  - params:
+      name: new_role1
+  - params:
+      name: new_role2
+
+add_policy:
+  - params:
+      name: new_policy1
+      policy:
+        actions:
+          - agent:delete
+        effect: allow
+        resources:
+          - agent:id:099
+  - params:
+      name: new_policy2
+      policy:
+        actions:
+          - agent:delete
+        effect: allow
+        resources:
+          - agent:id:098
+  - params:
+      name: user_policy
+      policy:
+        actions:
+          - agent:read
+        effect: allow
+        resources:
+          - agent:id:098
+
+set_role_policy:
+  - params:
+      role_id:
+        - 100
+      policy_ids:
+        - 100
+        - 102
+        - 101
+  - params:
+      role_id:
+        - 101
+      policy_ids:
+        - 102
+        - 101
+        - 100

--- a/framework/wazuh/tests/data/security/default/migration_policies.yml
+++ b/framework/wazuh/tests/data/security/default/migration_policies.yml
@@ -1,0 +1,22 @@
+default_policies:
+  new:
+    description: New default policies
+    policies:
+      policy1:
+        actions:
+          - agent:read
+        resources:
+          - agent:id:777
+        effect: allow
+      policy2:
+        actions:
+          - agent:read
+        resources:
+          - agent:id:888
+        effect: allow
+      policy3:
+        actions:
+          - group:read
+        resources:
+          - group:id:333
+        effect: allow

--- a/framework/wazuh/tests/data/security/default/mock_relationships.yml
+++ b/framework/wazuh/tests/data/security/default/mock_relationships.yml
@@ -1,0 +1,3 @@
+relationships:
+  users: {}
+  roles: {}

--- a/framework/wazuh/tests/data/security/default/new_default_policies.yml
+++ b/framework/wazuh/tests/data/security/default/new_default_policies.yml
@@ -1,0 +1,20 @@
+default_policies:
+  new:
+    description: Already existing policy
+    policies:
+      policy1:
+        actions:
+          - agent:read
+        resources:
+          - agent:id:888
+        effect: allow
+
+  another:
+    description: New default policy
+    policies:
+      policy:
+        actions:
+          - agent:read
+        resources:
+          - agent:id:578
+        effect: allow

--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -23,6 +23,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 
 security_cases = list()
 rbac_cases = list()
+default_orm_engine = create_engine("sqlite:///:memory:")
 os.chdir(test_data_path)
 
 for file in glob.glob('*.yml'):
@@ -46,6 +47,20 @@ def create_memory_db(sql_file, session):
                 session.commit()
 
 
+def reload_default_rbac_resources():
+    with patch('wazuh.core.common.ossec_uid'), patch('wazuh.core.common.ossec_gid'):
+        with patch('sqlalchemy.create_engine', return_value=default_orm_engine):
+            with patch('shutil.chown'), patch('os.chmod'):
+                import wazuh.rbac.orm as orm
+                reload(orm)
+                import wazuh.rbac.decorators as decorators
+                from wazuh.tests.util import RBAC_bypasser
+
+                decorators.expose_resources = RBAC_bypasser
+                from wazuh import security
+    return security, orm
+
+
 @pytest.fixture(scope='function')
 def db_setup():
     with patch('wazuh.core.common.ossec_uid'), patch('wazuh.core.common.ossec_gid'):
@@ -67,6 +82,20 @@ def db_setup():
         pass
 
     yield security, WazuhResult, core_security
+
+
+@pytest.fixture(scope='function')
+def new_default_resources():
+    security, orm = reload_default_rbac_resources()
+
+    with open(os.path.join(test_data_path, 'default', 'default_cases.yml')) as f:
+        new_resources = safe_load(f)
+
+    for function_, cases in new_resources.items():
+        for case in cases:
+            getattr(security, function_)(**case['params']).to_dict()
+
+    return security, orm
 
 
 def affected_are_equal(target_dict, expected_dict):
@@ -205,3 +234,103 @@ def test_invalid_roles_tokens(db_setup, role_list, expected_roles):
         _, _, core_security = db_setup
         core_security.invalid_roles_tokens(roles=[role_id for role_id in role_list])
         assert set(TM_mock.call_args.kwargs['roles']) == expected_roles
+
+
+def test_add_new_default_policies(new_default_resources):
+    """Check that new default policies are set in the correct range and that the migration proccess moves any possible
+    default policy in the user range to the default range."""
+
+    def mock_open_default_resources(*args, **kwargs):
+        args = list(args)
+        file_path = args[0]
+
+        if file_path.endswith('policies.yaml'):
+            new_args = [os.path.join(test_data_path, 'default', 'new_default_policies.yml')]
+        elif file_path.endswith('relationships.yaml'):
+            new_args = [os.path.join(test_data_path, 'default', 'mock_relationships.yml')]
+        else:
+            new_args = [file_path]
+
+        new_args += args[1:]
+
+        return open(*new_args, **kwargs)
+
+    security, orm = new_default_resources
+    with orm.PoliciesManager() as pm:
+        policies = sorted([p.id for p in pm.get_policies()]) or [1]
+        max_default_policy_id = max(filter(lambda x: not (x > orm.cloud_reserved_range), policies))
+
+    with patch('wazuh.rbac.orm.open', side_effect=mock_open_default_resources):
+        security, orm = reload_default_rbac_resources()
+
+    with orm.PoliciesManager() as pm:
+        new_policies = sorted([p.id for p in pm.get_policies()]) or [1]
+        new_max_default_policy_id = max(filter(lambda x: not (x > orm.cloud_reserved_range), new_policies))
+
+    assert len(policies) + 1 == len(new_policies)
+    assert max(policies) == max(new_policies)
+    assert max_default_policy_id + 2 == new_max_default_policy_id
+
+
+def test_migrate_default_policies(new_default_resources):
+    """Check that the migration process overwrites default policies in the user range including their relationships
+    and positions."""
+    def mock_open_default_resources(*args, **kwargs):
+        args = list(args)
+        file_path = args[0]
+
+        if file_path.endswith('policies.yaml'):
+            new_args = [os.path.join(test_data_path, 'default', 'migration_policies.yml')]
+        elif file_path.endswith('relationships.yaml'):
+            new_args = [os.path.join(test_data_path, 'default', 'mock_relationships.yml')]
+        else:
+            new_args = [file_path]
+
+        new_args += args[1:]
+
+        return open(*new_args, **kwargs)
+
+    security, orm = new_default_resources
+    with orm.RolesManager() as rm:
+        role1, role2 = rm.get_role('new_role1')['id'], rm.get_role('new_role2')['id']
+    policy1, policy2 = 'new_policy1', 'new_policy2'
+    user_policy = 'user_policy'
+    with orm.PoliciesManager() as pm:
+        policies = sorted([p.id for p in pm.get_policies()]) or [1]
+        max_default_policy_id = max(filter(lambda x: not (x > orm.cloud_reserved_range), policies))
+
+    with orm.RolesPoliciesManager() as rpm:
+        role1_policies = [p.id for p in rpm.get_all_policies_from_role(role_id=role1)]
+        role2_policies = [p.id for p in rpm.get_all_policies_from_role(role_id=role2)]
+
+    # Assert these new policies are in the user range
+    with orm.PoliciesManager() as pm:
+        policy1_id = pm.get_policy(policy1)['id']
+        policy2_id = pm.get_policy(policy2)['id']
+        user_policy_id = pm.get_policy(user_policy)['id']
+        assert policy1_id > orm.max_id_reserved
+        assert policy2_id > orm.max_id_reserved
+        assert user_policy_id > orm.max_id_reserved
+        assert {policy1_id, policy2_id, user_policy_id} == set(role1_policies)
+        assert {policy1_id, policy2_id, user_policy_id} == set(role2_policies)
+
+    with patch('wazuh.rbac.orm.open', side_effect=mock_open_default_resources):
+        security, orm = reload_default_rbac_resources()
+
+    with orm.RolesPoliciesManager() as rpm:
+        new_role1_policies = [p.id for p in rpm.get_all_policies_from_role(role_id=role1)]
+        new_role2_policies = [p.id for p in rpm.get_all_policies_from_role(role_id=role2)]
+
+    new_policy1_id, new_policy2_id = max_default_policy_id + 1, max_default_policy_id + 2
+    with orm.PoliciesManager() as pm:
+        assert new_policy1_id == pm.get_policy(policy1)['id']
+        assert new_policy2_id == pm.get_policy(policy2)['id']
+
+    assert role1_policies.index(policy1_id) == new_role1_policies.index(new_policy1_id)
+    assert role1_policies.index(policy2_id) == new_role1_policies.index(new_policy2_id)
+
+    assert role2_policies.index(policy1_id) == new_role2_policies.index(new_policy1_id)
+    assert role2_policies.index(policy2_id) == new_role2_policies.index(new_policy2_id)
+
+    assert role1_policies.index(user_policy_id) == new_role1_policies.index(user_policy_id)
+    assert role2_policies.index(user_policy_id) == new_role2_policies.index(user_policy_id)

--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -86,6 +86,9 @@ def db_setup():
 
 @pytest.fixture(scope='function')
 def new_default_resources():
+    global default_orm_engine
+    default_orm_engine = create_engine("sqlite:///:memory:")
+
     security, orm = reload_default_rbac_resources()
 
     with open(os.path.join(test_data_path, 'default', 'default_cases.yml')) as f:


### PR DESCRIPTION
Hello team,

With this PR we have improved the RBAC database migration process in order to manage default policies correctly. This development includes the correct handling of default policy IDs when there are user policies in the database. It also fixes any possible issue with them in case any default policy was added in the user range, including their previous relationships and positions within their linked roles.

New tests were added to check this new behaviour.

## Tests performed
### Unit tests
```
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /home/davidjiglesias/venvs/bin/python
cachedir: .pytest_cache
rootdir: /home/davidjiglesias/git/wazuh/framework
plugins: asyncio-0.14.0
collecting ... collected 71 items

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================== 71 passed, 3 warnings in 75.04s (0:01:15) ===================
```

Regards,
Víctor Fernández