### PR TITLE
Fix a segmentation fault in Vulnerability Detector

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -404,6 +404,7 @@
 #define VU_VER_INVALID_FORMAT       "(5588): Invalid format of Wazuh version for agent '%.3d'"
 #define VU_VER_READING_ERROR        "(5589): Couldn't read Wazuh version for agent '%.3d'"
 #define VU_OVAL_VULN_NOT_FOUND      "(5590): No vulnerabilities could be found in the OVAL for agent '%.3d'"
+#define VU_PKG_INVALID_VER          "(5591): Invalid version for package '%s' of the inventory: '%s'"
 
 /* File integrity monitoring error messages*/
 #define FIM_ERROR_ADD_FILE                          "(6600): Unable to add file to db: '%s'"

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector_nvd.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector_nvd.c
@@ -2808,6 +2808,27 @@ void test_wm_vuldet_check_specific_package_pkg_version_NULL(void **state)
     assert_int_equal(ret, 0);
 }
 
+void test_wm_vuldet_check_specific_package_pkg_version_empty(void **state)
+{
+    sqlite3 *db = (sqlite3 *)1;
+    sqlite3_stmt *stmt = NULL;
+
+    char *pkg_name = NULL;
+    char *pkg_source = "test";
+    char *pkg_version = "";
+    char *pkg_arch = NULL;
+    char *pkg_vendor = NULL;
+    OSHash *cve_table = NULL;
+    int8_t name_type = PACKAGE_SOURCE;
+    int *vuln_count = NULL;
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:vulnerability-detector");
+    expect_string(__wrap__mterror, formatted_msg, "(5591): Invalid version for package 'test' of the inventory: ''");
+
+    int ret = wm_vuldet_check_specific_package(db, FEED_DEBIAN, pkg_name, pkg_source, pkg_version, pkg_arch, pkg_vendor, cve_table, name_type, vuln_count);
+    assert_int_equal(ret, 0);
+}
+
 void test_wm_vuldet_check_specific_package_prepare_error(void **state)
 {
     sqlite3 *db = (sqlite3 *)1;
@@ -6078,6 +6099,7 @@ int main(void) {
         cmocka_unit_test(test_wm_vuldet_check_generic_package_insert_package_mac_with_vendor),
         //Tests wm_vuldet_check_specific_package
         cmocka_unit_test(test_wm_vuldet_check_specific_package_pkg_version_NULL),
+        cmocka_unit_test(test_wm_vuldet_check_specific_package_pkg_version_empty),
         cmocka_unit_test(test_wm_vuldet_check_specific_package_prepare_error),
         cmocka_unit_test(test_wm_vuldet_check_specific_package_done),
         cmocka_unit_test(test_wm_vuldet_check_specific_package_skip),

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2550,6 +2550,12 @@ int wm_vuldet_check_specific_package(sqlite3 *dbCVE, vu_feed feed, char *pkg_nam
     // Use a cleaned version without epoch and release so we can use a regex
     // within the sql query to gather all possible combinations (NVD does not store epoch).
     clean_version = wm_vuldet_clean_version(pkg_version);
+
+    if (clean_version == NULL) {
+        mterror(WM_VULNDETECTOR_LOGTAG, VU_PKG_INVALID_VER, pkg_reference, pkg_version);
+        return 0;
+    }
+
     len = strlen(clean_version) + 3;
     os_calloc(1, len, sql_version);
     snprintf(sql_version, len, "%%%s%%", clean_version);


### PR DESCRIPTION
|Related issue|
|---|
|#7935|

In Vulnerability Detector, function `wm_vuldet_clean_version()` removes unwanted prefixes or suffixes of the package version string. This function may return a null pointer if the version string does not follow the expected syntax. That would produce a segmentation fault.

## Proposed fix

- Let Vulnerability Detector notice that the version format is invalid, then log an error and continue.
```
wazuh-modulesd:vulnerability-detector: ERROR: (5591): Invalid version for package '...' of the inventory: '...'
```
- Extend the unit tests to check this condition.

## Tests

- [X] Build manager on Ubuntu 20.10.
- [x] Check that Modulesd does not crash anymore when reproducing #7935.
- [X] Add a unit test for this condition.

