### PR TITLE
Fix mem leaks in osregex regex_matching frees - FTS list - ACM Storage

### DIFF
--- a/src/analysisd/accumulator.c
+++ b/src/analysisd/accumulator.c
@@ -316,15 +316,22 @@ void FreeACMStore(OS_ACM_Store *obj)
 {
     if ( obj != NULL ) {
         mdebug2("accumulator: DEBUG: Freeing an accumulator struct.");
-        free(obj->dstuser);
-        free(obj->srcuser);
-        free(obj->dstip);
-        free(obj->srcip);
-        free(obj->dstport);
-        free(obj->srcport);
-        free(obj->data);
-        free(obj);
+        os_free(obj->dstuser);
+        os_free(obj->srcuser);
+        os_free(obj->dstip);
+        os_free(obj->srcip);
+        os_free(obj->dstport);
+        os_free(obj->srcport);
+        os_free(obj->data);
+        os_free(obj);
     }
+}
+
+/* Free accumulate */
+void w_analysisd_accumulate_free(OSHash **acm_store) {
+    (*acm_store)->free_data_function = (void (*)(void *)) FreeACMStore;
+    OSHash_Free(*acm_store);
+    *acm_store = NULL;
 }
 
 int acm_str_replace(char **dst, const char *src)

--- a/src/analysisd/accumulator.h
+++ b/src/analysisd/accumulator.h
@@ -54,4 +54,11 @@ Eventinfo *Accumulate(Eventinfo *lf, OSHash **acm_store, int *acm_lookups, time_
  */
 void Accumulate_CleanUp(OSHash **acm_store, int *acm_lookups, time_t *acm_purge_ts);
 
+/**
+ * @brief Free accumulate hash table
+ * 
+ * @param acm_store accumulate hash table to free
+ */
+void w_analysisd_accumulate_free(OSHash **acm_store);
+
 #endif /* ACCUMULATOR_H */

--- a/src/analysisd/logtest.c
+++ b/src/analysisd/logtest.c
@@ -554,10 +554,11 @@ void w_logtest_remove_session(char *token) {
 
     /* Remove fts list and hash */
     OSHash_Free(session->fts_store);
+    OSList_CleanOnlyNodes(session->fts_list);
     os_free(session->fts_list);
 
     /* Remove accumulator hash */
-    OSHash_Free(session->acm_store);
+    w_analysisd_accumulate_free(&session->acm_store);
 
     /* Free memory allocated in OSRegex execution */
     OSRegex_free_regex_matching(&session->decoder_match);

--- a/src/headers/list_op.h
+++ b/src/headers/list_op.h
@@ -53,10 +53,17 @@ void OSList_DeleteOldestNode(OSList *list) __attribute__((nonnull));
 void *OSList_AddData(OSList *list, void *data) __attribute__((nonnull(1)));
 
 /**
- * @brief Clears all nodes from a list..
+ * @brief Clears all the nodes from a list and frees the referenced data
  *
  * @param list List to delete
  */
 void OSList_CleanNodes(OSList *list);
+
+/**
+ * @brief Clears all the nodes from a list without freeing the referenced data
+ *
+ * @param list List to delete nodes
+ */
+void OSList_CleanOnlyNodes(OSList *list);
 
 #endif /* OS_LIST */

--- a/src/os_regex/os_regex.c
+++ b/src/os_regex/os_regex.c
@@ -52,7 +52,11 @@ void OSRegex_free_regex_matching (regex_matching *reg) {
         os_free(reg->sub_strings);
     }
 
-    if (reg->prts_str) os_free(reg->prts_str[0]);
-    os_free(reg->prts_str);
+     if (reg->prts_str) {
+        for (unsigned int i = 0; reg->d_size.prts_str_size[i] && reg->prts_str[i]; i++) {
+            os_free(reg->prts_str[i]);
+        }
+        os_free(reg->prts_str);
+    }
     os_free(reg->d_size.prts_str_size);
 }

--- a/src/shared/list_op.c
+++ b/src/shared/list_op.c
@@ -361,3 +361,29 @@ void OSList_CleanNodes(OSList *list) {
     w_mutex_unlock((pthread_mutex_t *)&list->mutex);
     w_rwlock_unlock((pthread_rwlock_t *)&list->wr_mutex);
 }
+
+void OSList_CleanOnlyNodes(OSList *list) {
+    if (list == NULL) {
+        return;
+    }
+
+    w_rwlock_wrlock((pthread_rwlock_t *)&list->wr_mutex);
+    w_mutex_lock((pthread_mutex_t *)&list->mutex);
+
+    OSListNode *aux_node = NULL;
+
+    while(list->first_node != NULL) {
+        aux_node = list->first_node;
+        list->first_node = aux_node->next;
+        os_free(aux_node);
+    }
+
+    list->last_node = NULL;
+    list->cur_node = NULL;
+    list->first_node = NULL;
+
+    list->currently_size = 0;
+
+    w_mutex_unlock((pthread_mutex_t *)&list->mutex);
+    w_rwlock_unlock((pthread_rwlock_t *)&list->wr_mutex);
+}

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -91,7 +91,8 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap
                              -Wl,--wrap,OSHash_SetFreeDataPointer -Wl,--wrap,OSHash_Delete \
                              -Wl,--wrap,pthread_rwlock_init -Wl,--wrap,pthread_rwlock_rdlock \
                              -Wl,--wrap,pthread_rwlock_unlock -Wl,--wrap,pthread_rwlock_wrlock \
-                             -Wl,--wrap,pthread_mutex_trylock -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Add")
+                             -Wl,--wrap,pthread_mutex_trylock -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Add \
+                             -Wl,--wrap,OSList_CleanOnlyNodes -Wl,--wrap,w_analysisd_accumulate_free")
 
 LIST(APPEND analysisd_names "test_logtest-config")
 LIST(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug2 -Wl,--wrap,get_nproc -Wl,--wrap,cJSON_CreateObject \

--- a/src/unit_tests/analysisd/test_logtest.c
+++ b/src/unit_tests/analysisd/test_logtest.c
@@ -159,6 +159,14 @@ int __wrap_OSHash_setSize(OSHash *self, unsigned int new_size) {
     return mock();
 }
 
+void __wrap_w_analysisd_accumulate_free(OSHash **acm_store) {
+    return;
+}
+
+void __wrap_OSList_CleanOnlyNodes(OSList *list) {
+    return;
+}
+
 int __wrap_OSHash_SetFreeDataPointer(OSHash *self, void (free_data_function)(void *)) {
     return mock_type(int);
 }
@@ -870,8 +878,6 @@ void test_w_logtest_remove_session_OK(void **state)
 
     will_return(__wrap_OSHash_Free, session);
 
-    will_return(__wrap_OSHash_Free, session);
-
     will_return(__wrap_pthread_mutex_destroy, 0);
 
     expect_string(__wrap__mdebug1, formatted_msg, "(7206): The session 'test' was closed successfully");
@@ -970,8 +976,6 @@ void test_w_logtest_check_inactive_sessions_remove(void **state)
 
     will_return(__wrap_OSHash_Free, session);
 
-    will_return(__wrap_OSHash_Free, session);
-
     will_return(__wrap_pthread_mutex_destroy, 0);
 
     expect_string(__wrap__mdebug1, formatted_msg, "(7206): The session 'test' was closed successfully");
@@ -1036,8 +1040,6 @@ void test_w_logtest_remove_old_session_one(void ** state) {
 
     will_return(__wrap_OSHash_Free, old_session);
 
-    will_return(__wrap_OSHash_Free, old_session);
-
     will_return(__wrap_pthread_mutex_destroy, 0);
 
     expect_string(__wrap__mdebug1, formatted_msg, "(7206): The session 'old_session' was closed successfully");
@@ -1088,8 +1090,6 @@ void test_w_logtest_remove_old_session_many(void ** state) {
     will_return(__wrap_OSHash_Delete, old_session);
 
     will_return(__wrap_OSStore_Free, NULL);
-
-    will_return(__wrap_OSHash_Free, old_session);
 
     will_return(__wrap_OSHash_Free, old_session);
 
@@ -1172,8 +1172,6 @@ void test_w_logtest_register_session_remove_old(void ** state) {
     will_return(__wrap_OSHash_Delete, old_session);
 
     will_return(__wrap_OSStore_Free, NULL);
-
-    will_return(__wrap_OSHash_Free, old_session);
 
     will_return(__wrap_OSHash_Free, old_session);
 
@@ -4059,8 +4057,6 @@ void test_w_logtest_process_request_remove_session_ok(void ** state)
     will_return(__wrap_OSHash_Delete, session);
 
     will_return(__wrap_OSStore_Free, session->decoder_store);
-
-    will_return(__wrap_OSHash_Free, session);
 
     will_return(__wrap_OSHash_Free, session);
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7911 |
|Closes #7878 |
|Closes #7877 |

Hi team!,

This PR fix 3 leaks:

1. **regex_matching** : The regex_matching structure has fields that change size dynamically. There are some situations in which when using this structure to make multiple matches when frees it, it did not do it completely.
2. The fts list must be free, without frees the content of the nodes, since they are referenced by a hash table.
3. ACM Storage: When deleting data from accumulators, the contents of all fields in the accumulator must also be free.

The Valgrind output showing these three types of memory leaks:
[Master_Valgrind.txt](https://github.com/wazuh/wazuh/files/6158982/Master_Valgrind.txt)

Attached are 900 test logs for testing and the valgrind reports for testing those logs in wazuh-logtest.
`cat test_logs_base.txt | /var/ossec/bin/wazuh-logtest`

[Valgrind report](https://github.com/wazuh/wazuh/files/6158983/PR_Valgrind.txt)  for test_logs_base.txt
logs for test: [test_logs_base.txt](https://github.com/wazuh/wazuh/files/6158984/test_logs_base.txt)

The test was also performed with `runtest.py`, [this is its report](https://github.com/wazuh/wazuh/files/6164430/Valgrind_runtest.txt)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] ~Windows~
  - [x] ~MAC OS X~
- [X] Source installation
- [] Package installation
- [X] Source upgrade
- [ ] Package upgrade
- [x] ~Review logs syntax and correct language~
- [x] ~QA templates contemplate the added capabilities~

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [X] Valgrind (memcheck and descriptor leaks check)
  - [x] ~Dr. Memory~
  - [x] ~AddressSanitizer~

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] ~Working on cluster environments~
- [x] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [x] ~Stress test for affected components~
