### PR TITLE
Added test for the new endpoint PUT /security/user... /run_as

### DIFF
--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -2047,12 +2047,26 @@ stages:
       json:
         username: newUser
         password: stringA1!
-        allow_run_as: true
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
       <<: *permission_denied
 
+---
+test_name: PUT /security/users/{user_id}/run_as
+
+stages:
+  - name: Try to change the allow_run_as field from one user
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/1/run_as"
+      method: PUT
+      params:
+        allow_run_as: 'false'
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      <<: *permission_denied
 ---
 test_name: DELETE /security/users
 

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -2062,7 +2062,7 @@ stages:
       url: "{protocol:s}://{host:s}:{port:d}/security/users/1/run_as"
       method: PUT
       params:
-        allow_run_as: 'false'
+        allow_run_as: false
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -2067,6 +2067,7 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       <<: *permission_denied
+
 ---
 test_name: DELETE /security/users
 

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -2056,7 +2056,7 @@ stages:
 test_name: PUT /security/users/{user_id}/run_as
 
 stages:
-  - name: Try to change the allow_run_as field from one user
+  - name: Try to change the allow_run_as field of a user
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/security/users/1/run_as"


### PR DESCRIPTION
|Related issue|
|---|
| #7997 |

Hello team,

This PR closes #7997.

I have fixed the test (POST security/users). Now the value of the run_as variable is checked in the test
(PUT /security/users/{user_id}/run_as) to be consistent with the changes in the api


### Test results

```
framework/wazuh/core/cluster/tests/
========================= 55 passed 4 warnings in 0.44s ==========================
```

```
framework/wazuh/core/cluster/dapi/tests/
========================= 23 passed, 9 warnings in 0.52s ==========================
```

```
framework/wazuh/core/tests/
========================= 652 passed, 9 warnings in 1.99s ==========================
```

```
framework/wazuh/tests/
========================= 756 passed, 11 warnings in 59.76s ==========================
```

```
framework/wazuh/rbac/tests/
========================= 227 passed, 3 warnings in 172.00s ==========================
```

```
api/api/test/
========================= 225 passed, 16 warnings in 1.10s ==========================
```

```
test_rbac_white_all_endpoints.tavern.yaml
         149 passed, 3 xfailed, 1 warnings
```