### PR TITLE
Standardize API data validation

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3928,7 +3928,7 @@ components:
       required: true
       schema:
         type: string
-        pattern: '^[\-\w]+$'
+        format: cdb_filename_path
     agents_list:
       in: query
       name: agents_list
@@ -5252,7 +5252,7 @@ components:
         type: array
         items:
           type: string
-          pattern: '^[\w\-]+\.xml(,[\w\-]+\.xml)*$'
+          format: xml_filename
     xml_filename_path:
       in: path
       name: filename
@@ -5260,7 +5260,7 @@ components:
       required: true
       schema:
         type: string
-        pattern: '^[\w\-]+\.xml$'
+        format: xml_filename_path
 
 
 tags:
@@ -11791,7 +11791,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
-        - $ref: '#/components/parameters/filename'
+        - $ref: '#/components/parameters/xml_filename'
         - $ref: '#/components/parameters/get_dirnames_path'
         - $ref: '#/components/parameters/statusRLDParam'
       responses:

--- a/api/api/test/test_validator.py
+++ b/api/api/test/test_validator.py
@@ -186,6 +186,9 @@ def test_is_safe_path():
     ("12345", "numbers_or_empty"),
     ("", "numbers_or_empty"),
     ("group_name.test", "group_names"),
+    ("cdb_test", "cdb_filename_path"),
+    ("local_rules.xml", "xml_filename_path"),
+    ("local_rules.xml,test_rule.xml", "xml_filename"),
 ])
 def test_validation_json_ok(value, format):
     """Verify that each value is of the indicated format."""
@@ -217,6 +220,12 @@ def test_validation_json_ok(value, format):
     ("test_name test", "names_or_empty"),
     ("12345abc", "numbers_or_empty"),
     ("group_name.test ", "group_names"),
+    ("cdb_test../../test", "cdb_filename_path"),
+    ("cdb_test.test", "cdb_filename_path"),
+    ("local_rules../../.xml", "xml_filename_path"),
+    ("local_rules", "xml_filename_path"),
+    ("local_rules.xml,../test_rule.xml", "xml_filename"),
+    ("local_rules.xml,test_rule", "xml_filename"),
 ])
 def test_validation_json_ko(value, format):
     """Verify that each value is not of the indicated format."""

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -242,17 +242,17 @@ def format_numbers_delete(value):
 
 
 @draft4_format_checker.checks("cdb_filename_path")
-def format_numbers_delete(value):
+def format_cdb_filename_path(value):
     return check_exp(value, _cdb_filename_path)
 
 
 @draft4_format_checker.checks("xml_filename")
-def format_numbers_delete(value):
+def format_xml_filename(value):
     return check_exp(value, _xml_filename)
 
 
 @draft4_format_checker.checks("xml_filename_path")
-def format_numbers_delete(value):
+def format_xml_filename_path(value):
     return check_exp(value, _xml_filename_path)
 
 

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -17,7 +17,6 @@ _array_numbers = re.compile(r'^\d+(,\d+)*$')
 _array_names = re.compile(r'^[\w\-\.%]+(,[\w\-\.%]+)*$')
 _base64 = re.compile(r'^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$')
 _boolean = re.compile(r'^true$|^false$')
-_cdb_list = re.compile(r'^#?[\w\s-]+:{1}(#?[\w\s-]+|)$')
 _dates = re.compile(r'^\d{8}$')
 _empty_boolean = re.compile(r'^$|(^true$|^false$)')
 _group_names = re.compile(r'^[A-Za-z0-9.\-_]+\b(?<!\ball)$')
@@ -33,6 +32,9 @@ _numbers = re.compile(r'^\d+$')
 _numbers_delete = re.compile(r'^\d+|all$')
 _wazuh_key = re.compile(r'[a-zA-Z0-9]+$')
 _paths = re.compile(r'^[\w\-\.\\\/:]+$')
+_cdb_filename_path = re.compile(r'^[\-\w]+$')
+_xml_filename_path = re.compile(r'^[\w\-]+\.xml$')
+_xml_filename = re.compile(r'^[\w\-]+\.xml(,[\w\-]+\.xml)*$')
 _query_param = re.compile(r"^(?:[\w\.\-]+(?:=|!=|<|>|~)[\w\.\- ]+)(?:(?:;|,)[\w\.\-]+(?:=|!=|<|>|~)[\w\.\- ]+)*$")
 _ranges = re.compile(r'[\d]+$|^[\d]{1,2}\-[\d]{1,2}$')
 _get_dirnames_path = re.compile(r'^(((etc|ruleset)\/(decoders|rules)[\w\-\/]*)|(etc\/lists[\w\-\/]*))$')
@@ -237,6 +239,21 @@ def format_numbers(value):
 @draft4_format_checker.checks("numbers_delete")
 def format_numbers_delete(value):
     return check_exp(value, _numbers_delete)
+
+
+@draft4_format_checker.checks("cdb_filename_path")
+def format_numbers_delete(value):
+    return check_exp(value, _cdb_filename_path)
+
+
+@draft4_format_checker.checks("xml_filename")
+def format_numbers_delete(value):
+    return check_exp(value, _xml_filename)
+
+
+@draft4_format_checker.checks("xml_filename_path")
+def format_numbers_delete(value):
+    return check_exp(value, _xml_filename_path)
 
 
 @draft4_format_checker.checks("path")


### PR DESCRIPTION
|Related issue|
|---|
| Closes #7544 |

## Description

Hi team!

This PR moves the validation pattern used in some endpoints (like in the example below) to the validator.py file:
https://github.com/wazuh/wazuh/blob/8f224328821321634160102264a909ddbb8605f2/api/api/spec/spec.yaml#L3924-L3931

**PD:** There is a failing unittest in the master branch, so this PR should be rebased once it is fixed.

Regards,
Selu.