### PR TITLE
Fix workers reconnection after master restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Cluster:**
+  - Fixed workers reconnection after restarting master node. Updated `asyncio.Task.all_tasks` method removed in Python 3.9. ([#8017](https://github.com/wazuh/wazuh/pull/8017))
+
 
 ## [v4.1.3] - 2021-03-23
 

--- a/framework/wazuh/core/cluster/client.py
+++ b/framework/wazuh/core/cluster/client.py
@@ -123,7 +123,7 @@ class AbstractClientManager:
             finally:
                 transport.close()
 
-            self.logger.info("The connection has ben closed. Reconnecting in 10 seconds.")
+            self.logger.info("The connection has been closed. Reconnecting in 10 seconds.")
             await asyncio.sleep(self.cluster_items['intervals']['worker']['connection_retry'])
 
 
@@ -214,7 +214,7 @@ class AbstractClient(common.Handler):
 
     def _cancel_all_tasks(self):
         """Iterate asyncio tasks and cancel each of them."""
-        for task in asyncio.Task.all_tasks():
+        for task in asyncio.all_tasks():
             task.cancel()
 
     def process_response(self, command: bytes, payload: bytes) -> bytes:


### PR DESCRIPTION
Hi team,

In this PR we have fixed an error with workers being unable to reconnect to the master node after it restarts. We have updated `asyncio.Task.all_tasks()` with `asyncio.all_tasks()` since the first was removed in python 3.9. More information: https://docs.python.org/3.8/library/asyncio-task.html#asyncio.Task.all_tasks

### Master:
```
root@wazuh-master:/# /var/ossec/bin/cluster_control -l
NAME         TYPE    VERSION  ADDRESS       
master-node  master  4.1.4    wazuh-master  
worker1      worker  4.1.4    172.23.0.4    
root@wazuh-master:/# service wazuh-manager restart
Killing wazuh-clusterd...
Killing wazuh-modulesd...
Killing ossec-monitord...
Killing ossec-logcollector...
Killing ossec-remoted...
Killing ossec-syscheckd...
Killing ossec-analysisd...
ossec-maild not running...
Killing ossec-execd...
Killing wazuh-db...
Killing ossec-authd...
ossec-agentlessd not running...
ossec-integratord not running...
ossec-dbd not running...
ossec-csyslogd not running...
Killing wazuh-apid...
Wazuh v4.1.4 Stopped
Starting Wazuh v4.1.4...
Started wazuh-apid...
Started ossec-csyslogd...
Started ossec-dbd...
Started ossec-integratord...
Started ossec-agentlessd...
Started ossec-authd...
Started wazuh-db...
Started ossec-execd...
Started ossec-analysisd...
Started ossec-syscheckd...
Started ossec-remoted...
Started ossec-logcollector...
Started ossec-monitord...
Started wazuh-modulesd...
Started wazuh-clusterd...
Completed.
root@wazuh-master:/# /var/ossec/bin/cluster_control -l
NAME         TYPE    VERSION  ADDRESS       
master-node  master  4.1.4    wazuh-master  
worker1      worker  4.1.4    172.23.0.4 
```

### Worker:
```
2021/03/25 16:59:00 INFO: [Worker worker1] [Main] The master closed the connection
2021/03/25 16:59:10 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2021/03/25 16:59:10 ERROR: [Local Server] [Main] Could not connect to master. Trying again in 10 seconds.
2021/03/25 16:59:20 INFO: [Worker worker1] [Main] Sucessfully connected to master.
```


Regards