### PR TITLE
Adding UTs for new vuln cve table insert and clear command

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -18,7 +18,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                         -Wl,--wrap,wdb_fim_delete -Wl,--wrap,wdb_syscheck_save -Wl,--wrap,wdb_syscheck_save2 \
                         -Wl,--wrap,wdbi_query_checksum -Wl,--wrap,wdbi_query_clear -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,wdb_step \
                         -Wl,--wrap,sqlite3_changes -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_last_insert_rowid \
-                        -Wl,--wrap,sqlite3_step")
+                        -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_open_agent2 -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_agents_insert_vuln_cve \
+                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cve")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
@@ -41,6 +42,10 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                             -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_begin2 -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,sqlite3_bind_int \
                             -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,wdb_exec_stmt_sized -Wl,--wrap,wdb_step -Wl,--wrap,sqlite3_bind_text \
                             -Wl,--wrap,sqlite3_bind_parameter_index -Wl,--wrap,cJSON_Delete -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int")
+
+list(APPEND wdb_tests_names "test_wdb_agents")
+list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step")
+
 
 list(APPEND wdb_tests_names "test_wdb_global_helpers")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,strerror \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -72,7 +72,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Delete_ex \
                              -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,sqlite3_close_v2 -Wl,--wrap,sqlite3_step \
                              -Wl,--wrap,sqlite3_column_count -Wl,--wrap,sqlite3_column_type -Wl,--wrap,sqlite3_column_name -Wl,--wrap,sqlite3_column_double \
-                             -Wl,--wrap,sqlite3_column_text")
+                             -Wl,--wrap,sqlite3_column_text -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,sqlite3_finalize -Wl,--wrap,sqlite3_reset \
+                             -Wl,--wrap,sqlite3_clear_bindings -Wl,--wrap,sqlite3_errmsg")
 
 list(APPEND wdb_tests_names "test_wdb_upgrade")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,wdb_metadata_table_check \

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2015-2020, Wazuh Inc.
- * September, 2020.
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ * March, 2021.
  *
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
@@ -405,10 +405,20 @@ void test_wdb_exec_stmt_error(void **state) {
 
 /* Tests wdb_exec_stmt_silent */
 
-void test_wdb_exec_stmt_silent_success(void **state) {
+void test_wdb_exec_stmt_silent_success_sqlite_done(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     expect_sqlite3_step_call(SQLITE_DONE);
+
+    int result = wdb_exec_stmt_silent(*data->wdb->stmt);
+
+    assert_int_equal(result, OS_SUCCESS);
+}
+
+void test_wdb_exec_stmt_silent_success_sqlite_row(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_sqlite3_step_call(SQLITE_ROW);
 
     int result = wdb_exec_stmt_silent(*data->wdb->stmt);
 
@@ -502,7 +512,8 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_sized_invalid_statement, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_sized_error, setup_wdb, teardown_wdb),
         //wdb_exec_stmt_silent
-        cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_silent_success, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_silent_success_sqlite_done, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_silent_success_sqlite_row, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_silent_invalid, setup_wdb, teardown_wdb),
         //wdb_init_stmt_in_cache
         cmocka_unit_test_setup_teardown(test_wdb_init_stmt_in_cache_success, setup_wdb, teardown_wdb),

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -24,6 +24,7 @@
 #include "../wrappers/wazuh/shared/hash_op_wrappers.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/externals/sqlite/sqlite3_wrappers.h"
+#include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
 
 typedef struct test_struct {
     wdb_t *wdb;
@@ -98,6 +99,7 @@ void test_wdb_open_tasks_create_error(void **state)
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
     will_return(__wrap_sqlite3_open_v2, OS_INVALID);
 
+    will_return(__wrap_sqlite3_errmsg, "out of memory");
     expect_string(__wrap__mdebug1, formatted_msg, "Couldn't create SQLite database 'queue/tasks/tasks.db': out of memory");
     will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
 
@@ -149,6 +151,8 @@ void test_wdb_open_global_create_fail(void **state)
     will_return(__wrap_sqlite3_open_v2, NULL);
     expect_value(__wrap_sqlite3_open_v2, flags, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
     will_return(__wrap_sqlite3_open_v2, OS_INVALID);
+
+    will_return(__wrap_sqlite3_errmsg, "out of memory");
     expect_string(__wrap__mdebug1, formatted_msg, "Couldn't create SQLite database 'queue/db/global.db': out of memory");
     will_return(__wrap_sqlite3_close_v2, OS_SUCCESS);
 
@@ -399,6 +403,79 @@ void test_wdb_exec_stmt_error(void **state) {
     cJSON_Delete(result);
 }
 
+/* Tests wdb_exec_stmt_silent */
+
+void test_wdb_exec_stmt_silent_success(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    int result = wdb_exec_stmt_silent(*data->wdb->stmt);
+
+    assert_int_equal(result, OS_SUCCESS);
+}
+
+void test_wdb_exec_stmt_silent_invalid(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_sqlite3_step_call(SQLITE_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "SQL statement execution failed");
+
+    int result = wdb_exec_stmt_silent(*data->wdb->stmt);
+
+    assert_int_equal(result, OS_INVALID);
+}
+
+/* Tests wdb_init_stmt_in_cache */
+
+void test_wdb_init_stmt_in_cache_success(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // wdb_begin2
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    expect_sqlite3_step_call(SQLITE_DONE);
+    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
+
+    // wdb_stmt_cache
+    will_return(__wrap_sqlite3_reset, SQLITE_OK);
+    will_return(__wrap_sqlite3_clear_bindings, SQLITE_OK);
+
+    sqlite3_stmt* result = wdb_init_stmt_in_cache(data->wdb, WDB_STMT_FIM_LOAD);
+
+    assert_non_null(result);
+}
+
+void test_wdb_init_stmt_in_cache_invalid_transaction(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // wdb_begin2
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_ERROR);
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__mdebug1, formatted_msg, "sqlite3_prepare_v2(): ERROR MESSAGE");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
+
+    sqlite3_stmt* result = wdb_init_stmt_in_cache(data->wdb, 0);
+
+    assert_null(result);
+}
+
+void test_wdb_init_stmt_in_cache_invalid_statement(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // wdb_begin2
+    will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
+    expect_sqlite3_step_call(SQLITE_DONE);
+    will_return(__wrap_sqlite3_finalize, SQLITE_OK);
+
+    // wdb_stmt_cache
+    expect_string(__wrap__merror, formatted_msg, "DB(000) SQL statement index (172) out of bounds");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
+
+    sqlite3_stmt* result = wdb_init_stmt_in_cache(data->wdb,WDB_STMT_SIZE);
+
+    assert_null(result);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] =
@@ -424,6 +501,13 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_sized_success_limited, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_sized_invalid_statement, setup_wdb, teardown_wdb),
         cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_sized_error, setup_wdb, teardown_wdb),
+        //wdb_exec_stmt_silent
+        cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_silent_success, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_exec_stmt_silent_invalid, setup_wdb, teardown_wdb),
+        //wdb_init_stmt_in_cache
+        cmocka_unit_test_setup_teardown(test_wdb_init_stmt_in_cache_success, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_init_stmt_in_cache_invalid_transaction, setup_wdb, teardown_wdb),
+        cmocka_unit_test_setup_teardown(test_wdb_init_stmt_in_cache_invalid_statement, setup_wdb, teardown_wdb)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -1,0 +1,134 @@
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "os_err.h"
+#include "wazuh_db/wdb.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../wrappers/externals/sqlite/sqlite3_wrappers.h"
+#include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
+#include "wazuhdb_op.h"
+#include "wazuh_db/wdb_agents.h"
+
+typedef struct test_struct {
+    wdb_t *wdb;
+    char *output;
+} test_struct_t;
+
+static int test_setup(void **state) {
+    test_struct_t *init_data = NULL;
+    os_calloc(1,sizeof(test_struct_t),init_data);
+    os_calloc(1,sizeof(wdb_t),init_data->wdb);
+    os_strdup("000",init_data->wdb->id);
+    os_calloc(256,sizeof(char),init_data->output);
+    os_calloc(1,sizeof(sqlite3 *),init_data->wdb->db);
+    *state = init_data;
+    return 0;
+}
+
+static int test_teardown(void **state){
+    test_struct_t *data  = (test_struct_t *)*state;
+    os_free(data->output);
+    os_free(data->wdb->id);
+    os_free(data->wdb->db);
+    os_free(data->wdb);
+    os_free(data);
+    return 0;
+}
+
+/* Tests wdb_agents_insert_vuln_cve */
+
+void test_wdb_agents_insert_vuln_cve_fail(void **state)
+{
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* name = "package";
+    const char* version = "4.0";
+    const char* architecture = "x86";
+    const char* cve = "CVE-2021-1200";
+
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_INSERT);
+
+    ret = wdb_agents_insert_vuln_cve(data->wdb, name, version, architecture, cve);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_agents_insert_vuln_cve_success(void **state)
+{
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* name = "package";
+    const char* version = "4.0";
+    const char* architecture = "x86";
+    const char* cve = "CVE-2021-1200";
+
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_INSERT);
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, name);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, version);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_string(__wrap_sqlite3_bind_text, buffer, architecture);
+    expect_value(__wrap_sqlite3_bind_text, pos, 4);
+    expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    ret = wdb_agents_insert_vuln_cve(data->wdb, name, version, architecture, cve);
+
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+/* Tests wdb_agents_clear_vuln_cve */
+
+void test_wdb_agents_clear_vuln_cve_fail(void **state)
+{
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_CLEAR);
+
+    ret = wdb_agents_clear_vuln_cve(data->wdb);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_agents_clear_vuln_cve_success(void **state)
+{
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_CLEAR);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    ret = wdb_agents_clear_vuln_cve(data->wdb);
+
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+
+int main()
+{
+    const struct CMUnitTest tests[] = {
+        /* Tests wdb_agents_insert_vuln_cve */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cve_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cve_success, test_setup, test_teardown),
+        /* Tests wdb_agents_clear_vuln_cve */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_success, test_setup, test_teardown)
+      };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ * March, 2021.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
 
 #include <stdarg.h>
 #include <stddef.h>
@@ -42,7 +51,7 @@ static int test_teardown(void **state){
 
 /* Tests wdb_agents_insert_vuln_cve */
 
-void test_wdb_agents_insert_vuln_cve_fail(void **state)
+void test_wdb_agents_insert_vuln_cve_statement_init_fail(void **state)
 {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -90,7 +99,7 @@ void test_wdb_agents_insert_vuln_cve_success(void **state)
 
 /* Tests wdb_agents_clear_vuln_cve */
 
-void test_wdb_agents_clear_vuln_cve_fail(void **state)
+void test_wdb_agents_clear_vuln_cve_statement_init_fail(void **state)
 {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -123,10 +132,10 @@ int main()
 {
     const struct CMUnitTest tests[] = {
         /* Tests wdb_agents_insert_vuln_cve */
-        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cve_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cve_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cve_success, test_setup, test_teardown),
         /* Tests wdb_agents_clear_vuln_cve */
-        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_success, test_setup, test_teardown)
       };
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
@@ -1,0 +1,26 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "wdb_agents_wrappers.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+int __wrap_wdb_agents_insert_vuln_cve( __attribute__((unused)) wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve) {
+    check_expected(name);
+    check_expected(version);
+    check_expected(architecture);
+    check_expected(cve);
+    return mock();
+}
+
+int __wrap_wdb_agents_clear_vuln_cve( __attribute__((unused)) wdb_t *wdb) {
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
@@ -1,0 +1,19 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+#ifndef WDB_AGENTS_WRAPPERS_H
+#define WDB_AGENTS_WRAPPERS_H
+
+#include "wazuh_db/wdb.h"
+
+int __wrap_wdb_agents_insert_vuln_cve(wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve);
+int __wrap_wdb_agents_clear_vuln_cve(wdb_t *wdb);
+
+#endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it
@@ -14,6 +14,11 @@
 #include <cmocka.h>
 
 wdb_t* __wrap_wdb_open_global() {
+    return mock_ptr_type(wdb_t*);
+}
+
+wdb_t* __wrap_wdb_open_agent2(int agent_id) {
+    check_expected(agent_id);
     return mock_ptr_type(wdb_t*);
 }
 
@@ -216,4 +221,13 @@ int __wrap_wdb_create_global(const char *path) {
 
 void __wrap_wdb_pool_append(wdb_t * wdb) {
     check_expected(wdb);
+}
+
+sqlite3_stmt* __wrap_wdb_init_stmt_in_cache( __attribute__((unused)) wdb_t* wdb, wdb_stmt statement_index){
+    check_expected(statement_index);
+    return mock_ptr_type(sqlite3_stmt*);
+}
+
+int __wrap_wdb_exec_stmt_silent(__attribute__((unused)) sqlite3_stmt* stmt) {
+    return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it
@@ -14,6 +14,8 @@
 #include "wazuh_db/wdb.h"
 
 wdb_t* __wrap_wdb_open_global();
+
+wdb_t* __wrap_wdb_open_agent2(int agent_id);
 
 int __wrap_wdb_begin2(wdb_t* aux);
 
@@ -72,5 +74,9 @@ int __wrap_wdb_close(wdb_t * wdb, bool commit);
 int __wrap_wdb_create_global(const char *path);
 
 void __wrap_wdb_pool_append(wdb_t * wdb);
+
+sqlite3_stmt* __wrap_wdb_init_stmt_in_cache(wdb_t* wdb, wdb_stmt statement_index);
+
+int __wrap_wdb_exec_stmt_silent(sqlite3_stmt* stmt);
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|#7514|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR implements 100% of coverage for the methods in  wdb_agents.c, wdb_parser.c and wdb.c

- wdb_agents_insert_vuln_cve
- wdb_agents_clear_vuln_cve
- wdb_parse_vuln_cve
- wdb_exec_stmt_silent
- wdb_init_stmt_in_cache

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [X] Added unit tests (for new features)
