### PR TITLE
Fix vuln_cve insert parsing

### DIFF
--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -6048,16 +6048,15 @@ int wdb_parse_vuln_cve(wdb_t* wdb, char* input, char* output) {
     int result = OS_INVALID;
     char * next;
     const char delim[] = " ";
-    char *savedptr = NULL;
+    char *tail = NULL;
 
-    next = strtok_r(input, delim, &savedptr);
+    next = strtok_r(input, delim, &tail);
 
     if (!next){
         snprintf(output, OS_MAXSTR + 1, "err Missing vuln_cve action");
     }
     else if (strcmp(next, "insert") == 0) {
-        next = strtok_r(NULL, delim, &savedptr);
-        result = wdb_parse_agents_insert_vuln_cve(wdb, next, output);
+        result = wdb_parse_agents_insert_vuln_cve(wdb, tail, output);
     }
     else if (strcmp(next, "clear") == 0) {
         result = wdb_parse_agents_clear_vuln_cve(wdb, output);


### PR DESCRIPTION
|Related issue|
|---|
|7648|

## Description

This PR introduced a fix to a vuln_cve insert command parsing bug found during Exploratory Testing. 
Previously, the payload of the insert command was being parsed searching for final white spaces, this leads to a wrong parsing if the JSON payload contains a white space inside.
Now, the payload is obtained from the tail of the command parsing.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] QA integration tests execution
