### PR TITLE
Add strict control of values in rids_closing_time option

### DIFF
--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -214,31 +214,21 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             }
             defined_queue_size = 1;
         } else if (strcmp(node[i]->element, xml_rids_closing_time) == 0) {
-            char *endptr;
-            logr->rids_closing_time = strtol(node[i]->content, &endptr, 0);
+            char * time_unit_ptr = NULL;
+            long rids_closing_time = 0;
+            const char * TIME_UNITS = "sSmMhHdD";
 
-            if (logr->rids_closing_time == 0 || logr->rids_closing_time == INT_MAX) {
-                merror("Invalid value for option '<%s>'", xml_rids_closing_time);
-                return OS_INVALID;
+            time_unit_ptr = strpbrk(node[i]->content, TIME_UNITS);
+            rids_closing_time = w_parse_time(node[i]->content);
+
+            if ((time_unit_ptr != NULL && *(time_unit_ptr + 1) !='\0') ||
+                (rids_closing_time <= 0 || rids_closing_time > INT_MAX)) {
+                    mwarn(REMOTED_INV_VALUE_DEFAULT, node[i]->content, xml_rids_closing_time);
+                    rids_closing_time = REMOTED_RIDS_CLOSING_TIME_DEFAULT;
             }
 
-            switch (*endptr) {
-            case 'd':
-                logr->rids_closing_time *= 86400;
-                break;
-            case 'h':
-                logr->rids_closing_time *= 3600;
-                break;
-            case 'm':
-                logr->rids_closing_time *= 60;
-                break;
-            case 's':
-            case '\0':
-                break;
-            default:
-                merror("Invalid value for option '<%s>'", xml_rids_closing_time);
-                return OS_INVALID;
-            }
+            logr->rids_closing_time = (int) rids_closing_time;
+
         } else {
             merror(XML_INVELEM, node[i]->element);
             return (OS_INVALID);

--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -14,6 +14,8 @@
 #define SYSLOG_CONN 1
 #define SECURE_CONN 2
 
+#define REMOTED_RIDS_CLOSING_TIME_DEFAULT   (5 * 60) ///< Default rids_closing_time value (5 minutes)
+
 #include "shared.h"
 #include "global-config.h"
 

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -77,4 +77,7 @@
 #define ANALYSISD_INV_VALUE_DEFAULT             "(7601): Invalid value for attribute '%s' in '%s' option " \
                                                 "(decoder `%s`). Default value will be taken"
 
+/* Remoted */
+#define REMOTED_INV_VALUE_DEFAULT               "(9004): Invalid value '%s' in '%s' option. " \
+                                                "Default value will be used."
 #endif /* WARN_MESSAGES_H */


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7643 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team!

This PR aims to add strict control of values in `rids_closing_time` option, specifically checking content after unit letter. In case invalid values exist, WARN message is logged and default value (5 minutes) is set. 
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options examples and outputs
The next example consist in the next base config block with variations in `rids_closing_time` values
```xml
  <remote>
    <connection>secure</connection>
    <port>1514</port>
    <protocol>tcp</protocol>
    <rids_closing_time>5m</rids_closing_time>
    <queue_size>131072</queue_size>
  </remote>
```
### Negative value without unit
```
    <rids_closing_time>-10</rids_closing_time>
```
```
2021/03/04 18:54:35 ossec-remoted: WARNING: (9004): Invalid value '-10' in 'rids_closing_time' option. Default value will be used.
```
### Negative value with unit
```
    <rids_closing_time>-50s</rids_closing_time>
```
```
2021/03/04 18:55:13 ossec-remoted: WARNING: (9004): Invalid value '-50s' in 'rids_closing_time' option. Default value will be used.
```
### Negative value with unit and garbage after it
```
    <rids_closing_time>-50minutes</rids_closing_time>
```
```
2021/03/04 18:55:40 ossec-remoted: WARNING: (9004): Invalid value '-50minutes' in 'rids_closing_time' option. Default value will be used.
```
### Any string value
```
    <rids_closing_time>ExampleValue</rids_closing_time>
```
```
2021/03/04 18:56:38 ossec-remoted: WARNING: (9004): Invalid value 'ExampleValue' in 'rids_closing_time' option. Default value will be used.
```
### Positive value without unit
```
    <rids_closing_time>10</rids_closing_time>
```
### Positive value with unit
```
    <rids_closing_time>20m</rids_closing_time>
```
### Positive value with unit and garbage after it
```
    <rids_closing_time>30days</rids_closing_time>
```
```
2021/03/04 18:57:30 ossec-remoted: WARNING: (9004): Invalid value '30days' in 'rids_closing_time' option. Default value will be used.
```



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [X] MAC OS X
- [x] Source installation
- [X] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [X] ~Review logs syntax and correct language~
- [X] ~QA templates contemplate the added capabilities~

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [X] ~Coverity~
  - [X] Valgrind (memcheck and descriptor leaks check)
  - [X] ~Dr. Memory~
  - [X] ~AddressSanitizer~
- Memory tests for Windows
  - [X] ~Scan-build report~
  - [X] ~Coverity~
  - [X] ~Dr. Memory~
- Memory tests for macOS
  - [X] ~Scan-build report~
  - [X] ~Leaks~
  - [X] ~AddressSanitizer~

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [X] ~The data flow works as expected (agent-manager-api-app)~
- [X] ~Added unit tests (for new features)~
- [X] ~Stress test for affected components~

Regards,
Nico