### PR TITLE
fix wrong macro to get the buffer length for getpwnam_r()

### DIFF
--- a/src/shared/privsep_op.c
+++ b/src/shared/privsep_op.c
@@ -91,7 +91,7 @@ struct group *w_getgrgid(gid_t gid, struct group *grp,  char *buf, int buflen) {
 
 uid_t Privsep_GetUser(const char *name)
 {
-    long int len =  sysconf(_SC_GETGR_R_SIZE_MAX);
+    long int len =  sysconf(_SC_GETPW_R_SIZE_MAX);
     len = len > 0 ? len : 1024;
     struct passwd pw = { .pw_name = NULL };
     char *buffer = NULL;


### PR DESCRIPTION
# Description
the macro in sysconf() used to get the buffer length for `getpwnam_r()` and `getgrnam_r()` are different.
getpwnam_r() ->sysconf(`_SC_GETPW_R_SIZE_MAX`)
getgrnam_r() -->sysconf(`_SC_GETGR_R_SIZE_MAX`)



