### PR TITLE
7598 curl fallback precompiled libs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1080,13 +1080,19 @@ endif
 
 ifneq (,$(PRECOMPILED_RES))
 external/%.tar.gz: external-precompiled/%.tar.gz
-else
-external/%.tar.gz:
-endif
+ifeq (,$(wildcard $(patsubst %.tar.gz,%,$@)))
 	$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@)
 	cd external && $(GUNZIP) $(patsubst external/%,%,$@)
 	cd external && $(TAR) $(patsubst external/%.gz,%,$@)
 	rm $(patsubst %.gz,%,$@)
+endif
+else
+external/%.tar.gz:
+	$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@)
+	cd external && $(GUNZIP) $(patsubst external/%,%,$@)
+	cd external && $(TAR) $(patsubst external/%.gz,%,$@)
+	rm $(patsubst %.gz,%,$@)
+endif
 
 ifneq (,$(PRECOMPILED_RES))
 external-precompiled/%.tar.gz:

--- a/src/Makefile
+++ b/src/Makefile
@@ -1078,11 +1078,19 @@ endif
 	cd external && $(TAR) $(patsubst external/%.gz,%,$@)
 	rm $(patsubst %.gz,%,$@)
 
-external/%.tar.gz:
+external/%.tar.gz: external-precompiled/%.tar.gz
 	$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@)
 	cd external && $(GUNZIP) $(patsubst external/%,%,$@)
 	cd external && $(TAR) $(patsubst external/%.gz,%,$@)
 	rm $(patsubst %.gz,%,$@)
+
+external-precompiled/%.tar.gz:
+ifneq (,$(PRECOMPILED_RES))
+	-$(CURL) external/$(patsubst external-precompiled/%,%,$@) $(RESOURCES_URL)/libraries/$(PRECOMPILED_RES)/$(patsubst external-precompiled/%,%,$@) || true
+	-cd external && $(GUNZIP) $(patsubst external-precompiled/%,%,$@) || true
+	-cd external && $(TAR) $(patsubst external-precompiled/%.gz,%,$@) || true
+	-rm external/$(patsubst external-precompiled/%.gz,%,$@) || true
+endif
 
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1078,14 +1078,18 @@ endif
 	cd external && $(TAR) $(patsubst external/%.gz,%,$@)
 	rm $(patsubst %.gz,%,$@)
 
+ifneq (,$(PRECOMPILED_RES))
 external/%.tar.gz: external-precompiled/%.tar.gz
+else
+external/%.tar.gz:
+endif
 	$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@)
 	cd external && $(GUNZIP) $(patsubst external/%,%,$@)
 	cd external && $(TAR) $(patsubst external/%.gz,%,$@)
 	rm $(patsubst %.gz,%,$@)
 
-external-precompiled/%.tar.gz:
 ifneq (,$(PRECOMPILED_RES))
+external-precompiled/%.tar.gz:
 	-$(CURL) external/$(patsubst external-precompiled/%,%,$@) $(RESOURCES_URL)/libraries/$(PRECOMPILED_RES)/$(patsubst external-precompiled/%,%,$@) || true
 	-cd external && $(GUNZIP) $(patsubst external-precompiled/%,%,$@) || true
 	-cd external && $(TAR) $(patsubst external-precompiled/%.gz,%,$@) || true

--- a/src/Makefile
+++ b/src/Makefile
@@ -1080,12 +1080,9 @@ endif
 
 ifneq (,$(PRECOMPILED_RES))
 external/%.tar.gz: external-precompiled/%.tar.gz
-ifeq (,$(wildcard $(patsubst %.tar.gz,%,$@)))
-	$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@)
-	cd external && $(GUNZIP) $(patsubst external/%,%,$@)
-	cd external && $(TAR) $(patsubst external/%.gz,%,$@)
-	rm $(patsubst %.gz,%,$@)
-endif
+	test -d $(patsubst %.tar.gz,%,$@) ||\
+	($(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@) &&\
+	cd external && $(GUNZIP) $(patsubst external/%,%,$@) && $(TAR) $(patsubst external/%.gz,%,$@) && rm $(patsubst external/%.gz,%,$@))
 else
 external/%.tar.gz:
 	$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@)

--- a/src/shared_modules/rsync/src/rsync.cpp
+++ b/src/shared_modules/rsync/src/rsync.cpp
@@ -57,7 +57,7 @@ EXPORTED RSYNC_HANDLE rsync_create()
         errorMessage += "Unrecognized error.";
     }
     // LCOV_EXCL_STOP
-    
+
     log_message(errorMessage);
     return retVal;
 }
@@ -99,8 +99,8 @@ EXPORTED int rsync_start_sync(const RSYNC_HANDLE handle,
     return retVal;
 }
 
-EXPORTED int rsync_register_sync_id(const RSYNC_HANDLE handle, 
-                                    const char* message_header_id, 
+EXPORTED int rsync_register_sync_id(const RSYNC_HANDLE handle,
+                                    const char* message_header_id,
                                     const DBSYNC_HANDLE dbsync_handle,
                                     const cJSON* sync_configuration,
                                     sync_callback_data_t callback_data)
@@ -133,9 +133,9 @@ EXPORTED int rsync_register_sync_id(const RSYNC_HANDLE handle,
         }
         // LCOV_EXCL_STOP
     }
-    
+
     log_message(errorMessage);
-    return retVal; 
+    return retVal;
 }
 
 EXPORTED int rsync_push_message(const RSYNC_HANDLE handle,
@@ -173,7 +173,7 @@ EXPORTED int rsync_close(const RSYNC_HANDLE handle)
 {
     std::string message;
     auto retVal { 0 };
-    
+
     try
     {
         RSyncImplementation::instance().releaseContext(handle);
@@ -247,10 +247,10 @@ void RemoteSync::startSync(const DBSYNC_HANDLE   dbsyncHandle,
         }
     };
     RSyncImplementation::instance().startRSync(m_handle, std::make_shared<DBSyncWrapper>(dbsyncHandle), startConfiguration, callbackWrapper);
-            
+
 }
 
-void RemoteSync::registerSyncID(const std::string&    messageHeaderID, 
+void RemoteSync::registerSyncID(const std::string&    messageHeaderID,
                                 const DBSYNC_HANDLE   dbsyncHandle,
                                 const nlohmann::json& syncConfiguration,
                                 SyncCallbackData      callbackData)
@@ -262,10 +262,10 @@ void RemoteSync::registerSyncID(const std::string&    messageHeaderID,
             callbackData(payload);
         }
     };
-    RSyncImplementation::instance().registerSyncId(m_handle, messageHeaderID, std::make_shared<DBSyncWrapper>(dbsyncHandle), syncConfiguration, callbackWrapper);       
+    RSyncImplementation::instance().registerSyncId(m_handle, messageHeaderID, std::make_shared<DBSyncWrapper>(dbsyncHandle), syncConfiguration, callbackWrapper);
 }
 
 void RemoteSync::pushMessage(const std::vector<uint8_t>& payload)
 {
-    RSyncImplementation::instance().push(m_handle, payload);       
+    RSyncImplementation::instance().push(m_handle, payload);
 }

--- a/src/wazuh_modules/syscollector/tests/sysNormalizer/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/tests/sysNormalizer/CMakeLists.txt
@@ -13,7 +13,7 @@ file(GLOB SYS_NORMALIZER_SRC
 
 add_definitions(-DWAZUH_UNIT_TESTING)
 
-add_executable(sys_normalizer_unit_test 
+add_executable(sys_normalizer_unit_test
     ${SYS_NORMALIZER_UNIT_TEST_SRC}
     ${SYS_NORMALIZER_SRC})
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/src/wazuh_modules/syscollector/testtool/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/testtool/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_CXX_FLAGS "-g -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Woverloaded-v
 file(GLOB SYSCOLLECTOR_TESTTOOL_SRC
         "${CMAKE_SOURCE_DIR}/testtool/*.cpp"
         )
-    
+
 add_executable(syscollector_test_tool
                ${SYSCOLLECTOR_TESTTOOL_SRC}
                )


### PR DESCRIPTION
Related issue
| #7598  |
| closes #7598  |

## Description
This PR aims to add a fallback mechanism when trying to download pre compiled external depedencies. If precompiled libraries donwload fails sources will be downloaded to be compiled later.

## DoD
- [X] changes in makefile
- [X] manual tests on ubuntu
- [X] manual tests on centos
- [X] manual tests on macos