### PR TITLE
Create new users and group in installation for Unix

### DIFF
--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -5,8 +5,8 @@
 set -e
 set -u
 
-if ! [ $# -eq 4 ]; then
-    echo "Usage: ${0} USERNAME_DEFAULT GROUPNAME DIRECTORY INSTYPE.";
+if ! [ $# -eq 3 ]; then
+    echo "Usage: ${0} USERNAME_DEFAULT GROUPNAME DIRECTORY.";
     exit 1;
 fi
 
@@ -15,14 +15,13 @@ echo "Wait for success..."
 USER=$1
 GROUP=$2
 DIR=$3
-INSTYPE=$4
 
 UNAME=$(uname);
 # Thanks Chuck L. for the mac addusers
 if [ "$UNAME" = "Darwin" ]; then
     if ! id -u "${USER}" > /dev/null 2>&1; then
         chmod +x ./init/darwin-addusers.sh
-        ./init/darwin-addusers.sh $USER $GROUP $DIR $INSTYPE
+        ./init/darwin-addusers.sh $USER $GROUP $DIR
     fi
 
 else

--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -22,7 +22,7 @@ UNAME=$(uname);
 if [ "$UNAME" = "Darwin" ]; then
     if ! id -u "${USER}" > /dev/null 2>&1; then
         chmod +x ./init/darwin-addusers.sh
-        ./init/darwin-addusers.sh $USER $GROUP $INSTYPE
+        ./init/darwin-addusers.sh $USER $GROUP $DIR $INSTYPE
     fi
 
 else
@@ -79,7 +79,7 @@ else
         elif [ "$UNAME" = "AIX" ]; then
             GID=$(cat /etc/group | grep wazuh| cut -d':' -f 3)
             uid=$(( $GID + 1 ))
-            echo "wazuh:x:$uid:$GID::/var/ossec:/bin/false" >> /etc/passwd
+            echo "${USER}:x:$uid:$GID::${DIR}:/bin/false" >> /etc/passwd
         else
             ${USERADD} "${USER}" -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}"
         fi

--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -5,26 +5,24 @@
 set -e
 set -u
 
-if ! [ $# -eq 6 ]; then
-    echo "Usage: ${0} USERNAME_DEFAULT USERNAME_MAIL USERNAME_REMOTE GROUPNAME DIRECTORY INSTYPE.";
+if ! [ $# -eq 4 ]; then
+    echo "Usage: ${0} USERNAME_DEFAULT GROUPNAME DIRECTORY INSTYPE.";
     exit 1;
 fi
 
 echo "Wait for success..."
 
 USER=$1
-USER_MAIL=$2
-USER_REM=$3
-GROUP=$4
-DIR=$5
-INSTYPE=$6
+GROUP=$2
+DIR=$3
+INSTYPE=$4
 
 UNAME=$(uname);
 # Thanks Chuck L. for the mac addusers
 if [ "$UNAME" = "Darwin" ]; then
     if ! id -u "${USER}" > /dev/null 2>&1; then
         chmod +x ./init/darwin-addusers.sh
-        ./init/darwin-addusers.sh $USER $USER_MAIL $USER_REM $GROUP $INSTYPE
+        ./init/darwin-addusers.sh $USER $GROUP $INSTYPE
     fi
 
 else
@@ -75,27 +73,17 @@ else
         fi
     fi
 
-    if [ "X$INSTYPE" = "Xserver" ]; then
-        NEWUSERS="${USER} ${USER_MAIL} ${USER_REM}"
-    elif [ "X$INSTYPE" = "Xlocal" ]; then
-        NEWUSERS="${USER} ${USER_MAIL}"
-    else
-        NEWUSERS=${USER}
-    fi
-
-    for U in ${NEWUSERS}; do
-        if ! grep "^${U}" /etc/passwd > /dev/null 2>&1; then
-            if [ "$UNAME" = "OpenBSD" -o "$UNAME" = "SunOS" -o "$UNAME" = "HP-UX" -o "$UNAME" = "NetBSD" ]; then
-                ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${U}"
-            elif [ "$UNAME" = "AIX" ]; then
-                GID=$(cat /etc/group | grep ossec| cut -d':' -f 3)
-                uid=$(( $GID + 1 ))
-                echo "ossec:x:$uid:$GID::/var/ossec:/bin/false" >> /etc/passwd
-            else
-                ${USERADD} "${U}" -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}"
-            fi
+    if ! grep "^${USER}" /etc/passwd > /dev/null 2>&1; then
+        if [ "$UNAME" = "OpenBSD" -o "$UNAME" = "SunOS" -o "$UNAME" = "HP-UX" -o "$UNAME" = "NetBSD" ]; then
+            ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${USER}"
+        elif [ "$UNAME" = "AIX" ]; then
+            GID=$(cat /etc/group | grep wazuh| cut -d':' -f 3)
+            uid=$(( $GID + 1 ))
+            echo "wazuh:x:$uid:$GID::/var/ossec:/bin/false" >> /etc/passwd
+        else
+            ${USERADD} "${USER}" -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}"
         fi
-    done
+    fi
 fi
 
 echo "success";

--- a/src/init/darwin-addusers.sh
+++ b/src/init/darwin-addusers.sh
@@ -19,14 +19,12 @@ function check_errm
 }
 
 USER=$1
-USER_MAIL=$2
-USER_REM=$3
-GROUP=$4
-INSTYPE=$5
+GROUP=$2
+INSTYPE=$3
 
-if ! [ $# -eq 5 ]; then
+if ! [ $# -eq 3 ]; then
     echo $#
-    echo "Usage: ${0} USERNAME_DEFAULT USERNAME_MAIL USERNAME_REMOTE GROUPNAME INSTYPE.";
+    echo "Usage: ${0} USERNAME_DEFAULT GROUPNAME INSTYPE.";
     exit 1;
 fi
 
@@ -82,34 +80,19 @@ sudo ${DSCL} localhost -createprop /Local/Default/Groups/${GROUP} Password "*"
 
 
 # Creating the users.
-
-if [ "X$INSTYPE" = "Xserver" ]; then
-    NEWUSERS="${USER} ${USER_MAIL} ${USER_REM}"
-elif [ "X$INSTYPE" = "Xlocal" ]; then
-    NEWUSERS="${USER} ${USER_MAIL}"
+if [[ $(dscl . -read /Users/${USER} 2>/dev/null) ]]
+   then
+   echo "${USER} already exists";
 else
-    NEWUSERS=${USER}
+   sudo ${DSCL} localhost -create /Local/Default/Users/${USER}
+   check_errm "Error creating user ${USER}" "87"
+   sudo ${DSCL} localhost -createprop /Local/Default/Users/${USER} RecordName ${USER}
+   sudo ${DSCL} localhost -createprop /Local/Default/Users/${USER} RealName "${USER}acct"
+   sudo ${DSCL} localhost -createprop /Local/Default/Users/${USER} NFSHomeDirectory /var/ossec
+   sudo ${DSCL} localhost -createprop /Local/Default/Users/${USER} UniqueID ${i}
+   sudo ${DSCL} localhost -createprop /Local/Default/Users/${USER} PrimaryGroupID ${new_gid}
+   sudo ${DSCL} localhost -append /Local/Default/Groups/${GROUP} GroupMembership ${USER}
+   sudo ${DSCL} localhost -createprop /Local/Default/Users/${USER} Password "*"
 fi
 
-for U in ${NEWUSERS}; do
-    if [[ $(dscl . -read /Users/${U} 2>/dev/null) ]]
-       then
-       echo "${U} already exists";
-    else
-       sudo ${DSCL} localhost -create /Local/Default/Users/${U}
-       check_errm "Error creating user ${U}" "87"
-       sudo ${DSCL} localhost -createprop /Local/Default/Users/${U} RecordName ${U}
-       sudo ${DSCL} localhost -createprop /Local/Default/Users/${U} RealName "${U}acct"
-       sudo ${DSCL} localhost -createprop /Local/Default/Users/${U} NFSHomeDirectory /var/ossec
-       sudo ${DSCL} localhost -createprop /Local/Default/Users/${U} UniqueID ${i}
-       sudo ${DSCL} localhost -createprop /Local/Default/Users/${U} PrimaryGroupID ${new_gid}
-       sudo ${DSCL} localhost -append /Local/Default/Groups/${GROUP} GroupMembership ${U}
-       sudo ${DSCL} localhost -createprop /Local/Default/Users/${U} Password "*"
-    fi
-
-    i=$[i+1]
-done
-
-sudo ${DSCL} . create /Users/ossec IsHidden 1
-sudo ${DSCL} . create /Users/ossecm IsHidden 1
-sudo ${DSCL} . create /Users/ossecr IsHidden 1
+sudo ${DSCL} . create /Users/wazuh IsHidden 1

--- a/src/init/darwin-addusers.sh
+++ b/src/init/darwin-addusers.sh
@@ -21,11 +21,10 @@ function check_errm
 USER=$1
 GROUP=$2
 DIR=$3
-INSTYPE=$4
 
-if ! [ $# -eq 4 ]; then
+if ! [ $# -eq 3 ]; then
     echo $#
-    echo "Usage: ${0} USERNAME_DEFAULT GROUPNAME DIRECTORY INSTYPE.";
+    echo "Usage: ${0} USERNAME_DEFAULT GROUPNAME DIRECTORY.";
     exit 1;
 fi
 

--- a/src/init/darwin-addusers.sh
+++ b/src/init/darwin-addusers.sh
@@ -20,11 +20,12 @@ function check_errm
 
 USER=$1
 GROUP=$2
-INSTYPE=$3
+DIR=$3
+INSTYPE=$4
 
-if ! [ $# -eq 3 ]; then
+if ! [ $# -eq 4 ]; then
     echo $#
-    echo "Usage: ${0} USERNAME_DEFAULT GROUPNAME INSTYPE.";
+    echo "Usage: ${0} USERNAME_DEFAULT GROUPNAME DIRECTORY INSTYPE.";
     exit 1;
 fi
 
@@ -88,7 +89,7 @@ else
    check_errm "Error creating user ${USER}" "87"
    sudo ${DSCL} localhost -createprop /Local/Default/Users/${USER} RecordName ${USER}
    sudo ${DSCL} localhost -createprop /Local/Default/Users/${USER} RealName "${USER}acct"
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/${USER} NFSHomeDirectory /var/ossec
+   sudo ${DSCL} localhost -createprop /Local/Default/Users/${USER} NFSHomeDirectory ${DIR}
    sudo ${DSCL} localhost -createprop /Local/Default/Users/${USER} UniqueID ${i}
    sudo ${DSCL} localhost -createprop /Local/Default/Users/${USER} PrimaryGroupID ${new_gid}
    sudo ${DSCL} localhost -append /Local/Default/Groups/${GROUP} GroupMembership ${USER}

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -702,7 +702,7 @@ InstallCommon()
         INSTALL="/opt/freeware/bin/install"
     fi
 
-    ./init/adduser.sh ${WAZUH_USER} ${WAZUH_GROUP} ${PREFIX} ${INSTYPE}
+    ./init/adduser.sh ${WAZUH_USER} ${WAZUH_GROUP} ${PREFIX}
 
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${PREFIX}/
   ${INSTALL} -d -m 0770 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${PREFIX}/logs


### PR DESCRIPTION
|Related issue|
|---|
|#7703|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR creates the new user and group that are added to the system when installing Wazuh in Unix platforms. For that, I modified the adduser.sh and darwin-addusers.sh scripts.

## Logs/Alerts example

### Ubuntu 20
```
ll /var/ossec/

drwxr-x--- 15 root  wazuh 4096 Mar  2 15:58 ./
drwxr-xr-x 14 root  root  4096 Mar  2 15:58 ../
drwxrwx---  2 root  wazuh 4096 Mar  2 15:58 .ssh/
drwxr-x---  3 root  wazuh 4096 Mar  2 15:58 active-response/
drwxr-x---  2 root  wazuh 4096 Mar  2 15:58 agentless/
drwxr-x---  2 root  wazuh 4096 Mar  2 15:58 backup/
drwxr-x---  2 root  root  4096 Mar  2 15:58 bin/
drwxrwx---  3 wazuh wazuh 4096 Mar  2 15:58 etc/
drwxr-x---  2 root  wazuh 4096 Mar  2 15:58 lib/
drwxrwx---  3 wazuh wazuh 4096 Mar  2 15:58 logs/
drwxr-x---  9 root  wazuh 4096 Mar  2 15:58 queue/
drwxr-x---  3 root  wazuh 4096 Mar  2 15:58 ruleset/
drwxrwx--T  2 root  wazuh 4096 Mar  2 15:58 tmp/
drwxr-x---  7 root  wazuh 4096 Mar  2 15:58 var/
drwxr-x---  5 root  wazuh 4096 Mar  2 15:58 wodles/
```
### macOS

```
# ls -l /Library/Ossec/

total 0
drwxrwx---   2 root   wazuh   64 Mar  2 08:44 .ssh
drwxr-x---   3 root   wazuh   96 Mar  2 08:44 active-response
drwxr-x---  14 root   wazuh  448 Mar  2 08:44 agentless
drwxr-x---   2 root   wazuh   64 Mar  2 08:44 backup
drwxr-x---  10 root   wheel  320 Mar  2 08:44 bin
drwxrwx---   9 wazuh  wazuh  288 Mar  2 08:45 etc
drwxr-x---   7 root   wazuh  224 Mar  2 08:44 lib
drwxrwx---   6 wazuh  wazuh  192 Mar  2 08:44 logs
drwxr-x---   9 root   wazuh  288 Mar  2 08:44 queue
drwxr-x---   3 root   wazuh   96 Mar  2 08:44 ruleset
drwxrwx--T   2 root   wazuh   64 Mar  2 08:44 tmp
drwxr-x---   7 root   wazuh  224 Mar  2 08:45 var
drwxr-x---   5 root   wazuh  160 Mar  2 08:45 wodles
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] MAC OS X
- [x] Source installation

<!-- Checks for huge PRs that affect the product more generally -->
- [x] User and group wazuh in Linux
- [x] User and group wazuh in macOS
