### PR TITLE
Fix utils.py unittest

### DIFF
--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -551,13 +551,17 @@ stages:
             - <<: *ports_response
               agent_id: '001'
             - <<: *ports_response
+              agent_id: '001'
+            - <<: *ports_response
+              agent_id: '003'
+            - <<: *ports_response
               agent_id: '003'
             - <<: *ports_response
               agent_id: '005'
             - <<: *ports_response
               agent_id: '007'
           failed_items: []
-          total_affected_items: !anyint
+          total_affected_items: 6
           total_failed_items: 0
 
 ---

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -557,7 +557,7 @@ stages:
             - <<: *ports_response
               agent_id: '007'
           failed_items: []
-          total_affected_items: 4
+          total_affected_items: !anyint
           total_failed_items: 0
 
 ---

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -22,8 +22,7 @@ from pyexpat import ExpatError
 from shutil import Error, copyfile, move
 from subprocess import CalledProcessError, check_output
 from xml.dom.minidom import parseString
-from xml.etree import ElementTree as ET
-from xml.etree.ElementTree import fromstring
+from xml.etree import ElementTree
 
 import wazuh.core.results as results
 from api import configuration
@@ -737,7 +736,7 @@ def load_wazuh_xml(xml_path, data=None):
                '\n'.join([f'<!ENTITY {name} "{value}">' for name, value in custom_entities.items()]) + \
                '\n]>\n'
 
-    return fromstring(entities + '<root_tag>' + data + '</root_tag>')
+    return ElementTree.fromstring(entities + '<root_tag>' + data + '</root_tag>')
 
 
 class WazuhVersion:
@@ -1610,7 +1609,7 @@ def upload_file(content, path, check_xml_formula_values=True):
     def escape_formula_values(xml_string):
         """Prepend with a single quote possible formula injections."""
         formula_characters = ('=', '+', '-', '@')
-        et = ET.ElementTree(ET.fromstring(f'<root>{xml_string}</root>'))
+        et = ElementTree.ElementTree(ElementTree.fromstring(f'<root>{xml_string}</root>'))
         full_preprend, beginning_preprend = list(), list()
         for node in et.iter():
             if node.tag and node.tag.startswith(formula_characters):


### PR DESCRIPTION
|Related issue|
|---|
| Closes #7969 |

## Description

Hey team,

It turns out that there was some bug in the way ElementTree was imported here:
https://github.com/wazuh/wazuh/blob/3bda4b89ac9f58be762f6a327eee2ac9f0176f09/framework/wazuh/core/utils.py#L25-L26

The error occurred when running any other tests that imported `utils.py` module before running `test_utils.py`. There might be a problem with the alias when trying to redefine it. 

In any case, it is working fine after this PR.

Regards,
Selu.