### PR TITLE
Fixed false positive of Coverity

### DIFF
--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1871,6 +1871,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
     /* Done over here */
     retval = 0;
+    config_ruleinfo = NULL;
 
 cleanup:
 
@@ -1898,7 +1899,7 @@ cleanup:
     OS_ClearNode(rule);
     OS_ClearNode(rule_opt);
     
-    if (retval) {
+    if (config_ruleinfo != NULL) {
         os_remove_ruleinfo(config_ruleinfo);
     }
 


### PR DESCRIPTION
Hello team,

This RP solves the following false positive of Coverity:
```
** CID 219713:  Resource leaks  (RESOURCE_LEAK)
/analysisd/rules.c: 1909 in Rules_OP_ReadRules()


________________________________________________________________________________________________________
*** CID 219713:  Resource leaks  (RESOURCE_LEAK)
/analysisd/rules.c: 1909 in Rules_OP_ReadRules()
1903         }
1904     
1905         /* Clean global node */
1906         OS_ClearNode(node);
1907         OS_ClearXML(&xml);
1908     
>>>     CID 219713:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "config_ruleinfo" going out of scope leaks the storage it points to.
1909         return retval;
1910     }
1911     
1912     /* Allocate memory at "*at" and copy *str to it.
1913      * If *at already exist, realloc the memory and cat str on it.
1914      * Returns the new string
```
Regards !

# Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
