### PR TITLE
Update 0010-active-response_decoders.xml

### DIFF
--- a/ruleset/decoders/0010-active-response_decoders.xml
+++ b/ruleset/decoders/0010-active-response_decoders.xml
@@ -47,3 +47,50 @@ Tue 08/28/2018 09:27:23.14 "active-response/bin/netsh.cmd" add "-" "1.2.3.4" "15
     <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d /\S+/active-response/bin/\S+: </prematch>
     <plugin_decoder offset="after_prematch">JSON_Decoder</plugin_decoder>
 </decoder>
+
+
+
+
+
+
+
+<!-- NEW -->
+<decoder name="ar_log">
+  <prematch>active-response/bin/</prematch>
+</decoder>
+
+<decoder name="ar_log_fields">
+    <parent>ar_log</parent>
+    <regex type="pcre2">\/bin\/(\S+)"\s+(\S+)</regex>
+    <order>script, type</order>
+</decoder>
+
+<decoder name="ar_log_fields">
+    <parent>ar_log</parent>
+    <regex type="pcre2">\/bin\/(\S+)\s+(\S+)</regex>
+    <order>script, type</order>
+</decoder>
+
+<decoder name="ar_log_fields">
+    <parent>ar_log</parent>
+    <regex type="pcre2">\/bin\/\S+"\s+\S+\s(\w+)</regex>
+    <order>dstuser</order>
+</decoder>
+
+<decoder name="ar_log_fields">
+    <parent>ar_log</parent>
+    <regex type="pcre2">\/bin\/\S+\s+\S+\s(\w+)</regex>
+    <order>dstuser</order>
+</decoder>
+
+<decoder name="ar_log_fields">
+    <parent>ar_log</parent>
+    <regex>(\d+.\d+.\d+.\d+)</regex>
+    <order>srcip</order>
+</decoder>
+
+<decoder name="ar_log_fields">
+    <parent>ar_log</parent>
+    <regex>(\d+)"$|(\d+)$</regex>
+    <order>id</order>
+</decoder>


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Here is a diffreent version of the decoders to make it work with other languages (French, English, etc.).
It first tries to decode if it is a windows log and then a linux one, because of a ".
## Configuration options



## Logs/Alerts example

Linux:
EN : Wed Dec 7 18:12:14 UTC 2016 /var/ossec/active-response/bin/route-null.sh delete - 192.168.2.4 1481134294.521764 100
FR : mer 17 mar 2021 10:54:16 CET /var/ossec/active-response/bin/disable-account.sh add usertest - 1615974856.216416928 5720

Windows :
EN : Wed 12/07/2016 19:40:06.89 "active-response/bin/restart-ossec.cmd" add "-" "10.99.99.12" "(from_the_server) (no_rule_id)"
FR : 17-03-21 10:16:55,83 "active-response/bin/restart-ossec.cmd" add "-" "null" "(from_the_server) (no_rule_id)"

## Tests

**LINUX :** 

**EN :**
```
**Phase 2: Completed decoding.
        name: 'ar_log'
        id: '100'
        script: 'route-null.sh'
        srcip: '192.168.2.4'
        type: 'delete'

**Phase 3: Completed filtering (rules).
        id: '606'
        level: '3'
        description: 'Host Unblocked by route-null.sh Active Response'
        groups: '['ossec', 'active_response']'
        firedtimes: '1'
        gdpr: '['IV_35.7.d']'
        gpg13: '['4.13']'
        mail: 'True'
        nist_800_53: '['SI.4']'
        pci_dss: '['11.4']'
        tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3', 'CC7.4']'
**Alert to be generated.
```

**FR :**
```
**Phase 2: Completed decoding.
        name: 'ar_log'
        dstuser: 'usertest'
        id: '5720'
        script: 'disable-account.sh'
        type: 'add'

**Phase 3: Completed filtering (rules).
        id: '607'
        level: '3'
        description: 'Active response: disable-account.sh - add'
        groups: '['ossec', 'active_response']'
        firedtimes: '1'
        gdpr: '['IV_35.7.d']'
        mail: 'True'
        nist_800_53: '['SI.4']'
        pci_dss: '['11.4']'
        tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3', 'CC7.4']'
**Alert to be generated.
```

**WINDOWS :** 

**EN :**
```
**Phase 2: Completed decoding.
        name: 'ar_log'
        script: 'restart-ossec.cmd'
        srcip: '10.99.99.12'
        type: 'add'

**Phase 3: Completed filtering (rules).
        id: '607'
        level: '3'
        description: 'Active response: restart-ossec.cmd - add'
        groups: '['ossec', 'active_response']'
        firedtimes: '2'
        gdpr: '['IV_35.7.d']'
        mail: 'True'
        nist_800_53: '['SI.4']'
        pci_dss: '['11.4']'
        tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3', 'CC7.4']'
**Alert to be generated.
```

**FR :**
```

**Phase 2: Completed decoding.
        name: 'ar_log'
        script: 'restart-ossec.cmd'
        type: 'add'

**Phase 3: Completed filtering (rules).
        id: '607'
        level: '3'
        description: 'Active response: restart-ossec.cmd - add'
        groups: '['ossec', 'active_response']'
        firedtimes: '3'
        gdpr: '['IV_35.7.d']'
        mail: 'True'
        nist_800_53: '['SI.4']'
        pci_dss: '['11.4']'
        tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3', 'CC7.4']'
**Alert to be generated.
```

<br>

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
