### PR TITLE
Add Tasks tag to API spec

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5302,6 +5302,8 @@ tags:
     description: "File integrity monitoring"
   - name: Syscollector
     description: "Syscollector information"
+  - name: Tasks
+    description: "Tasks information"
   - name: Vulnerability
     description: "Vulnerabilities information"
 
@@ -15743,7 +15745,7 @@ paths:
   /tasks/status:
     get:
       tags:
-        - tasks
+        - Tasks
       summary: "List tasks"
       description: "Returns all available information about the specified tasks"
       operationId: api.controllers.task_controller.get_tasks_status


### PR DESCRIPTION
Hello team,

This PR adds a new tag to the API spec. This addition affects to the API reference documentation, showing its correct group now as it can be seen in the screenshot below (redoc compiled locally so it does not have the Wazuh style):

![image](https://user-images.githubusercontent.com/37274979/111309107-ccbcc000-865b-11eb-86a4-4ddd7001a44b.png)

Regards,
Víctor Fernández