### PR TITLE
Move vuln_cve clear command to full scan

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -123,9 +123,12 @@ STATIC int wm_vuldet_index_debian(sqlite3 *db, const char *target, update_node *
 /**
  * @brief For an specific agent, copy all installed packages' information from SYS_PROGRAM to the AGENTS table.
  * @param agent_software Pointer to an agent node.
+ * @param db The agent sqlite Data Base.
+ * @param ignore_time The configured scan ignore time to determine if a full scan is required.
+ * @param request The request type that was used. Full or partial.
  * @return 0 on success, -1 otherwise.
  */
-STATIC int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignore_time);
+STATIC int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignore_time, int* request);
 
 /**
  * @brief Search for known vulnerabilities (NVD and OVAL feeds), and report all found CVEs.
@@ -2035,13 +2038,6 @@ int wm_vuldet_report_agent_vulnerabilities(sqlite3 *db, agent_software *agent, w
         goto end;
     }
 
-    int sock = wm_vuldet_get_wdb_socket();
-
-    //Clean the vulnerabilities in the agent database
-    if (OS_INVALID == wdb_agents_vuln_cve_clear(atoi(agent->agent_id), &sock)) {
-        mtwarn(WM_VULNDETECTOR_LOGTAG, "Failed to clear vulnerabilities from the agent %s database", agent->agent_id);
-    }
-
     if (agent->dist == FEED_WIN) {
 
         if (wm_vuldet_win_nvd_vulnerabilities(db, agent, flags)) {
@@ -2130,8 +2126,9 @@ int wm_vuldet_check_agent_vulnerabilities(agent_software *agents, wm_vuldet_flag
         // Reset the tables before scanning each agent
         wm_vuldet_reset_tables(db);
 
+        int request = 0;
         // First step: collect its software
-        if (result = wm_vuldet_get_software_info(agents_it, db, ignore_time), result == OS_INVALID) {
+        if (result = wm_vuldet_get_software_info(agents_it, db, ignore_time, &request), result == OS_INVALID) {
             mterror(WM_VULNDETECTOR_LOGTAG, VU_GET_SOFTWARE_ERROR, atoi(agents_it->agent_id));
             break;
         }
@@ -2139,6 +2136,13 @@ int wm_vuldet_check_agent_vulnerabilities(agent_software *agents, wm_vuldet_flag
         // result == 2 skips the agent
         // is used when no hotfixes are available or no packages have been marked for scanning
         if (result != 2) {
+            if (VU_SOFTWARE_FULL_REQ == request) {
+                //Clean the vulnerabilities in the agent database
+                int sock = wm_vuldet_get_wdb_socket();
+                if (OS_INVALID == wdb_agents_vuln_cve_clear(atoi(agents_it->agent_id), &sock)) {
+                    mtwarn(WM_VULNDETECTOR_LOGTAG, "Failed to clear vulnerabilities from the agent %s database", agents_it->agent_id);
+                }
+            }
             // Second step: find and report vulnerabilities
             if (wm_vuldet_report_agent_vulnerabilities(db, agents_it, flags) < 0) {
                 mterror(WM_VULNDETECTOR_LOGTAG, VU_REPORT_ERROR, atoi(agents_it->agent_id), sqlite3_errmsg(db));
@@ -4362,13 +4366,12 @@ int wm_vuldet_json_parser(char *json_path, wm_vuldet_db *parsed_vulnerabilities,
     return retval;
 }
 
-int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignore_time) {
+int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignore_time, int* request) {
     unsigned int i;
     int size;
     char buffer[OS_SIZE_6144];
     char json_str[OS_SIZE_6144 + 10];
     char scan_id[OS_SIZE_128];
-    int request;
     int retval = OS_INVALID;
     cJSON *obj = NULL;
     cJSON *package_list = NULL;
@@ -4382,8 +4385,8 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
     mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_AGENT_SOFTWARE_REQ, atoi(agent->agent_id));
 
     // Check to see if the scan has already been reported
-    request = wm_vuldet_select_scan_type(agent->agent_id, ignore_time, &hotfix_config_enabled);
-    switch (request) {
+    *request = wm_vuldet_select_scan_type(agent->agent_id, ignore_time, &hotfix_config_enabled);
+    switch (*request) {
         case OS_INVALID:
             goto end;
         case VU_SOFTWARE_FULL_REQ:
@@ -4421,7 +4424,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
 
     // Request and store packages
     i = 0;
-    snprintf(buffer, OS_SIZE_6144, vu_queries[request], agent->agent_id, scan_id, VU_MAX_PACK_REQ, i);
+    snprintf(buffer, OS_SIZE_6144, vu_queries[*request], agent->agent_id, scan_id, VU_MAX_PACK_REQ, i);
     if (wm_vuldet_send_wdb(buffer)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_SOFTWARE_REQUEST_ERROR, atoi(agent->agent_id));
         goto end;
@@ -4464,7 +4467,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
             }
 
             i += VU_MAX_PACK_REQ;
-            snprintf(buffer, OS_SIZE_6144, vu_queries[request], agent->agent_id, scan_id, VU_MAX_PACK_REQ, i);
+            snprintf(buffer, OS_SIZE_6144, vu_queries[*request], agent->agent_id, scan_id, VU_MAX_PACK_REQ, i);
             if (wm_vuldet_send_wdb(buffer)) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_SOFTWARE_REQUEST_ERROR, atoi(agent->agent_id));
                 goto end;
@@ -4611,7 +4614,7 @@ int wm_vuldet_get_software_info(agent_software *agent, sqlite3 *db, time_t ignor
         }
         sqlite3_exec(db, vu_queries[END_T], NULL, NULL, NULL);
         agent->info = 1;
-    } else if (request == VU_SOFTWARE_REQUEST) {
+    } else if (*request == VU_SOFTWARE_REQUEST) {
         mtdebug1(WM_VULNDETECTOR_LOGTAG, VU_NO_SOFTWARE, atoi(agent->agent_id));
         if (agent->dist != FEED_WIN) {
             // If no new inventory is available, skip the agent


### PR DESCRIPTION
|Related issue|
|---|
|7650|

## Description
This PR refactor **wm_vuldet_get_software_info** to extract the request type and uses this information to only execute the vuln_cve clear command when a full scan takes place.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Debug and log analysis to check the functionality