### PR TITLE
Fixed returns in the sacl functions to differentiate between errors

### DIFF
--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -150,27 +150,28 @@ int set_winsacl(const char *dir, int position) {
     ZeroMemory(&old_sacl_info, sizeof(ACL_SIZE_INFORMATION));
 
     // Check if the sacl has what the whodata scanner needs
-    switch(is_valid_sacl(old_sacl, (syscheck.wdata.dirs_status[position].object_type == WD_STATUS_FILE_TYPE) ? 1 : 0)) {
-        case 0:
-            mdebug1(FIM_SACL_CHECK_CONFIGURE, dir);
-            syscheck.wdata.dirs_status[position].status |= WD_IGNORE_REST;
+    switch (is_valid_sacl(old_sacl, (syscheck.wdata.dirs_status[position].object_type == WD_STATUS_FILE_TYPE) ? 1 : 0)) {
+    case 0:
+        // It is not necessary to configure the SACL of the directory
+        retval = 0;
+        goto end;
+    case 1:
+        mdebug1(FIM_SACL_CHECK_CONFIGURE, dir);
+        syscheck.wdata.dirs_status[position].status |= WD_IGNORE_REST;
 
+        // Empty SACL
+        if (!old_sacl) {
+            old_sacl_info.AclBytesInUse = sizeof(ACL);
+        } else {
             // Get SACL size
             if (!GetAclInformation(old_sacl, (LPVOID)&old_sacl_info, sizeof(ACL_SIZE_INFORMATION), AclSizeInformation)) {
                 merror(FIM_ERROR_SACL_GETSIZE, dir);
                 goto end;
             }
+        }
         break;
-        case 1:
-            // It is not necessary to configure the SACL of the directory
-            retval = 0;
-            goto end;
-        case 2:
-            // Empty SACL
-            syscheck.wdata.dirs_status[position].status |= WD_IGNORE_REST;
-            old_sacl_info.AclBytesInUse = sizeof(ACL);
-            break;
     }
+
     if (!ev_sid_size) {
         ev_sid_size = GetLengthSid(everyone_sid);
     }
@@ -268,29 +269,29 @@ int is_valid_sacl(PACL sacl, int is_file) {
     if (!everyone_sid) {
         if (!AllocateAndInitializeSid(&world_auth, 1, SECURITY_WORLD_RID, 0, 0, 0, 0, 0, 0, 0, &everyone_sid)) {
             merror(FIM_ERROR_WHODATA_GET_SID, GetLastError());
-            return 0;
+            return 2;
         }
     }
 
     if (!sacl) {
         mdebug2(FIM_SACL_NOT_FOUND);
-        return 2;
+        return 1;
     }
 
     for (i = 0; i < sacl->AceCount; i++) {
         if (!GetAce(sacl, i, (LPVOID*)&ace)) {
             merror(FIM_ERROR_WHODATA_GET_ACE, GetLastError());
-            return 0;
+            return 1;
         }
 
         if ((is_file || (ace->Header.AceFlags & inherit_flag)) && // Check folder and subfolders
             (ace->Header.AceFlags & SUCCESSFUL_ACCESS_ACE_FLAG) && // Check successful attemp
             ((ace->Mask & (criteria)) == criteria) && // Check write, delete, change_permissions and change_attributes permission
             (EqualSid((PSID)&ace->SidStart, everyone_sid))) { // Check everyone user
-            return 1;
+            return 0;
         }
     }
-    return 0;
+    return 1;
 }
 
 int set_privilege(HANDLE hdle, LPCTSTR privilege, int enable) {
@@ -935,7 +936,7 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
                     d_status->status |= WD_STATUS_EXISTS;
                 } else {
                     // Check if the SACL is invalid
-                    if (check_object_sacl(syscheck.dir[i], (d_status->object_type == WD_STATUS_FILE_TYPE) ? 1 : 0)) {
+                    if (check_object_sacl(syscheck.dir[i], (d_status->object_type == WD_STATUS_FILE_TYPE) ? 1 : 0) == 1) {
                         minfo(FIM_WHODATA_SACL_CHANGED, syscheck.dir[i]);
                         // Mark the directory to prevent its children from
                         // sending partial whodata alerts
@@ -1095,14 +1096,14 @@ void set_subscription_query(wchar_t *query) {
 int check_object_sacl(char *obj, int is_file) {
     HANDLE hdle = NULL;
     PACL sacl = NULL;
-    int retval = 1;
+    int retval = 2;
     PSECURITY_DESCRIPTOR security_descriptor = NULL;
     long int result;
     int privilege_enabled = 0;
 
     if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &hdle)) {
         merror(FIM_ERROR_SACL_OPENPROCESSTOKEN, GetLastError());
-        return 1;
+        return retval;
     }
 
     if (set_privilege(hdle, priv, TRUE)) {
@@ -1116,10 +1117,7 @@ int check_object_sacl(char *obj, int is_file) {
         goto end;
     }
 
-    if (is_valid_sacl(sacl, is_file) == 1) {
-        // Is a valid SACL
-        retval = 0;
-    }
+    retval = is_valid_sacl(sacl, is_file);
 
 end:
     if (privilege_enabled) {

--- a/src/syscheckd/whodata/win_whodata.c
+++ b/src/syscheckd/whodata/win_whodata.c
@@ -94,18 +94,42 @@ STATIC int restore_policies = 0;
 // Whodata function headers
 void restore_sacls();
 int set_privilege(HANDLE hdle, LPCTSTR privilege, int enable);
-int is_valid_sacl(PACL sacl, int is_file);
 unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attribute__((unused)) void *_void, EVT_HANDLE event);
 int set_policies();
 void set_subscription_query(wchar_t *query);
 extern int wm_exec(char *command, char **output, int *exitcode, int secs, const char * add_path);
 int restore_audit_policies();
-int check_object_sacl(char *obj, int is_file);
 int whodata_hash_add(OSHash *table, char *id, void *data, char *tag);
 void notify_SACL_change(char *dir);
 int whodata_path_filter(char **path);
 void whodata_adapt_path(char **path);
 int whodata_check_arch();
+
+/**
+ * @brief Checks the sacl status of an object.
+ *
+ * @param obj String with the object to be checked
+ * @param is_file Boolean to check if it is file
+
+ * @return Returns the sacl status of an object.
+ * @retval 0: if the object has valid sacl.
+ * @retval 1: if the object has invalid sacl.
+ * @retval 2: if the object cannot be opened, set privileges or obtain security information.
+ */
+int check_object_sacl(char *obj, int is_file);
+
+/**
+ * @brief Checks if sacl is valid
+ *
+ * @param sacl PACL with the sacl to be checked
+ * @param is_file Boolean to check if it is file
+
+ * @return Returns the status of the sacl passed as a parameter
+ * @retval 0: if sacl is valid
+ * @retval 1: if sacl is invalid or NULL
+ * @retval 2: if we cannot allocate the everyone_sid variable
+ */
+int is_valid_sacl(PACL sacl, int is_file);
 
 // Whodata list operations
 char *get_whodata_path(const short unsigned int *win_path);
@@ -150,7 +174,9 @@ int set_winsacl(const char *dir, int position) {
     ZeroMemory(&old_sacl_info, sizeof(ACL_SIZE_INFORMATION));
 
     // Check if the sacl has what the whodata scanner needs
-    switch (is_valid_sacl(old_sacl, (syscheck.wdata.dirs_status[position].object_type == WD_STATUS_FILE_TYPE) ? 1 : 0)) {
+    int is_file = syscheck.wdata.dirs_status[position].object_type == WD_STATUS_FILE_TYPE ? 1 : 0;
+
+    switch (is_valid_sacl(old_sacl, is_file)) {
     case 0:
         // It is not necessary to configure the SACL of the directory
         retval = 0;
@@ -169,6 +195,9 @@ int set_winsacl(const char *dir, int position) {
                 goto end;
             }
         }
+        break;
+    default:
+        // Can't access everyone_sid variable, nothing to do
         break;
     }
 
@@ -936,7 +965,7 @@ long unsigned int WINAPI state_checker(__attribute__((unused)) void *_void) {
                     d_status->status |= WD_STATUS_EXISTS;
                 } else {
                     // Check if the SACL is invalid
-                    if (check_object_sacl(syscheck.dir[i], (d_status->object_type == WD_STATUS_FILE_TYPE) ? 1 : 0) == 1) {
+                    if (check_object_sacl(syscheck.dir[i], (d_status->object_type == WD_STATUS_FILE_TYPE)) == 1) {
                         minfo(FIM_WHODATA_SACL_CHANGED, syscheck.dir[i]);
                         // Mark the directory to prevent its children from
                         // sending partial whodata alerts

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -614,11 +614,14 @@ void test_set_winsacl_unable_to_get_acl_info(void **state) {
     {
         expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
         expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-        will_return(wrap_AllocateAndInitializeSid, 0);
+        will_return(wrap_AllocateAndInitializeSid, 1);
+
+        will_return(wrap_GetAce, &old_sacl);
+        will_return(wrap_GetAce, 0);
 
         will_return(wrap_GetLastError, (unsigned int) 700);
 
-        expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+        expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
     }
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6263): Setting up SACL for 'C:\\a\\path'");
@@ -689,11 +692,14 @@ void test_set_winsacl_fail_to_alloc_new_sacl(void **state) {
     {
         expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
         expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-        will_return(wrap_AllocateAndInitializeSid, 0);
+        will_return(wrap_AllocateAndInitializeSid, 1);
+
+        will_return(wrap_GetAce, &old_sacl);
+        will_return(wrap_GetAce, 0);
 
         will_return(wrap_GetLastError, (unsigned int) 700);
 
-        expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+        expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
     }
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6263): Setting up SACL for 'C:\\a\\path'");
@@ -767,11 +773,14 @@ void test_set_winsacl_fail_to_initialize_new_sacl(void **state) {
     {
         expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
         expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-        will_return(wrap_AllocateAndInitializeSid, 0);
+        will_return(wrap_AllocateAndInitializeSid, 1);
+
+        will_return(wrap_GetAce, &old_sacl);
+        will_return(wrap_GetAce, 0);
 
         will_return(wrap_GetLastError, (unsigned int) 700);
 
-        expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+        expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
     }
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6263): Setting up SACL for 'C:\\a\\path'");
@@ -851,11 +860,14 @@ void test_set_winsacl_fail_getting_ace_from_old_sacl(void **state) {
     {
         expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
         expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-        will_return(wrap_AllocateAndInitializeSid, 0);
+        will_return(wrap_AllocateAndInitializeSid, 1);
+
+        will_return(wrap_GetAce, &old_sacl);
+        will_return(wrap_GetAce, 0);
 
         will_return(wrap_GetLastError, (unsigned int) 700);
 
-        expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+        expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
     }
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6263): Setting up SACL for 'C:\\a\\path'");
@@ -938,11 +950,14 @@ void test_set_winsacl_fail_adding_old_ace_into_new_sacl(void **state) {
     {
         expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
         expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-        will_return(wrap_AllocateAndInitializeSid, 0);
+        will_return(wrap_AllocateAndInitializeSid, 1);
+
+        will_return(wrap_GetAce, &old_sacl);
+        will_return(wrap_GetAce, 0);
 
         will_return(wrap_GetLastError, (unsigned int) 700);
 
-        expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+        expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
     }
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6263): Setting up SACL for 'C:\\a\\path'");
@@ -1028,11 +1043,14 @@ void test_set_winsacl_fail_to_alloc_new_ace(void **state) {
     {
         expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
         expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-        will_return(wrap_AllocateAndInitializeSid, 0);
+        will_return(wrap_AllocateAndInitializeSid, 1);
+
+        will_return(wrap_GetAce, &old_sacl);
+        will_return(wrap_GetAce, 0);
 
         will_return(wrap_GetLastError, (unsigned int) 700);
 
-        expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+        expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
     }
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6263): Setting up SACL for 'C:\\a\\path'");
@@ -1124,11 +1142,14 @@ void test_set_winsacl_fail_to_copy_sid(void **state) {
     {
         expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
         expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-        will_return(wrap_AllocateAndInitializeSid, 0);
+        will_return(wrap_AllocateAndInitializeSid, 1);
+
+        will_return(wrap_GetAce, &old_sacl);
+        will_return(wrap_GetAce, 0);
 
         will_return(wrap_GetLastError, (unsigned int) 700);
 
-        expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+        expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
     }
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6263): Setting up SACL for 'C:\\a\\path'");
@@ -1223,11 +1244,14 @@ void test_set_winsacl_fail_to_add_ace(void **state) {
     {
         expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
         expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-        will_return(wrap_AllocateAndInitializeSid, 0);
+        will_return(wrap_AllocateAndInitializeSid, 1);
+
+        will_return(wrap_GetAce, &old_sacl);
+        will_return(wrap_GetAce, 0);
 
         will_return(wrap_GetLastError, (unsigned int) 700);
 
-        expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+        expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
     }
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6263): Setting up SACL for 'C:\\a\\path'");
@@ -1327,11 +1351,14 @@ void test_set_winsacl_fail_to_set_security_info(void **state) {
     {
         expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
         expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-        will_return(wrap_AllocateAndInitializeSid, 0);
+        will_return(wrap_AllocateAndInitializeSid, 1);
+
+        will_return(wrap_GetAce, &old_sacl);
+        will_return(wrap_GetAce, 0);
 
         will_return(wrap_GetLastError, (unsigned int) 700);
 
-        expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+        expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
     }
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6263): Setting up SACL for 'C:\\a\\path'");
@@ -1440,11 +1467,14 @@ void test_set_winsacl_success(void **state) {
     {
         expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
         expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-        will_return(wrap_AllocateAndInitializeSid, 0);
+        will_return(wrap_AllocateAndInitializeSid, 1);
+
+        will_return(wrap_GetAce, &old_sacl);
+        will_return(wrap_GetAce, 0);
 
         will_return(wrap_GetLastError, (unsigned int) 700);
 
-        expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+        expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
     }
 
     expect_string(__wrap__mdebug1, formatted_msg, "(6263): Setting up SACL for 'C:\\a\\path'");
@@ -2993,7 +3023,7 @@ void test_is_valid_sacl_sid_error(void **state) {
     expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
 
     ret = is_valid_sacl(sacl, 0);
-    assert_int_equal(ret, 0);
+    assert_int_equal(ret, 2);
 }
 
 void test_is_valid_sacl_sacl_not_found(void **state) {
@@ -3010,7 +3040,7 @@ void test_is_valid_sacl_sacl_not_found(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, "(6267): No SACL found on target. A new one will be created.");
 
     ret = is_valid_sacl(sacl, 0);
-    assert_int_equal(ret, 2);
+    assert_int_equal(ret, 1);
 }
 
 void test_is_valid_sacl_ace_not_found(void **state) {
@@ -3039,7 +3069,7 @@ void test_is_valid_sacl_ace_not_found(void **state) {
     expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '800'.");
 
     ret = is_valid_sacl(new_sacl, 0);
-    assert_int_equal(ret, 0);
+    assert_int_equal(ret, 1);
 }
 
 void test_is_valid_sacl_not_valid(void **state) {
@@ -3065,7 +3095,7 @@ void test_is_valid_sacl_not_valid(void **state) {
     will_return(wrap_GetAce, 1);
 
     ret = is_valid_sacl(new_sacl, 1);
-    assert_int_equal(ret, 0);
+    assert_int_equal(ret, 1);
 }
 
 void test_is_valid_sacl_valid(void **state) {
@@ -3092,7 +3122,7 @@ void test_is_valid_sacl_valid(void **state) {
     will_return(wrap_EqualSid, 1);
 
     ret = is_valid_sacl(&new_sacl, 1);
-    assert_int_equal(ret, 1);
+    assert_int_equal(ret, 0);
 }
 
 void test_replace_device_path_invalid_path(void **state) {
@@ -5749,7 +5779,7 @@ void test_check_object_sacl_open_process_error(void **state) {
 
     ret = check_object_sacl("C:\\a\\path", 0);
 
-    assert_int_equal(ret, 1);
+    assert_int_equal(ret, 2);
 }
 
 void test_check_object_sacl_unable_to_set_privilege(void **state) {
@@ -5781,7 +5811,7 @@ void test_check_object_sacl_unable_to_set_privilege(void **state) {
 
     ret = check_object_sacl("C:\\a\\path", 0);
 
-    assert_int_equal(ret, 1);
+    assert_int_equal(ret, 2);
 }
 
 void test_check_object_sacl_unable_to_retrieve_security_info(void **state) {
@@ -5831,7 +5861,7 @@ void test_check_object_sacl_unable_to_retrieve_security_info(void **state) {
 
     ret = check_object_sacl("C:\\a\\path", 0);
 
-    assert_int_equal(ret, 1);
+    assert_int_equal(ret, 2);
 }
 
 void test_check_object_sacl_invalid_sacl(void **state) {
@@ -5869,11 +5899,14 @@ void test_check_object_sacl_invalid_sacl(void **state) {
 
         expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
         expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-        will_return(wrap_AllocateAndInitializeSid, 0);
+        will_return(wrap_AllocateAndInitializeSid, 1);
+
+        will_return(wrap_GetAce, &acl);
+        will_return(wrap_GetAce, 0);
 
         will_return(wrap_GetLastError, (unsigned int) 700);
 
-        expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+        expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
     }
 
     // Inside set_privilege
@@ -6652,11 +6685,14 @@ void test_state_checker_file_with_invalid_sacl(void **state) {
 
             expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
             expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-            will_return(wrap_AllocateAndInitializeSid, 0);
+            will_return(wrap_AllocateAndInitializeSid, 1);
+
+            will_return(wrap_GetAce, &acl);
+            will_return(wrap_GetAce, 0);
 
             will_return(wrap_GetLastError, (unsigned int) 700);
 
-            expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+            expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
         }
 
         // Inside set_privilege
@@ -6932,11 +6968,14 @@ void test_state_checker_dir_readded_succesful(void **state) {
         {
             expect_memory(wrap_AllocateAndInitializeSid, pIdentifierAuthority, &world_auth, 6);
             expect_value(wrap_AllocateAndInitializeSid, nSubAuthorityCount, 1);
-            will_return(wrap_AllocateAndInitializeSid, 0);
+            will_return(wrap_AllocateAndInitializeSid, 1);
+
+            will_return(wrap_GetAce, &old_sacl);
+            will_return(wrap_GetAce, 0);
 
             will_return(wrap_GetLastError, (unsigned int) 700);
 
-            expect_string(__wrap__merror, formatted_msg, "(6632): Could not obtain the sid of Everyone. Error '700'.");
+            expect_string(__wrap__merror, formatted_msg, "(6633): Could not extract the ACE information. Error: '700'.");
         }
 
         expect_string(__wrap__mdebug1, formatted_msg, "(6263): Setting up SACL for 'c:\\a\\path'");

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -6643,6 +6643,8 @@ void test_state_checker_file_with_invalid_sacl(void **state) {
     ACL acl;
     SID_IDENTIFIER_AUTHORITY world_auth = {SECURITY_WORLD_SID_AUTHORITY};
 
+    acl.AceCount = 1;
+
     expect_string(__wrap__mdebug1, formatted_msg, "(6233): Checking thread set to '300' seconds.");
 
     will_return(__wrap_FOREVER, 1);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/6419|


## Description

This PR fixes how the functions `check_object_sacl` and `is_valid_sacl` work with the returns values, to make the functionality of error handling more accurate.

### is_valid_sacl
Return:
- 0 if sacl is valid
- 1 if sacl is invalid or NULL
- 2 if cannot initialize **everyone_sid**

### check_object_sacl
Return:
- 2 if fail some of preparation
- the same return obtained in **is_valid_sacl**

## Tests

Fixed unit test related to these functions.
