### PR TITLE
Fix remoted config for ipv6 - only yes/no

### DIFF
--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -162,6 +162,10 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         } else if (strcasecmp(node[i]->element, xml_remote_ipv6) == 0) {
             if (strcasecmp(node[i]->content, "yes") == 0) {
                 logr->ipv6[pl] = 1;
+            } else if (strcasecmp(node[i]->content, "no") == 0) {
+                logr->ipv6[pl] = 0;
+            } else {
+                mwarn(REMOTED_INV_VALUE_IGNORE, node[i]->content, xml_remote_ipv6);
             }
         } else if (strcasecmp(node[i]->element, xml_remote_lip) == 0) {
             os_strdup(node[i]->content, logr->lip[pl]);

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -77,4 +77,7 @@
 #define ANALYSISD_INV_VALUE_DEFAULT             "(7601): Invalid value for attribute '%s' in '%s' option " \
                                                 "(decoder `%s`). Default value will be taken"
 
+/* Remoted */
+#define REMOTED_INV_VALUE_IGNORE                "(9001): Ignored invalid value '%s' for '%s'."
+
 #endif /* WARN_MESSAGES_H */


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7702|

## Description

Hi team!

This PR adds a warning when using invalid values in the ipv6 label of remote config.
The tag will only accept the values yes or no. Any other value will be ignored.


PR Output:

```xml
  <remote>
    <connection>syslog</connection>
    <port>601</port>
    <protocol>tcp</protocol>
    <ipv6>si</ipv6>
  </remote>
```
```console
# /var/ossec/bin/wazuh-control restart                                 
2021/03/04 15:00:53 wazuh-remoted: WARNING: (9001): Ignored invalid value 'si' for 'ipv6'.
wazuh-clusterd not running...
....
```


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] ~MAC OS X~
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] ~QA templates contemplate the added capabilities~

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] ~Coverity~
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] ~Dr. Memory~
  - [ ] ~AddressSanitizer~

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [ ] ~Added unit tests (for new features)~
- [ ] ~Stress test for affected components~
