### PR TITLE
8024 cURL cannot download VD feeds.

### DIFF
--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -13,6 +13,12 @@
 #include "os_crypto/sha256/sha256_op.h"
 #include <os_net/os_net.h>
 
+/*
+ * These values ​​were taken from how libcurl looks for the paths at compilation time,
+ * here it is modified to be able to support the precompiled deps.
+ *
+ * https://github.com/curl/curl/blob/5930cb1c465ef5f0de6f1b91a843bb6f0bed1f23/acinclude.m4#L2182
+ */
 const char* certs_list[] = {
     "/etc/ssl/certs/ca-certificates.crt",       // Debian systems
     "/etc/pki/tls/certs/ca-bundle.crt",         // Redhat and Mandriva

--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -46,7 +46,7 @@ char const * find_cert_list() {
     return ret_val;
 }
 
-int wurl_get(const char * url, const char * dest, const char * header, const char *data, const long timeout){
+int wurl_get(const char * url, const char * dest, const char * header, const char *data, const long timeout) {
     CURL *curl;
     FILE *fp;
     CURLcode res;
@@ -54,7 +54,7 @@ int wurl_get(const char * url, const char * dest, const char * header, const cha
     char errbuf[CURL_ERROR_SIZE];
     int old_mask;
 
-    if (curl){
+    if (curl) {
         char const *cert = find_cert_list();
 
         old_mask = umask(0006);
@@ -83,7 +83,7 @@ int wurl_get(const char * url, const char * dest, const char * header, const cha
         }
 
         // Enable SSL check if url is HTTPS
-        if (!strncmp(url,"https",5)){
+        if (!strncmp(url,"https",5)) {
             curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
             curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 1L);
             if (NULL != cert) {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8024 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
## Description

This bug occurs after the pre-compiled changes, basically, during the build of libcurl, a series of paths is searched for the crt files by default, this varies in different operating systems.
The problem occurs since the deps were compiled in debian based systems, and when this was ported to redhat based systems that path was not found, since it varies according to the environment.

The problem could be solved by applying the same rule used to identify this, in runtime, setting the default path using CURLOPT_CAINFO

Actual result: Can't download files from https sites.
Expected result: Can download files from https sites.
Reporter: @pereyra-m 

```
2021/03/22 14:46:48 wazuh-modulesd[20807] url.c:75 at wurl_get(): DEBUG: CURL ERROR: error setting certificate verify locations:
  CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: none
```



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [X] MAC OS X
- [X] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [X] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
