### PR TITLE
Fix usb-storage-attached regex pattern to support blank space

### DIFF
--- a/ruleset/decoders/0140-kernel_decoders.xml
+++ b/ruleset/decoders/0140-kernel_decoders.xml
@@ -180,11 +180,13 @@ Mar 23 15:04:52 manager kernel: [62828.333722] usb 1-1: New USB device found, id
 Mar 23 15:05:23 manager kernel: usb 1-1: USB disconnect, device number 2
 Mar 23 15:05:23 manager kernel: [62859.373865] usb 1-1: USB disconnect, device number 2
 
+Mar 15 23:14:34 manager kernel: [ 195.634715] usb 1-1: New USB device found, idVendor=0bda, idProduct=568a, bcdDevice=65.10
+Mar 15 23:14:34 manager kernel: [ 290.678326] usb 1-1: USB disconnect, device number 2
 -->
 <decoder name="usb-storage-attached">
     <parent>kernel</parent>
-    <prematch offset="after_parent">^usb|^[\S+] usb</prematch>
-    <regex offset="after_parent">^(usb) |^[\S+] (usb)</regex>
+    <prematch offset="after_parent">^usb|^[\s*\S+] usb</prematch>
+    <regex offset="after_parent">^(usb) |^[\s*\S+] (usb)</regex>
     <order>id</order>
 </decoder>
 

--- a/ruleset/testing/tests/kernel_usb.ini
+++ b/ruleset/testing/tests/kernel_usb.ini
@@ -1,0 +1,35 @@
+[kernel_usb: attach usb]
+log 1 pass = Mar 23 15:04:52 manager kernel: usb 1-1: New USB device found, idVendor=0930, idProduct=6544
+rule = 81101
+alert = 3
+decoder = kernel
+
+[kernel_usb: attach usb with kernel id]
+log 1 pass = Mar 23 15:04:52 manager kernel: [62828.333722] usb 1-1: New USB device found, idVendor=0930, idProduct=6544
+rule = 81101
+alert = 3
+decoder = kernel
+
+[kernel_usb: attach usb with kernel id and blank spaces]
+log 1 pass = Mar 15 23:14:34 manager kernel: [ 195.634715] usb 1-1: New USB device found, idVendor=0bda, idProduct=568a, bcdDevice=65.10
+rule = 81101
+alert = 3
+decoder = kernel
+
+[kernel_usb: disconnect usb]
+log 1 pass = Mar 23 15:05:23 manager kernel: usb 1-1: USB disconnect, device number 2
+rule = 81102
+alert = 3
+decoder = kernel
+
+[kernel_usb: disconnect usb with kernel id]
+log 1 pass = Mar 23 15:05:23 manager kernel: [62859.373865] usb 1-1: USB disconnect, device number 2
+rule = 81102
+alert = 3
+decoder = kernel
+
+[kernel_usb: disconnect usb with kernel id and blank spaces]
+log 1 pass = Mar 23 15:05:23 manager kernel: [  259.373865] usb 1-1: USB disconnect, device number 2
+rule = 81102
+alert = 3
+decoder = kernel


### PR DESCRIPTION
|Related issue|
|---|
|Closes wazuh/wazuh-ruleset#827|


Hi team!,

This PR fixes the problem of blank spaces in front of the ID in USB-related kernel logs.
Also adds the respective tests for `runtest.py`

## Logtest output

### PR output:
Without blank spaces

```
Mar 23 15:04:52 manager kernel: [62828.333722] usb 1-1: New USB device found, idVendor=0930, idProduct=6544

**Phase 1: Completed pre-decoding.
        full event: 'Mar 23 15:04:52 manager kernel: [62828.333722] usb 1-1: New USB device found, idVendor=0930, idProduct=6544'
        timestamp: 'Mar 23 15:04:52'
        hostname: 'manager'
        program_name: 'kernel'

**Phase 2: Completed decoding.
        name: 'kernel'
        parent: 'kernel'
        id: 'usb'

**Phase 3: Completed filtering (rules).
        id: '81101'
        level: '3'
        description: 'Attached USB Storage'
        groups: '['usb']'
        firedtimes: '1'
        gpg13: '['4.8']'
        mail: 'False'
**Alert to be generated.

```
With blank spaces
```
Mar 23 15:04:52 manager kernel: [  62828.333722] usb 1-1: New USB device found, idVendor=0930, idProduct=6544

**Phase 1: Completed pre-decoding.
        full event: 'Mar 23 15:04:52 manager kernel: [  62828.333722] usb 1-1: New USB device found, idVendor=0930, idProduct=6544'
        timestamp: 'Mar 23 15:04:52'
        hostname: 'manager'
        program_name: 'kernel'

**Phase 2: Completed decoding.
        name: 'kernel'
        parent: 'kernel'
        id: 'usb'

**Phase 3: Completed filtering (rules).
        id: '81101'
        level: '3'
        description: 'Attached USB Storage'
        groups: '['usb']'
        firedtimes: '2'
        gpg13: '['4.8']'
        mail: 'False'
**Alert to be generated.
```

### Master output:

Without blank spaces
```
Starting wazuh-logtest v4.2.0
Type one log per line

Mar 23 15:04:52 manager kernel: [62828.333722] usb 1-1: New USB device found, idVendor=0930, idProduct=6544

**Phase 1: Completed pre-decoding.
        full event: 'Mar 23 15:04:52 manager kernel: [62828.333722] usb 1-1: New USB device found, idVendor=0930, idProduct=6544'
        timestamp: 'Mar 23 15:04:52'
        hostname: 'manager'
        program_name: 'kernel'

**Phase 2: Completed decoding.
        name: 'kernel'
        parent: 'kernel'
        id: 'usb'

**Phase 3: Completed filtering (rules).
        id: '81101'
        level: '3'
        description: 'Attached USB Storage'
        groups: '['usb']'
        firedtimes: '1'
        gpg13: '['4.8']'
        mail: 'False'
**Alert to be generated.

```

With blank spaces
```
Mar 23 15:04:52 manager kernel: [  62828.333722] usb 1-1: New USB device found, idVendor=0930, idProduct=6544

**Phase 1: Completed pre-decoding.
        full event: 'Mar 23 15:04:52 manager kernel: [  62828.333722] usb 1-1: New USB device found, idVendor=0930, idProduct=6544'
        timestamp: 'Mar 23 15:04:52'
        hostname: 'manager'
        program_name: 'kernel'

**Phase 2: Completed decoding.
        name: 'kernel'
```

## runtest.py

```
╰─# ./runtests.py
- [ File = ./tests/sudo.ini ] ---------
........

- [ File = ./tests/nextcloud.ini ] ---------
.......

- [ File = ./tests/su.ini ] ---------
.....

- [ File = ./tests/pfsense.ini ] ---------
..

- [ File = ./tests/pix.ini ] ---------
......................

- [ File = ./tests/openvpn_ldap.ini ] ---------
..

- [ File = ./tests/apache.ini ] ---------
............

- [ File = ./tests/syslog.ini ] ---------
......

- [ File = ./tests/sophos.ini ] ---------
........

- [ File = ./tests/postfix.ini ] ---------
..

- [ File = ./tests/pam.ini ] ---------
.....

- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................

- [ File = ./tests/SonicWall.ini ] ---------
........

- [ File = ./tests/firewalld.ini ] ---------
..

- [ File = ./tests/mcafee_epo.ini ] ---------
.

- [ File = ./tests/cisco_ios.ini ] ---------
...............

- [ File = ./tests/iptables.ini ] ---------
........

- [ File = ./tests/apparmor.ini ] ---------
.....

- [ File = ./tests/squid_rules.ini ] ---------
..

- [ File = ./tests/oscap.ini ] ---------
................................

- [ File = ./tests/macos-sshd.ini ] ---------
.....................

- [ File = ./tests/exim.ini ] ---------
.....

- [ File = ./tests/panda_paps.ini ] ---------
........

- [ File = ./tests/sysmon.ini ] ---------
...

- [ File = ./tests/systemd.ini ] ---------
..

- [ File = ./tests/opensmtpd.ini ] ---------
.......

- [ File = ./tests/cimserver.ini ] ---------
..

- [ File = ./tests/api.ini ] ---------
.........

- [ File = ./tests/cpanel.ini ] ---------
.......

- [ File = ./tests/kernel_usb.ini ] ---------
......

- [ File = ./tests/netscreen.ini ] ---------
....

- [ File = ./tests/web_rules.ini ] ---------
.....

- [ File = ./tests/sshd.ini ] ---------
...........................

- [ File = ./tests/auditd.ini ] ---------
.

- [ File = ./tests/paloalto.ini ] ---------
....

- [ File = ./tests/owlh.ini ] ---------
....

- [ File = ./tests/nginx.ini ] ---------
............

- [ File = ./tests/modsecurity.ini ] ---------
......

- [ File = ./tests/vsftpd.ini ] ---------
....

- [ File = ./tests/openldap.ini ] ---------
.........

- [ File = ./tests/cisco_asa.ini ] ---------
........................................................................................

- [ File = ./tests/rsh.ini ] ---------
..

- [ File = ./tests/dovecot.ini ] ---------
...............

- [ File = ./tests/ossec.ini ] ---------
.....

- [ File = ./tests/unbound.ini ] ---------


- [ File = ./tests/mailscanner.ini ] ---------
.

- [ File = ./tests/junos.ini ] ---------
...

- [ File = ./tests/samba.ini ] ---------
....

- [ File = ./tests/sophos_fw.ini ] ---------
..........

- [ File = ./tests/named.ini ] ---------
.....

- [ File = ./tests/web_appsec.ini ] ---------
...............................

- [ File = ./tests/proftpd.ini ] ---------
.......

- [ File = ./tests/dropbear.ini ] ---------
...

- [ File = ./tests/doas.ini ] ---------
....
```

Regards, 
Julian
