### PR TITLE
Added new wazuh-db command to update status in agent vuln_cves table.

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -19,7 +19,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                         -Wl,--wrap,wdbi_query_checksum -Wl,--wrap,wdbi_query_clear -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,wdb_step \
                         -Wl,--wrap,sqlite3_changes -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_last_insert_rowid \
                         -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_open_agent2 -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_agents_insert_vuln_cve \
-                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cve")
+                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cve -Wl,--wrap,wdb_agents_update_status_vuln_cve")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -471,6 +471,10 @@ void test_wdb_init_stmt_in_cache_invalid_transaction(void **state) {
 
 void test_wdb_init_stmt_in_cache_invalid_statement(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
+    int STR_SIZE = 48;
+    char error_message[STR_SIZE];
+
+    snprintf(error_message, STR_SIZE, "DB(000) SQL statement index (%d) out of bounds", WDB_STMT_SIZE);
 
     // wdb_begin2
     will_return(__wrap_sqlite3_prepare_v2, SQLITE_OK);
@@ -478,7 +482,7 @@ void test_wdb_init_stmt_in_cache_invalid_statement(void **state) {
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
     // wdb_stmt_cache
-    expect_string(__wrap__merror, formatted_msg, "DB(000) SQL statement index (174) out of bounds");
+    expect_string(__wrap__merror, formatted_msg, error_message);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
     sqlite3_stmt* result = wdb_init_stmt_in_cache(data->wdb,WDB_STMT_SIZE);

--- a/src/unit_tests/wazuh_db/test_wdb.c
+++ b/src/unit_tests/wazuh_db/test_wdb.c
@@ -478,7 +478,7 @@ void test_wdb_init_stmt_in_cache_invalid_statement(void **state) {
     will_return(__wrap_sqlite3_finalize, SQLITE_OK);
 
     // wdb_stmt_cache
-    expect_string(__wrap__merror, formatted_msg, "DB(000) SQL statement index (172) out of bounds");
+    expect_string(__wrap__merror, formatted_msg, "DB(000) SQL statement index (174) out of bounds");
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
     sqlite3_stmt* result = wdb_init_stmt_in_cache(data->wdb,WDB_STMT_SIZE);

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -127,6 +127,61 @@ void test_wdb_agents_clear_vuln_cve_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_agents_update_status_vuln_cve*/
+
+test_wdb_agents_update_status_vuln_cve_statement_init_fail(void **state){
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* old_status = "valid";
+    const char* new_status = "pending";
+
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_UPDATE);
+
+    ret = wdb_agents_update_status_vuln_cve(data->wdb, old_status, new_status);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+test_wdb_agents_update_status_vuln_cve_success(void **state){
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* old_status = "valid";
+    const char* new_status = "pending";
+
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_UPDATE);
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, new_status);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, old_status);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    ret = wdb_agents_update_status_vuln_cve(data->wdb, old_status, new_status);
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+test_wdb_agents_update_status_vuln_cve_success_all(void **state){
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* old_status = "*";
+    const char* new_status = "pending";
+
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_UPDATE_ALL);
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, new_status);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    ret = wdb_agents_update_status_vuln_cve(data->wdb, old_status, new_status);
+    assert_int_equal(ret, OS_SUCCESS);
+}
 
 int main()
 {
@@ -136,7 +191,11 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cve_success, test_setup, test_teardown),
         /* Tests wdb_agents_clear_vuln_cve */
         cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_statement_init_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_success, test_setup, test_teardown)
+        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_success, test_setup, test_teardown),
+        /* Tests wdb_agents_update_status_vuln_cve */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cve_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cve_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cve_success_all, test_setup, test_teardown),
       };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -339,6 +339,184 @@ void test_wdb_agents_vuln_cve_clear_success(void **state)
     assert_int_equal(OS_SUCCESS, ret);
 }
 
+/* Tests wdb_agents_vuln_cve_update_status */
+
+test_wdb_agents_vuln_cve_update_status_error_json(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *old_status = "valid";
+    const char *new_status = "obsolete";
+
+    will_return(__wrap_cJSON_CreateObject, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
+
+    ret = wdb_agents_vuln_cve_update_status(id, old_status, new_status, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+test_wdb_agents_vuln_cve_update_status_error_socket(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *old_status = "valid";
+    const char *new_status = "obsolete";
+    const char *json_str = NULL;
+
+    os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
+    const char *query_str = "agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "old_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "valid");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "new_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "obsolete");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_INVALID);
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error in the response from socket");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}");
+
+    ret = wdb_agents_vuln_cve_update_status(id, old_status, new_status, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+test_wdb_agents_vuln_cve_update_status_error_sql_execution(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *old_status = "valid";
+    const char *new_status = "obsolete";
+    const char *json_str = NULL;
+
+    os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
+    const char *query_str = "agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "old_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "valid");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "new_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "obsolete");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, -100); // Returning any error
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}");
+
+    ret = wdb_agents_vuln_cve_update_status(id, old_status, new_status, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+test_wdb_agents_vuln_cve_update_status_error_result(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *old_status = "valid";
+    const char *new_status = "obsolete";
+    const char *json_str = NULL;
+
+    os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
+    const char *query_str = "agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "old_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "valid");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "new_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "obsolete");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
+
+    ret = wdb_agents_vuln_cve_update_status(id, old_status, new_status, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+test_wdb_agents_vuln_cve_update_status_success(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *old_status = "valid";
+    const char *new_status = "obsolete";
+    const char *json_str = NULL;
+
+    os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
+    const char *query_str = "agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "old_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "valid");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "new_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "obsolete");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    ret = wdb_agents_vuln_cve_update_status(id, old_status, new_status, NULL);
+
+    assert_int_equal(OS_SUCCESS, ret);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] =
@@ -354,6 +532,12 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_clear_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_clear_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_clear_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cve_update_status*/
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_update_status_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_update_status_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_update_status_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_update_status_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_update_status_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
@@ -24,3 +24,9 @@ int __wrap_wdb_agents_insert_vuln_cve( __attribute__((unused)) wdb_t *wdb, const
 int __wrap_wdb_agents_clear_vuln_cve( __attribute__((unused)) wdb_t *wdb) {
     return mock();
 }
+
+int __wrap_wdb_agents_update_status_vuln_cve( __attribute__((unused)) wdb_t *wdb, const char* old_status, const char* new_status) {
+    check_expected(old_status);
+    check_expected(new_status);
+    return mock();
+}

--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -15,7 +15,7 @@
 static const char *agents_db_commands[] = {
     [WDB_AGENTS_VULN_CVE_INSERT] = "agent %d vuln_cve insert %s",
     [WDB_AGENTS_VULN_CVE_CLEAR] = "agent %d vuln_cve clear",
-    [WDB_AGENTS_VULN_CVE_UPDATE] = "agent %d vuln_cve update %s"
+    [WDB_AGENTS_VULN_CVE_UPDATE_STATUS] = "agent %d vuln_cve update_status %s"
 };
 
 int wdb_agents_vuln_cve_insert(int id,
@@ -123,10 +123,10 @@ int wdb_agents_vuln_cve_clear(int id,
     return result;
 }
 
-int wdb_agents_vuln_cve_update(int id,
-                                      const char *old_status,
-                                      const char *new_status,
-                                      int *sock) {
+int wdb_agents_vuln_cve_update_status(int id,
+                               const char *old_status,
+                               const char *new_status,
+                               int *sock) {
     int result = 0;
     cJSON *data_in = NULL;
     char *data_in_str = NULL;
@@ -147,7 +147,7 @@ int wdb_agents_vuln_cve_update(int id,
 
     data_in_str = cJSON_PrintUnformatted(data_in);
     os_malloc(WDBQUERY_SIZE, wdbquery);
-    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVE_UPDATE], id, data_in_str);
+    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVE_UPDATE_STATUS], id, data_in_str);
 
     os_malloc(WDBOUTPUT_SIZE, wdboutput);
     result = wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);

--- a/src/wazuh_db/helpers/wdb_agents_helpers.h
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.h
@@ -16,7 +16,8 @@
 
 typedef enum agents_db_access {
     WDB_AGENTS_VULN_CVE_INSERT,
-    WDB_AGENTS_VULN_CVE_CLEAR
+    WDB_AGENTS_VULN_CVE_CLEAR,
+    WDB_AGENTS_VULN_CVE_UPDATE
 } agents_db_access;
 
 /**
@@ -46,5 +47,19 @@ int wdb_agents_vuln_cve_insert(int id,
  */
 int wdb_agents_vuln_cve_clear(int id,
                               int *sock);
+
+/** 
+ * @brief Updates all or a specific status from the vuln_cve table in the agents database. 
+ *  
+ * @param[in] id The agent ID.
+ * @param[in] old_status The status that is going to be updated.
+ * @param[in] new_status The new status.
+ * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
+ * @return Returns 0 on success or -1 on error.
+ */
+int wdb_agents_vuln_cve_update(int id,
+                                      const char *old_status,
+                                      const char *new_status,
+                                      int *sock);
 
 #endif

--- a/src/wazuh_db/helpers/wdb_agents_helpers.h
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.h
@@ -52,7 +52,7 @@ int wdb_agents_vuln_cve_clear(int id,
  * @brief Updates all or a specific status from the vuln_cve table in the agents database. 
  *  
  * @param[in] id The agent ID.
- * @param[in] old_status The status that is going to be updated.
+ * @param[in] old_status The status that is going to be updated. The '*' option changes all statuses.
  * @param[in] new_status The new status.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns 0 on success or -1 on error.

--- a/src/wazuh_db/helpers/wdb_agents_helpers.h
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.h
@@ -17,7 +17,7 @@
 typedef enum agents_db_access {
     WDB_AGENTS_VULN_CVE_INSERT,
     WDB_AGENTS_VULN_CVE_CLEAR,
-    WDB_AGENTS_VULN_CVE_UPDATE
+    WDB_AGENTS_VULN_CVE_UPDATE_STATUS
 } agents_db_access;
 
 /**
@@ -57,7 +57,7 @@ int wdb_agents_vuln_cve_clear(int id,
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_agents_vuln_cve_update(int id,
+int wdb_agents_vuln_cve_update_status(int id,
                                       const char *old_status,
                                       const char *new_status,
                                       int *sock);

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -206,7 +206,9 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_RANGE] = "DELETE FROM sys_osinfo WHERE os_name > ? AND os_name < ?;",
     [WDB_STMT_SYSCOLLECTOR_OSINFO_CLEAR] = "DELETE FROM sys_osinfo;",
     [WDB_STMT_VULN_CVE_INSERT] = "INSERT OR IGNORE INTO vuln_cves (name, version, architecture, cve) VALUES(?,?,?,?);",
-    [WDB_STMT_VULN_CVE_CLEAR] = "DELETE FROM vuln_cves;"
+    [WDB_STMT_VULN_CVE_CLEAR] = "DELETE FROM vuln_cves;",
+    [WDB_STMT_VULN_CVE_UPDATE] = "UPDATE vuln_cves SET status = ? WHERE status = ?;",
+    [WDB_STMT_VULN_CVE_UPDATE_ALL] = "UPDATE vuln_cves SET status = ?"
 };
 
 wdb_config wconfig;

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1775,7 +1775,7 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
  *  * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.
  */
- int wdb_parse_agents_update_vuln_cve(wdb_t* wdb, char* input, char* output);
+ int wdb_parse_agents_update_status_vuln_cve(wdb_t* wdb, char* input, char* output);
 
 /**
  * Update old tasks with status in progress to status timeout

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1775,7 +1775,7 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
  *  * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.
  */
- int wdb_parse_agents_update_status_vuln_cve(wdb_t* wdb, char* input, char* output);
+ int wdb_parse_agents_vuln_cve_update_status(wdb_t* wdb, char* input, char* output);
 
 /**
  * Update old tasks with status in progress to status timeout

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -224,6 +224,8 @@ typedef enum wdb_stmt {
     WDB_STMT_SYSCOLLECTOR_OSINFO_CLEAR,
     WDB_STMT_VULN_CVE_INSERT,
     WDB_STMT_VULN_CVE_CLEAR,
+    WDB_STMT_VULN_CVE_UPDATE,
+    WDB_STMT_VULN_CVE_UPDATE_ALL,
     WDB_STMT_SIZE // This must be the last constant
 } wdb_stmt;
 
@@ -1764,6 +1766,16 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
  */
  int wdb_parse_agents_clear_vuln_cve(wdb_t* wdb, char* output);
 
+/**
+ * @brief Function to parse the vuln_cve update action.
+ * 
+ * @param [in] wdb The global struct database.
+ * @param [in] input String with the the data in json format.
+ * @param [out] output Response of the query.
+ *  * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+ int wdb_parse_agents_update_vuln_cve(wdb_t* wdb, char* input, char* output);
 
 /**
  * Update old tasks with status in progress to status timeout

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -26,19 +26,16 @@ int wdb_agents_clear_vuln_cve(wdb_t *wdb) {
 }
 
 int wdb_agents_update_status_vuln_cve(wdb_t *wdb, const char* old_status, const char* new_status) {
-    sqlite3_stmt* stmt = NULL;
     
-    if (strcmp(old_status, "*") == 0) {
-        stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVE_UPDATE_ALL);
-    } else {
-        stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVE_UPDATE);
-    }
+    bool update_all = (strcmp(old_status, "*") == 0);
+
+    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, update_all ? WDB_STMT_VULN_CVE_UPDATE_ALL : WDB_STMT_VULN_CVE_UPDATE);
     
     if (stmt == NULL) {
         return OS_INVALID;
     }
 
-    if (strcmp(old_status, "*") == 0) {
+    if (update_all) {
         sqlite3_bind_text(stmt, 1, new_status, -1, NULL);
     } else {
         sqlite3_bind_text(stmt, 1, new_status, -1, NULL);

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -24,3 +24,22 @@ int wdb_agents_clear_vuln_cve(wdb_t *wdb) {
 
     return wdb_exec_stmt_silent(stmt);
 }
+
+int wdb_agents_update_vuln_cve(wdb_t *wdb, const char* old_status, const char* new_status) {
+    sqlite3_stmt* stmt = NULL;
+    
+    if (strcmp(old_status, "*") == 0) {
+        stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVE_UPDATE_ALL);
+    } else {
+        stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVE_UPDATE);
+    }
+    
+    if (stmt == NULL) {
+        return OS_INVALID;
+    }
+
+    sqlite3_bind_text(stmt, 1, new_status, -1, NULL);
+    sqlite3_bind_text(stmt, 2, old_status, -1, NULL);
+
+    return wdb_exec_stmt_silent(stmt);
+}

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -25,7 +25,7 @@ int wdb_agents_clear_vuln_cve(wdb_t *wdb) {
     return wdb_exec_stmt_silent(stmt);
 }
 
-int wdb_agents_update_vuln_cve(wdb_t *wdb, const char* old_status, const char* new_status) {
+int wdb_agents_update_status_vuln_cve(wdb_t *wdb, const char* old_status, const char* new_status) {
     sqlite3_stmt* stmt = NULL;
     
     if (strcmp(old_status, "*") == 0) {
@@ -38,8 +38,12 @@ int wdb_agents_update_vuln_cve(wdb_t *wdb, const char* old_status, const char* n
         return OS_INVALID;
     }
 
-    sqlite3_bind_text(stmt, 1, new_status, -1, NULL);
-    sqlite3_bind_text(stmt, 2, old_status, -1, NULL);
+    if (strcmp(old_status, "*") == 0) {
+        sqlite3_bind_text(stmt, 1, new_status, -1, NULL);
+    } else {
+        sqlite3_bind_text(stmt, 1, new_status, -1, NULL);
+        sqlite3_bind_text(stmt, 2, old_status, -1, NULL);
+    }
 
     return wdb_exec_stmt_silent(stmt);
 }

--- a/src/wazuh_db/wdb_agents.h
+++ b/src/wazuh_db/wdb_agents.h
@@ -38,7 +38,7 @@ int wdb_agents_insert_vuln_cve(wdb_t *wdb, const char* name, const char* version
  * @brief Function to update the status field in agent database vuln_cve table.
  * 
  * @param [in] wdb The 'agents' struct database.
- * @param [in] old_status The status that is going to be updated.
+ * @param [in] old_status The status that is going to be updated. The '*' option changes all statuses.
  * @param [in] new_status The new status.
  * @return Returns 0 on success or -1 on error.
  */

--- a/src/wazuh_db/wdb_agents.h
+++ b/src/wazuh_db/wdb_agents.h
@@ -34,4 +34,14 @@ int wdb_agents_clear_vuln_cve(wdb_t *wdb);
  */
 int wdb_agents_insert_vuln_cve(wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve);
 
+/**
+ * @brief Function to update the status field in agent database vuln_cve table.
+ * 
+ * @param [in] wdb The 'agents' struct database.
+ * @param [in] old_status The status that is going to be updated.
+ * @param [in] new_status The new status.
+ * @return Returns 0 on success or -1 on error.
+ */
+int wdb_agents_update_vuln_cve(wdb_t *wdb, const char* old_status, const char* new_status);
+
 #endif

--- a/src/wazuh_db/wdb_agents.h
+++ b/src/wazuh_db/wdb_agents.h
@@ -42,6 +42,6 @@ int wdb_agents_insert_vuln_cve(wdb_t *wdb, const char* name, const char* version
  * @param [in] new_status The new status.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_agents_update_vuln_cve(wdb_t *wdb, const char* old_status, const char* new_status);
+int wdb_agents_update_status_vuln_cve(wdb_t *wdb, const char* old_status, const char* new_status);
 
 #endif

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -6062,7 +6062,7 @@ int wdb_parse_vuln_cve(wdb_t* wdb, char* input, char* output) {
         result = wdb_parse_agents_clear_vuln_cve(wdb, output);
     }
     else if (strcmp(next, "update_status") == 0) {
-        result = wdb_parse_agents_update_status_vuln_cve(wdb, tail, output);
+        result = wdb_parse_agents_vuln_cve_update_status(wdb, tail, output);
     }
     else {
         snprintf(output, OS_MAXSTR + 1, "err Invalid vuln_cve action: %s", next);
@@ -6121,7 +6121,7 @@ int wdb_parse_agents_clear_vuln_cve(wdb_t* wdb, char* output) {
     return ret;
 }
 
-int wdb_parse_agents_update_status_vuln_cve(wdb_t* wdb, char* input, char* output) {
+int wdb_parse_agents_vuln_cve_update_status(wdb_t* wdb, char* input, char* output) {
     cJSON *data = NULL;
     const char *error = NULL;
     int ret = OS_INVALID;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -6061,8 +6061,8 @@ int wdb_parse_vuln_cve(wdb_t* wdb, char* input, char* output) {
     else if (strcmp(next, "clear") == 0) {
         result = wdb_parse_agents_clear_vuln_cve(wdb, output);
     }
-    else if (strcmp(next, "update") == 0) {
-        result = wdb_parse_agents_update_vuln_cve(wdb, tail, output);
+    else if (strcmp(next, "update_status") == 0) {
+        result = wdb_parse_agents_update_status_vuln_cve(wdb, tail, output);
     }
     else {
         snprintf(output, OS_MAXSTR + 1, "err Invalid vuln_cve action: %s", next);
@@ -6121,7 +6121,7 @@ int wdb_parse_agents_clear_vuln_cve(wdb_t* wdb, char* output) {
     return ret;
 }
 
-int wdb_parse_agents_update_vuln_cve(wdb_t* wdb, char* input, char* output) {
+int wdb_parse_agents_update_status_vuln_cve(wdb_t* wdb, char* input, char* output) {
     cJSON *data = NULL;
     const char *error = NULL;
     int ret = OS_INVALID;
@@ -6143,7 +6143,7 @@ int wdb_parse_agents_update_vuln_cve(wdb_t* wdb, char* input, char* output) {
         }
 
         else {
-            ret = wdb_agents_update_vuln_cve(wdb, old_status->valuestring, new_status->valuestring);
+            ret = wdb_agents_update_status_vuln_cve(wdb, old_status->valuestring, new_status->valuestring);
             if (OS_SUCCESS != ret) {
                 mdebug1("DB(%s) Cannot execute vuln_cve update command; SQL err: %s", wdb->id, sqlite3_errmsg(wdb->db));
                 snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cve update command; SQL err: %s", sqlite3_errmsg(wdb->db));

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -6145,8 +6145,8 @@ int wdb_parse_agents_vuln_cve_update_status(wdb_t* wdb, char* input, char* outpu
         else {
             ret = wdb_agents_update_status_vuln_cve(wdb, old_status->valuestring, new_status->valuestring);
             if (OS_SUCCESS != ret) {
-                mdebug1("DB(%s) Cannot execute vuln_cve update command; SQL err: %s", wdb->id, sqlite3_errmsg(wdb->db));
-                snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cve update command; SQL err: %s", sqlite3_errmsg(wdb->db));
+                mdebug1("DB(%s) Cannot execute vuln_cve update_status command; SQL err: %s", wdb->id, sqlite3_errmsg(wdb->db));
+                snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cve update_status command; SQL err: %s", sqlite3_errmsg(wdb->db));
             }
             else {
                 snprintf(output, OS_MAXSTR + 1, "ok");


### PR DESCRIPTION
|Related issue|
|---|
|#7916|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR implements a new wazuh-db command that let us update the `status` attribute in the agent `vuln_cves` table.
<!--
Add a clear description of how the problem has been solved.
-->

## DOD
Generating a dummy vuln_cves table for testing.

![image](https://user-images.githubusercontent.com/13010397/111671480-be0b1000-87f7-11eb-9528-4b304f356561.png)

And performing a query through Wazuh-db. 

`python3 wdb-query-agent.py 'agent 001 vuln_cve update_status {"old_status":"pending","new_status":"valid"}'`

We change `pending` by `valid` 

![image](https://user-images.githubusercontent.com/13010397/111671890-235f0100-87f8-11eb-8f1d-449a7c0fbde7.png)

Also we can change the entire `status` column with a new value using. 

`python3 wdb-query-agent.py 'agent 001 vuln_cve update_status {"old_status":"*","new_status":"pending"}'`

To get.

![image](https://user-images.githubusercontent.com/13010397/111671922-2c4fd280-87f8-11eb-9977-5213875b448c.png)

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Review logs syntax and correct language