### PR TITLE
Add force_reconnect_interval config to Wazuh Agent

### DIFF
--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -70,6 +70,10 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     }
 
     minfo("Using notify time: %d and max time to reconnect: %d", agt->notify_time, agt->max_time_reconnect_try);
+    if (agt->force_reconnect_interval) {
+        //JJP Ver como queda este mensaje
+        minfo("Using force_reconnect_interval, Wazuh Agent will reconnect every %d seconds", agt->force_reconnect_interval);
+    }
 
     if (!getuname()) {
         merror(MEM_ERROR, errno, strerror(errno));

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -71,8 +71,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
 
     minfo("Using notify time: %d and max time to reconnect: %d", agt->notify_time, agt->max_time_reconnect_try);
     if (agt->force_reconnect_interval) {
-        //JJP Ver como queda este mensaje
-        minfo("Using force_reconnect_interval, Wazuh Agent will reconnect every %d seconds", agt->force_reconnect_interval);
+        minfo("Using force_reconnect_interval, Wazuh Agent will reconnect every %ld %s", w_seconds_to_time_value(agt->force_reconnect_interval), w_seconds_to_time_unit(agt->force_reconnect_interval, TRUE));
     }
 
     if (!getuname()) {

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -71,7 +71,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
 
     minfo("Using notify time: %d and max time to reconnect: %d", agt->notify_time, agt->max_time_reconnect_try);
     if (agt->force_reconnect_interval) {
-        minfo("Using force_reconnect_interval, Wazuh Agent will reconnect every %ld %s", w_seconds_to_time_value(agt->force_reconnect_interval), w_seconds_to_time_unit(agt->force_reconnect_interval, TRUE));
+        minfo("Using force reconnect interval, Wazuh Agent will reconnect every %ld %s", w_seconds_to_time_value(agt->force_reconnect_interval), w_seconds_to_time_unit(agt->force_reconnect_interval, TRUE));
     }
 
     if (!getuname()) {

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -152,6 +152,7 @@ extern int min_eps;
 /* Global variables. Only modified during startup. */
 
 extern time_t available_server;
+extern time_t last_connection_time;
 extern int run_foreground;
 extern keystore keys;
 extern agent *agt;

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -16,6 +16,7 @@
 
 /* Global variables */
 time_t available_server;
+time_t last_connection_time;
 int run_foreground;
 keystore keys;
 agent *agt;
@@ -85,6 +86,7 @@ cJSON *getClientConfig(void) {
     if (agt->profile) cJSON_AddStringToObject(client,"config-profile",agt->profile);
     cJSON_AddNumberToObject(client,"notify_time",agt->notify_time);
     cJSON_AddNumberToObject(client,"time-reconnect",agt->max_time_reconnect_try);
+    cJSON_AddNumberToObject(client,"force_reconnect_interval",agt->force_reconnect_interval);
     cJSON_AddNumberToObject(client,"ip_update_interval",agt->main_ip_update_interval);
     if (agt->lip) cJSON_AddStringToObject(client,"local_ip",agt->lip);
     if (agt->flags.auto_restart) cJSON_AddStringToObject(client,"auto_restart","yes"); else cJSON_AddStringToObject(client,"auto_restart","no");

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -114,11 +114,12 @@ void run_notify()
         os_delwait();
         w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
     }
+#endif
 
     /* Check if the agent has to be reconnected */
     if (agt->force_reconnect_interval && (curr_time - last_connection_time) >= agt->force_reconnect_interval) {
         /* Set lock and wait for it */
-        minfo("Wazuh Agent will be reconnected because of force_reconnect_interval");
+        minfo("Wazuh Agent will be reconnected because of force reconnect interval");
         os_setwait();
         w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
 
@@ -128,8 +129,6 @@ void run_notify()
         os_delwait();
         w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
     }
-
-#endif
 
     /* Check if time has elapsed */
     if ((curr_time - g_saved_time) < agt->notify_time) {

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -116,16 +116,14 @@ void run_notify()
     }
 
     /* Check if the agent has to be reconnected */
-    if (agt->force_reconnect_interval && (curr_time - last_connection_time) > agt->force_reconnect_interval) {
+    if (agt->force_reconnect_interval && (curr_time - last_connection_time) >= agt->force_reconnect_interval) {
         /* Set lock and wait for it */
-        mdebug1("Wazuh Agent will be reconnected because of force_reconnect_interval");
+        minfo("Wazuh Agent will be reconnected because of force_reconnect_interval");
         os_setwait();
         w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
 
         /* Send sync message */
         start_agent(0);
-
-        mdebug1("Wazuh Agent is now reconnected");
 
         os_delwait();
         w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -114,6 +114,23 @@ void run_notify()
         os_delwait();
         w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
     }
+
+    /* Check if the agent has to be reconnected */
+    if (agt->force_reconnect_interval && (curr_time - last_connection_time) > agt->force_reconnect_interval) {
+        /* Set lock and wait for it */
+        mdebug1("Wazuh Agent will be reconnected because of force_reconnect_interval");
+        os_setwait();
+        w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
+
+        /* Send sync message */
+        start_agent(0);
+
+        mdebug1("Wazuh Agent is now reconnected");
+
+        os_delwait();
+        w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
+    }
+
 #endif
 
     /* Check if time has elapsed */

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -120,6 +120,7 @@ bool connect_server(int server_id, bool verbose)
             }
         #endif
         agt->rip_id = server_id;
+        last_connection_time = (int)time(NULL);
         return true;
     }
     return false;

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -145,14 +145,11 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, xml_force_reconnect_interval) == 0) {
-            if (!OS_StrIsNum(node[i]->content)) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
-                return (OS_INVALID);
-            }
-            logr->force_reconnect_interval = atoi(node[i]->content);
-            if (logr->force_reconnect_interval < 0) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
-                return (OS_INVALID);
+            long t = w_parse_time(node[i]->content);
+            if (t <= 0) {
+                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
+            } else {
+                logr->force_reconnect_interval = t;
             }
         } else if (strcmp(node[i]->element, xml_main_ip_update_interval) == 0) {
             if (!OS_StrIsNum(node[i]->content)) {

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -146,7 +146,7 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
             }
         } else if (strcmp(node[i]->element, xml_force_reconnect_interval) == 0) {
             long t = w_parse_time(node[i]->content);
-            if (t <= 0) {
+            if (t < 0) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 logr->force_reconnect_interval = t;

--- a/src/config/client-config.c
+++ b/src/config/client-config.c
@@ -31,6 +31,7 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     const char *xml_ar_disabled = "disable-active-response";
     const char *xml_notify_time = "notify_time";
     const char *xml_max_time_reconnect_try = "time-reconnect";
+    const char *xml_force_reconnect_interval = "force_reconnect_interval";
     const char *xml_main_ip_update_interval = "ip_update_interval";
     const char *xml_profile_name = "config-profile";
     const char *xml_auto_restart = "auto_restart";
@@ -46,6 +47,7 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     agent * logr = (agent *)d1;
     logr->notify_time = 0;
     logr->max_time_reconnect_try = 0;
+    logr->force_reconnect_interval = 0;
     logr->main_ip_update_interval = 0;
     logr->rip_id = 0;
     logr->server_count = 0;
@@ -139,6 +141,16 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
             }
             logr->max_time_reconnect_try = atoi(node[i]->content);
             if (logr->max_time_reconnect_try < 0) {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
+        } else if (strcmp(node[i]->element, xml_force_reconnect_interval) == 0) {
+            if (!OS_StrIsNum(node[i]->content)) {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
+            logr->force_reconnect_interval = atoi(node[i]->content);
+            if (logr->force_reconnect_interval < 0) {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -38,7 +38,7 @@ typedef struct _agent {
     char *lip;
     int notify_time;
     int max_time_reconnect_try;
-    int force_reconnect_interval;
+    long force_reconnect_interval;
     int main_ip_update_interval;
     char *profile;
     int buffer;

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -38,6 +38,7 @@ typedef struct _agent {
     char *lip;
     int notify_time;
     int max_time_reconnect_try;
+    int force_reconnect_interval;
     int main_ip_update_interval;
     char *profile;
     int buffer;

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -26,12 +26,29 @@
 char *convert_windows_string(LPCWSTR string);
 #endif
 
+// Time values for conversion
+#define W_WEEK_SECONDS      604800
+#define W_DAY_SECONDS       86400
+#define W_HOUR_SECONDS      3600
+#define W_MINUTE_SECONDS    60
+
+// Time units
+#define W_WEEKS_L   "week(s)"
+#define W_WEEKS_S   "w"
+#define W_DAYS_L    "day(s)"
+#define W_DAYS_S    "d"
+#define W_HOURS_L   "hour(s)"
+#define W_HOURS_S   "h"
+#define W_MINUTES_L "minute(s)"
+#define W_MINUTES_S "m"
+#define W_SECONDS_L "second(s)"
+#define W_SECONDS_S "s"
+
 // Convert string to lowercase
 #define str_lowercase(str_lc) { char *x = str_lc; while (*x != '\0') { *x = tolower(*x); x++; } }
 
 // Convert string to uppercase
 #define str_uppercase(str_lc) { char *x = str_lc; while (*x != '\0') { *x = toupper(*x); x++; } }
-
 
 // Convert double to string
 #define w_double_str(x) ({char *do_str; os_calloc(20, sizeof(char),do_str); snprintf(do_str, 19, "%f", x); do_str;})
@@ -163,7 +180,7 @@ long w_parse_time(const char * string);
 
 /**
  * @brief Convert seconds into the greater valid time unit (s|m|h|d|w).
- * The convertion will always round down the output. 
+ * The conversion will always round down the output. 
  *
  * s: seconds
  * m: minutes
@@ -182,7 +199,7 @@ char* w_seconds_to_time_unit(long seconds, bool long_format);
 
 /**
  * @brief Convert seconds into the greater time value.
- *  * The convertion will always round down the output.
+ *  * The conversion will always round down the output.
  *
  * @param seconds Positive amount of seconds.
  * @return Value of the seconds converted to the greater time unit.

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -160,6 +160,35 @@ int w_parse_bool(const char * string);
  */
 long w_parse_time(const char * string);
 
+/**
+ * @brief Convert seconds into the greater valid time unit (s|m|h|d|w).
+ * The convertion will always round down the output. 
+ *
+ * s: seconds
+ * m: minutes
+ * h: hours
+ * d: days
+ * w: weeks
+ *
+ * @param seconds Positive amount of seconds.
+ * @param long_format Format of the output. 
+ *                    TRUE: long format ("second(s)").
+ *                    FALSE: short format ("s")
+ * @return String with the time unit.
+ * @retval "invalid" if the input is negative. A time unit if the input is valid.
+ */
+char* w_seconds_to_time_unit(long seconds, bool long_format);
+
+/**
+ * @brief Convert seconds into the greater time value.
+ *  * The convertion will always round down the output.
+ *
+ * @param seconds Positive amount of seconds.
+ * @return Value of the seconds converted to the greater time unit.
+ * @retval - if the input is negative. A time value if the input is valid.
+ */
+long w_seconds_to_time_value(long seconds);
+
 /*
  * @brief Length of the initial segment of s which consists entirely of non-escaped bytes different from reject
  *

--- a/src/headers/string_op.h
+++ b/src/headers/string_op.h
@@ -12,6 +12,7 @@
 #define H_STRINGOP_OS
 
 #include <external/cJSON/cJSON.h>
+#include <stdbool.h>
 
 #ifdef WIN32
 #include <winsock2.h>

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -759,6 +759,54 @@ long w_parse_time(const char * string) {
     return seconds >= 0 ? seconds : -1;
 }
 
+// Get time unit from seconds
+
+char*  w_seconds_to_time_unit(long seconds, bool long_format) {
+
+    if (seconds < 0) {
+        return "invalid";
+    }
+    else if (seconds >= 604800) {
+        return long_format ? "week(s)" : "w" ;
+    }
+    else if (seconds >= 86400) {
+        return long_format ? "day(s)" : "d" ;
+    }
+    else if (seconds >= 3600) {
+        return long_format ? "hour(s)" : "h" ;
+    }
+    else if (seconds >= 60) {
+       return long_format ? "minute(s)" : "m" ;
+    }
+    else  {
+       return long_format ? "second(s)" : "s" ;
+    }
+}
+
+// Get time value from seconds
+
+long w_seconds_to_time_value(long seconds) {
+    
+    if(seconds < 0) {
+        return -1;
+    }
+    else if (seconds >= 604800) {
+        return seconds/604800;
+    }
+    else if (seconds >= 86400) {
+        return seconds/86400;
+    }
+    else if (seconds >= 3600) {
+        return seconds/3600;
+    }
+    else if (seconds >= 60) {
+        return seconds/60;
+    }
+    else {
+        return seconds;
+    }
+}
+
 char* decode_hex_buffer_2_ascii_buffer(const char * const encoded_buffer, const size_t buffer_size)
 {
     if (!encoded_buffer) {

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -11,6 +11,7 @@
 #include "shared.h"
 #include "string.h"
 #include "../os_regex/os_regex.h"
+#include "string_op.h"
 
 #ifdef WIN32
 #ifdef EVENTCHANNEL_SUPPORT

--- a/src/shared/string_op.c
+++ b/src/shared/string_op.c
@@ -739,19 +739,19 @@ long w_parse_time(const char * string) {
     switch (*end) {
     case '\0':
         break;
+    case 'w':
+        seconds *= W_WEEK_SECONDS;
+        break;
     case 'd':
-        seconds *= 86400;
+        seconds *= W_DAY_SECONDS;
         break;
     case 'h':
-        seconds *= 3600;
+        seconds *= W_HOUR_SECONDS;
         break;
     case 'm':
-        seconds *= 60;
+        seconds *= W_MINUTE_SECONDS;
         break;
     case 's':
-        break;
-    case 'w':
-        seconds *= 604800;
         break;
     default:
         return -1;
@@ -767,20 +767,20 @@ char*  w_seconds_to_time_unit(long seconds, bool long_format) {
     if (seconds < 0) {
         return "invalid";
     }
-    else if (seconds >= 604800) {
-        return long_format ? "week(s)" : "w" ;
+    else if (seconds >= W_WEEK_SECONDS) {
+        return long_format ? W_WEEKS_L : W_WEEKS_S ;
     }
-    else if (seconds >= 86400) {
-        return long_format ? "day(s)" : "d" ;
+    else if (seconds >= W_DAY_SECONDS) {
+        return long_format ? W_DAYS_L : W_DAYS_S ;
     }
-    else if (seconds >= 3600) {
-        return long_format ? "hour(s)" : "h" ;
+    else if (seconds >= W_HOUR_SECONDS) {
+        return long_format ? W_HOURS_L : W_HOURS_S ;
     }
-    else if (seconds >= 60) {
-       return long_format ? "minute(s)" : "m" ;
+    else if (seconds >= W_MINUTE_SECONDS) {
+       return long_format ? W_MINUTES_L : W_MINUTES_S ;
     }
-    else  {
-       return long_format ? "second(s)" : "s" ;
+    else {
+       return long_format ? W_SECONDS_L : W_SECONDS_S ;
     }
 }
 
@@ -791,17 +791,17 @@ long w_seconds_to_time_value(long seconds) {
     if(seconds < 0) {
         return -1;
     }
-    else if (seconds >= 604800) {
-        return seconds/604800;
+    else if (seconds >= W_WEEK_SECONDS) {
+        return seconds/W_WEEK_SECONDS;
     }
-    else if (seconds >= 86400) {
-        return seconds/86400;
+    else if (seconds >= W_DAY_SECONDS) {
+        return seconds/W_DAY_SECONDS;
     }
-    else if (seconds >= 3600) {
-        return seconds/3600;
+    else if (seconds >= W_HOUR_SECONDS) {
+        return seconds/W_HOUR_SECONDS;
     }
-    else if (seconds >= 60) {
-        return seconds/60;
+    else if (seconds >= W_MINUTE_SECONDS) {
+        return seconds/W_MINUTE_SECONDS;
     }
     else {
         return seconds;

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -105,6 +105,10 @@ int local_start()
         minfo("Max time to reconnect can't be less than notify_time(%d), using notify_time*3 (%d)", agt->notify_time, agt->max_time_reconnect_try);
     }
     minfo("Using notify time: %d and max time to reconnect: %d", agt->notify_time, agt->max_time_reconnect_try);
+    if (agt->force_reconnect_interval) {
+        //JJP Ver como queda este mensaje
+        minfo("Using force_reconnect_interval, Wazuh Agent will reconnect every %d seconds", agt->force_reconnect_interval);
+    }
 
     // Resolve hostnames
     rc = 0;

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -106,8 +106,8 @@ int local_start()
     }
     minfo("Using notify time: %d and max time to reconnect: %d", agt->notify_time, agt->max_time_reconnect_try);
     if (agt->force_reconnect_interval) {
-        //JJP Ver como queda este mensaje
-        minfo("Using force_reconnect_interval, Wazuh Agent will reconnect every %d seconds", agt->force_reconnect_interval);
+        minfo("Using force_reconnect_interval, Wazuh Agent will reconnect every %ld %s", \
+               w_seconds_to_time_value(agt->force_reconnect_interval), w_seconds_to_time_unit(agt->force_reconnect_interval, TRUE));
     }
 
     // Resolve hostnames

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -106,7 +106,7 @@ int local_start()
     }
     minfo("Using notify time: %d and max time to reconnect: %d", agt->notify_time, agt->max_time_reconnect_try);
     if (agt->force_reconnect_interval) {
-        minfo("Using force_reconnect_interval, Wazuh Agent will reconnect every %ld %s", \
+        minfo("Using force reconnect interval, Wazuh Agent will reconnect every %ld %s", \
                w_seconds_to_time_value(agt->force_reconnect_interval), w_seconds_to_time_unit(agt->force_reconnect_interval, TRUE));
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|#7893|

## Description
This PR adds **force_reconnect_interval** config to the agent. 
This new configuration is **disabled** by default and isn't included in **ossec.conf** out of the box. Setting it to **0** or excluding it from **ossec.conf** means **disabled**.
This feature accepts (w|d|h|m|s) format. Setting it as <force_reconnect_interval>2m</force_reconnect_interval> means that the agent will close the connection with the manager and reconnect every 120 seconds. This feature has a minimum accepted value of 1 second.

When this feature is enabled, one INFO log will be written to inform the user that the feature is enabled and the reconnection period. 

This reconnection is explicitly written in the logs with **INFO** tag. This is done this way because the disconnection and connection to a manager will always log an INFO message informing this action, so, it will be clear for users to know the reason for this.

Also, this reconnection sets a lock and a **NACTIVE** status on the agent. This is required because we need to block any thread capable to send data to the manager to avoid it tries to send it during the reconnection. Leading to errors and WARNING messages like `WARNING: (1218): Unable to send message to 'server': No such file or directory`
Setting this lock, have a small possibility of unchaining the following WARNING message if a thread was already going to send data when the reconnection occurs: `WARNING: Process locked due to agent is offline. Waiting for connection...`

## Logs/Alerts example
![image](https://user-images.githubusercontent.com/11434230/111645641-af186380-87df-11eb-9a2e-fbed77aba956.png)

![image](https://user-images.githubusercontent.com/11434230/111645939-f9014980-87df-11eb-8bf0-26395ddeb52a.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
- [X] Source installation
- [X] Package installation
<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [X] Valgrind (memcheck and descriptor leaks check)
