### PR TITLE
Save the vulnerabilities found during the Vulnerability Detector scans in the agents' databases

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1240,6 +1240,8 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
 
     start_time = time(NULL);
 
+    int sock = wm_vuldet_get_wdb_socket();
+
     hash_node = OSHash_Begin(cve_table, &inode_it);
 
     while(hash_node) {
@@ -1310,7 +1312,7 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
             }
 
             //Save the vulnerability in the agent database
-            wdb_agents_vuln_cve_insert(atoi(report->agent_id), report->software, report->version, report->arch, report->cve, NULL);
+            wdb_agents_vuln_cve_insert(atoi(report->agent_id), report->software, report->version, report->arch, report->cve, &sock);
             // Sending CVE report
             if (wm_vuldet_send_cve_report(report)) {
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_SEND_AGENT_REPORT_ERROR, report->cve, report->software, atoi(agents_it->agent_id));
@@ -2023,8 +2025,10 @@ int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agent, w
         goto end;
     }
 
+    int sock = wm_vuldet_get_wdb_socket();
+
     //Clean the vulnerabilities in the agent database
-    wdb_agents_vuln_cve_clear(atoi(agent->agent_id), NULL);
+    wdb_agents_vuln_cve_clear(atoi(agent->agent_id), &sock);
 
     if (agent->dist == FEED_WIN) {
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -2039,7 +2039,7 @@ int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agent, w
 
     //Clean the vulnerabilities in the agent database
     if (OS_INVALID == wdb_agents_vuln_cve_clear(atoi(agent->agent_id), &sock)) {
-        mtwarn(WM_VULNDETECTOR_LOGTAG, "Failed to remove vulnerabilities from the agent %s database", agent->agent_id);
+        mtwarn(WM_VULNDETECTOR_LOGTAG, "Failed to clear vulnerabilities from the agent %s database", agent->agent_id);
     }
 
     if (agent->dist == FEED_WIN) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -16,6 +16,7 @@
 #include "wm_vuln_detector_evr.h"
 #include "addagent/manage_agents.h"
 #include "wazuh_db/helpers/wdb_global_helpers.h"
+#include "wazuh_db/helpers/wdb_agents_helpers.h"
 #include <netinet/tcp.h>
 #include <openssl/ssl.h>
 #include <os_net/os_net.h>
@@ -2021,6 +2022,9 @@ int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agent, w
         retval = 0;   // Scan next agent
         goto end;
     }
+
+    //Clean the vulnerabilities in the agent database
+    wdb_agents_vuln_cve_clear(atoi(agent->agent_id), NULL);
 
     if (agent->dist == FEED_WIN) {
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1235,6 +1235,7 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
     int vuln_reported = 0;
     int vuln_reported_nvd = 0;
     int vuln_reported_vendor = 0;
+    int cve_insert_result = OS_SUCCESS;
 
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_START_VUL_AG_SEND, atoi(agents_it->agent_id));
 
@@ -1312,7 +1313,12 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
             }
 
             //Save the vulnerability in the agent database
-            wdb_agents_vuln_cve_insert(atoi(report->agent_id), report->software, report->version, report->arch, report->cve, &sock);
+            if (OS_INVALID == wdb_agents_vuln_cve_insert(atoi(report->agent_id), report->software, report->version, report->arch, report->cve, &sock)) {
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to insert %s for package %s in the agent %s database",
+                         report->cve, report->software, report->agent_id);
+                cve_insert_result = OS_INVALID;
+            }
+
             // Sending CVE report
             if (wm_vuldet_send_cve_report(report)) {
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_SEND_AGENT_REPORT_ERROR, report->cve, report->software, atoi(agents_it->agent_id));
@@ -1334,6 +1340,10 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
     }
 
     wdb_finalize(stmt);
+
+    if (OS_INVALID == cve_insert_result) {
+        mtwarn(WM_VULNDETECTOR_LOGTAG, "Failed to insert vulnerabilities in the agent %s database", agents_it->agent_id);
+    }
 
     if (agents_it->dist != FEED_MAC) {
         mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_VULN_SEND_AG_FEED, vuln_reported_nvd, atoi(agents_it->agent_id), "NVD");
@@ -2028,7 +2038,9 @@ int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agent, w
     int sock = wm_vuldet_get_wdb_socket();
 
     //Clean the vulnerabilities in the agent database
-    wdb_agents_vuln_cve_clear(atoi(agent->agent_id), &sock);
+    if (OS_INVALID == wdb_agents_vuln_cve_clear(atoi(agent->agent_id), &sock)) {
+        mtwarn(WM_VULNDETECTOR_LOGTAG, "Failed to remove vulnerabilities from the agent %s database", agent->agent_id);
+    }
 
     if (agent->dist == FEED_WIN) {
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1308,6 +1308,8 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
                 }
             }
 
+            //Save the vulnerability in the agent database
+            wdb_agents_vuln_cve_insert(atoi(report->agent_id), report->software, report->version, report->arch, report->cve, NULL);
             // Sending CVE report
             if (wm_vuldet_send_cve_report(report)) {
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_SEND_AGENT_REPORT_ERROR, report->cve, report->software, atoi(agents_it->agent_id));

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2082,6 +2082,7 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
     char *last_mod;
     char *url;
     char *ref_source;
+    int cve_insert_result = OS_SUCCESS;
     int retval = OS_INVALID;
 
     int sock = wm_vuldet_get_wdb_socket();
@@ -2214,11 +2215,20 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
         snprintf(report->title, OS_SIZE_512, "%s affects %s", report->cve, report->software);
 
         //Save the vulnerability in the agent database
-        wdb_agents_vuln_cve_insert(atoi(report->agent_id), report->software, report->version, report->arch, report->cve, &sock);
+        if (OS_INVALID == wdb_agents_vuln_cve_insert(atoi(report->agent_id), report->software, report->version, report->arch, report->cve, &sock)) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to insert %s for package %s in the agent %s database",
+                        report->cve, report->software, report->agent_id);
+            cve_insert_result = OS_INVALID;
+        }
+
         // Sending CVE report
         wm_vuldet_send_cve_report(report);
         wm_vuldet_free_nvd_report(f_report_node);
         free(f_report_node);
+    }
+
+    if (OS_INVALID == cve_insert_result) {
+        mtwarn(WM_VULNDETECTOR_LOGTAG, "Failed to insert vulnerabilities in the agent %s database", agent->agent_id);
     }
 
     retval = 0;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2084,6 +2084,8 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
     char *ref_source;
     int retval = OS_INVALID;
 
+    int sock = wm_vuldet_get_wdb_socket();
+
     report_node = *nvd_report;
     while(report_node) {
         wm_vuldet_free_report(report);
@@ -2212,7 +2214,7 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
         snprintf(report->title, OS_SIZE_512, "%s affects %s", report->cve, report->software);
 
         //Save the vulnerability in the agent database
-        wdb_agents_vuln_cve_insert(atoi(report->agent_id), report->software, report->version, report->arch, report->cve, NULL);
+        wdb_agents_vuln_cve_insert(atoi(report->agent_id), report->software, report->version, report->arch, report->cve, &sock);
         // Sending CVE report
         wm_vuldet_send_cve_report(report);
         wm_vuldet_free_nvd_report(f_report_node);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -5,6 +5,7 @@
 #include "wm_vuln_detector_evr.h"
 #include <os_net/os_net.h>
 #include "wazuh_db/helpers/wdb_global_helpers.h"
+#include "wazuh_db/helpers/wdb_agents_helpers.h"
 
 #ifdef WAZUH_UNIT_TESTING
 // Remove STATIC qualifier from tests
@@ -2210,6 +2211,9 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
         os_calloc(OS_SIZE_512, sizeof(char), report->title);
         snprintf(report->title, OS_SIZE_512, "%s affects %s", report->cve, report->software);
 
+        //Save the vulnerability in the agent database
+        wdb_agents_vuln_cve_insert(atoi(report->agent_id), report->software, report->version, report->arch, report->cve, NULL);
+        // Sending CVE report
         wm_vuldet_send_cve_report(report);
         wm_vuldet_free_nvd_report(f_report_node);
         free(f_report_node);


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7517 |

## Description

This pull request includes all the necessary changes in Vulnerability Detector to:

- Clean the agents' databases from vulnerabilities before starting each scan.
- Save the vulnerabilities found during the scans in the agents' databases.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade