### PR TITLE
[7620] Changed warning message by debug1 one

### DIFF
--- a/src/wazuh_modules/wmcom.c
+++ b/src/wazuh_modules/wmcom.c
@@ -97,11 +97,11 @@ void wmcom_send(char * message)
     if (sock = OS_ConnectUnixDomain(DEFAULTDIR WM_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR), sock < 0) {
         switch (errno) {
             case ECONNREFUSED:
-                mwarn("At wmcom_send(): Target wmodules refused connection. The component might be disabled");
+                mdebug1("Target wmodules refused connection. The component might be disabled");
                 break;
 
             default:
-                mwarn("At wmcom_send(): Could not connect to socket wmodules: %s (%d).", strerror(errno), errno);
+                mdebug1("Could not connect to socket wmodules: %s (%d).", strerror(errno), errno);
         }
     }
     else


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7620 |

## **Description**
This issue was discovered by the @chemamartinez  team, and it aims to avoid being too verbose in the logging when the wcom_send function is called, because it is verbose, it is due to the lack of synchronization in shutdown, between agentd and modulesd.

Current result: Warning Log
Expected result: Debug level 1 log.

Log:
`2021/02/24 16:04:29 wazuh-agentd: WARNING: At wmcom_send(): Target wmodules refused connection. The component might be disabled`

Destination branch: `dev-syscollector-tde`


## **DoD**
- [X] Change from warning to debug level 1 log.
- [X] Remove "At wmcom_send(): from the log body"
- [x] CI Pass
