### PR TITLE
[7685] Makefile only sources flag

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -581,6 +581,7 @@ help: failtarget
 	@echo "   make ONEWAY=yes              Disables manager's ACK towards agent. It allows connecting agents without backward connection from manager. Allowed values are 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make CLEANFULL=yes           Makes the alert mailing subject clear in the format: '<location> - <level> - <description>'. Allowed values are 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make RESOURCES_URL           Set the Wazuh resources URL"
+	@echo "   make EXTERNAL_SRC_ONLY=yes   Combined with 'deps', it downloads only the external source code to be compiled as part of Wazuh building.
 	@echo "   make USE_ZEROMQ=yes          Build with zeromq support. Allowed values are auto, 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make USE_PRELUDE=yes         Build with prelude support. Allowed values are auto, 1, yes, YES, y and Y, otherwise, the flag is ignored"
 	@echo "   make USE_INOTIFY=yes         Build with inotify support. Allowed values are auto, 1, yes, YES, y and Y, otherwise, the flag is ignored"
@@ -626,6 +627,7 @@ settings:
 	@echo "    ONEWAY:             ${ONEWAY}"
 	@echo "    CLEANFULL:          ${CLEANFULL}"
 	@echo "    RESOURCES_URL:      ${RESOURCES_URL}"
+	@echo "    EXTERNAL_SRC_ONLY:  ${EXTERNAL_SRC_ONLY}"
 	@echo "    DISABLE_SHARED:     ${DISABLE_SHARED}"
 	@echo "User settings:"
 	@echo "    OSSEC_GROUP:        ${OSSEC_GROUP}"
@@ -1066,7 +1068,10 @@ PRECOMPILED_OS := el5
 endif
 
 ifeq (${PREFIX},/var/ossec)
+ifeq (,$(filter ${EXTERNAL_SRC_ONLY},YES yes y Y 1))
+# If EXTERNAL_SRC_ONLY=YES is not defined, lets look for the precompiled libs
 PRECOMPILED_RES := $(PRECOMPILED_OS)$(PRECOMPILED_ARCH)
+endif
 endif
 
 # Agent dependencies


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7685|

## **Description**

This issue aims to establish a new argument in the deps download, which makes the source code download explicit, instead of the precompiled ones.

Thus, in the next step, the makefile will seek to compile these dependencies.

## **DoD**
- [X] Modify makefile
- [X] Modify documentation
- [X] Manual testing cases:

1. `make deps`-> Will try to get libraries from RESOURCES_URL and if it doesn't exist it will fallback with sources URL.
2. `make RESOURCES_URL=<URL> deps` -> Will try to get libraries from RESOURCES_URL and if a particular lib doesn't exist it will fallback with sources URL.
3. `make EXTERNAL_SRC_ONLY=yes deps` -> Will go with sources URL directly.
4. `make RESOURCES_URL=<URL> EXTERNAL_SRC_ONLY=YES deps` -> Will go with sources URL directly.

- [x] CI PASS
