### PR TITLE
Fix Vulnerability Detector UT

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
@@ -43,7 +43,7 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,fflush -Wl,--wrap,fprintf -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,getpid -Wl,--wrap,OSHash_Add_ex \
                                 -Wl,--wrap,wurl_request_uncompress_bz2_gz -Wl,--wrap,w_uncompress_bz2_gz_file -Wl,--wrap,wstr_replace \
                                 -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap=wstr_split -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Execute_ex \
-                                -Wl,--wrap,fgetpos -Wl,--wrap,wdb_agents_vuln_cve_insert -Wl,--wrap,wdb_agents_vuln_cve_clear")
+                                -Wl,--wrap,fgetpos -Wl,--wrap,wdb_agents_vuln_cve_insert -Wl,--wrap,wdb_agents_vuln_cve_clear -Wl,--wrap,wdb_get_all_agents")
 
 list(APPEND vulndetector_names "test_wm_vuln_detector_evr")
 list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,OS_ConnectUnixDomain \

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -328,12 +328,6 @@ static int setup_cve_report(void **state) {
     will_return_always(__wrap_OPENSSL_init_ssl, 1);
     will_return(__wrap_OPENSSL_init_crypto, 1);
 
-    int *array = NULL;
-    os_malloc(sizeof(int), array);
-    array[0] = OS_INVALID;
-    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
-    will_return(__wrap_wdb_get_all_agents, array);
-
     wm_vuldet_init(vuldet);
 
     vu_report *report = calloc(1, sizeof(vu_report));
@@ -5511,12 +5505,6 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
     will_return_always(__wrap_OPENSSL_init_ssl, 1);
     will_return(__wrap_OPENSSL_init_crypto, 1);
 
-    int *array = NULL;
-    os_malloc(sizeof(int), array);
-    array[0] = OS_INVALID;
-    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
-    will_return(__wrap_wdb_get_all_agents, array);
-
     wm_vuldet_init(vuldet);
 
 
@@ -5855,12 +5843,6 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **
 
     will_return_always(__wrap_OPENSSL_init_ssl, 1);
     will_return(__wrap_OPENSSL_init_crypto, 1);
-
-    int *array = NULL;
-    os_malloc(sizeof(int), array);
-    array[0] = OS_INVALID;
-    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
-    will_return(__wrap_wdb_get_all_agents, array);
 
     wm_vuldet_init(vuldet);
 
@@ -17277,6 +17259,26 @@ void test_wm_vuldet_fetch_MSU_max_attempts(void **state)
 
 }
 
+// Tests wm_vuldet_init
+
+void test_wm_vuldet_init_success(void **state)
+{
+    wm_vuldet_t *vuldet = calloc(1, sizeof(wm_vuldet_t));
+    vuldet->flags.enabled = 1;
+    vuldet->flags.run_on_start = 1;
+
+    expect_string(__wrap_StartMQ, path, DEFAULTQPATH);
+    expect_value(__wrap_StartMQ, type, WRITE);
+    will_return(__wrap_StartMQ, 1);
+
+    will_return_always(__wrap_OPENSSL_init_ssl, 1);
+    will_return(__wrap_OPENSSL_init_crypto, 1);
+
+    wm_vuldet_init(vuldet);
+
+    os_free(vuldet);
+}
+
 // Tests wm_vuldet_clean_vuln_cve_db
 
 void test_wm_vuldet_clean_vuln_cve_db_success(void **state)
@@ -17774,6 +17776,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_updated, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_invalid_hash, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_max_attempts, setup_group, teardown_group),
+        // Tests wm_vuldet_init
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_success, setup_group, teardown_group),
         // Tests wm_vuldet_clean_vuln_cve_db
         cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_success, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_get_agents_error, setup_group, teardown_group),

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -91,6 +91,7 @@ bool wm_vuldet_update_MSU(update_node *update);
 int wm_vuldet_fetch_MSU(update_node *update, char *repo);
 int wm_vuldet_compare_vendors(char * vendor);
 void wm_vuldel_truncate_revision(char * revision);
+void wm_vuldet_init_vuln_cve_db(void);
 
 /* setup/teardown */
 
@@ -17313,6 +17314,56 @@ void test_wm_vuldet_fetch_MSU_max_attempts(void **state)
 
 }
 
+// Tests wm_vuldet_init_vuln_cve_db
+
+void test_wm_vuldet_init_vuln_cve_db_success(void **state)
+{
+    int *array = NULL;
+    os_malloc(sizeof(int)*3, array);
+    array[0] = 0;
+    array[1] = 1;
+    array[2] = OS_INVALID;
+
+    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
+    will_return(__wrap_wdb_get_all_agents, array);
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 1);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
+
+    wm_vuldet_init_vuln_cve_db();
+}
+
+void test_wm_vuldet_init_vuln_cve_db_get_agents_error(void **state)
+{
+    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
+    will_return(__wrap_wdb_get_all_agents, NULL);
+    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtwarn, formatted_msg, "Unable to get agent's ID array to clear vuln_cve table");
+
+    wm_vuldet_init_vuln_cve_db();
+}
+
+void test_wm_vuldet_init_vuln_cve_db_clear_table_error(void **state)
+{
+    int *array = NULL;
+    os_malloc(sizeof(int)*3, array);
+    array[0] = 0;
+    array[1] = 1;
+    array[2] = OS_INVALID;
+
+    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
+    will_return(__wrap_wdb_get_all_agents, array);
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 1);
+    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_INVALID);
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Error clearing vuln_cve table for agent 1");
+
+    wm_vuldet_init_vuln_cve_db();
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -17761,6 +17812,10 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_updated, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_invalid_hash, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_max_attempts, setup_group, teardown_group),
+        // Tests wm_vuldet_init_vuln_cve_db
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_vuln_cve_db_success, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_vuln_cve_db_get_agents_error, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_vuln_cve_db_clear_table_error, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -91,7 +91,7 @@ bool wm_vuldet_update_MSU(update_node *update);
 int wm_vuldet_fetch_MSU(update_node *update, char *repo);
 int wm_vuldet_compare_vendors(char * vendor);
 void wm_vuldel_truncate_revision(char * revision);
-void wm_vuldet_init_vuln_cve_db(void);
+void wm_vuldet_clean_vuln_cve_db(void);
 
 /* setup/teardown */
 
@@ -17314,9 +17314,9 @@ void test_wm_vuldet_fetch_MSU_max_attempts(void **state)
 
 }
 
-// Tests wm_vuldet_init_vuln_cve_db
+// Tests wm_vuldet_clean_vuln_cve_db
 
-void test_wm_vuldet_init_vuln_cve_db_success(void **state)
+void test_wm_vuldet_clean_vuln_cve_db_success(void **state)
 {
     int *array = NULL;
     os_malloc(sizeof(int)*3, array);
@@ -17331,20 +17331,20 @@ void test_wm_vuldet_init_vuln_cve_db_success(void **state)
     expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 1);
     will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
-    wm_vuldet_init_vuln_cve_db();
+    wm_vuldet_clean_vuln_cve_db();
 }
 
-void test_wm_vuldet_init_vuln_cve_db_get_agents_error(void **state)
+void test_wm_vuldet_clean_vuln_cve_db_get_agents_error(void **state)
 {
     expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
     will_return(__wrap_wdb_get_all_agents, NULL);
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtwarn, formatted_msg, "Unable to get agent's ID array to clear vuln_cve table");
 
-    wm_vuldet_init_vuln_cve_db();
+    wm_vuldet_clean_vuln_cve_db();
 }
 
-void test_wm_vuldet_init_vuln_cve_db_clear_table_error(void **state)
+void test_wm_vuldet_clean_vuln_cve_db_clear_table_error(void **state)
 {
     int *array = NULL;
     os_malloc(sizeof(int)*3, array);
@@ -17361,7 +17361,7 @@ void test_wm_vuldet_init_vuln_cve_db_clear_table_error(void **state)
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "Error clearing vuln_cve table for agent 1");
 
-    wm_vuldet_init_vuln_cve_db();
+    wm_vuldet_clean_vuln_cve_db();
 }
 
 int main(void)
@@ -17812,10 +17812,10 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_updated, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_invalid_hash, setup_group, teardown_group),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_max_attempts, setup_group, teardown_group),
-        // Tests wm_vuldet_init_vuln_cve_db
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_vuln_cve_db_success, setup_group, teardown_group),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_vuln_cve_db_get_agents_error, setup_group, teardown_group),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_init_vuln_cve_db_clear_table_error, setup_group, teardown_group),
+        // Tests wm_vuldet_clean_vuln_cve_db
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_success, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_get_agents_error, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_clear_table_error, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -328,6 +328,12 @@ static int setup_cve_report(void **state) {
     will_return_always(__wrap_OPENSSL_init_ssl, 1);
     will_return(__wrap_OPENSSL_init_crypto, 1);
 
+    int *array = NULL;
+    os_malloc(sizeof(int), array);
+    array[0] = OS_INVALID;
+    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
+    will_return(__wrap_wdb_get_all_agents, array);
+
     wm_vuldet_init(vuldet);
 
     vu_report *report = calloc(1, sizeof(vu_report));
@@ -5488,6 +5494,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_adding_data_from_OVAL_erro
 
 void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void **state)
 {
+    // wm_vuldet_init
     wm_vuldet_t *vuldet = calloc(1, sizeof(wm_vuldet_t));
 
     if (!vuldet) {
@@ -5504,7 +5511,14 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
     will_return_always(__wrap_OPENSSL_init_ssl, 1);
     will_return(__wrap_OPENSSL_init_crypto, 1);
 
+    int *array = NULL;
+    os_malloc(sizeof(int), array);
+    array[0] = OS_INVALID;
+    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
+    will_return(__wrap_wdb_get_all_agents, array);
+
     wm_vuldet_init(vuldet);
+
 
     agent_software *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
@@ -5825,6 +5839,7 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
 
 void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **state)
 {
+    // wm_vuldet_init
     wm_vuldet_t *vuldet = calloc(1, sizeof(wm_vuldet_t));
 
     if (!vuldet) {
@@ -5841,7 +5856,14 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **
     will_return_always(__wrap_OPENSSL_init_ssl, 1);
     will_return(__wrap_OPENSSL_init_crypto, 1);
 
+    int *array = NULL;
+    os_malloc(sizeof(int), array);
+    array[0] = OS_INVALID;
+    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
+    will_return(__wrap_wdb_get_all_agents, array);
+
     wm_vuldet_init(vuldet);
+
 
     agent_software *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
@@ -8748,29 +8770,6 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_info_NULL(void **state)
 
 }
 
-void test_wm_vuldet_report_agent_vulnerabilities_vuln_cve_clear_error(void **state)
-{
-    sqlite3 *db = (sqlite3 *)1;
-    agent_software *agent = *state;
-    OSHash *cve_table = (OSHash *)1;
-
-    agent->info = 'T';
-    agent->dist = FEED_WIN;
-
-    //Clear the vulnerabilities in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_INVALID);
-
-    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtwarn, formatted_msg, "Failed to clear vulnerabilities from the agent 000 database");
-
-    will_return(__wrap_wm_vuldet_win_nvd_vulnerabilities, -1);
-
-    int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
-    assert_int_equal(ret, -1);
-
-}
-
 void test_wm_vuldet_report_agent_vulnerabilities_agent_windows_error(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
@@ -8779,10 +8778,6 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_windows_error(void **stat
 
     agent->info = 'T';
     agent->dist = FEED_WIN;
-
-    //Clear the vulnerabilities in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     will_return(__wrap_wm_vuldet_win_nvd_vulnerabilities, -1);
 
@@ -8800,10 +8795,6 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_windows_OK(void **state)
     agent->info = 'T';
     agent->dist = FEED_WIN;
 
-    //Clear the vulnerabilities in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
-
     will_return(__wrap_wm_vuldet_win_nvd_vulnerabilities, 0);
 
     int ret = wm_vuldet_report_agent_vulnerabilities(db, agent, NULL);
@@ -8819,10 +8810,6 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_create_hash_error(v
 
     agent->info = 'T';
     agent->dist = FEED_CANONICAL;
-
-    //Clear the vulnerabilities in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 0);
@@ -8842,10 +8829,6 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_setSize_hash_error(
 
     agent->info = 'T';
     agent->dist = FEED_CANONICAL;
-
-    //Clear the vulnerabilities in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 1);
@@ -8868,10 +8851,6 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_oval_vulnerabilitie
 
     agent->info = 'T';
     agent->dist = FEED_CANONICAL;
-
-    //Clear the vulnerabilities in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, cve_table);
@@ -8918,10 +8897,6 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_nvd_vulnerabilities
     agent->info = 'T';
     agent->dist = FEED_DEBIAN;
     agent->dist_ver = FEED_BUSTER;
-
-    //Clear the vulnerabilities in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, cve_table);
@@ -9000,10 +8975,6 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_rm_false_positivies
     os_calloc(1, sizeof(OSHashNode), node);
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_NVD)))
         return;
-
-    //Clear the vulnerabilities in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     agent->info = 'T';
     agent->dist = FEED_DEBIAN;
@@ -9116,10 +9087,6 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_send_agent_report_e
     if(!flags) {
         return;
     }
-
-    //Clear the vulnerabilities in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     agent->info = 'T';
     agent->dist = FEED_DEBIAN;
@@ -9266,10 +9233,6 @@ void test_wm_vuldet_report_agent_vulnerabilities_agent_linux_OK(void **state)
     os_calloc(1, sizeof(OSHashNode), node);
     if (!node || (OS_INVALID == build_test_hash_node(node, VU_SRC_NVD)))
         return;
-
-    //Clear the vulnerabilities in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
 
     agent->info = 'T';
     agent->dist = FEED_DEBIAN;
@@ -17589,7 +17552,6 @@ int main(void)
         cmocka_unit_test(test_wm_vuldet_free_cve_node),
         // Tests wm_vuldet_report_agent_vulnerabilities
         cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_info_NULL, setup_agent_software, teardown_agent_software),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_vuln_cve_clear_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_windows_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_windows_OK, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_report_agent_vulnerabilities_agent_linux_create_hash_error, setup_agent_software, teardown_agent_software),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -300,9 +300,9 @@ STATIC int wm_vuldet_compare_vendors(char * vendor);
 STATIC void wm_vuldel_truncate_revision(char * revision);
 
 /**
- * @brief Initialize every agent vuln_cve DB by clearing the table.
+ * @brief Clean every agent vuln_cve DB.
  */
-STATIC void wm_vuldet_init_vuln_cve_db(void);
+STATIC void wm_vuldet_clean_vuln_cve_db(void);
 
 int wdb_vuldet_sock = -1;
 int *vu_queue;
@@ -7139,7 +7139,7 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
     wm_vuldet_flags *flags = &vuldet->flags;
     int i;
 
-    wm_vuldet_init_vuln_cve_db();
+    wm_vuldet_clean_vuln_cve_db();
 
     if (!flags->enabled) {
         mtdebug1(WM_VULNDETECTOR_LOGTAG, "Module disabled. Exiting...");
@@ -7647,7 +7647,7 @@ void wm_vuldel_truncate_revision(char * revision) {
     return;
 }
 
-void wm_vuldet_init_vuln_cve_db(void) {
+void wm_vuldet_clean_vuln_cve_db(void) {
     int sock = wm_vuldet_get_wdb_socket();
     int *id_array = wdb_get_all_agents(TRUE, &sock);
     if (!id_array) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -299,6 +299,11 @@ STATIC int wm_vuldet_compare_vendors(char * vendor);
  */
 STATIC void wm_vuldel_truncate_revision(char * revision);
 
+/**
+ * @brief Initialize every agent vuln_cve DB by clearing the table.
+ */
+STATIC void wm_vuldet_init_vuln_cve_db(void);
+
 int wdb_vuldet_sock = -1;
 int *vu_queue;
 // Define time to sleep between messages sent
@@ -7134,6 +7139,8 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
     wm_vuldet_flags *flags = &vuldet->flags;
     int i;
 
+    wm_vuldet_init_vuln_cve_db();
+
     if (!flags->enabled) {
         mtdebug1(WM_VULNDETECTOR_LOGTAG, "Module disabled. Exiting...");
         pthread_exit(NULL);
@@ -7638,6 +7645,21 @@ void wm_vuldel_truncate_revision(char * revision) {
         }
     }
     return;
+}
+
+void wm_vuldet_init_vuln_cve_db(void) {
+    int sock = wm_vuldet_get_wdb_socket();
+    int *id_array = wdb_get_all_agents(TRUE, &sock);
+    if (!id_array) {
+        mtwarn(WM_VULNDETECTOR_LOGTAG, "Unable to get agent's ID array to clear vuln_cve table");
+        return;
+    }
+    for (size_t i = 0; id_array[i] != OS_INVALID; i++) {
+        if (OS_SUCCESS != wdb_agents_vuln_cve_clear(id_array[i], &sock)) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Error clearing vuln_cve table for agent %d", id_array[i]);
+        }
+    }
+    os_free(id_array);
 }
 
 #endif

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -7139,9 +7139,10 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
     wm_vuldet_flags *flags = &vuldet->flags;
     int i;
 
-    wm_vuldet_clean_vuln_cve_db();
-
     if (!flags->enabled) {
+        // If vuldet is disabled we must clean the vulnerable software tables
+        wm_vuldet_clean_vuln_cve_db();
+
         mtdebug1(WM_VULNDETECTOR_LOGTAG, "Module disabled. Exiting...");
         pthread_exit(NULL);
     }


### PR DESCRIPTION
|Related issue|
|---|
|7717|

## Description
This PR fixes the Vulnerability Detector Unit Tests after the refactor of the vuln_cve table clear.
It also adds UT for wm_vuldet_init.


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] UT execution

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Valgrind (memcheck and descriptor leaks check)
