### PR TITLE
7741 arch linux os info parser

### DIFF
--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -151,7 +151,7 @@ bool UnixOsParser::parseFile(std::istream& in, nlohmann::json& info)
         {"VERSION_CODENAME", "os_codename"}
     };
     const auto ret {parseUnixFile(KEY_MAP, SEPARATOR, in, info)};
-    if (ret)
+    if (ret && info.find("os_version") != info.end())
     {
         findMajorMinorVersionInString(info["os_version"], info);
     }

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -90,6 +90,33 @@ TEST_F(SysInfoParsersTest, UnixCentos)
     EXPECT_EQ("8", output["os_major"]);
 }
 
+TEST_F(SysInfoParsersTest, UnixArch)
+{
+    constexpr auto UNIX_RELEASE_FILE
+    {
+        R"(
+        NAME="Arch Linux"
+        PRETTY_NAME="Arch Linux"
+        ID=arch
+        BUILD_ID=rolling
+        ANSI_COLOR="38;2;23;147;209"
+        HOME_URL="https://www.archlinux.org/"
+        DOCUMENTATION_URL="https://wiki.archlinux.org/"
+        SUPPORT_URL="https://bbs.archlinux.org/"
+        BUG_REPORT_URL="https://bugs.archlinux.org/"
+        LOGO=archlinux
+        )"
+    };
+    nlohmann::json output;
+    std::stringstream info{UNIX_RELEASE_FILE};
+    const auto spParser{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("Arch Linux", output["os_name"]);
+    EXPECT_EQ("arch", output["os_platform"]);
+}
+
+
+
 TEST_F(SysInfoParsersTest, Ubuntu)
 {
     constexpr auto UBUNTU_RELEASE_FILE


### PR DESCRIPTION
|Related issue|
| #7741  |
| closes #7741  |

## Description
This PR aims to fix the exception thrown in the data provider when parsing os release files without os_version information.
The issue was reported for arch linux.

## DoD
- [X] modify data provider code
- [X] update/add UTs
- [X] manual tests on arch linux
![image](https://user-images.githubusercontent.com/54002291/110006467-74e79600-7cf8-11eb-8bd6-5adeaa39f200.png)
