### PR TITLE
Add parameters and body to API logs with level: info

### DIFF
--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -3,7 +3,6 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 import logging
 import re
-from json import JSONDecodeError
 
 from aiohttp.abc import AbstractAccessLogger
 
@@ -19,7 +18,7 @@ class AccessLogger(AbstractAccessLogger):
         self.logger.info(f'{request.get("user", "unknown_user")} '
                          f'{request.remote} '
                          f'"{request.method} {request.path}" '
-                         f'with parameters {dict(request.query)} and body {request.get("body","{}")} '
+                         f'with parameters {dict(request.query)} and body {request.get("body", "{}")} '
                          f'done in {time:.3f}s: {response.status}')
 
 

--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -1,10 +1,13 @@
 # Copyright (C) 2015-2019, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
-from wazuh.core.wlogging import WazuhLogger
 import logging
 import re
+from json import JSONDecodeError
+
 from aiohttp.abc import AbstractAccessLogger
+
+from wazuh.core.wlogging import WazuhLogger
 
 # compile regex when the module is imported so it's not necessary to compile it everytime log.info is called
 request_pattern = re.compile(r'\[.+\]|\s+\*\s+')
@@ -16,6 +19,7 @@ class AccessLogger(AbstractAccessLogger):
         self.logger.info(f'{request.get("user", "unknown_user")} '
                          f'{request.remote} '
                          f'"{request.method} {request.path}" '
+                         f'with parameters {dict(request.query)} and body {request.get("body","{}")} '
                          f'done in {time:.3f}s: {response.status}')
 
 

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -79,10 +79,11 @@ async def request_logging(request, handler):
     """Add request info to logging."""
     logger.debug2(f'Receiving headers {dict(request.headers)}')
     try:
-        body = f' and body {await request.json()}'
+        body = f'{await request.json()}'
+        request['body'] = body
     except JSONDecodeError:
-        body = ''
-    logger.debug(f'Receiving request "{request.method} {request.path}" with parameters {dict(request.query)}{body}')
+        pass
+
     return await handler(request)
 
 

--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -21,6 +21,8 @@ def test_accesslogger_log(mock_logger_info):
     alogging.AccessLogger.log(MagicMock(), request=request, response=MagicMock(), time=0.0)
 
     assert request.method_calls[0] == call.get('user', 'unknown_user')
+    assert request.method_calls[1] == call.query.keys()
+    assert request.method_calls[2] == call.get('body', '{}')
 
 
 @patch('wazuh.core.wlogging.WazuhLogger.__init__')


### PR DESCRIPTION
|Related issue|
|---|
| #7735 |

This pull request closes #7735.

In this PR, I have removed the API logs generated with log level `debug` what showed the request parameters and body.

The request parameters and body are now showed with the log generated using log level `info`:

`
2021/03/04 15:11:45 INFO: wazuh 172.27.0.1 "GET /security/user/authenticate" with parameters {'raw': 'true'} and body {} done in 0.174s: 200`

`2021/03/04 15:11:50 INFO: wazuh 172.27.0.1 "GET /sca/000" with parameters {'pretty': 'true', 'wait_for_complete': 'true'} and body {} done in 0.066s: 200`

`2021/03/04 15:12:13 INFO: wazuh 172.27.0.1 "POST /agents" with parameters {'pretty': 'true'} and body {'name': 'aaa', 'ip': '1111'} done in 0.053s: 400`

`2021/03/04 15:12:16 INFO: wazuh 172.27.0.1 "POST /agents" with parameters {} and body {'name': 'aaa', 'ip': '1111'} done in 0.055s: 400`


I have also updated the unittest `test_alogging.py`.

### Test results

```
framework/wazuh/core/cluster/tests/
========================= 55 passed, 2 warnings in 0.35s ==========================
```

```
framework/wazuh/core/cluster/dapi/tests/
========================= 22 passed, 11 warnings in 0.63s =========================
```

```
framework/wazuh/core/tests/
======================== 643 passed, 11 warnings in 2.36s =========================
```

```
api/api/test/
======================== 180 passed, 16 warnings in 0.84s =========================
```

```
framework/wazuh/tests/
======================== 677 passed, 12 warnings in 48.90s ========================
```

```
framework/wazuh/rbac/tests/
=================== 224 passed, 1 warning in 141.58s (0:02:21) ====================
```

Regards,
Manuel.