### PR TITLE
Updating the Vulnerability Detector unit tests

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
@@ -43,7 +43,7 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,fflush -Wl,--wrap,fprintf -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,getpid -Wl,--wrap,OSHash_Add_ex \
                                 -Wl,--wrap,wurl_request_uncompress_bz2_gz -Wl,--wrap,w_uncompress_bz2_gz_file -Wl,--wrap,wstr_replace \
                                 -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap=wstr_split -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Execute_ex \
-                                -Wl,--wrap,fgetpos")
+                                -Wl,--wrap,fgetpos -Wl,--wrap,wdb_agents_vuln_cve_insert -Wl,--wrap,wdb_agents_vuln_cve_clear")
 
 list(APPEND vulndetector_names "test_wm_vuln_detector_evr")
 list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,OS_ConnectUnixDomain \

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -8756,7 +8756,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_vuln_cve_clear_error(void **sta
     agent->info = 'T';
     agent->dist = FEED_WIN;
 
-    //Save the vulnerability in the agent database
+    //Clear the vulnerabilities in the agent database
     expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
     will_return(__wrap_wdb_agents_vuln_cve_clear, OS_INVALID);
 
@@ -8779,7 +8779,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_windows_error(void **stat
     agent->info = 'T';
     agent->dist = FEED_WIN;
 
-    //Save the vulnerability in the agent database
+    //Clear the vulnerabilities in the agent database
     expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
     will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
@@ -8799,7 +8799,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_windows_OK(void **state)
     agent->info = 'T';
     agent->dist = FEED_WIN;
 
-    //Save the vulnerability in the agent database
+    //Clear the vulnerabilities in the agent database
     expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
     will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
@@ -8819,7 +8819,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_create_hash_error(v
     agent->info = 'T';
     agent->dist = FEED_CANONICAL;
 
-    //Save the vulnerability in the agent database
+    //Clear the vulnerabilities in the agent database
     expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
     will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
@@ -8842,7 +8842,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_setSize_hash_error(
     agent->info = 'T';
     agent->dist = FEED_CANONICAL;
 
-    //Save the vulnerability in the agent database
+    //Clear the vulnerabilities in the agent database
     expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
     will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
@@ -8868,7 +8868,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_oval_vulnerabilitie
     agent->info = 'T';
     agent->dist = FEED_CANONICAL;
 
-    //Save the vulnerability in the agent database
+    //Clear the vulnerabilities in the agent database
     expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
     will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
@@ -8918,7 +8918,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_nvd_vulnerabilities
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
 
-    //Save the vulnerability in the agent database
+    //Clear the vulnerabilities in the agent database
     expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
     will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
@@ -9000,7 +9000,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_rm_false_positivies
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_NVD)))
         return;
 
-    //Save the vulnerability in the agent database
+    //Clear the vulnerabilities in the agent database
     expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
     will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
@@ -9116,7 +9116,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_send_agent_report_e
         return;
     }
 
-    //Save the vulnerability in the agent database
+    //Clear the vulnerabilities in the agent database
     expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
     will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
@@ -9266,7 +9266,7 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_OK(void **state)
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_NVD)))
         return;
 
-    //Save the vulnerability in the agent database
+    //Clear the vulnerabilities in the agent database
     expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
     will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -254,6 +254,7 @@ static int build_test_hash_node(OSHashNode* node, uint8_t feed) {
 
     w_strdup("libhogweed4", next->bin_name);
     w_strdup("5.3.4", next->version);
+    w_strdup("x86_64", next->arch);
     next->feed |= feed;
 
     cve_vuln_cond_NVD* nvd_cond = NULL;
@@ -4846,6 +4847,175 @@ void test_wm_vuldet_send_agent_report_fill_report_oval_error(void **state)
     os_free(node);
 }
 
+void test_wm_vuldet_send_agent_report_vuln_cve_insert_error(void **state)
+{
+    agent_software *agent = *state;
+    sqlite3 *db = (sqlite3 *)1;
+    OSHash *cve_table = (OSHash *)1;
+
+    wm_max_eps = 1000000;
+
+    agent->dist = FEED_UBUNTU;
+    agent->dist_ver = FEED_FOCAL;
+
+    OSHashNode* node = NULL;
+    os_calloc(1, sizeof(OSHashNode), node);
+    if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_OVAL)))
+        return;
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(5466): Sending vulnerabilities report for agent '000'");
+
+    will_return(__wrap_time, (time_t)1);
+
+    expect_value(__wrap_OSHash_Begin, self, cve_table);
+    will_return(__wrap_OSHash_Begin, node);
+    will_return_always(__wrap_sqlite3_bind_text, 0);
+    will_return_always(__wrap_sqlite3_bind_int, 0);
+    // CVE info query
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "CVE-2016-6489");
+    expect_sqlite3_step_call(SQLITE_ROW);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "1");
+    expect_value(__wrap_sqlite3_column_text, iCol, 1);
+    will_return(__wrap_sqlite3_column_text, "CWE-502");
+    expect_value(__wrap_sqlite3_column_text, iCol, 2);
+    will_return(__wrap_sqlite3_column_text, "cve@mitre.org");
+    expect_value(__wrap_sqlite3_column_text, iCol, 3);
+    will_return(__wrap_sqlite3_column_text, "The CVE description or rationale.");
+    expect_value(__wrap_sqlite3_column_text, iCol, 4);
+    will_return(__wrap_sqlite3_column_text, "4.0");
+    expect_value(__wrap_sqlite3_column_text, iCol, 5);
+    will_return(__wrap_sqlite3_column_text, "2017-04-14");
+    expect_value(__wrap_sqlite3_column_text, iCol, 6);
+    will_return(__wrap_sqlite3_column_text, "2017-07-01");
+    //Query for references
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
+    expect_sqlite3_step_call(SQLITE_ROW);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "http://rhn.redhat.com/errata/RHSA-2016-2582.html");
+    expect_value(__wrap_sqlite3_column_text, iCol, 1);
+    will_return(__wrap_sqlite3_column_text, "REDHAT");
+    expect_sqlite3_step_call(SQLITE_DONE);
+    //Query for scoring
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, 1  );
+    expect_sqlite3_step_call(SQLITE_ROW);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "");
+    expect_value(__wrap_sqlite3_column_double, iCol, 1);
+    will_return(__wrap_sqlite3_column_double, 0);
+    expect_value(__wrap_sqlite3_column_double, iCol, 2);
+    will_return(__wrap_sqlite3_column_double, 0);
+    expect_value(__wrap_sqlite3_column_double, iCol, 3);
+    will_return(__wrap_sqlite3_column_double, 0);
+    expect_value(__wrap_sqlite3_column_text, iCol, 4);
+    will_return(__wrap_sqlite3_column_text, NULL);
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    // Query for oval data
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "CVE-2016-6489");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "FOCAL");
+    expect_sqlite3_step_call(SQLITE_ROW);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, vu_severities[VU_HIGH]);
+    expect_value(__wrap_sqlite3_column_text, iCol, 1);
+    will_return(__wrap_sqlite3_column_text, "2017-04-14");
+    expect_value(__wrap_sqlite3_column_text, iCol, 2);
+    will_return(__wrap_sqlite3_column_text, "2017-07-01");
+    expect_value(__wrap_sqlite3_column_text, iCol, 3);
+    will_return(__wrap_sqlite3_column_text, "The CVE description or rationale.");
+    expect_value(__wrap_sqlite3_column_text, iCol, 4);
+    will_return(__wrap_sqlite3_column_text, "6.9");
+    expect_value(__wrap_sqlite3_column_text, iCol, 5);
+    will_return(__wrap_sqlite3_column_text, "3.6");
+    expect_value(__wrap_sqlite3_column_text, iCol, 6);
+    will_return(__wrap_sqlite3_column_text, "AV:N/AC:M/Au:N/C:N/I:N/A:C");
+    expect_value(__wrap_sqlite3_column_text, iCol, 7);
+    will_return(__wrap_sqlite3_column_text, "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H");
+    expect_value(__wrap_sqlite3_column_text, iCol, 8);
+    will_return(__wrap_sqlite3_column_text, "CWE-502");
+    //Query for oval references
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "CVE-2016-6489");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "FOCAL");
+    expect_sqlite3_step_call(SQLITE_ROW);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "http://rhn.redhat.com/errata/RHSA-2016-2582.html");
+    expect_sqlite3_step_call(SQLITE_DONE);
+    //Query for oval bugzilla references
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "CVE-2016-6489");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "FOCAL");
+    expect_sqlite3_step_call(SQLITE_ROW);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "http://rhn.redhat.org/cgi-bin/bugreport.cgi?bug=925286");
+    expect_sqlite3_step_call(SQLITE_DONE);
+    //Query for oval advisories
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "CVE-2016-6489");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "FOCAL");
+    expect_sqlite3_step_call(SQLITE_ROW);
+    expect_value(__wrap_sqlite3_column_text, iCol, 0);
+    will_return(__wrap_sqlite3_column_text, "RHSA-2020:0975");
+    expect_sqlite3_step_call(SQLITE_DONE);
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, cve, "CVE-2016-6489");
+    will_return(__wrap_wdb_agents_vuln_cve_insert, OS_INVALID);
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Failed to insert CVE-2016-6489 for package libhogweed4 in the agent 000 database");
+    // Sending CVE report
+    will_return(__wrap_cJSON_CreateObject, NULL);
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5559): Could not send the 'CVE-2016-6489' report for 'libhogweed4' in the agent '000'");
+
+    expect_value(__wrap_OSHash_Next, self, cve_table);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtwarn, formatted_msg, "Failed to insert vulnerabilities in the agent 000 database");
+
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'NVD' feed.");
+
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5482): A total of '0' vulnerabilities have been reported for agent '000' thanks to the 'vendor' feed.");
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(5469): A total of '0' vulnerabilities have been reported for agent '000'");
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
+    will_return(__wrap_time, (time_t)1);
+    expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'report' vulnerabilities in agent '000'");
+
+    int ret = wm_vuldet_send_agent_report(db, cve_table, agent);
+
+    assert_int_equal(ret, OS_SUCCESS);
+
+    wm_vuldet_free_cve_node(node->data);
+    os_free(node->key);
+    os_free(node);
+}
+
 void test_wm_vuldet_send_agent_report_send_cve_report_error(void **state)
 {
     agent_software *agent = *state;
@@ -4976,7 +5146,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_error(void **state)
     expect_value(__wrap_wdb_agents_vuln_cve_insert, id, 0);
     expect_string(__wrap_wdb_agents_vuln_cve_insert, name, "libhogweed4");
     expect_string(__wrap_wdb_agents_vuln_cve_insert, version, "5.3.4");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, architecture, "CVE-2016-6489");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, architecture, "x86_64");
     expect_string(__wrap_wdb_agents_vuln_cve_insert, cve, "CVE-2016-6489");
     will_return(__wrap_wdb_agents_vuln_cve_insert, OS_SUCCESS);
     // Sending CVE report
@@ -5140,6 +5310,13 @@ void test_wm_vuldet_send_agent_report_send_cve_report_negative_version(void **st
     expect_value(__wrap_sqlite3_column_text, iCol, 0);
     will_return(__wrap_sqlite3_column_text, "RHSA-2020:0975");
     expect_sqlite3_step_call(SQLITE_DONE);
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, version, "");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, cve, "CVE-2016-6489");
+    will_return(__wrap_wdb_agents_vuln_cve_insert, OS_SUCCESS);
     // Sending CVE report
     will_return(__wrap_cJSON_CreateObject, NULL);
 
@@ -5453,6 +5630,14 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
     will_return(__wrap_sqlite3_column_text, "RHSA-2020:0975");
     expect_sqlite3_step_call(SQLITE_DONE);
 
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, cve, "CVE-2016-6489");
+    will_return(__wrap_wdb_agents_vuln_cve_insert, OS_SUCCESS);
+
     // Sending the CVE report
     cJSON* alert = (cJSON *)1;
     cJSON* alert_cve = (cJSON *)1;
@@ -5479,6 +5664,8 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
     expect_string(__wrap_cJSON_AddStringToObject, string, "libhogweed4");
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
     expect_string(__wrap_cJSON_AddStringToObject, string, "5.3.4");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "x86_64");
     expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
     expect_string(__wrap_cJSON_AddStringToObject, string, "Package less than 4.3-2");
     // Adding cvss information
@@ -5780,6 +5967,14 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **
     will_return(__wrap_sqlite3_column_text, "RHSA-2020:0975");
     expect_sqlite3_step_call(SQLITE_DONE);
 
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, cve, "CVE-2016-6489");
+    will_return(__wrap_wdb_agents_vuln_cve_insert, OS_SUCCESS);
+
     // Sending the CVE report
     cJSON* alert = (cJSON *)1;
     cJSON* alert_cve = (cJSON *)1;
@@ -5806,6 +6001,8 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **
     expect_string(__wrap_cJSON_AddStringToObject, string, "libhogweed4");
     expect_string(__wrap_cJSON_AddStringToObject, name, "version");
     expect_string(__wrap_cJSON_AddStringToObject, string, "5.3.4");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "x86_64");
     expect_string(__wrap_cJSON_AddStringToObject, name, "condition");
     expect_string(__wrap_cJSON_AddStringToObject, string, "Package matches a vulnerable version");
     // Adding cvss information
@@ -8550,6 +8747,29 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_info_NULL(void **state)
 
 }
 
+void test_wm_vuldet_report_agent_vulnerabilities_vuln_cve_clear_error(void **state)
+{
+    sqlite3 *db = (sqlite3 *)1;
+    agent_software *agent = *state;
+    OSHash *cve_table = (OSHash *)1;
+
+    agent->info = 'T';
+    agent->dist = FEED_WIN;
+
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_INVALID);
+
+    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtwarn, formatted_msg, "Failed to clear vulnerabilities from the agent 000 database");
+
+    will_return(__wrap_wm_vuldet_win_nvd_vulnerabilities, -1);
+
+    int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
+    assert_int_equal(ret, -1);
+
+}
+
 void test_wm_vuldet_report_agent_vulnerabilities_agent_windows_error(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
@@ -8558,6 +8778,11 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_windows_error(void **stat
 
     agent->info = 'T';
     agent->dist = FEED_WIN;
+
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
+
     will_return(__wrap_wm_vuldet_win_nvd_vulnerabilities, -1);
 
     int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
@@ -8573,6 +8798,11 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_windows_OK(void **state)
 
     agent->info = 'T';
     agent->dist = FEED_WIN;
+
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
+
     will_return(__wrap_wm_vuldet_win_nvd_vulnerabilities, 0);
 
     int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
@@ -8588,6 +8818,10 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_create_hash_error(v
 
     agent->info = 'T';
     agent->dist = FEED_CANONICAL;
+
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 0);
@@ -8607,6 +8841,10 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_setSize_hash_error(
 
     agent->info = 'T';
     agent->dist = FEED_CANONICAL;
+
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 1);
@@ -8629,6 +8867,10 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_oval_vulnerabilitie
 
     agent->info = 'T';
     agent->dist = FEED_CANONICAL;
+
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, cve_table);
@@ -8675,6 +8917,10 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_nvd_vulnerabilities
     agent->info = 'T';
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
+
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, cve_table);
@@ -8753,6 +8999,10 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_rm_false_positivies
     os_calloc(1, sizeof(OSHashNode), node);
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_NVD)))
         return;
+
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     agent->info = 'T';
     agent->dist = FEED_DEBIAN;
@@ -8865,6 +9115,10 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_send_agent_report_e
     if(!flags) {
         return;
     }
+
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     agent->info = 'T';
     agent->dist = FEED_DEBIAN;
@@ -9011,6 +9265,10 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_OK(void **state)
     os_calloc(1, sizeof(OSHashNode), node);
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_NVD)))
         return;
+
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     agent->info = 'T';
     agent->dist = FEED_DEBIAN;
@@ -17194,6 +17452,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_fill_report_nvd_references_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_fill_report_nvd_scoring_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_fill_report_oval_error, setup_agent_software, teardown_agent_software),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_vuln_cve_insert_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_send_cve_report_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_send_cve_report_negative_version, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_send_cve_report_adding_data_from_OVAL_error, setup_agent_software, teardown_agent_software),
@@ -17279,6 +17538,7 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_free_cve_node),
         // Tests wm_vuldet_report_agent_vulnerabilities
         cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_info_NULL, setup_agent_software, teardown_agent_software),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_vuln_cve_clear_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_windows_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_windows_OK, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_linux_create_hash_error, setup_agent_software, teardown_agent_software),

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -32,6 +32,7 @@
 #include "../../wrappers/wazuh/os_regex/os_regex_wrappers.h"
 #include "../../wrappers/wazuh/os_net/os_net_wrappers.h"
 #include "../../wrappers/wazuh/wazuh_modules/wm_vuln_detector_wrappers.h"
+#include "../../wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h"
 
 #include "../../wazuh_modules/wmodules.h"
 #include "../../../wazuh_modules/vulnerability_detector/wm_vuln_detector_db.h"
@@ -4971,6 +4972,13 @@ void test_wm_vuldet_send_agent_report_send_cve_report_error(void **state)
     expect_value(__wrap_sqlite3_column_text, iCol, 0);
     will_return(__wrap_sqlite3_column_text, "RHSA-2020:0975");
     expect_sqlite3_step_call(SQLITE_DONE);
+    //Save the vulnerability in the agent database
+    expect_value(__wrap_wdb_agents_vuln_cve_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, architecture, "CVE-2016-6489");
+    expect_string(__wrap_wdb_agents_vuln_cve_insert, cve, "CVE-2016-6489");
+    will_return(__wrap_wdb_agents_vuln_cve_insert, OS_SUCCESS);
     // Sending CVE report
     will_return(__wrap_cJSON_CreateObject, NULL);
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
@@ -1,0 +1,35 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "wdb_agents_helpers_wrappers.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdlib.h>
+
+int __wrap_wdb_agents_vuln_cve_insert(int id,
+                                      const char *name,
+                                      const char *version,
+                                      const char *architecture,
+                                      const char *cve,
+                                      __attribute__((unused)) int *sock) {
+    check_expected(id);
+    check_expected(name);
+    check_expected(version);
+    check_expected(architecture);
+    check_expected(cve);
+    return mock_type(int);
+}
+
+int __wrap_wdb_agents_vuln_cve_clear(int id,
+                                     __attribute__((unused)) int *sock) {
+    check_expected(id);
+    return mock_type(int);
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef WDB_AGENTS_HELPERS_WRAPPERS_H
+#define WDB_AGENTS_HELPERS_WRAPPERS_H
+
+#include "wazuh_db/wdb.h"
+
+int __wrap_wdb_agents_vuln_cve_insert(int id,
+                                      const char *name,
+                                      const char *version,
+                                      const char *architecture,
+                                      const char *cve,
+                                      __attribute__((unused)) int *sock);
+
+int __wrap_wdb_agents_vuln_cve_clear(int id,
+                                     __attribute__((unused)) int *sock);
+
+#endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1313,7 +1313,7 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
             }
 
             //Save the vulnerability in the agent database
-            if (OS_INVALID == wdb_agents_vuln_cve_insert(atoi(report->agent_id), report->software, report->version, report->arch, report->cve, &sock)) {
+            if (OS_INVALID == wdb_agents_vuln_cve_insert(atoi(agents_it->agent_id), report->software, report->version, report->arch, report->cve, &sock)) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to insert %s for package %s in the agent %s database",
                          report->cve, report->software, report->agent_id);
                 cve_insert_result = OS_INVALID;


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7518 |

## Description

This pull request updates the vulnerability detector unit tests in order to cover the new paths added as part of the implementation that saves the CVEs in the agents' databases. In addition, it fixes the test cases that got broken because of that implementation.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
