### PR TITLE
systemd-timesyncd typo cis debian10

### DIFF
--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -888,7 +888,7 @@ checks:
     rules:
       - 'c:dpkg -s ntp -> r:install ok installed'
       - 'c:dpkg -s chrony -> r:install ok installed'
-      - 'c:systemctl is-enabled systemd-timescynd -> enabled'
+      - 'c:systemctl is-enabled systemd-timesyncd -> enabled'
 
   - id: 2552
     title: "Ensure systemd-timesyncd is configured"


### PR DESCRIPTION
|Related issue|
|---|
|#7671|


## Description

This PR solves a typo in cis_debian10.yml file, id: 2551, right wording is systemd-timesyncd


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] ~~Scan-build report~~
  - [X] ~~Coverity~~
  - [X] ~~Valgrind (memcheck and descriptor leaks check)~~
  - [X] ~~Dr. Memory~~
  - [X] ~~AddressSanitizer~~
- Memory tests for Windows
  - [X] ~~Scan-build report~~
  - [X] ~~Coverity~~
  - [X] ~~Dr. Memory~~
- Memory tests for macOS
  - [X] ~~Scan-build report~~
  - [X] ~~Leaks~~
  - [X] ~~AddressSanitizer~~

<!-- Checks for huge PRs that affect the product more generally -->
- [X] ~~Retrocompatibility with older Wazuh versions~~
- [X] ~~Working on cluster environments~~
- [X] ~~Configuration on demand reports new parameters~~
- [X] ~~The data flow works as expected (agent-manager-api-app)~~
- [X] ~~Added unit tests (for new features)~~
- [X] ~~Stress test for affected components~~
