### PR TITLE
Develop Python upgrade to the latest stable version (currently v3.9.2)

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -1,8 +1,8 @@
 pip==20.3.3
 wheel==0.34.2
-aiohttp-cache==2.0.2
+aiohttp-cache==2.2.0
 aiohttp-cors==0.7.0
-aiohttp-jinja2==1.2.0
+aiohttp-jinja2==1.4.2
 aiohttp-swagger==1.0.14
 aiohttp==3.7.4
 asn1crypto==1.3.0
@@ -27,11 +27,11 @@ docutils==0.15.2
 ecdsa==0.13.3
 future==0.17.1
 google-api-core==1.16.0
-google-auth==1.14.1
+google-auth==1.28.0
 google-cloud-pubsub==1.4.3
 googleapis-common-protos==1.51.0
 grpc-google-iam-v1==0.12.3
-grpcio==1.28.1
+grpcio>=1.28.1,<=1.36.1
 idna==2.9
 inflection==0.3.1
 itsdangerous==1.1.0
@@ -51,7 +51,7 @@ python-dateutil==2.8.1
 python-jose==3.0.1
 pytz==2020.1
 requests==2.23.0
-rsa==4.0
+rsa==4.7.2
 s3transfer==0.3.3
 secure==0.2.1
 setuptools==46.1.3
@@ -59,7 +59,7 @@ six==1.14.0
 SQLAlchemy==1.3.11
 swagger-ui-bundle==0.0.3
 urllib3==1.25.9
-uvloop==0.14.0
+uvloop==0.15.2
 websocket-client==0.57.0
 Werkzeug==1.0.1
 xmltodict==0.12.0

--- a/src/Makefile
+++ b/src/Makefile
@@ -889,7 +889,7 @@ endif
 TAR := tar -xf
 GUNZIP := gunzip
 CURL := curl -so
-DEPS_VERSION = 11
+DEPS_VERSION = 12
 RESOURCES_URL := https://packages.wazuh.com/deps/$(DEPS_VERSION)
 CPYTHON := cpython
 ifeq (${PREFIX},/var/ossec)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1686,9 +1686,9 @@ endif
 wpython: install_dependencies install_framework install_api install_mitre
 
 ifeq (${uname_S},Darwin)
-WLIBPYTHON=libpython3.8.dylib
+WLIBPYTHON=libpython3.9.dylib
 else
-WLIBPYTHON=libpython3.8.so.1.0
+WLIBPYTHON=libpython3.9.so.1.0
 endif
 
 build_python:


### PR DESCRIPTION
|Related issue|
|---|
|#7220|

Hi team,

This PR closes #7220. In this PR we have changed the version of Python from 3.8.6 to 3.9.2. In addition to this we have changed the version of some of the dependencies so that they are compatible with Python 3.9.

Regards,

Adrián Peña
