### PR TITLE
Fix unknown_user string and 308 code in API logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project will be documented in this file.
 
 - **API:**
   - Fixed wrong API messages returned when getting agents' upgrade results. ([#7587](https://github.com/wazuh/wazuh/pull/7587))
+  - Fixed wrong `user` string in API logs when receiving responses with status codes 308 or 404. ([#7709](https://github.com/wazuh/wazuh/pull/7709))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@ All notable changes to this project will be documented in this file.
 
 - **API:**
   - Fixed wrong API messages returned when getting agents' upgrade results. ([#7587](https://github.com/wazuh/wazuh/pull/7587))
-  - Fixed wrong `user` string in API logs when receiving responses with status codes 308 or 404. ([#7709](https://github.com/wazuh/wazuh/pull/7709))
 
 ### Removed
 

--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -6,11 +6,16 @@ import logging
 import re
 
 from aiohttp.abc import AbstractAccessLogger
+from werkzeug.exceptions import Unauthorized
 
+from api.authentication import decode_token
 from wazuh.core.wlogging import WazuhLogger
 
 # compile regex when the module is imported so it's not necessary to compile it everytime log.info is called
 request_pattern = re.compile(r'\[.+\]|\s+\*\s+')
+
+# Variable used to specify an unknown user
+UNKNOWN_USER_STRING = "unknown_user"
 
 
 class AccessLogger(AbstractAccessLogger):
@@ -22,7 +27,17 @@ class AccessLogger(AbstractAccessLogger):
             query['password'] = '****'
         if 'password' in body:
             body['password'] = '****'
-        self.logger.info(f'{request.get("user", "unknown_user")} '
+
+        # With permanent redirect, not found responses or any response with no token information,
+        # decode the JWT token to get the username
+        user = request.get('user', '')
+        if not user:
+            try:
+                user = decode_token(request.headers["authorization"][7:])["sub"]
+            except Unauthorized:
+                user = UNKNOWN_USER_STRING
+
+        self.logger.info(f'{user} '
                          f'{request.remote} '
                          f'"{request.method} {request.path}" '
                          f'with parameters {json.dumps(query)} and body {json.dumps(body)} '

--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -27,7 +27,13 @@ with patch('wazuh.core.common.ossec_uid'):
 ])
 @patch('api.alogging.json.dumps')
 def test_accesslogger_log(mock_dumps, side_effect, user):
-    """Test expected methods are called when using log()."""
+    """Test expected methods are called when using log().
+
+    Parameters
+    ----------
+    response : StreamResponse
+        Response used to log a mocked request.
+    """
 
     class MockedRequest(MagicMock):
         def get(self, *args, **kwargs):

--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -31,17 +31,19 @@ def test_accesslogger_log(mock_dumps, side_effect, user):
 
     Parameters
     ----------
-    response : StreamResponse
-        Response used to log a mocked request.
+    side_effect : function
+        Side effect used in the decode_token mock.
+    user : str
+        User returned by the request.get function of alogging.py, which is mocked using a class.
     """
 
     class MockedRequest(MagicMock):
         def get(self, *args, **kwargs):
             return user
 
-    if not user:
-        with patch('api.alogging.decode_token', side_effect=side_effect) as mocked_decode_token:
-            alogging.AccessLogger.log(MagicMock(), request=MockedRequest(), response=MagicMock(), time=0.0)
+    with patch('api.alogging.decode_token', side_effect=side_effect) as mocked_decode_token:
+        alogging.AccessLogger.log(MagicMock(), request=MockedRequest(), response=MagicMock(), time=0.0)
+        if not user:
             mocked_decode_token.assert_called_once()
 
 

--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -14,7 +14,7 @@ variables:
   pass: wazuh
   basic_auth: dGVzdGluZzp3YXp1aA== # b64 encoded user:pass, update if user or pass changes
   basic_auth_context: d2F6dWgtd3VpOndhenVoLXd1aQ== # b64 encoded user:pass, update if user or pass changes
-  login_endpoint: /security/user/authenticate
+  login_endpoint: security/user/authenticate
 
   # delays
   restart_delay: 30


### PR DESCRIPTION
|Related issue|
|---|
| #7622 |

This pull request closes #7622.

In this PR, I have investigated the `unknown_user` API log appearing with a `308` status code.

### 308 RESPONSE

The Wazuh API is sending a 308 response. This code indicates a **Permanent Redirect** and means that the requested resource has been permanently moved to another URI, as indicated by the special **Location** header returned within the response.

The `308` status code appears when the endpoint we want to call has a double `/` at the beginning.

This is happening in our testing environment, we are using the following variable, located at `common.yml`:

`login_endpoint: /security/user/authenticate
`
When we use this variable in `conftest.py`, we are adding another `/` :

`login_url = f"{common['protocol']}://{common['host']}:{common['port']}/{common['login_endpoint']}"
`
This causes a redirection and thus the `308` code.

With the apropriate path, the error disappears. I have changed that path in our testing environment.

### UNKNOWN_USER STRING

A different problem is the `unknown_user` string when the `308` or `404` status codes appear. It is an error because are logged in and the API should include the actual user in the log.

When receiving responses with status `308` or `404`, `request` doesn't have the keys `user` and `token_info`.
The following logs show the actual `log`, `request.keys()`, `request.values()`, `request.headers` and each `header` with its content, respectively.


```
2021/03/02 08:02:35 INFO: wazuh 127.0.0.1 "GET /security/user/authenticate" done in 0.168s: 200
2021/03/02 08:02:35 INFO: ['user', 'token_info']
2021/03/02 08:02:35 INFO: ['wazuh', {'sub': 'wazuh', 'active': True}]
2021/03/02 08:02:35 INFO: ['Host', 'Authorization', 'User-Agent', 'Accept']
2021/03/02 08:02:35 INFO: Host : localhost:55000
2021/03/02 08:02:35 INFO: Authorization : Basic d2F6dWg6d2F6dWg=
2021/03/02 08:02:35 INFO: User-Agent : curl/7.68.0
2021/03/02 08:02:35 INFO: Accept : */*
```


```
2021/03/02 08:02:50 INFO: unknown_user 127.0.0.1 "GET /user/authenticate" done in 0.003s: 308
2021/03/02 08:02:50 INFO: []
2021/03/02 08:02:50 INFO: []
2021/03/02 08:02:50 INFO: ['Host', 'Authorization', 'User-Agent', 'Accept']
2021/03/02 08:02:50 INFO: Host : localhost:55000
2021/03/02 08:02:50 INFO: Authorization : Basic d2F6dWg6d2F6dWg=
2021/03/02 08:02:50 INFO: User-Agent : curl/7.68.0
2021/03/02 08:02:50 INFO: Accept : */*
```


In the second log we can't get the token as the login was unsuccessful (the authorization is a basic auth).

With the following call:

`curl -k -X GET "https://localhost:55000/sca/000" -H "Authorization: Bearer $TOKEN"
`

Logs:

```
2021/03/02 08:05:58 INFO: wazuh 127.0.0.1 "GET /sca/000" done in 0.059s: 200
2021/03/02 08:05:58 INFO: ['user', 'token_info']
2021/03/02 08:05:58 INFO: ['wazuh', {'iss': 'wazuh', 'aud': 'Wazuh API REST', 'nbf': 1614672355, 'exp': 1614673255, 'sub': 'wazuh', 'run_as': False, 'rbac_roles': [1], 'rbac_policies': {'agent:create': {'*:*:*': 'allow'}, 'group:create': {'*:*:*': 'allow'}, 'agent:read': {'agent:id:*': 'allow', 'agent:group:*': 'allow'}, 'agent:delete': {'agent:id:*': 'allow', 'agent:group:*': 'allow'}, 'agent:modify_group': {'agent:id:*': 'allow', 'agent:group:*': 'allow'}, 'agent:restart': {'agent:id:*': 'allow', 'agent:group:*': 'allow'}, 'agent:upgrade': {'agent:id:*': 'allow', 'agent:group:*': 'allow'}, 'group:read': {'group:id:*': 'allow'}, 'group:delete': {'group:id:*': 'allow'}, 'group:update_config': {'group:id:*': 'allow'}, 'group:modify_assignments': {'group:id:*': 'allow'}, 'active-response:command': {'agent:id:*': 'allow'}, 'security:create': {'*:*:*': 'allow'}, 'security:create_user': {'*:*:*': 'allow'}, 'security:read_config': {'*:*:*': 'allow'}, 'security:update_config': {'*:*:*': 'allow'}, 'security:revoke': {'*:*:*': 'allow'}, 'security:read': {'role:id:*': 'allow', 'policy:id:*': 'allow', 'user:id:*': 'allow', 'rule:id:*': 'allow'}, 'security:update': {'role:id:*': 'allow', 'policy:id:*': 'allow', 'user:id:*': 'allow', 'rule:id:*': 'allow'}, 'security:delete': {'role:id:*': 'allow', 'policy:id:*': 'allow', 'user:id:*': 'allow', 'rule:id:*': 'allow'}, 'cluster:status': {'*:*:*': 'allow'}, 'manager:read': {'*:*:*': 'allow'}, 'manager:read_api_config': {'*:*:*': 'allow'}, 'manager:update_config': {'*:*:*': 'allow'}, 'manager:restart': {'*:*:*': 'allow'}, 'cluster:read_api_config': {'node:id:*': 'allow'}, 'cluster:read': {'node:id:*': 'allow'}, 'cluster:restart': {'node:id:*': 'allow'}, 'cluster:update_config': {'node:id:*': 'allow'}, 'ciscat:read': {'agent:id:*': 'allow'}, 'decoders:read': {'decoder:file:*': 'allow'}, 'decoders:delete': {'decoder:file:*': 'allow'}, 'decoders:update': {'*:*:*': 'allow'}, 'lists:read': {'list:file:*': 'allow'}, 'lists:delete': {'list:file:*': 'allow'}, 'lists:update': {'*:*:*': 'allow'}, 'rootcheck:clear': {'agent:id:*': 'allow'}, 'rootcheck:read': {'agent:id:*': 'allow'}, 'rootcheck:run': {'agent:id:*': 'allow'}, 'rules:read': {'rule:file:*': 'allow'}, 'rules:delete': {'rule:file:*': 'allow'}, 'rules:update': {'*:*:*': 'allow'}, 'mitre:read': {'*:*:*': 'allow'}, 'sca:read': {'agent:id:*': 'allow'}, 'syscheck:clear': {'agent:id:*': 'allow'}, 'syscheck:read': {'agent:id:*': 'allow'}, 'syscheck:run': {'agent:id:*': 'allow'}, 'syscollector:read': {'agent:id:*': 'allow'}, 'logtest:run': {'*:*:*': 'allow'}, 'task:status': {'*:*:*': 'allow'}, 'rbac_mode': 'white'}}]
2021/03/02 08:05:58 INFO: ['Host', 'User-Agent', 'Accept', 'Authorization']
2021/03/02 08:05:58 INFO: Host : localhost:55000
2021/03/02 08:05:58 INFO: User-Agent : curl/7.68.0
2021/03/02 08:05:58 INFO: Accept : */*
2021/03/02 08:05:58 INFO: Authorization : Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjE0NjcyMzU1LCJleHAiOjE2MTQ2NzMyNTUsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.nJp1X5TPqcfgaObzRo80FJUPfYea9ZC2Muitzza4cUw
```

With:

`curl -k -X GET "https://localhost:55000/scaa/000" -H "Authorization: Bearer $TOKEN"
`

or

`curl -k -X GET "https://localhost:55000//sca/000" -H "Authorization: Bearer $TOKEN"
`

Logs:

```
2021/03/02 08:06:56 INFO: unknown_user 127.0.0.1 "GET /scaa/000" done in 0.005s: 404
2021/03/02 08:06:56 INFO: []
2021/03/02 08:06:56 INFO: []
2021/03/02 08:06:56 INFO: ['Host', 'User-Agent', 'Accept', 'Authorization']
2021/03/02 08:06:56 INFO: Host : localhost:55000
2021/03/02 08:06:56 INFO: User-Agent : curl/7.68.0
2021/03/02 08:06:56 INFO: Accept : */*
2021/03/02 08:06:56 INFO: Authorization : Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjE0NjcyMzU1LCJleHAiOjE2MTQ2NzMyNTUsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.nJp1X5TPqcfgaObzRo80FJUPfYea9ZC2Muitzza4cUw
```

```
2021/03/02 08:07:22 INFO: unknown_user 127.0.0.1 "GET /000" done in 0.002s: 308
2021/03/02 08:07:22 INFO: []
2021/03/02 08:07:22 INFO: []
2021/03/02 08:07:22 INFO: ['Host', 'User-Agent', 'Accept', 'Authorization']
2021/03/02 08:07:22 INFO: Host : localhost:55000
2021/03/02 08:07:22 INFO: User-Agent : curl/7.68.0
2021/03/02 08:07:22 INFO: Accept : */*
2021/03/02 08:07:22 INFO: Authorization : Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjE0NjcyMzU1LCJleHAiOjE2MTQ2NzMyNTUsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.nJp1X5TPqcfgaObzRo80FJUPfYea9ZC2Muitzza4cUw
```

When receiving a `308` or `404` status code, the API is logging the call without using the middlewares. This is why we are getting a `request` without `keys` or `values`.

I have updated the `log` function of our `AccessLogger` class (`alogging.py`) to decode the JWT token and include the username in the log when the response given has status `308` or `404`.

I have also updated the `test_alogging.py` unittest to include new test cases and mock the new function imported (`decode_token`).

```
test_alogging.py ..........                                                                                   [100%]
============================ 10 passed, 1 warning in 0.15s ============================
```

Regards,
Manuel.