### PR TITLE
Fix string length when parsing sync-agent-info-get response

### DIFF
--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -5110,7 +5110,7 @@ int wdb_parse_global_sync_agent_info_get(wdb_t* wdb, char* input, char* output) 
     }
 
     wdbc_result status = wdb_global_sync_agent_info_get(wdb, &last_id, &agent_info_sync);
-    snprintf(output, WDB_MAX_RESPONSE_SIZE, "%s %s",  WDBC_RESULT[status], agent_info_sync);
+    snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[status], agent_info_sync);
     os_free(agent_info_sync)
     if (status != WDBC_DUE) {
         last_id = 0;


### PR DESCRIPTION
|Related issue|
|---|
|7872|

## Description
This PR fixes a bug in the parsing of **sync-agent-info-get**. 
The response of this command can be up to **WDB_MAX_RESPONSE_SIZE** (65022 bytes), and it was being appended to a header and inserted into a buffer using **snprintf** bounded to the same  **WDB_MAX_RESPONSE_SIZE**, this leads to chopping the last bytes of the response.

To fix it, the response is now copied with a bound of **MAX_STR + 1** that is the size of the final buffer.

Also, two new Unit Tests were implemented to catch and test this scenario.


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Package installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [X] Valgrind (memcheck and descriptor leaks check)
