### PR TITLE
Ensure agent_ip buffer has a null terminator on error

### DIFF
--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -54,7 +54,7 @@ char *get_agent_ip()
     }
 
     last_update = now;
-    *agent_ip = '\0';
+    agent_ip[0] = '\0';
 
     for (i = SOCK_ATTEMPTS; i > 0; --i) {
         if (sock = control_check_connection(), sock >= 0) {
@@ -66,6 +66,7 @@ char *get_agent_ip()
                 if (OS_RecvUnix(sock, IPSIZE, agent_ip) <= 0) {
                     mdebug1("Error receiving msg from control socket (%d) %s", errno, strerror(errno));
                     last_update = 0;
+                    agent_ip[0] = '\0';
                 }
             }
 


### PR DESCRIPTION
|Related issue|
|---|
|#7596|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Character '\0' now is set in agent_ip[0] if the call to OS_RecvUnix returns <= 0 to prevent errors in later call to strdup(agent_ip).

Tests pending to resolution of issue on wazuh-qa repository (https://github.com/wazuh/wazuh-qa/issues/1145) about some errors in remoted-simulator. This PR should not affect the correctly execution of the tests. Report: [agentd_info.zip](https://github.com/wazuh/wazuh/files/6147775/agentd_info.zip)


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report

