### PR TITLE
Added new function to save audit rules when audit is in immutable mode

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -261,7 +261,7 @@
 #define FIM_WILDCARDS_REMOVE_DIRECTORY      "(6362): Removing entry '%s' due to it has not been expanded by the wildcards"
 #define FIM_WILDCARDS_UPDATE_FINALIZE       "(6363): Configuration wildcards update finalize."
 #define FIM_REALTIME_MAXNUM_WATCHES         "(6364): Unable to add directory to real time monitoring: '%s' - Maximum size permitted."
-
+#define FIM_ADDED_RULE_TO_FILE              "(6365): Added directory '%s' to audit rules file."
 
 /* Modules messages */
 #define WM_UPGRADE_RESULT_AGENT_INFO         "(8151): Agent Information obtained: '%s'"

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -58,6 +58,7 @@
 #define FIM_FILE_SIZE_LIMIT_DISABLED        "(6042): File size limit disabled."
 #define FIM_DISK_QUOTA_LIMIT_DISABLED       "(6043): Disk quota limit disabled."
 #define FIM_NO_DIFF_REGISTRY                "(6044): Option nodiff enabled for %s '%s'."
+#define FIM_AUDIT_CREATED_RULE_FILE         "(6045): Created audit rule file, due to audit immutable mode, rules will be loaded in the next reboot"
 
 /* wazuh-logtest information messages */
 #define LOGTEST_INITIALIZED                 "(7200): Logtest started"

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -58,7 +58,7 @@
 #define FIM_FILE_SIZE_LIMIT_DISABLED        "(6042): File size limit disabled."
 #define FIM_DISK_QUOTA_LIMIT_DISABLED       "(6043): Disk quota limit disabled."
 #define FIM_NO_DIFF_REGISTRY                "(6044): Option nodiff enabled for %s '%s'."
-#define FIM_AUDIT_CREATED_RULE_FILE         "(6045): Created audit rule file, due to audit immutable mode, rules will be loaded in the next reboot"
+#define FIM_AUDIT_CREATED_RULE_FILE         "(6045): Created audit rules file, due to audit immutable mode rules will be loaded in the next reboot."
 
 /* wazuh-logtest information messages */
 #define LOGTEST_INITIALIZED                 "(7200): Logtest started"

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -27,6 +27,8 @@
 #define AUDIT_HEALTHCHECK_DIR       "tmp"
 #define AUDIT_HEALTHCHECK_KEY       "wazuh_hc"
 #define AUDIT_HEALTHCHECK_FILE      "tmp/audit_hc"
+#define AUDIT_RULES_FILE            "/etc/audit_rules_wazuh.conf"
+#define AUDIT_RULES_LINK            "/etc/audit/rules.d/audit_rules_wazuh.conf"
 
 #ifdef WIN32
 #define FIM_REGULAR _S_IFREG

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -27,8 +27,6 @@
 #define AUDIT_HEALTHCHECK_DIR       "tmp"
 #define AUDIT_HEALTHCHECK_KEY       "wazuh_hc"
 #define AUDIT_HEALTHCHECK_FILE      "tmp/audit_hc"
-#define AUDIT_RULES_FILE            "/etc/audit_rules_wazuh.conf"
-#define AUDIT_RULES_LINK            "/etc/audit/rules.d/audit_rules_wazuh.conf"
 
 #ifdef WIN32
 #define FIM_REGULAR _S_IFREG

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -482,10 +482,16 @@ void audit_set_db_consistency(void);
 int check_auditd_enabled(void);
 
 /**
+ * @brief Create the necessary file to store the audit rules to be loaded by the immutable mode.
+ *
+*/
+void audit_create_rules_file();
+
+/**
  * @brief Set all directories that don't have audit rules and have whodata enabled to realtime.
  *
 */
-void audit_no_rules_to_realtime();
+void audit_rules_to_realtime();
 
 /**
  * @brief Set Auditd socket configuration

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -237,7 +237,7 @@ void audit_create_rules_file() {
     }
 
     char abs_rules_file_path[PATH_MAX] = {'\0'};
-    abspath(AUDIT_RULES_FILE, buffer, PATH_MAX);
+    abspath(AUDIT_RULES_FILE, abs_rules_file_path, PATH_MAX);
 
     // Create symlink to audit rules file
     if (symlink(abs_rules_file_path, AUDIT_RULES_LINK) < 0) {

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -255,7 +255,7 @@ void audit_create_rules_file() {
         }
     }
 
-    mdebug2(FIM_AUDIT_CREATED_RULE_FILE);
+    minfo(FIM_AUDIT_CREATED_RULE_FILE);
 }
 
 void audit_rules_to_realtime() {

--- a/src/syscheckd/whodata/syscheck_audit.h
+++ b/src/syscheckd/whodata/syscheck_audit.h
@@ -15,6 +15,14 @@
 #include "../syscheck.h"
 #include "audit_op.h"
 
+#define AUDIT_RULES_FILE            "etc/audit_rules_wazuh.rules"
+#define AUDIT_RULES_LINK            "/etc/audit/rules.d/audit_rules_wazuh.rules"
+#define PLUGINS_DIR_AUDIT_2         "/etc/audisp/plugins.d"
+#define PLUGINS_DIR_AUDIT_3         "/etc/audit/plugins.d"
+#define AUDIT_CONF_LINK             "af_wazuh.conf"
+#define BUF_SIZE OS_MAXSTR
+#define MAX_CONN_RETRIES 5          // Max retries to reconnect to Audit socket
+
 #define WHODATA_PERMS (AUDIT_PERM_WRITE | AUDIT_PERM_ATTR)
 
 #define AUDIT_HEALTHCHECK_KEY "wazuh_hc"

--- a/src/syscheckd/whodata/syscheck_audit.h
+++ b/src/syscheckd/whodata/syscheck_audit.h
@@ -15,14 +15,6 @@
 #include "../syscheck.h"
 #include "audit_op.h"
 
-#define AUDIT_RULES_FILE            "etc/audit_rules_wazuh.rules"
-#define AUDIT_RULES_LINK            "/etc/audit/rules.d/audit_rules_wazuh.rules"
-#define PLUGINS_DIR_AUDIT_2         "/etc/audisp/plugins.d"
-#define PLUGINS_DIR_AUDIT_3         "/etc/audit/plugins.d"
-#define AUDIT_CONF_LINK             "af_wazuh.conf"
-#define BUF_SIZE OS_MAXSTR
-#define MAX_CONN_RETRIES 5          // Max retries to reconnect to Audit socket
-
 #define WHODATA_PERMS (AUDIT_PERM_WRITE | AUDIT_PERM_ATTR)
 
 #define AUDIT_HEALTHCHECK_KEY "wazuh_hc"

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -60,7 +60,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
                               -Wl,--wrap,atomic_int_set -Wl,--wrap,atomic_int_dec -Wl,--wrap,atomic_int_inc \
                               -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,pthread_rwlock_unlock \
                               -Wl,--wrap,pthread_rwlock_rdlock -Wl,--wrap,OS_SHA1_Str \
-                              -Wl,--wrap,OS_SHA1_File")
+                              -Wl,--wrap,OS_SHA1_File -Wl,--wrap,audit_open -Wl,--wrap,audit_close")
 
     target_link_libraries(test_syscheck_audit SYSCHECK_O ${TEST_DEPS})
 

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -1211,7 +1211,7 @@ void test_audit_create_rules_file(void **state) {
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6360): Added directory '/test0' to audit rules file.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(6361): Added directory '/test0' to audit rules file.");
 
     expect_any(__wrap_fprintf, __stream);
     expect_string(__wrap_fprintf, formatted_msg, "-w /test0 -p wa -k wazuh_fim\n");
@@ -1219,6 +1219,8 @@ void test_audit_create_rules_file(void **state) {
 
     expect_any(__wrap_fclose, _File);
     will_return(__wrap_fclose, 0);
+
+    expect_abspath(AUDIT_RULES_FILE, 0);
 
     expect_string(__wrap_symlink, path1, AUDIT_RULES_FILE);
     expect_string(__wrap_symlink, path2, AUDIT_RULES_LINK);
@@ -1253,7 +1255,7 @@ void test_audit_create_rules_file_fclose_fail(void **state) {
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6360): Added directory '/test0' to audit rules file.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(6361): Added directory '/test0' to audit rules file.");
 
     expect_any(__wrap_fprintf, __stream);
     expect_string(__wrap_fprintf, formatted_msg, "-w /test0 -p wa -k wazuh_fim\n");
@@ -1277,7 +1279,7 @@ void test_audit_create_rules_file_symlink_exist(void **state) {
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6360): Added directory '/test0' to audit rules file.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(6361): Added directory '/test0' to audit rules file.");
 
     expect_any(__wrap_fprintf, __stream);
     expect_string(__wrap_fprintf, formatted_msg, "-w /test0 -p wa -k wazuh_fim\n");
@@ -1285,6 +1287,8 @@ void test_audit_create_rules_file_symlink_exist(void **state) {
 
     expect_any(__wrap_fclose, _File);
     will_return(__wrap_fclose, 0);
+
+    expect_abspath(AUDIT_RULES_FILE, 0);
 
     expect_string(__wrap_symlink, path1, AUDIT_RULES_FILE);
     expect_string(__wrap_symlink, path2, AUDIT_RULES_LINK);
@@ -1315,7 +1319,7 @@ void test_audit_create_rules_file_unlink_fail(void **state) {
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6360): Added directory '/test0' to audit rules file.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(6361): Added directory '/test0' to audit rules file.");
 
     expect_any(__wrap_fprintf, __stream);
     expect_string(__wrap_fprintf, formatted_msg, "-w /test0 -p wa -k wazuh_fim\n");
@@ -1323,6 +1327,8 @@ void test_audit_create_rules_file_unlink_fail(void **state) {
 
     expect_any(__wrap_fclose, _File);
     will_return(__wrap_fclose, 0);
+
+    expect_abspath(AUDIT_RULES_FILE, 0);
 
     expect_string(__wrap_symlink, path1, AUDIT_RULES_FILE);
     expect_string(__wrap_symlink, path2, AUDIT_RULES_LINK);
@@ -1350,7 +1356,7 @@ void test_audit_create_rules_file_symlink_fail(void **state) {
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6360): Added directory '/test0' to audit rules file.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(6361): Added directory '/test0' to audit rules file.");
 
     expect_any(__wrap_fprintf, __stream);
     expect_string(__wrap_fprintf, formatted_msg, "-w /test0 -p wa -k wazuh_fim\n");
@@ -1358,6 +1364,8 @@ void test_audit_create_rules_file_symlink_fail(void **state) {
 
     expect_any(__wrap_fclose, _File);
     will_return(__wrap_fclose, 0);
+
+    expect_abspath(AUDIT_RULES_FILE, 0);
 
     expect_string(__wrap_symlink, path1, AUDIT_RULES_FILE);
     expect_string(__wrap_symlink, path2, AUDIT_RULES_LINK);

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -1226,7 +1226,7 @@ void test_audit_create_rules_file(void **state) {
     expect_string(__wrap_symlink, path2, AUDIT_RULES_LINK);
     will_return(__wrap_symlink, 1);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6045): Created audit rule file, due to audit immutable mode, rules will be loaded in the next reboot");
+    expect_string(__wrap__minfo, formatted_msg, "(6045): Created audit rules file, due to audit immutable mode rules will be loaded in the next reboot.");
 
     audit_create_rules_file();
 }
@@ -1303,7 +1303,7 @@ void test_audit_create_rules_file_symlink_exist(void **state) {
     expect_string(__wrap_symlink, path2, AUDIT_RULES_LINK);
     will_return(__wrap_symlink, 0);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6045): Created audit rule file, due to audit immutable mode, rules will be loaded in the next reboot");
+    expect_string(__wrap__minfo, formatted_msg, "(6045): Created audit rules file, due to audit immutable mode rules will be loaded in the next reboot.");
 
     audit_create_rules_file();
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/6393|


## Description
In this PR I have added enough functionality so that when audit is in immutable mode, just before passing all whodata monitored directories to realtime, we can save all the necessary rules in an audit rules file so that on the next restart they can be loaded.

It is good to remember, that in order for this to work properly, we must disable the audit healthcheck as long as we want to have audit in immutable mode.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
