### PR TITLE
Fix FIM data races 

### DIFF
--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -395,7 +395,7 @@ typedef struct _config {
     long sync_response_timeout;     /* Minimum time between receiving a sync response and starting a new sync session */
     long sync_queue_size;           /* Data synchronization message queue size */
     long sync_max_eps;              /* Maximum events per second for synchronization messages. */
-    unsigned max_eps;               /* Maximum events per second. */
+    int max_eps;               /* Maximum events per second. */
 
     /* Windows only registry checking */
 #ifdef WIN32

--- a/src/headers/atomic.h
+++ b/src/headers/atomic.h
@@ -1,0 +1,43 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2009 Trend Micro Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+/* Common API for dealing with atomic operations */
+
+#ifndef ATOMIC_H
+#define ATOMIC_H
+
+#include <pthread.h>
+#include "pthreads_op.h"
+
+#define ATOMIC_INT_INITIALIZER(v) { .data = v, .mutex = PTHREAD_MUTEX_INITIALIZER}
+
+typedef struct _atomic_int_t {
+    int data;
+    pthread_mutex_t mutex;
+} atomic_int_t;
+
+/**
+ * @brief Thread safe function that gets the the value of an atomic int.
+ *
+ * @param atomic atomic int structure to get the data value.
+ * @return int A copy of the atomic_int value.
+ */
+int atomic_int_get(atomic_int_t *atomic);
+
+/**
+ * @brief Thread safe functions that sets the value of an atomic int
+ *
+ * @param atomic atomic_int_t structure that is used.
+ * @param value Value that will be used to set the atomic int value.
+ */
+void atomic_int_set(atomic_int_t *atomic, int value);
+
+
+#endif // ATOMIC_H

--- a/src/headers/atomic.h
+++ b/src/headers/atomic.h
@@ -18,7 +18,7 @@
 
 #define ATOMIC_INT_INITIALIZER(v) { .data = v, .mutex = PTHREAD_MUTEX_INITIALIZER}
 
-typedef struct _atomic_int_t {
+typedef struct atomic_int_s {
     int data;
     pthread_mutex_t mutex;
 } atomic_int_t;
@@ -26,7 +26,7 @@ typedef struct _atomic_int_t {
 /**
  * @brief Thread safe function that gets the the value of an atomic int.
  *
- * @param atomic atomic int structure to get the data value.
+ * @param atomic atomic_int_t structure to get the data value.
  * @return int A copy of the atomic_int value.
  */
 int atomic_int_get(atomic_int_t *atomic);
@@ -39,5 +39,20 @@ int atomic_int_get(atomic_int_t *atomic);
  */
 void atomic_int_set(atomic_int_t *atomic, int value);
 
+/**
+ * @brief Thread safe functions that increments the value of an atomic int.
+ *
+ * @param atomic atomic_int_t structure that is used.
+ * @return The value of the atomic int (incremented)
+ */
+int atomic_int_inc(atomic_int_t *atomic);
+
+/**
+ * @brief Thread safe functions that decrements the value of an atomic int.
+ *
+ * @param atomic atomic_int_t structure that is used.
+ * @return The value of the atomic int (decremented)
+ */
+int atomic_int_dec(atomic_int_t *atomic);
 
 #endif // ATOMIC_H

--- a/src/headers/atomic.h
+++ b/src/headers/atomic.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * Copyright (C) 2009 Trend Micro Inc.
  * All rights reserved.
  *
@@ -24,7 +24,7 @@ typedef struct atomic_int_s {
 } atomic_int_t;
 
 /**
- * @brief Thread safe function that gets the the value of an atomic int.
+ * @brief Thread safe function to get the the value of an atomic int.
  *
  * @param atomic atomic_int_t structure to get the data value.
  * @return int A copy of the atomic_int value.
@@ -32,26 +32,26 @@ typedef struct atomic_int_s {
 int atomic_int_get(atomic_int_t *atomic);
 
 /**
- * @brief Thread safe functions that sets the value of an atomic int
+ * @brief Thread safe function to set the value of an atomic int
  *
- * @param atomic atomic_int_t structure that is used.
- * @param value Value that will be used to set the atomic int value.
+ * @param atomic atomic_int_t structure to be updated.
+ * @param value Integer value that will be used to set the atomic int value.
  */
 void atomic_int_set(atomic_int_t *atomic, int value);
 
 /**
- * @brief Thread safe functions that increments the value of an atomic int.
+ * @brief Thread safe function to increment the value of an atomic int by one.
  *
- * @param atomic atomic_int_t structure that is used.
- * @return The value of the atomic int (incremented)
+ * @param atomic atomic_int_t structure to be updated.
+ * @return The final value of the atomic int.
  */
 int atomic_int_inc(atomic_int_t *atomic);
 
 /**
- * @brief Thread safe functions that decrements the value of an atomic int.
+ * @brief Thread safe function to decrement the value of an atomic int by one.
  *
- * @param atomic atomic_int_t structure that is used.
- * @return The value of the atomic int (decremented)
+ * @param atomic atomic_int_t structure to be updated.
+ * @return The final value of the atomic int.
  */
 int atomic_int_dec(atomic_int_t *atomic);
 

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -201,7 +201,7 @@ extern const char *__local_name;
 
 #define w_strlen(x) ({ size_t ret = 0; if (x) ret = strlen(x); ret;})
 
-// Calculate the number of elements within an array. 
+// Calculate the number of elements within an array.
 // Only static arrays allowed.
 #define array_size(array) (sizeof(array)/sizeof(array[0]))
 
@@ -272,5 +272,6 @@ extern const char *__local_name;
 #include "bzip2_op.h"
 #include "enrollment_op.h"
 #include "buffer_op.h"
+#include "atomic.h"
 
 #endif /* SHARED_H */

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -19,11 +19,14 @@
 #endif
 
 /// Pending restart bit field
-static struct {
-    unsigned syscheck:1;
-    unsigned rootcheck:1;
-} os_restart;
+typedef struct os_restart_s {
+    atomic_int_t syscheck;
+    atomic_int_t rootcheck;
+} os_restart_t;
 
+
+static os_restart_t os_restart = {.syscheck = ATOMIC_INT_INITIALIZER(0),
+                                  .rootcheck = ATOMIC_INT_INITIALIZER(0)};
 #ifndef WIN32
 
 //Alloc and create an agent removal command payload
@@ -44,8 +47,8 @@ static cJSON* w_create_agent_add_payload(const char *name, const char *ip, const
  */
 int os_check_restart_syscheck()
 {
-    int current = os_restart.syscheck;
-    os_restart.syscheck = 0;
+    int current = atomic_int_get(&(os_restart.syscheck));
+    atomic_int_set(&(os_restart.syscheck), 0);
     return current;
 }
 
@@ -54,16 +57,16 @@ int os_check_restart_syscheck()
  */
 int os_check_restart_rootcheck()
 {
-    int current = os_restart.rootcheck;
-    os_restart.rootcheck = 0;
+    int current = atomic_int_get(&(os_restart.rootcheck));
+    atomic_int_set(&(os_restart.rootcheck), 0);
     return current;
 }
 
 /* Set syscheck and rootcheck to be restarted */
 void os_set_restart_syscheck()
 {
-    os_restart.syscheck = 1;
-    os_restart.rootcheck = 1;
+    atomic_int_set(&(os_restart.syscheck), 1);
+    atomic_int_set(&(os_restart.rootcheck), 1);
 }
 
 /* Read the agent name for the current agent

--- a/src/shared/atomic.c
+++ b/src/shared/atomic.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015-2020, Wazuh Inc.
+ * December 18, 2018.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "shared.h"
+
+int atomic_int_get(atomic_int_t *atomic) {
+    int retval = 0;
+
+    w_mutex_lock(&atomic->mutex);
+    retval = atomic->data;
+    w_mutex_unlock(&atomic->mutex);
+
+    return retval;
+}
+
+void atomic_int_set(atomic_int_t *atomic, int value) {
+    w_mutex_lock(&atomic->mutex);
+    atomic->data = value;
+    w_mutex_unlock(&atomic->mutex);
+}
+
+int atomic_int_inc(atomic_int_t *atomic) {
+    int retval = 0;
+    w_mutex_lock(&atomic->mutex);
+    atomic->data++;
+    retval = atomic->data;
+    w_mutex_unlock(&atomic->mutex);
+    return retval;
+};
+
+int atomic_int_dec(atomic_int_t *atomic) {
+    int retval = 0;
+    w_mutex_lock(&atomic->mutex);
+    atomic->data--;
+    retval = atomic->data;
+    w_mutex_unlock(&atomic->mutex);
+    return retval;
+}

--- a/src/shared/atomic.c
+++ b/src/shared/atomic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020, Wazuh Inc.
+ * Copyright (C) 2015-2021, Wazuh Inc.
  * December 18, 2018.
  *
  * This program is free software; you can redistribute it
@@ -11,6 +11,8 @@
 #include "shared.h"
 
 int atomic_int_get(atomic_int_t *atomic) {
+    assert(atomic != NULL);
+
     int retval = 0;
 
     w_mutex_lock(&atomic->mutex);
@@ -21,12 +23,16 @@ int atomic_int_get(atomic_int_t *atomic) {
 }
 
 void atomic_int_set(atomic_int_t *atomic, int value) {
+    assert(atomic != NULL);
+
     w_mutex_lock(&atomic->mutex);
     atomic->data = value;
     w_mutex_unlock(&atomic->mutex);
 }
 
 int atomic_int_inc(atomic_int_t *atomic) {
+    assert(atomic != NULL);
+
     int retval = 0;
     w_mutex_lock(&atomic->mutex);
     atomic->data++;
@@ -36,6 +42,8 @@ int atomic_int_inc(atomic_int_t *atomic) {
 };
 
 int atomic_int_dec(atomic_int_t *atomic) {
+    assert(atomic != NULL);
+
     int retval = 0;
     w_mutex_lock(&atomic->mutex);
     atomic->data--;

--- a/src/shared/wait_op.c
+++ b/src/shared/wait_op.c
@@ -88,16 +88,16 @@ void os_wait()
 void os_wait()
 {
     struct stat file_status;
-    static int just_unlocked = 0;
+    static atomic_int_t just_unlocked = ATOMIC_INT_INITIALIZER(0);
 
     /* If the wait file is not present, keep going */
     if (stat(WAIT_FILE, &file_status) == -1) {
-        just_unlocked = 1;
+        atomic_int_set(&just_unlocked, 1);
         return;
     }
 
     /* Wait until the lock is gone */
-    if (just_unlocked){
+    if (atomic_int_get(&just_unlocked) == 1){
         mwarn(WAITING_MSG);
     } else {
         mdebug1(WAITING_MSG);
@@ -112,13 +112,13 @@ void os_wait()
         sleep(LOCK_LOOP);
     }
 
-    if (just_unlocked) {
+    if (atomic_int_get(&just_unlocked) == 1) {
         minfo(WAITING_FREE);
     } else {
         mdebug1(WAITING_FREE);
     }
 
-    just_unlocked = 1;
+    atomic_int_set(&just_unlocked, 1);
 
     return;
 }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -149,7 +149,9 @@ time_t fim_scan() {
         fim_checker(path, &evt_data, dir_it);
 #ifndef WIN32
         if (dir_it->options & REALTIME_ACTIVE) {
+            w_mutex_lock(&syscheck.fim_realtime_mutex);
             realtime_adddir(path, dir_it, (dir_it->options & CHECK_FOLLOW) ? 1 : 0);
+            w_mutex_unlock(&syscheck.fim_realtime_mutex);
         }
 #endif
         os_free(path);
@@ -215,8 +217,9 @@ time_t fim_scan() {
         _base_line = 1;
     }
     else {
-        // In the first scan, the fim inicialization is different between Linux and Windows.
+        // In the first scan, the fim initialization is different between Linux and Windows.
         // Realtime watches are set after the first scan in Windows.
+        w_mutex_lock(&syscheck.fim_realtime_mutex);
         if (syscheck.realtime != NULL) {
             if (syscheck.realtime->queue_overflow) {
                 realtime_sanitize_watch_map();
@@ -224,6 +227,7 @@ time_t fim_scan() {
             }
             mdebug2(FIM_NUM_WATCHES, syscheck.realtime->dirtb->elements);
         }
+        w_mutex_unlock(&syscheck.fim_realtime_mutex);
     }
 
     minfo(FIM_FREQUENCY_ENDED);
@@ -337,7 +341,9 @@ void fim_checker(const char *path, event_data_t *evt_data, const directory_t *pa
         }
 #ifndef WIN32
         if (configuration->options & REALTIME_ACTIVE) {
+            w_mutex_lock(&syscheck.fim_realtime_mutex);
             realtime_adddir(path, configuration, (configuration->options & CHECK_FOLLOW) ? 1 : 0);
+            w_mutex_unlock(&syscheck.fim_realtime_mutex);
         }
 #endif
         fim_directory(path, evt_data, configuration);

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -46,6 +46,7 @@ int main(int argc, char **argv)
     gid_t gid;
     const char *group = GROUPGLOBAL;
     directory_t *dir_it = NULL;
+    int start_realtime = 0;
 
     /* Set the name */
     OS_SetName(ARGV0);
@@ -235,6 +236,7 @@ int main(int argc, char **argv)
             if (dir_it->options & REALTIME_ACTIVE) {
 #if defined (INOTIFY_ENABLED) || defined (WIN32)
                 minfo(FIM_REALTIME_MONITORING_DIRECTORY, dir_it->path);
+                start_realtime = 1;
 #else
                 mwarn(FIM_WARN_REALTIME_DISABLED, dir_it->path);
                 dir_it->options &= ~REALTIME_ACTIVE;
@@ -245,6 +247,10 @@ int main(int argc, char **argv)
     }
 
     fim_initialize();
+
+    if (start_realtime == 1) {
+        realtime_start();
+    }
 
     // Audit events thread
     if (!syscheck.disabled && syscheck.enable_whodata) {
@@ -262,6 +268,12 @@ int main(int argc, char **argv)
                     dir_it->options |= REALTIME_ACTIVE;
                 }
             }
+        w_mutex_lock(&syscheck.fim_realtime_mutex);
+        if (syscheck.realtime == NULL) {
+            realtime_start();
+        }
+        w_mutex_unlock(&syscheck.fim_realtime_mutex);
+
         }
 #else
         merror(FIM_ERROR_WHODATA_AUDIT_SUPPORT);

--- a/src/syscheckd/main.c
+++ b/src/syscheckd/main.c
@@ -268,11 +268,11 @@ int main(int argc, char **argv)
                     dir_it->options |= REALTIME_ACTIVE;
                 }
             }
-        w_mutex_lock(&syscheck.fim_realtime_mutex);
-        if (syscheck.realtime == NULL) {
-            realtime_start();
-        }
-        w_mutex_unlock(&syscheck.fim_realtime_mutex);
+            w_mutex_lock(&syscheck.fim_realtime_mutex);
+            if (syscheck.realtime == NULL) {
+                realtime_start();
+            }
+            w_mutex_unlock(&syscheck.fim_realtime_mutex);
 
         }
 #else

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -110,7 +110,7 @@ void send_syscheck_msg(const cJSON *_msg) {
 
     static atomic_int_t n_msg_sent = ATOMIC_INT_INITIALIZER(0);
 
-    if (atomic_int_inc(&n_msg_sent) == syscheck.max_eps) {
+    if (atomic_int_inc(&n_msg_sent) >= syscheck.max_eps) {
         sleep(1);
         atomic_int_set(&n_msg_sent, 0);
     }
@@ -757,7 +757,6 @@ STATIC void fim_delete_realtime_watches(const directory_t *configuration) {
         return;
     }
 
-    w_mutex_lock(&syscheck.fim_realtime_mutex);
     for (hash_node = OSHash_Begin(syscheck.realtime->dirtb, &inode_it); hash_node;
          hash_node = OSHash_Next(syscheck.realtime->dirtb, &inode_it, hash_node)) {
         data = hash_node->data;
@@ -781,7 +780,6 @@ STATIC void fim_delete_realtime_watches(const directory_t *configuration) {
         free(OSHash_Delete_ex(syscheck.realtime->dirtb, wd_str));
         deletion_it--;
     }
-    w_mutex_unlock(&syscheck.fim_realtime_mutex);
 
     W_Vector_free(watch_to_delete);
 #endif

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -108,11 +108,11 @@ void send_syscheck_msg(const cJSON *_msg) {
         return;
     }
 
-    static unsigned n_msg_sent = 0;
+    static atomic_int_t n_msg_sent = ATOMIC_INT_INITIALIZER(0);
 
-    if (++n_msg_sent == syscheck.max_eps) {
+    if (atomic_int_inc(&n_msg_sent) == syscheck.max_eps) {
         sleep(1);
-        n_msg_sent = 0;
+        atomic_int_set(&n_msg_sent, 0);
     }
 }
 

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -460,6 +460,7 @@ int realtime_start() {
                 dir_it->options |= SCHEDULED_ACTIVE;
             }
         return(-1);
+        }
     }
     OSHash_SetFreeDataPointer(syscheck.realtime->dirtb, (void (*)(void *))free_win32rtfim_data);
 

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -122,13 +122,14 @@ void realtime_process() {
     buf[REALTIME_EVENT_BUFFER] = '\0';
 
     w_mutex_lock(&syscheck.fim_realtime_mutex);
-
     len = read(syscheck.realtime->fd, buf, REALTIME_EVENT_BUFFER);
+    w_mutex_unlock(&syscheck.fim_realtime_mutex);
 
     if (len < 0) {
         merror(FIM_ERROR_REALTIME_READ_BUFFER);
     }
     else if (len > 0) {
+        w_mutex_lock(&syscheck.fim_realtime_mutex);
         rb_tree * tree = rbtree_init();
 
         for (size_t i = 0; i < (size_t) len; i += REALTIME_EVENT_SIZE + event->len) {

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -99,7 +99,6 @@ int Start_win32_Syscheck()
     int debug_level = 0;
     int r = 0;
     char *cfg = OSSECCONF;
-    directory_t *dir_it;
     /* Read internal options */
     read_internal(debug_level);
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -99,6 +99,7 @@ int Start_win32_Syscheck()
     int debug_level = 0;
     int r = 0;
     char *cfg = OSSECCONF;
+    directory_t *dir_it;
     /* Read internal options */
     read_internal(debug_level);
 
@@ -253,6 +254,12 @@ int Start_win32_Syscheck()
 
         /* Start up message */
         minfo(STARTUP_MSG, getpid());
+        foreach_array(dir_it, syscheck.directories) {
+            if (dir_it->options & REALTIME_ACTIVE) {
+                realtime_start();
+                break;
+            }
+        }
     }
 
     /* Some sync time */

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -445,7 +445,7 @@ void remove_audit_rule_syscheck(const char *path);
  * @brief Read an audit event from socket
  *
  * @param [out] audit_sock The audit socket to read the events from
- * @param [in] running atomic_int that checks to check the running status of the thread.
+ * @param [in] running atomic_int that holds the status of the running thread.
  */
 void audit_read_events(int *audit_sock, atomic_int_t *running);
 

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -445,9 +445,9 @@ void remove_audit_rule_syscheck(const char *path);
  * @brief Read an audit event from socket
  *
  * @param [out] audit_sock The audit socket to read the events from
- * @param [in] reading_mode READING_MODE or HEALTHCHECK_MODE
+ * @param [in] running atomic_int that checks to check the running status of the thread.
  */
-void audit_read_events(int *audit_sock, int reading_mode);
+void audit_read_events(int *audit_sock, atomic_int_t *running);
 
 /**
  * @brief Makes Audit thread to wait for audit healthcheck to be performed

--- a/src/syscheckd/whodata/audit_healthcheck.c
+++ b/src/syscheckd/whodata/audit_healthcheck.c
@@ -24,6 +24,8 @@ int audit_health_check(int audit_socket) {
     char abs_path_healthcheck[PATH_MAX] = {'\0'};
     char abs_path_healthcheck_file[PATH_MAX] = {'\0'};
     FILE *fp = NULL;
+    struct timespec wait_time = {0, 0};
+
 
     w_mutex_init(&audit_hc_mutex, NULL);
 
@@ -80,12 +82,19 @@ int audit_health_check(int audit_socket) {
         mdebug1(FIM_HEALTHCHECK_CHECK_RULE); // LCOV_EXCL_LINE
     }
     atomic_int_set(&hc_thread_active, 0);
+
+    // Lock this thread (with 5 seconds timeout) until the healthcheck thread has ended.
+    w_mutex_lock(&audit_hc_mutex);
+    gettime(&wait_time);
+    wait_time.tv_sec += 5;
+    pthread_cond_timedwait(&audit_hc_started, &audit_hc_mutex, &wait_time);
+    w_mutex_unlock(&audit_hc_mutex);
+
     return retval;
 }
 
 // LCOV_EXCL_START
 void *audit_healthcheck_thread(int *audit_sock) {
-
     w_mutex_lock(&audit_hc_mutex);
     atomic_int_set(&hc_thread_active, 1);
     w_cond_signal(&audit_hc_started);
@@ -96,6 +105,10 @@ void *audit_healthcheck_thread(int *audit_sock) {
     audit_read_events(audit_sock, &hc_thread_active);
 
     mdebug2(FIM_HEALTHCHECK_THREAD_FINISHED);
+
+    w_mutex_lock(&audit_hc_mutex);
+    w_cond_broadcast(&audit_hc_started);
+    w_mutex_unlock(&audit_hc_mutex);
 
     return NULL;
 }

--- a/src/syscheckd/whodata/audit_healthcheck.c
+++ b/src/syscheckd/whodata/audit_healthcheck.c
@@ -26,7 +26,6 @@ int audit_health_check(int audit_socket) {
     FILE *fp = NULL;
     struct timespec wait_time = {0, 0};
 
-
     w_mutex_init(&audit_hc_mutex, NULL);
 
     // Audit needs an absolute path to add rules

--- a/src/syscheckd/whodata/audit_parse.c
+++ b/src/syscheckd/whodata/audit_parse.c
@@ -443,7 +443,7 @@ void audit_parse(char *buffer) {
                     snprintf(msg_alert, 512, "ossec: Audit: Detected rules manipulation: Max rules reload retries");
                     SendMSG(syscheck.queue, msg_alert, "syscheck", LOCALFILE_MQ);
                     // Stop thread
-                    audit_thread_active = 0;
+                    atomic_int_set(&audit_thread_active, 0);
                 }
             }
             os_free(p_dir);
@@ -836,7 +836,7 @@ void audit_parse(char *buffer) {
                 // i686: 5 open
                 // i686: 295 openat
                 mdebug2(FIM_HEALTHCHECK_CREATE, syscall);
-                audit_health_check_creation = 1;
+                atomic_int_set(&audit_health_check_creation, 1);
             } else if (!strcmp(syscall, "87") || !strcmp(syscall, "263") || !strcmp(syscall, "10") ||
                        !strcmp(syscall, "301")) {
                 // x86_64: 87 unlink

--- a/src/syscheckd/whodata/audit_rule_handling.c
+++ b/src/syscheckd/whodata/audit_rule_handling.c
@@ -245,7 +245,7 @@ void clean_rules(void) {
 
     w_mutex_lock(&rules_mutex);
 
-    audit_thread_active = 0;
+    atomic_int_set(&audit_thread_active, 0);
     mdebug2(FIM_AUDIT_DELETE_RULE);
 
     for (node = OSList_GetFirstNode(whodata_directories); node != NULL;
@@ -274,7 +274,7 @@ int fim_audit_rules_init() {
 
 void *audit_reload_thread() {
     sleep(RELOAD_RULES_INTERVAL);
-    while (audit_thread_active) {
+    while (atomic_int_get(&audit_thread_active) == 1) {
         fim_audit_reload_rules();
 
         sleep(RELOAD_RULES_INTERVAL);

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -301,7 +301,6 @@ void *audit_main(audit_data_t *audit_data) {
     count_reload_retries = 0;
     atomic_int_set(&audit_thread_active,0);
 
-
     w_mutex_lock(&audit_mutex);
     atomic_int_set(&audit_thread_active, 1);
     w_cond_signal(&audit_thread_started);

--- a/src/syscheckd/whodata/syscheck_audit.c
+++ b/src/syscheckd/whodata/syscheck_audit.c
@@ -341,6 +341,11 @@ void *audit_main(audit_data_t *audit_data) {
         dir_it->options &= ~ WHODATA_ACTIVE;
         dir_it->options |= REALTIME_ACTIVE;
 
+        w_mutex_lock(&syscheck.fim_realtime_mutex);
+        if (syscheck.realtime == NULL) {
+            realtime_start();
+        }
+        w_mutex_unlock(&syscheck.fim_realtime_mutex);
         realtime_adddir(path, 0, (dir_it->options & CHECK_FOLLOW) ? 1 : 0);
         free(path);
     }

--- a/src/syscheckd/whodata/syscheck_audit.h
+++ b/src/syscheckd/whodata/syscheck_audit.h
@@ -52,8 +52,8 @@ int fim_rules_initial_load();
 void clean_regex();
 
 extern pthread_mutex_t audit_mutex;
-extern volatile int audit_thread_active;
-extern volatile int hc_thread_active;
+extern atomic_int_t audit_thread_active;
+extern atomic_int_t hc_thread_active;
+extern atomic_int_t audit_health_check_creation;
 extern unsigned int count_reload_retries;
-extern volatile int audit_health_check_creation;
 #endif // SYSCHECK_AUDIT_H

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -149,6 +149,9 @@ endif()
 list(APPEND shared_tests_names "test_keys")
 list(APPEND shared_tests_flags "-Wl,--wrap,rbtree_get")
 
+list(APPEND shared_tests_names "test_atomic")
+list(APPEND shared_tests_flags "-Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock")
+
 # Compiling tests
 list(LENGTH shared_tests_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/shared/test_atomic.c
+++ b/src/unit_tests/shared/test_atomic.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+
+#include "../../headers/atomic.h"
+#include "../wrappers/posix/pthread_wrappers.h"
+
+atomic_int_t test_variable = ATOMIC_INT_INITIALIZER(0);
+
+
+static int setup_variable(void **state) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    atomic_int_set(&test_variable, 1231);
+    return 0;
+}
+
+static int teardown_variable(void **state) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    atomic_int_set(&test_variable, 0);
+    return 0;
+}
+
+
+static void test_atomic_int_get(void **state) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    int ret = atomic_int_get(&test_variable);
+
+    assert_int_equal(ret, 1231);
+    assert_int_equal(test_variable.data, 1231);
+
+}
+
+static void test_atomic_int_set(void **state) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    atomic_int_set(&test_variable, 2718);
+
+    assert_int_equal(test_variable.data, 2718);
+}
+
+static void test_atomic_int_inc(void **state) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    int ret = atomic_int_inc(&test_variable);
+
+    assert_int_equal(test_variable.data, 1232);
+    assert_int_equal(ret, 1232);
+}
+
+
+static void test_atomic_int_dec(void **state) {
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    int ret = atomic_int_dec(&test_variable);
+
+    assert_int_equal(test_variable.data, 1230);
+    assert_int_equal(ret, 1230);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_atomic_int_get, setup_variable, teardown_variable),
+        cmocka_unit_test_setup_teardown(test_atomic_int_set, setup_variable, teardown_variable),
+        cmocka_unit_test_setup_teardown(test_atomic_int_inc, setup_variable, teardown_variable),
+        cmocka_unit_test_setup_teardown(test_atomic_int_dec, setup_variable, teardown_variable),
+        };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/shared/test_atomic.c
+++ b/src/unit_tests/shared/test_atomic.c
@@ -19,35 +19,19 @@
 #include "../../headers/atomic.h"
 #include "../wrappers/posix/pthread_wrappers.h"
 
-atomic_int_t test_variable = ATOMIC_INT_INITIALIZER(0);
-
-
-static int setup_variable(void **state) {
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    atomic_int_set(&test_variable, 1231);
-    return 0;
-}
-
-static int teardown_variable(void **state) {
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
-    atomic_int_set(&test_variable, 0);
-    return 0;
-}
-
-
 static void test_atomic_int_get(void **state) {
+    atomic_int_t test_variable = ATOMIC_INT_INITIALIZER(1231);
+
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
     int ret = atomic_int_get(&test_variable);
 
     assert_int_equal(ret, 1231);
-    assert_int_equal(test_variable.data, 1231);
-
 }
 
 static void test_atomic_int_set(void **state) {
+    atomic_int_t test_variable = ATOMIC_INT_INITIALIZER(1231);
+
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
     atomic_int_set(&test_variable, 2718);
@@ -56,30 +40,31 @@ static void test_atomic_int_set(void **state) {
 }
 
 static void test_atomic_int_inc(void **state) {
+    atomic_int_t test_variable = ATOMIC_INT_INITIALIZER(1231);
+
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
     int ret = atomic_int_inc(&test_variable);
 
-    assert_int_equal(test_variable.data, 1232);
     assert_int_equal(ret, 1232);
 }
 
-
 static void test_atomic_int_dec(void **state) {
+    atomic_int_t test_variable = ATOMIC_INT_INITIALIZER(1231);
+
     expect_function_call(__wrap_pthread_mutex_lock);
     expect_function_call(__wrap_pthread_mutex_unlock);
     int ret = atomic_int_dec(&test_variable);
 
-    assert_int_equal(test_variable.data, 1230);
     assert_int_equal(ret, 1230);
 }
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(test_atomic_int_get, setup_variable, teardown_variable),
-        cmocka_unit_test_setup_teardown(test_atomic_int_set, setup_variable, teardown_variable),
-        cmocka_unit_test_setup_teardown(test_atomic_int_inc, setup_variable, teardown_variable),
-        cmocka_unit_test_setup_teardown(test_atomic_int_dec, setup_variable, teardown_variable),
+        cmocka_unit_test(test_atomic_int_get),
+        cmocka_unit_test(test_atomic_int_set),
+        cmocka_unit_test(test_atomic_int_inc),
+        cmocka_unit_test(test_atomic_int_dec),
         };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/shared/test_queue_op.c
+++ b/src/unit_tests/shared/test_queue_op.c
@@ -42,7 +42,7 @@ void callback_queue_pop_ex() {
 void callback_queue_push_ex() {
     int *ptr = malloc(sizeof(int));
     *ptr = 0;
-    queue_push_ex(queue_ptr, ptr);   
+    queue_push_ex(queue_ptr, ptr);
 }
 /*****************WRAPS********************/
 int __wrap_pthread_mutex_lock(pthread_mutex_t *mutex) {
@@ -58,7 +58,7 @@ int __wrap_pthread_mutex_unlock(pthread_mutex_t *mutex) {
 int __wrap_pthread_cond_wait(pthread_cond_t *cond,pthread_mutex_t *mutex) {
     check_expected_ptr(cond);
     check_expected_ptr(mutex);
-    // callback function to avoid infinite loops when testing 
+    // callback function to avoid infinite loops when testing
     if (callback_ptr)
         callback_ptr();
     return 0;
@@ -68,7 +68,7 @@ int __wrap_pthread_cond_timedwait(pthread_cond_t *cond,pthread_mutex_t *mutex, c
     check_expected_ptr(cond);
     check_expected_ptr(mutex);
     check_expected_ptr(abstime);
-    // callback function to avoid infinite loops when testing 
+    // callback function to avoid infinite loops when testing
     if (callback_ptr)
         callback_ptr();
     return mock_type(int);
@@ -149,7 +149,7 @@ void test_queue_push_ex_block(void **state) {
     expect_value_count(__wrap_pthread_mutex_lock, mutex,  &queue->mutex, QUEUE_SIZE + 1);
     expect_value_count(__wrap_pthread_mutex_unlock, mutex, &queue->mutex, QUEUE_SIZE + 1);
 
-    // Set callback and wait 
+    // Set callback and wait
     expect_value(__wrap_pthread_cond_wait, cond, &queue->available_not_empty);
     expect_value(__wrap_pthread_cond_wait, mutex, &queue->mutex);
     callback_ptr = callback_queue_pop_ex;

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -202,7 +202,7 @@ if(${TARGET} STREQUAL "winagent")
                                     -Wl,--wrap=rootcheck_init \
                                     -Wl,--wrap=start_daemon \
                                     -Wl,--wrap=File_DateofChange \
-                                    -Wl,--wrap,getpid")
+                                    -Wl,--wrap,getpid, -Wl,--wrap,realtime_start")
 
 else()
   list(APPEND syscheckd_tests_flags "${SYSCHECK_BASE_FLAGS}")

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -647,11 +647,9 @@ void test_realtime_process_overflow(void **state) {
     will_return(__wrap_read, 21);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_function_call(__wrap_pthread_mutex_lock);
     expect_string(__wrap__mwarn, formatted_msg, "Real-time inotify kernel queue is full. Some events may be lost. Next scheduled scan will recover lost data.");
     expect_string(__wrap_send_log_msg, msg, "ossec: Real-time inotify kernel queue is full. Some events may be lost. Next scheduled scan will recover lost data.");
     will_return(__wrap_send_log_msg, 1);
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     char **paths = NULL;
     paths = os_AddStrArray("/test", paths);

--- a/src/unit_tests/syscheckd/test_run_realtime.c
+++ b/src/unit_tests/syscheckd/test_run_realtime.c
@@ -1386,8 +1386,6 @@ void test_realtime_adddir_max_limit_reached(void **state) {
     expect_string(__wrap__merror, formatted_msg,
         "(6616): Unable to add directory to real time monitoring: 'C:\\a\\path' - Maximum size permitted.");
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
     ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 
     assert_int_equal(ret, 0);
@@ -1405,8 +1403,6 @@ void test_realtime_adddir_duplicate_entry(void **state) {
 
     expect_string(__wrap_w_directory_exists, path, "C:\\a\\path");
     will_return(__wrap_w_directory_exists, 1);
-
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 
@@ -1428,8 +1424,6 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_valid_handle(vo
 
     expect_value(wrap_CloseHandle, hObject, 1234);
     will_return(wrap_CloseHandle, 0);
-
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 
@@ -1473,8 +1467,6 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_closed_handle(v
     snprintf(debug_msg, OS_SIZE_128, FIM_REALTIME_CALLBACK, "C:\\a\\path");
     expect_string(__wrap__mdebug1, formatted_msg, debug_msg);
 
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
     ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 
     assert_int_equal(ret, 1);
@@ -1492,8 +1484,6 @@ void test_realtime_adddir_duplicate_entry_non_existent_directory_invalid_handle(
 
     expect_string(__wrap_w_directory_exists, path, "C:\\a\\path");
     will_return(__wrap_w_directory_exists, 0);
-
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 
@@ -1514,8 +1504,6 @@ void test_realtime_adddir_handle_error(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg,
         "(6290): Unable to add directory to real time monitoring: 'C:\\a\\path'");
-
-    expect_function_call(__wrap_pthread_mutex_unlock);
 
     ret = realtime_adddir("C:\\a\\path", syscheck.directories[0], 0);
 

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -366,6 +366,11 @@ void test_Start_win32_Syscheck_whodata_active(void **state) {
     expect_function_call(__wrap_os_wait);
 
     expect_function_call(__wrap_start_daemon);
+    expect_value(wrap_CreateEvent, lpEventAttributes, NULL);
+    expect_value(wrap_CreateEvent, bManualReset, TRUE);
+    expect_value(wrap_CreateEvent, bInitialState, FALSE);
+    expect_value(wrap_CreateEvent, lpName, NULL);
+    will_return(wrap_CreateEvent, (HANDLE)123456);
 
     Start_win32_Syscheck();
 }

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -364,13 +364,7 @@ void test_Start_win32_Syscheck_whodata_active(void **state) {
     expect_string(__wrap__minfo, formatted_msg, info_msg);
 
     expect_function_call(__wrap_os_wait);
-
     expect_function_call(__wrap_start_daemon);
-    expect_value(wrap_CreateEvent, lpEventAttributes, NULL);
-    expect_value(wrap_CreateEvent, bManualReset, TRUE);
-    expect_value(wrap_CreateEvent, bInitialState, FALSE);
-    expect_value(wrap_CreateEvent, lpName, NULL);
-    will_return(wrap_CreateEvent, (HANDLE)123456);
 
     Start_win32_Syscheck();
 }

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -8,12 +8,14 @@ if(NOT ${TARGET} STREQUAL "winagent")
     target_compile_options(test_audit_healthcheck PRIVATE "-Wall")
 
     set(AUDIT_HC_FLAGS "-Wl,--wrap=_mdebug1,--wrap=_mdebug2 -Wl,--wrap,audit_add_rule \
-                        -Wl,--wrap,pthread_cond_init -Wl,--wrap,pthread_cond_wait -Wl,--wrap,pthread_mutex_lock \
+                        -Wl,--wrap,pthread_cond_wait -Wl,--wrap,pthread_mutex_lock \
                         -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,CreateThread \
                         -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
                         -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc \
                         -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink -Wl,--wrap,audit_delete_rule \
-                        -Wl,--wrap,select -Wl,--wrap,audit_parse -Wl,--wrap=abspath")
+                        -Wl,--wrap,select -Wl,--wrap,audit_parse -Wl,--wrap=abspath -Wl,--wrap,atomic_int_get \
+                        -Wl,--wrap,atomic_int_set -Wl,--wrap,atomic_int_dec -Wl,--wrap,atomic_int_inc \
+                        -Wl,--wrap,pthread_cond_timedwait -Wl,--wrap,gettime")
 
     target_link_libraries(test_audit_healthcheck SYSCHECK_O ${TEST_DEPS})
 
@@ -31,7 +33,8 @@ if(NOT ${TARGET} STREQUAL "winagent")
                               -Wl,--wrap=fread,--wrap=fseek,--wrap=fwrite,--wrap=remove,--wrap=fgetc \
                               -Wl,--wrap=getpid,--wrap=sleep,--wrap=unlink,--wrap=audit_delete_rule \
                               -Wl,--wrap=select,--wrap=audit_parse,--wrap=audit_get_rule_list,--wrap=audit_close \
-                              -Wl,--wrap=search_audit_rule,--wrap=audit_open")
+                              -Wl,--wrap=search_audit_rule,--wrap=audit_open -Wl,--wrap,atomic_int_get \
+                              -Wl,--wrap,atomic_int_set -Wl,--wrap,atomic_int_dec -Wl,--wrap,atomic_int_inc")
 
     target_link_libraries(test_audit_rule_handling SYSCHECK_O ${TEST_DEPS})
 
@@ -44,7 +47,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
 
     set(SYSCHECK_AUDIT_FLAGS "-Wl,--wrap,_mdebug1,--wrap,_mdebug2 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
                               -Wl,--wrap,_minfo -Wl,--wrap,pthread_cond_wait -Wl,--wrap,pthread_mutex_lock \
-                              -Wl,--wrap,openproc -Wl,--wrap,readproc -Wl,--wrap,freeproc -Wl,--wrap,FOREVER \
+                              -Wl,--wrap,openproc -Wl,--wrap,readproc -Wl,--wrap,freeproc \
                               -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,audit_add_rule -Wl,--wrap,audit_restart  \
                               -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,closeproc  -Wl,--wrap,recv -Wl,--wrap,IsDir \
                               -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,IsSocket -Wl,--wrap,fprintf \
@@ -53,7 +56,8 @@ if(NOT ${TARGET} STREQUAL "winagent")
                               -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink -Wl,--wrap,audit_delete_rule \
                               -Wl,--wrap,select -Wl,--wrap,audit_parse -Wl,--wrap,symlink -Wl,--wrap,SendMSG \
                               -Wl,--wrap,audit_get_rule_list -Wl,--wrap,fim_audit_reload_rules \
-                              -Wl,--wrap,search_audit_rule -Wl,--wrap,abspath")
+                              -Wl,--wrap,search_audit_rule -Wl,--wrap,abspath -Wl,--wrap,atomic_int_get \
+                              -Wl,--wrap,atomic_int_set -Wl,--wrap,atomic_int_dec -Wl,--wrap,atomic_int_inc")
 
     target_link_libraries(test_syscheck_audit SYSCHECK_O ${TEST_DEPS})
 
@@ -73,7 +77,9 @@ if(NOT ${TARGET} STREQUAL "winagent")
                            -Wl,--wrap,get_user -Wl,--wrap,get_group -Wl,--wrap,readlink -Wl,--wrap,audit_get_rule_list \
                            -Wl,--wrap,SendMSG -Wl,--wrap,fim_whodata_event -Wl,--wrap,search_audit_rule \
                            -Wl,--wrap,audit_close -Wl,--wrap,fim_manipulated_audit_rules \
-                           -Wl,--wrap,fim_audit_reload_rules -Wl,--wrap,remove_audit_rule_syscheck")
+                           -Wl,--wrap,fim_audit_reload_rules -Wl,--wrap,remove_audit_rule_syscheck \
+                           -Wl,--wrap,atomic_int_get -Wl,--wrap,atomic_int_set -Wl,--wrap,atomic_int_dec \
+                           -Wl,--wrap,atomic_int_inc")
 
     target_link_libraries(test_audit_parse SYSCHECK_O ${TEST_DEPS})
 

--- a/src/unit_tests/syscheckd/whodata/test_audit_healthcheck.c
+++ b/src/unit_tests/syscheckd/whodata/test_audit_healthcheck.c
@@ -38,7 +38,7 @@ extern atomic_int_t audit_health_check_creation;
 extern atomic_int_t hc_thread_active;
 extern atomic_int_t audit_thread_active;
 extern pthread_mutex_t audit_hc_mutex;
-extern pthread_cond_t audit_hc_started;
+extern pthread_cond_t audit_hc_cond;
 
 extern void __real_atomic_int_set(atomic_int_t *atomic, int value);
 extern int __real_atomic_int_get(atomic_int_t *atomic);
@@ -76,7 +76,7 @@ void prepare_audit_healthcheck_thread() {
 
     expect_value(__wrap_atomic_int_get, atomic, &hc_thread_active);
     will_return(__wrap_atomic_int_get, 0);
-    expect_value(__wrap_pthread_cond_wait, cond, &audit_hc_started);
+    expect_value(__wrap_pthread_cond_wait, cond, &audit_hc_cond);
     expect_value(__wrap_pthread_cond_wait, mutex, &audit_hc_mutex);
 
     expect_value(__wrap_atomic_int_get, atomic, &hc_thread_active);

--- a/src/unit_tests/syscheckd/whodata/test_audit_healthcheck.c
+++ b/src/unit_tests/syscheckd/whodata/test_audit_healthcheck.c
@@ -23,16 +23,25 @@
 #include "wrappers/wazuh/shared/audit_op_wrappers.h"
 #include "wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "wrappers/wazuh/shared/file_op_wrappers.h"
+#include "wrappers/wazuh/shared/atomic_wrappers.h"
+#include "wrappers/wazuh/shared/time_op_wrappers.h"
+#include "wrappers/wazuh/shared/pthreads_op_wrappers.h"
+
+
 #include "wrappers/wazuh/syscheckd/audit_parse_wrappers.h"
 
 
 #define PERMS (AUDIT_PERM_WRITE | AUDIT_PERM_ATTR)
 
 
-extern volatile int audit_health_check_creation;
-extern volatile int hc_thread_active;
-extern volatile int audit_thread_active;
-int hc_success = 0;
+extern atomic_int_t audit_health_check_creation;
+extern atomic_int_t hc_thread_active;
+extern atomic_int_t audit_thread_active;
+extern pthread_mutex_t audit_hc_mutex;
+extern pthread_cond_t audit_hc_started;
+
+extern void __real_atomic_int_set(atomic_int_t *atomic, int value);
+extern int __real_atomic_int_get(atomic_int_t *atomic);
 
 /* setup/teardown */
 static int setup_group(void **state) {
@@ -49,47 +58,52 @@ static int teardown_group(void **state) {
     return 0;
 }
 
-static int setup_hc_success(void **state) {
-    hc_success = 1;
-    audit_health_check_creation = 1;
-    return 0;
-}
-
-static int teardown_hc_success(void **state) {
-    hc_success = 0;
-    audit_health_check_creation = 0;
-
-    return 0;
-}
-
-int __wrap_pthread_cond_init(pthread_cond_t *__cond, const pthread_condattr_t *__cond_attr) {
+int __wrap_pthread_cond_timedwait(pthread_cond_t *restrict cond, pthread_mutex_t *restrict mutex,
+                                   const struct timespec *restrict abstime) {
     function_called();
     return 0;
 }
 
-int __wrap_pthread_cond_wait(pthread_cond_t *__cond, pthread_mutex_t *__mutex) {
-    function_called();
+/**
+ * @brief Functions that prepares the wraps calls for starting the audit healthcheck thread
+ */
+void prepare_audit_healthcheck_thread() {
+    will_return(__wrap_audit_add_rule, -EEXIST);
 
-    hc_thread_active = 1;
+    expect_string(__wrap__mdebug1, formatted_msg, FIM_AUDIT_HEALTHCHECK_START);
 
-    return 0;
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_value(__wrap_atomic_int_get, atomic, &hc_thread_active);
+    will_return(__wrap_atomic_int_get, 0);
+    expect_value(__wrap_pthread_cond_wait, cond, &audit_hc_started);
+    expect_value(__wrap_pthread_cond_wait, mutex, &audit_hc_mutex);
+
+    expect_value(__wrap_atomic_int_get, atomic, &hc_thread_active);
+    will_return(__wrap_atomic_int_get, 1);
+    expect_function_call(__wrap_pthread_mutex_unlock);
 }
 
-int __wrap_pthread_mutex_lock (pthread_mutex_t *__mutex) {
-    function_called();
-    return 0;
-}
 
-int __wrap_pthread_mutex_unlock (pthread_mutex_t *__mutex) {
-    function_called();
-    return 0;
-}
+/**
+ * @brief Functions that prepares the wraps calls for stopping the audit healthcheck thread
+ */
+void prepare_post_audit_healthcheck_thread() {
+    expect_string(__wrap_unlink, file, AUDIT_HEALTHCHECK_FILE);
+    will_return(__wrap_unlink, 0);
 
-int __wrap_CreateThread(void * (*function_pointer)(void *), void *data) {
-    if(hc_success) {
-        audit_health_check_creation = 1;
-    }
-    return 1;
+    expect_string(__wrap_audit_delete_rule, path, AUDIT_HEALTHCHECK_DIR);
+    expect_value(__wrap_audit_delete_rule, perms, PERMS);
+    expect_string(__wrap_audit_delete_rule, key, "wazuh_hc");
+    will_return(__wrap_audit_delete_rule, 1);
+
+    expect_value(__wrap_atomic_int_set, atomic, &hc_thread_active);
+    will_return(__wrap_atomic_int_set, 0);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    will_return(__wrap_gettime, 1232);
+    expect_function_call(__wrap_pthread_cond_timedwait);
+    expect_function_call(__wrap_pthread_mutex_unlock);
 }
 
 /* audit_health_check() tests */
@@ -106,25 +120,23 @@ void test_audit_health_check_fail_to_add_rule(void **state) {
     ret = audit_health_check(123456);
 
     assert_int_equal(ret, -1);
-    assert_int_equal(hc_thread_active, 0);
+    assert_int_equal(hc_thread_active.data, 0);
 }
 
 void test_audit_health_check_fail_to_create_hc_file(void **state) {
     int ret;
-
-    hc_thread_active = 0;
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    __real_atomic_int_set(&hc_thread_active, 1);
 
     expect_abspath(AUDIT_HEALTHCHECK_DIR, 1);
     expect_abspath(AUDIT_HEALTHCHECK_FILE, 1);
 
-    will_return(__wrap_audit_add_rule, -EEXIST);
-
-    expect_string(__wrap__mdebug1, formatted_msg, FIM_AUDIT_HEALTHCHECK_START);
-
-    expect_function_call(__wrap_pthread_cond_init);
     expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_cond_wait);
     expect_function_call(__wrap_pthread_mutex_unlock);
+    __real_atomic_int_set(&audit_health_check_creation, 0);
+
+    prepare_audit_healthcheck_thread();
 
     expect_string_count(__wrap_fopen, path, AUDIT_HEALTHCHECK_FILE, 10);
     expect_string_count(__wrap_fopen, mode, "w", 10);
@@ -133,39 +145,34 @@ void test_audit_health_check_fail_to_create_hc_file(void **state) {
     expect_string_count(__wrap__mdebug1, formatted_msg, FIM_AUDIT_HEALTHCHECK_FILE, 10);
 
     expect_value_count(__wrap_sleep, seconds, 1, 10);
-
+    expect_value_count(__wrap_atomic_int_get, atomic, &audit_health_check_creation, 10);
+    will_return_count(__wrap_atomic_int_get, 0, 10);
+    // outside do while
+    expect_value(__wrap_atomic_int_get, atomic, &audit_health_check_creation);
+    will_return(__wrap_atomic_int_get, 0);
     expect_string(__wrap__mdebug1, formatted_msg, FIM_HEALTHCHECK_CREATE_ERROR);
 
-    expect_string(__wrap_unlink, file, AUDIT_HEALTHCHECK_FILE);
-    will_return(__wrap_unlink, 0);
-
-    expect_string(__wrap_audit_delete_rule, path, AUDIT_HEALTHCHECK_DIR);
-    expect_value(__wrap_audit_delete_rule, perms, PERMS);
-    expect_string(__wrap_audit_delete_rule, key, "wazuh_hc");
-    will_return(__wrap_audit_delete_rule, 1);
+    prepare_post_audit_healthcheck_thread();
 
     ret = audit_health_check(123456);
 
     assert_int_equal(ret, -1);
-    assert_int_equal(hc_thread_active, 0);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    assert_int_equal(__real_atomic_int_get(&hc_thread_active), 0);
 }
 
 void test_audit_health_check_no_creation_event_detected(void **state) {
     int ret;
 
-    hc_thread_active = 0;
-
     expect_abspath(AUDIT_HEALTHCHECK_DIR, 1);
     expect_abspath(AUDIT_HEALTHCHECK_FILE, 1);
 
-    will_return(__wrap_audit_add_rule, -EEXIST);
-
-    expect_string(__wrap__mdebug1, formatted_msg, FIM_AUDIT_HEALTHCHECK_START);
-
-    expect_function_call(__wrap_pthread_cond_init);
     expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_cond_wait);
     expect_function_call(__wrap_pthread_mutex_unlock);
+    __real_atomic_int_set(&hc_thread_active, 0);
+
+    prepare_audit_healthcheck_thread();
 
     expect_string_count(__wrap_fopen, path, AUDIT_HEALTHCHECK_FILE, 10);
     expect_string_count(__wrap_fopen, mode, "w", 10);
@@ -175,39 +182,36 @@ void test_audit_health_check_no_creation_event_detected(void **state) {
     will_return_count(__wrap_fclose, 0, 10);
 
     expect_value_count(__wrap_sleep, seconds, 1, 10);
+    expect_value_count(__wrap_atomic_int_get, atomic, &audit_health_check_creation, 10);
+    will_return_count(__wrap_atomic_int_get, 0, 10);
 
+    // outside the loop
+    expect_value(__wrap_atomic_int_get, atomic, &audit_health_check_creation);
+    will_return(__wrap_atomic_int_get, 0);
     expect_string(__wrap__mdebug1, formatted_msg, FIM_HEALTHCHECK_CREATE_ERROR);
 
-    expect_string(__wrap_unlink, file, AUDIT_HEALTHCHECK_FILE);
-    will_return(__wrap_unlink, 0);
-
-    expect_string(__wrap_audit_delete_rule, path, AUDIT_HEALTHCHECK_DIR);
-    expect_value(__wrap_audit_delete_rule, perms, PERMS);
-    expect_string(__wrap_audit_delete_rule, key, "wazuh_hc");
-    will_return(__wrap_audit_delete_rule, 1);
+    prepare_post_audit_healthcheck_thread();
 
     ret = audit_health_check(123456);
 
     assert_int_equal(ret, -1);
-    assert_int_equal(hc_thread_active, 0);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    assert_int_equal(__real_atomic_int_get(&hc_thread_active), 0);
 }
 
 void test_audit_health_check_success(void **state) {
     int ret;
 
-    hc_thread_active = 0;
-
     expect_abspath(AUDIT_HEALTHCHECK_DIR, 1);
     expect_abspath(AUDIT_HEALTHCHECK_FILE, 1);
 
-    will_return(__wrap_audit_add_rule, 1);
-
-    expect_string(__wrap__mdebug1, formatted_msg, FIM_AUDIT_HEALTHCHECK_START);
-
-    expect_function_call(__wrap_pthread_cond_init);
     expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_cond_wait);
     expect_function_call(__wrap_pthread_mutex_unlock);
+    __real_atomic_int_set(&hc_thread_active, 0);
+
+    prepare_audit_healthcheck_thread();
 
     expect_string(__wrap_fopen, path, AUDIT_HEALTHCHECK_FILE);
     expect_string(__wrap_fopen, mode, "w");
@@ -217,21 +221,22 @@ void test_audit_health_check_success(void **state) {
     will_return(__wrap_fclose, 0);
 
     expect_value(__wrap_sleep, seconds, 1);
+    expect_value(__wrap_atomic_int_get, atomic, &audit_health_check_creation);
+    will_return(__wrap_atomic_int_get, 1);
 
+    // outside the loop
+    expect_value(__wrap_atomic_int_get, atomic, &audit_health_check_creation);
+    will_return(__wrap_atomic_int_get, 1);
     expect_string(__wrap__mdebug1, formatted_msg, FIM_HEALTHCHECK_SUCCESS);
 
-    expect_string(__wrap_unlink, file, AUDIT_HEALTHCHECK_FILE);
-    will_return(__wrap_unlink, 0);
-
-    expect_string(__wrap_audit_delete_rule, path, AUDIT_HEALTHCHECK_DIR);
-    expect_value(__wrap_audit_delete_rule, perms, PERMS);
-    expect_string(__wrap_audit_delete_rule, key, "wazuh_hc");
-    will_return(__wrap_audit_delete_rule, 1);
+    prepare_post_audit_healthcheck_thread();
 
     ret = audit_health_check(123456);
-
     assert_int_equal(ret, 0);
-    assert_int_equal(hc_thread_active, 0);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    assert_int_equal(__real_atomic_int_get(&hc_thread_active), 0);
 }
 
 
@@ -240,7 +245,7 @@ int main(void) {
        cmocka_unit_test(test_audit_health_check_fail_to_add_rule),
         cmocka_unit_test(test_audit_health_check_fail_to_create_hc_file),
         cmocka_unit_test(test_audit_health_check_no_creation_event_detected),
-        cmocka_unit_test_setup_teardown(test_audit_health_check_success, setup_hc_success, teardown_hc_success),
+        cmocka_unit_test(test_audit_health_check_success),
         };
 
     return cmocka_run_group_tests(tests, setup_group, teardown_group);

--- a/src/unit_tests/syscheckd/whodata/test_audit_parse.c
+++ b/src/unit_tests/syscheckd/whodata/test_audit_parse.c
@@ -549,6 +549,8 @@ void test_audit_parse_delete_recursive(void **state) {
     expect_string_count(__wrap__mwarn, formatted_msg, FIM_WARN_AUDIT_RULES_MODIFIED, 5);
     expect_function_calls(__wrap_fim_audit_reload_rules, 4);
 
+    expect_value(__wrap_atomic_int_set, atomic, &audit_thread_active);
+    will_return(__wrap_atomic_int_set, 0);
 
     expect_string_count(__wrap_SendMSG, message, "ossec: Audit: Detected rules manipulation: Audit rules removed", 5);
     expect_string_count(__wrap_SendMSG, locmsg, SYSCHECK, 6);
@@ -765,7 +767,7 @@ void test_audit_parse_rm_hc(void **state) {
 
 void test_audit_parse_add_hc(void **state) {
     (void) state;
-
+    extern atomic_int_t audit_health_check_creation;
     char * buffer = " \
         type=SYSCALL msg=audit(1571988027.797:3004340): arch=c000003e syscall=257 success=yes exit=0 a0=ffffff9c a1=55578e6d8490 a2=200 a3=7f9cd931bca0 items=3 ppid=3211 pid=56650 auid=2 uid=30 gid=5 euid=2 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts3 ses=5 comm=\"touch\" exe=\"/usr/bin/touch\" key=\"wazuh_hc\" \
         type=CWD msg=audit(1571988027.797:3004340): cwd=\"/root/test\" \
@@ -777,6 +779,9 @@ void test_audit_parse_add_hc(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6251): Match audit_key: 'key=\"wazuh_hc\"'");
     expect_string(__wrap__mdebug2, formatted_msg, "(6252): Whodata health-check: Detected file creation event (257)");
+
+    expect_value(__wrap_atomic_int_set, atomic, &audit_health_check_creation);
+    will_return(__wrap_atomic_int_set, 1);
 
     audit_parse(buffer);
 }

--- a/src/unit_tests/syscheckd/whodata/test_audit_rule_handling.c
+++ b/src/unit_tests/syscheckd/whodata/test_audit_rule_handling.c
@@ -64,6 +64,8 @@ extern OSList *whodata_directories;
 
 extern int audit_rule_manipulation;
 
+extern atomic_int_t audit_thread_active;
+
 /* setup/teardown */
 static int setup_group(void **state) {
     syscheck.directories = GENERAL_CONFIG;
@@ -288,6 +290,9 @@ static void test_clean_rules(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
     expect_string(__wrap__mdebug2, formatted_msg, FIM_AUDIT_DELETE_RULE);
+
+    expect_value(__wrap_atomic_int_set, atomic, &audit_thread_active);
+    will_return(__wrap_atomic_int_set, 0);
 
     expect_any_count(__wrap_audit_delete_rule, path, whodata_directories->currently_size);
     expect_any_count(__wrap_audit_delete_rule, perms, whodata_directories->currently_size);

--- a/src/unit_tests/wrappers/wazuh/shared/atomic_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/atomic_wrappers.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2020, Wazuh Inc.
+/* Copyright (C) 2015-2021, Wazuh Inc.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it

--- a/src/unit_tests/wrappers/wazuh/shared/atomic_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/atomic_wrappers.c
@@ -1,0 +1,34 @@
+/* Copyright (C) 2015-2020, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "atomic_wrappers.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+int __wrap_atomic_int_get(atomic_int_t *atomic) {
+    check_expected_ptr(atomic);
+    return mock();
+}
+
+void __wrap_atomic_int_set(atomic_int_t *atomic, __attribute__((unused)) int value) {
+    check_expected_ptr(atomic);
+    atomic->data = mock();
+}
+
+int __wrap_atomic_int_inc(atomic_int_t *atomic) {
+    check_expected_ptr(atomic);
+    return mock();
+}
+
+int __wrap_atomic_int_dec(atomic_int_t *atomic) {
+    check_expected_ptr(atomic);
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/shared/atomic_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/atomic_wrappers.h
@@ -1,0 +1,22 @@
+/* Copyright (C) 2015-2021, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+#ifndef ATOMIC_WRAPPERS
+#define ATOMIC_WRAPPERS
+
+#include "headers/atomic.h"
+
+int __wrap_atomic_int_get(atomic_int_t *atomic);
+
+void __wrap_atomic_int_set(atomic_int_t *atomic, __attribute__((unused)) int value);
+
+int __wrap_atomic_int_inc(atomic_int_t *atomic);
+
+int __wrap_atomic_int_dec(atomic_int_t *atomic);
+
+#endif //ATOMIC_WRAPPERS


### PR DESCRIPTION
|Related issue|
|---|
|#6708|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims to fix the data races reported in issue #6708.
A new shared library has been added in order to handle atomic operations.

Closes #6708

## Tests
### scheduled, realtime and whodata
***configuration***
```xml
    <directories realtime="yes">/testdir1</directories>
    <directories>/testdir2</directories>
    <directories whodata="yes">/testdir3</directories>
```
***helgrind output***
```
e monitoring: '/testdir3'
2021/03/17 07:27:40 wazuh-syscheckd[7351] audit_rule_handling.c:249 at clean_rules(): DEBUG: (6250): Deleting Audit rules.
==7351== 
==7351== Use --history-level=approx or =none to gain increased speed, at
==7351== the cost of reduced accuracy of conflicting-access information
==7351== For lists of detected and suppressed errors, rerun with: -s
==7351== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 4119 from 602)
root@ubuntuagent:/var/ossec# 
```

### Whodata
***configuration***
```xml
    <directories whodata="yes">/testdir3</directories>
```
***helgrind output***
```
2021/03/17 07:30:02 wazuh-syscheckd[7381] audit_rule_handling.c:249 at clean_rules(): DEBUG: (6250): Deleting Audit rules.
==7381== 
==7381== Use --history-level=approx or =none to gain increased speed, at
==7381== the cost of reduced accuracy of conflicting-access information
==7381== For lists of detected and suppressed errors, rerun with: -s
==7381== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 3464 from 302)
root@ubuntuagent:/var/ossec# 

```


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [ ] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] ThreadSanitizer
  - [x] Helgrind
- Memory tests for Windows
  - [ ] Scan-build report

