### PR TITLE
Rollback MITRE IDs to valid ones that match with IDs stored in mitre.db

### DIFF
--- a/ruleset/rules/0015-ossec_rules.xml
+++ b/ruleset/rules/0015-ossec_rules.xml
@@ -41,7 +41,7 @@
     <match>Agent disconnected</match>
     <description>Ossec agent disconnected.</description>
     <mitre>
-      <id technique="Impair Defenses: Disable or Modify Tools" tactic="Defense Evasion" tacticID="TA0005">T1562.001</id>
+      <id>T1089</id>
     </mitre>
     <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,</group>
   </rule>
@@ -51,7 +51,7 @@
     <match>Agent removed</match>
     <description>Ossec agent removed.</description>
     <mitre>
-      <id technique="Impair Defenses: Disable or Modify Tools" tactic="Defense Evasion" tacticID="TA0005">T1562.001</id>
+      <id>T1089</id>
     </mitre>
     <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,</group>
   </rule>
@@ -131,7 +131,7 @@
     <match>Adware|Spyware</match>
     <description>Windows Adware/Spyware application found.</description>
     <mitre>
-      <id technique="Software Deployment Tools" tactic="Lateral Movement" tacticID="TA0008">T1072</id>
+      <id>T1017</id>
     </mitre>
     <group>rootcheck,gpg13_4.2,gdpr_IV_35.7.d,</group>
   </rule>
@@ -219,7 +219,7 @@
     <decoded_as>syscheck_integrity_changed</decoded_as>
     <description>Integrity checksum changed.</description>
     <mitre>
-      <id technique="Data Manipulation: Stored Data Manipulation" tactic="Impact" tacticID="TA0040">T1565.001</id>
+      <id>T1492</id>
     </mitre>
     <group>syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -229,8 +229,8 @@
     <decoded_as>syscheck_deleted</decoded_as>
     <description>File deleted.</description>
     <mitre>
-      <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
-      <id technique="Data Destruction" tactic="Impact" tacticID="TA0040">T1485</id>
+      <id>T1107</id>
+      <id>T1485</id>
     </mitre>
     <group>syscheck,syscheck_entry_deleted,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -285,7 +285,7 @@
     <match>^ossec: File size reduced</match>
     <description>Log file size reduced.</description>
     <mitre>
-      <id technique="Data Manipulation: Stored Data Manipulation" tactic="Impact" tacticID="TA0040">T1565.001</id>
+      <id>T1492</id>
     </mitre>
     <group>attacks,pci_dss_10.5.2,pci_dss_11.4,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.9,nist_800_53_SI.4,tsc_CC6.1,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,</group>
   </rule>
@@ -306,7 +306,7 @@
     <group>syscheck,syscheck_entry_modified,syscheck_registry,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <description>Registry Key Integrity Checksum Changed</description>
     <mitre>
-      <id technique="Data Manipulation: Stored Data Manipulation" tactic="Impact" tacticID="TA0040">T1565.001</id>
+      <id>T1492</id>
     </mitre>
   </rule>
 
@@ -316,8 +316,8 @@
     <group>syscheck,syscheck_entry_deleted,syscheck_registry,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <description>Registry Key Entry Deleted.</description>
     <mitre>
-      <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
-      <id technique="Data Destruction" tactic="Impact" tacticID="TA0040">T1485</id>
+      <id>T1107</id>
+      <id>T1485</id>
     </mitre>
   </rule>
 
@@ -471,7 +471,7 @@
     <group>syscheck,syscheck_entry_modified,syscheck_registry,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <description>Registry Value Integrity Checksum Changed</description>
     <mitre>
-      <id technique="Data Manipulation: Stored Data Manipulation" tactic="Impact" tacticID="TA0040">T1565.001</id>
+      <id>T1492</id>
     </mitre>
   </rule>
 
@@ -481,8 +481,8 @@
     <group>syscheck,syscheck_entry_deleted,syscheck_registry,pci_dss_11.5,gpg13_4.13,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <description>Registry Value Entry Deleted.</description>
     <mitre>
-      <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
-      <id technique="Data Destruction" tactic="Impact" tacticID="TA0040">T1485</id>
+      <id>T1107</id>
+      <id>T1485</id>
     </mitre>
   </rule>
 

--- a/ruleset/rules/0020-syslog_rules.xml
+++ b/ruleset/rules/0020-syslog_rules.xml
@@ -173,7 +173,7 @@
     <match>ILLEGAL ROOT LOGIN|ROOT LOGIN REFUSED</match>
     <description>syslog: Illegal root login.</description>
     <mitre>
-      <id technique="Abuse Elevation Control Mechanism: Sudo and Sudo Caching" tactic="Privilege Escalation" tacticID="TA0004">T1548.003</id>
+      <id>T1169</id>
     </mitre>
     <group>invalid_login,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AC.6,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -405,7 +405,7 @@
     <match>module verification failed</match>
     <description>Unsigned kernel module was loaded</description>
     <mitre>
-      <id technique="Boot or Logon Autostart Execution: Kernel Modules and Extensions" tactic="Persistence" tacticID="TA0003">T1547.006</id>
+      <id>T1215</id>
     </mitre>
   </rule>
 
@@ -414,7 +414,7 @@
     <match>PKCS#7 signature not signed with a trusted key</match>
     <description>Signed but untrusted kernel module was loaded</description>
     <mitre>
-      <id technique="Boot or Logon Autostart Execution: Kernel Modules and Extensions" tactic="Persistence" tacticID="TA0003">T1547.006</id>
+      <id>T1215</id>
     </mitre>
   </rule>
 
@@ -504,7 +504,7 @@
     <match>REPLACE (root)</match>
     <description>Root's crontab entry changed.</description>
     <mitre>
-      <id technique="Abuse Elevation Control Mechanism: Sudo and Sudo Caching" tactic="Privilege Escalation" tacticID="TA0004">T1548.003</id>
+      <id>T1169</id>
     </mitre>
     <group>pci_dss_10.2.7,pci_dss_10.6.1,pci_dss_10.2.2,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AU.6,nist_800_53_AC.6,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -532,7 +532,7 @@
     <user>^root</user>
     <description>User missed the password to change UID to root.</description>
     <mitre>
-      <id technique="Abuse Elevation Control Mechanism: Sudo and Sudo Caching" tactic="Privilege Escalation" tacticID="TA0004">T1548.003</id>
+      <id>T1169</id>
     </mitre>
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_CC7.4</group>
   </rule>
@@ -644,7 +644,7 @@
     <match>incorrect password attempt</match>
     <description>Failed attempt to run sudo.</description>
     <mitre>
-      <id technique="Abuse Elevation Control Mechanism: Sudo and Sudo Caching" tactic="Privilege Escalation" tacticID="TA0004">T1548.003</id>
+      <id>T1169</id>
     </mitre>
     <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -654,7 +654,7 @@
     <regex> ; USER=root ; COMMAND=| ; USER=root ; TSID=\S+ ; COMMAND=</regex>
     <description>Successful sudo to ROOT executed.</description>
     <mitre>
-      <id technique="Abuse Elevation Control Mechanism: Sudo and Sudo Caching" tactic="Privilege Escalation" tacticID="TA0004">T1548.003</id>
+      <id>T1169</id>
     </mitre>
     <group>pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.6,gpg13_7.8,gpg13_7.13,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AC.6,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -664,7 +664,7 @@
     <regex> ; USER=\S+ ; COMMAND=| ; USER=\S+ ; TSID=\S+ ; COMMAND=</regex>
     <description>Successful sudo executed.</description>
     <mitre>
-      <id technique="Abuse Elevation Control Mechanism: Sudo and Sudo Caching" tactic="Privilege Escalation" tacticID="TA0004">T1548.003</id>
+      <id>T1169</id>
     </mitre>
     <group>pci_dss_10.2.5,pci_dss_10.2.2,gpg13_7.6,gpg13_7.8,gpg13_7.13,gdpr_IV_32.2,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -674,7 +674,7 @@
     <if_fts />
     <description>First time user executed sudo.</description>
     <mitre>
-      <id technique="Abuse Elevation Control Mechanism: Sudo and Sudo Caching" tactic="Privilege Escalation" tacticID="TA0004">T1548.003</id>
+      <id>T1169</id>
     </mitre>
   </rule>
 
@@ -683,7 +683,7 @@
     <match>3 incorrect password attempts</match>
     <description>Three failed attempts to run sudo</description>
     <mitre>
-      <id technique="Abuse Elevation Control Mechanism: Sudo and Sudo Caching" tactic="Privilege Escalation" tacticID="TA0004">T1548.003</id>
+      <id>T1169</id>
     </mitre>
     <group>pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -693,7 +693,7 @@
     <match>user NOT in sudoers</match>
     <description>Unauthorized user attempted to use sudo.</description>
     <mitre>
-      <id technique="Abuse Elevation Control Mechanism: Sudo and Sudo Caching" tactic="Privilege Escalation" tacticID="TA0004">T1548.003</id>
+      <id>T1169</id>
     </mitre>
     <group>pci_dss_10.2.2,pci_dss_10.2.5,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.6,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>

--- a/ruleset/rules/0065-pix_rules.xml
+++ b/ruleset/rules/0065-pix_rules.xml
@@ -186,7 +186,7 @@
     <id>^5-111003</id>
     <description>PIX: Firewall configuration deleted.</description>
     <mitre>
-      <id technique="Impair Defenses: Disable or Modify System Firewall" tactic="Defense Evasion" tacticID="TA0005">T1562.004</id>
+      <id>T1089</id>
     </mitre>
     <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.a.1,hipaa_164.312.b,nist_800_53_CM.3,nist_800_53_CM.5,nist_800_53_AU.8,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -196,7 +196,7 @@
     <id>^5-111005|^5-111004|^5-111002|^5-111007</id>
     <description>PIX: Firewall configuration changed.</description>
     <mitre>
-      <id technique="Impair Defenses: Disable or Modify System Firewall" tactic="Defense Evasion" tacticID="TA0005">T1562.004</id>
+      <id>T1089</id>
     </mitre>
     <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,gdpr_IV_35.7.d,hipaa_164.312.a.1,hipaa_164.312.b,nist_800_53_CM.3,nist_800_53_CM.5,nist_800_53_AU.8,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -212,8 +212,8 @@
     <id>^5-502101|^5-502102</id>
     <description>PIX: User created or modified on the Firewall.</description>
     <mitre>
-      <id technique="Impair Defenses: Disable or Modify System Firewall" tactic="Defense Evasion" tacticID="TA0005">T1562.004</id>
-      <id technique="External Remote Services" tactic="Persistence" tacticID="TA0003">T1133</id>
+      <id>T1089</id>
+      <id>T1133</id>
     </mitre>
     <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.a.2.I,hipaa_164.312.a.2.II,hipaa_164.312.b,nist_800_53_AC.2,nist_800_53_IA.4,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>

--- a/ruleset/rules/0070-netscreenfw_rules.xml
+++ b/ruleset/rules/0070-netscreenfw_rules.xml
@@ -87,7 +87,7 @@
     <id>^00767</id>
     <description>Netscreen firewall: configuration changed.</description>
     <mitre>
-      <id technique="Impair Defenses: Disable or Modify System Firewall" tactic="Defense Evasion" tacticID="TA0005">T1562.004</id>
+      <id>T1089</id>
     </mitre>
     <group>config_changed,pci_dss_1.1.1,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.a.1,nist_800_53_CM.3,nist_800_53_CM.5,tsc_CC8.1,</group>
   </rule>

--- a/ruleset/rules/0110-ms_dhcp_rules.xml
+++ b/ruleset/rules/0110-ms_dhcp_rules.xml
@@ -60,7 +60,7 @@ ID,Date,Time,Description,IP Address,Host Name,MAC Address
 	<id>^00</id>
     <description>MS-DHCP: The log was started.</description>
     <mitre>
-      <id technique="Create or Modify System Process: Windows Service" tactic="Persistence" tacticID="TA0003">T1543.003</id>
+      <id>T1050</id>
     </mitre>
     <group>service_start,pci_dss_10.2.6,gpg13_4.14,gpg13_10.1,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -339,7 +339,7 @@ Server 2008 IPv6 Event ID  Meaning
 	<id>^11010</id>
     <description>MS-DHCP: Started.</description>
     <mitre>
-      <id technique="Create or Modify System Process: Windows Service" tactic="Persistence" tacticID="TA0003">T1543.003</id>
+      <id>T1050</id>
     </mitre>
     <group>service_start,</group>
   </rule>
@@ -434,7 +434,7 @@ Server 2008 IPv6 Event ID  Meaning
 	<id>^11023</id>
     <description>MS-DHCP: Service not authorized in AD.</description>
     <mitre>
-      <id technique="System Services: Service Execution" tactic="Execution" tacticID="TA0002">T1569.002</id>
+      <id>T1035</id>
     </mitre>
     <group>dhcp_ipv6,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -451,7 +451,7 @@ Server 2008 IPv6 Event ID  Meaning
 	<id>^11025</id>
     <description>MS-DHCP: Service has not determined if it is authorized in AD.</description>
     <mitre>
-      <id technique="System Services: Service Execution" tactic="Execution" tacticID="TA0002">T1569.002</id>
+      <id>T1035</id>
     </mitre>
     <group>dhcp_ipv6,pci_dss_10.6.1,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>

--- a/ruleset/rules/0175-proftpd_rules.xml
+++ b/ruleset/rules/0175-proftpd_rules.xml
@@ -82,7 +82,8 @@
     <info type="link">http://www.kb.cert.org/vuls/id/328867</info>
     <info type="text">US-Cert Note VU#328867: Multiple vendors' firewalls do not adequately keep state of FTP traffic</info>
     <mitre>
-      <id technique="Non-Standard Port" tactic="Command and Control" tacticID="TA0011">T1571</id>
+      <id>T1065</id>
+      <id>T1043</id>
     </mitre>
     <group>pci_dss_10.6.1,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_SI.4,tsc_CC7.2,tsc_CC7.3,tsc_CC6.1,tsc_CC6.8,</group>
   </rule>

--- a/ruleset/rules/0265-php_rules.xml
+++ b/ruleset/rules/0265-php_rules.xml
@@ -78,7 +78,7 @@
     <description>PHP internal error (server out of space).</description>
     <options>alert_by_email</options>
     <mitre>
-      <id technique="Disk Wipe: Disk Content Wipe" tactic="Impact" tacticID="TA0040">T1561.001</id>
+      <id>T1488</id>
     </mitre>
     <group>low_diskspace,</group>
     <group>attack,pci_dss_6.5,pci_dss_10.2.7,gpg13_4.3,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.14,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>

--- a/ruleset/rules/0270-web_appsec_rules.xml
+++ b/ruleset/rules/0270-web_appsec_rules.xml
@@ -170,8 +170,8 @@
     <regex> "GET \S+/shell.php?cmd=</regex>
     <description>Simple shell.php command execution.</description>
     <mitre>
-      <id technique="Server Software Component: Web Shell" tactic="Persistence" tacticID="TA0003">T1505.003</id>
-      <id technique="Exploitation for Client Execution" tactic="Execution" tacticID="TA0002">T1203</id>
+      <id>T1100</id>
+      <id>T1203</id>
     </mitre>
    <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
    </rule>
@@ -229,7 +229,7 @@
     <regex> "GET /\S+.php?\S+%00</regex>
     <description>Anomaly URL query (attempting to pass null termination).</description>
     <mitre>
-      <id technique="Credentials from Password Stores: Credentials from Web Browsers" tactic="Credential Access" tacticID="TA0006">T1555.003</id>
+      <id>T1503</id>
     </mitre>
     <group>pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>

--- a/ruleset/rules/0275-squid_rules.xml
+++ b/ruleset/rules/0275-squid_rules.xml
@@ -183,7 +183,7 @@
     <info type="link">http://www.symantec.com/avcenter/venc/data/w32.beagle.dp.html</info>
     <info type="text">W32.Beagle.DP is a Worm that drops Trojan.Lodear and opens a back door on the compromised computer.</info>
     <mitre>
-      <id technique="Data Manipulation: Stored Data Manipulation" tactic="Impact" tacticID="TA0040">T1565.001</id>
+      <id>T1492</id>
     </mitre>
     <group>pci_dss_11.4,pci_dss_6.2,gdpr_IV_35.7.d,nist_800_53_SI.4,nist_800_53_SI.2,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>

--- a/ruleset/rules/0320-clam_av_rules.xml
+++ b/ruleset/rules/0320-clam_av_rules.xml
@@ -80,7 +80,7 @@
     <match>stop|Stop</match>
     <description>Clamd stopped</description>
     <mitre>
-      <id technique="Impair Defenses: Disable or Modify Tools" tactic="Defense Evasion" tacticID="TA0005">T1562.001</id>
+      <id>T1089</id>
     </mitre>
     <group>virus,pci_dss_5.1,gpg13_4.14,nist_800_53_SI.3,tsc_A1.2,</group>
   </rule>

--- a/ruleset/rules/0345-netscaler_rules.xml
+++ b/ruleset/rules/0345-netscaler_rules.xml
@@ -74,7 +74,7 @@ id (Decoder): AAA, UI, API, SSLVPN, EVENT, SSLLOG, APPFW, TCP, ROUTING, SNMP, AC
         <regex>Command "(\.*delete\.*)"</regex>
         <description>Netscaler: UI/API dangerous command</description>
         <mitre>
-            <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
+            <id>T1107</id>
         </mitre>
         <group>netscaler-cmd,gdpr_IV_35.7.d,</group>
     </rule>

--- a/ruleset/rules/0360-serv-u_rules.xml
+++ b/ruleset/rules/0360-serv-u_rules.xml
@@ -193,7 +193,7 @@ TypeMessage:
         <match>File deleted</match>
         <description>Serv-U: File deleted</description>
         <mitre>
-            <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
+            <id>T1107</id>
         </mitre>
         <group>gdpr_II_5.1.f,</group>
     </rule>
@@ -220,7 +220,7 @@ TypeMessage:
         <match>Directory deleted</match>
         <description>Serv-U: Directory deleted</description>
         <mitre>
-            <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
+            <id>T1107</id>
         </mitre>
         <group>gdpr_II_5.1.f,</group>
     </rule>

--- a/ruleset/rules/0365-auditd_rules.xml
+++ b/ruleset/rules/0365-auditd_rules.xml
@@ -120,8 +120,8 @@
         <field name="audit.type">ANOM_ACCESS_FS</field>
         <description>Auditd: file or a directory access ended abnormally</description>
         <mitre>
-            <id technique="Exploitation for Client Execution" tactic="Execution" tacticID="TA0002">T1203</id>
-            <id technique="Data Manipulation: Stored Data Manipulation" tactic="Impact" tacticID="TA0040">T1565.001</id>
+            <id>T1203</id>
+            <id>T1492</id>
         </mitre>
         <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gdpr_IV_35.7.d,gdpr_IV_30.1.g,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.6,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     </rule>
@@ -202,7 +202,7 @@
         <field name="audit.type">ANOM_ROOT_TRANS</field>
         <description>Auditd: user becomes root</description>
         <mitre>
-            <id technique="Abuse Elevation Control Mechanism: Sudo and Sudo Caching" tactic="Privilege Escalation" tacticID="TA0004">T1548.003</id>
+            <id>T1169</id>
         </mitre>
         <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,gpg13_7.9,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SI.4,nist_800_53_AU.6,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     </rule>
@@ -412,7 +412,7 @@
         <match>type=DELETE</match>
         <description>Audit: Deleted: $(audit.file.name)</description>
         <mitre>
-            <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
+            <id>T1107</id>
         </mitre>
         <group>audit_watch_write,audit_watch_delete,gdpr_II_5.1.f,gdpr_IV_30.1.g,</group>
     </rule>

--- a/ruleset/rules/0390-fortigate_rules.xml
+++ b/ruleset/rules/0390-fortigate_rules.xml
@@ -86,7 +86,7 @@ ID: 81600 - 80799
         <same_source_ip />
         <description>Fortigate: Multiple changed configuration events from same source.</description>
         <mitre>
-            <id technique="Impair Defenses: Disable or Modify System Firewall" tactic="Defense Evasion" tacticID="TA0005">T1562.004</id>
+            <id>T1089</id>
         </mitre>
         <group>gdpr_IV_35.7.d,</group>
     </rule>

--- a/ruleset/rules/0435-ms_logs_rules.xml
+++ b/ruleset/rules/0435-ms_logs_rules.xml
@@ -49,7 +49,7 @@
         <id>^6005$</id>
         <description>The Event log service was started</description>
         <mitre>
-            <id technique="Create or Modify System Process: Windows Service" tactic="Persistence" tacticID="TA0003">T1543.003</id>
+            <id>T1050</id>
         </mitre>
         <group>windows_log_service_started,gpg13_10.1,</group>
     </rule>

--- a/ruleset/rules/0545-osquery_rules.xml
+++ b/ruleset/rules/0545-osquery_rules.xml
@@ -335,7 +335,7 @@
     <field name="osquery.name">suid_bin</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): File $(osquery.columns.path) has setuid enabled</description>
     <mitre>
-      <id technique="Abuse Elevation Control Mechanism: Setuid and Setgid" tactic="Persistence" tacticID="TA0003">T1548.001</id>
+      <id>T1166</id>
     </mitre>
     <group>incident_response,</group>
     <options>no_full_log</options>
@@ -1202,7 +1202,7 @@
     <field name="osquery.name">CCleaner_Trojan.Floxif</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): CCleaner Trojan Floxif detected on registry path $(osquery.columns.path)</description>
     <mitre>
-      <id technique="Boot or Logon Autostart Execution: Registry Run Keys / Startup Folder" tactic="Persistence" tacticID="TA0003">T1547.001</id>
+      <id>T1060</id>
     </mitre>
     <group>windows_attacks,</group>
     <options>no_full_log</options>
@@ -1213,7 +1213,7 @@
     <field name="osquery.name">CCleaner_Trojan_stage2.Floxif</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): CCleaner Trojan Floxif detected on service $(osquery.columns.name) for user $(osquery.columns.user_account)</description>
     <mitre>
-      <id technique="System Services: Service Execution" tactic="Execution" tacticID="TA0002">T1569.002</id>
+      <id>T1035</id>
     </mitre>
     <group>windows_attacks,</group>
     <options>no_full_log</options>
@@ -1270,8 +1270,8 @@
     <field name="osquery.name">StickyKeys_Registry_Backdoor</field>
     <description>osquery: $(osquery.pack) $(osquery.subquery): Sticky registry key backdoor detected for key $(osquery.columns.path)</description>
     <mitre>
-      <id technique="Boot or Logon Autostart Execution: Registry Run Keys / Startup Folder" tactic="Persistence" tacticID="TA0003">T1547.001</id>
-      <id technique="Modify Registry" tactic="Defense Evasion" tacticID="TA0005">T1112</id>
+      <id>T1060</id>
+      <id>T1112</id>
     </mitre>
     <group>windows_attacks,</group>
     <options>no_full_log</options>

--- a/ruleset/rules/0560-docker_integration_rules.xml
+++ b/ruleset/rules/0560-docker_integration_rules.xml
@@ -31,7 +31,7 @@ ID: 87900 - 87999
         <field name="docker.status">^destroy$</field>
         <description>Docker: Container $(docker.Actor.Attributes.name) destroyed</description>
         <mitre>
-            <id technique="Disk Wipe: Disk Content Wipe" tactic="Impact" tacticID="TA0040">T1561.001</id>
+            <id>T1488</id>
         </mitre>
         <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.14,nist_800_53_SI.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,</group>
         <options>no_full_log</options>
@@ -124,8 +124,8 @@ ID: 87900 - 87999
         <field name="docker.Action">^destroy$</field>
         <description>Docker: Volume destroyed in $(docker.Actor.Attributes.driver)</description>
         <mitre>
-            <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
-            <id technique="Disk Wipe: Disk Content Wipe" tactic="Impact" tacticID="TA0040">T1561.001</id>
+            <id>T1107</id>
+            <id>T1488</id>
         </mitre>
         <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.14,nist_800_53_SI.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,</group>
         <options>no_full_log</options>
@@ -182,8 +182,8 @@ ID: 87900 - 87999
         <field name="docker.status">^delete$</field>
         <description>Docker: Container $(docker.Actor.Attributes.name) deleted</description>
         <mitre>
-            <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
-            <id technique="Disk Wipe: Disk Content Wipe" tactic="Impact" tacticID="TA0040">T1561.001</id>
+            <id>T1107</id>
+            <id>T1488</id>
         </mitre>
         <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.14,nist_800_53_SI.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,</group>
         <options>no_full_log</options>
@@ -261,8 +261,8 @@ ID: 87900 - 87999
         <field name="docker.Action">^destroy$</field>
         <description>Docker: Network $(docker.Actor.Attributes.name) deleted</description>
         <mitre>
-            <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
-            <id technique="Data Destruction" tactic="Impact" tacticID="TA0040">T1485</id>
+            <id>T1107</id>
+            <id>T1485</id>
         </mitre>
         <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.14,nist_800_53_SI.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,</group>
         <options>no_full_log</options>
@@ -341,8 +341,8 @@ ID: 87900 - 87999
         <field name="docker.Action">^remove$</field>
         <description>Docker: Secret '$(docker.Actor.Attributes.name)' removed</description>
         <mitre>
-            <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
-            <id technique="Data Destruction" tactic="Impact" tacticID="TA0040">T1485</id>
+            <id>T1107</id>
+            <id>T1485</id>
         </mitre>
         <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.14,nist_800_53_SI.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,</group>
         <options>no_full_log</options>
@@ -382,8 +382,8 @@ ID: 87900 - 87999
         <field name="docker.Action">^remove$</field>
         <description>Docker: Plugin $(docker.Actor.Attributes.name) removed</description>
         <mitre>
-            <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
-            <id technique="Data Destruction" tactic="Impact" tacticID="TA0040">T1485</id>
+            <id>T1107</id>
+            <id>T1485</id>
         </mitre>
         <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.14,nist_800_53_SI.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,</group>
         <options>no_full_log</options>
@@ -472,8 +472,8 @@ ID: 87900 - 87999
         <field name="docker.Action">^remove$</field>
         <description>Docker: Service $(docker.Actor.Attributes.name) deleted</description>
         <mitre>
-            <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
-            <id technique="Data Destruction" tactic="Impact" tacticID="TA0040">T1485</id>
+            <id>T1107</id>
+            <id>T1485</id>
         </mitre>
         <group>pci_dss_10.2.7,pci_dss_11.5,hipaa_164.312.b,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_AU.14,nist_800_53_SI.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,</group>
         <options>no_full_log</options>

--- a/ruleset/rules/0565-ms_ipsec_rules.xml
+++ b/ruleset/rules/0565-ms_ipsec_rules.xml
@@ -40,7 +40,7 @@
     <id>^4960$</id>
     <description>IPsec dropped an inbound packet that failed an integrity check</description>
     <mitre>
-      <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
+      <id>T1107</id>
     </mitre>
     <group>windows,</group>
   </rule>
@@ -50,7 +50,7 @@
     <id>^4961$|^4962$</id>
     <description>IPsec dropped an inbound packet that failed a replay check</description>
     <mitre>
-      <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
+      <id>T1107</id>
     </mitre>
     <group>windows,</group>
   </rule>
@@ -60,7 +60,7 @@
     <id>^4963$</id>
     <description>IPsec dropped an inbound clear text packet that should have been secured</description>
     <mitre>
-      <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
+      <id>T1107</id>
     </mitre>
     <group>windows,</group>
   </rule>

--- a/ruleset/rules/0580-win-security_rules.xml
+++ b/ruleset/rules/0580-win-security_rules.xml
@@ -192,7 +192,8 @@
     <description>Windows audit log was cleared</description>
     <options>no_full_log</options>
     <mitre>
-      <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
+      <id>T1070</id>
+      <id>T1107</id>
     </mitre>
     <group>logs_cleared,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -1020,8 +1021,8 @@
     <field name="win.eventdata.failureCode">0x22</field>
     <description>Windows DC - Possible replay attack</description>
     <mitre>
-      <id technique="Rogue Domain Controller" tactic="Defense Evasion" tacticID="TA0005">T1207</id>
-      <id technique="Use Alternate Authentication Material: Pass the Hash" tactic="Lateral Movement" tacticID="TA0008">T1550.002</id>
+      <id>T1207</id>
+      <id>T1075</id>
     </mitre>
     <options>no_full_log</options>
     <group>authentication_failed,attacks,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>

--- a/ruleset/rules/0585-win-application_rules.xml
+++ b/ruleset/rules/0585-win-application_rules.xml
@@ -624,7 +624,7 @@
     <field name="win.system.eventID">^19$</field>
     <description>The EventSystem service is disabled or attempting to start during Safe Mode</description>
     <mitre>
-      <id technique="Create or Modify System Process: Windows Service" tactic="Persistence" tacticID="TA0003">T1543.003</id>
+      <id>T1031</id>
     </mitre>
     <options>no_full_log</options>
   </rule>
@@ -634,7 +634,7 @@
     <field name="win.system.eventID">^20$|^21$</field>
     <description>Volume Shadow Copy Service: COM+ database corrupted, writers will not receive events</description>
     <mitre>
-      <id technique="Create or Modify System Process: Windows Service" tactic="Persistence" tacticID="TA0003">T1543.003</id>
+      <id>T1031</id>
     </mitre>
     <options>no_full_log</options>
   </rule>
@@ -679,7 +679,7 @@
     <field name="win.system.eventID">^4609$</field>
     <description>Bad return code detected during internal processing of the EventSystem service</description>
     <mitre>
-      <id technique="Create or Modify System Process: Windows Service" tactic="Persistence" tacticID="TA0003">T1543.003</id>
+      <id>T1031</id>
     </mitre>
     <options>no_full_log</options>
   </rule>

--- a/ruleset/rules/0590-win-system_rules.xml
+++ b/ruleset/rules/0590-win-system_rules.xml
@@ -244,8 +244,8 @@
     <field name="win.system.eventID">^8023$</field>
     <description>The value for the parameter to the browser service was illegal</description>
     <mitre>
-      <id technique="Exploitation for Client Execution" tactic="Execution" tacticID="TA0002">T1203</id>
-      <id technique="Credentials from Password Stores: Credentials from Web Browsers" tactic="Credential Access" tacticID="TA0006">T1555.003</id>
+      <id>T1203</id>
+      <id>T1503</id>
     </mitre>
     <options>no_full_log</options>
   </rule>
@@ -314,7 +314,7 @@
     <field name="win.system.eventID">^7045$</field>
     <description>New Windows Service Created</description>
     <mitre>
-      <id technique="Create or Modify System Process: Windows Service" tactic="Persistence" tacticID="TA0003">T1543.003</id>
+      <id>T1050</id>
     </mitre>
     <options>no_full_log</options>
     <options>no_email_alert</options>

--- a/ruleset/rules/0601-win-vipre_rules.xml
+++ b/ruleset/rules/0601-win-vipre_rules.xml
@@ -87,7 +87,7 @@
     <field name="win.system.eventID">^4106$</field>
     <description>Active protection disabled</description>
     <mitre>
-      <id technique="Impair Defenses: Disable or Modify Tools" tactic="Defense Evasion" tacticID="TA0005">T1562.001</id>
+      <id>T1089</id>
     </mitre>
     <options>no_full_log</options>
 </rule>
@@ -286,7 +286,7 @@
     <field name="win.system.eventID">^4141$</field>
     <description>An item has been deleted from quarantine</description>
     <mitre>
-        <id technique="Indicator Removal on Host: File Deletion" tactic="Defense Evasion" tacticID="TA0005">T1070.004</id>
+        <id>T1107</id>
     </mitre>
     <options>no_full_log</options>
 </rule>

--- a/ruleset/rules/0610-win-ms_logs_rules.xml
+++ b/ruleset/rules/0610-win-ms_logs_rules.xml
@@ -87,7 +87,7 @@
     <field name="win.system.eventID">^6005$</field>
     <description>The Event log service was started</description>
     <mitre>
-      <id technique="Create or Modify System Process: Windows Service" tactic="Persistence" tacticID="TA0003">T1543.003</id>
+      <id>T1050</id>
     </mitre>
     <options>no_full_log</options>
     <group>windows_log_service_started,gpg13_10.1,</group>

--- a/ruleset/rules/0625-cisco-asa_rules.xml
+++ b/ruleset/rules/0625-cisco-asa_rules.xml
@@ -187,7 +187,7 @@
     <id>^5-111005|^5-111004|^5-111002|^5-111007</id>
     <description>ASA: Firewall configuration changed.</description>
     <mitre>
-      <id technique="Impair Defenses: Disable or Modify System Firewall" tactic="Defense Evasion" tacticID="TA0005">T1562.004</id>
+      <id>T1089</id>
     </mitre>
     <group>config_changed,pci_dss_1.1.1,pci_dss_10.4,gpg13_4.13,gdpr_IV_35.7.d,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
@@ -209,7 +209,7 @@
     <id>^5-502101|^5-502102</id>
     <description>ASA: User created or modified on the Firewall.</description>
     <mitre>
-      <id technique="Impair Defenses: Disable or Modify System Firewall" tactic="Defense Evasion" tacticID="TA0005">T1562.004</id>
+      <id>T1089</id>
     </mitre>
     <group>adduser,account_changed,pci_dss_8.1.2,pci_dss_10.2.5,gpg13_4.13,gdpr_IV_35.7.d,gdpr_IV_32.2,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>

--- a/ruleset/rules/0700-paloalto_rules.xml
+++ b/ruleset/rules/0700-paloalto_rules.xml
@@ -33,7 +33,7 @@
     <field name="severity">high</field>
     <description>Palo Alto SYSTEM: $(severity) severity log on $(device_name): $(description)</description>
     <mitre>
-      <id technique="Impair Defenses: Disable or Modify System Firewall" tactic="Defense Evasion" tacticID="TA0005">T1562.004</id>
+      <id>T1089</id>
     </mitre>
     <group>pci_dss_1.4,pci_dss_10.6.1,10.8,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_CC6.7,tsc_CC7.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.b</group>
   </rule>
@@ -42,8 +42,8 @@
     <field name="severity">critical</field>
     <description>Palo Alto SYSTEM: $(severity) severity log on $(device_name): $(description)</description>
     <mitre>
-      <id technique="Impair Defenses: Disable or Modify System Firewall" tactic="Defense Evasion" tacticID="TA0005">T1562.004</id>
-      <id technique="Endpoint Denial of Service: OS Exhaustion Flood" tactic="Impact" tacticID="TA0040">T1499.001</id>
+      <id>T1089</id>
+      <id>T1499</id>
     </mitre>
     <group>pci_dss_1.4,pci_dss_10.6.1,10.8,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_CC6.7,tsc_CC7.4,gpg13_4.12,gdpr_IV_35.7.d,hipaa_164.312.b</group>
   </rule>


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7780 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR roles back the new MITRE IDs that were included in the ruleset on this previous commit: https://github.com/wazuh/wazuh/pull/7260/files.

These new IDs are not included in the current data stored in `mitre.db`, so they raise warning messages when querying the database.

Old MITRE IDs were put back on their places to avoid warning messages in `ossec.log` related to queries against `mitre.db`.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

- [x] Ruleset unit tests (`runtests.py`)
- [x] No warning/error messages in `ossec.log` related to MITRE IDs (`runtests.py`)
