### PR TITLE
Update 0010-active-response_decoders.xml

### DIFF
--- a/ruleset/decoders/0010-active-response_decoders.xml
+++ b/ruleset/decoders/0010-active-response_decoders.xml
@@ -1,6 +1,7 @@
 <!--
   -  Active response decoders
   -  Author: Daniel Cid.
+  -  Custom by: Simon. V
   -  Updated by Wazuh, Inc.
   -  Copyright (C) 2015-2020, Wazuh Inc.
   -  Copyright (C) 2009 Trend Micro Inc.
@@ -22,28 +23,35 @@ Wed 12/07/2016 19:39:40.15 "active-response/bin/route-null.cmd" add "-" "10.99.9
 Wed 12/07/2016 19:40:06.89 "active-response/bin/restart-ossec.cmd" add "-" "10.99.99.12" "(from_the_server) (no_rule_id)"
 Wed 12/07/2016 16:48:15.37 "active-response/bin/route-null.cmd" add "-" "192.168.2.66" "1481129296.262924 100001 /home/test.txt (null)"
 Wed 12/07/2016 16:48:15.37 "active-response/bin/route-null.cmd" delete "-" "192.168.2.66" "1481129296.262924 100001 /home/test.txt (null)"
-Tue 08/28/2018 09:25:23.14 "active-response/bin/netsh.cmd" delete "-" "1.2.3.4" "1535465731.23945822 18258 (some-hostname) any->WinEvtLog (null)"
-Tue 08/28/2018 09:27:23.14 "active-response/bin/netsh.cmd" add "-" "1.2.3.4" "1535466424.24354011 18258 (some-hostname) any->WinEvtLog (null)"
+08/28/2018  09:25 "active-response/bin/netsh.cmd" delete "-" "1.2.3.4" "1535465731.23945822 18258 (some-hostname) any->WinEvtLog (null)"
+08/28/2018  09:27 "active-response/bin/netsh.cmd" add "-" "1.2.3.4" "1535466424.24354011 18258 (some-hostname) any->WinEvtLog (null)"
 -->
 
 
 <decoder name="ar_log">
-  <prematch>^\w\w\w \w+\s+\d+ \d\d:\d\d:\d\d \p*\w+ \d+ /\S+/active-response/bin/|^\w\w\w \d\d/\d\d/\d\d\d\d \.+"active-response/bin/|^\d\d/\d\d/\d\d\d\d \.+"active-response/bin/</prematch>
+  <prematch>active-response/bin/</prematch>
 </decoder>
 
 <decoder name="ar_log_fields">
     <parent>ar_log</parent>
-    <regex offset="after_parent">^(\S+) (\S+) \S+ (\S+) (\.+) |^(\S+)" (\S+) "\S+" "(\S+)" "(\.+) </regex>
-    <order>script, type, srcip, id</order>
+    <regex type="pcre2">\/bin\/(\S+)"\s+(\S+)|\/bin\/(\S+)\s+(\S+)</regex>
+    <order>script, type</order>
 </decoder>
 
 <decoder name="ar_log_fields">
     <parent>ar_log</parent>
-    <regex offset="after_regex">^(\d+)|(\.+\))</regex>
-    <order>extra_data</order>
+    <regex type="pcre2">\/bin\/\S+"\s+\S+\s(\w+)|\/bin\/\S+\s+\S+\s(\w+)</regex>
+    <order>dstuser</order>
 </decoder>
 
-<decoder name="ar_log_json">
-    <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d /\S+/active-response/bin/\S+: </prematch>
-    <plugin_decoder offset="after_prematch">JSON_Decoder</plugin_decoder>
+<decoder name="ar_log_fields">
+    <parent>ar_log</parent>
+    <regex>(\d+.\d+.\d+.\d+)</regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="ar_log_fields">
+    <parent>ar_log</parent>
+    <regex>(\d+)"$|(\d+)$</regex>
+    <order>id</order>
 </decoder>

--- a/ruleset/decoders/0520-watchguard_decoders.xml
+++ b/ruleset/decoders/0520-watchguard_decoders.xml
@@ -1,0 +1,142 @@
+<!-- WatchGuard - LEEF Format -->
+<decoder name="Watchguard">
+  <prematch>|WatchGuard|</prematch>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">msg=([a-z,A-Z,\d,\s,\-,(,),@,.]+)</regex>
+  <order>data</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">(\w+)@Firebox-DB.+from.(\d+.\d+.\d+.\d+).(.+$)</regex>
+  <order>dstuser, srcip,  extra_data</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex>(\d\d:\d\d:\d\d)</regex>
+  <order>time</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">ip_len=(\S+)\s+ip_TTL</regex>
+  <order>ip_len</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">ip_TTL=(\S+)\s+proto</regex>
+  <order>ip_TTL</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">tcp_offset=(\S+)\s+tcp_flag</regex>
+  <order>tcp_offset</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">tcp_flag=(\S+)\s+tcp_seq</regex>
+  <order>tcp_flag</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">tcp_seq=(\S+)\s+tcp_window</regex>
+  <order>tcp_seq</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex>tcp_window=(\S+)</regex>
+  <order>tcp_window</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">in_if=(\S+)\s+out_if</regex>
+  <order>in_if</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">out_if=(\S+)\s+ip_len</regex>
+  <order>out_if</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">policy=(\S+.\S+.\S+)\s+d</regex>
+  <order>policy</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex>devTime=(\S+\s\S+\s\S+) </regex>
+  <order>date</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex>sys_name=(\w\d\d)</regex>
+  <order>sys_name</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">\|(\d{8})\|</regex>
+  <order>id</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">src=(\S+)\s+src</regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">srcPort=(\S+)\s+dst</regex>
+  <order>srcport</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">srcPort=(\S+)\s+srcPostNAT=</regex>
+  <order>srcport</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">dst=(\S+)\s+dstPort=</regex>
+  <order>dstip</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">dstPostNAT=(\S+)\s+tcp_off</regex>
+  <order>dstip</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">dst=\S+\s+dstPort=(\S+)</regex>
+  <order>dstport</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">disp=(\S+)\s+in_if</regex>
+  <order>action</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">proto=(\S+)\s+src=</regex>
+  <order>protocol</order>
+</decoder>

--- a/ruleset/rules/0715-watchguard_rules.xml
+++ b/ruleset/rules/0715-watchguard_rules.xml
@@ -1,0 +1,102 @@
+!--
+This file happens to be very personal for some rules.
+Like the names of the firewall interfaces, the name of the admin, etc. 
+(users are defined from the moment their name is different from "admin").
+You must change the interface names in the file for your watchguard firewall,
+as well as the name of your admin(s).
+-->
+
+<group name="watchguard">
+
+  <rule id="200001" level="3">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - Allowed traffic from external</description>
+    <regex>in_if=0-External</regex>
+    <action>Allow</action>
+  </rule>
+
+  <rule id="200002" level="5">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - Denied traffic from external</description>
+    <regex>in_if=0-External</regex>
+    <action>Deny</action>
+  </rule>
+
+  <rule id="200003" level="3">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - Allowed traffic from lan</description>
+    <regex>in_if=1-Trusted</regex>
+    <action>Allow</action>
+  </rule>
+
+  <rule id="200004" level="5">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - Denied traffic from lan</description>
+    <regex>in_if=1-Trusted</regex>
+    <action>Deny</action>
+  </rule>
+
+  <rule id="200005" level="3">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - Allowed traffic from dmz</description>
+    <regex>in_if=2-DMZ</regex>
+    <action>Allow</action>
+  </rule>
+
+  <rule id="200006" level="5">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - Denied traffic from dmz</description>
+    <regex>in_if=2-DMZ</regex>
+    <action>Deny</action>
+  </rule>
+
+  <rule id="200007" level="3">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - Admin logged in</description>
+    <user>admin</user>
+    <extra_data>logged in</extra_data>
+  </rule>
+
+  <rule id="200008" level="3">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - Admin logged out</description>
+    <user>admin</user>
+    <extra_data>logged out</extra_data>
+  </rule>
+
+  <rule id="200009" level="9">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - Admin password incorrect</description>
+    <user>admin</user>
+    <extra_data>password is incorrect</extra_data>
+  </rule>
+
+  <rule id="200010" level="5">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - User password incorrect</description>
+    <user>!admin</user>
+    <extra_data>password is incorrect</extra_data>
+  </rule>
+
+  <rule id="200011" level="3">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - User logged in</description>
+    <user>!admin</user>
+    <extra_data>logged in</extra_data>
+  </rule>
+
+  <rule id="200012" level="3">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - User logged out</description>
+    <user>!admin</user>
+    <extra_data>logged out</extra_data>
+  </rule>
+
+  <rule id="200013" level="5">
+    <decoded_as>Watchguard</decoded_as>
+    <description>WatchGuard - Invalid credentials</description>
+    <user>!admin</user>
+    <extra_data>invalid credentials</extra_data>
+  </rule>
+
+</group>


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description


French logs were not correctly decoded at the active-response level, this version supports more languages.


## Configuration options


I have established new regex lines while keeping the previous linux/windows compatibility


## Logs/Alerts example

Linux:
EN : Wed Dec 7 18:12:14 UTC 2016 /var/ossec/active-response/bin/route-null.sh delete - 192.168.2.4 1481134294.521764 100
FR : mer 17 mar 2021 10:54:16 CET /var/ossec/active-response/bin/disable-account.sh add usertest - 1615974856.216416928 5720

Windows :
EN : Wed 12/07/2016 19:40:06.89 "active-response/bin/restart-ossec.cmd" add "-" "10.99.99.12" "(from_the_server) (no_rule_id)"
FR : 17-03-21 10:16:55,83 "active-response/bin/restart-ossec.cmd" add "-" "null" "(from_the_server) (no_rule_id)"
