### PR TITLE
Improved parallelism in osregex execute and rule engine

### DIFF
--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -43,7 +43,7 @@ void DecodeEvent(struct _Eventinfo *lf, OSHash *rules_hash, regex_matching *deco
 
         /* First check program name */
         if (lf->program_name) {
-            if (!w_expression_match(nnode->program_name, lf->program_name, NULL, NULL)) {
+            if (!w_expression_match(nnode->program_name, lf->program_name, NULL, decoder_match)) {
                 continue;
             }
             pmatch = lf->log;

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -2523,7 +2523,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
             return (NULL);
         }
 
-        if (w_expression_match(rule->program_name, lf->program_name, NULL, NULL)
+        if (w_expression_match(rule->program_name, lf->program_name, NULL, rule_match)
             == rule->program_name->negate) {
             return (NULL);
         }
@@ -2535,7 +2535,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
             return (NULL);
         }
 
-        if (w_expression_match(rule->id, lf->id, NULL, NULL) == rule->id->negate) {
+        if (w_expression_match(rule->id, lf->id, NULL, rule_match) == rule->id->negate) {
             return (NULL);
         }
     }
@@ -2546,7 +2546,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
             return (NULL);
         }
 
-        if (w_expression_match(rule->system_name, lf->systemname, NULL, NULL)
+        if (w_expression_match(rule->system_name, lf->systemname, NULL, rule_match)
             == rule->system_name->negate) {
             return (NULL);
         }
@@ -2557,21 +2557,21 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
         if (!lf->protocol) {
             return (NULL);
         }
-        if (w_expression_match(rule->protocol, lf->protocol, NULL, NULL) == rule->protocol->negate) {
+        if (w_expression_match(rule->protocol, lf->protocol, NULL, rule_match) == rule->protocol->negate) {
             return (NULL);
         }
     }
 
     /* Check if any word to match exists */
     if (rule->match) {
-        if (w_expression_match(rule->match, lf->log, NULL, NULL) == rule->match->negate) {
+        if (w_expression_match(rule->match, lf->log, NULL, rule_match) == rule->match->negate) {
             return (NULL);
         }
     }
 
     /* Check if exist any regex for this rule */
     if (rule->regex) {
-        bool matches = w_expression_match(rule->regex, lf->log, NULL, NULL);
+        bool matches = w_expression_match(rule->regex, lf->log, NULL, rule_match);
         if (matches == rule->regex->negate) {
             return NULL;
         }
@@ -2583,7 +2583,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
             return (NULL);
         }
 
-        if (w_expression_match(rule->action, lf->action, NULL, NULL) == rule->action->negate) {
+        if (w_expression_match(rule->action, lf->action, NULL, rule_match) == rule->action->negate) {
             return (NULL);
         }
     }
@@ -2594,7 +2594,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
             return (NULL);
         }
 
-        if (w_expression_match(rule->url, lf->url, NULL, NULL) == rule->url->negate) {
+        if (w_expression_match(rule->url, lf->url, NULL, rule_match) == rule->url->negate) {
             return (NULL);
         }
     }
@@ -2605,7 +2605,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
             return (NULL);
         }
 
-        if (w_expression_match(rule->location, lf->location, NULL, NULL) == rule->location->negate) {
+        if (w_expression_match(rule->location, lf->location, NULL, rule_match) == rule->location->negate) {
             return (NULL);
         }
     }
@@ -2617,7 +2617,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
             return NULL;
         }
 
-        bool matches = w_expression_match(rule->fields[i]->regex, field, NULL, NULL);
+        bool matches = w_expression_match(rule->fields[i]->regex, field, NULL, rule_match);
         if (matches == rule->fields[i]->regex->negate) {
             return NULL;
         }
@@ -2631,7 +2631,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                 return (NULL);
             }
 
-            if (w_expression_match(rule->srcip, lf->srcip, NULL, NULL) == rule->srcip->negate) {
+            if (w_expression_match(rule->srcip, lf->srcip, NULL, rule_match) == rule->srcip->negate) {
                 return (NULL);
             }
         }
@@ -2642,7 +2642,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                 return (NULL);
             }
 
-            if (w_expression_match(rule->dstip, lf->dstip, NULL, NULL) == rule->dstip->negate) {
+            if (w_expression_match(rule->dstip, lf->dstip, NULL, rule_match) == rule->dstip->negate) {
                 return (NULL);
             }
         }
@@ -2652,7 +2652,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                 return (NULL);
             }
 
-            if (w_expression_match(rule->srcport, lf->srcport, NULL, NULL) == rule->srcport->negate) {
+            if (w_expression_match(rule->srcport, lf->srcport, NULL, rule_match) == rule->srcport->negate) {
                 return (NULL);
             }
         }
@@ -2661,7 +2661,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                 return (NULL);
             }
 
-            if (w_expression_match(rule->dstport, lf->dstport, NULL, NULL) == rule->dstport->negate) {
+            if (w_expression_match(rule->dstport, lf->dstport, NULL, rule_match) == rule->dstport->negate) {
                 return (NULL);
             }
         }
@@ -2679,11 +2679,11 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
         /* Checking if exist any user to match */
         if (rule->user) {
             if (lf->dstuser) {
-                if (w_expression_match(rule->user, lf->dstuser, NULL, NULL) == rule->user->negate) {
+                if (w_expression_match(rule->user, lf->dstuser, NULL, rule_match) == rule->user->negate) {
                     return (NULL);
                 }
             } else if (lf->srcuser) {
-                if (w_expression_match(rule->user, lf->srcuser, NULL, NULL) == rule->user->negate) {
+                if (w_expression_match(rule->user, lf->srcuser, NULL, rule_match) == rule->user->negate) {
                     return (NULL);
                 }
             } else {
@@ -2698,7 +2698,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                 return NULL;
             }
 
-            if (w_expression_match(rule->srcgeoip, lf->srcgeoip, NULL, NULL) == rule->srcgeoip->negate) {
+            if (w_expression_match(rule->srcgeoip, lf->srcgeoip, NULL, rule_match) == rule->srcgeoip->negate) {
                 return NULL;
             }
         }
@@ -2709,7 +2709,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                 return NULL;
             }
 
-            if (w_expression_match(rule->dstgeoip, lf->dstgeoip, NULL, NULL) == rule->dstgeoip->negate) {
+            if (w_expression_match(rule->dstgeoip, lf->dstgeoip, NULL, rule_match) == rule->dstgeoip->negate) {
                 return NULL;
             }
         }
@@ -2741,7 +2741,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
             if (!lf->data) {
                 return (NULL);
             }
-            if (w_expression_match(rule->data, lf->data, NULL, NULL) == rule->data->negate) {
+            if (w_expression_match(rule->data, lf->data, NULL, rule_match) == rule->data->negate) {
                 return (NULL);
             }
         }
@@ -2752,7 +2752,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                 return(NULL);
             }
 
-            if (w_expression_match(rule->extra_data, lf->extra_data, NULL, NULL)
+            if (w_expression_match(rule->extra_data, lf->extra_data, NULL, rule_match)
                 == rule->extra_data->negate) {
                 return (NULL);
             }
@@ -2764,7 +2764,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                 return (NULL);
             }
 
-            if (w_expression_match(rule->hostname, lf->hostname, NULL, NULL) == rule->hostname->negate) {
+            if (w_expression_match(rule->hostname, lf->hostname, NULL, rule_match) == rule->hostname->negate) {
                 return (NULL);
             }
         }
@@ -2775,7 +2775,7 @@ RuleInfo *OS_CheckIfRuleMatch(struct _Eventinfo *lf, EventList *last_events,
                 return (NULL);
             }
 
-            if (w_expression_match(rule->status, lf->status, NULL, NULL) == rule->status->negate) {
+            if (w_expression_match(rule->status, lf->status, NULL, rule_match) == rule->status->negate) {
                 return (NULL);
             }
         }

--- a/src/os_regex/os_regex.h
+++ b/src/os_regex/os_regex.h
@@ -83,17 +83,30 @@ typedef struct _OSMatch {
  */
 int OSRegex_Compile(const char *pattern, OSRegex *reg, int flags);
 
-/* Compare an already compiled regular expression with
- * a not NULL string.
- * Returns end of str on success or NULL on error.
- * The error code is set on reg->error.
+/**
+ * @brief Compares an already compiled OSRegex regular expression with a string
+ * 
+ * @warning Do not mix between `OSRegex_Execute` and `OSRegex_Execute_ex` calls for the same pointer `reg`
+ * @param str string to test
+ * @param reg compiled pattern
+ * @return Returns the end of the string on success or NULL otherwise
  */
 const char *OSRegex_Execute(const char *str, OSRegex *reg) __attribute__((nonnull(2)));
 
-/* Extension of OSRegex_Execute that allows to choose
- * external sub_strings and prts_str.
- * Returns end of str on success or NULL on error.
- * The error code is set on reg->error.
+/**
+ * @brief Compares an already compiled OSRegex regular expression with a string
+ * 
+ * Extension of OSRegex_Execute that allows to choose between external sub_strings and prts_str.
+ * The regex_match structure handles match patterns and serves to parallelize the regex
+ * 
+ * @warning If any call to `OSRegex_Execute_ex` has a null `regex_match` argument then 
+ * all calls to with the same pointer `reg` must have a null regex_match argument (This limits the parallelism)
+ * @warning Do not mix between `OSRegex_Execute_ex` and `OSRegex_Execute` calls for the same pointer `reg`
+ * 
+ * @param str string to test
+ * @param reg compiled pattern
+ * @param regex_match Structure to manage pattern matches
+ * @return Returns the end of the string on success or NULL otherwise
  */
  const char *OSRegex_Execute_ex(const char *str, OSRegex *reg, regex_matching *regex_match) __attribute__((nonnull(2)));
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7938 |

Hi Team!,

This PR is small but brings big performance improvements to Analaysisd. It ensures parallelism at the time of decoding and rule matching, improving the performance of version 4.1 by up to 262% with 16 threads.

Rule trees and decoders trees that include regexes are shared between threads. The execution of regexes involves taking a semaphore that is part of the regex structure, this implies that if a thread takes the semaphore and performs a context switch, the other threads that need to process the same regex will be queued until the first thread returns it.
The very nature of the decoders makes this more likely at the decoding stage than at the matching stage.

The solution is only to lock the semaphore in case you are not using the parallelism mechanism of the OSRegex_Execute_ex function and force the rules engine to always use this mechanism.

For the tests we used the `gettimeofday()` function that allows us to measure the time it takes to perform actions by co-considering the CPU-off. The following times were measured:

- **Decode time**: It is the time it takes to decode the event. (Specifically the time taken by the `DecodeEvent` function)
- **Rule match time**: Time it takes to match the rule (The time from the time it tries to match with the first rule until before the event is copied to the queue to be written in the alert.log).
- **OS_Regex time**: It is the time (cumulative) used in the OSRegex_Execute_ex function, both in the decoding phase and in the rule matching phase.
- Number of times that OSRegex_Execute_ex was called with that event (If we divide it by `OS_Regex time` gives us the average time it takes to make a match for that event),

The tests were performed with the same number of threads for decoding and rule matching. 1, 2, 4 and 8 threads each, on a 16-thread virtual machine.

In a test on the master branch (v4.2) 8910 logs were sent (10 times the same set of 981 logs) and the following results were obtained

![master](https://user-images.githubusercontent.com/1891958/112494539-e64bbf00-8d61-11eb-9239-8cef7740b4c7.png)

The time it takes is from 56us (average time between decode and match) with one thread, up to 252us for 16 threads.
With the optimization of this PR, better results were obtained, from 54us with one thread to 94us with 16 threads.

![PR](https://user-images.githubusercontent.com/1891958/112494514-e1870b00-8d61-11eb-841c-1fce13983a4f.png)

A time comparison shows their improvement

![PR vs Master](https://user-images.githubusercontent.com/1891958/112494491-daf89380-8d61-11eb-9e3c-f7157d05545a.png)


Attached is what is needed to replicate the tests.
[analysisd_performance.zip](https://github.com/wazuh/wazuh/files/6185194/analysisd_performance.zip) contains a set of 891 logs for testing, a go script to send the data from different locations and a bash script (very badly programmed) that runs Wazuh, change its configuration and reports the times by extracting the data in alerts.log.


Instructions:
- Apply the patches (`0002-First-optimeze.patch` may not be applied, it is the patch with optimizations).
- Adjust the paths in `test_per.sh`.
- Run `test_per.sh` and wait a few minutes, it will generate all the necessary results for that branch.



## Tests

  - [x] IT
  - [x] UT
  
  
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind in logtest (memcheck and descriptor leaks check)
  - [x] Valgrind in Analysisd (memcheck and descriptor leaks check)
  - [x] Valgrind in Analysisd and logtest at the same time (memcheck and descriptor leaks check)
  - [x] Helgrind (`parallel-regex` tool)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [x] Stress test for affected components
