### PR TITLE
Fixing scan-build and Coverity issues reported over the branch dev-cves-by-agent

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -546,7 +546,7 @@ os_info *get_unix_version()
             info->os_platform = strdup("ubuntu");
             while (fgets(buff, sizeof(buff) - 1, version_release)) {
                 tag = strtok_r(buff, "=", &save_ptr);
-                if (strcmp(tag,"DISTRIB_RELEASE") == 0){
+                if (tag && strcmp(tag,"DISTRIB_RELEASE") == 0){
                     info->os_version = strdup(strtok_r(NULL, "\n", &save_ptr));
                     break;
                 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1322,8 +1322,8 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
 
             //Save the vulnerability in the agent database
             if (OS_INVALID == wdb_agents_vuln_cve_insert(atoi(agents_it->agent_id), report->software, report->version, report->arch, report->cve, &sock)) {
-                mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to insert %s for package %s in the agent %s database",
-                         report->cve, report->software, report->agent_id);
+                mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to insert %s for package %s in the agent %.3d database",
+                         report->cve ? report->cve : "null", report->software ? report->software : "null", atoi(agents_it->agent_id));
                 cve_insert_result = OS_INVALID;
             }
 
@@ -1350,7 +1350,7 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
     wdb_finalize(stmt);
 
     if (OS_INVALID == cve_insert_result) {
-        mtwarn(WM_VULNDETECTOR_LOGTAG, "Failed to insert vulnerabilities in the agent %s database", agents_it->agent_id);
+        mtwarn(WM_VULNDETECTOR_LOGTAG, "Failed to insert vulnerabilities in the agent %.3d database", atoi(agents_it->agent_id));
     }
 
     if (agents_it->dist != FEED_MAC) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2202,10 +2202,12 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
             cpe_data = wm_vuldet_decode_cpe(report_node->generated_cpe);
         }
 
-        os_strdup((NULL != report_node->raw_product) ? report_node->raw_product : cpe_data->product, report->software);
-        os_strdup((NULL != report_node->raw_version) ? report_node->raw_version : cpe_data->version, report->version);
-        os_strdup((NULL != report_node->raw_arch) ? report_node->raw_arch :
-                  (NULL != cpe_data->target_hw) ? cpe_data->target_hw : "*", report->arch);
+        os_strdup(report_node->raw_product ? report_node->raw_product :
+                  (cpe_data && cpe_data->product) ? cpe_data->product : "" , report->software);
+        os_strdup(report_node->raw_version ? report_node->raw_version :
+                  (cpe_data && cpe_data->version) ? cpe_data->version : "", report->version);
+        os_strdup(report_node->raw_arch ? report_node->raw_arch :
+                  (cpe_data && cpe_data->target_hw) ? cpe_data->target_hw : "*", report->arch);
 
         report->pending = report_node->pending;
         wm_vuldet_build_nvd_condition(report_node, &report->condition, &report->is_hotfix);
@@ -2222,9 +2224,11 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
         snprintf(report->title, OS_SIZE_512, "%s affects %s", report->cve, report->software);
 
         //Save the vulnerability in the agent database
-        if (OS_INVALID == wdb_agents_vuln_cve_insert(atoi(report->agent_id), report->software, report->version, report->arch, report->cve, &sock)) {
+        if (OS_INVALID == wdb_agents_vuln_cve_insert(atoi(agent->agent_id), report->software, report->version, report->arch, report->cve, &sock)) {
             mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to insert %s for package %s in the agent %s database",
-                        report->cve, report->software, report->agent_id);
+                     !report->cve ? report->cve : "null",
+                     !report->software ? report->software : "null",
+                     !report->agent_id ? report->agent_id : "null");
             cve_insert_result = OS_INVALID;
         }
 
@@ -2236,7 +2240,8 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
     }
 
     if (OS_INVALID == cve_insert_result) {
-        mtwarn(WM_VULNDETECTOR_LOGTAG, "Failed to insert vulnerabilities in the agent %s database", agent->agent_id);
+        mtwarn(WM_VULNDETECTOR_LOGTAG, "Failed to insert vulnerabilities in the agent %s database",
+               !agent->agent_id ? agent->agent_id : "null");
     }
 
     retval = 0;


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7611 |

## Description

This pull request implements some fixes for the errors reported by `scan-build`. After implementing the fixes, `scab-build` was executed to verify the fixes and we got the next confirmation message.

```
make: Leaving directory 'wazuh/src'
scan-build: Removing directory '/tmp/scan-build-2021-03-03-214151-298390-1' because it contains no reports.
scan-build: No bugs found.
```

It also contains a fix for the next issue reported by Coverity:

```
** CID 216927:  Null pointer dereferences  (NULL_RETURNS)
/shared/version_op.c: 549 in get_unix_version()


________________________________________________________________________________________________________
*** CID 216927:  Null pointer dereferences  (NULL_RETURNS)
/shared/version_op.c: 549 in get_unix_version()
543             // Ubuntu
544             } else if (version_release = fopen("/etc/lsb-release","r"), version_release){
545                 info->os_name = strdup("Ubuntu");
546                 info->os_platform = strdup("ubuntu");
547                 while (fgets(buff, sizeof(buff) - 1, version_release)) {
548                     tag = strtok_r(buff, "=", &save_ptr);
>>>     CID 216927:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing a pointer that might be "NULL" "tag" when calling "strcmp".
549                     if (strcmp(tag,"DISTRIB_RELEASE") == 0){
550                         info->os_version = strdup(strtok_r(NULL, "\n", &save_ptr));
551                         break;
552                     }
553                 }
554
```

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity