### PR TITLE
Rename wazuh-logtest.legacy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ src/wazuh-csyslogd
 src/wazuh-dbd
 src/wazuh-execd
 src/wazuh-logcollector
-src/wazuh-logtest.legacy
+src/wazuh-logtest-legacy
 src/wazuh-maild
 src/wazuh-monitord
 src/wazuh-remoted

--- a/src/Makefile
+++ b/src/Makefile
@@ -680,7 +680,7 @@ BUILD_SERVER+=wazuh-monitord
 BUILD_SERVER+=wazuh-reportd
 BUILD_SERVER+=wazuh-authd
 BUILD_SERVER+=wazuh-analysisd
-BUILD_SERVER+=wazuh-logtest.legacy
+BUILD_SERVER+=wazuh-logtest-legacy
 BUILD_SERVER+=wazuh-dbd -
 BUILD_SERVER+=wazuh-integratord
 BUILD_SERVER+=wazuh-modulesd
@@ -1861,7 +1861,7 @@ analysisd/%-live.o: analysisd/%.c analysisd/compiled_rules/compiled_rules.h
 analysisd/%-test.o: analysisd/%.c analysisd/compiled_rules/compiled_rules.h
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DTESTRULE -DARGV0=\"wazuh-analysisd\" -I./analysisd -c $< -o $@
 
-wazuh-logtest.legacy: ${analysisd_test_o} ${output_o} ${format_o} analysisd/testrule-test.o analysisd/analysisd-test.o alerts.a cdb.a decoders-test.a
+wazuh-logtest-legacy: ${analysisd_test_o} ${output_o} ${format_o} analysisd/testrule-test.o analysisd/analysisd-test.o alerts.a cdb.a decoders-test.a
 	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 wazuh-analysisd: ${analysisd_live_o} analysisd/analysisd-live.o ${output_o} ${format_o} alerts.a cdb.a decoders-live.a

--- a/src/active-response/restart.sh
+++ b/src/active-response/restart.sh
@@ -36,7 +36,7 @@ echo "`date` $0 $1 $2 $3 $4 $5" >> ${PWD}/logs/active-responses.log
 
 # Rules and decoders test
 if [ "$TYPE" = "manager" ]; then
-    if !(${PWD}/bin/wazuh-logtest -t > /dev/null 2>&1); then
+    if !(${PWD}/bin/wazuh-logtest-legacy -t > /dev/null 2>&1); then
         exit 1;
     fi
 fi

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -934,7 +934,7 @@ InstallLocal()
     ${INSTALL} -m 0750 -o root -g 0 wazuh-monitord ${PREFIX}/bin
     ${INSTALL} -m 0750 -o root -g 0 wazuh-reportd ${PREFIX}/bin
     ${INSTALL} -m 0750 -o root -g 0 wazuh-maild ${PREFIX}/bin
-    ${INSTALL} -m 0750 -o root -g 0 wazuh-logtest.legacy ${PREFIX}/bin
+    ${INSTALL} -m 0750 -o root -g 0 wazuh-logtest-legacy ${PREFIX}/bin
     ${INSTALL} -m 0750 -o root -g 0 wazuh-csyslogd ${PREFIX}/bin
     ${INSTALL} -m 0750 -o root -g 0 wazuh-dbd ${PREFIX}/bin
     ${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} verify-agent-conf ${PREFIX}/bin/

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -218,7 +218,7 @@ testconfig()
 start_service()
 {
     echo "Starting $NAME $VERSION..."
-    TEST=$(${DIR}/bin/wazuh-logtest.legacy -t  2>&1)
+    TEST=$(${DIR}/bin/wazuh-logtest-legacy -t  2>&1)
     echo $TEST
 
     if [ ! -z "$TEST" ]; then

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -262,7 +262,7 @@ start_service()
         echo "Starting $NAME $VERSION..."
     fi
 
-    TEST=$(${DIR}/bin/wazuh-logtest.legacy -t  2>&1 | grep "ERROR")
+    TEST=$(${DIR}/bin/wazuh-logtest-legacy -t  2>&1 | grep "ERROR")
     if [ ! -z "$TEST" ]; then
         if [ $USE_JSON = true ]; then
             echo -n '{"error":21,"message":"OSSEC analysisd: Testing rules failed. Configuration error."}'


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/7963|

## Description

Hello team,

This PR is for renaming `wazuh-logtest.legacy` to `wazuh-logtest-legacy`.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] ~Windows~
  - [X] ~MAC OS X~
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] ~Scan-build report~
  - [X] ~Coverity~
  - [X] ~Valgrind (memcheck and descriptor leaks check)~
  - [X] ~Dr. Memory~
  - [X] ~AddressSanitizer~
- Memory tests for Windows
  - [X] ~Scan-build report~
  - [X] ~Coverity~
  - [X] ~Dr. Memory~
- Memory tests for macOS
  - [X] ~Scan-build report~
  - [X] ~Leaks~
  - [X] ~AddressSanitizer~

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [X] ~Added unit tests (for new features)~
- [X] ~Stress test for affected components~

Regards.
