### PR TITLE
Added shared permission flags for writing and deleting to CreateFile

### DIFF
--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1274,7 +1274,7 @@ end:
 time_t get_UTC_modification_time(const char *file){
     HANDLE hdle;
     FILETIME modification_date;
-    if (hdle = CreateFile(file, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL), \
+    if (hdle = CreateFile(file, GENERIC_READ, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL), \
         hdle == INVALID_HANDLE_VALUE) {
         mferror(FIM_WARN_OPEN_HANDLE_FILE, file, GetLastError());
         return 0;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/7869|

## Description
This PR solves a bug in **get_UTC_modification_time**, where the **CreateFile** function did not have the necessary flags to examine a file when it was opened by another application. It was necessary to have shared write and delete permissions, which were missing:
