### PR TITLE
Update agent GET integration test

### DIFF
--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1264,8 +1264,6 @@ stages:
         error: !anyint
         data:
           active-response:
-            ca_store: !anything
-            ca_verification: !anystr
             disabled: !anystr
 
   - name: Request-Com-Internal (Manager)


### PR DESCRIPTION
Hello team,

This PR adapts `test_agent_GET_endpoints` API integration test to the changes introduced by Core team in https://github.com/wazuh/wazuh/pull/6601. The `ca_verification` and `ca_store` tags were moved from `active-response` to `agent-upgrade`.

## Test results

```
test_agent_GET_endpoints.tavern.yaml 
	 90 passed, 1 warnings
```