### PR TITLE
Update API endpoint tag

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -15731,7 +15731,7 @@ paths:
   /vulnerability/{agent_id}:
     get:
       tags:
-        - Vulnerabilities
+        - Vulnerability
       summary: "Get vulnerabilities"
       description: "Return the vulnerabilities of an agent"
       operationId: api.controllers.vulnerability_controller.get_vulnerability_agent


### PR DESCRIPTION
## Description

Hi team!

After some renames perforemd againts the new `GET /vulnerability/{agent_id}` endpoint, the tag of the endpoint did not match the one specified in the spec, which can lead to an incorrect API reference page.

It is corrected in this PR.

Regards,
Selu.