### PR TITLE
Removes <PRI> header in syslog tcp

### DIFF
--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * Copyright (C) 2009 Trend Micro Inc.
  * All right reserved.
  *
@@ -25,7 +25,7 @@
  * @param syslog_msg RAW syslog message
  * @return Length of the PRI header, 0 if not present
  */
-STATIC size_t w_get_header_pri_len(const char * syslog_msg);
+STATIC size_t w_get_pri_header_len(const char * syslog_msg);
 
 /* Checks if an IP is not allowed */
 static int OS_IPNotAllowed(char *srcip)
@@ -56,7 +56,7 @@ void send_buffer(sockbuffer_t *socket_buffer, char *srcip) {
     char * buffer_pt = NULL; 
 
     // ignore syslog PRI header
-    data_pt += w_get_header_pri_len(data_pt);
+    data_pt += w_get_pri_header_len(data_pt);
 
     buffer_pt = strchr(data_pt, '\n');
 
@@ -76,7 +76,7 @@ void send_buffer(sockbuffer_t *socket_buffer, char *srcip) {
         socket_buffer->data_len = socket_buffer->data_len - (offset + 1);
         data_pt += (offset + 1);
         // ignore syslog PRI header
-        data_pt += w_get_header_pri_len(data_pt);
+        data_pt += w_get_pri_header_len(data_pt);
         // Find the next '\n'
         buffer_pt = strchr(data_pt, '\n');
     }
@@ -181,14 +181,14 @@ void HandleSyslogTCP()
     }
 }
 
-STATIC size_t w_get_header_pri_len(const char * syslog_msg) {
+STATIC size_t w_get_pri_header_len(const char * syslog_msg) {
 
     size_t retval = 0;          // Offset
     char * pri_head_end = NULL; // end of <PRI> head
 
     if (syslog_msg != NULL && syslog_msg[0] == '<') {
         pri_head_end = strchr(syslog_msg + 1, '>');
-        if (pri_head_end) {
+        if (pri_head_end != NULL) {
             retval = (pri_head_end + 1) - syslog_msg;
         }
     }

--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -12,13 +12,20 @@
 #include "os_net/os_net.h"
 #include "remoted.h"
 
+#ifdef WAZUH_UNIT_TESTING
+// Remove static qualifier when unit testing
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 /**
  * @brief Get the offset of the syslog message, discarding the PRI header.
  * 
  * @param syslog_msg RAW syslog message
  * @return Length of the PRI header, 0 if not present
  */
-static size_t w_get_header_pri_len(char * syslog_msg);
+STATIC size_t w_get_header_pri_len(const char * syslog_msg);
 
 /* Checks if an IP is not allowed */
 static int OS_IPNotAllowed(char *srcip)
@@ -174,7 +181,7 @@ void HandleSyslogTCP()
     }
 }
 
-static size_t w_get_header_pri_len(char * syslog_msg) {
+STATIC size_t w_get_header_pri_len(const char * syslog_msg) {
 
     size_t retval = 0;          // Offset
     char * pri_head_end = NULL; // end of <PRI> head

--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -12,6 +12,13 @@
 #include "os_net/os_net.h"
 #include "remoted.h"
 
+/**
+ * @brief Get the offset of the syslog message, discarding the PRI header.
+ * 
+ * @param syslog_msg RAW syslog message
+ * @return Length of the PRI header, 0 if not present
+ */
+static size_t w_get_header_pri_len(char * syslog_msg);
 
 /* Checks if an IP is not allowed */
 static int OS_IPNotAllowed(char *srcip)
@@ -39,7 +46,12 @@ static int OS_IPNotAllowed(char *srcip)
 void send_buffer(sockbuffer_t *socket_buffer, char *srcip) {
     char *data_pt = socket_buffer->data;
     int offset;
-    char *buffer_pt = strchr(data_pt, '\n');
+    char * buffer_pt = NULL; 
+
+    // ignore syslog PRI header
+    data_pt += w_get_header_pri_len(data_pt);
+
+    buffer_pt = strchr(data_pt, '\n');
 
     while(buffer_pt != NULL) {
         // Get the position of '\n' in buffer
@@ -56,6 +68,8 @@ void send_buffer(sockbuffer_t *socket_buffer, char *srcip) {
         // Re-calculate the used size of buffer and remove the message from the buffer
         socket_buffer->data_len = socket_buffer->data_len - (offset + 1);
         data_pt += (offset + 1);
+        // ignore syslog PRI header
+        data_pt += w_get_header_pri_len(data_pt);
         // Find the next '\n'
         buffer_pt = strchr(data_pt, '\n');
     }
@@ -158,4 +172,19 @@ void HandleSyslogTCP()
             continue;
         }
     }
+}
+
+static size_t w_get_header_pri_len(char * syslog_msg) {
+
+    size_t retval = 0;          // Offset
+    char * pri_head_end = NULL; // end of <PRI> head
+
+    if (syslog_msg != NULL && syslog_msg[0] == '<') {
+        pri_head_end = strchr(syslog_msg + 1, '>');
+        if (pri_head_end) {
+            retval = (pri_head_end + 1) - syslog_msg;
+        }
+    }
+
+    return retval;
 }

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -31,6 +31,8 @@ list(APPEND remoted_flags "-Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -
 
 list(APPEND remoted_names "test_remote-config")
 list(APPEND remoted_flags "-Wl,--wrap,_mwarn")
+list(APPEND remoted_names "test_syslogtcp")
+list(APPEND remoted_flags "-W")
 
 list(LENGTH remoted_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/remoted/test_syslogtcp.c
+++ b/src/unit_tests/remoted/test_syslogtcp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
@@ -20,7 +20,7 @@
 
 
 /* Forward declarations */
-size_t w_get_header_pri_len(const char * syslog_msg);
+size_t w_get_pri_header_len(const char * syslog_msg);
 
 /* setup/teardown */
 
@@ -38,47 +38,47 @@ static int group_teardown(void ** state) {
 
 /* Tests */
 
-// w_get_header_pri_len
+// w_get_pri_header_len
 
-void test_w_get_header_pri_len_null(void ** state) {
+void test_w_get_pri_header_len_null(void ** state) {
 
     const ssize_t expected_retval = 0;
-    ssize_t retval = w_get_header_pri_len(NULL);
+    ssize_t retval = w_get_pri_header_len(NULL);
 
     assert_int_equal(retval, expected_retval);
 }
 
-void test_w_get_header_pri_len_no_pri(void ** state) {
+void test_w_get_pri_header_len_no_pri(void ** state) {
 
     const ssize_t expected_retval = 0;
-    ssize_t retval = w_get_header_pri_len("test log");
+    ssize_t retval = w_get_pri_header_len("test log");
 
     assert_int_equal(retval, expected_retval);
 }
 
-void test_w_get_header_pri_len_w_pri(void ** state) {
+void test_w_get_pri_header_len_w_pri(void ** state) {
 
     const ssize_t expected_retval = 4;
-    ssize_t retval = w_get_header_pri_len("<18>test log");
+    ssize_t retval = w_get_pri_header_len("<18>test log");
 
     assert_int_equal(retval, expected_retval);
 }
 
-void test_w_get_header_pri_len_not_end(void ** state) {
+void test_w_get_pri_header_len_not_end(void ** state) {
 
     const ssize_t expected_retval = 0;
-    ssize_t retval = w_get_header_pri_len("<18 test log");
+    ssize_t retval = w_get_pri_header_len("<18 test log");
 
     assert_int_equal(retval, expected_retval);
 }
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        // Test w_get_header_pri_len
-        cmocka_unit_test(test_w_get_header_pri_len_null),
-        cmocka_unit_test(test_w_get_header_pri_len_no_pri),
-        cmocka_unit_test(test_w_get_header_pri_len_w_pri),
-        cmocka_unit_test(w_get_header_pri_len),
+        // Test w_get_pri_header_len
+        cmocka_unit_test(test_w_get_pri_header_len_null),
+        cmocka_unit_test(test_w_get_pri_header_len_no_pri),
+        cmocka_unit_test(test_w_get_pri_header_len_w_pri),
+        cmocka_unit_test(test_w_get_pri_header_len_not_end),
  
     };
 

--- a/src/unit_tests/remoted/test_syslogtcp.c
+++ b/src/unit_tests/remoted/test_syslogtcp.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "remoted/remoted.h"
+#include "headers/shared.h"
+#include "os_net/os_net.h"
+
+
+/* Forward declarations */
+size_t w_get_header_pri_len(const char * syslog_msg);
+
+/* setup/teardown */
+
+static int group_setup(void ** state) {
+    test_mode = 1;
+    return 0;
+}
+
+static int group_teardown(void ** state) {
+    test_mode = 0;
+    return 0;
+}
+
+/* Wrappers */
+
+/* Tests */
+
+// w_get_header_pri_len
+
+void test_w_get_header_pri_len_null(void ** state) {
+
+    const ssize_t expected_retval = 0;
+    ssize_t retval = w_get_header_pri_len(NULL);
+
+    assert_int_equal(retval, expected_retval);
+}
+
+void test_w_get_header_pri_len_no_pri(void ** state) {
+
+    const ssize_t expected_retval = 0;
+    ssize_t retval = w_get_header_pri_len("test log");
+
+    assert_int_equal(retval, expected_retval);
+}
+
+void test_w_get_header_pri_len_w_pri(void ** state) {
+
+    const ssize_t expected_retval = 4;
+    ssize_t retval = w_get_header_pri_len("<18>test log");
+
+    assert_int_equal(retval, expected_retval);
+}
+
+void test_w_get_header_pri_len_not_end(void ** state) {
+
+    const ssize_t expected_retval = 0;
+    ssize_t retval = w_get_header_pri_len("<18 test log");
+
+    assert_int_equal(retval, expected_retval);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        // Test w_get_header_pri_len
+        cmocka_unit_test(test_w_get_header_pri_len_null),
+        cmocka_unit_test(test_w_get_header_pri_len_no_pri),
+        cmocka_unit_test(test_w_get_header_pri_len_w_pri),
+        cmocka_unit_test(w_get_header_pri_len),
+ 
+    };
+
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
+}


### PR DESCRIPTION
|Related issue|
|---|
|Closes  #7381|

## Description

Hi Team,

This PR fixes the problem with the PRI header in syslog messages sent to the Wazuh syslog server when using the TCP protocol.

This message format is defined in section 4.1.1 of RFC 3164 ([here](https://tools.ietf.org/html/rfc3164#section-4.1.1)).

The message can optionally have a header between `<` ('less-than' character) and `>` ('greater-than' character).
This header must be discarded before sending it to `analysisd`. Currently the Wazuh syslog server with the UDP protocol correctly discards this message.

Regards,
Julian

## Feature tests

#### Config for test
```xml
  <remote>
    <connection>syslog</connection>
    <port>600</port>
    <protocol>tcp</protocol>
    <allowed-ips>any</allowed-ips>
  </remote>
```

### Tests
- [X] Single log without PRI header
```
echo "Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user single-log-no-header from 127.0.0.1 port 41328 - test 1" | nc -v -w 0 192.168.0.35 600
```

- [X] Single log with PRI header
```
echo "<1>Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user single-log-w-header from 127.0.0.1 port 41328 - test 2" | nc -v -w 0 192.168.0.35 600
```

- [X] Multi log with PRI header 
```
echo "<2>Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user multi-log-1-w-header from 127.0.0.1 port 41328 - test 3\n<2>Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user multi-log-2-w-header from 127.0.0.1 port 41328 - test 3" | nc -v -w 0 192.168.0.35 600
```

- [X] Multi log - mix without/with PRI header 
```
echo "Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user multi-log-1-no-header from 127.0.0.1 port 41328 - test 4\n<3>Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user multi-log-2-w-header from 127.0.0.1 port 41328- test 4" | nc -v -w 0 192.168.0.35 600
```

- [X] Multi log - mix with/without PRI header 
```
echo "<4>Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user multi-log-1-no-header from 127.0.0.1 port 41328 - test 5\nFeb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user multi-log-2-no-header from 127.0.0.1 port 41328 - test 5" | nc -v -w 0 192.168.0.35 600
```

- [X] Bad format
```
echo "<1Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user single-log-w-header from 127.0.0.1 port 41328 - test 2" | nc -v -w 0 192.168.0.35 600

echo "<2Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user multi-log-1-w-header from 127.0.0.1 port 41328 - test 3\n<2Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user multi-log-2-w-header from 127.0.0.1 port 41328 - test 3\n" | nc -v -w 0 192.168.0.35 600

echo "Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user multi-log-1-no-header from 127.0.0.1 port 41328 - test 4\n<3Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user multi-log-2-w-header from 127.0.0.1 port - test 4\n" | nc -v -w 0 192.168.0.35 600

echo "<4Feb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user multi-log-1-no-header from 127.0.0.1 port 41328 - test 5\nFeb  4 16:39:29 ip-10-142-167-43 sshd[6787]: Invalid user multi-log-2-no-header from 127.0.0.1 port 41328 - test 5\n" | nc -v -w 0 192.168.0.35 600
```

## Tests


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
