### PR TITLE
Removed MITRE alerts in debug messages

### DIFF
--- a/src/analysisd/output/jsonout.c
+++ b/src/analysisd/output/jsonout.c
@@ -22,9 +22,6 @@ void jsonout_output_event(const Eventinfo *lf)
     if (strstr(json_alert,"gcp")) {
         mdebug2("Sending gcp event: %s", json_alert);
     }
-    if (strstr(json_alert,"mitre")) {
-        mdebug2("Sending mitre event: %s", json_alert);
-    }
     free(json_alert);
     return;
 }


### PR DESCRIPTION
|Related issue|
|---|
|-|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The following lines add MITRE alerts to debug messages that are displayed in ossec.log.
https://github.com/wazuh/wazuh/blob/b366f05859ec6625469e184374caa1169e1df60c/src/analysisd/output/jsonout.c#L25-L27

MITRE integration tests used these debug messages to verify it works correctly. However, the tests changed to monitor alerts.json instead of ossec.log. Therefore, these debug messages are no longer needed.


## Integration tests

I copy here the results of the integration tests without using `analysisd.debug=2`

```
# python3 -m pytest -v test_analysisd/test_mitre/
======================================== test session starts ========================================
platform linux -- Python 3.8.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.5', 'Platform': 'Linux-5.8.0-44-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '6.2.2', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'metadata': '1.11.0', 'html': '2.0.1', 'testinfra': '5.0.0'}}
rootdir: /home/daniel/Wazuh/wazuh-qa/tests/integration, configfile: pytest.ini
plugins: metadata-1.11.0, html-2.0.1, testinfra-5.0.0
collected 14 items                                                                                  

test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test1.xml] PASSED [  7%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test2.xml] PASSED [ 14%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test3.xml] PASSED [ 21%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test4.xml] PASSED [ 28%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test5.xml] PASSED [ 35%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test6.xml] PASSED [ 42%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test7.xml] PASSED [ 50%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test8.xml] PASSED [ 57%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test9.xml] PASSED [ 64%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test10.xml] PASSED [ 71%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test11.xml] PASSED [ 78%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test12.xml] PASSED [ 85%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test13.xml] PASSED [ 92%]
test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/daniel/Wazuh/wazuh-qa/tests/integration/test_analysisd/test_mitre/data/test14.xml] PASSED [100%]

================================== 14 passed in 379.36s (0:06:19) ===================================
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

- [x] MITRE integration tests passed