### PR TITLE
Clean dangling agent group files by Modulesd

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -2132,6 +2132,33 @@ void test_wdb_get_agent_name_success(void **state) {
     os_free(name);
 }
 
+void test_wdb_get_agent_name_not_found(void **state) {
+    cJSON *root = NULL;
+    cJSON *row = NULL;
+    cJSON *str = NULL;
+    int id = 1;
+    char *name = NULL;
+
+    root = __real_cJSON_CreateArray();
+    __real_cJSON_AddItemToArray(root, row);
+
+    // Calling Wazuh DB
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, root);
+
+    // Getting JSON data
+    will_return(__wrap_cJSON_GetObjectItem, str);
+
+    expect_function_call(__wrap_cJSON_Delete);
+
+    name = wdb_get_agent_name(id, NULL);
+
+    assert_string_equal("", name);
+
+    __real_cJSON_Delete(root);
+    os_free(name);
+}
+
 /* Tests wdb_remove_agent_db */
 
 void test_wdb_remove_agent_db_error_removing_db(void **state) {
@@ -4830,6 +4857,7 @@ int main()
         /* Tests wdb_get_agent_name */
         cmocka_unit_test_setup_teardown(test_wdb_get_agent_name_error_no_json_response, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_get_agent_name_success, setup_wdb_global_helpers, teardown_wdb_global_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_get_agent_name_not_found, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         /* Tests wdb_remove_agent_db */
         cmocka_unit_test_setup_teardown(test_wdb_remove_agent_db_error_removing_db, setup_wdb_global_helpers, teardown_wdb_global_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_remove_agent_db_error_removing_db_shm_wal, setup_wdb_global_helpers, teardown_wdb_global_helpers),

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -685,6 +685,8 @@ char* wdb_get_agent_name(int id, int *sock) {
     json_name = cJSON_GetObjectItem(root->child,"name");
     if (cJSON_IsString(json_name) && json_name->valuestring != NULL) {
         os_strdup(json_name->valuestring, output);
+    } else {
+        os_strdup("", output);
     }
 
     cJSON_Delete(root);
@@ -900,7 +902,7 @@ int wdb_remove_agent(int id, int *sock) {
             if (WDBC_OK == wdbc_parse_result(wdboutput, &payload)) {
                 result = wdb_delete_agent_belongs(id, query_sock);
 
-                if ((OS_SUCCESS == result) && name &&
+                if ((OS_SUCCESS == result) && name && *name &&
                      OS_INVALID == wdb_remove_agent_db(id, name)) {
                      mdebug1("Unable to remove agent DB: %d - %s", id, name);
                 }

--- a/src/wazuh_db/helpers/wdb_global_helpers.h
+++ b/src/wazuh_db/helpers/wdb_global_helpers.h
@@ -190,7 +190,9 @@ cJSON* wdb_get_agent_labels(int id, int *sock);
  *
  * @param[in] id Id of the agent that the name must be selected.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
- * @return A string with the agent name on success or NULL on failure.
+ * @return A string with the agent name on success.
+ * @retval "" when the agent is not found.
+ * @retval NULL on database failure.
  */
 char* wdb_get_agent_name(int id, int *sock);
 

--- a/src/wazuh_db/wdb_fim.c
+++ b/src/wazuh_db/wdb_fim.c
@@ -202,6 +202,11 @@ int wdb_delete_fim(int id) {
     if (!name)
         return -1;
 
+    if (*name == '\0') {
+        free(name);
+        return -1;
+    }
+
     db = wdb_open_agent(id, name);
     free(name);
 

--- a/src/wazuh_db/wdb_rootcheck.c
+++ b/src/wazuh_db/wdb_rootcheck.c
@@ -77,6 +77,11 @@ int wdb_delete_pm(int id) {
     if (!name)
         return -1;
 
+    if (*name == '\0') {
+        free(name);
+        return -1;
+    }
+
     db = wdb_open_agent(id, name);
     free(name);
 

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -336,17 +336,19 @@ void wm_clean_dangling_db() {
                 *end = 0;
 
                 if (name = wdb_get_agent_name(atoi(dirent->d_name), &wdb_wmdb_sock), name) {
-                    // Agent found: OK
-                    free(name);
-                } else {
-                    *end = '-';
+                    if (*name == '\0') {
+                        // Agent not found.
+                        *end = '-';
 
-                    if (snprintf(path, sizeof(path), "%s/%s", dirname, dirent->d_name) < (int)sizeof(path)) {
-                        mtwarn(WM_DATABASE_LOGTAG, "Removing dangling DB file: '%s'", path);
-                        if (remove(path) < 0) {
-                            mtdebug1(WM_DATABASE_LOGTAG, DELETE_ERROR, path, errno, strerror(errno));
+                        if (snprintf(path, sizeof(path), "%s/%s", dirname, dirent->d_name) < (int)sizeof(path)) {
+                            mtwarn(WM_DATABASE_LOGTAG, "Removing dangling DB file: '%s'", path);
+                            if (remove(path) < 0) {
+                                mtdebug1(WM_DATABASE_LOGTAG, DELETE_ERROR, path, errno, strerror(errno));
+                            }
                         }
                     }
+
+                    free(name);
                 }
             } else {
                 mtwarn(WM_DATABASE_LOGTAG, "Strange file found: '%s/%s'", dirname, dirent->d_name);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7856|

This PR aims to introduce two change into the agent database synchronization module:

1. If a valid numeric file appears in the folder `queue/agent-info`, but it does not refer to an existing agent, the module shall delete the file.
2. Scan the folder `queue/agent-info` in the first and scheduled synchronization stages. Find every file related to a non-existing agent and delete it.

## Changes affecting shared components

`wdb_get_agent_name()` returned `NULL` when it failed to find an agent, either because the agent was not found or due to a database connection failure. From now on, `wdb_get_agent_name()` returns an empty string ("").

## Affected artifacts

- `wazuh-modulesd` on the manager.

## Logs/Alerts example

- Find a strange file on startup:
```
2021/03/12 14:40:11 wazuh-modulesd:database: WARNING: Strange file found: '/var/ossec/queue/agent-groups/invalid1'
```

- Find a newly pushed strange file:
```
2021/03/12 14:40:24 wazuh-modulesd:database: ERROR: Couldn't extract agent ID from file /var/ossec/queue/agent-groups/invalid2
```

- Find a file belonging to a non-existing agent:
```
2021/03/12 14:44:27 wazuh-modulesd:database[43371] wm_database.c:499 at wm_sync_file(): DEBUG: Synchronizing file '/var/ossec/queue/agent-groups/002'
2021/03/12 14:44:27 wazuh-modulesd:database[43371] wm_database.c:531 at wm_sync_file(): DEBUG: Deleting dangling group file '002'.
```

## Tests

- [X] Compile manager on Linux.
- [X] Perform the actions described above.
- [X] Run Modulesd on Valgrind.
- [X] Add unit test for the new case of `wdb_get_agent_name()`.
- [ ] Scan code with Coverity.

### Valgrind report

```
==43135== LEAK SUMMARY:
==43135==    definitely lost: 0 bytes in 0 blocks
==43135==    indirectly lost: 0 bytes in 0 blocks
==43135==      possibly lost: 3,280 bytes in 12 blocks
==43135==    still reachable: 219,717 bytes in 60 blocks
==43135==         suppressed: 0 bytes in 0 blocks
```