### PR TITLE
Use jsonschema validator for API config

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -14,9 +14,11 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
+from jsonschema import validate, ValidationError
 
 from api.api_exception import APIError
-from api.constants import SECURITY_CONFIG_PATH
+from api.constants import CONFIG_FILE_PATH, SECURITY_CONFIG_PATH
+from api.validator import api_config_schema, security_config_schema
 from wazuh.core import common
 
 default_security_configuration = {
@@ -27,6 +29,9 @@ default_security_configuration = {
 default_api_configuration = {
     "host": "0.0.0.0",
     "port": 55000,
+    "use_only_authd": False,
+    "drop_privileges": True,
+    "experimental_features": False,
     "https": {
         "enabled": True,
         "key": "api/configuration/ssl/server.key",
@@ -55,9 +60,6 @@ default_api_configuration = {
         "block_time": 300,
         "max_request_per_minute": 300
     },
-    "use_only_authd": False,
-    "drop_privileges": True,
-    "experimental_features": False,
     "remote_commands": {
         "localfile": {
             "enabled": True,
@@ -98,17 +100,27 @@ def append_wazuh_path(dictionary: Dict, path_fields: List[Tuple[str, str]]):
             pass
 
 
-def fill_dict(default: Dict, config: Dict) -> Dict:
-    """Fills a dictionary's missing values using default ones.
+def fill_dict(default: Dict, config: Dict, json_schema: Dict) -> Dict:
+    """Validate and fill a dictionary's missing values using default ones.
 
-    :param default: Dictionary with default values
-    :param config: Dictionary to fill
-    :return: Filled dictionary
+    Parameters
+    ----------
+    default : dict
+        Dictionary with default values.
+    config : dict
+        Dictionary to be filled.
+    json_schema : dict
+        Jsonschema with allowed properties.
+
+    Returns
+    -------
+    dict
+        Filled dictionary.
     """
-    # Check there aren't extra configuration values in user's configuration:
-    for k in config.keys():
-        if k not in default.keys():
-            raise APIError(2000, details=', '.join(config.keys() - default.keys()))
+    try:
+        validate(instance=config, schema=json_schema)
+    except ValidationError as e:
+        raise APIError(2000, details=e.message)
 
     for k, val in filter(lambda x: isinstance(x[1], dict), config.items()):
         for item, value in config[k].items():
@@ -196,7 +208,7 @@ def generate_self_signed_certificate(private_key, certificate_path):
     os.chmod(certificate_path, 0o400)
 
 
-def read_yaml_config(config_file=common.api_config_path, default_conf=None) -> Dict:
+def read_yaml_config(config_file=CONFIG_FILE_PATH, default_conf=None) -> Dict:
     """Reads user API configuration and merges it with the default one
 
     :return: API configuration
@@ -233,18 +245,27 @@ def read_yaml_config(config_file=common.api_config_path, default_conf=None) -> D
     else:
         configuration = None
 
-    # If any value is missing from user's cluster configuration, add the default one:
     if configuration is None:
         configuration = copy.deepcopy(default_conf)
     else:
+        # If any value is missing from user's configuration, add the default one:
         dict_to_lowercase(configuration)
-        configuration = fill_dict(default_conf, configuration)
+        schema = security_config_schema if config_file == SECURITY_CONFIG_PATH else api_config_schema
+        configuration = fill_dict(default_conf, configuration, schema)
 
     # Append wazuh_path to all paths in configuration
     append_wazuh_path(configuration, [('logs', 'path'), ('https', 'key'), ('https', 'cert'), ('https', 'ca')])
 
     return configuration
 
+
+# Check if the default configuration is valid according to its jsonschema, so we are forced to update the schema if any
+# change is performed to the configuration.
+try:
+    validate(instance=default_security_configuration, schema=security_config_schema)
+    validate(instance=default_api_configuration, schema=api_config_schema)
+except ValidationError as e:
+    raise APIError(2000, details=e.message)
 
 # Configuration - global object
 api_conf = dict()

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -11,22 +11,25 @@ from api import configuration, api_exception
 from wazuh.core import common
 
 custom_api_configuration = {
-    "host": "127.0.1.1",
-    "port": 1000,
+    "host": "0.0.0.0",
+    "port": 55000,
+    "use_only_authd": False,
+    "drop_privileges": True,
+    "experimental_features": False,
     "https": {
         "enabled": True,
         "key": "api/configuration/ssl/server.key",
         "cert": "api/configuration/ssl/server.crt",
         "use_ca": False,
         "ca": "api/configuration/ssl/ca.crt",
-        "ssl_cipher": "TLSv1.1"
+        "ssl_cipher": "TLSv1.2"
     },
     "logs": {
-        "level": "DEBUG",
-        "path": "/api/logs/wazuhapi.log"
+        "level": "info",
+        "path": "logs/api.log"
     },
     "cors": {
-        "enabled": True,
+        "enabled": False,
         "source_route": "*",
         "expose_headers": "*",
         "allow_headers": "*",
@@ -34,11 +37,23 @@ custom_api_configuration = {
     },
     "cache": {
         "enabled": True,
-        "time": 5
+        "time": 0.750
     },
-    "use_only_authd": False,
-    "drop_privileges": True,
-    "experimental_features": False
+    "access": {
+        "max_login_attempts": 50,
+        "block_time": 300,
+        "max_request_per_minute": 300
+    },
+    "remote_commands": {
+        "localfile": {
+            "enabled": True,
+            "exceptions": []
+        },
+        "wodle_command": {
+            "enabled": True,
+            "exceptions": []
+        }
+    }
 }
 
 custom_incomplete_configuration = {
@@ -81,15 +96,52 @@ def test_read_configuration(mock_open, mock_exists, read_config):
         check_config_values(config, read_config, configuration.default_api_configuration)
 
 
+@pytest.mark.parametrize('config', [
+    {'invalid_key': 'value'},
+    {'host': 1234},
+    {'port': 'invalid_type'},
+    {'use_only_authd': 'invalid_type'},
+    {'drop_privileges': 'invalid_type'},
+    {'experimental_features': 'invalid_type'},
+    {'https': {'enabled': 'invalid_type'}},
+    {'https': {'key': 12345}},
+    {'https': {'cert': 12345}},
+    {'https': {'use_ca': 12345}},
+    {'https': {'ca': 12345}},
+    {'https': {'ssl_cipher': 12345}},
+    {'https': {'invalid_subkey': 'value'}},
+    {'logs': {'level': 12345}},
+    {'logs': {'path': 12345}},
+    {'logs': {'invalid_subkey': 'value'}},
+    {'cors': {'enabled': 'invalid_type'}},
+    {'cors': {'source_route': 12345}},
+    {'cors': {'expose_headers': 12345}},
+    {'cors': {'allow_headers': 12345}},
+    {'cors': {'allow_credentials': 12345}},
+    {'cors': {'invalid_subkey': 'value'}},
+    {'cache': {'enabled': 'invalid_type'}},
+    {'cache': {'time': 'invalid_type'}},
+    {'cache': {'invalid_subkey': 'value'}},
+    {'access': {'max_login_attempts': 'invalid_type'}},
+    {'access': {'block_time': 'invalid_type'}},
+    {'access': {'max_request_per_minute': 'invalid_type'}},
+    {'access': {'invalid_subkey': 'invalid_type'}},
+    {'remote_commands': {'localfile': {'enabled': 'invalid_type'}}},
+    {'remote_commands': {'localfile': {'exceptions': [0, 1, 2]}}},
+    {'remote_commands': {'localfile': {'invalid_subkey': 'invalid_type'}}},
+    {'remote_commands': {'wodle_command': {'enabled': 'invalid_type'}}},
+    {'remote_commands': {'wodle_command': {'exceptions': [0, 1, 2]}}},
+    {'remote_commands': {'wodle_command': {'invalid_subkey': 'invalid_type'}}},
+])
 @patch('os.path.exists', return_value=True)
-def test_read_wrong_configuration(mock_exists):
+def test_read_wrong_configuration(mock_exists, config):
     """Verify that expected exceptions are raised when incorrect configuration"""
     with patch('api.configuration.yaml.safe_load') as m:
         with pytest.raises(api_exception.APIError, match=r'\b2004\b'):
             configuration.read_yaml_config()
 
         with patch('builtins.open'):
-            m.return_value = {'marta': 'yay'}
+            m.return_value = config
             with pytest.raises(api_exception.APIError, match=r'\b2000\b'):
                 configuration.read_yaml_config()
 

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -43,6 +43,98 @@ _type_format = re.compile(r'^xml$|^json$')
 _yes_no_boolean = re.compile(r'^yes$|^no$')
 
 
+security_config_schema = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "auth_token_exp_timeout": {"type": "integer"},
+        "rbac_mode": {"type": "string", "enum": ["white", "black"]}
+    }
+}
+
+api_config_schema = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "host": {"type": "string"},
+        "port": {"type": "number"},
+        "use_only_authd": {"type": "boolean"},
+        "drop_privileges": {"type": "boolean"},
+        "experimental_features": {"type": "boolean"},
+        "https": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "enabled": {"type": "boolean"},
+                "key": {"type": "string"},
+                "cert": {"type": "string"},
+                "use_ca": {"type": "boolean"},
+                "ca": {"type": "string"},
+                "ssl_cipher": {"type": "string"},
+            },
+        },
+        "logs": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "level": {"type": "string"},
+                "path": {"type": "string"},
+            },
+        },
+        "cors": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "enabled": {"type": "boolean"},
+                "source_route": {"type": "string"},
+                "expose_headers": {"type": "string"},
+                "allow_headers": {"type": "string"},
+                "allow_credentials": {"type": "boolean"},
+            },
+        },
+        "cache": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "enabled": {"type": "boolean"},
+                "time": {"type": "number"},
+            },
+        },
+        "access": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "max_login_attempts": {"type": "integer"},
+                "block_time": {"type": "integer"},
+                "max_request_per_minute": {"type": "integer"},
+            },
+        },
+        "remote_commands": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "localfile": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "exceptions": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+                "wodle_command": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "exceptions": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+            },
+        },
+    },
+}
+
+
 def check_exp(exp: str, regex: str) -> bool:
     """
     Function to check if an expression matches a regex


### PR DESCRIPTION
|Related issue|
|---|
| Closes #7195 |

## Description

Hello team!

As explained in #7195, currently only first level keys in the API (and security) configuration were validated. Therefore, things like below were incorrectly allowed:
```YAML
 https:
     new_invalid_option: "whatever"
```

JSONschema has been used in order to specify the accepted config structure, so anything different (at any level), will raise an exception like this:
```
Configuration not valid: 2000 - Some parameters are not expected in the configuration file (WAZUH_PATH/api/configuration/api.yaml): Additional properties are not allowed ('invalid_option' was unexpected).
```

In order to keep consistency with the default configuration dicts shown below, those are validated too against the schema when starting Wazuh:
https://github.com/wazuh/wazuh/blob/49f89fa9b92f062fba21627b599222387db7b740/api/api/configuration.py#L22-L71

## API tests output
```
python3 -m pytest api/api/ --disable-warnings
=================================================== test session starts ===================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/selu/Git/wazuh/api
plugins: trio-0.6.0, asyncio-0.14.0
collected 180 items                                                                                                       

api/api/test/test_alogging.py ........                                                                              [  4%]
api/api/test/test_authentication.py ..........                                                                      [ 10%]
api/api/test/test_configuration.py .......                                                                          [ 13%]
api/api/test/test_util.py ...................................                                                       [ 33%]
api/api/test/test_validator.py .................................................................................... [ 80%]
....................................                                                                                [100%]

============================================ 180 passed, 16 warnings in 1.01s =============================================
```

Regards!
Selu.
