### PR TITLE
Create a configuration label to disable the event correlation

### DIFF
--- a/etc/templates/config/generic/rules.template
+++ b/etc/templates/config/generic/rules.template
@@ -8,6 +8,7 @@
     <list>etc/lists/security-eventchannel</list>
 
     <!-- User-defined ruleset -->
+    <event_correlation>yes</event_correlation>
     <decoder_dir>etc/decoders</decoder_dir>
     <rule_dir>etc/rules</rule_dir>
   </ruleset>

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -2102,7 +2102,8 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
                     rule_ar++;
                 }
             }
-            
+
+
             /* Copy the structure to the state memory of if_matched_sid */
             if (t_currently_rule->sid_prev_matched) {
                 OSListNode *node;

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -2102,8 +2102,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
                     rule_ar++;
                 }
             }
-
-
+            
             /* Copy the structure to the state memory of if_matched_sid */
             if (t_currently_rule->sid_prev_matched) {
                 OSListNode *node;

--- a/src/analysisd/asyscom.c
+++ b/src/analysisd/asyscom.c
@@ -152,6 +152,18 @@ size_t asyscom_getconfig(const char * section, char ** output) {
         } else {
             goto error;
         }
+    }
+    else if (strcmp(section, "ruleset") == 0) {
+        if (cfg = getRulesetConfig(), cfg) {
+            os_strdup("ok", *output);
+            json_str = cJSON_PrintUnformatted(cfg);
+            wm_strcat(output, json_str, ' ');
+            free(json_str);
+            cJSON_Delete(cfg);
+            return strlen(*output);
+        } else {
+            goto error;
+        }
     } else {
         goto error;
     }

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -47,6 +47,7 @@ int GlobalConf(const char *cfgfile)
     Config.jsonout_output = 1;
     Config.alerts_log = 1;
     Config.memorysize = 8192;
+    Config.do_correlate_events = DEFAULT_DO_CORRELATE_EVENTS;
     Config.mailnotify = -1;
     Config.keeplogdate = 0;
     Config.syscheck_alert_new = 1;

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -324,3 +324,42 @@ cJSON *getManagerLabelsConfig(void) {
 
     return root;
 }
+
+
+cJSON * getRulesetConfig(void) {
+
+    cJSON * root = cJSON_CreateObject();
+    cJSON * ruleset = cJSON_CreateObject();
+
+    if (Config.includes != NULL) {
+        cJSON * rule_files = cJSON_CreateArray();
+        // All the included rules files are added to the JSON structure (the explicitly excluded ones are not added)
+        for (int i = 0; Config.includes[i] != NULL; i++) {
+            cJSON_AddItemToArray(rule_files, cJSON_CreateString(Config.includes[i]));
+        }
+        cJSON_AddItemToObject(ruleset, "rule_files", rule_files);
+    }
+
+    if (Config.decoders != NULL) {
+        cJSON * decoder_files = cJSON_CreateArray();
+        // All the included decoders files are added to the JSON structure (the explicitly excluded ones are not added)
+        for (int i = 0; Config.decoders[i] != NULL; i++) {
+            cJSON_AddItemToArray(decoder_files, cJSON_CreateString(Config.decoders[i]));
+        }
+        cJSON_AddItemToObject(ruleset, "decoder_files", decoder_files);
+    }
+
+    if (Config.lists != NULL) {
+        cJSON * list = cJSON_CreateArray();
+        for (int i = 0; Config.lists[i] != NULL; i++) {
+            cJSON_AddItemToArray(list, cJSON_CreateString(Config.lists[i]));
+        }
+        cJSON_AddItemToObject(ruleset, "list", list);
+    }
+
+    cJSON_AddStringToObject(ruleset, "event_correlation", Config.do_correlate_events ? "yes":"no");
+
+    cJSON_AddItemToObject(root, "ruleset", ruleset);
+
+    return root;
+}

--- a/src/analysisd/config.h
+++ b/src/analysisd/config.h
@@ -37,6 +37,7 @@ cJSON *getARManagerConfig(void);
 cJSON *getARCommandsConfig(void);
 cJSON *getAlertsConfig(void);
 cJSON *getDecodersConfig(void);
+cJSON * getRulesetConfig(void);
 void _getDecodersListJSON(OSDecoderNode *list, cJSON *array);
 cJSON *getRulesConfig(void);
 void _getRulesListJSON(RuleNode *list, cJSON *array);

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1871,6 +1871,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
     /* Done over here */
     retval = 0;
+    config_ruleinfo = NULL;
 
 cleanup:
 
@@ -1898,7 +1899,7 @@ cleanup:
     OS_ClearNode(rule);
     OS_ClearNode(rule_opt);
     
-    if (retval) {
+    if (config_ruleinfo != NULL) {
         os_remove_ruleinfo(config_ruleinfo);
     }
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -2502,6 +2502,10 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
             rule->decoded_as != lf->decoder_info->id)) {
         return (NULL);
     }
+    
+    if (rule->frequency > 0 && !Config.do_correlate_events) {
+        return NULL;
+    }
 
     /* Check program name */
     if (rule->program_name) {

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -71,6 +71,7 @@ typedef struct __Config {
 
     /* For the correlation */
     int memorysize;
+    bool do_correlate_events;
 
     /* List of files to ignore (syscheck) */
     char **syscheck_ignore;
@@ -116,6 +117,9 @@ typedef struct __Config {
     ssize_t max_output_size;
     long queue_size;
 } _Config;
+
+
+#define DEFAULT_DO_CORRELATE_EVENTS     true
 
 
 void config_free(_Config *config);

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -83,7 +83,7 @@
                                                 "(decoder `%s`). Default value will be used"
 #define ANALYSISD_DEC_DEPRECATED_OPT_VALUE      "(7603): Deprecated value '%s' in '%s' option " \
                                                 "(decoder `%s`). Default value will be used"
-#define ANALYSISD_INV_CORRELATION_VALUE         "(7604): Wrong event_correlation's label value: '%s'. " \
+#define ANALYSISD_INV_CORRELATION_VALUE         "(7604): Invalid value '%s' in 'event_correlation' label. " \
                                                 "Allowed values are 'yes' or 'no'. Default value 'yes' will be used."
 
 /* Logcollector */

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -83,6 +83,8 @@
                                                 "(decoder `%s`). Default value will be used"
 #define ANALYSISD_DEC_DEPRECATED_OPT_VALUE      "(7603): Deprecated value '%s' in '%s' option " \
                                                 "(decoder `%s`). Default value will be used"
+#define ANALYSISD_INV_CORRELATION_VALUE         "(7604): Wrong event_correlation's label value: '%s'. " \
+                                                "Allowed values are 'yes' or 'no'. Default value 'yes' will be used."
 
 /* Logcollector */
 #define LOGCOLLECTOR_INV_VALUE_DEFAULT          "(8000): Invalid value '%s' for attribute '%s' in '%s' option. " \


### PR DESCRIPTION
|Related issue|
|---|
|#7863|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

In order to handle whether the events should be correlated or not, as required in the issue ["Disable event correlation" (#7863)](https://github.com/wazuh/wazuh/issues/7863), we propose to add a new "**event_correlation**" **label** to the **_ossec.conf's ruleset section_**, which allows the users to select between enabling the event correlation (_event_correlation=yes_) or disabling it (_event_correlation=no_).

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

Event correlation config should be added (or ommited, then the default value "yes" is used) to /var/ossec/etc/ossec.conf file in the 
configuration block `<ruleset>...</ruleset>`, as follows:
``` xml
  <ruleset>
    <!-- Default ruleset -->
    <decoder_dir>ruleset/decoders</decoder_dir>
    <rule_dir>ruleset/rules</rule_dir>
    <rule_exclude>0215-policy_rules.xml</rule_exclude>
    <list>etc/lists/audit-keys</list>
    <list>etc/lists/amazon/aws-eventnames</list>
    <list>etc/lists/security-eventchannel</list>

    <!-- User-defined ruleset -->
    <decoder_dir>etc/decoders</decoder_dir>
    <rule_dir>etc/rules</rule_dir>

    <event_correlation>yes</event_correlation>
  </ruleset>
```
Only "yes" or "no" values are valid parameters in the "event_correlation" label, any other value will be disregarded and then the default value ("yes") will be used.

## Logs/Alerts example

When setting an unexpected parameter, anything apart from "yes" or "no", warning messages will be displayed each time this label is evaluated informing that the input value will be dismissed and the default one will be used.

Eg:  `<event_correlation>nop</event_correlation>`

``` bash
# cat /var/ossec/logs/ossec.log | grep -a "event_correlation"
2021/03/15 14:13:56 wazuh-dbd: WARNING: (10000): Wrong event_correlation's label value: 'nop'. Allowed values are 'yes' or 'no'. Default value 'yes' will be used.
2021/03/15 14:13:56 wazuh-analysisd: WARNING: (10000): Wrong event_correlation's label value: 'nop'. Allowed values are 'yes' or 'no'. Default value 'yes' will be used.
2021/03/15 14:13:56 wazuh-analysisd: WARNING: (10000): Wrong event_correlation's label value: 'nop'. Allowed values are 'yes' or 'no'. Default value 'yes' will be used.
2021/03/15 14:13:58 wazuh-dbd: WARNING: (10000): Wrong event_correlation's label value: 'nop'. Allowed values are 'yes' or 'no'. Default value 'yes' will be used.
2021/03/15 14:14:02 wazuh-analysisd: WARNING: (10000): Wrong event_correlation's label value: 'nop'. Allowed values are 'yes' or 'no'. Default value 'yes' will be used.
```

## Tests

### Ruleset's runtest.py

#### case: _event_correlation = yes_

_*Please, see "Annexed Comment I" in the comments*_

#### case: _event_correlation = no_

_*Please, see "Annexed Comment II" in the comments*_

### Active Config

``` bash
# go run wazuh_sock.go -f /var/ossec/queue/sockets/analysis -m "getconfig ruleset"
```
_*Please, see "Annexed Comment III" in the comments*_

### Other Checks

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [X] ~Windows~
  - [X] ~MAC OS X~
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [X] ~Dr. Memory~
  - [X] ~AddressSanitizer~
- Memory tests for Windows
  - [X] ~Scan-build report~
  - [X] ~Coverity~
  - [X] ~Dr. Memory~
- Memory tests for macOS
  - [X] ~Scan-build report~
  - [X] ~Leaks~
  - [X] ~AddressSanitizer~

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
