### PR TITLE
wazuh-logtest: add support for testing location information

### DIFF
--- a/framework/scripts/wazuh-logtest.py
+++ b/framework/scripts/wazuh-logtest.py
@@ -180,9 +180,9 @@ class WazuhDeamonProtocol:
         json_msg = json.loads(msg)
         # Get only the payload
         if json_msg['error']:
-            error_msg = ['\n\t{0}'.format(i) for i in json_msg['message']]
+            error_msg = json_msg['message']
             error_n = json_msg['error']
-            raise ValueError(str(error_n) + ''.join(error_msg))
+            raise ValueError(f'{error_n}: {error_msg}')
         data = json_msg['data']
         return data
 
@@ -259,13 +259,13 @@ class WazuhLogtest:
         recv_packet = self.socket.send(request)
 
         # Get logtest reply
+        logging.debug(f'Reply: %s\n', str(recv_packet,'utf-8'))
         reply = self.protocol.unwrap(recv_packet)
-        logging.debug('Reply: %s\n', reply)
 
         if reply['codemsg'] < 0:
             error_msg = ['\n\t{0}'.format(i) for i in reply['messages']]
             error_n = reply['codemsg']
-            raise ValueError(str(error_n) + ''.join(error_msg))
+            raise ValueError(f'{error_n}: {"".join(error_msg)}')
 
         # Save the token
         self.last_token = reply['token']

--- a/framework/scripts/wazuh-logtest.py
+++ b/framework/scripts/wazuh-logtest.py
@@ -39,9 +39,14 @@ def init_argparse():
     )
     parser.add_argument(
         "-U", help='Unit test. Refer to ruleset/testing/runtests.py',
-        nargs=1,
         metavar='rule:alert:decoder',
         dest='ut'
+    )
+    parser.add_argument(
+        "-l", help='Use custom location. Default "stdin"',
+        default='stdin',
+        metavar='location',
+        dest='location'
     )
     parser.add_argument(
         "-q", help='Quiet execution',
@@ -67,13 +72,13 @@ def main():
 
     # Handle unit test request
     if args.ut:
-        ut = args.ut[0].split(":")
+        ut = args.ut.split(":")
         if len(ut) != 3:
-            logging.error('Unit test configuration wrong syntax: %s', args.ut[0])
+            logging.error('Unit test configuration wrong syntax: %s', args.ut)
             sys.exit(1)
 
     # Initialize wazuh-logtest component
-    w_logtest = WazuhLogtest()
+    w_logtest = WazuhLogtest(location=args.location)
     logging.info('Starting wazuh-logtest %s', Wazuh.get_version_str())
     logging.info('Type one log per line')
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7535 |

## Description

Hi team!
This PR aims to solve #7535 by adding a command line parameter to set custom `location` value while testing logs using `wazuh-logtest`. This value will be used as long `wazuh-logtest` is open, no matter the session expire or was closed.

## Configuration options

The new parameter `-l` is optional and his default value is `stdin` in order to maintain retrocompatibility with `ossec-logtest`. Now, `wazuh-logtest` help menu looks like:
```
/var/ossec/bin/wazuh-logtest -h                                                                                                                                                                      usage: wazuh-logtest.py [-h] [-V] [-d] [-U rule:alert:decoder] [-l location] [-q]

Tool for developing, tuning, and debugging rules.

optional arguments:
  -h, --help            show this help message and exit
  -V                    Version and license message
  -d                    Execute in debug mode
  -U rule:alert:decoder
                        Unit test. Refer to ruleset/testing/runtests.py
  -l location           Use custom location. Default "stdin"
  -q                    Quiet execution
```
## Logs/Alerts example
The next rule was created (in `<WAZUHDIR>/etc/rules/local_rules.xml`) in order to check this PR
```xml
<group name="location-test,">

  <rule id="100001" level="3">
    <decoded_as>json</decoded_as>
    <location>(testhostname) any->/custom_location</location>
    <description>Custom location test rule</description>
  </rule>

</group>
```
Also, the following log must trigger an alert
```
{"A location test":"this is"}
```
### Default execution without `-l` (location) parameter
Debug flag was used to watch that location value is the expected one
```
/var/ossec/bin/wazuh-logtest -d
2021-03-02 13:58:59,309 wazuh-logtest[INFO] Starting wazuh-logtest v4.2.0
2021-03-02 13:58:59,309 wazuh-logtest[INFO] Type one log per line

{"A location test":"this is"}
2021-03-02 13:59:08,943 wazuh-logtest[INFO] 
2021-03-02 13:59:08,944 wazuh-logtest[DEBUG] Request: {"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location": "stdin", "log_format": "syslog", "event": "{\"A location test\":\"this is\"}"}}

2021-03-02 13:59:09,258 wazuh-logtest[DEBUG] Reply: {"error":0,"data":{"messages":["INFO: (7202): Session initialized with token '11d0edcb'"],"token":"11d0edcb","output":{"timestamp":"2021-03-02T13:59:09.257+0000","agent":{"id":"000","name":"wazuh-dev"},"manager":{"name":"wazuh-dev"},"id":"1614693549.325343","full_log":"{\"A location test\":\"this is\"}","decoder":{"name":"json"},"data":{"A location test":"this is"},"location":"stdin"},"alert":false,"codemsg":0}}

2021-03-02 13:59:09,258 wazuh-logtest[DEBUG] {
  "messages": [
    "INFO: (7202): Session initialized with token '11d0edcb'"
  ],
  "token": "11d0edcb",
  "output": {
    "timestamp": "2021-03-02T13:59:09.257+0000",
    "agent": {
      "id": "000",
      "name": "wazuh-dev"
    },
    "manager": {
      "name": "wazuh-dev"
    },
    "id": "1614693549.325343",
    "full_log": "{\"A location test\":\"this is\"}",
    "decoder": {
      "name": "json"
    },
    "data": {
      "A location test": "this is"
    },
    "location": "stdin"
  },
  "alert": false,
  "codemsg": 0
}
2021-03-02 13:59:09,258 wazuh-logtest[INFO] **Phase 1: Completed pre-decoding.
2021-03-02 13:59:09,258 wazuh-logtest[INFO]     full event: '{"A location test":"this is"}'
2021-03-02 13:59:09,258 wazuh-logtest[INFO] 
2021-03-02 13:59:09,258 wazuh-logtest[INFO] **Phase 2: Completed decoding.
2021-03-02 13:59:09,258 wazuh-logtest[INFO]     name: 'json'
2021-03-02 13:59:09,258 wazuh-logtest[INFO]     A location test: 'this is'
```
### Execution with `-l` (location) parameter
Debug flag was used to watch that location value is the expected one
#### Location match
```
/var/ossec/bin/wazuh-logtest -d -l "[123] (testhostname) any->/custom_location"                                                                     
2021-03-02 14:06:23,877 wazuh-logtest[INFO] Starting wazuh-logtest v4.2.0
2021-03-02 14:06:23,878 wazuh-logtest[INFO] Type one log per line

{"A location test":"this is"}
2021-03-02 14:06:32,237 wazuh-logtest[INFO] 
2021-03-02 14:06:32,237 wazuh-logtest[DEBUG] Request: {"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location": "[123] (testhostname) any->/custom_location", "log_format": "syslog", "event": "{\"A location test\":\"this is\"}"}}

2021-03-02 14:06:32,480 wazuh-logtest[DEBUG] Reply: {"error":0,"data":{"messages":["INFO: (7202): Session initialized with token '4b32536a'"],"token":"4b32536a","output":{"timestamp":"2021-03-02T14:06:32.480+0000","rule":{"level":3,"description":"Custom location test rule","id":"100001","firedtimes":1,"mail":false,"groups":["location-test"]},"agent":{"id":"123","name":"testhostname"},"manager":{"name":"wazuh-dev"},"id":"1614693992.325343","full_log":"{\"A location test\":\"this is\"}","decoder":{"name":"json"},"data":{"A location test":"this is"},"location":"/custom_location"},"alert":true,"codemsg":0}}

2021-03-02 14:06:32,480 wazuh-logtest[DEBUG] {
  "messages": [
    "INFO: (7202): Session initialized with token '4b32536a'"
  ],
  "token": "4b32536a",
  "output": {
    "timestamp": "2021-03-02T14:06:32.480+0000",
    "rule": {
      "level": 3,
      "description": "Custom location test rule",
      "id": "100001",
      "firedtimes": 1,
      "mail": false,
      "groups": [
        "location-test"
      ]
    },
    "agent": {
      "id": "123",
      "name": "testhostname"
    },
    "manager": {
      "name": "wazuh-dev"
    },
    "id": "1614693992.325343",
    "full_log": "{\"A location test\":\"this is\"}",
    "decoder": {
      "name": "json"
    },
    "data": {
      "A location test": "this is"
    },
    "location": "/custom_location"
  },
  "alert": true,
  "codemsg": 0
}
2021-03-02 14:06:32,481 wazuh-logtest[INFO] **Phase 1: Completed pre-decoding.
2021-03-02 14:06:32,481 wazuh-logtest[INFO]     full event: '{"A location test":"this is"}'
2021-03-02 14:06:32,481 wazuh-logtest[INFO] 
2021-03-02 14:06:32,481 wazuh-logtest[INFO] **Phase 2: Completed decoding.
2021-03-02 14:06:32,481 wazuh-logtest[INFO]     name: 'json'
2021-03-02 14:06:32,481 wazuh-logtest[INFO]     A location test: 'this is'
2021-03-02 14:06:32,481 wazuh-logtest[INFO] 
2021-03-02 14:06:32,481 wazuh-logtest[INFO] **Phase 3: Completed filtering (rules).
2021-03-02 14:06:32,481 wazuh-logtest[INFO]     id: '100001'
2021-03-02 14:06:32,481 wazuh-logtest[INFO]     level: '3'
2021-03-02 14:06:32,481 wazuh-logtest[INFO]     description: 'Custom location test rule'
2021-03-02 14:06:32,481 wazuh-logtest[INFO]     groups: '['location-test']'
2021-03-02 14:06:32,481 wazuh-logtest[INFO]     firedtimes: '1'
2021-03-02 14:06:32,481 wazuh-logtest[INFO]     mail: 'False'
2021-03-02 14:06:32,481 wazuh-logtest[INFO] **Alert to be generated.

```
#### Location do not match
```
/var/ossec/bin/wazuh-logtest -d -l "[123] (otherhostname) any->/custom_location"

2021-03-02 14:15:42,422 wazuh-logtest[INFO] Starting wazuh-logtest v4.2.0
2021-03-02 14:15:42,423 wazuh-logtest[INFO] Type one log per line

{"A location test":"this is"}
2021-03-02 14:15:53,454 wazuh-logtest[INFO] 
2021-03-02 14:15:53,455 wazuh-logtest[DEBUG] Request: {"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location": "[123] (otherhostname) any->/custom_location", "log_format": "syslog", "event": "{\"A location test\":\"this is\"}"}}

2021-03-02 14:15:53,744 wazuh-logtest[DEBUG] Reply: {"error":0,"data":{"messages":["INFO: (7202): Session initialized with token '10c82c65'"],"token":"10c82c65","output":{"timestamp":"2021-03-02T14:15:53.744+0000","agent":{"id":"123","name":"otherhostname"},"manager":{"name":"wazuh-dev"},"id":"1614694553.325343","full_log":"{\"A location test\":\"this is\"}","decoder":{"name":"json"},"data":{"A location test":"this is"},"location":"/custom_location"},"alert":false,"codemsg":0}}

2021-03-02 14:15:53,745 wazuh-logtest[DEBUG] {
  "messages": [
    "INFO: (7202): Session initialized with token '10c82c65'"
  ],
  "token": "10c82c65",
  "output": {
    "timestamp": "2021-03-02T14:15:53.744+0000",
    "agent": {
      "id": "123",
      "name": "otherhostname"
    },
    "manager": {
      "name": "wazuh-dev"
    },
    "id": "1614694553.325343",
    "full_log": "{\"A location test\":\"this is\"}",
    "decoder": {
      "name": "json"
    },
    "data": {
      "A location test": "this is"
    },
    "location": "/custom_location"
  },
  "alert": false,
  "codemsg": 0
}
2021-03-02 14:15:53,745 wazuh-logtest[INFO] **Phase 1: Completed pre-decoding.
2021-03-02 14:15:53,745 wazuh-logtest[INFO]     full event: '{"A location test":"this is"}'
2021-03-02 14:15:53,745 wazuh-logtest[INFO] 
2021-03-02 14:15:53,745 wazuh-logtest[INFO] **Phase 2: Completed decoding.
2021-03-02 14:15:53,745 wazuh-logtest[INFO]     name: 'json'
2021-03-02 14:15:53,745 wazuh-logtest[INFO]     A location test: 'this is'

```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] ~Linux~
  - [x] ~Windows~
  - [x] ~MAC OS X~
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [x] ~QA templates contemplate the added capabilities~

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] ~Scan-build report~
  - [x] ~Coverity~
  - [x] ~Valgrind (memcheck and descriptor leaks check)~
  - [x] ~Dr. Memory~
  - [x] ~AddressSanitizer~
- Memory tests for Windows
  - [x] ~Scan-build report~
  - [x] ~Coverity~
  - [x] ~Dr. Memory~
- Memory tests for macOS
  - [x] ~Scan-build report~
  - [x] ~Leaks~
  - [x] ~AddressSanitizer~

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

Regards,
Nico