### PR TITLE
Metadata table changed to key->value format

### DIFF
--- a/tools/mitre/const.py
+++ b/tools/mitre/const.py
@@ -36,6 +36,8 @@ TACTIC_ID_t= 'tactic_id'
 TECH_ID_t= 'tech_id'
 
 DB_VERSION_t = 'db_version'
+DB_VERSION_N_t = '1'
+MITRE_VERSION_t = 'mitre_version'
 
 ### Relationships
 DATASOURCE_r= 'DataSource'
@@ -70,7 +72,6 @@ ATTACK_PATTERN_j= 'attack-pattern'
 
 ID_j= 'id'
 VERSION_j= 'spec_version'
-IDENTITY_j= 'identity'
 MARKING_DEFINITION_j= 'marking-definition'
 DEFINITION_j= 'definition'
 STATEMENT_j= 'statement'

--- a/tools/mitre/const.py
+++ b/tools/mitre/const.py
@@ -10,6 +10,11 @@ TIME_FORMAT= '%Y-%m-%dT%H:%M:%S.%fZ'
 
 ### Table
 
+# Metadata
+DB_VERSION_t = 'db_version'
+DB_VERSION_N_t = '1'
+MITRE_VERSION_t = 'mitre_version'
+
 ID_t= 'id'
 KEY_t= 'key'
 VALUE_t= 'value'
@@ -34,10 +39,6 @@ SOURCE_ID_t= 'source_id'
 TARGET_ID_t= 'target_id'
 TACTIC_ID_t= 'tactic_id'
 TECH_ID_t= 'tech_id'
-
-DB_VERSION_t = 'db_version'
-DB_VERSION_N_t = '1'
-MITRE_VERSION_t = 'mitre_version'
 
 ### Relationships
 DATASOURCE_r= 'DataSource'
@@ -72,9 +73,6 @@ ATTACK_PATTERN_j= 'attack-pattern'
 
 ID_j= 'id'
 VERSION_j= 'spec_version'
-MARKING_DEFINITION_j= 'marking-definition'
-DEFINITION_j= 'definition'
-STATEMENT_j= 'statement'
 NAME_j= 'name'
 DESCRIPTION_j= 'description'
 CREATED_j= 'created'

--- a/tools/mitre/const.py
+++ b/tools/mitre/const.py
@@ -11,7 +11,8 @@ TIME_FORMAT= '%Y-%m-%dT%H:%M:%S.%fZ'
 ### Table
 
 ID_t= 'id'
-VERSION_t= 'version'
+KEY_t= 'key'
+VALUE_t= 'value'
 NAME_t= 'name'
 DESCRIPTION_t= 'description'
 CREATED_t= 'created_time'
@@ -33,6 +34,8 @@ SOURCE_ID_t= 'source_id'
 TARGET_ID_t= 'target_id'
 TACTIC_ID_t= 'tactic_id'
 TECH_ID_t= 'tech_id'
+
+DB_VERSION_t = 'db_version'
 
 ### Relationships
 DATASOURCE_r= 'DataSource'

--- a/tools/mitre/mitredb.py
+++ b/tools/mitre/mitredb.py
@@ -451,10 +451,15 @@ def parse_json(pathfile, session, database):
         relationship_table_subtechique_of = []
 
         metadata = Metadata()
+        metadata.key = const.DB_VERSION_t
+        metadata.value = const.DB_VERSION_N_t
+        session.add(metadata)
         with open(pathfile) as json_file:
             datajson = json.load(json_file)
-            metadata.key = const.DB_VERSION_t
+            metadata = Metadata()
+            metadata.key = const.MITRE_VERSION_t
             metadata.value = datajson[const.VERSION_j]
+            session.add(metadata)
             for data_object in datajson[const.OBJECT_j]:
                 if data_object[const.TYPE_j] == const.INTRUSION_SET_j:
                     groups = parse_table_(Groups, data_object)
@@ -504,7 +509,6 @@ def parse_json(pathfile, session, database):
             technique = session.query(Technique).get(table[0])
             technique.subtechnique_of = table[1]
 
-        session.add(metadata)
         session.commit()
 
     except TypeError as t_e:

--- a/tools/mitre/mitredb.py
+++ b/tools/mitre/mitredb.py
@@ -31,15 +31,13 @@ class Metadata(Base):
     """
     In this table are stored the metadata of json file
     The information stored:
-        version: version of json (PK)
-        name: name
-        description: description
+        key: key (PK)
+        value: value
     """
     __tablename__ = "metadata"
 
-    version = Column(const.VERSION_t, String, primary_key=True)
-    name = Column(const.NAME_t, String, nullable=False)
-    description = Column(const.DESCRIPTION_t, String, default=None)
+    key = Column(const.KEY_t, String, primary_key=True)
+    value = Column(const.VALUE_t, String, nullable=False)
 
 
 class Technique(Base):
@@ -455,13 +453,10 @@ def parse_json(pathfile, session, database):
         metadata = Metadata()
         with open(pathfile) as json_file:
             datajson = json.load(json_file)
-            metadata.version = datajson[const.VERSION_j]
+            metadata.key = const.DB_VERSION_t
+            metadata.value = datajson[const.VERSION_j]
             for data_object in datajson[const.OBJECT_j]:
-                if data_object[const.TYPE_j] == const.IDENTITY_j:
-                    metadata.name = data_object[const.NAME_j]
-                elif data_object[const.TYPE_j] == const.MARKING_DEFINITION_j:
-                    metadata.description = data_object[const.DEFINITION_j][const.STATEMENT_j]
-                elif data_object[const.TYPE_j] == const.INTRUSION_SET_j:
+                if data_object[const.TYPE_j] == const.INTRUSION_SET_j:
                     groups = parse_table_(Groups, data_object)
                     session.add(groups)
                 elif data_object[const.TYPE_j] == const.COURSE_OF_ACTION_j:


### PR DESCRIPTION
## Description

The metadata table changed to the key->value format to have the same format as the rest of the metadata tables in the other databases

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
