### PR TITLE
Improve validator.py safe path checking

### DIFF
--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -146,13 +146,13 @@ def test_allowed_fields():
 def test_is_safe_path():
     """Verify that is_safe_path() works as expected"""
     assert is_safe_path('/api/configuration/api.yaml')
-    assert is_safe_path('etc/rules/local_rules.xml', follow_symlinks=False)
-    assert is_safe_path('etc/ossec.conf', follow_symlinks=True)
-    assert is_safe_path('ruleset/decoders/decoder.xml', follow_symlinks=False)
-    assert not is_safe_path('/api/configuration/api.yaml', basedir='non-existent')
-    assert not is_safe_path('etc/lists/../../../../../../var/ossec/api/scripts/wazuh-apid.py', follow_symlinks=True)
-    assert not is_safe_path('./etc/rules/rule.xml', follow_symlinks=False)
-    assert not is_safe_path('./ruleset/decoders/decoder.xml./', follow_symlinks=False)
+    assert is_safe_path('etc/rules/local_rules.xml', relative=False)
+    assert is_safe_path('etc/ossec.conf', relative=True)
+    assert is_safe_path('ruleset/decoders/decoder.xml', relative=False)
+    assert not is_safe_path('/api/configuration/api.yaml', basedir='non-existent', relative=False)
+    assert not is_safe_path('etc/lists/../../../../../../var/ossec/api/scripts/wazuh-apid.py', relative=True)
+    assert not is_safe_path('./etc/rules/rule.xml', relative=False)
+    assert not is_safe_path('./ruleset/decoders/decoder.xml./', relative=False)
 
 
 @pytest.mark.parametrize('value, format', [

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -92,12 +92,11 @@ def is_safe_path(path: str, basedir: str = common.ossec_path, relative: bool = T
     if './' in path or '../' in path:
         return False
 
-    if relative:
-        # Resolve symbolic links
-        full_path = os.path.realpath(os.path.join(basedir, path))
-        return os.path.commonpath([full_path, basedir]) == basedir
+    # Resolve symbolic links if present
+    full_path = os.path.realpath(os.path.join(basedir, path.lstrip("/")) if relative else path)
+    full_basedir = os.path.abspath(basedir)
 
-    return os.path.commonpath([os.path.abspath(path), basedir]) == basedir
+    return os.path.commonpath([full_path, full_basedir]) == full_basedir
 
 
 @draft4_format_checker.checks("alphanumeric")

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -80,38 +80,24 @@ def allowed_fields(filters: Dict) -> List:
     return [field for field in filters]
 
 
-def is_safe_path(path: str, basedir: str = common.ossec_path, follow_symlinks: bool = True) -> bool:
+def is_safe_path(path: str, basedir: str = common.ossec_path, relative: bool = True) -> bool:
     """
     Checks if a path is correct
     :param path: Path to be checked
     :param basedir: Wazuh installation directory
-    :param follow_symlinks: True if path is relative, False if it is absolute
+    :param relative: True if path is relative, False if it is absolute
     :return: True if path is correct, False otherwise
     """
     # Protect path
     if './' in path or '../' in path:
         return False
 
-    # Resolve symbolic links
-    if follow_symlinks:
-        full_path = common.ossec_path + path
-        return os.path.realpath(full_path).startswith(basedir)
+    if relative:
+        # Resolve symbolic links
+        full_path = os.path.realpath(os.path.join(basedir, path))
+        return os.path.commonpath([full_path, basedir]) == basedir
 
-    return os.path.abspath(path).startswith(basedir)
-
-
-def is_wazuh_path(path: str, basedir: str = common.ossec_path) -> bool:
-    """
-    Check if an absolute path is inside Wazuh installation directory
-    :param path: Path to be checked
-    :param basedir: Wazuh installation directory
-    :return: True if path is correct, False otherwise
-    """
-    # Protect path
-    if './' in path or '../' in path:
-        return False
-
-    return os.path.abspath(path).startswith(basedir)
+    return os.path.commonpath([os.path.abspath(path), basedir]) == basedir
 
 
 @draft4_format_checker.checks("alphanumeric")
@@ -171,7 +157,7 @@ def format_path(value):
 
 @draft4_format_checker.checks("wazuh_path")
 def format_wazuh_path(value):
-    if not is_wazuh_path(value):
+    if not is_safe_path(value, relative=False):
         return False
     return check_exp(value, _paths)
 


### PR DESCRIPTION
Hello team,

This PR closes #7903. It applies minor modifications over the `validator.py` module to improve the way we check if a path is safe. It also unifies two functions that were used for the same purpose.

## Changes
- `is_wazuh_path` function was removed. `is_safe_path` function will be used instead.
- The way we handle paths in `is_safe_path` function has been improved.
- The `follow_symlinks` parameter in `is_safe_path` has been renamed to `relative` as it was used mainly to handle relative paths, not just symbolic links.

## Tests results
```
============================================= test session starts ==============================================
platform linux -- Python 3.8.5, pytest-5.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/carlos/GIT/wazuh/api
plugins: metadata-1.11.0, tavern-1.0.0, html-3.1.1, testinfra-5.0.0
collected 180 items                                                                                            

api/api/test/test_alogging.py ........                                                                   [  4%]
api/api/test/test_authentication.py ..........                                                           [ 10%]
api/api/test/test_configuration.py .......                                                               [ 13%]
api/api/test/test_util.py ...................................                                            [ 33%]
api/api/test/test_validator.py ......................................................................... [ 73%]
...............................................                                                          [100%]
=================================== 180 passed, 16 warnings in 1.13 seconds ====================================
```

```
test_agent_DELETE_endpoints.tavern.yaml 
	 6 passed, 1 warnings

test_agent_GET_endpoints.tavern.yaml 
	 90 passed, 1 warnings

test_agent_POST_endpoints.tavern.yaml 
	 5 passed, 1 warnings

test_agent_PUT_endpoints.tavern.yaml 
	 9 passed, 1 warnings

test_cdb_list_endpoints.tavern.yaml 
	 5 passed, 1 warnings

test_cluster_endpoints.tavern.yaml 
         44 passed, 1 xpassed, 1 warnings

test_decoder_endpoints.tavern.yaml 
	 25 passed, 1 warnings

test_manager_endpoints.tavern.yaml 
	 31 passed, 1 warnings

test_rule_endpoints.tavern.yaml 
	 15 passed, 17 warnings
```