### PR TITLE
Fix links to images (img->assets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,27 +77,27 @@ The Wazuh WUI provides a powerful user interface for data visualization and anal
 
 **Security events**
 
-![Overview](https://github.com/wazuh/wazuh-kibana-app/blob/master/public/img/app2.png)
+![Overview](https://github.com/wazuh/wazuh-kibana-app/blob/master/public/assets/app2.png)
 
 **Integrity monitoring**
 
-![Overview](https://github.com/wazuh/wazuh-kibana-app/blob/master/public/img/app3.png)
+![Overview](https://github.com/wazuh/wazuh-kibana-app/blob/master/public/assets/app3.png)
 
 **Vulnerability detection**
 
-![Overview](https://github.com/wazuh/wazuh-kibana-app/blob/master/public/img/app4.png)
+![Overview](https://github.com/wazuh/wazuh-kibana-app/blob/master/public/assets/app4.png)
 
 **Regulatory compliance**
 
-![Overview](https://github.com/wazuh/wazuh-kibana-app/blob/master/public/img/app5.png)
+![Overview](https://github.com/wazuh/wazuh-kibana-app/blob/master/public/assets/app5.png)
 
 **Agents overview**
 
-![Overview](https://github.com/wazuh/wazuh-kibana-app/blob/master/public/img/app6.png)
+![Overview](https://github.com/wazuh/wazuh-kibana-app/blob/master/public/assets/app6.png)
 
 **Agent summary**
 
-![Overview](https://github.com/wazuh/wazuh-kibana-app/blob/master/public/img/app7.png)
+![Overview](https://github.com/wazuh/wazuh-kibana-app/blob/master/public/assets/app7.png)
 
 ## Orchestration
 


### PR DESCRIPTION
## Description

The images within wazuh/wazuh-kibana-app repo have been moved from img to assets folder.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

not relevant, see preview of file.
