### PR TITLE
Refactor login_user into run_as login controller and the default login controller

### DIFF
--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -4,7 +4,7 @@
 
 import logging
 import re
-from json import JSONDecodeError
+from typing import Union
 
 from aiohttp import web
 
@@ -28,28 +28,23 @@ logger = logging.getLogger('wazuh-api')
 auth_re = re.compile(r'basic (.*)', re.IGNORECASE)
 
 
-async def login_user(request, user: str, raw=False):
+async def login_user(user: str, raw: bool = False) -> web.Response:
     """User/password authentication to get an access token.
     This method should be called to get an API token. This token will expire at some time. # noqa: E501
 
     Parameters
     ----------
-    request : connexion.request
     user : str
-        Name of the user who wants to be authenticated
+        Name of the user who wants to be authenticated.
     raw : bool, optional
-        Respond in raw format
+        Respond in raw format. Default `False`
 
     Returns
     -------
-    TokenResponseModel
+    web.Response
+        Raw or JSON response with the generated access token.
     """
     f_kwargs = {'user_id': user}
-    try:
-        # Add authorization context in case there is body in request
-        f_kwargs['auth_context'] = await request.json()
-    except JSONDecodeError:
-        pass
 
     dapi = DistributedAPI(f=preprocessor.get_permissions,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
@@ -61,14 +56,49 @@ async def login_user(request, user: str, raw=False):
 
     token = None
     try:
-        token = generate_token(user_id=user, data=data.dikt, run_as='auth_context' in f_kwargs.keys())
+        token = generate_token(user_id=user, data=data.dikt)
     except WazuhException as e:
         raise_if_exc(e)
 
-    if raw:
-        return web.Response(text=token, content_type='text/plain', status=200)
-    else:
-        return web.json_response(data=WazuhResult({'data': TokenResponseModel(token=token)}), status=200, dumps=dumps)
+    return web.Response(text=token, content_type='text/plain', status=200) if raw \
+        else web.json_response(data=WazuhResult({'data': TokenResponseModel(token=token)}), status=200, dumps=dumps)
+
+
+async def run_as_login(request, user: str, raw: bool = False) -> web.Response:
+    """User/password authentication to get an access token.
+    This method should be called to get an API token using an authorization context body. This token will expire at some time. # noqa: E501
+
+    Parameters
+    ----------
+    request : connexion.request
+    user : str
+        Name of the user who wants to be authenticated.
+    raw : bool, optional
+        Respond in raw format. Default `False`
+
+    Returns
+    -------
+    web.Response
+        Raw or JSON response with the generated access token.
+    """
+    f_kwargs = {'user_id': user, 'auth_context': await request.json()}
+
+    dapi = DistributedAPI(f=preprocessor.get_permissions,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='local_master',
+                          is_async=False,
+                          logger=logger
+                          )
+    data = raise_if_exc(await dapi.distribute_function())
+
+    token = None
+    try:
+        token = generate_token(user_id=user, data=data.dikt, run_as=True)
+    except WazuhException as e:
+        raise_if_exc(e)
+
+    return web.Response(text=token, content_type='text/plain', status=200) if raw \
+        else web.json_response(data=WazuhResult({'data': TokenResponseModel(token=token)}), status=200, dumps=dumps)
 
 
 async def get_user_me(request, pretty=False, wait_for_complete=False):

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -4,7 +4,6 @@
 
 import logging
 import re
-from typing import Union
 
 from aiohttp import web
 
@@ -147,7 +146,7 @@ async def get_user_me_policies(request, pretty=False, wait_for_complete=False):
     Users information
     """
     data = WazuhResult({'data': request['token_info']['rbac_policies'],
-                       'message': "Current user processed policies information was returned"})
+                        'message': "Current user processed policies information was returned"})
 
     return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -13939,7 +13939,7 @@ paths:
       description: "This method should be called to get an API token using an authorization context body. This token
       will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT
       /security/config"
-      operationId: api.controllers.security_controller.login_user
+      operationId: api.controllers.security_controller.run_as_login
       parameters:
         - $ref: '#/components/parameters/raw'
       security:


### PR DESCRIPTION
|Related issue|
|---|
| #7845 |

This PR closes #7845 .

In this pull request, I have added a new security controller for the `run_as` login. Despite the fact that we were using 2 different endpoints for login and run_as login, both were using the same controller `login_user`.

I have updated the `login_user` controller and created a `run_as_login` controller. With this change, both endpoints' OperationIDs are different and the documentation (API reference) error dissapears.

### Test results:

```
pytest framework/wazuh/tests/
====================== 744 passed, 12 warnings in 54.53s =======================

pytest framework/wazuh/core/tests/
======================= 652 passed, 11 warnings in 2.12s =======================

pytest framework/wazuh/rbac/tests/
================== 227 passed, 1 warning in 152.28s (0:02:32) ==================

pytest api/api/test/
======================= 180 passed, 15 warnings in 0.96s =======================
```


Regards,
Manuel.