### PR TITLE
Change Remoted's warning about disconnected agent to debug-1 log

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -629,10 +629,8 @@ int OS_SetSendTimeout(int socket, int seconds)
 #endif
 }
 
-/* Send secure TCP message
- * This function prepends a header containing message size as 4-byte little-endian unsigned integer.
- * Return 0 on success or OS_SOCKTERR on error.
- */
+// Send secure TCP message
+
 int OS_SendSecureTCP(int sock, uint32_t size, const void * msg) {
     int retval = OS_SOCKTERR;
     void* buffer = NULL;
@@ -819,7 +817,7 @@ int OS_RecvSecureClusterTCP(int sock, char * ret, size_t length) {
                 return -1;
             }
     }
-   
+
     if (strncmp(buffer+8, "err --------", CMD_SIZE) == 0) {
         return -2;
     }

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -102,9 +102,16 @@ void OS_SetKeepalive_Options(__attribute__((unused)) int socket, int idle, int i
  */
 int OS_SetSendTimeout(int socket, int seconds);
 
-/* Send secure TCP message
+/**
+ * @brief Send secure TCP message
+ *
  * This function prepends a header containing message size as 4-byte little-endian unsigned integer.
- * Return 0 on success or OS_SOCKTERR on error.
+ *
+ * @param sock Socket file descriptor.
+ * @param size Message length, in bytes.
+ * @param msg Pointer to the message content.
+ * @retval 0 on success.
+ * @retval OS_SOCKTERR on error.
  */
 int OS_SendSecureTCP(int sock, uint32_t size, const void * msg);
 
@@ -115,7 +122,7 @@ int OS_SendSecureTCP(int sock, uint32_t size, const void * msg);
 int OS_RecvSecureTCP(int sock, char * ret,uint32_t size);
 
 /**
- * @brief Send secure TCP Cluster message 
+ * @brief Send secure TCP Cluster message
  * @param sock Socket to write on
  * @param command Command to send
  * @param payload Payload of the command to send

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -86,7 +86,7 @@ int send_msg(const char *agent_id, const char *msg, ssize_t msg_length)
     /* If we don't have the agent id, ignore it */
     if (keys.keyentries[key_id]->rcvd < (time(0) - logr.global.agents_disconnection_time)) {
         key_unlock();
-        mwarn(SEND_DISCON, keys.keyentries[key_id]->id);
+        mdebug1(SEND_DISCON, keys.keyentries[key_id]->id);
         return (-1);
     }
 


### PR DESCRIPTION
When Remoted is requested to send a message to an agent that is disconnected, it rejects the operation and prints this log:

> ossec-remoted: WARNING: (1245): Sending message to disconnected agent '001'.

Remoted takes an agent as disconnected when it sent no keep-alive message during more than `agents_disconnection_time` seconds. However, the message above does not necessarily represent a malfunction, and it's prone to flood the log. So, we're changing the log mode from warning to level-1 debug.

In addition, I detected a mistake in the documentation of the function `OS_SendSecureTCP`, and I fix that in this PR.

## Affected artifacts

- Binary daemon _ossec-remoted_.

## Tests

- [X] Build manager on Linux.
- [X] Pass unit tests for the manager.