### PR TITLE
Increase the default agent disconnection detection time to 10 minutes

### DIFF
--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -16,8 +16,8 @@
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
-    <agents_disconnection_time>20s</agents_disconnection_time>
-    <agents_disconnection_alert_time>100s</agents_disconnection_alert_time
+    <agents_disconnection_time>10m</agents_disconnection_time>
+    <agents_disconnection_alert_time>0</agents_disconnection_alert_time
   </global>
 
   <alerts>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -16,8 +16,8 @@
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
-    <agents_disconnection_time>20s</agents_disconnection_time>
-    <agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
+    <agents_disconnection_time>10m</agents_disconnection_time>
+    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
   </global>
 
   <alerts>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -16,8 +16,8 @@
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
-    <agents_disconnection_time>20s</agents_disconnection_time>
-    <agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
+    <agents_disconnection_time>10m</agents_disconnection_time>
+    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
   </global>
 
   <!-- Choose between plain or json format (or both) for internal logs -->

--- a/etc/templates/config/generic/global.template
+++ b/etc/templates/config/generic/global.template
@@ -9,6 +9,6 @@
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
-    <agents_disconnection_time>20s</agents_disconnection_time>
-    <agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
+    <agents_disconnection_time>10m</agents_disconnection_time>
+    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
   </global>

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -186,8 +186,8 @@ int MonitordConfig(const char *cfg, monitor_config *mond, int no_agents, short d
     mond->emailidsname = NULL;
 
     /* Setting default agent's global configuration */
-    mond->global.agents_disconnection_time = 20;
-    mond->global.agents_disconnection_alert_time = 100;
+    mond->global.agents_disconnection_time = 600;
+    mond->global.agents_disconnection_alert_time = 0;
 
     modules |= CREPORTS;
 

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -40,8 +40,8 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
     buffer_relax = getDefine_Int("remoted", "buffer_relax", 0, 2);
 
     /* Setting default values for global parameters */
-    cfg->global.agents_disconnection_time = 20;
-    cfg->global.agents_disconnection_alert_time = 100;
+    cfg->global.agents_disconnection_time = 600;
+    cfg->global.agents_disconnection_alert_time = 0;
 
     if (ReadConfig(modules, cfgfile, cfg, NULL) < 0 ||
         ReadConfig(CGLOBAL, cfgfile, &cfg->global, NULL) < 0 ) {

--- a/src/unit_tests/monitord/test_monitord.c
+++ b/src/unit_tests/monitord/test_monitord.c
@@ -479,8 +479,8 @@ void test_MonitordConfig_success(void **state) {
     result = MonitordConfig(cfg, &mond, no_agents, day_wait);
 
     assert_int_equal(result, OS_SUCCESS);
-    assert_int_equal(mond.global.agents_disconnection_time, 20);
-    assert_int_equal(mond.global.agents_disconnection_alert_time, 100);
+    assert_int_equal(mond.global.agents_disconnection_time, 600);
+    assert_int_equal(mond.global.agents_disconnection_alert_time, 0);
 
     assert_null(mond.agents);
     assert_null(mond.smtpserver);


### PR DESCRIPTION
|Version|Installation|Component|
|---|---|---|
|4.1.0|Manager|Monitord|

Per the changes introduced by #6396 in version 4.1, the parameter that defines how long the manager expects keepalives from agents before marking them as disconnected is now configurable. Before, it was a constant, and it was set to 30 minutes. As of 4.1, the new option value is 20 minutes by default.

We've observed that this value is not enough to dampen eventual delays in synchronization. That may cause false-positive alerts about agents disconnected. Due to this issue, we've decided to increase the default option value to 10 minutes. However, the previous value is still allowed.

## Affected artifacts

- Configuration file _ossec.conf_ in the manager.
- Binaries _ossec-remoted_ and _ossec-monitord_.

## Tests

- [X] Build a manager on Linux.
- [X] Check the configuration at _ossec.conf_ in a new installation.
- [X] Check the run-time configuration after removing the explicit values.

### Checking the run-time configuration

- Monitord

```json
# curl -w\\n -sk -H "Authorization: Bearer $(curl -u wazuh:wazuh -sk -X GET "https://localhost:55000/security/user/authenticate?raw=true")" -X GET "https://localhost:55000/agents/000/config/monitor/global"
{
  "data": {
    "monitord": {
      "agents_disconnection_time": 600,
      "agents_disconnection_alert_time": 0
    }
  },
  "error": 0
}
```

- Remoted
```json
# curl -w\\n -sk -H "Authorization: Bearer $(curl -u wazuh:wazuh -sk -X GET "https://localhost:55000/security/user/authenticate?raw=true")" -X GET "https://localhost:55000/agents/000/config/request/global"
{
  "data": {
    "global": {
      "remoted": {
        "agents_disconnection_alert_time": 0,
        "agents_disconnection_time": 600
      }
    }
  },
  "error": 0
}
```