### PR TITLE
Add new SecurityError error code

### DIFF
--- a/api/test/integration/test_security_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_POST_endpoints.tavern.yaml
@@ -390,7 +390,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: POST
       json:
-        name: "test_i1"
+        name: "test_new_policy"
         policy:
           actions:
             - "agent:delete"
@@ -407,9 +407,9 @@ stages:
           affected_items: []
           failed_items:
             - error:
-                code: 4009
+                code: 4027
               id:
-                - test_i1
+                - test_new_policy
           total_affected_items: 0
           total_failed_items: 1
 
@@ -422,7 +422,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
       method: POST
       json:
-        name: "test_i1"
+        name: "test_invalid"
         policy:
           actions:
             - "[agent:delete"
@@ -441,7 +441,7 @@ stages:
             - error:
                 code: 4006
               id:
-                - test_i1
+                - test_invalid
           total_affected_items: 0
           total_failed_items: 1
 

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -483,7 +483,8 @@ class WazuhException(Exception):
         4007: {'message': 'The specified policy does not exist',
                'remediation': 'Please, create the specified policy with the endpoint POST /security/policies'},
         4008: {'message': 'The specified resource is required for a correct Wazuh\'s functionality'},
-        4009: {'message': 'The specified name or policy already exists'},
+        4009: {'message': 'The specified policy name already exists',
+               'remediation': 'Please, use a different name for the new policy.'},
         4010: {'message': 'The specified role-policy relation does not exist',
                'remediation': 'Please, create the specified role-policy relation with the endpoint '
                               'POST /security/roles/{role_id}/policies'},
@@ -515,6 +516,8 @@ class WazuhException(Exception):
         4025: {'message': 'The specify relationship could not be removed'},
         4026: {'message': 'The specified resource cannot be removed or updated.',
                'remediation': 'Protected resources must be updated or removed using the CLI.'},
+        4027: {'message': 'The specified policy body is already being used in another policy',
+               'remediation': 'Please, provide a different and unique policy body or use the existing policy instead.'},
         4500: {'message': 'The specified resources are invalid',
                'remediation': 'Please, make sure permissions are properly defined, '
                               f'for more information on setting up permissions please visit https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/api/rbac/configuration.html'},

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -79,7 +79,7 @@ class SecurityError(IntEnum):
     RELATIONSHIP_ERROR = -8
     # Protected resources of the system
     PROTECTED_RESOURCES = -9
-    # sqlalchemy UniqueConstraint or CheckConstraint failed
+    # Database constraint error
     CONSTRAINT_ERROR = -10
 
 

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -1479,16 +1479,16 @@ class PoliciesManager:
         True -> Success | Invalid policy | Missing key (actions, resources, effect) or invalid policy (regex)
         """
         try:
-            # Check if the specified policy name is already in use
-            if self.get_policy(name) != SecurityError.POLICY_NOT_EXIST:
-                return SecurityError.ALREADY_EXIST
-
             # Check if the policy body is valid
             if not policy or not json_validator(policy) or len(policy.keys()) != 3:
                 return SecurityError.INVALID
 
+            # Check if the specified policy name is already in use
+            if self.get_policy(name) != SecurityError.POLICY_NOT_EXIST:
+                return SecurityError.ALREADY_EXIST
+
             # To add a policy it must have the keys actions, resources, effect
-            if 'actions' in policy.keys() and 'resources' in policy.keys() and 'effect' in policy.keys():
+            if 'actions' in policy and 'resources' in policy and 'effect' in policy:
                 # The keys actions and resources must be lists and the key effect must be str
                 if isinstance(policy['actions'], list) and isinstance(policy['resources'], list) \
                         and isinstance(policy['effect'], str):
@@ -2778,7 +2778,7 @@ class DatabaseManager:
                                       hash_password=True,
                                       resource_type=resource_type,
                                       check_default=check_default)
-                auth_manager.edit_run_as(user_id=auth.get_user(username=d_username)['id'],
+                auth_manager.edit_run_as(user_id=auth_manager.get_user(username=d_username)['id'],
                                          allow_run_as=payload['allow_run_as'])
 
         old_roles = get_data(Roles, Roles.id)

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -79,8 +79,8 @@ class SecurityError(IntEnum):
     RELATIONSHIP_ERROR = -8
     # Protected resources of the system
     PROTECTED_RESOURCES = -9
-    # A policy with the same body but different name already exists in the database
-    POLICY_BODY_ALREADY_EXIST = -10
+    # sqlalchemy UniqueConstraint or CheckConstraint failed
+    CONSTRAINT_ERROR = -10
 
 
 class ResourceType(Enum):
@@ -1524,7 +1524,7 @@ class PoliciesManager:
                 return SecurityError.INVALID
         except IntegrityError:
             self.session.rollback()
-            return SecurityError.POLICY_BODY_ALREADY_EXIST
+            return SecurityError.CONSTRAINT_ERROR
 
     def delete_policy(self, policy_id: int):
         """Delete an existent policy in the system. This function can remove a resource regardless of its resource_type.

--- a/framework/wazuh/rbac/tests/test_orm.py
+++ b/framework/wazuh/rbac/tests/test_orm.py
@@ -167,6 +167,14 @@ def test_add_policy(orm_setup):
             # Obtain not existent policy
             assert pm.get_policy('noexist') == orm_setup.SecurityError.POLICY_NOT_EXIST
 
+            # Attempt to insert a duplicate policy (same body, different name)
+            assert pm.add_policy(name='newPolicyName',
+                                 policy=policy) == orm_setup.SecurityError.POLICY_BODY_ALREADY_EXIST
+
+            # Attempt to insert a duplicate policy (same name, different body)
+            policy['actions'] = ['agents:read']
+            assert pm.add_policy(name='newPolicy1', policy=policy) == orm_setup.SecurityError.ALREADY_EXIST
+
 
 def test_add_rule(orm_setup):
     """Check rules in the database"""

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -650,7 +650,7 @@ def add_policy(name: str = None, policy: str = None, resource_type: ResourceType
             result.add_failed_item(id_=name, error=WazuhError(4009))
         elif status == SecurityError.INVALID:
             result.add_failed_item(id_=name, error=WazuhError(4006))
-        elif status == SecurityError.POLICY_BODY_ALREADY_EXIST:
+        elif status == SecurityError.CONSTRAINT_ERROR:
             result.add_failed_item(id_=name, error=WazuhError(4027))
         else:
             result.affected_items.append(pm.get_policy(name=name))

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -646,10 +646,12 @@ def add_policy(name: str = None, policy: str = None, resource_type: ResourceType
                                       all_msg='Policy was successfully created')
     with PoliciesManager() as pm:
         status = pm.add_policy(name=name, policy=policy, resource_type=resource_type)
-        if status == SecurityError.ALREADY_EXIST or status == SecurityError.POLICY_BODY_ALREADY_EXIST:
+        if status == SecurityError.ALREADY_EXIST:
             result.add_failed_item(id_=name, error=WazuhError(4009))
         elif status == SecurityError.INVALID:
             result.add_failed_item(id_=name, error=WazuhError(4006))
+        elif status == SecurityError.POLICY_BODY_ALREADY_EXIST:
+            result.add_failed_item(id_=name, error=WazuhError(4027))
         else:
             result.affected_items.append(pm.get_policy(name=name))
             result.total_affected_items += 1

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -646,7 +646,7 @@ def add_policy(name: str = None, policy: str = None, resource_type: ResourceType
                                       all_msg='Policy was successfully created')
     with PoliciesManager() as pm:
         status = pm.add_policy(name=name, policy=policy, resource_type=resource_type)
-        if status == SecurityError.ALREADY_EXIST:
+        if status == SecurityError.ALREADY_EXIST or status == SecurityError.POLICY_BODY_ALREADY_EXIST:
             result.add_failed_item(id_=name, error=WazuhError(4009))
         elif status == SecurityError.INVALID:
             result.add_failed_item(id_=name, error=WazuhError(4006))

--- a/framework/wazuh/tests/data/security/policies_test_cases.yml
+++ b/framework/wazuh/tests/data/security/policies_test_cases.yml
@@ -144,6 +144,19 @@ add_policy:
       failed_items:
         "4009":
           - wazuhPolicy
+  - params:
+      name: valid_policy_name
+      policy:
+        actions:
+          - policy:read
+        effect: deny
+        resources:
+          - policy:id:*
+    result:
+      affected_items: []
+      failed_items:
+        "4027":
+          - valid_policy_name
 update_policy:
   - params:
       policy_id:

--- a/framework/wazuh/tests/data/security/users_test_cases.yml
+++ b/framework/wazuh/tests/data/security/users_test_cases.yml
@@ -10,6 +10,7 @@ edit_run_as:
           allow_run_as: false
           roles:
             - 1
+          resource_type: default
       failed_items: {}
   - params:
       user_id: 2
@@ -21,6 +22,7 @@ edit_run_as:
           allow_run_as: true
           roles:
             - 1
+          resource_type: default
       failed_items: {}
   - params:
       user_id: 2


### PR DESCRIPTION
Hello team,

This PR closes #7804.

A new `SecurityError` error code named `CONSTRAINT_ERROR` has been created for the `orm` module. This new error code can be used to identify when a policy addition is rejected because the policy body is already in use and when is rejected because the name of the policy is already being used by another policy.

Here is the list of changed introduced:

- New `SecurityError` error code added (`CONSTRAINT_ERROR`)
- `add_policy function` in orm module updated to use the new `SecurityError`
- New exception (4027) has been added.
- `security` module updated to use the new exception.
- `test_orm unit` test updated accordingly.
- API security integration tests updated accordingly

## Unit test results
```
============================================= test session starts ==============================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/wazuh/framework
plugins: metadata-1.11.0, tavern-1.0.0, html-3.1.1, testinfra-5.0.0
collected 753 items                                                                                            

framework/wazuh/tests/test_active_response.py ............                                               [  1%]
framework/wazuh/tests/test_agent.py .................................................................... [ 10%]
................                                                                                         [ 12%]
framework/wazuh/tests/test_cdb_list.py .....................................................             [ 19%]
framework/wazuh/tests/test_ciscat.py .................................                                   [ 24%]
framework/wazuh/tests/test_cluster.py .....ss                                                            [ 25%]
framework/wazuh/tests/test_decoder.py ...................................                                [ 29%]
framework/wazuh/tests/test_group.py ........                                                             [ 30%]
framework/wazuh/tests/test_logtest.py ......                                                             [ 31%]
framework/wazuh/tests/test_manager.py .................................                                  [ 35%]
framework/wazuh/tests/test_mitre.py .................................................................... [ 45%]
........................................................................................................ [ 58%]
........                                                                                                 [ 59%]
framework/wazuh/tests/test_rootcheck.py .................................................                [ 66%]
framework/wazuh/tests/test_rule.py ........................................................              [ 73%]
framework/wazuh/tests/test_sca.py .......                                                                [ 74%]
framework/wazuh/tests/test_security.py ................................................................. [ 83%]
...........................................EE                                                            [ 89%]
framework/wazuh/tests/test_stats.py ................                                                     [ 91%]
framework/wazuh/tests/test_syscheck.py ........................                                          [ 94%]
framework/wazuh/tests/test_syscollector.py ............                                                  [ 96%]
framework/wazuh/tests/test_task.py ............................                                          [100%]
======================== 749 passed, 2 skipped, 15 warnings, 2 error in 121.57 seconds =========================
```

**Note**: Two `test_security` tests are failing due because these tests introduced in https://github.com/wazuh/wazuh/pull/7594 must be adapted to the changes of this rbac migration branch. It will be fixed in https://github.com/wazuh/wazuh/issues/7799

```
============================================= test session starts ==============================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/wazuh/framework
plugins: metadata-1.11.0, tavern-1.0.0, html-3.1.1, testinfra-5.0.0
collected 651 items                                                                                            

framework/wazuh/core/tests/test_active_response.py ..............                                        [  2%]
framework/wazuh/core/tests/test_agent.py ............................................................... [ 11%]
...........................................................................................              [ 25%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                       [ 31%]
framework/wazuh/core/tests/test_common.py .......                                                        [ 32%]
framework/wazuh/core/tests/test_configuration.py ....................................                    [ 38%]
framework/wazuh/core/tests/test_decoder.py ................                                              [ 40%]
framework/wazuh/core/tests/test_input_validator.py ...                                                   [ 41%]
framework/wazuh/core/tests/test_logtest.py ..                                                            [ 41%]
framework/wazuh/core/tests/test_manager.py .................                                             [ 44%]
framework/wazuh/core/tests/test_pyDaemonModule.py ......                                                 [ 45%]
framework/wazuh/core/tests/test_results.py ........................................                      [ 51%]
framework/wazuh/core/tests/test_rootcheck.py ..........                                                  [ 52%]
framework/wazuh/core/tests/test_rule.py ......................                                           [ 56%]
framework/wazuh/core/tests/test_stats.py ....                                                            [ 56%]
framework/wazuh/core/tests/test_syscollector.py ...                                                      [ 57%]
framework/wazuh/core/tests/test_utils.py ............................................................... [ 66%]
........................................................................................................ [ 82%]
....................................................                                                     [ 90%]
framework/wazuh/core/tests/test_wazuh_queue.py ...................                                       [ 93%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                     [ 96%]
framework/wazuh/core/tests/test_wdb.py .....................                                             [100%]
=================================== 651 passed, 11 warnings in 2.73 seconds ====================================
```

```
============================================= test session starts ==============================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/wazuh/framework
plugins: metadata-1.11.0, tavern-1.0.0, html-3.1.1, testinfra-5.0.0
collected 226 items                                                                                            

framework/wazuh/rbac/tests/test_auth_context.py ..                                                       [  0%]
framework/wazuh/rbac/tests/test_decorators.py .......................................................... [ 26%]
...............................................                                                          [ 47%]
framework/wazuh/rbac/tests/test_default_configuration.py ............................................... [ 68%]
.......                                                                                                  [ 71%]
framework/wazuh/rbac/tests/test_orm.py ......................................................            [ 95%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                              [100%]
=================================== 226 passed, 1 warnings in 339.03 seconds ===================================
```

## API integration tests results

```
test_rbac_black_security_endpoints.tavern.yaml 
	 25 passed, 1 warnings

test_rbac_white_security_endpoints.tavern.yaml 
	 25 passed, 1 warnings

test_security_DELETE_endpoints.tavern.yaml 
	 15 passed, 1 warnings

test_security_GET_endpoints.tavern.yaml 
	 18 passed, 1 warnings

test_security_POST_endpoints.tavern.yaml 
	 7 passed, 1 warnings

test_security_PUT_endpoints.tavern.yaml 
	 9 passed, 1 warnings


```
