### PR TITLE
Implementing a NO-AR command to force the agent reconnection to the manager

### DIFF
--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -150,7 +150,7 @@ void *receiver_thread(__attribute__((unused)) void *none)
                 /* Force reconnect agent to the manager */
                 else if (strncmp(tmp_msg, HC_FORCE_RECONNECT, strlen(HC_FORCE_RECONNECT)) == 0) {
                     /* Set lock and wait for it */
-                    minfo("Wazuh Agent will be reconnected because of a force_reconnect AR message was received");
+                    minfo("Wazuh Agent will be reconnected because a force_reconnect AR message was received");
                     os_setwait();
                     w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
 

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -147,6 +147,21 @@ void *receiver_thread(__attribute__((unused)) void *none)
                     continue;
                 }
 
+                /* Force reconnect agent to the manager */
+                else if (strncmp(tmp_msg, HC_FORCE_RECONNECT, strlen(HC_FORCE_RECONNECT)) == 0) {
+                    /* Set lock and wait for it */
+                    minfo("Wazuh Agent will be reconnected because of force_reconnect_interval");
+                    os_setwait();
+                    w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
+
+                    /* Send sync message */
+                    start_agent(0);
+
+                    os_delwait();
+                    w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
+                    continue;
+                }
+
                 /* Restart syscheck */
                 else if (strncmp(tmp_msg, HC_SK, strlen(HC_SK)) == 0) {
                     ag_send_syscheck(tmp_msg + strlen(HC_SK));

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -150,7 +150,7 @@ void *receiver_thread(__attribute__((unused)) void *none)
                 /* Force reconnect agent to the manager */
                 else if (strncmp(tmp_msg, HC_FORCE_RECONNECT, strlen(HC_FORCE_RECONNECT)) == 0) {
                     /* Set lock and wait for it */
-                    minfo("Wazuh Agent will be reconnected because a force_reconnect AR message was received");
+                    minfo("Wazuh Agent will be reconnected because a reconnect message was received");
                     os_setwait();
                     w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
 

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -150,7 +150,7 @@ void *receiver_thread(__attribute__((unused)) void *none)
                 /* Force reconnect agent to the manager */
                 else if (strncmp(tmp_msg, HC_FORCE_RECONNECT, strlen(HC_FORCE_RECONNECT)) == 0) {
                     /* Set lock and wait for it */
-                    minfo("Wazuh Agent will be reconnected because of force_reconnect_interval");
+                    minfo("Wazuh Agent will be reconnected because of a force_reconnect AR message was received");
                     os_setwait();
                     w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
 

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -128,7 +128,7 @@ int receive_msg()
             /* Force reconnect agent to the manager */
             else if (strncmp(tmp_msg, HC_FORCE_RECONNECT, strlen(HC_FORCE_RECONNECT)) == 0) {
                 /* Set lock and wait for it */
-                minfo("Wazuh Agent will be reconnected because of force_reconnect_interval");
+                minfo("Wazuh Agent will be reconnected because of a force_reconnect AR message was received");
                 os_setwait();
                 w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
 

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -125,6 +125,21 @@ int receive_msg()
                 continue;
             }
 
+            /* Force reconnect agent to the manager */
+            else if (strncmp(tmp_msg, HC_FORCE_RECONNECT, strlen(HC_FORCE_RECONNECT)) == 0) {
+                /* Set lock and wait for it */
+                minfo("Wazuh Agent will be reconnected because of force_reconnect_interval");
+                os_setwait();
+                w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
+
+                /* Send sync message */
+                start_agent(0);
+
+                os_delwait();
+                w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
+                continue;
+            }
+
             /* Syscheck */
             else if (strncmp(tmp_msg, HC_SK, strlen(HC_SK)) == 0) {
                 ag_send_syscheck(tmp_msg + strlen(HC_SK));

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -128,7 +128,7 @@ int receive_msg()
             /* Force reconnect agent to the manager */
             else if (strncmp(tmp_msg, HC_FORCE_RECONNECT, strlen(HC_FORCE_RECONNECT)) == 0) {
                 /* Set lock and wait for it */
-                minfo("Wazuh Agent will be reconnected because a force_reconnect AR message was received");
+                minfo("Wazuh Agent will be reconnected because a reconnect message was received");
                 os_setwait();
                 w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
 

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -128,7 +128,7 @@ int receive_msg()
             /* Force reconnect agent to the manager */
             else if (strncmp(tmp_msg, HC_FORCE_RECONNECT, strlen(HC_FORCE_RECONNECT)) == 0) {
                 /* Set lock and wait for it */
-                minfo("Wazuh Agent will be reconnected because of a force_reconnect AR message was received");
+                minfo("Wazuh Agent will be reconnected because a force_reconnect AR message was received");
                 os_setwait();
                 w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
 

--- a/src/headers/rc.h
+++ b/src/headers/rc.h
@@ -41,5 +41,6 @@
 #define HC_SYSCOLLECTOR     "syscollector_"
 #define HC_FIM_FILE         "fim_file "
 #define HC_FIM_REGISTRY     "fim_registry "
+#define HC_FORCE_RECONNECT  "force_reconnect"
 
 #endif /* RC_H */


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7895 |

## Description

This pull request implements a mechanism to handle the agent force reconnection requests sent through the RESTfull API (see https://github.com/wazuh/wazuh/issues/7896) to the agents.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Package installation

- Memory tests for Linux
  - [x] Scan-build report
- Memory tests for Windows
  - [x] Scan-build report