### PR TITLE
Send disconnection message from agent

### DIFF
--- a/ruleset/decoders/0200-ossec_decoders.xml
+++ b/ruleset/decoders/0200-ossec_decoders.xml
@@ -34,7 +34,7 @@
   <parent>ossec</parent>
   <type>ossec</type>
   <prematch offset="after_parent">^Agent started:</prematch>
-  <regex offset="after_prematch">^ '(\S+\S)'</regex>
+  <regex offset="after_prematch">^ '(\S+)'</regex>
   <order>extra_data</order>
   <fts>name, location, extra_data</fts>
 </decoder>
@@ -43,7 +43,7 @@
   <parent>ossec</parent>
   <type>ossec</type>
   <prematch offset="after_parent">^Agent stopped:</prematch>
-  <regex offset="after_prematch">^ '(\S+\S)'</regex>
+  <regex offset="after_prematch">^ '(\S+)'</regex>
   <order>extra_data</order>
   <fts>name, location, extra_data</fts>
 </decoder>

--- a/ruleset/decoders/0200-ossec_decoders.xml
+++ b/ruleset/decoders/0200-ossec_decoders.xml
@@ -39,6 +39,15 @@
   <fts>name, location, extra_data</fts>
 </decoder>
 
+<decoder name="ossec-agent-stop">
+  <parent>ossec</parent>
+  <type>ossec</type>
+  <prematch offset="after_parent">^Agent stopped:</prematch>
+  <regex offset="after_prematch">^ '(\S+\S)'</regex>
+  <order>extra_data</order>
+  <fts>name, location, extra_data</fts>
+</decoder>
+
 <decoder name="ossec-alert1">
    <parent>ossec</parent>
    <prematch>^ossec: Alert Level:</prematch>

--- a/ruleset/rules/0015-ossec_rules.xml
+++ b/ruleset/rules/0015-ossec_rules.xml
@@ -56,6 +56,13 @@
     <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,</group>
   </rule>
 
+  <rule id="506" level="3">
+    <if_sid>500</if_sid>
+    <match>Agent stopped</match>
+    <description>Ossec agent stopped.</description>
+    <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,</group>
+  </rule>
+
   <rule id="509" level="0">
     <category>ossec</category>
     <decoded_as>rootcheck</decoded_as>
@@ -494,4 +501,3 @@
   </rule>
 
 </group>
-

--- a/ruleset/rules/0015-ossec_rules.xml
+++ b/ruleset/rules/0015-ossec_rules.xml
@@ -60,6 +60,9 @@
     <if_sid>500</if_sid>
     <match>Agent stopped</match>
     <description>Ossec agent stopped.</description>
+    <mitre>
+      <id>T1089</id>
+    </mitre>
     <group>pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,</group>
   </rule>
 

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -76,8 +76,8 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     } else
         minfo("Version detected -> %s", getuname());
 
-    /* Send disconnection message at exit */
-    if (atexit(send_disconnection_message)) {
+    /* Send agent stopped message at exit */
+    if (atexit(send_agent_stopped_message)) {
         merror(ATEXIT_ERROR);
     }
 

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -73,12 +73,8 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
 
     if (!getuname()) {
         merror(MEM_ERROR, errno, strerror(errno));
-    } else
+    } else {
         minfo("Version detected -> %s", getuname());
-
-    /* Send agent stopped message at exit */
-    if (atexit(send_agent_stopped_message)) {
-        merror(ATEXIT_ERROR);
     }
 
     /* Try to connect to server */
@@ -169,6 +165,9 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     // Start request module
     req_init();
     w_create_thread(req_receiver, NULL);
+
+    /* Send agent stopped message at exit */
+    atexit(send_agent_stopped_message);
 
     /* Send first notification */
     run_notify();

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -76,6 +76,11 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     } else
         minfo("Version detected -> %s", getuname());
 
+    /* Send disconnection message at exit */
+    if (atexit(send_disconnection_message)) {
+        merror(ATEXIT_ERROR);
+    }
+
     /* Try to connect to server */
     os_setwait();
 
@@ -109,7 +114,6 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     signal(SIGPIPE, SIG_IGN);
 
     /* Launch rotation thread */
-
     rotate_log = getDefine_Int("monitord", "rotate_log", 0, 1);
     if (rotate_log) {
         w_create_thread(w_rotate_log_thread, (void *)NULL);
@@ -121,9 +125,10 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
         buffer_init();
 
         w_create_thread(dispatch_buffer, (void *)NULL);
-    }else{
+    } else {
         minfo(DISABLED_BUFFER);
     }
+
     /* Connect remote */
     rc = 0;
     while (rc < agt->server_count) {

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -89,6 +89,9 @@ char *get_agent_ip();
 /* Initialize handshake to server */
 void start_agent(int is_startup);
 
+/* Send disconnection message to server */
+void send_disconnection_message();
+
 /* Connect to the server */
 bool connect_server(int initial_id, bool verbose);
 

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -89,11 +89,11 @@ char *get_agent_ip();
 /* Initialize handshake to server */
 void start_agent(int is_startup);
 
-/* Send disconnection message to server */
-void send_disconnection_message();
-
 /* Connect to the server */
 bool connect_server(int initial_id, bool verbose);
+
+/* Send agent stopped message to server */
+void send_agent_stopped_message();
 
 /**
  * Tries to enroll to a server indicated by server_rip

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -442,7 +442,7 @@ void send_agent_stopped_message() {
 
     snprintf(msg, OS_MAXSTR, "%s%s", CONTROL_HEADER, HC_SHUTDOWN);
 
-    /* Send start up message */
+    /* Send shutdown message */
     send_msg(msg, -1);
 
     /* Read until our reply comes back */

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -413,7 +413,7 @@ static bool agent_handshake_to_server(int server_id, bool is_startup) {
 /**
  * @brief Sends log message about start up
  * */
-static void send_msg_on_startup(void){
+static void send_msg_on_startup(void) {
 
     char msg[OS_MAXSTR + 2] = { '\0' };
     char fmsg[OS_MAXSTR + 1] = { '\0' };
@@ -465,7 +465,7 @@ void send_agent_stopped_message() {
 /**
  * @brief Send log message about shutdown
  * */
-static void send_msg_on_shutdown(void){
+static void send_msg_on_shutdown(void) {
 
     char msg[OS_MAXSTR + 2] = { '\0' };
     char fmsg[OS_MAXSTR + 1] = { '\0' };

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -32,6 +32,7 @@ static void w_agentd_keys_init (void);
 static bool agent_handshake_to_server(int server_id, bool is_startup);
 static bool agent_ping_to_server(int server_id);
 static void send_msg_on_startup(void);
+static void send_msg_on_shutdown(void);
 
 /**
  * @brief Connects to a specified server
@@ -180,38 +181,6 @@ void start_agent(int is_startup)
         } else {
             current_server_id = 0;
             mwarn("Unable to connect to any server.");
-        }
-    }
-}
-
-/* Send disconnection message to server before exit */
-void send_disconnection_message() {
-    size_t msg_length;
-    ssize_t recv_b = 0;
-
-    char *tmp_msg;
-    char msg[OS_MAXSTR + 2] = { '\0' };
-    char buffer[OS_MAXSTR + 1] = { '\0' };
-    char cleartext[OS_MAXSTR + 1] = { '\0' };
-
-    snprintf(msg, OS_MAXSTR, "%s%s", CONTROL_HEADER, HC_SHUTDOWN);
-
-    /* Send start up message */
-    send_msg(msg, -1);
-
-    /* Read until our reply comes back */
-    recv_b = receive_message(buffer, OS_MAXSTR);
-
-    if (recv_b > 0) {
-        if (ReadSecMSG(&keys, buffer, cleartext, 0, recv_b - 1, &msg_length, agt->server[agt->rip_id].rip, &tmp_msg) != KS_VALID) {
-            mwarn(MSG_ERROR, agt->server[agt->rip_id].rip);
-        }
-        else {
-            if (IsValidHeader(tmp_msg) && (strcmp(tmp_msg, HC_ACK) == 0)) {
-                minfo(AG_DISCONNECTED);
-                /* Send shutdown alert message */
-                //send_msg_on_shutdown();
-            }
         }
     }
 }
@@ -451,6 +420,58 @@ static void send_msg_on_startup(void){
 
     /* Send log message about start up */
     snprintf(msg, OS_MAXSTR, OS_AG_STARTED,
+            keys.keyentries[0]->name,
+            keys.keyentries[0]->ip->ip);
+    os_snprintf(fmsg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ,
+            "ossec", msg);
+
+    send_msg(fmsg, -1);
+}
+
+/**
+ * @brief Send agent stopped message to server before exit
+ * */
+void send_agent_stopped_message() {
+    size_t msg_length;
+    ssize_t recv_b = 0;
+
+    char *tmp_msg;
+    char msg[OS_MAXSTR + 2] = { '\0' };
+    char buffer[OS_MAXSTR + 1] = { '\0' };
+    char cleartext[OS_MAXSTR + 1] = { '\0' };
+
+    snprintf(msg, OS_MAXSTR, "%s%s", CONTROL_HEADER, HC_SHUTDOWN);
+
+    /* Send start up message */
+    send_msg(msg, -1);
+
+    /* Read until our reply comes back */
+    recv_b = receive_message(buffer, OS_MAXSTR);
+
+    if (recv_b > 0) {
+        if (ReadSecMSG(&keys, buffer, cleartext, 0, recv_b - 1, &msg_length, agt->server[agt->rip_id].rip, &tmp_msg) != KS_VALID) {
+            mwarn(MSG_ERROR, agt->server[agt->rip_id].rip);
+        }
+        else {
+            if (IsValidHeader(tmp_msg) && (strcmp(tmp_msg, HC_ACK) == 0)) {
+                minfo(AG_DISCONNECTED);
+                /* Send shutdown alert message */
+                send_msg_on_shutdown();
+            }
+        }
+    }
+}
+
+/**
+ * @brief Send log message about shutdown
+ * */
+static void send_msg_on_shutdown(void){
+
+    char msg[OS_MAXSTR + 2] = { '\0' };
+    char fmsg[OS_MAXSTR + 1] = { '\0' };
+
+    /* Send log message about shutdown */
+    snprintf(msg, OS_MAXSTR, OS_AG_STOPPED,
             keys.keyentries[0]->name,
             keys.keyentries[0]->ip->ip);
     os_snprintf(fmsg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ,

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -646,6 +646,7 @@
 /* OSSEC alert messages */
 #define OS_AD_STARTED   "ossec: Ossec started."
 #define OS_AG_STARTED   "ossec: Agent started: '%s->%s'."
+#define OS_AG_STOPPED   "ossec: Agent stopped: '%s->%s'."
 #define OS_AG_DISCON    "ossec: Agent disconnected: '%s'."
 #define OS_AG_REMOVED   "ossec: Agent removed: '%s'."
 

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -274,7 +274,6 @@
 #define AG_NOKEYS_EXIT  "(4109): Unable to start without auth keys. Exiting."
 #define AG_INV_MNGIP    "(4112): Invalid server address found: '%s'"
 #define AG_ENROLL_FAIL  "(4113): Auto Enrollment configuration failed."
-#define AG_DISCONNECTED "(4114): Agent disconnected from server."
 
 /* Rules reading errors */
 #define RL_INV_ROOT     "(5101): Invalid root element: '%s'."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -274,6 +274,7 @@
 #define AG_NOKEYS_EXIT  "(4109): Unable to start without auth keys. Exiting."
 #define AG_INV_MNGIP    "(4112): Invalid server address found: '%s'"
 #define AG_ENROLL_FAIL  "(4113): Auto Enrollment configuration failed."
+#define AG_DISCONNECTED "(4114): Agent disconnected from server."
 
 /* Rules reading errors */
 #define RL_INV_ROOT     "(5101): Invalid root element: '%s'."

--- a/src/headers/rc.h
+++ b/src/headers/rc.h
@@ -28,6 +28,7 @@
 #define FILE_UPDATE_HEADER  "up file "
 #define FILE_CLOSE_HEADER   "close file "
 #define HC_STARTUP          "agent startup "
+#define HC_SHUTDOWN         "agent shutdown "
 #define HC_ACK              "agent ack "
 #define HC_SK_DB_COMPLETED  "syscheck-db-completed"
 #define HC_SK_RESTART       "syscheck restart"

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -21,6 +21,8 @@
 #include "sec.h"
 
 #define FD_LIST_INIT_VALUE 1024
+#define REMOTED_MSG_HEADER "1:" ARGV0 ":"
+#define AG_STOP_MSG REMOTED_MSG_HEADER OS_AG_STOPPED
 
 /* Pending data structure */
 

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -30,6 +30,8 @@
 extern void send_msg_on_startup(void);
 extern bool agent_handshake_to_server(int server_id, bool is_startup);
 extern bool agent_ping_to_server(int server_id);
+extern void send_msg_on_shutdown(void);
+extern void send_agent_stopped_message();
 extern int _s_verify_counter;
 
 #ifndef TEST_WINAGENT
@@ -500,6 +502,51 @@ static void test_agent_ping_to_server_udp_ok(void **state) {
     assert_true(agent_ping_to_server(0));
 }
 
+/* send_agent_stopped_message */
+static void test_send_agent_stopped_message(void **state) {
+
+    /* Sending the shutdown message */
+    will_return(__wrap_wnet_select, 1);
+    expect_any(__wrap_OS_RecvSecureTCP, sock);
+    expect_any(__wrap_OS_RecvSecureTCP, size);
+    will_return(__wrap_OS_RecvSecureTCP, SERVER_ENC_ACK);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(SERVER_ENC_ACK));
+    expect_string(__wrap_send_msg, msg, "#!-agent shutdown ");
+    expect_string(__wrap_send_msg, msg, "1:ossec:ossec: Agent stopped: 'agent0->any'.");
+    expect_string(__wrap_ReadSecMSG, buffer, SERVER_ENC_ACK);
+    will_return(__wrap_ReadSecMSG, "#!-agent ack ");
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_string(__wrap__minfo, formatted_msg, "(4114): Agent disconnected from server.");
+
+    send_agent_stopped_message();
+}
+
+static void test_send_agent_stopped_message_error(void **state) {
+
+    /* Decode error */
+    will_return(__wrap_wnet_select, 1);
+    expect_any(__wrap_OS_RecvSecureTCP, sock);
+    expect_any(__wrap_OS_RecvSecureTCP, size);
+    will_return(__wrap_OS_RecvSecureTCP, SERVER_WRONG_ACK);
+    will_return(__wrap_OS_RecvSecureTCP, strlen(SERVER_WRONG_ACK));
+    expect_string(__wrap_send_msg, msg, "#!-agent shutdown ");
+    expect_string(__wrap_ReadSecMSG, buffer, SERVER_WRONG_ACK);
+    will_return(__wrap_ReadSecMSG, SERVER_WRONG_ACK);
+    will_return(__wrap_ReadSecMSG, KS_CORRUPT);
+
+    expect_string(__wrap__mwarn, formatted_msg, "(1214): Problem receiving message from '(null)'.");
+
+    send_agent_stopped_message();
+}
+
+/* send_msg_on_shutdown */
+static void test_send_msg_on_shutdown(void **state) {
+
+    /* Shutdown message to server */
+    expect_string(__wrap_send_msg, msg, "1:ossec:ossec: Agent stopped: 'agent0->any'.");
+    send_msg_on_shutdown();
+}
 
 int main(void) {
     const struct CMUnitTest tests[] = {
@@ -513,6 +560,9 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_agent_ping_to_server_udp_receive_invalid, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_agent_ping_to_server_tcp_ok, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_agent_ping_to_server_udp_ok, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_send_agent_stopped_message, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_send_agent_stopped_message_error, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_send_msg_on_shutdown, setup_test, teardown_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -233,8 +233,8 @@ int local_start()
                         (LPDWORD)&threadID);
     }
 
-    /* Send disconnection message at exit */
-    if (atexit(send_disconnection_message)) {
+    /* Send agent stopped message at exit */
+    if (atexit(send_agent_stopped_message)) {
         merror(ATEXIT_ERROR);
     }
 

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -233,11 +233,6 @@ int local_start()
                         (LPDWORD)&threadID);
     }
 
-    /* Send agent stopped message at exit */
-    if (atexit(send_agent_stopped_message)) {
-        merror(ATEXIT_ERROR);
-    }
-
     /* Check if server is connected */
     os_setwait();
     start_agent(1);
@@ -278,6 +273,9 @@ int local_start()
     }
 
     atexit(stop_wmodules);
+
+    /* Send agent stopped message at exit */
+    atexit(send_agent_stopped_message);
 
     /* Start logcollector -- main process here */
     LogCollectorStart();

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -233,6 +233,11 @@ int local_start()
                         (LPDWORD)&threadID);
     }
 
+    /* Send disconnection message at exit */
+    if (atexit(send_disconnection_message)) {
+        merror(ATEXIT_ERROR);
+    }
+
     /* Check if server is connected */
     os_setwait();
     start_agent(1);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/7871|

## Description

This PR adds the capability for agents to send a disconnect message to the manager on exit.

In addition, an alert of level 3 is generated indicating that the agent was stopped. 

## Logs/Alerts example

**alert.log**

```
** Alert 1616697417.1717480: - ossec,pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,
2021 Mar 25 15:36:57 (ubuntu18) any->ossec
Rule: 506 (level 3) -> 'Ossec agent stopped.'
ossec: Agent stopped: 'ubuntu18->any'.
```

**alert.json**

```json
{
	"timestamp": "2021-03-25T15:36:57.711-0300",
	"rule": {
		"level": 3,
		"description": "Ossec agent stopped.",
		"id": "506",
		"firedtimes": 7,
		"mail": false,
		"groups": ["ossec"],
		"pci_dss": ["10.6.1", "10.2.6"],
		"gpg13": ["10.1"],
		"gdpr": ["IV_35.7.d"],
		"hipaa": ["164.312.b"],
		"nist_800_53": ["AU.6", "AU.14", "AU.5"],
		"tsc": ["CC7.2", "CC7.3", "CC6.8"]
	},
	"agent": {
		"id": "001",
		"name": "ubuntu18",
		"ip": "10.0.2.50"
	},
	"manager": {
		"name": "tomas-VirtualBox"
	},
	"id": "1616697417.1717480",
	"full_log": "ossec: Agent stopped: 'ubuntu18->any'.",
	"decoder": {
		"parent": "ossec",
		"name": "ossec"
	},
	"data": {
		"extra_data": "ubuntu18->any"
	},
	"location": "ossec"
}
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Source upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Working on cluster environments
- [x] Added unit tests (for new features)
