### PR TITLE
Clear vuln_cve table when Vulnerability Detector is disabled

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
@@ -43,7 +43,7 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,fflush -Wl,--wrap,fprintf -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,getpid -Wl,--wrap,OSHash_Add_ex \
                                 -Wl,--wrap,wurl_request_uncompress_bz2_gz -Wl,--wrap,w_uncompress_bz2_gz_file -Wl,--wrap,wstr_replace \
                                 -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap=wstr_split -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Execute_ex \
-                                -Wl,--wrap,fgetpos -Wl,--wrap,wdb_agents_vuln_cve_insert -Wl,--wrap,wdb_agents_vuln_cve_clear")
+                                -Wl,--wrap,fgetpos -Wl,--wrap,wdb_agents_vuln_cve_insert -Wl,--wrap,wdb_agents_vuln_cve_clear -Wl,--wrap,wdb_get_all_agents")
 
 list(APPEND vulndetector_names "test_wm_vuln_detector_evr")
 list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,OS_ConnectUnixDomain \

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -91,6 +91,7 @@ bool wm_vuldet_update_MSU(update_node *update);
 int wm_vuldet_fetch_MSU(update_node *update, char *repo);
 int wm_vuldet_compare_vendors(char * vendor);
 void wm_vuldel_truncate_revision(char * revision);
+void wm_vuldet_init_vuln_cve_db(void);
 
 /* setup/teardown */
 
@@ -17313,6 +17314,56 @@ void test_wm_vuldet_fetch_MSU_max_attempts(void **state)
 
 }
 
+// Tests wm_vuldet_init_vuln_cve_db
+
+void test_wm_vuldet_init_vuln_cve_db_success(void **state)
+{
+    int *array = NULL;
+    os_malloc(sizeof(int)*3, array);
+    array[0] = 0;
+    array[1] = 1;
+    array[2] = OS_INVALID;
+
+    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
+    will_return(__wrap_wdb_get_all_agents, array);
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 1);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
+
+    wm_vuldet_init_vuln_cve_db();
+}
+
+void test_wm_vuldet_init_vuln_cve_db_get_agents_error(void **state)
+{
+    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
+    will_return(__wrap_wdb_get_all_agents, NULL);
+    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtwarn, formatted_msg, "Unable to get agent's ID array to clear vuln_cve table");
+
+    wm_vuldet_init_vuln_cve_db();
+}
+
+void test_wm_vuldet_init_vuln_cve_db_clear_table_error(void **state)
+{
+    int *array = NULL;
+    os_malloc(sizeof(int)*3, array);
+    array[0] = 0;
+    array[1] = 1;
+    array[2] = OS_INVALID;
+
+    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
+    will_return(__wrap_wdb_get_all_agents, array);
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 1);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_INVALID);
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Error clearing vuln_cve table for agent 1");
+
+    wm_vuldet_init_vuln_cve_db();
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -17761,6 +17812,10 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_updated, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_invalid_hash, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_max_attempts, setup_group, teardown_group),
+        // Tests wm_vuldet_init_vuln_cve_db
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_vuln_cve_db_success, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_vuln_cve_db_get_agents_error, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_vuln_cve_db_clear_table_error, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -91,7 +91,7 @@ bool wm_vuldet_update_MSU(update_node *update);
 int wm_vuldet_fetch_MSU(update_node *update, char *repo);
 int wm_vuldet_compare_vendors(char * vendor);
 void wm_vuldel_truncate_revision(char * revision);
-void wm_vuldet_init_vuln_cve_db(void);
+void wm_vuldet_clean_vuln_cve_db(void);
 
 /* setup/teardown */
 
@@ -17314,9 +17314,9 @@ void test_wm_vuldet_fetch_MSU_max_attempts(void **state)
 
 }
 
-// Tests wm_vuldet_init_vuln_cve_db
+// Tests wm_vuldet_clean_vuln_cve_db
 
-void test_wm_vuldet_init_vuln_cve_db_success(void **state)
+void test_wm_vuldet_clean_vuln_cve_db_success(void **state)
 {
     int *array = NULL;
     os_malloc(sizeof(int)*3, array);
@@ -17331,20 +17331,20 @@ void test_wm_vuldet_init_vuln_cve_db_success(void **state)
     expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 1);
     will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
-    wm_vuldet_init_vuln_cve_db();
+    wm_vuldet_clean_vuln_cve_db();
 }
 
-void test_wm_vuldet_init_vuln_cve_db_get_agents_error(void **state)
+void test_wm_vuldet_clean_vuln_cve_db_get_agents_error(void **state)
 {
     expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
     will_return(__wrap_wdb_get_all_agents, NULL);
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtwarn, formatted_msg, "Unable to get agent's ID array to clear vuln_cve table");
 
-    wm_vuldet_init_vuln_cve_db();
+    wm_vuldet_clean_vuln_cve_db();
 }
 
-void test_wm_vuldet_init_vuln_cve_db_clear_table_error(void **state)
+void test_wm_vuldet_clean_vuln_cve_db_clear_table_error(void **state)
 {
     int *array = NULL;
     os_malloc(sizeof(int)*3, array);
@@ -17361,7 +17361,7 @@ void test_wm_vuldet_init_vuln_cve_db_clear_table_error(void **state)
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "Error clearing vuln_cve table for agent 1");
 
-    wm_vuldet_init_vuln_cve_db();
+    wm_vuldet_clean_vuln_cve_db();
 }
 
 int main(void)
@@ -17812,10 +17812,10 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_updated, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_invalid_hash, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_max_attempts, setup_group, teardown_group),
-        // Tests wm_vuldet_init_vuln_cve_db
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_vuln_cve_db_success, setup_group, teardown_group),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_vuln_cve_db_get_agents_error, setup_group, teardown_group),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_vuln_cve_db_clear_table_error, setup_group, teardown_group),
+        // Tests wm_vuldet_clean_vuln_cve_db
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_success, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_get_agents_error, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_clear_table_error, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -300,9 +300,9 @@ STATIC int wm_vuldet_compare_vendors(char * vendor);
 STATIC void wm_vuldel_truncate_revision(char * revision);
 
 /**
- * @brief Initialize every agent vuln_cve DB by clearing the table.
+ * @brief Clean every agent vuln_cve DB.
  */
-STATIC void wm_vuldet_init_vuln_cve_db(void);
+STATIC void wm_vuldet_clean_vuln_cve_db(void);
 
 int wdb_vuldet_sock = -1;
 int *vu_queue;
@@ -7139,7 +7139,7 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
     wm_vuldet_flags *flags = &vuldet->flags;
     int i;
 
-    wm_vuldet_init_vuln_cve_db();
+    wm_vuldet_clean_vuln_cve_db();
 
     if (!flags->enabled) {
         mtdebug1(WM_VULNDETECTOR_LOGTAG, "Module disabled. Exiting...");
@@ -7647,7 +7647,7 @@ void wm_vuldel_truncate_revision(char * revision) {
     return;
 }
 
-void wm_vuldet_init_vuln_cve_db(void) {
+void wm_vuldet_clean_vuln_cve_db(void) {
     int sock = wm_vuldet_get_wdb_socket();
     int *id_array = wdb_get_all_agents(TRUE, &sock);
     if (!id_array) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -299,6 +299,11 @@ STATIC int wm_vuldet_compare_vendors(char * vendor);
  */
 STATIC void wm_vuldel_truncate_revision(char * revision);
 
+/**
+ * @brief Initialize every agent vuln_cve DB by clearing the table.
+ */
+STATIC void wm_vuldet_init_vuln_cve_db(void);
+
 int wdb_vuldet_sock = -1;
 int *vu_queue;
 // Define time to sleep between messages sent
@@ -7134,6 +7139,8 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
     wm_vuldet_flags *flags = &vuldet->flags;
     int i;
 
+    wm_vuldet_init_vuln_cve_db();
+
     if (!flags->enabled) {
         mtdebug1(WM_VULNDETECTOR_LOGTAG, "Module disabled. Exiting...");
         pthread_exit(NULL);
@@ -7638,6 +7645,21 @@ void wm_vuldel_truncate_revision(char * revision) {
         }
     }
     return;
+}
+
+void wm_vuldet_init_vuln_cve_db(void) {
+    int sock = wm_vuldet_get_wdb_socket();
+    int *id_array = wdb_get_all_agents(TRUE, &sock);
+    if (!id_array) {
+        mtwarn(WM_VULNDETECTOR_LOGTAG, "Unable to get agent's ID array to clear vuln_cve table");
+        return;
+    }
+    for (size_t i = 0; id_array[i] != OS_INVALID; i++) {
+        if (OS_SUCCESS != wdb_agents_vuln_cve_clear(id_array[i], &sock)) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Error clearing vuln_cve table for agent %d", id_array[i]);
+        }
+    }
+    os_free(id_array);
 }
 
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -7139,9 +7139,10 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
     wm_vuldet_flags *flags = &vuldet->flags;
     int i;
 
-    wm_vuldet_clean_vuln_cve_db();
-
     if (!flags->enabled) {
+        // If vuldet is disabled we must clean the vulnerable software tables
+        wm_vuldet_clean_vuln_cve_db();
+
         mtdebug1(WM_VULNDETECTOR_LOGTAG, "Module disabled. Exiting...");
         pthread_exit(NULL);
     }


### PR DESCRIPTION
|Related issue|
|---|
|7698|

## Description
This PR adds the functionality to clear the vuln_cve table of each agent in the manager if Vulnerabilty Detector is disabled.
This clear is performed only if Vulnerability Detector is disabled to guarantee that there will be no outdated data on the table.
It also creates the UT for the new function.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report

