### PR TITLE
Fix agents_GET and cluster API integration tests

### DIFF
--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1469,7 +1469,7 @@ stages:
             - connection: !anystr
               ipv6: !anystr
               port: !anystr
-              protocol: !anystr
+              protocol: !anylist
               queue_size: !anystr
 
   - name: Request-Request-Internal

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1228,7 +1228,7 @@ stages:
               - connection: !anystr
                 ipv6: !anystr
                 port: !anystr
-                protocol: !anystr
+                protocol: !anylist
                 queue_size: !anystr
           failed_items: []
           total_affected_items: 1


### PR DESCRIPTION
Hi team,

`cluster` and `agent_GET` tests are failing. These tests need to be changed to assert any list in the `protocol` fields in the GET request/remote config tests.

```
test_cluster_endpoints.tavern.yaml 
	 1 failed, 43 passed, 1 xpassed, 58 warnings

test_agent_GET_endpoints.tavern.yaml 
	 1 failed, 90 passed, 98 warnings
```

**Test results:**

```
test_agent_GET_endpoints.tavern.yaml 
         91 passed, 98 warnings

test_cluster_endpoints.tavern.yaml 
	 44 passed, 1 xpassed, 58 warnings
```

`syscollector` test will be fixed when solving: https://github.com/wazuh/wazuh/issues/7585 
```
test_syscollector_endpoints.tavern.yaml 
	 1 failed, 160 passed, 176 warnings

test_rbac_black_syscollector_endpoints.tavern.yaml 
	 9 passed, 11 warnings

test_rbac_white_syscollector_endpoints.tavern.yaml 
	 9 passed, 11 warnings

test_experimental_endpoints.tavern.yaml 
	 11 passed, 13 warnings
```

Regards,
Manuel.