### PR TITLE
Added additional information to spec.yaml

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -20,7 +20,7 @@ info:
 
     Login with USER and PASSWORD:
 
-    `curl -u <USER>:<PASSWORD> -k -X GET "https://<HOST_IP>:55000/security/user/authenticate`
+    `curl -u <USER>:<PASSWORD> -k -X GET "https://<HOST_IP>:55000/security/user/authenticate"
     ```json
     {
         "data": {
@@ -36,7 +36,7 @@ info:
     Change the token base duration:
 
     `curl -k -X PUT "https://<HOST_IP>:55000/security/config" -H "Authorization: Bearer <YOUR_JWT_TOKEN>"
-    -d '{"auth_token_exp_timeout":"<NEW_EXPIRE_TIME_IN_SECONDS>"}'`
+    -d '{"auth_token_exp_timeout":<NEW_EXPIRE_TIME_IN_SECONDS>}'`
 
     <SecurityDefinitions />
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -20,7 +20,7 @@ info:
 
     Login with USER and PASSWORD:
 
-    `curl -u <USER>:<PASSWORD> -k -X GET "https://<HOST_IP>:55000/security/user/authenticate"
+    `curl -u <USER>:<PASSWORD> -k -X GET "https://<HOST_IP>:55000/security/user/authenticate"`
     ```json
     {
         "data": {

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -14,6 +14,10 @@ info:
     information between parties as a JSON object. Perform a call with `basicAuth` to `GET /security/user/authenticate`
     and obtain a JWT token in order to run any endpoint.
 
+    JWT tokens have a default duration of 900 seconds. To change this value, you must perform a call with a valid
+    JWT token to `PUT /security/config`. After this change, you will need to get a new JWT token as all previously
+    issued tokens are revoked when any change is performed on security configuration.
+
     Login with USER and PASSWORD:
 
     `curl -u <USER>:<PASSWORD> -k -X GET "https://<HOST_IP>:55000/security/user/authenticate`
@@ -28,6 +32,11 @@ info:
     Use the token from previous response to perform any endpoint request:
 
     `curl -k -X <METHOD> "https://<HOST_IP>:55000/<ENDPOINT>" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"`
+
+    Change the token base duration:
+
+    `curl -k -X PUT "https://<HOST_IP>:55000/security/config" -H "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    -d '{"auth_token_exp_timeout":"<NEW_EXPIRE_TIME_IN_SECONDS>"}'`
 
     <SecurityDefinitions />
 


### PR DESCRIPTION
|Related issue|

Hello team,

In this PR I have added some additional information to spec.yaml to specify that the JWT tokens have a default
duration of 900 seconds and the CURL call able to change this setting 



