### PR TITLE
7728 centos5 precompiled packages url

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,6 +16,8 @@ uname_V := $(shell sh -c 'uname -v 2>/dev/null || echo not')
 HAS_CHECKMODULE = $(shell command -v checkmodule > /dev/null && echo YES)
 HAS_SEMODULE_PACKAGE = $(shell command -v semodule_package > /dev/null && echo YES)
 CHECK_ARCHLINUX := $(shell sh -c 'grep "Arch Linux" /etc/os-release > /dev/null && echo YES || echo not')
+CHECK_CENTOS5 := $(shell sh -c 'grep "CentOS release 5." /etc/redhat-release > /dev/null && echo YES || echo not')
+
 ARCH_FLAGS =
 
 ROUTE_PATH := $(shell pwd)
@@ -1057,6 +1059,10 @@ endif
 endif
 endif
 endif
+endif
+
+ifeq ($(CHECK_CENTOS5),YES)
+PRECOMPILED_OS := el5
 endif
 
 ifeq (${PREFIX},/var/ossec)


### PR DESCRIPTION
|Related issue|
| #7728 |
| closes #7728 |

## Description
This PR aims to add a centos5 check in order to build the precompiled resources url for the OS.

## DoD
- [X] add condition to build resources url on centos 5.
- [X] manual tests on centos 5 amd64
![image](https://user-images.githubusercontent.com/54002291/109872858-c0903600-7c4b-11eb-968a-c30667538355.png)
- [X] manual tests on centos 5 i386
![image](https://user-images.githubusercontent.com/54002291/109883529-50d57780-7c5a-11eb-975f-78f143cd47c5.png)

