### PR TITLE
Restore and fix default policies name

### DIFF
--- a/framework/wazuh/rbac/default/policies.yaml
+++ b/framework/wazuh/rbac/default/policies.yaml
@@ -153,7 +153,7 @@ default_policies:
   lists_read:
     description: Allow reading all lists paths in the system.
     policies:
-      lists:
+      rules:
         actions:
           - lists:read
         resources:
@@ -163,7 +163,7 @@ default_policies:
   lists_all:
     description: Allow managing all CDB lists files in the system.
     policies:
-      files:
+      rules:
         actions:
           - lists:read
           - lists:delete


### PR DESCRIPTION
## Description

Hi team! 

Some policies, whose name were incorrect, were updated in this PR: https://github.com/wazuh/wazuh/pull/7562

https://github.com/wazuh/wazuh/blob/6c9e3fdcc0324e48620243faf7c9217b8d480a3e/framework/wazuh/rbac/default/policies.yaml#L156

However, there is still not a mechanism that let us rename default policies created in older versions. Therefore, this fix needs to be performed in the future. In the meantime, it is deleted in this PR so no other problems arise when upgrading from older versions.

Regards,
Selu.