### PR TITLE
Fixing information addition in the CVEs insert for windows vulnerabilities

### DIFF
--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2072,6 +2072,7 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
     vu_nvd_report *report_node;
     vu_nvd_report *f_report_node;
     vu_report *report = NULL;
+    cpe* cpe_data = NULL;
     int result;
     char *cve;
     char *cwe;
@@ -2196,10 +2197,16 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
             os_strdup(vu_severities[VU_UNKNOWN], report->severity);
         }
 
-        os_strdup(report_node->raw_product, report->software);
-        os_strdup(report_node->raw_version, report->version);
-        os_strdup(report_node->generated_cpe, report->generated_cpe);
-        os_strdup(report_node->raw_arch, report->arch);
+        if (NULL != report_node->generated_cpe) {
+            os_strdup(report_node->generated_cpe, report->generated_cpe);
+            cpe_data = wm_vuldet_decode_cpe(report_node->generated_cpe);
+        }
+
+        os_strdup((NULL != report_node->raw_product) ? report_node->raw_product : cpe_data->product, report->software);
+        os_strdup((NULL != report_node->raw_version) ? report_node->raw_version : cpe_data->version, report->version);
+        os_strdup((NULL != report_node->raw_arch) ? report_node->raw_arch :
+                  (NULL != cpe_data->target_hw) ? cpe_data->target_hw : "*", report->arch);
+
         report->pending = report_node->pending;
         wm_vuldet_build_nvd_condition(report_node, &report->condition, &report->is_hotfix);
 
@@ -2224,7 +2231,8 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
         // Sending CVE report
         wm_vuldet_send_cve_report(report);
         wm_vuldet_free_nvd_report(f_report_node);
-        free(f_report_node);
+        os_free(f_report_node);
+        os_free(cpe_data);
     }
 
     if (OS_INVALID == cve_insert_result) {


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7653 |

## Description

This pull request implements all the necessary changes to fix the issue in reference. The fix implements a mechanism to get the missing information from the CPE when the information is not available in the vulnerability data structure.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation