### PR TITLE
8019 scan build warning

### DIFF
--- a/src/data_provider/src/packages/berkeleyRpmDbHelper.h
+++ b/src/data_provider/src/packages/berkeleyRpmDbHelper.h
@@ -89,11 +89,11 @@ class BerkeleyRpmDBReader final
                     bytes = &bytes[FIRST_ENTRY_OFFSET];
 
                     retVal.resize(indexSize);
+
+                    auto ucp { reinterpret_cast<uint8_t *>(bytes) };
                     // Read all indexes
                     for (auto i = 0; i < indexSize; ++i)
                     {
-                        auto ucp { reinterpret_cast<uint8_t *>(bytes) };
-
                         const auto tag { Utils::toInt32BE(ucp) };
                         ucp += sizeof(int32_t);
 
@@ -120,7 +120,10 @@ class BerkeleyRpmDBReader final
                             retVal[i].count = Utils::toInt32BE(ucp);
                             ucp += sizeof(int32_t);
                         }
-                        bytes = &bytes[ENTRY_SIZE];
+                        else
+                        {
+                            ucp = reinterpret_cast<uint8_t *>(&bytes[ENTRY_SIZE]);
+                        }
                     }
                 }
             }

--- a/src/data_provider/src/packages/berkeleyRpmDbHelper.h
+++ b/src/data_provider/src/packages/berkeleyRpmDbHelper.h
@@ -75,13 +75,13 @@ class BerkeleyRpmDBReader final
         {
             auto bytes { reinterpret_cast<uint8_t *>(data.data) };
             std::vector<BerkeleyHeaderEntry> retVal;
-            constexpr auto byteSizeInt32{ sizeof(int32_t) };
+            constexpr auto BYTE_SIZE_INT32{ sizeof(int32_t) };
 
             if (data.size >= FIRST_ENTRY_OFFSET)
             {
                 const auto indexSize { Utils::toInt32BE(bytes) };
 
-                const auto dataSize { Utils::toInt32BE(bytes + byteSizeInt32) };
+                const auto dataSize { Utils::toInt32BE(bytes + BYTE_SIZE_INT32) };
 
                 const auto estimatedHeaderTagSize { FIRST_ENTRY_OFFSET + indexSize * ENTRY_SIZE + dataSize };
 
@@ -96,7 +96,7 @@ class BerkeleyRpmDBReader final
                     for (auto i = 0; i < indexSize; ++i)
                     {
                         const auto tag { Utils::toInt32BE(ucp) };
-                        ucp += byteSizeInt32;
+                        ucp += BYTE_SIZE_INT32;
 
                         const auto it
                         {
@@ -113,17 +113,17 @@ class BerkeleyRpmDBReader final
                             retVal[i].tag = it->second;
 
                             retVal[i].type = Utils::toInt32BE(ucp);
-                            ucp += byteSizeInt32;
+                            ucp += BYTE_SIZE_INT32;
 
                             retVal[i].offset = Utils::toInt32BE(ucp);
-                            ucp += byteSizeInt32;
+                            ucp += BYTE_SIZE_INT32;
 
                             retVal[i].count = Utils::toInt32BE(ucp);
-                            ucp += byteSizeInt32;
+                            ucp += BYTE_SIZE_INT32;
                         }
                         else
                         {
-                            ucp += ENTRY_SIZE - byteSizeInt32;
+                            ucp += ENTRY_SIZE - BYTE_SIZE_INT32;
                         }
                     }
                 }

--- a/src/data_provider/src/packages/berkeleyRpmDbHelper.h
+++ b/src/data_provider/src/packages/berkeleyRpmDbHelper.h
@@ -75,12 +75,13 @@ class BerkeleyRpmDBReader final
         {
             auto bytes { reinterpret_cast<uint8_t *>(data.data) };
             std::vector<BerkeleyHeaderEntry> retVal;
+            constexpr auto byteSizeInt32{ sizeof(int32_t) };
 
             if (data.size >= FIRST_ENTRY_OFFSET)
             {
                 const auto indexSize { Utils::toInt32BE(bytes) };
 
-                const auto dataSize { Utils::toInt32BE(bytes + sizeof(int32_t)) };
+                const auto dataSize { Utils::toInt32BE(bytes + byteSizeInt32) };
 
                 const auto estimatedHeaderTagSize { FIRST_ENTRY_OFFSET + indexSize * ENTRY_SIZE + dataSize };
 
@@ -95,7 +96,7 @@ class BerkeleyRpmDBReader final
                     for (auto i = 0; i < indexSize; ++i)
                     {
                         const auto tag { Utils::toInt32BE(ucp) };
-                        ucp += sizeof(int32_t);
+                        ucp += byteSizeInt32;
 
                         const auto it
                         {
@@ -112,17 +113,17 @@ class BerkeleyRpmDBReader final
                             retVal[i].tag = it->second;
 
                             retVal[i].type = Utils::toInt32BE(ucp);
-                            ucp += sizeof(int32_t);
+                            ucp += byteSizeInt32;
 
                             retVal[i].offset = Utils::toInt32BE(ucp);
-                            ucp += sizeof(int32_t);
+                            ucp += byteSizeInt32;
 
                             retVal[i].count = Utils::toInt32BE(ucp);
-                            ucp += sizeof(int32_t);
+                            ucp += byteSizeInt32;
                         }
                         else
                         {
-                            ucp += ENTRY_SIZE - sizeof(int32_t);
+                            ucp += ENTRY_SIZE - byteSizeInt32;
                         }
                     }
                 }

--- a/src/data_provider/src/packages/berkeleyRpmDbHelper.h
+++ b/src/data_provider/src/packages/berkeleyRpmDbHelper.h
@@ -122,7 +122,7 @@ class BerkeleyRpmDBReader final
                         }
                         else
                         {
-                            ucp = reinterpret_cast<uint8_t *>(&bytes[ENTRY_SIZE]);
+                            ucp += ENTRY_SIZE - sizeof(int32_t);
                         }
                     }
                 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8019 |

## Description
|Wazuh version|Component|Install type|Install method|Platform|
|---|---|---|---|---|
| 4.2.0-1 | Syscollector | Manager/Agent | Packages/Sources | Linux |
## Description
Scan build reports never read the variable.

![imagen](https://user-images.githubusercontent.com/14300208/112515708-46982c00-8d75-11eb-9a9f-96e641ecf17b.png)
![imagen](https://user-images.githubusercontent.com/14300208/112515743-50219400-8d75-11eb-9c0e-fdf1b3f8c87e.png)


**Actual result:** 1 scan-build warning.
**Expected result:** 0 scan-build warnings

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [x] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
