### PR TITLE
Fixed the equals comparator for OVAL feeds in Vulnerability Detector

### DIFF
--- a/ruleset/rules/0520-vulnerability-detector_rules.xml
+++ b/ruleset/rules/0520-vulnerability-detector_rules.xml
@@ -21,25 +21,11 @@
       <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
-  <rule id="23507" level="4">
-      <if_sid>23503</if_sid>
-      <options>no_full_log</options>
-      <field name="vulnerability.package.condition">Could not</field>
-      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name)</description>
-  </rule>
-
   <rule id="23504" level="7">
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.severity">Medium|-</field>
       <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
-  </rule>
-
-  <rule id="23508" level="6">
-      <if_sid>23504</if_sid>
-      <options>no_full_log</options>
-      <field name="vulnerability.package.condition">Could not</field>
-      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
   <rule id="23505" level="10">
@@ -49,25 +35,11 @@
       <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
-  <rule id="23509" level="9">
-      <if_sid>23505</if_sid>
-      <options>no_full_log</options>
-      <field name="vulnerability.package.condition">Could not</field>
-      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name)</description>
-  </rule>
-
   <rule id="23506" level="13">
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.severity">Critical</field>
       <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
-  </rule>
-
-  <rule id="23510" level="12">
-      <if_sid>23506</if_sid>
-      <options>no_full_log</options>
-      <field name="vulnerability.package.condition">Could not</field>
-      <description>It was not possible to verify whether $(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
 </group>

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -92,6 +92,7 @@
 #define VU_METADATA_CLEAN     "(5484): Cleaning metadata for target '%s'"
 #define VU_UNS_OS             "(5485): Agent '%.3d' has an unsupported OS: '%s'"
 #define VU_PACKAGE_TP_SOURCE  "(5486): Discarded package '%s' from a third-party source ('%s') for agent '%.3d'"
+#define VU_ERROR_CMP_VER      "(5487): Unknown relation '%s' between versions '%s' and '%s' for package '%s'"
 
 /* File integrity monitoring debug messages */
 #define FIM_DIFF_SKIPPED                    "(6200): Diff execution skipped for containing insecure characters."

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -3176,12 +3176,12 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_error_comparing(void **st
     will_return(__wrap_OSHash_Get, Pkg2);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'package' inserted into the vulnerability 'CVE-2020-1234'. Version (10) 'unexisting relation' '5.1.1' (feed 'OVAL').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Unknown relation 'unexisting relation' between versions '10' and '5.1.1' for package 'package'");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug1, formatted_msg, "(5457): The OVAL found a total of '1' potential vulnerabilities for agent '000'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(5457): The OVAL found a total of '0' potential vulnerabilities for agent '000'");
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     will_return(__wrap_time, (time_t)1);
     expect_string(__wrap__mtdebug1, formatted_msg, "(5470): It took '0' seconds to 'find OVAL' vulnerabilities in agent '000'");

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -2383,7 +2383,7 @@ void test_wm_checks_package_vulnerability_eq(void **state)
 {
     char *version_a = "1:5.3.2-3.9.7";
     char *version_b = "2:6.1.1-2.6.8";
-    char *operation = "equal";
+    char *operation = "equals";
 
     expect_value(__wrap_pkg_version_relate, rel, PKG_RELATION_EQ);
     will_return(__wrap_pkg_version_relate, false);

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -3157,26 +3157,8 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_error_comparing(void **st
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
 
-    // Adding cve node
-    cve_vuln_pkg *Pkg2 = NULL;
-    os_calloc(1, sizeof(cve_vuln_pkg), Pkg2);
-    if (!Pkg2)
-        return;
-
-    os_strdup("src_name2", Pkg2->src_name);
-    os_strdup("package2", Pkg2->bin_name);
-    os_strdup("5.1.2", Pkg2->version);
-    os_strdup("x64", Pkg2->arch);
-
-    expect_string(__wrap_OSHash_Add, key, "CVE-2020-1234");
-    will_return(__wrap_OSHash_Add, 1);
-
-    expect_value(__wrap_OSHash_Get, self, cve_table);
-    expect_string(__wrap_OSHash_Get, key, "CVE-2020-1234");
-    will_return(__wrap_OSHash_Get, Pkg2);
-
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Unknown relation 'unexisting relation' between versions '10' and '5.1.1' for package 'package'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5487): Unknown relation 'unexisting relation' between versions '10' and '5.1.1' for package 'package'");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3190,7 +3172,6 @@ void test_wm_vuldet_linux_oval_vulnerabilities_one_row_error_comparing(void **st
 
     assert_int_equal(OS_SUCCESS, ret);
 
-    wm_vuldet_free_cve_node(Pkg2);
 }
 
 void test_wm_vuldet_linux_oval_vulnerabilities_vulnerable(void **state)
@@ -3328,13 +3309,17 @@ void test_wm_vuldet_linux_oval_vulnerabilities_insert_package_error(void **state
     expect_value(__wrap_sqlite3_column_text, iCol, 4);
     will_return(__wrap_sqlite3_column_text, "x64");
     expect_value(__wrap_sqlite3_column_text, iCol, 5);
-    will_return(__wrap_sqlite3_column_text, "unexisting relation");
+    will_return(__wrap_sqlite3_column_text, "greater than");
     expect_value(__wrap_sqlite3_column_text, iCol, 6);
     will_return(__wrap_sqlite3_column_text, "5.1.1");
     expect_value(__wrap_sqlite3_column_text, iCol, 7);
     will_return(__wrap_sqlite3_column_text, "10");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+
+    // wm_checks_package_vulnerability
+    expect_value(__wrap_pkg_version_relate, rel, PKG_RELATION_GT);
+    will_return(__wrap_pkg_version_relate, true);
 
     // Adding cve node
     cve_vuln_pkg *Pkg2 = NULL;
@@ -3351,7 +3336,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_insert_package_error(void **state
     will_return(__wrap_OSHash_Add, 0);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(5572): Couldn't insert the package 'package' into the vulnerability 'CVE-2020-1234'. Version (10) 'unexisting relation' '5.1.1' (feed 'OVAL').");
+    expect_string(__wrap__mterror, formatted_msg, "(5572): Couldn't insert the package 'package' into the vulnerability 'CVE-2020-1234'. Version (10) 'greater than' '5.1.1' (feed 'OVAL').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3408,17 +3393,21 @@ void test_wm_vuldet_linux_oval_vulnerabilities_duplicated_package(void **state)
     expect_value(__wrap_sqlite3_column_text, iCol, 2);
     will_return(__wrap_sqlite3_column_text, "source");
     expect_value(__wrap_sqlite3_column_text, iCol, 3);
-    will_return(__wrap_sqlite3_column_text, "5.1.2");
+    will_return(__wrap_sqlite3_column_text, "4.0");
     expect_value(__wrap_sqlite3_column_text, iCol, 4);
     will_return(__wrap_sqlite3_column_text, "x64");
     expect_value(__wrap_sqlite3_column_text, iCol, 5);
-    will_return(__wrap_sqlite3_column_text, "unexisting relation");
+    will_return(__wrap_sqlite3_column_text, "less than");
     expect_value(__wrap_sqlite3_column_text, iCol, 6);
     will_return(__wrap_sqlite3_column_text, "5.1.1");
     expect_value(__wrap_sqlite3_column_text, iCol, 7);
-    will_return(__wrap_sqlite3_column_text, "10");
+    will_return(__wrap_sqlite3_column_text, "4.0.0");
     expect_value(__wrap_sqlite3_column_text, iCol, 8);
     will_return(__wrap_sqlite3_column_text, NULL);
+
+    // wm_checks_package_vulnerability
+    expect_value(__wrap_pkg_version_relate, rel, PKG_RELATION_LT);
+    will_return(__wrap_pkg_version_relate, true);
 
     // Adding cve node
     cve_vuln_pkg *vuln_pkg = NULL;
@@ -3428,15 +3417,15 @@ void test_wm_vuldet_linux_oval_vulnerabilities_duplicated_package(void **state)
 
     os_strdup("package", vuln_pkg->bin_name);
     w_strdup("source", vuln_pkg->src_name);
-    os_strdup("10", vuln_pkg->version);
+    os_strdup("4.0.0", vuln_pkg->version);
     os_strdup("x64", vuln_pkg->arch);
 
     os_calloc(1, sizeof(cve_vuln_cond), vuln_pkg->vuln_cond);
 
     os_strdup("", vuln_pkg->vuln_cond->state);
-    w_strdup("unexisting relation", vuln_pkg->vuln_cond->operation);
+    w_strdup("less than", vuln_pkg->vuln_cond->operation);
     w_strdup("5.1.1", vuln_pkg->vuln_cond->operation_value);
-    os_strdup("Could not compare package versions (unexisting relation 5.1.1).", vuln_pkg->vuln_cond->condition); //*condition = '\0';
+    os_strdup("Fake condition", vuln_pkg->vuln_cond->condition); //*condition = '\0';
 
     expect_string(__wrap_OSHash_Add, key, "CVE-2020-1234");
     will_return(__wrap_OSHash_Add, 1);
@@ -3446,7 +3435,7 @@ void test_wm_vuldet_linux_oval_vulnerabilities_duplicated_package(void **state)
     will_return(__wrap_OSHash_Get, vuln_pkg);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5459): Trying to insert duplicated package 'package' into the vulnerability 'CVE-2020-1234'. Version (10) 'unexisting relation' '5.1.1' (feed 'OVAL').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5459): Trying to insert duplicated package 'package' into the vulnerability 'CVE-2020-1234'. Version (4.0.0) 'less than' '5.1.1' (feed 'OVAL').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector_nvd.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector_nvd.c
@@ -1318,7 +1318,7 @@ void test_wm_vuldet_check_generic_package_no_starts_no_ends_children(void **stat
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'test' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '*' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'test' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '*' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -2961,7 +2961,7 @@ void test_wm_vuldet_check_specific_package_no_vulnerable(void **state)
     will_return(__wrap_wm_checks_package_vulnerability, 0);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5460): Package 'test' not vulnerable to 'CVE-0000-0000'. Version (0.0.0) not 'equal' '1.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5460): Package 'test' not vulnerable to 'CVE-0000-0000'. Version (0.0.0) not 'equals' '1.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3018,7 +3018,7 @@ void test_wm_vuldet_check_specific_package_vulnerable(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'test' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'test' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3075,7 +3075,7 @@ void test_wm_vuldet_check_specific_package_no_children_no_siblings(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'test' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'test' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3210,7 +3210,7 @@ void test_wm_vuldet_check_specific_package_children_OK(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'test' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'test' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3345,7 +3345,7 @@ void test_wm_vuldet_check_specific_package_siblings_OK(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'test' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'test' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3422,7 +3422,7 @@ void test_wm_vuldet_check_specific_package_os_package_valid(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,-1);
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(5572): Couldn't insert the package 'ubuntu_linux' into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mterror, formatted_msg, "(5572): Couldn't insert the package 'ubuntu_linux' into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3552,7 +3552,7 @@ void test_wm_vuldet_check_specific_package_insert_package_error(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,-1);
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mterror, formatted_msg, "(5572): Couldn't insert the package 'test' into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mterror, formatted_msg, "(5572): Couldn't insert the package 'test' into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3626,7 +3626,7 @@ void test_wm_vuldet_check_specific_package_duplicated_package(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,1);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5459): Trying to insert duplicated package 'test' into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5459): Trying to insert duplicated package 'test' into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3700,7 +3700,7 @@ void test_wm_vuldet_check_specific_package_insert_package_OK(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'test' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'test' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3777,7 +3777,7 @@ void test_wm_vuldet_check_specific_package_insert_package_Ubuntu(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'ubuntu_linux' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'ubuntu_linux' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3854,7 +3854,7 @@ void test_wm_vuldet_check_specific_package_insert_package_Debian(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'debian_linux' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'debian_linux' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -3931,7 +3931,7 @@ void test_wm_vuldet_check_specific_package_insert_package_RedHat(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'enterprise_linux' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'enterprise_linux' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -4008,7 +4008,7 @@ void test_wm_vuldet_check_specific_package_insert_package_linux_kernel(void **st
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'linux_kernel' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'linux_kernel' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -4082,7 +4082,7 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_os_x(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'mac_os_x' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'equal' '10.15.1' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'mac_os_x' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'equals' '10.15.1' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -4156,7 +4156,7 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_os_x_server(void *
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'mac_os_x_server' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'equal' '10.15.1' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'mac_os_x_server' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'equals' '10.15.1' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -4230,7 +4230,7 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_os(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'mac_os' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'equal' '10.15.1' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'mac_os' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'equals' '10.15.1' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -4304,7 +4304,7 @@ void test_wm_vuldet_check_specific_package_insert_package_macos(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'macos' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'equal' '10.15.1' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'macos' inserted into the vulnerability 'CVE-0000-0000'. Version (10.15.1) 'equals' '10.15.1' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -4384,7 +4384,7 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_no_vendor(void **s
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'safari' inserted into the vulnerability 'CVE-0000-0000'. Version (2.1.3) 'equal' '2.1.3' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'safari' inserted into the vulnerability 'CVE-0000-0000'. Version (2.1.3) 'equals' '2.1.3' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -4464,7 +4464,7 @@ void test_wm_vuldet_check_specific_package_insert_package_mac_with_vendor(void *
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'safari' inserted into the vulnerability 'CVE-0000-0000'. Version (2.1.3) 'equal' '2.1.3' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'safari' inserted into the vulnerability 'CVE-0000-0000'. Version (2.1.3) 'equals' '2.1.3' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -4830,7 +4830,7 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_source_no_vulnerable(void **state)
     will_return(__wrap_wm_checks_package_vulnerability, 0);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5460): Package 'source' not vulnerable to 'CVE-0000-0000'. Version (1.1.1) not 'equal' '1.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5460): Package 'source' not vulnerable to 'CVE-0000-0000'. Version (1.1.1) not 'equals' '1.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -4975,7 +4975,7 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_source_vulnerable(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'source' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'source' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -5251,7 +5251,7 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_name_no_vulnerable(void **state)
     will_return(__wrap_wm_checks_package_vulnerability, 0);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5460): Package 'name' not vulnerable to 'CVE-0000-0000'. Version (2.0.0) not 'equal' '1.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5460): Package 'name' not vulnerable to 'CVE-0000-0000'. Version (2.0.0) not 'equals' '1.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -5396,7 +5396,7 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_name_vulnerable(void **state)
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'name' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'name' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -5541,7 +5541,7 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_pkg_source_version_NULL(void **sta
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'source' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'source' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -5841,7 +5841,7 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_app_pkg_mac_no_vendor(void **state
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'safari' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'safari' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 
@@ -5999,7 +5999,7 @@ void test_wm_vuldet_linux_nvd_vulnerabilities_app_pkg_mac_with_vendor(void **sta
 
     will_return(__wrap_wm_vuldet_add_cve_node,0);
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'safari' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equal' '0.0.0' (feed 'NVD').");
+    expect_string(__wrap__mtdebug2, formatted_msg, "(5458): Package 'safari' inserted into the vulnerability 'CVE-0000-0000'. Version (0.0.0) 'equals' '0.0.0' (feed 'NVD').");
 
     expect_sqlite3_step_call(SQLITE_DONE);
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -436,7 +436,7 @@ const char *vu_package_comp[] = {
     "less than or equal",
     "greater than",
     "greater than or equal",
-    "equal",
+    "equals",
     "not equal",
     "exists"
 };
@@ -1926,7 +1926,7 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
             continue;
         }
 
-        // Considering that we correlate de vendor CVEs with the NVD CVEs,
+        // Considering that we correlate the vendor CVEs with the NVD CVEs,
         // we will take as a reference the configured year for the NVD.
         if (nvd_year > wm_vuldet_get_cve_year(cve)) continue;
 

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -1956,7 +1956,8 @@ int wm_vuldet_linux_oval_vulnerabilities(sqlite3 *db, agent_software *agents_it,
             mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_PACKAGE_NOT_VULN, package, cve, version, operation, operation_value, "OVAL");
             continue;
         } else if (v_type == VU_ERROR_CMP) {
-            snprintf(condition, OS_SIZE_1024, "Could not compare package versions (%s %s).", operation, operation_value);
+            mtdebug2(WM_VULNDETECTOR_LOGTAG, VU_ERROR_CMP_VER, operation, version, operation_value, package);
+            continue;
         } else {
             snprintf(state, 15, "Fixed");
         }


### PR DESCRIPTION
|Related issue|
|---|
| #7855 |

## Description

This pull request closes #7855 by adding the following changes:

- The `equals` operator has been fixed to match with the one read from the OVAL feeds
- Rules 23507, 23508, 23509, and 23510 have been removed. They were reporting vulnerabilities when package versions could not be compared.
- UTs have been adapted to the previous changes

## Logs

After the fix, the comparison works as expected
```
2021/03/12 15:40:31 wazuh-modulesd:vulnerability-detector[310858] wm_vuln_detector.c:1956 at wm_vuldet_linux_oval_vulnerabilities(): DEBUG: (5460): Package 'kernel' not vulnerable to 'CVE-2019-10126'. Version (3.10.0-1160.el7) not 'equals' '3.10.0-1062.1.2.el7' (feed 'OVAL').
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
- [x] Added unit tests (for new features)
