### PR TITLE
Implemented UTs for new Wazuh-db command

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -19,7 +19,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                         -Wl,--wrap,wdbi_query_checksum -Wl,--wrap,wdbi_query_clear -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,wdb_step \
                         -Wl,--wrap,sqlite3_changes -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_last_insert_rowid \
                         -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_open_agent2 -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_agents_insert_vuln_cve \
-                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cve")
+                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cve -Wl,--wrap,wdb_agents_update_status_vuln_cve")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -127,6 +127,59 @@ void test_wdb_agents_clear_vuln_cve_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+test_wdb_agents_update_status_vuln_cve_statement_init_fail(void **state){
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* old_status = "valid";
+    const char* new_status = "pending";
+
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_UPDATE);
+
+    ret = wdb_agents_update_status_vuln_cve(data->wdb, old_status, new_status);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+test_wdb_agents_update_status_vuln_cve_success(void **state){
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* old_status = "valid";
+    const char* new_status = "pending";
+
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_UPDATE);
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, new_status);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, old_status);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    ret = wdb_agents_update_status_vuln_cve(data->wdb, old_status, new_status);
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+test_wdb_agents_update_status_vuln_cve_success_all(void **state){
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* old_status = "*";
+    const char* new_status = "pending";
+
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_UPDATE_ALL);
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, new_status);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    ret = wdb_agents_update_status_vuln_cve(data->wdb, old_status, new_status);
+    assert_int_equal(ret, OS_SUCCESS);
+}
 
 int main()
 {
@@ -136,7 +189,11 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cve_success, test_setup, test_teardown),
         /* Tests wdb_agents_clear_vuln_cve */
         cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_statement_init_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_success, test_setup, test_teardown)
+        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_success, test_setup, test_teardown),
+        /* Tests wdb_agents_update_vuln_cve */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cve_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cve_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cve_success_all, test_setup, test_teardown),
       };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -127,6 +127,8 @@ void test_wdb_agents_clear_vuln_cve_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_agents_update_status_vuln_cve*/
+
 test_wdb_agents_update_status_vuln_cve_statement_init_fail(void **state){
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -190,7 +192,7 @@ int main()
         /* Tests wdb_agents_clear_vuln_cve */
         cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_success, test_setup, test_teardown),
-        /* Tests wdb_agents_update_vuln_cve */
+        /* Tests wdb_agents_update_status_vuln_cve */
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cve_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cve_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cve_success_all, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -355,6 +355,7 @@ test_wdb_agents_vuln_cve_update_status_error_json(void **state){
 
     assert_int_equal(OS_INVALID, ret);
 }
+
 test_wdb_agents_vuln_cve_update_status_error_socket(void **state){
     int ret = 0;
     int id = 1;
@@ -393,6 +394,7 @@ test_wdb_agents_vuln_cve_update_status_error_socket(void **state){
 
     assert_int_equal(OS_INVALID, ret);
 }
+
 test_wdb_agents_vuln_cve_update_status_error_sql_execution(void **state){
     int ret = 0;
     int id = 1;
@@ -431,6 +433,7 @@ test_wdb_agents_vuln_cve_update_status_error_sql_execution(void **state){
 
     assert_int_equal(OS_INVALID, ret);
 }
+
 test_wdb_agents_vuln_cve_update_status_error_result(void **state){
     int ret = 0;
     int id = 1;
@@ -470,6 +473,7 @@ test_wdb_agents_vuln_cve_update_status_error_result(void **state){
 
     assert_int_equal(OS_INVALID, ret);
 }
+
 test_wdb_agents_vuln_cve_update_status_success(void **state){
     int ret = 0;
     int id = 1;

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -425,7 +425,7 @@ test_wdb_agents_vuln_cve_update_status_error_sql_execution(void **state){
     expect_string(__wrap_wdbc_query_ex, query, query_str);
     expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
     will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, -100); // Returning any error
+    will_return(__wrap_wdbc_query_ex, -1);
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -425,7 +425,7 @@ test_wdb_agents_vuln_cve_update_status_error_sql_execution(void **state){
     expect_string(__wrap_wdbc_query_ex, query, query_str);
     expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
     will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, -1);
+    will_return(__wrap_wdbc_query_ex, -100); // Returning any error
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -361,8 +361,9 @@ test_wdb_agents_vuln_cve_update_status_error_socket(void **state){
     int id = 1;
     const char *old_status = "valid";
     const char *new_status = "obsolete";
+    const char *json_str = NULL;
 
-    const char *json_str = strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}");
+    os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
     const char *query_str = "agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
     const char *response = "err";
 
@@ -400,8 +401,9 @@ test_wdb_agents_vuln_cve_update_status_error_sql_execution(void **state){
     int id = 1;
     const char *old_status = "valid";
     const char *new_status = "obsolete";
+    const char *json_str = NULL;
 
-    const char *json_str = strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}");
+    os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
     const char *query_str = "agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
     const char *response = "err";
 
@@ -439,8 +441,9 @@ test_wdb_agents_vuln_cve_update_status_error_result(void **state){
     int id = 1;
     const char *old_status = "valid";
     const char *new_status = "obsolete";
+    const char *json_str = NULL;
 
-    const char *json_str = strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}");
+    os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
     const char *query_str = "agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
     const char *response = "err";
 
@@ -479,8 +482,9 @@ test_wdb_agents_vuln_cve_update_status_success(void **state){
     int id = 1;
     const char *old_status = "valid";
     const char *new_status = "obsolete";
+    const char *json_str = NULL;
 
-    const char *json_str = strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}");
+    os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
     const char *query_str = "agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
     const char *response = "err";
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
@@ -24,3 +24,9 @@ int __wrap_wdb_agents_insert_vuln_cve( __attribute__((unused)) wdb_t *wdb, const
 int __wrap_wdb_agents_clear_vuln_cve( __attribute__((unused)) wdb_t *wdb) {
     return mock();
 }
+
+int __wrap_wdb_agents_update_status_vuln_cve( __attribute__((unused)) wdb_t *wdb, const char* old_status, const char* new_status) {
+    check_expected(old_status);
+    check_expected(new_status);
+    return mock();
+}

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -6145,8 +6145,8 @@ int wdb_parse_agents_vuln_cve_update_status(wdb_t* wdb, char* input, char* outpu
         else {
             ret = wdb_agents_update_status_vuln_cve(wdb, old_status->valuestring, new_status->valuestring);
             if (OS_SUCCESS != ret) {
-                mdebug1("DB(%s) Cannot execute vuln_cve update command; SQL err: %s", wdb->id, sqlite3_errmsg(wdb->db));
-                snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cve update command; SQL err: %s", sqlite3_errmsg(wdb->db));
+                mdebug1("DB(%s) Cannot execute vuln_cve update_status command; SQL err: %s", wdb->id, sqlite3_errmsg(wdb->db));
+                snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cve update_status command; SQL err: %s", sqlite3_errmsg(wdb->db));
             }
             else {
                 snprintf(output, OS_MAXSTR + 1, "ok");


### PR DESCRIPTION
|Related issue|
|---|
|#7916|
## Description
Implemented UTs for new wazuh-db command
## DOD
Valgrind output
[UTs_valgrind.txt](https://github.com/wazuh/wazuh/files/6172532/UTs_valgrind.txt)
## Tests
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Review logs syntax and correct language
- Memory tests for Linux
  - [X] Valgrind (memcheck and descriptor leaks check)
- [X] Added unit tests (for new features)