### PR TITLE
Fix missing wazuh_config tag in AR

### DIFF
--- a/src/analysisd/ar_json.c
+++ b/src/analysisd/ar_json.c
@@ -23,7 +23,7 @@ static char *get_node_name()
     char* node_name = NULL;
     OS_XML xml;
 
-    const char *(xml_node[]) = {"ossec_config", "cluster", "node_name", NULL};
+    const char *(xml_node[]) = {"wazuh_config", "cluster", "node_name", NULL};
     if (OS_ReadXML(DEFAULTCPATH, &xml) >= 0) {
         node_name = OS_GetOneContentforElement(&xml, xml_node);
     }


### PR DESCRIPTION
## Description

This PR fixes a problem after merging https://github.com/wazuh/wazuh/pull/7380.

A new usage of `ossec_config` tag in AR module has not been changed to `wazuh_config`.

Now, all tags have been renamed from `ossec_config` to `wazuh_config`.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language
