### PR TITLE
Fixing Vulnerability Detector scans for all the agents in the master node even if the agents are connected to a worker node

### DIFF
--- a/src/analysisd/ar_json.c
+++ b/src/analysisd/ar_json.c
@@ -8,28 +8,13 @@
 */
 
 #include "config.h"
+#include "shared.h"
 #include "format/to_json.h"
 
 #define VERSION 1
 #ifndef ARGV0
 #define ARGV0 "wazuh-analysisd"
 #endif
-
-/**
- * @return Node name, remember to free memory after return.
- */
-static char *get_node_name()
-{
-    char* node_name = NULL;
-    OS_XML xml;
-
-    const char *(xml_node[]) = {"ossec_config", "cluster", "node_name", NULL};
-    if (OS_ReadXML(DEFAULTCPATH, &xml) >= 0) {
-        node_name = OS_GetOneContentforElement(&xml, xml_node);
-    }
-    OS_ClearXML(&xml);
-    return node_name;
-}
 
 /**
  * @brief Build the JSON message

--- a/src/headers/cluster_utils.h
+++ b/src/headers/cluster_utils.h
@@ -15,7 +15,10 @@
 // Returns 1 if the node is a worker, 0 if it is not and -1 if error.
 int w_is_worker(void);
 
-// Returns the master node or "undefined" if any node is specified.
+// Returns the master node or "undefined" if any node is specified. The memory should be freed by the caller.
 char *get_master_node(void);
+
+// Returns the node name of the manager in cluster. The memory should be freed by the caller.
+char *get_node_name(void);
 
 #endif

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -57,17 +57,8 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
         mwarn("Queue size is very high. The application may run out of memory.");
     }
 
-    const char *(xmlf[]) = {"ossec_config", "cluster", "node_name", NULL};
-
-    OS_XML xml;
-
-    if (OS_ReadXML(cfgfile, &xml) < 0){
-        merror_exit(XML_ERROR, cfgfile, xml.err, xml.err_line);
-    }
-
-    node_name = OS_GetOneContentforElement(&xml, xmlf);
-
-    OS_ClearXML(&xml);
+    /* Get node name of the manager in cluster */
+    node_name = get_node_name();
 
     return (1);
 }

--- a/src/shared/cluster_utils.c
+++ b/src/shared/cluster_utils.c
@@ -1,6 +1,6 @@
 /*
  * URL download support library
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * October 26, 2018.
  *
  * This program is free software; you can redistribute it
@@ -13,24 +13,13 @@
 #include "../config/config.h"
 #include "../config/global-config.h"
 
-// Returns 1 if the node is a worker, 0 if it is not and -1 if error.
 int w_is_worker(void) {
-
     OS_XML xml;
     const char * xmlf[] = {"ossec_config", "cluster", NULL};
     const char * xmlf2[] = {"ossec_config", "cluster", "node_type", NULL};
     const char * xmlf3[] = {"ossec_config", "cluster", "disabled", NULL};
     const char *cfgfile = DEFAULTCPATH;
-    int modules = 0;
-    int is_worker = 0;
-    _Config cfg;
-    memset(&cfg, 0, sizeof(_Config));
-
-    modules |= CCLUSTER;
-
-    if (ReadConfig(modules, cfgfile, &cfg, NULL) < 0) {
-        return (OS_INVALID);
-    }
+    int is_worker = OS_INVALID;
 
     if (OS_ReadXML(cfgfile, &xml) < 0) {
         mdebug1(XML_ERROR, cfgfile, xml.err, xml.err_line);
@@ -41,7 +30,7 @@ int w_is_worker(void) {
                 if (cl_type && cl_type[0] != '\0') {
                     char * cl_status = OS_GetOneContentforElement(&xml, xmlf3);
                     if(cl_status && cl_status[0] != '\0'){
-                	    if (!strcmp(cl_status, "no")) {
+                        if (!strcmp(cl_status, "no")) {
                             if (!strcmp(cl_type, "client") || !strcmp(cl_type, "worker")) {
                                 is_worker = 1;
                             } else {
@@ -50,13 +39,13 @@ int w_is_worker(void) {
                         } else {
                             is_worker = 0;
                         }
-                	} else {
+                    } else {
                         if (!strcmp(cl_type, "client") || !strcmp(cl_type, "worker")) {
                             is_worker = 1;
                         } else {
-                        	is_worker = 0;
+                            is_worker = 0;
                         }
-                	}
+                    }
                     free(cl_status);
                     free(cl_type);
                 }
@@ -66,32 +55,20 @@ int w_is_worker(void) {
         }
     }
     OS_ClearXML(&xml);
-    config_free(&cfg);
 
     return is_worker;
 }
 
 
 char *get_master_node(void) {
-
     OS_XML xml;
     const char * xmlf[] = {"ossec_config", "cluster", "nodes", "node", NULL};
     const char *cfgfile = DEFAULTCPATH;
-    _Config cfg;
-    int modules = 0;
     char *master_node = NULL;
-    memset(&cfg, 0, sizeof(_Config));
-
-    modules |= CCLUSTER;
-
-    if (ReadConfig(modules, cfgfile, &cfg, NULL) < 0) {
-        master_node = strdup("undefined");
-    }
 
     if (OS_ReadXML(cfgfile, &xml) < 0) {
         mdebug1(XML_ERROR, cfgfile, xml.err, xml.err_line);
     } else {
-        os_free(master_node);
         master_node = OS_GetOneContentforElement(&xml, xmlf);
     }
 
@@ -101,7 +78,26 @@ char *get_master_node(void) {
         master_node = strdup("undefined");
     }
 
-    config_free(&cfg);
-
     return master_node;
+}
+
+char *get_node_name(void) {
+    OS_XML xml;
+    const char * xmlf[] = {"ossec_config", "cluster", "node_name", NULL};
+    const char *cfgfile = DEFAULTCPATH;
+    char *node_name = NULL;
+
+    if (OS_ReadXML(cfgfile, &xml) < 0) {
+        mdebug1(XML_ERROR, cfgfile, xml.err, xml.err_line);
+    } else {
+        node_name = OS_GetOneContentforElement(&xml, xmlf);
+    }
+
+    OS_ClearXML(&xml);
+
+    if (!node_name) {
+        node_name = strdup("undefined");
+    }
+
+    return node_name;
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
@@ -36,14 +36,14 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_setSize -Wl,--wrap,OSHash_Clean -Wl,--wrap,wm_vuldet_linux_nvd_vulnerabilities \
                                 -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,time -Wl,--wrap,wstr_end -Wl,--wrap=fgetc \
                                 -Wl,--wrap,json_fread -Wl,--wrap,remove -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,wurl_request -Wl,--wrap,sleep \
-                                -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,fgets -Wl,--wrap,fwrite -Wl,--wrap,localtime \
+                                -Wl,--wrap,sqlite3_open_v2 -Wl,--wrap,fgets -Wl,--wrap,fwrite -Wl,--wrap,localtime -Wl,--wrap,OS_GetOneContentforElement \
                                 -Wl,--wrap,OS_ReadXML -Wl,--wrap,OS_GetElementsbyNode -Wl,--wrap,OSRegex_Compile -Wl,--wrap,OSRegex_Execute \
                                 -Wl,--wrap,w_get_file_content -Wl,--wrap,wm_vuldet_json_nvd_parser -Wl,--wrap,wm_vuldet_json_wcpe_parser \
                                 -Wl,--wrap,wm_vuldet_json_msu_parser -Wl,--wrap,opendir -Wl,--wrap,closedir -Wl,--wrap,readdir -Wl,--wrap,w_is_file \
                                 -Wl,--wrap,fflush -Wl,--wrap,fprintf -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,getpid -Wl,--wrap,OSHash_Add_ex \
                                 -Wl,--wrap,wurl_request_uncompress_bz2_gz -Wl,--wrap,w_uncompress_bz2_gz_file -Wl,--wrap,wstr_replace \
                                 -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap=wstr_split -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Execute_ex \
-                                -Wl,--wrap,fgetpos")
+                                -Wl,--wrap,fgetpos -Wl,--wrap,OS_ClearXML")
 
 list(APPEND vulndetector_names "test_wm_vuln_detector_evr")
 list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wrap,_mtdebug1 -Wl,--wrap,_mtdebug2 -Wl,--wrap,OS_ConnectUnixDomain \

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.c
@@ -44,6 +44,14 @@ int __wrap_OS_ReadXML(const char *file, OS_XML *_lxml) {
     return mock();
 }
 
+char* __wrap_OS_GetOneContentforElement(OS_XML *_lxml, const char **element_name) {
+    return mock_type(char *);
+}
+
+void __wrap_OS_ClearXML(OS_XML *_lxml) {
+    return;
+}
+
 xml_node **__wrap_OS_GetElementsbyNode(const OS_XML *_lxml, const xml_node *node) {
     return mock_type(xml_node **);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.c
@@ -40,28 +40,32 @@ int __wrap_w_uncompress_bz2_gz_file(const char * path, const char * dest) {
 
 // wm_vuln_detector mocks
 
-int __wrap_OS_ReadXML(const char *file, OS_XML *_lxml) {
+int __wrap_OS_ReadXML(__attribute__ ((__unused__)) const char *file,
+                      __attribute__ ((__unused__)) OS_XML *_lxml) {
     return mock();
 }
 
-char* __wrap_OS_GetOneContentforElement(OS_XML *_lxml, const char **element_name) {
+char* __wrap_OS_GetOneContentforElement(__attribute__ ((__unused__)) OS_XML *_lxml,
+                                        __attribute__ ((__unused__)) const char **element_name) {
     return mock_type(char *);
 }
 
-void __wrap_OS_ClearXML(OS_XML *_lxml) {
+void __wrap_OS_ClearXML(__attribute__ ((__unused__)) OS_XML *_lxml) {
     return;
 }
 
-xml_node **__wrap_OS_GetElementsbyNode(const OS_XML *_lxml, const xml_node *node) {
+xml_node **__wrap_OS_GetElementsbyNode(__attribute__ ((__unused__)) const OS_XML *_lxml,
+                                       __attribute__ ((__unused__)) const xml_node *node) {
     return mock_type(xml_node **);
 }
 
-char * __wrap_w_get_file_content(const char * path, int max_size) {
+char * __wrap_w_get_file_content(__attribute__ ((__unused__)) const char * path,
+                                 __attribute__ ((__unused__)) int max_size) {
     return mock_type(char *);
 }
 
 // wm_vuln_detector_evr mocks
 
-struct tm *__wrap_localtime(const time_t *t) {
+struct tm *__wrap_localtime(__attribute__ ((__unused__)) const time_t *t) {
     return mock_type(struct tm *);
 }

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.h
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/mocks_wm_vuln_detector.h
@@ -28,6 +28,10 @@ int __wrap_w_uncompress_bz2_gz_file(const char * path, const char * dest);
 
 int __wrap_OS_ReadXML(const char *file, OS_XML *_lxml);
 
+char* __wrap_OS_GetOneContentforElement(OS_XML *_lxml, const char **element_name);
+
+void __wrap_OS_ClearXML(OS_XML *_lxml);
+
 xml_node **__wrap_OS_GetElementsbyNode(const OS_XML *_lxml, const xml_node *node);
 
 char * __wrap_w_get_file_content(const char * path, int max_size);

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -325,6 +325,9 @@ static int setup_cve_report(void **state) {
     will_return_always(__wrap_OPENSSL_init_ssl, 1);
     will_return(__wrap_OPENSSL_init_crypto, 1);
 
+    will_return(__wrap_OS_ReadXML, 1);
+    will_return(__wrap_OS_GetOneContentforElement, "node01");
+
     wm_vuldet_init(vuldet);
 
     vu_report *report = calloc(1, sizeof(vu_report));
@@ -5318,6 +5321,9 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
     will_return_always(__wrap_OPENSSL_init_ssl, 1);
     will_return(__wrap_OPENSSL_init_crypto, 1);
 
+    will_return(__wrap_OS_ReadXML, 1);
+    will_return(__wrap_OS_GetOneContentforElement, "node01");
+
     wm_vuldet_init(vuldet);
 
     agent_software *agent = *state;
@@ -5644,6 +5650,9 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **
 
     will_return_always(__wrap_OPENSSL_init_ssl, 1);
     will_return(__wrap_OPENSSL_init_crypto, 1);
+
+    will_return(__wrap_OS_ReadXML, 1);
+    will_return(__wrap_OS_GetOneContentforElement, "node01");
 
     wm_vuldet_init(vuldet);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -163,10 +163,11 @@ STATIC vu_feed wm_vuldet_set_allowed_feed(const char *os_name, const char *os_ve
  * @brief Initialize the main structure(linked list) of all Syscollector agents
  * for later analysis.
  *
+ * @param node_name The node name of the manager in cluster.
  * @param agents_software Pointer to the new linked list.
  * @return 0 on success, -1 otherwise.
  */
-STATIC int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **updates);
+STATIC int wm_vuldet_set_agents_info(const char *node_name, agent_software **agents_software, update_node **updates);
 
 /**
  * @brief Compare two packages structures (src_name, bin_name, version and arch).
@@ -4652,7 +4653,7 @@ void *wm_vuldet_main(wm_vuldet_t * vuldet) {
     return NULL;
 }
 
-int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **updates) {
+int wm_vuldet_set_agents_info(const char *node_name, agent_software **agents_software, update_node **updates) {
     agent_software *agents = NULL;
     agent_software *f_agent = NULL;
     int set_manager = 1;
@@ -4736,7 +4737,7 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
             name = json_field->valuestring;
         }
 
-        json_field = cJSON_GetObjectItem(json_agt_info->child, "os_build") ;
+        json_field = cJSON_GetObjectItem(json_agt_info->child, "os_build");
         if(cJSON_IsNumber(json_field)){
             build = json_field->valueint;
         }
@@ -7057,7 +7058,7 @@ void wm_vuldet_run_scan(wm_vuldet_t *vuldet) {
         return;
     }
 
-    if (wm_vuldet_set_agents_info(&vuldet->agents_software, vuldet->updates)) {
+    if (wm_vuldet_set_agents_info(vuldet->node_name, &vuldet->agents_software, vuldet->updates)) {
         mterror(WM_VULNDETECTOR_LOGTAG, VU_NO_AGENT_ERROR);
     } else {
         if (wm_vuldet_check_agent_vulnerabilities(vuldet->agents_software, &vuldet->flags, vuldet->ignore_time)) {
@@ -7158,17 +7159,7 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
     }
 
     /* Get node name of this manager in cluster */
-    const char *(xml_node[]) = {"ossec_config", "cluster", "node_name", NULL};
-
-    OS_XML xml;
-
-    if (OS_ReadXML(DEFAULTCPATH, &xml) < 0){
-        mterror(WM_VULNDETECTOR_LOGTAG, XML_ERROR, DEFAULTCPATH, xml.err, xml.err_line);
-    }
-
-    node_name = OS_GetOneContentforElement(&xml, xml_node);
-
-    OS_ClearXML(&xml);
+    vuldet->node_name = get_node_name();
 }
 
 int wm_vuldet_select_scan_type(char *agent_id, time_t ignore_time, char *hotfix_config_enabled) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -295,6 +295,7 @@ STATIC int wm_vuldet_compare_vendors(char * vendor);
  */
 STATIC void wm_vuldel_truncate_revision(char * revision);
 
+char* node_name;
 int wdb_vuldet_sock = -1;
 int *vu_queue;
 // Define time to sleep between messages sent
@@ -4712,22 +4713,30 @@ int wm_vuldet_set_agents_info(agent_software **agents_software, update_node **up
             continue;
         }
 
+        json_field = cJSON_GetObjectItem(json_agt_info->child, "node_name");
+        if(cJSON_IsString(json_field) && json_field->valuestring != NULL) {
+            if (0 != strcmp(json_field->valuestring, node_name)) {
+                cJSON_Delete(json_agt_info);
+                continue;
+            }
+        }
+
         json_field = cJSON_GetObjectItem(json_agt_info->child, "os_name");
-        if(cJSON_IsString(json_field) && json_field->valuestring != NULL){
+        if(cJSON_IsString(json_field) && json_field->valuestring != NULL) {
             os_name = json_field->valuestring;
         }
 
         json_field = cJSON_GetObjectItem(json_agt_info->child, "os_major");
-        if(cJSON_IsString(json_field) && json_field->valuestring != NULL){
+        if(cJSON_IsString(json_field) && json_field->valuestring != NULL) {
             os_major = json_field->valuestring;
         }
 
         json_field = cJSON_GetObjectItem(json_agt_info->child, "name");
-        if(cJSON_IsString(json_field) && json_field->valuestring != NULL){
+        if(cJSON_IsString(json_field) && json_field->valuestring != NULL) {
             name = json_field->valuestring;
         }
 
-        json_field = cJSON_GetObjectItem(json_agt_info->child, "os_build");
+        json_field = cJSON_GetObjectItem(json_agt_info->child, "os_build") ;
         if(cJSON_IsNumber(json_field)){
             build = json_field->valueint;
         }
@@ -7147,6 +7156,19 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
         // Initial sleep
         sleep(time_sleep);
     }
+
+    /* Get node name of this manager in cluster */
+    const char *(xml_node[]) = {"ossec_config", "cluster", "node_name", NULL};
+
+    OS_XML xml;
+
+    if (OS_ReadXML(DEFAULTCPATH, &xml) < 0){
+        mterror(WM_VULNDETECTOR_LOGTAG, XML_ERROR, DEFAULTCPATH, xml.err, xml.err_line);
+    }
+
+    node_name = OS_GetOneContentforElement(&xml, xml_node);
+
+    OS_ClearXML(&xml);
 }
 
 int wm_vuldet_select_scan_type(char *agent_id, time_t ignore_time, char *hotfix_config_enabled) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -116,7 +116,6 @@ extern const char *vu_feed_ext[];
 extern const char *vu_package_comp[];
 extern const char *vu_severities[];
 extern const char *vu_cpe_tags[];
-extern char *node_name;
 extern int wdb_vuldet_sock;
 typedef struct cpe_list cpe_list;
 typedef struct nvd_vulnerability nvd_vulnerability;
@@ -405,6 +404,7 @@ typedef struct update_node {
 } update_node;
 
 typedef struct wm_vuldet_t {
+    char *node_name;
     update_node *updates[OS_SUPP_SIZE];
     time_t detection_interval;
     time_t ignore_time;

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.h
@@ -116,6 +116,7 @@ extern const char *vu_feed_ext[];
 extern const char *vu_package_comp[];
 extern const char *vu_severities[];
 extern const char *vu_cpe_tags[];
+extern char *node_name;
 extern int wdb_vuldet_sock;
 typedef struct cpe_list cpe_list;
 typedef struct nvd_vulnerability nvd_vulnerability;

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -200,17 +200,7 @@ void wm_sync_manager() {
         mterror(WM_DATABASE_LOGTAG, "Couldn't get manager's hostname: %s.", strerror(errno));
 
     /* Get node name of the manager in cluster */
-    const char *(xml_node[]) = {"ossec_config", "cluster", "node_name", NULL};
-
-    OS_XML xml;
-
-    if (OS_ReadXML(DEFAULTCPATH, &xml) < 0){
-        merror_exit(XML_ERROR, DEFAULTCPATH, xml.err, xml.err_line);
-    }
-
-    manager_data->node_name = OS_GetOneContentforElement(&xml, xml_node);
-
-    OS_ClearXML(&xml);
+    manager_data->node_name = get_node_name();
 
     if ((os_uname = strdup(getuname()))) {
         char *ptr;


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7743 |

## Description

This pull request implements a mechanism in Vulnerability Detector to determine if the active agents are reporting to the current manager. If so, the agent is scanned, otherways the agent is skipped.

With this implementation, we avoid scanning agents in multiples nodes in cluster scenarios. Even when the agents are moving from one node to another one.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade