### PR TITLE
Fix API errors with cluster disabled and node_type worker

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -132,18 +132,8 @@ class DistributedAPI:
             else:
                 self.debug_log(f"Receiving parameters {self.f_kwargs}")
 
-            import pydevd_pycharm
-            pydevd_pycharm.settrace('172.18.0.1', port=1234, stdoutToServer=True, stderrToServer=True)
-
             is_dapi_enabled = self.cluster_items['distributed_api']['enabled']
             is_cluster_disabled = self.node == local_client and not check_cluster_status()
-
-            # # if it is a cluster API request and the cluster is not enabled, raise an exception
-            # if is_cluster_disabled and 'cluster' in self.input_json['function'] and \
-            #         self.input_json['function'] != '/cluster/status' and \
-            #         self.input_json['function'] != '/cluster/config' and \
-            #         self.input_json['function'] != '/cluster/node':
-            #     raise exception.WazuhException(3013)
 
             # First case: execute the request locally.
             # If the distributed api is not enabled

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -81,31 +81,36 @@ def test_DistributedAPI(install_type_mock, kwargs):
        new=AsyncMock(return_value=WazuhResult({'result': 'forward'})))
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_remote_request',
        new=AsyncMock(return_value=WazuhResult({'result': 'remote'})))
-@pytest.mark.parametrize('api_request, request_type, node, expected', [
-    (agent.get_agents_summary_status, 'local_master', 'master', 'local'),
-    (agent.restart_agents, 'distributed_master', 'master', 'forward'),
-    (cluster.get_node_wrapper, 'local_any', 'worker', 'local'),
-    (ciscat.get_ciscat_results, 'distributed_master', 'worker', 'remote')
+@pytest.mark.parametrize('api_request, request_type, node, expected, cluster_enabled', [
+    (agent.get_agents_summary_status, 'local_master', 'master', 'local', True),
+    (agent.restart_agents, 'distributed_master', 'master', 'forward', True),
+    (cluster.get_node_wrapper, 'local_any', 'worker', 'local', True),
+    (ciscat.get_ciscat_results, 'distributed_master', 'worker', 'remote', True),
+    (manager.status, 'local_master', 'worker', 'local', False)
 ])
-@patch('wazuh.core.cluster.dapi.dapi.wazuh.core.cluster.cluster.check_cluster_status', return_value=False)
-def test_DistributedAPI_distribute_function(cluster_status_mock, api_request, request_type, node, expected):
+def test_DistributedAPI_distribute_function(api_request, request_type, node, expected, cluster_enabled):
     """Test distribute_function functionality with different test cases.
 
     Parameters
     ----------
     api_request : callable
-        Function to be executed
+        Function to be executed.
     request_type : str
-        Request type (local_master, distributed_master, local_any)
+        Request type (local_master, distributed_master, local_any).
     node : str
-        Node type (Master and Workers)
+        Node type (Master and Workers).
     expected : str
-        Expected result
+        Expected result.
+    cluster_enabled : bool
+        Indicates whether cluster is enabled or not.
     """
-    with patch('wazuh.core.cluster.cluster.get_node', return_value={'type': node}):
-        dapi = DistributedAPI(f=api_request, logger=logger, request_type=request_type)
-        data = raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
-        assert data.render()['result'] == expected
+
+    # Mock check_cluster_status and get_node
+    with patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=cluster_enabled):
+        with patch('wazuh.core.cluster.cluster.get_node', return_value={'type': node}):
+            dapi = DistributedAPI(f=api_request, logger=logger, request_type=request_type)
+            data = raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
+            assert data.render()['result'] == expected
 
 
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_local_request',
@@ -115,8 +120,7 @@ def test_DistributedAPI_distribute_function(cluster_status_mock, api_request, re
 @pytest.mark.parametrize('api_request, request_type, node, expected', [
     (agent.restart_agents, 'distributed_master', 'master', 'local')
 ])
-@patch('wazuh.core.cluster.dapi.dapi.wazuh.core.cluster.cluster.check_cluster_status', return_value=False)
-def test_DistributedAPI_distribute_function_mock_solver(cluster_status_mock, api_request, request_type, node, expected):
+def test_DistributedAPI_distribute_function_mock_solver(api_request, request_type, node, expected):
     """Test distribute_function functionality with unknown node.
 
     Parameters
@@ -226,9 +230,8 @@ def test_DistributedAPI_local_request(mock_local_request):
             assert type(e) == KeyError
 
 
-@patch('wazuh.core.cluster.cluster.check_cluster_status', return_value=False)
 @patch('wazuh.core.cluster.local_client.LocalClient.execute', new=AsyncMock(return_value='{"Testing": 1}'))
-def test_DistributedAPI_remote_request(mock_cluster_status):
+def test_DistributedAPI_remote_request():
     """Test `execute_remote_request` method from class DistributedAPI."""
     dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'remote'}
     raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
@@ -246,11 +249,11 @@ def test_DistributedAPI_logger():
     raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=1001)
 
 
-@patch('wazuh.core.cluster.cluster.check_cluster_status', return_value=False)
 @patch('wazuh.core.cluster.local_client.LocalClient.send_file', new=AsyncMock(return_value='{"Testing": 1}'))
 @patch('wazuh.core.cluster.local_client.LocalClient.execute', new=AsyncMock(return_value='{"Testing": 1}'))
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.get_solver_node',
        new=AsyncMock(return_value=WazuhResult({'testing': ['001', '002']})))
+@patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
 def test_DistributedAPI_tmp_file(mock_cluster_status):
     """Test the behaviour when processing temporal files to be send. Master node and unknown node."""
     open('/tmp/dapi_file.txt', 'a').close()
@@ -266,10 +269,10 @@ def test_DistributedAPI_tmp_file(mock_cluster_status):
         raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
 
 
-@patch('wazuh.core.cluster.cluster.check_cluster_status', return_value=False)
 @patch('wazuh.core.cluster.local_client.LocalClient.send_file', new=AsyncMock(return_value='{"Testing": 1}'))
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.get_solver_node',
        new=AsyncMock(return_value=WazuhResult({'testing': ['001', '002']})))
+@patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
 def test_DistributedAPI_tmp_file_cluster_error(mock_cluster_status):
     """Test the behaviour when an error raises with temporal files function."""
     open('/tmp/dapi_file.txt', 'a').close()
@@ -297,11 +300,11 @@ def filter_node_mock(filter_node=None, *args, **kwargs):
     cluster.get_nodes_info(*args, filter_node=filter_node, **kwargs)
 
 
-@patch('wazuh.core.cluster.cluster.check_cluster_status', return_value=False)
 @patch('wazuh.core.cluster.local_client.LocalClient.execute',
        new=AsyncMock(return_value='{"items": [{"name": "master"}], "totalItems": 1}'))
 @patch('wazuh.agent.Agent.get_agents_overview', return_value={'items': [{'id': '001', 'node_name': 'master'},
                                                                         {'id': '002', 'node_name': 'master'}]})
+@patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
 def test_DistributedAPI_get_solver_node(mock_cluster_status, mock_agents_overview):
     """Test `get_solver_node` function."""
     nodes_info_result = AffectedItemsWazuhResult()


### PR DESCRIPTION
|Related issue|
|---|
| #7610 |

Hi team,

This PR closes #7610 .

In this pull request, I have updated the `dapi.py` file.

In the `distribute_function` method of `DistributedAPI`, the request was not executed locally when the `cluster` was `disabled` and the `node_type` was `worker`. This happened because the condition **If the cluster is disabled or the request type is local_any** wasn't covered and the request was executed remotely.

I have added a variable indicating when the cluster is disabled to avoid this error. I have included this check in the if statement for executing the request locally.

Regards,
Manuel.