### PR TITLE
Updating agents DB schema to improve CVE alerts mechanism

### DIFF
--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -117,6 +117,8 @@ CREATE TABLE IF NOT EXISTS sys_osinfo (
     version TEXT,
     os_release TEXT,
     checksum TEXT NOT NULL CHECK (checksum <> ''),
+    triaged INTEGER(1) DEFAULT 0,
+    reference TEXT DEFAULT '' NOT NULL,
     PRIMARY KEY (scan_id, os_name)
 );
 
@@ -345,14 +347,19 @@ CREATE TABLE IF NOT EXISTS vuln_cves (
     version TEXT,
     architecture TEXT,
     cve TEXT,
-    PRIMARY KEY (name, version, architecture, cve)
+    reference TEXT DEFAULT '' NOT NULL,
+    type TEXT DEFAULT 'UNDEFINED' NOT NULL CHECK (type IN ('OS', 'PACKAGE','UNDEFINED')),
+    status TEXT DEFAULT 'PENDING' NOT NULL CHECK (status IN ('VALID', 'PENDING', 'OBSOLETE')),
+    PRIMARY KEY (reference, cve)
 );
 CREATE INDEX IF NOT EXISTS packages_id ON vuln_cves (name);
 CREATE INDEX IF NOT EXISTS cves_id ON vuln_cves (cve);
+CREATE INDEX IF NOT EXISTS cve_type ON vuln_cves (type);
+CREATE INDEX IF NOT EXISTS cve_status ON vuln_cves (status);
 
 BEGIN;
 
-INSERT INTO metadata (key, value) VALUES ('db_version', '7');
+INSERT INTO metadata (key, value) VALUES ('db_version', '8');
 INSERT INTO scan_info (module) VALUES ('fim');
 INSERT INTO scan_info (module) VALUES ('syscollector');
 INSERT INTO sync_info (component) VALUES ('fim');

--- a/src/wazuh_db/schema_upgrade_v8.sql
+++ b/src/wazuh_db/schema_upgrade_v8.sql
@@ -1,0 +1,33 @@
+/*
+ * SQL Schema for upgrading databases
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ *
+ * March 16, 2021.
+ *
+ * This program is a free software, you can redistribute it
+ * and/or modify it under the terms of GPLv2.
+*/
+
+ALTER TABLE sys_osinfo ADD COLUMN reference TEXT DEFAULT '' NOT NULL;
+ALTER TABLE sys_osinfo ADD COLUMN triaged INTEGER(1) DEFAULT 0;
+
+DROP TABLE IF EXISTS vuln_cves;
+
+CREATE TABLE IF NOT EXISTS vuln_cves (
+    name TEXT,
+    version TEXT,
+    architecture TEXT,
+    cve TEXT,
+    reference TEXT DEFAULT '' NOT NULL,
+    type TEXT DEFAULT 'UNDEFINED' NOT NULL CHECK (type IN ('OS', 'PACKAGE','UNDEFINED')),
+    status TEXT DEFAULT 'PENDING' NOT NULL CHECK (status IN ('VALID', 'PENDING', 'OBSOLETE')),
+    PRIMARY KEY (reference, cve)
+);
+CREATE INDEX IF NOT EXISTS packages_id ON vuln_cves (name);
+CREATE INDEX IF NOT EXISTS cves_id ON vuln_cves (cve);
+CREATE INDEX IF NOT EXISTS cve_type ON vuln_cves (type);
+CREATE INDEX IF NOT EXISTS cve_status ON vuln_cves (status);
+
+UPDATE vuln_metadata SET LAST_SCAN = '0';
+
+INSERT OR REPLACE INTO metadata (key, value) VALUES ('db_version', 8);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -285,6 +285,7 @@ extern char *schema_upgrade_v4_sql;
 extern char *schema_upgrade_v5_sql;
 extern char *schema_upgrade_v6_sql;
 extern char *schema_upgrade_v7_sql;
+extern char *schema_upgrade_v8_sql;
 extern char *schema_global_upgrade_v1_sql;
 extern char *schema_global_upgrade_v2_sql;
 

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -37,7 +37,8 @@ wdb_t * wdb_upgrade(wdb_t *wdb) {
         schema_upgrade_v4_sql,
         schema_upgrade_v5_sql,
         schema_upgrade_v6_sql,
-        schema_upgrade_v7_sql
+        schema_upgrade_v7_sql,
+        schema_upgrade_v8_sql
     };
 
     char db_version[OS_SIZE_256 + 2];


### PR DESCRIPTION
|Related issue|
|---|
|7888|


## Description

This PR updates the agent's DB schema. The `sys_osinfo` table now has the **reference** and **triaged** columns.
Also, the `vuln_cves` table has the **type**, **reference** and **status** columns.
The upgrade mechanism was considered for both tables.

The main aspects of the implementation are:

- The new `sys_osinfo` columns have a default value but not a **CHECK** constraint. The corresponding insertion method are not implemented yet, and the OS information needs to be inserted.
- Something similar happens with the `vuln_cves` table. There are default values only to allow the vulnerabilities insertion, and they could be changed later.
- The **PRIMARY KEY** of the `vuln_cves` table has changed.
- In every update, the `vuln_cves` is cleared and the **LAST_SCAN** value is set to 0

## Tests

Both clean and update installations were tested. All the tables have the correct columns, and the data insertion can be performed successfully. No errors were found in the logs. 

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
