### PR TITLE
Adding a Wazuh DB command to remove vulnerabilities from the vuln_cves table of the agents' databases

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -48,7 +48,7 @@ list(APPEND wdb_tests_names "test_wdb_agents")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step \
                              -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,cJSON_Delete \
                              -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_AddItemToObject \
-                             -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_GetObjectItem")
+                             -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,wdb_exec_stmt_sized")
 
 
 list(APPEND wdb_tests_names "test_wdb_global_helpers")

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -18,8 +18,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                         -Wl,--wrap,wdb_fim_delete -Wl,--wrap,wdb_syscheck_save -Wl,--wrap,wdb_syscheck_save2 \
                         -Wl,--wrap,wdbi_query_checksum -Wl,--wrap,wdbi_query_clear -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,wdb_step \
                         -Wl,--wrap,sqlite3_changes -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_last_insert_rowid \
-                        -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_open_agent2 -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_agents_insert_vuln_cve \
-                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cve -Wl,--wrap,wdb_agents_update_status_vuln_cve")
+                        -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_open_agent2 -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_agents_insert_vuln_cves \
+                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cves -Wl,--wrap,wdb_agents_update_status_vuln_cves")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -19,7 +19,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                         -Wl,--wrap,wdbi_query_checksum -Wl,--wrap,wdbi_query_clear -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,wdb_step \
                         -Wl,--wrap,sqlite3_changes -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_last_insert_rowid \
                         -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_open_agent2 -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_agents_insert_vuln_cves \
-                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cves -Wl,--wrap,wdb_agents_update_status_vuln_cves")
+                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cves -Wl,--wrap,wdb_agents_update_status_vuln_cves \
+                        -Wl,--wrap,wdb_agents_remove_vuln_cves -Wl,--wrap,wdb_agents_remove_by_status_vuln_cves")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
@@ -44,7 +45,10 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                             -Wl,--wrap,sqlite3_bind_parameter_index -Wl,--wrap,cJSON_Delete -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int")
 
 list(APPEND wdb_tests_names "test_wdb_agents")
-list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step")
+list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step \
+                             -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,cJSON_Delete \
+                             -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_AddItemToObject \
+                             -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_GetObjectItem")
 
 
 list(APPEND wdb_tests_names "test_wdb_global_helpers")
@@ -64,8 +68,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_Parse \
                              -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddNumberToObject \
                              -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_GetObjectItem \
-                             -Wl,--wrap,cJSON_Delete -Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,wdbc_query_parse_json \
-                             -Wl,--wrap,wdbc_query_parse")
+                             -Wl,--wrap,cJSON_ParseWithOpts -Wl,--wrap,cJSON_Delete -Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result \
+                             -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_Duplicate -Wl,--wrap,wdbc_query_parse_json -Wl,--wrap,wdbc_query_parse")
 
 list(APPEND wdb_tests_names "test_wdb")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,pthread_mutex_lock \

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -19,6 +19,7 @@
 #include "wazuh_db/wdb.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/externals/sqlite/sqlite3_wrappers.h"
+#include "../wrappers/externals/cJSON/cJSON_wrappers.h"
 #include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
 #include "wazuhdb_op.h"
 #include "wazuh_db/wdb_agents.h"
@@ -33,7 +34,6 @@ static int test_setup(void **state) {
     os_calloc(1,sizeof(test_struct_t),init_data);
     os_calloc(1,sizeof(wdb_t),init_data->wdb);
     os_strdup("000",init_data->wdb->id);
-    os_calloc(256,sizeof(char),init_data->output);
     os_calloc(1,sizeof(sqlite3 *),init_data->wdb->db);
     *state = init_data;
     return 0;
@@ -97,36 +97,6 @@ void test_wdb_agents_insert_vuln_cves_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-/* Tests wdb_agents_clear_vuln_cves */
-
-void test_wdb_agents_clear_vuln_cves_statement_init_fail(void **state)
-{
-    int ret = -1;
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_CLEAR);
-
-    ret = wdb_agents_clear_vuln_cves(data->wdb);
-
-    assert_int_equal(ret, OS_INVALID);
-}
-
-void test_wdb_agents_clear_vuln_cves_success(void **state)
-{
-    int ret = -1;
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_CLEAR);
-
-    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
-
-    ret = wdb_agents_clear_vuln_cves(data->wdb);
-
-    assert_int_equal(ret, OS_SUCCESS);
-}
-
 /* Tests wdb_agents_update_status_vuln_cves*/
 
 void test_wdb_agents_update_status_vuln_cves_statement_init_fail(void **state){
@@ -183,19 +153,343 @@ void test_wdb_agents_update_status_vuln_cves_success_all(void **state){
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_agents_remove_vuln_cves */
+
+void test_wdb_agents_remove_vuln_cves_invalid_data(void **state)
+{
+    int ret = -1;
+    const char *cve = NULL;
+    const char *reference = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid data provided");
+
+    ret = wdb_agents_remove_vuln_cves(data->wdb, cve, reference);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_agents_remove_vuln_cves_statement_init_fail(void **state)
+{
+    int ret = -1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "ref-cve-xxxx-yyyy";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_DELETE_ENTRY);
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+
+    ret = wdb_agents_remove_vuln_cves(data->wdb, cve, reference);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_agents_remove_vuln_cves_success(void **state)
+{
+    int ret = -1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "ref-cve-xxxx-yyyy";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_DELETE_ENTRY);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    ret = wdb_agents_remove_vuln_cves(data->wdb, cve, reference);
+
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+/* Tests wdb_agents_remove_by_status_vuln_cves */
+
+void test_wdb_agents_remove_by_status_vuln_cves_statement_init_fail(void **state)
+{
+    int ret = -1;
+    const char *status = "OBSOLETE";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // Preparing statement
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
+
+    ret = wdb_agents_remove_by_status_vuln_cves(data->wdb, status, &data->output);
+
+    assert_string_equal(data->output, "Cannot cache statement");
+    assert_int_equal(ret, WDBC_ERROR);
+}
+
+void test_wdb_agents_remove_by_status_vuln_cves_statement_bind_fail(void **state)
+{
+    int ret = -1;
+    const char *status = "OBSOLETE";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // Preparing statement
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, SQLITE_ERROR, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, status);
+
+    will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+
+    ret = wdb_agents_remove_by_status_vuln_cves(data->wdb, status, &data->output);
+
+    assert_string_equal(data->output, "Cannot bind sql statement");
+    assert_int_equal(ret, WDBC_ERROR);
+}
+
+void test_wdb_agents_remove_by_status_vuln_cves_no_cves_for_detele(void **state)
+{
+    int ret = -1;
+    const char *status = "OBSOLETE";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // Preparing statement
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, status);
+
+    // Executing statement
+    will_return(__wrap_wdb_exec_stmt, NULL);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_remove_by_status_vuln_cves(data->wdb, status, &data->output);
+
+    assert_string_equal(data->output, "[]");
+    assert_int_equal(ret, WDBC_OK);
+}
+
+void test_wdb_agents_remove_by_status_vuln_cves_error_removing_cve(void **state)
+{
+    int ret = -1;
+    cJSON *root = NULL;
+    cJSON *row = NULL;
+    cJSON *str1 = NULL;
+    cJSON *str2 = NULL;
+    const char *status = "OBSOLETE";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    root = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str1 = __real_cJSON_CreateString("cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "cve", str1);
+    str2 = __real_cJSON_CreateString("ref-cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "reference", str2);
+    __real_cJSON_AddItemToArray(root, row);
+
+    // Preparing statement
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, status);
+
+    // Executing statement
+    will_return(__wrap_wdb_exec_stmt, root);
+    will_return(__wrap_cJSON_GetObjectItem, str1);
+    will_return(__wrap_cJSON_GetObjectItem, str2);
+
+    // Removing vulnerability
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_DELETE_ENTRY);
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+    expect_string(__wrap__merror, formatted_msg, "Error removing vulnerability from the inventory database: cve-xxxx-yyyy");
+
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_remove_by_status_vuln_cves(data->wdb, status, &data->output);
+
+    assert_string_equal(data->output, "Error removing vulnerability from the inventory database:  cve-xxxx-yyyy");
+    assert_int_equal(ret, WDBC_ERROR);
+
+    __real_cJSON_Delete(root);
+}
+
+void test_wdb_agents_remove_by_status_vuln_cves_success(void **state)
+{
+    int ret = -1;
+    cJSON *root = NULL;
+    cJSON *row = NULL;
+    cJSON *str1 = NULL;
+    cJSON *str2 = NULL;
+    const char *status = "OBSOLETE";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    root = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str1 = __real_cJSON_CreateString("cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "cve", str1);
+    str2 = __real_cJSON_CreateString("ref-cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "reference", str2);
+    __real_cJSON_AddItemToArray(root, row);
+
+    // Preparing statement
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, status);
+
+    // Executing statement first time
+    will_return(__wrap_wdb_exec_stmt, root);
+    will_return(__wrap_cJSON_GetObjectItem, str1);
+    will_return(__wrap_cJSON_GetObjectItem, str2);
+
+    // Removing vulnerability
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_DELETE_ENTRY);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "cve-xxxx-yyyy");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "ref-cve-xxxx-yyyy");
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Executing statement second time
+    will_return(__wrap_wdb_exec_stmt, root);
+    will_return(__wrap_cJSON_GetObjectItem, str1);
+    will_return(__wrap_cJSON_GetObjectItem, str2);
+
+    // Removing vulnerability
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_DELETE_ENTRY);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "cve-xxxx-yyyy");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "ref-cve-xxxx-yyyy");
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Executing statement third time
+    will_return(__wrap_wdb_exec_stmt, NULL);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_remove_by_status_vuln_cves(data->wdb, status, &data->output);
+
+    assert_string_equal(data->output, "[{\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"ref-cve-xxxx-yyyy\"},{\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"ref-cve-xxxx-yyyy\"}]");
+    assert_int_equal(ret, WDBC_OK);
+
+    __real_cJSON_Delete(root);
+}
+
+void test_wdb_agents_remove_by_status_vuln_cves_full(void **state)
+{
+    int ret = -1;
+    cJSON *root = NULL;
+    cJSON *row = NULL;
+    cJSON *str1 = NULL;
+    cJSON *str2 = NULL;
+    const char *status = "OBSOLETE";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    root = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str1 = __real_cJSON_CreateString("cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "cve", str1);
+    str2 = __real_cJSON_CreateString("ref-cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "reference", str2);
+    __real_cJSON_AddItemToArray(root, row);
+    // Creating a cJSON array bigger than WDB_MAX_RESPONSE_SIZE
+    for(int i = 0; i < 2500; i++){
+        __real_cJSON_AddStringToObject(row,"test_field", "test_value");
+    }
+
+    // Preparing statement
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, status);
+
+    // Executing statement first time
+    will_return(__wrap_wdb_exec_stmt, root);
+    will_return(__wrap_cJSON_GetObjectItem, str1);
+    will_return(__wrap_cJSON_GetObjectItem, str2);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_remove_by_status_vuln_cves(data->wdb, status, &data->output);
+
+    assert_string_equal(data->output, "[]");
+    assert_int_equal(ret, WDBC_DUE);
+
+    __real_cJSON_Delete(root);
+}
+
+/* Tests wdb_agents_clear_vuln_cves */
+
+void test_wdb_agents_clear_vuln_cves_statement_init_fail(void **state)
+{
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_CLEAR);
+
+    ret = wdb_agents_clear_vuln_cves(data->wdb);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_agents_clear_vuln_cves_success(void **state)
+{
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_CLEAR);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    ret = wdb_agents_clear_vuln_cves(data->wdb);
+
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] = {
         /* Tests wdb_agents_insert_vuln_cves */
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success, test_setup, test_teardown),
-        /* Tests wdb_agents_clear_vuln_cves */
-        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_statement_init_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_success, test_setup, test_teardown),
         /* Tests wdb_agents_update_status_vuln_cves */
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_success_all, test_setup, test_teardown),
+        /* Tests wdb_agents_remove_vuln_cves */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_vuln_cves_invalid_data, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_vuln_cves_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_vuln_cves_success, test_setup, test_teardown),
+        /* Tests wdb_agents_remove_by_status_vuln_cves */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_by_status_vuln_cves_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_by_status_vuln_cves_statement_bind_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_by_status_vuln_cves_no_cves_for_detele, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_by_status_vuln_cves_error_removing_cve, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_by_status_vuln_cves_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_by_status_vuln_cves_full, test_setup, test_teardown),
+        /* Tests wdb_agents_clear_vuln_cves */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_success, test_setup, test_teardown),
       };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -49,9 +49,9 @@ static int test_teardown(void **state){
     return 0;
 }
 
-/* Tests wdb_agents_insert_vuln_cve */
+/* Tests wdb_agents_insert_vuln_cves */
 
-void test_wdb_agents_insert_vuln_cve_statement_init_fail(void **state)
+void test_wdb_agents_insert_vuln_cves_statement_init_fail(void **state)
 {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -61,14 +61,14 @@ void test_wdb_agents_insert_vuln_cve_statement_init_fail(void **state)
     const char* cve = "CVE-2021-1200";
 
     will_return(__wrap_wdb_init_stmt_in_cache, NULL);
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_INSERT);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_INSERT);
 
-    ret = wdb_agents_insert_vuln_cve(data->wdb, name, version, architecture, cve);
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve);
 
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_agents_insert_vuln_cve_success(void **state)
+void test_wdb_agents_insert_vuln_cves_success(void **state)
 {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -78,7 +78,7 @@ void test_wdb_agents_insert_vuln_cve_success(void **state)
     const char* cve = "CVE-2021-1200";
 
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_INSERT);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_INSERT);
 
     will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
@@ -92,65 +92,65 @@ void test_wdb_agents_insert_vuln_cve_success(void **state)
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 
-    ret = wdb_agents_insert_vuln_cve(data->wdb, name, version, architecture, cve);
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve);
 
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-/* Tests wdb_agents_clear_vuln_cve */
+/* Tests wdb_agents_clear_vuln_cves */
 
-void test_wdb_agents_clear_vuln_cve_statement_init_fail(void **state)
+void test_wdb_agents_clear_vuln_cves_statement_init_fail(void **state)
 {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_init_stmt_in_cache, NULL);
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_CLEAR);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_CLEAR);
 
-    ret = wdb_agents_clear_vuln_cve(data->wdb);
+    ret = wdb_agents_clear_vuln_cves(data->wdb);
 
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_agents_clear_vuln_cve_success(void **state)
+void test_wdb_agents_clear_vuln_cves_success(void **state)
 {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_CLEAR);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_CLEAR);
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 
-    ret = wdb_agents_clear_vuln_cve(data->wdb);
+    ret = wdb_agents_clear_vuln_cves(data->wdb);
 
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-/* Tests wdb_agents_update_status_vuln_cve*/
+/* Tests wdb_agents_update_status_vuln_cves*/
 
-void test_wdb_agents_update_status_vuln_cve_statement_init_fail(void **state){
+void test_wdb_agents_update_status_vuln_cves_statement_init_fail(void **state){
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* old_status = "valid";
     const char* new_status = "pending";
 
     will_return(__wrap_wdb_init_stmt_in_cache, NULL);
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_UPDATE);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_UPDATE);
 
-    ret = wdb_agents_update_status_vuln_cve(data->wdb, old_status, new_status);
+    ret = wdb_agents_update_status_vuln_cves(data->wdb, old_status, new_status);
 
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_agents_update_status_vuln_cve_success(void **state){
+void test_wdb_agents_update_status_vuln_cves_success(void **state){
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* old_status = "valid";
     const char* new_status = "pending";
 
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_UPDATE);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_UPDATE);
 
     will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
@@ -160,18 +160,18 @@ void test_wdb_agents_update_status_vuln_cve_success(void **state){
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 
-    ret = wdb_agents_update_status_vuln_cve(data->wdb, old_status, new_status);
+    ret = wdb_agents_update_status_vuln_cves(data->wdb, old_status, new_status);
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-void test_wdb_agents_update_status_vuln_cve_success_all(void **state){
+void test_wdb_agents_update_status_vuln_cves_success_all(void **state){
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* old_status = "*";
     const char* new_status = "pending";
 
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVE_UPDATE_ALL);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_UPDATE_ALL);
 
     will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
@@ -179,23 +179,23 @@ void test_wdb_agents_update_status_vuln_cve_success_all(void **state){
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 
-    ret = wdb_agents_update_status_vuln_cve(data->wdb, old_status, new_status);
+    ret = wdb_agents_update_status_vuln_cves(data->wdb, old_status, new_status);
     assert_int_equal(ret, OS_SUCCESS);
 }
 
 int main()
 {
     const struct CMUnitTest tests[] = {
-        /* Tests wdb_agents_insert_vuln_cve */
-        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cve_statement_init_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cve_success, test_setup, test_teardown),
-        /* Tests wdb_agents_clear_vuln_cve */
-        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_statement_init_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cve_success, test_setup, test_teardown),
-        /* Tests wdb_agents_update_status_vuln_cve */
-        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cve_statement_init_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cve_success, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cve_success_all, test_setup, test_teardown),
+        /* Tests wdb_agents_insert_vuln_cves */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success, test_setup, test_teardown),
+        /* Tests wdb_agents_clear_vuln_cves */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_success, test_setup, test_teardown),
+        /* Tests wdb_agents_update_status_vuln_cves */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_success_all, test_setup, test_teardown),
       };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -35,9 +35,9 @@ int teardown_wdb_agents_helpers(void **state) {
     return 0;
 }
 
-/* Tests wdb_agents_vuln_cve_insert */
+/* Tests wdb_agents_vuln_cves_insert */
 
-void test_wdb_agents_vuln_cve_insert_error_json(void **state)
+void test_wdb_agents_vuln_cves_insert_error_json(void **state)
 {
     int ret = 0;
     int id = 1;
@@ -50,12 +50,12 @@ void test_wdb_agents_vuln_cve_insert_error_json(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
 
-    ret = wdb_agents_vuln_cve_insert(id, name, version, architecture, cve, NULL);
+    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_insert_error_socket(void **state)
+void test_wdb_agents_vuln_cves_insert_error_socket(void **state)
 {
     int ret = 0;
     int id = 1;
@@ -65,7 +65,7 @@ void test_wdb_agents_vuln_cve_insert_error_socket(void **state)
     const char *cve = "CVE-2021-1001";
 
     const char *json_str = strdup("{\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
-    const char *query_str = "agent 1 vuln_cve insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
+    const char *query_str = "agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -94,14 +94,14 @@ void test_wdb_agents_vuln_cve_insert_error_socket(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error in the response from socket");
-    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cve insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
 
-    ret = wdb_agents_vuln_cve_insert(id, name, version, architecture, cve, NULL);
+    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_insert_error_sql_execution(void **state)
+void test_wdb_agents_vuln_cves_insert_error_sql_execution(void **state)
 {
     int ret = 0;
     int id = 1;
@@ -111,7 +111,7 @@ void test_wdb_agents_vuln_cve_insert_error_sql_execution(void **state)
     const char *cve = "CVE-2021-1001";
 
     const char *json_str = strdup("{\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
-    const char *query_str = "agent 1 vuln_cve insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
+    const char *query_str = "agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -140,14 +140,14 @@ void test_wdb_agents_vuln_cve_insert_error_sql_execution(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");
-    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cve insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
 
-    ret = wdb_agents_vuln_cve_insert(id, name, version, architecture, cve, NULL);
+    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_insert_error_result(void **state)
+void test_wdb_agents_vuln_cves_insert_error_result(void **state)
 {
     int ret = 0;
     int id = 1;
@@ -157,7 +157,7 @@ void test_wdb_agents_vuln_cve_insert_error_result(void **state)
     const char *cve = "CVE-2021-1001";
 
     const char *json_str = strdup("{\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
-    const char *query_str = "agent 1 vuln_cve insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
+    const char *query_str = "agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -189,12 +189,12 @@ void test_wdb_agents_vuln_cve_insert_error_result(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
     expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
 
-    ret = wdb_agents_vuln_cve_insert(id, name, version, architecture, cve, NULL);
+    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_insert_success(void **state)
+void test_wdb_agents_vuln_cves_insert_success(void **state)
 {
     int ret = 0;
     int id = 1;
@@ -204,7 +204,7 @@ void test_wdb_agents_vuln_cve_insert_success(void **state)
     const char *cve = "CVE-2021-1001";
 
     const char *json_str = strdup("{\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
-    const char *query_str = "agent 1 vuln_cve insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
+    const char *query_str = "agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -235,19 +235,19 @@ void test_wdb_agents_vuln_cve_insert_success(void **state)
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
-    ret = wdb_agents_vuln_cve_insert(id, name, version, architecture, cve, NULL);
+    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, NULL);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
 
-/* Tests wdb_agents_vuln_cve_clear */
+/* Tests wdb_agents_vuln_cves_clear */
 
-void test_wdb_agents_vuln_cve_clear_error_socket(void **state)
+void test_wdb_agents_vuln_cves_clear_error_socket(void **state)
 {
     int ret = 0;
     int id = 1;
 
-    const char *query_str = "agent 1 vuln_cve clear";
+    const char *query_str = "agent 1 vuln_cves clear";
     const char *response = "err";
 
     // Calling Wazuh DB
@@ -259,19 +259,19 @@ void test_wdb_agents_vuln_cve_clear_error_socket(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error in the response from socket");
-    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cve clear");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves clear");
 
-    ret = wdb_agents_vuln_cve_clear(id, NULL);
+    ret = wdb_agents_vuln_cves_clear(id, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_clear_error_sql_execution(void **state)
+void test_wdb_agents_vuln_cves_clear_error_sql_execution(void **state)
 {
     int ret = 0;
     int id = 1;
 
-    const char *query_str = "agent 1 vuln_cve clear";
+    const char *query_str = "agent 1 vuln_cves clear";
     const char *response = "err";
 
     // Calling Wazuh DB
@@ -283,19 +283,19 @@ void test_wdb_agents_vuln_cve_clear_error_sql_execution(void **state)
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");
-    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cve clear");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves clear");
 
-    ret = wdb_agents_vuln_cve_clear(id, NULL);
+    ret = wdb_agents_vuln_cves_clear(id, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_clear_error_result(void **state)
+void test_wdb_agents_vuln_cves_clear_error_result(void **state)
 {
     int ret = 0;
     int id = 1;
 
-    const char *query_str = "agent 1 vuln_cve clear";
+    const char *query_str = "agent 1 vuln_cves clear";
     const char *response = "err";
 
     // Calling Wazuh DB
@@ -310,17 +310,17 @@ void test_wdb_agents_vuln_cve_clear_error_result(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
     expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
 
-    ret = wdb_agents_vuln_cve_clear(id, NULL);
+    ret = wdb_agents_vuln_cves_clear(id, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_clear_success(void **state)
+void test_wdb_agents_vuln_cves_clear_success(void **state)
 {
     int ret = 0;
     int id = 1;
 
-    const char *query_str = "agent 1 vuln_cve clear";
+    const char *query_str = "agent 1 vuln_cves clear";
     const char *response = "err";
 
     // Calling Wazuh DB
@@ -334,14 +334,14 @@ void test_wdb_agents_vuln_cve_clear_success(void **state)
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
-    ret = wdb_agents_vuln_cve_clear(id, NULL);
+    ret = wdb_agents_vuln_cves_clear(id, NULL);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
 
-/* Tests wdb_agents_vuln_cve_update_status */
+/* Tests wdb_agents_vuln_cves_update_status */
 
-void test_wdb_agents_vuln_cve_update_status_error_json(void **state){
+void test_wdb_agents_vuln_cves_update_status_error_json(void **state){
     int ret = 0;
     int id = 1;
     const char *old_status = "valid";
@@ -351,12 +351,12 @@ void test_wdb_agents_vuln_cve_update_status_error_json(void **state){
 
     expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
 
-    ret = wdb_agents_vuln_cve_update_status(id, old_status, new_status, NULL);
+    ret = wdb_agents_vuln_cves_update_status(id, old_status, new_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_update_status_error_socket(void **state){
+void test_wdb_agents_vuln_cves_update_status_error_socket(void **state){
     int ret = 0;
     int id = 1;
     const char *old_status = "valid";
@@ -364,7 +364,7 @@ void test_wdb_agents_vuln_cve_update_status_error_socket(void **state){
     const char *json_str = NULL;
 
     os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
-    const char *query_str = "agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
+    const char *query_str = "agent 1 vuln_cves update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -389,14 +389,14 @@ void test_wdb_agents_vuln_cve_update_status_error_socket(void **state){
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error in the response from socket");
-    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}");
 
-    ret = wdb_agents_vuln_cve_update_status(id, old_status, new_status, NULL);
+    ret = wdb_agents_vuln_cves_update_status(id, old_status, new_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_update_status_error_sql_execution(void **state){
+void test_wdb_agents_vuln_cves_update_status_error_sql_execution(void **state){
     int ret = 0;
     int id = 1;
     const char *old_status = "valid";
@@ -404,7 +404,7 @@ void test_wdb_agents_vuln_cve_update_status_error_sql_execution(void **state){
     const char *json_str = NULL;
 
     os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
-    const char *query_str = "agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
+    const char *query_str = "agent 1 vuln_cves update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -429,14 +429,14 @@ void test_wdb_agents_vuln_cve_update_status_error_sql_execution(void **state){
 
     // Handling result
     expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");
-    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}");
 
-    ret = wdb_agents_vuln_cve_update_status(id, old_status, new_status, NULL);
+    ret = wdb_agents_vuln_cves_update_status(id, old_status, new_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_update_status_error_result(void **state){
+void test_wdb_agents_vuln_cves_update_status_error_result(void **state){
     int ret = 0;
     int id = 1;
     const char *old_status = "valid";
@@ -444,7 +444,7 @@ void test_wdb_agents_vuln_cve_update_status_error_result(void **state){
     const char *json_str = NULL;
 
     os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
-    const char *query_str = "agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
+    const char *query_str = "agent 1 vuln_cves update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -472,12 +472,12 @@ void test_wdb_agents_vuln_cve_update_status_error_result(void **state){
     will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
     expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
 
-    ret = wdb_agents_vuln_cve_update_status(id, old_status, new_status, NULL);
+    ret = wdb_agents_vuln_cves_update_status(id, old_status, new_status, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_update_status_success(void **state){
+void test_wdb_agents_vuln_cves_update_status_success(void **state){
     int ret = 0;
     int id = 1;
     const char *old_status = "valid";
@@ -485,7 +485,7 @@ void test_wdb_agents_vuln_cve_update_status_success(void **state){
     const char *json_str = NULL;
 
     os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
-    const char *query_str = "agent 1 vuln_cve update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
+    const char *query_str = "agent 1 vuln_cves update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
     const char *response = "err";
 
     will_return(__wrap_cJSON_CreateObject, 1);
@@ -512,7 +512,7 @@ void test_wdb_agents_vuln_cve_update_status_success(void **state){
     expect_any(__wrap_wdbc_parse_result, result);
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
-    ret = wdb_agents_vuln_cve_update_status(id, old_status, new_status, NULL);
+    ret = wdb_agents_vuln_cves_update_status(id, old_status, new_status, NULL);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
@@ -521,23 +521,23 @@ int main()
 {
     const struct CMUnitTest tests[] =
     {
-        /* Tests wdb_agents_vuln_cve_insert*/
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_insert_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_insert_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_insert_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_insert_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_insert_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        /* Tests wdb_agents_vuln_cve_clear*/
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_clear_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_clear_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_clear_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_clear_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        /* Tests wdb_agents_vuln_cve_update_status*/
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_update_status_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_update_status_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_update_status_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_update_status_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_update_status_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cves_insert*/
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cves_clear*/
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cves_update_status*/
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -421,9 +421,9 @@ void test_wdb_agents_vuln_cves_update_status_success(void **state){
     assert_int_equal(OS_SUCCESS, ret);
 }
 
-/* Tests wdb_agents_vuln_cve_remove_entry */
+/* Tests wdb_agents_vuln_cves_remove_entry */
 
-void test_wdb_agents_vuln_cve_remove_entry_error_json(void **state)
+void test_wdb_agents_vuln_cves_remove_entry_error_json(void **state)
 {
     int ret = 0;
     int id = 1;
@@ -434,12 +434,12 @@ void test_wdb_agents_vuln_cve_remove_entry_error_json(void **state)
     will_return(__wrap_cJSON_CreateObject, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
 
-    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+    ret = wdb_agents_vuln_cves_remove_entry(id, cve, reference, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_remove_entry_error_socket(void **state){
+void test_wdb_agents_vuln_cves_remove_entry_error_socket(void **state){
     int ret = 0;
     int id = 1;
     const char *cve = "cve-xxxx-yyyy";
@@ -476,12 +476,12 @@ void test_wdb_agents_vuln_cve_remove_entry_error_socket(void **state){
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);
 
-    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+    ret = wdb_agents_vuln_cves_remove_entry(id, cve, reference, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_remove_entry_error_sql_execution(void **state){
+void test_wdb_agents_vuln_cves_remove_entry_error_sql_execution(void **state){
     int ret = 0;
     int id = 1;
     const char *cve = "cve-xxxx-yyyy";
@@ -518,12 +518,12 @@ void test_wdb_agents_vuln_cve_remove_entry_error_sql_execution(void **state){
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);
 
-    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+    ret = wdb_agents_vuln_cves_remove_entry(id, cve, reference, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_remove_entry_error_result(void **state){
+void test_wdb_agents_vuln_cves_remove_entry_error_result(void **state){
     int ret = 0;
     int id = 1;
     const char *cve = "cve-xxxx-yyyy";
@@ -561,12 +561,12 @@ void test_wdb_agents_vuln_cve_remove_entry_error_result(void **state){
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);
 
-    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+    ret = wdb_agents_vuln_cves_remove_entry(id, cve, reference, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_remove_entry_success(void **state){
+void test_wdb_agents_vuln_cves_remove_entry_success(void **state){
     int ret = 0;
     int id = 1;
     const char *cve = "cve-xxxx-yyyy";
@@ -603,7 +603,7 @@ void test_wdb_agents_vuln_cve_remove_entry_success(void **state){
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);
 
-    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+    ret = wdb_agents_vuln_cves_remove_entry(id, cve, reference, NULL);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
@@ -990,12 +990,12 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        /* Tests wdb_agents_vuln_cve_remove_entry */
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cves_remove_entry */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_entry_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_entry_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_entry_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_entry_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_entry_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         /* Tests wdb_agents_vuln_cves_remove_by_status */
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_error_wdb_query, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -19,6 +19,9 @@
 #include "wazuh_db/helpers/wdb_agents_helpers.h"
 #include "wazuhdb_op.h"
 
+#include "../wrappers/externals/cJSON/cJSON_wrappers.h"
+#include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
+
 extern int test_mode;
 
 /* setup/teardown */
@@ -205,7 +208,7 @@ void test_wdb_agents_vuln_cves_insert_success(void **state)
 
     const char *json_str = strdup("{\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
     const char *query_str = "agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
-    const char *response = "err";
+    const char *response = "ok";
 
     will_return(__wrap_cJSON_CreateObject, 1);
     will_return_always(__wrap_cJSON_AddStringToObject, 1);
@@ -236,105 +239,6 @@ void test_wdb_agents_vuln_cves_insert_success(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
     ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, NULL);
-
-    assert_int_equal(OS_SUCCESS, ret);
-}
-
-/* Tests wdb_agents_vuln_cves_clear */
-
-void test_wdb_agents_vuln_cves_clear_error_socket(void **state)
-{
-    int ret = 0;
-    int id = 1;
-
-    const char *query_str = "agent 1 vuln_cves clear";
-    const char *response = "err";
-
-    // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, OS_INVALID);
-
-    // Handling result
-    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error in the response from socket");
-    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves clear");
-
-    ret = wdb_agents_vuln_cves_clear(id, NULL);
-
-    assert_int_equal(OS_INVALID, ret);
-}
-
-void test_wdb_agents_vuln_cves_clear_error_sql_execution(void **state)
-{
-    int ret = 0;
-    int id = 1;
-
-    const char *query_str = "agent 1 vuln_cves clear";
-    const char *response = "err";
-
-    // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, -100); // Returning any error
-
-    // Handling result
-    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");
-    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves clear");
-
-    ret = wdb_agents_vuln_cves_clear(id, NULL);
-
-    assert_int_equal(OS_INVALID, ret);
-}
-
-void test_wdb_agents_vuln_cves_clear_error_result(void **state)
-{
-    int ret = 0;
-    int id = 1;
-
-    const char *query_str = "agent 1 vuln_cves clear";
-    const char *response = "err";
-
-    // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
-
-    // Parsing Wazuh DB result
-    expect_any(__wrap_wdbc_parse_result, result);
-    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
-    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
-
-    ret = wdb_agents_vuln_cves_clear(id, NULL);
-
-    assert_int_equal(OS_INVALID, ret);
-}
-
-void test_wdb_agents_vuln_cves_clear_success(void **state)
-{
-    int ret = 0;
-    int id = 1;
-
-    const char *query_str = "agent 1 vuln_cves clear";
-    const char *response = "err";
-
-    // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
-
-    // Parsing Wazuh DB result
-    expect_any(__wrap_wdbc_parse_result, result);
-    will_return(__wrap_wdbc_parse_result, WDBC_OK);
-
-    ret = wdb_agents_vuln_cves_clear(id, NULL);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
@@ -486,7 +390,7 @@ void test_wdb_agents_vuln_cves_update_status_success(void **state){
 
     os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
     const char *query_str = "agent 1 vuln_cves update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
-    const char *response = "err";
+    const char *response = "ok";
 
     will_return(__wrap_cJSON_CreateObject, 1);
     will_return_always(__wrap_cJSON_AddStringToObject, 1);
@@ -517,6 +421,559 @@ void test_wdb_agents_vuln_cves_update_status_success(void **state){
     assert_int_equal(OS_SUCCESS, ret);
 }
 
+/* Tests wdb_agents_vuln_cve_remove_entry */
+
+void test_wdb_agents_vuln_cve_remove_entry_error_json(void **state)
+{
+    int ret = 0;
+    int id = 1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "reference-cve-xxxx-yyyy";
+
+    // Creating JSON data_in
+    will_return(__wrap_cJSON_CreateObject, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
+
+    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cve_remove_entry_error_socket(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "reference-cve-xxxx-yyyy";
+    const char *json_str = NULL;
+
+    os_strdup("{\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "cve-xxxx-yyyy");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "reference-cve-xxxx-yyyy");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_INVALID);
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error in the response from socket");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves remove {\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}");
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cve_remove_entry_error_sql_execution(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "reference-cve-xxxx-yyyy";
+    const char *json_str = NULL;
+
+    os_strdup("{\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "cve-xxxx-yyyy");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "reference-cve-xxxx-yyyy");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, -100); // Returning any error
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves remove {\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}");
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cve_remove_entry_error_result(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "reference-cve-xxxx-yyyy";
+    const char *json_str = NULL;
+
+    os_strdup("{\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "cve-xxxx-yyyy");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "reference-cve-xxxx-yyyy");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cve_remove_entry_success(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "reference-cve-xxxx-yyyy";
+    const char *json_str = NULL;
+
+    os_strdup("{\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}";
+    const char *response = "ok";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "cve-xxxx-yyyy");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "reference-cve-xxxx-yyyy");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+
+    assert_int_equal(OS_SUCCESS, ret);
+}
+
+/* Tests wdb_agents_vuln_cves_remove_by_status */
+
+void test_wdb_agents_vuln_cves_remove_by_status_error_json(void **state)
+{
+    cJSON *ret_cves = NULL;
+    int id = 1;
+    const char *status = "OBSOLETE";
+
+    // Creating JSON data_in
+    will_return(__wrap_cJSON_CreateObject, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
+
+    ret_cves = wdb_agents_vuln_cves_remove_by_status(id, status, NULL);
+
+    assert_null(ret_cves);
+}
+
+void test_wdb_agents_vuln_cves_remove_by_status_error_wdb_query(void **state)
+{
+    cJSON *ret_cves = NULL;
+    int id = 1;
+    const char *status = "OBSOLETE";
+    const char *json_str = NULL;
+
+    os_strdup("{\"status\":\"OBSOLETE\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"status\":\"OBSOLETE\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OBSOLETE");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_INVALID);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error removing vulnerabilities from the agent database.");
+    expect_function_call(__wrap_cJSON_Delete);
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret_cves = wdb_agents_vuln_cves_remove_by_status(id, status, NULL);
+
+    assert_null(ret_cves);
+}
+
+void test_wdb_agents_vuln_cves_remove_by_status_error_result(void **state)
+{
+    cJSON *ret_cves = NULL;
+    int id = 1;
+    const char *status = "OBSOLETE";
+    const char *json_str = NULL;
+
+    os_strdup("{\"status\":\"OBSOLETE\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"status\":\"OBSOLETE\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OBSOLETE");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret_cves = wdb_agents_vuln_cves_remove_by_status(id, status, NULL);
+
+    assert_null(ret_cves);
+}
+
+void test_wdb_agents_vuln_cves_remove_by_status_error_json_result(void **state)
+{
+    cJSON *ret_cves = NULL;
+    int id = 1;
+    const char *status = "OBSOLETE";
+    const char *json_str = NULL;
+
+    os_strdup("{\"status\":\"OBSOLETE\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"status\":\"OBSOLETE\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OBSOLETE");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    // Parsing JSON result
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid vuln_cves JSON results syntax after removing vulnerabilities.");
+    expect_string(__wrap__mdebug2, formatted_msg, "JSON error near: (null)");
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret_cves = wdb_agents_vuln_cves_remove_by_status(id, status, NULL);
+
+    assert_null(ret_cves);
+}
+
+void test_wdb_agents_vuln_cves_remove_by_status_success_ok(void **state)
+{
+    cJSON *ret_cves = NULL;
+    int id = 1;
+    const char *status = "OBSOLETE";
+    const char *json_str = NULL;
+
+    os_strdup("{\"status\":\"OBSOLETE\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"status\":\"OBSOLETE\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OBSOLETE");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    // Parsing JSON result
+    will_return(__wrap_cJSON_ParseWithOpts, 1);
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret_cves = wdb_agents_vuln_cves_remove_by_status(id, status, NULL);
+
+    assert_ptr_equal(1, ret_cves);
+}
+
+void test_wdb_agents_vuln_cves_remove_by_status_success_due(void **state)
+{
+    cJSON *ret_cves = NULL;
+    cJSON *root1 = NULL;
+    cJSON *root2 = NULL;
+    cJSON *row = NULL;
+    cJSON *str = NULL;
+    int id = 1;
+    const char *status = "OBSOLETE";
+    const char *json_str = NULL;
+
+    os_strdup("{\"status\":\"OBSOLETE\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"status\":\"OBSOLETE\"}";
+    const char *response = "ok";
+
+    root1 = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str = __real_cJSON_CreateString("cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "cve", str);
+    __real_cJSON_AddItemToArray(root1, row);
+    root2 = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str = __real_cJSON_CreateString("cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "cve", str);
+    __real_cJSON_AddItemToArray(root2, row);
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OBSOLETE");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    //// First call to Wazuh DB
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_DUE);
+
+    // Parsing JSON result
+    will_return(__wrap_cJSON_ParseWithOpts, root1);
+
+    //// Second call to Wazuh DB
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    // Parsing JSON result
+    will_return(__wrap_cJSON_ParseWithOpts, root2);
+    will_return(__wrap_cJSON_Duplicate, row);
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret_cves = wdb_agents_vuln_cves_remove_by_status(id, status, NULL);
+
+    assert_ptr_equal(root1, ret_cves);
+    __real_cJSON_Delete(root1);
+    __real_cJSON_Delete(root2);
+}
+
+/* Tests wdb_agents_vuln_cves_clear */
+
+void test_wdb_agents_vuln_cves_clear_error_socket(void **state)
+{
+    int ret = 0;
+    int id = 1;
+
+    const char *query_str = "agent 1 vuln_cves clear";
+    const char *response = "err";
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_INVALID);
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error in the response from socket");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves clear");
+
+    ret = wdb_agents_vuln_cves_clear(id, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cves_clear_error_sql_execution(void **state)
+{
+    int ret = 0;
+    int id = 1;
+
+    const char *query_str = "agent 1 vuln_cves clear";
+    const char *response = "err";
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, -100); // Returning any error
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves clear");
+
+    ret = wdb_agents_vuln_cves_clear(id, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cves_clear_error_result(void **state)
+{
+    int ret = 0;
+    int id = 1;
+
+    const char *query_str = "agent 1 vuln_cves clear";
+    const char *response = "err";
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
+
+    ret = wdb_agents_vuln_cves_clear(id, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cves_clear_success(void **state)
+{
+    int ret = 0;
+    int id = 1;
+
+    const char *query_str = "agent 1 vuln_cves clear";
+    const char *response = "ok";
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    ret = wdb_agents_vuln_cves_clear(id, NULL);
+
+    assert_int_equal(OS_SUCCESS, ret);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] =
@@ -527,17 +984,30 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        /* Tests wdb_agents_vuln_cves_clear*/
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         /* Tests wdb_agents_vuln_cves_update_status*/
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cve_remove_entry */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cves_remove_by_status */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_error_wdb_query, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_error_json_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_success_ok, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_success_due, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cves_clear*/
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -741,75 +741,75 @@ void test_wdb_parse_rootcheck_save_update_insert_success(void **state)
     os_free(query);
 }
 
-/* vuln_cve Tests */
+/* vuln_cves Tests */
 
-void test_vuln_cve_syntax_error(void **state) {
+void test_vuln_cves_syntax_error(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("agent 000 vuln_cve", query);
+    os_strdup("agent 000 vuln_cves", query);
 
     expect_value(__wrap_wdb_open_agent2, agent_id, atoi(data->wdb->id));
     will_return(__wrap_wdb_open_agent2, (wdb_t*)1); // Returning any value
-    expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: vuln_cve");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: vuln_cves");
 
-    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Invalid vuln_cve query syntax.");
-    expect_string(__wrap__mdebug2, formatted_msg, "DB(000) vuln_cve query error near: vuln_cve");
+    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Invalid vuln_cves query syntax.");
+    expect_string(__wrap__mdebug2, formatted_msg, "DB(000) vuln_cves query error near: vuln_cves");
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, "err Invalid vuln_cve query syntax, near 'vuln_cve'");
+    assert_string_equal(data->output, "err Invalid vuln_cves query syntax, near 'vuln_cves'");
     assert_int_equal(ret, OS_INVALID);
 
     os_free(query);
 }
 
-void test_vuln_cve_invalid_action(void **state) {
+void test_vuln_cves_invalid_action(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
-    os_strdup("agent 000 vuln_cve invalid", query);
+    os_strdup("agent 000 vuln_cves invalid", query);
     expect_value(__wrap_wdb_open_agent2, agent_id, atoi(data->wdb->id));
     will_return(__wrap_wdb_open_agent2, (wdb_t*)1); // Returning any value
-    expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: vuln_cve invalid");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agent 000 query: vuln_cves invalid");
 
     ret = wdb_parse(query, data->output);
 
-    assert_string_equal(data->output, "err Invalid vuln_cve action: invalid");
+    assert_string_equal(data->output, "err Invalid vuln_cves action: invalid");
     assert_int_equal(ret, OS_INVALID);
 
     os_free(query);
 }
 
-void test_vuln_cve_missing_action(void **state) {
+void test_vuln_cves_missing_action(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
     os_strdup("", query);
 
-    ret = wdb_parse_vuln_cve(data->wdb, query, data->output);
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
-    assert_string_equal(data->output, "err Missing vuln_cve action");
+    assert_string_equal(data->output, "err Missing vuln_cves action");
     assert_int_equal(ret, OS_INVALID);
 
     os_free(query);
 }
 
-void test_vuln_cve_insert_syntax_error(void **state) {
+void test_vuln_cves_insert_syntax_error(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
     os_strdup("insert {\"name\":\"package\",\"version\":}", query);
 
-    // wdb_parse_agents_insert_vuln_cve
-    expect_string(__wrap__mdebug1, formatted_msg, "Invalid vuln_cve JSON syntax when inserting vulnerable package.");
+    // wdb_parse_agents_insert_vuln_cves
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid vuln_cves JSON syntax when inserting vulnerable package.");
     expect_string(__wrap__mdebug2, formatted_msg, "JSON error near: }");
 
-    ret = wdb_parse_vuln_cve(data->wdb, query, data->output);
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{\"name\":\"package\",\"version\":}'");
     assert_int_equal(ret, OS_INVALID);
@@ -817,18 +817,18 @@ void test_vuln_cve_insert_syntax_error(void **state) {
     os_free(query);
 }
 
-void test_vuln_cve_insert_constraint_error(void **state) {
+void test_vuln_cves_insert_constraint_error(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
     os_strdup("insert {\"name\":\"package\",\"version\":\"2.2\",\"architecture\":\"x86\"}", query);
 
-    // wdb_parse_agents_insert_vuln_cve
-    expect_string(__wrap__mdebug1, formatted_msg, "Invalid vuln_cve JSON data when inserting vulnerable package."
+    // wdb_parse_agents_insert_vuln_cves
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid vuln_cves JSON data when inserting vulnerable package."
     " Not compliant with constraints defined in the database.");
 
-    ret = wdb_parse_vuln_cve(data->wdb, query, data->output);
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
     assert_string_equal(data->output, "err Invalid JSON data, missing required fields");
     assert_int_equal(ret, OS_INVALID);
@@ -836,45 +836,45 @@ void test_vuln_cve_insert_constraint_error(void **state) {
     os_free(query);
 }
 
-void test_vuln_cve_insert_command_error(void **state) {
+void test_vuln_cves_insert_command_error(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
     os_strdup("insert {\"name\":\"package\",\"version\":\"2.2\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1500\"}", query);
 
-    // wdb_parse_agents_insert_vuln_cve
-    will_return(__wrap_wdb_agents_insert_vuln_cve, OS_INVALID);
-    expect_string(__wrap_wdb_agents_insert_vuln_cve, name, "package");
-    expect_string(__wrap_wdb_agents_insert_vuln_cve, version, "2.2");
-    expect_string(__wrap_wdb_agents_insert_vuln_cve, architecture, "x86");
-    expect_string(__wrap_wdb_agents_insert_vuln_cve, cve, "CVE-2021-1500");
+    // wdb_parse_agents_insert_vuln_cves
+    will_return(__wrap_wdb_agents_insert_vuln_cves, OS_INVALID);
+    expect_string(__wrap_wdb_agents_insert_vuln_cves, name, "package");
+    expect_string(__wrap_wdb_agents_insert_vuln_cves, version, "2.2");
+    expect_string(__wrap_wdb_agents_insert_vuln_cves, architecture, "x86");
+    expect_string(__wrap_wdb_agents_insert_vuln_cves, cve, "CVE-2021-1500");
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot execute vuln_cve insert command; SQL err: ERROR MESSAGE");
+    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot execute vuln_cves insert command; SQL err: ERROR MESSAGE");
 
-    ret = wdb_parse_vuln_cve(data->wdb, query, data->output);
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
-    assert_string_equal(data->output, "err Cannot execute vuln_cve insert command; SQL err: ERROR MESSAGE");
+    assert_string_equal(data->output, "err Cannot execute vuln_cves insert command; SQL err: ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
 
     os_free(query);
 }
 
-void test_vuln_cve_insert_command_success(void **state) {
+void test_vuln_cves_insert_command_success(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
     os_strdup("insert {\"name\":\"package\",\"version\":\"2.2\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1500\"}", query);
 
-    // wdb_parse_agents_insert_vuln_cve
-    will_return(__wrap_wdb_agents_insert_vuln_cve, OS_SUCCESS);
-    expect_string(__wrap_wdb_agents_insert_vuln_cve, name, "package");
-    expect_string(__wrap_wdb_agents_insert_vuln_cve, version, "2.2");
-    expect_string(__wrap_wdb_agents_insert_vuln_cve, architecture, "x86");
-    expect_string(__wrap_wdb_agents_insert_vuln_cve, cve, "CVE-2021-1500");
+    // wdb_parse_agents_insert_vuln_cves
+    will_return(__wrap_wdb_agents_insert_vuln_cves, OS_SUCCESS);
+    expect_string(__wrap_wdb_agents_insert_vuln_cves, name, "package");
+    expect_string(__wrap_wdb_agents_insert_vuln_cves, version, "2.2");
+    expect_string(__wrap_wdb_agents_insert_vuln_cves, architecture, "x86");
+    expect_string(__wrap_wdb_agents_insert_vuln_cves, cve, "CVE-2021-1500");
 
-    ret = wdb_parse_vuln_cve(data->wdb, query, data->output);
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -882,37 +882,37 @@ void test_vuln_cve_insert_command_success(void **state) {
     os_free(query);
 }
 
-void test_vuln_cve_clear_command_error(void **state) {
+void test_vuln_cves_clear_command_error(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
     os_strdup("clear", query);
 
-    // wdb_parse_agents_clear_vuln_cve
-    will_return(__wrap_wdb_agents_clear_vuln_cve, OS_INVALID);
+    // wdb_parse_agents_clear_vuln_cves
+    will_return(__wrap_wdb_agents_clear_vuln_cves, OS_INVALID);
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot execute vuln_cve clear command; SQL err: ERROR MESSAGE");
+    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot execute vuln_cves clear command; SQL err: ERROR MESSAGE");
 
-    ret = wdb_parse_vuln_cve(data->wdb, query, data->output);
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
-    assert_string_equal(data->output, "err Cannot execute vuln_cve clear command; SQL err: ERROR MESSAGE");
+    assert_string_equal(data->output, "err Cannot execute vuln_cves clear command; SQL err: ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
 
     os_free(query);
 }
 
-void test_vuln_cve_clear_command_success(void **state) {
+void test_vuln_cves_clear_command_success(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
     os_strdup("clear", query);
 
-    // wdb_parse_agents_clear_vuln_cve
-    will_return(__wrap_wdb_agents_clear_vuln_cve, OS_SUCCESS);
+    // wdb_parse_agents_clear_vuln_cves
+    will_return(__wrap_wdb_agents_clear_vuln_cves, OS_SUCCESS);
 
-    ret = wdb_parse_vuln_cve(data->wdb, query, data->output);
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -920,18 +920,18 @@ void test_vuln_cve_clear_command_success(void **state) {
     os_free(query);
 }
 
-void test_vuln_cve_update_status_syntax_error(void **state){
+void test_vuln_cves_update_status_syntax_error(void **state){
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
     os_strdup("update_status {\"old_status\",\"new_status\"}", query);
 
-    // wdb_parse_agents_update_status_vuln_cve
-    expect_string(__wrap__mdebug1, formatted_msg, "Invalid vuln_cve JSON syntax when updating status value.");
+    // wdb_parse_agents_update_status_vuln_cves
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid vuln_cves JSON syntax when updating status value.");
     expect_string(__wrap__mdebug2, formatted_msg, "JSON error near: ,\"new_status\"}");
 
-    ret = wdb_parse_vuln_cve(data->wdb, query, data->output);
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
     assert_string_equal(data->output, "err Invalid JSON syntax, near '{\"old_status\",\"new_status\"}'");
     assert_int_equal(ret, OS_INVALID);
@@ -939,18 +939,18 @@ void test_vuln_cve_update_status_syntax_error(void **state){
     os_free(query);
 }
 
-void test_vuln_cve_update_status_constraint_error(void **state){
+void test_vuln_cves_update_status_constraint_error(void **state){
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
     os_strdup("update_status {\"old_status\":\"new_status\"}", query);
 
-    // wdb_parse_agents_update_status_vuln_cve
-    expect_string(__wrap__mdebug1, formatted_msg, "Invalid vuln_cve JSON data when updating status value."
+    // wdb_parse_agents_update_status_vuln_cves
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid vuln_cves JSON data when updating status value."
     " Not compliant with constraints defined in the database.");
 
-    ret = wdb_parse_vuln_cve(data->wdb, query, data->output);
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
     assert_string_equal(data->output, "err Invalid JSON data, missing required fields");
     assert_int_equal(ret, OS_INVALID);
@@ -958,41 +958,41 @@ void test_vuln_cve_update_status_constraint_error(void **state){
     os_free(query);
 }
 
-void test_vuln_cve_update_status_command_error(void **state){
+void test_vuln_cves_update_status_command_error(void **state){
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
     os_strdup("update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", query);
 
-    // wdb_parse_agents_update_status_vuln_cve
-    will_return(__wrap_wdb_agents_update_status_vuln_cve, OS_INVALID);
-    expect_string(__wrap_wdb_agents_update_status_vuln_cve, old_status, "valid");
-    expect_string(__wrap_wdb_agents_update_status_vuln_cve, new_status, "obsolete");
+    // wdb_parse_agents_update_status_vuln_cves
+    will_return(__wrap_wdb_agents_update_status_vuln_cves, OS_INVALID);
+    expect_string(__wrap_wdb_agents_update_status_vuln_cves, old_status, "valid");
+    expect_string(__wrap_wdb_agents_update_status_vuln_cves, new_status, "obsolete");
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
-    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot execute vuln_cve update_status command; SQL err: ERROR MESSAGE");
+    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot execute vuln_cves update_status command; SQL err: ERROR MESSAGE");
 
-    ret = wdb_parse_vuln_cve(data->wdb, query, data->output);
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
-    assert_string_equal(data->output, "err Cannot execute vuln_cve update_status command; SQL err: ERROR MESSAGE");
+    assert_string_equal(data->output, "err Cannot execute vuln_cves update_status command; SQL err: ERROR MESSAGE");
     assert_int_equal(ret, OS_INVALID);
 
     os_free(query);
 }
 
-void test_vuln_cve_update_status_command_success(void **state){
+void test_vuln_cves_update_status_command_success(void **state){
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
 
     os_strdup("update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", query);
 
-    // wdb_parse_agents_update_status_vuln_cve
-    will_return(__wrap_wdb_agents_update_status_vuln_cve, OS_SUCCESS);
-    expect_string(__wrap_wdb_agents_update_status_vuln_cve, old_status, "valid");
-    expect_string(__wrap_wdb_agents_update_status_vuln_cve, new_status, "obsolete");
+    // wdb_parse_agents_update_status_vuln_cves
+    will_return(__wrap_wdb_agents_update_status_vuln_cves, OS_SUCCESS);
+    expect_string(__wrap_wdb_agents_update_status_vuln_cves, old_status, "valid");
+    expect_string(__wrap_wdb_agents_update_status_vuln_cves, new_status, "obsolete");
 
-    ret = wdb_parse_vuln_cve(data->wdb, query, data->output);
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
     assert_string_equal(data->output, "ok");
     assert_int_equal(ret, OS_SUCCESS);
@@ -1046,20 +1046,20 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_rootcheck_save_update_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_rootcheck_save_update_insert_cache_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_rootcheck_save_update_insert_success, test_setup, test_teardown),
-        /* vuln_cve Tests */
-        cmocka_unit_test_setup_teardown(test_vuln_cve_syntax_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cve_invalid_action, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cve_missing_action, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cve_insert_syntax_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cve_insert_constraint_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cve_insert_command_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cve_insert_command_success, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cve_clear_command_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cve_clear_command_success, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cve_update_status_syntax_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cve_update_status_constraint_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cve_update_status_command_error, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_vuln_cve_update_status_command_success, test_setup, test_teardown),
+        /* vuln_cves Tests */
+        cmocka_unit_test_setup_teardown(test_vuln_cves_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_invalid_action, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_missing_action, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_insert_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_insert_constraint_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_insert_command_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_insert_command_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_clear_command_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_clear_command_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_constraint_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_command_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_command_success, test_setup, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/CMakeLists.txt
@@ -43,7 +43,7 @@ list(APPEND vulndetector_flags "-Wl,--wrap,_merror -Wl,--wrap,_mterror -Wl,--wra
                                 -Wl,--wrap,fflush -Wl,--wrap,fprintf -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,getpid -Wl,--wrap,OSHash_Add_ex \
                                 -Wl,--wrap,wurl_request_uncompress_bz2_gz -Wl,--wrap,w_uncompress_bz2_gz_file -Wl,--wrap,wstr_replace \
                                 -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap=wstr_split -Wl,--wrap,OSMatch_Execute -Wl,--wrap,OSRegex_Execute_ex \
-                                -Wl,--wrap,fgetpos -Wl,--wrap,wdb_agents_vuln_cve_insert -Wl,--wrap,wdb_agents_vuln_cve_clear -Wl,--wrap,wdb_get_all_agents \
+                                -Wl,--wrap,fgetpos -Wl,--wrap,wdb_agents_vuln_cves_insert -Wl,--wrap,wdb_agents_vuln_cves_clear -Wl,--wrap,wdb_get_all_agents \
                                 -Wl,--wrap,OS_ClearXML")
 
 list(APPEND vulndetector_names "test_wm_vuln_detector_evr")

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -91,7 +91,7 @@ bool wm_vuldet_update_MSU(update_node *update);
 int wm_vuldet_fetch_MSU(update_node *update, char *repo);
 int wm_vuldet_compare_vendors(char * vendor);
 void wm_vuldel_truncate_revision(char * revision);
-void wm_vuldet_clean_vuln_cve_db(void);
+void wm_vuldet_clean_vuln_cves_db(void);
 
 /* setup/teardown */
 
@@ -4840,7 +4840,7 @@ void test_wm_vuldet_send_agent_report_fill_report_oval_error(void **state)
     os_free(node);
 }
 
-void test_wm_vuldet_send_agent_report_vuln_cve_insert_error(void **state)
+void test_wm_vuldet_send_agent_report_vuln_cves_insert_error(void **state)
 {
     agent_software *agent = *state;
     sqlite3 *db = (sqlite3 *)1;
@@ -4967,12 +4967,12 @@ void test_wm_vuldet_send_agent_report_vuln_cve_insert_error(void **state)
     will_return(__wrap_sqlite3_column_text, "RHSA-2020:0975");
     expect_sqlite3_step_call(SQLITE_DONE);
     //Save the vulnerability in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_insert, id, 0);
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, name, "libhogweed4");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, version, "5.3.4");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, architecture, "x86_64");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, cve, "CVE-2016-6489");
-    will_return(__wrap_wdb_agents_vuln_cve_insert, OS_INVALID);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
+    will_return(__wrap_wdb_agents_vuln_cves_insert, OS_INVALID);
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "Failed to insert CVE-2016-6489 for package libhogweed4 in the agent 000 database");
     // Sending CVE report
@@ -5136,12 +5136,12 @@ void test_wm_vuldet_send_agent_report_send_cve_report_error(void **state)
     will_return(__wrap_sqlite3_column_text, "RHSA-2020:0975");
     expect_sqlite3_step_call(SQLITE_DONE);
     //Save the vulnerability in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_insert, id, 0);
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, name, "libhogweed4");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, version, "5.3.4");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, architecture, "x86_64");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, cve, "CVE-2016-6489");
-    will_return(__wrap_wdb_agents_vuln_cve_insert, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
+    will_return(__wrap_wdb_agents_vuln_cves_insert, OS_SUCCESS);
     // Sending CVE report
     will_return(__wrap_cJSON_CreateObject, NULL);
 
@@ -5304,12 +5304,12 @@ void test_wm_vuldet_send_agent_report_send_cve_report_negative_version(void **st
     will_return(__wrap_sqlite3_column_text, "RHSA-2020:0975");
     expect_sqlite3_step_call(SQLITE_DONE);
     //Save the vulnerability in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_insert, id, 0);
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, name, "libhogweed4");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, version, "");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, architecture, "x86_64");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, cve, "CVE-2016-6489");
-    will_return(__wrap_wdb_agents_vuln_cve_insert, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
+    will_return(__wrap_wdb_agents_vuln_cves_insert, OS_SUCCESS);
     // Sending CVE report
     will_return(__wrap_cJSON_CreateObject, NULL);
 
@@ -5629,12 +5629,12 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
     expect_sqlite3_step_call(SQLITE_DONE);
 
     //Save the vulnerability in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_insert, id, 0);
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, name, "libhogweed4");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, version, "5.3.4");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, architecture, "x86_64");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, cve, "CVE-2016-6489");
-    will_return(__wrap_wdb_agents_vuln_cve_insert, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
+    will_return(__wrap_wdb_agents_vuln_cves_insert, OS_SUCCESS);
 
     // Sending the CVE report
     cJSON* alert = (cJSON *)1;
@@ -5971,12 +5971,12 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **
     expect_sqlite3_step_call(SQLITE_DONE);
 
     //Save the vulnerability in the agent database
-    expect_value(__wrap_wdb_agents_vuln_cve_insert, id, 0);
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, name, "libhogweed4");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, version, "5.3.4");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, architecture, "x86_64");
-    expect_string(__wrap_wdb_agents_vuln_cve_insert, cve, "CVE-2016-6489");
-    will_return(__wrap_wdb_agents_vuln_cve_insert, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, id, 0);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, name, "libhogweed4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
+    will_return(__wrap_wdb_agents_vuln_cves_insert, OS_SUCCESS);
 
     // Sending the CVE report
     cJSON* alert = (cJSON *)1;
@@ -17280,9 +17280,9 @@ void test_wm_vuldet_init_success(void **state)
     os_free(vuldet);
 }
 
-// Tests wm_vuldet_clean_vuln_cve_db
+// Tests wm_vuldet_clean_vuln_cves_db
 
-void test_wm_vuldet_clean_vuln_cve_db_success(void **state)
+void test_wm_vuldet_clean_vuln_cves_db_success(void **state)
 {
     int *array = NULL;
     os_malloc(sizeof(int)*3, array);
@@ -17292,25 +17292,25 @@ void test_wm_vuldet_clean_vuln_cve_db_success(void **state)
 
     expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
     will_return(__wrap_wdb_get_all_agents, array);
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 1);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cves_clear, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_clear, id, 1);
+    will_return(__wrap_wdb_agents_vuln_cves_clear, OS_SUCCESS);
 
-    wm_vuldet_clean_vuln_cve_db();
+    wm_vuldet_clean_vuln_cves_db();
 }
 
-void test_wm_vuldet_clean_vuln_cve_db_get_agents_error(void **state)
+void test_wm_vuldet_clean_vuln_cves_db_get_agents_error(void **state)
 {
     expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
     will_return(__wrap_wdb_get_all_agents, NULL);
     expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtwarn, formatted_msg, "Unable to get agent's ID array to clear vuln_cve table");
+    expect_string(__wrap__mtwarn, formatted_msg, "Unable to get agent's ID array to clear vuln_cves table");
 
-    wm_vuldet_clean_vuln_cve_db();
+    wm_vuldet_clean_vuln_cves_db();
 }
 
-void test_wm_vuldet_clean_vuln_cve_db_clear_table_error(void **state)
+void test_wm_vuldet_clean_vuln_cves_db_clear_table_error(void **state)
 {
     int *array = NULL;
     os_malloc(sizeof(int)*3, array);
@@ -17320,14 +17320,14 @@ void test_wm_vuldet_clean_vuln_cve_db_clear_table_error(void **state)
 
     expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
     will_return(__wrap_wdb_get_all_agents, array);
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 1);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_INVALID);
+    expect_value(__wrap_wdb_agents_vuln_cves_clear, id, 0);
+    will_return(__wrap_wdb_agents_vuln_cves_clear, OS_SUCCESS);
+    expect_value(__wrap_wdb_agents_vuln_cves_clear, id, 1);
+    will_return(__wrap_wdb_agents_vuln_cves_clear, OS_INVALID);
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Error clearing vuln_cve table for agent 1");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Error clearing vuln_cves table for agent 1");
 
-    wm_vuldet_clean_vuln_cve_db();
+    wm_vuldet_clean_vuln_cves_db();
 }
 
 int main(void)
@@ -17469,7 +17469,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_fill_report_nvd_references_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_fill_report_nvd_scoring_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_fill_report_oval_error, setup_agent_software, teardown_agent_software),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_vuln_cve_insert_error, setup_agent_software, teardown_agent_software),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_vuln_cves_insert_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_send_cve_report_error, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_send_cve_report_negative_version, setup_agent_software, teardown_agent_software),
         cmocka_unit_test_setup_teardown(test_wm_vuldet_send_agent_report_send_cve_report_adding_data_from_OVAL_error, setup_agent_software, teardown_agent_software),
@@ -17779,10 +17779,10 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_max_attempts, setup_group, teardown_group),
         // Tests wm_vuldet_init
         cmocka_unit_test_setup_teardown(test_wm_vuldet_init_success, setup_group, teardown_group),
-        // Tests wm_vuldet_clean_vuln_cve_db
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_success, setup_group, teardown_group),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_get_agents_error, setup_group, teardown_group),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_clear_table_error, setup_group, teardown_group),
+        // Tests wm_vuldet_clean_vuln_cves_db
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cves_db_success, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cves_db_get_agents_error, setup_group, teardown_group),
+        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cves_db_clear_table_error, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
@@ -125,6 +125,13 @@ cJSON * __wrap_cJSON_Parse(__attribute__ ((__unused__)) const char *value) {
     return mock_type(cJSON *);
 }
 
+cJSON * __wrap_cJSON_ParseWithOpts(__attribute__ ((__unused__)) const char *value,
+                                   const char **return_parse_end,
+                                   __attribute__ ((__unused__)) cJSON_bool require_null_terminated) {
+    *return_parse_end = NULL;
+    return mock_type(cJSON *);
+}
+
 char * __wrap_cJSON_PrintUnformatted(__attribute__ ((__unused__)) const cJSON *item) {
     return mock_type(char *);
 }
@@ -145,8 +152,8 @@ cJSON* __wrap_cJSON_Duplicate(__attribute__ ((__unused__)) const cJSON *item, __
     return mock_type(cJSON*);
 }
 
-cJSON* __wrap_cJSON_AddBoolToObject(__attribute__ ((__unused__)) cJSON * const object, 
-                                    __attribute__ ((__unused__))const char * const name, 
+cJSON* __wrap_cJSON_AddBoolToObject(__attribute__ ((__unused__)) cJSON * const object,
+                                    __attribute__ ((__unused__))const char * const name,
                                     __attribute__ ((__unused__))const cJSON_bool boolean) {
     return mock_type(cJSON *);
 }

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.h
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.h
@@ -83,6 +83,8 @@ void expect_cJSON_IsObject_call(int ret);
 
 cJSON * __wrap_cJSON_Parse(const char *value);
 
+cJSON * __wrap_cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated);
+
 extern cJSON * __real_cJSON_Parse(const char *value);
 
 char * __wrap_cJSON_PrintUnformatted(const cJSON *item);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
@@ -14,7 +14,7 @@
 #include <cmocka.h>
 #include <stdlib.h>
 
-int __wrap_wdb_agents_vuln_cve_insert(int id,
+int __wrap_wdb_agents_vuln_cves_insert(int id,
                                       const char *name,
                                       const char *version,
                                       const char *architecture,
@@ -28,7 +28,7 @@ int __wrap_wdb_agents_vuln_cve_insert(int id,
     return mock_type(int);
 }
 
-int __wrap_wdb_agents_vuln_cve_clear(int id,
+int __wrap_wdb_agents_vuln_cves_clear(int id,
                                      __attribute__((unused)) int *sock) {
     check_expected(id);
     return mock_type(int);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
@@ -13,14 +13,14 @@
 
 #include "wazuh_db/wdb.h"
 
-int __wrap_wdb_agents_vuln_cve_insert(int id,
+int __wrap_wdb_agents_vuln_cves_insert(int id,
                                       const char *name,
                                       const char *version,
                                       const char *architecture,
                                       const char *cve,
                                       __attribute__((unused)) int *sock);
 
-int __wrap_wdb_agents_vuln_cve_clear(int id,
+int __wrap_wdb_agents_vuln_cves_clear(int id,
                                      __attribute__((unused)) int *sock);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
@@ -13,7 +13,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-int __wrap_wdb_agents_insert_vuln_cve( __attribute__((unused)) wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve) {
+int __wrap_wdb_agents_insert_vuln_cves( __attribute__((unused)) wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve) {
     check_expected(name);
     check_expected(version);
     check_expected(architecture);
@@ -21,11 +21,11 @@ int __wrap_wdb_agents_insert_vuln_cve( __attribute__((unused)) wdb_t *wdb, const
     return mock();
 }
 
-int __wrap_wdb_agents_clear_vuln_cve( __attribute__((unused)) wdb_t *wdb) {
+int __wrap_wdb_agents_clear_vuln_cves( __attribute__((unused)) wdb_t *wdb) {
     return mock();
 }
 
-int __wrap_wdb_agents_update_status_vuln_cve( __attribute__((unused)) wdb_t *wdb, const char* old_status, const char* new_status) {
+int __wrap_wdb_agents_update_status_vuln_cves( __attribute__((unused)) wdb_t *wdb, const char* old_status, const char* new_status) {
     check_expected(old_status);
     check_expected(new_status);
     return mock();

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
@@ -13,7 +13,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-int __wrap_wdb_agents_insert_vuln_cves( __attribute__((unused)) wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve) {
+int __wrap_wdb_agents_insert_vuln_cves(__attribute__((unused)) wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve) {
     check_expected(name);
     check_expected(version);
     check_expected(architecture);
@@ -21,12 +21,24 @@ int __wrap_wdb_agents_insert_vuln_cves( __attribute__((unused)) wdb_t *wdb, cons
     return mock();
 }
 
-int __wrap_wdb_agents_clear_vuln_cves( __attribute__((unused)) wdb_t *wdb) {
+int __wrap_wdb_agents_update_status_vuln_cves(__attribute__((unused)) wdb_t *wdb, const char* old_status, const char* new_status) {
+    check_expected(old_status);
+    check_expected(new_status);
     return mock();
 }
 
-int __wrap_wdb_agents_update_status_vuln_cves( __attribute__((unused)) wdb_t *wdb, const char* old_status, const char* new_status) {
-    check_expected(old_status);
-    check_expected(new_status);
+int __wrap_wdb_agents_remove_vuln_cves(__attribute__((unused)) wdb_t *wdb, const char* cve, const char* reference) {
+    check_expected(cve);
+    check_expected(reference);
+    return mock();
+}
+
+wdbc_result __wrap_wdb_agents_remove_by_status_vuln_cves(__attribute__((unused)) wdb_t *wdb, const char* status, char **output) {
+    check_expected(status);
+    os_strdup(mock_ptr_type(char*), *output);
+    return mock();
+}
+
+int __wrap_wdb_agents_clear_vuln_cves(__attribute__((unused)) wdb_t *wdb) {
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
@@ -14,6 +14,9 @@
 #include "wazuh_db/wdb.h"
 
 int __wrap_wdb_agents_insert_vuln_cves(wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve);
+int __wrap_wdb_agents_update_status_vuln_cves(wdb_t *wdb, const char* old_status, const char* new_status);
+int __wrap_wdb_agents_remove_vuln_cves(wdb_t *wdb, const char* cve, const char* reference);
+wdbc_result __wrap_wdb_agents_remove_by_status_vuln_cves(wdb_t *wdb, const char* status, char **output);
 int __wrap_wdb_agents_clear_vuln_cves(wdb_t *wdb);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
@@ -13,7 +13,7 @@
 
 #include "wazuh_db/wdb.h"
 
-int __wrap_wdb_agents_insert_vuln_cve(wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve);
-int __wrap_wdb_agents_clear_vuln_cve(wdb_t *wdb);
+int __wrap_wdb_agents_insert_vuln_cves(wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve);
+int __wrap_wdb_agents_clear_vuln_cves(wdb_t *wdb);
 
 #endif

--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -14,8 +14,9 @@
 
 static const char *agents_db_commands[] = {
     [WDB_AGENTS_VULN_CVES_INSERT] = "agent %d vuln_cves insert %s",
-    [WDB_AGENTS_VULN_CVES_CLEAR] = "agent %d vuln_cves clear",
-    [WDB_AGENTS_VULN_CVES_UPDATE_STATUS] = "agent %d vuln_cves update_status %s"
+    [WDB_AGENTS_VULN_CVES_UPDATE_STATUS] = "agent %d vuln_cves update_status %s",
+    [WDB_AGENTS_VULN_CVES_REMOVE] = "agent %d vuln_cves remove %s",
+    [WDB_AGENTS_VULN_CVES_CLEAR] = "agent %d vuln_cves clear"
 };
 
 int wdb_agents_vuln_cves_insert(int id,
@@ -81,48 +82,6 @@ int wdb_agents_vuln_cves_insert(int id,
     return result;
 }
 
-int wdb_agents_vuln_cves_clear(int id,
-                              int *sock) {
-    int result = 0;
-    char *wdbquery = NULL;
-    char *wdboutput = NULL;
-    char *payload = NULL;
-    int aux_sock = -1;
-
-    os_malloc(WDBQUERY_SIZE, wdbquery);
-    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVES_CLEAR], id);
-
-    os_malloc(WDBOUTPUT_SIZE, wdboutput);
-    result = wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);
-
-    switch (result) {
-        case OS_SUCCESS:
-            if (WDBC_OK != wdbc_parse_result(wdboutput, &payload)) {
-                mdebug1("Agents DB (%d) Error reported in the result of the query", id);
-                result = OS_INVALID;
-            }
-            break;
-        case OS_INVALID:
-            mdebug1("Agents DB (%d) Error in the response from socket", id);
-            mdebug2("Agents DB (%d) SQL query: %s", id, wdbquery);
-            result = OS_INVALID;
-            break;
-        default:
-            mdebug1("Agents DB (%d) Cannot execute SQL query", id);
-            mdebug2("Agents DB (%d) SQL query: %s", id, wdbquery);
-            result = OS_INVALID;
-    }
-
-    if (!sock) {
-        wdbc_close(&aux_sock);
-    }
-
-    os_free(wdbquery);
-    os_free(wdboutput);
-
-    return result;
-}
-
 int wdb_agents_vuln_cves_update_status(int id,
                                const char *old_status,
                                const char *new_status,
@@ -176,6 +135,181 @@ int wdb_agents_vuln_cves_update_status(int id,
 
     cJSON_Delete(data_in);
     os_free(data_in_str);
+    os_free(wdbquery);
+    os_free(wdboutput);
+
+    return result;
+}
+
+int wdb_agents_vuln_cve_remove_entry(int id,
+                                     char *cve,
+                                     char *reference,
+                                     int *sock) {
+    int result = 0;
+    cJSON *data_in = NULL;
+    char *data_in_str = NULL;
+    char *wdbquery = NULL;
+    char *wdboutput = NULL;
+    char *payload = NULL;
+    int aux_sock = -1;
+
+    data_in = cJSON_CreateObject();
+
+    if (!data_in) {
+        mdebug1("Error creating data JSON for Wazuh DB.");
+        return OS_INVALID;
+    }
+
+    cJSON_AddStringToObject(data_in, "cve", cve);
+    cJSON_AddStringToObject(data_in, "reference", reference);
+
+    data_in_str = cJSON_PrintUnformatted(data_in);
+    os_malloc(WDBQUERY_SIZE, wdbquery);
+    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVES_REMOVE], id, data_in_str);
+
+    os_malloc(WDBOUTPUT_SIZE, wdboutput);
+    result = wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);
+
+    switch (result) {
+        case OS_SUCCESS:
+            if (WDBC_OK != wdbc_parse_result(wdboutput, &payload)) {
+                mdebug1("Agents DB (%d) Error reported in the result of the query", id);
+                result = OS_INVALID;
+            }
+            break;
+        case OS_INVALID:
+            mdebug1("Agents DB (%d) Error in the response from socket", id);
+            mdebug2("Agents DB (%d) SQL query: %s", id, wdbquery);
+            result = OS_INVALID;
+            break;
+        default:
+            mdebug1("Agents DB (%d) Cannot execute SQL query", id);
+            mdebug2("Agents DB (%d) SQL query: %s", id, wdbquery);
+            result = OS_INVALID;
+    }
+
+    if (!sock) {
+        wdbc_close(&aux_sock);
+    }
+
+    cJSON_Delete(data_in);
+    os_free(data_in_str);
+    os_free(wdbquery);
+    os_free(wdboutput);
+
+    return result;
+}
+
+cJSON* wdb_agents_vuln_cves_remove_by_status(int id,
+                                            char *status,
+                                            int *sock) {
+    cJSON *data_in = NULL;
+    char *data_in_str = NULL;
+    char *wdbquery = NULL;
+    char *wdboutput = NULL;
+    char *payload = NULL;
+    cJSON *data_out = NULL;
+    wdbc_result wdb_res = WDBC_DUE;
+    int aux_sock = -1;
+
+    data_in = cJSON_CreateObject();
+
+    if (!data_in) {
+        mdebug1("Error creating data JSON for Wazuh DB.");
+        return data_out;
+    }
+
+    cJSON_AddStringToObject(data_in, "status", status);
+
+    data_in_str = cJSON_PrintUnformatted(data_in);
+    os_malloc(WDBQUERY_SIZE, wdbquery);
+    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVES_REMOVE], id, data_in_str);
+
+    os_malloc(WDBOUTPUT_SIZE, wdboutput);
+    while (wdb_res == WDBC_DUE) {
+        // Query WazuhDB
+        if (wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE) == 0) {
+            wdb_res = wdbc_parse_result(wdboutput, &payload);
+
+            if (WDBC_OK == wdb_res || WDBC_DUE == wdb_res) {
+                const char *error = NULL;
+                cJSON *cves = cJSON_ParseWithOpts(payload, &error, TRUE);
+
+                if (!cves) {
+                    mdebug1("Invalid vuln_cves JSON results syntax after removing vulnerabilities.");
+                    mdebug2("JSON error near: %s", error);
+                    wdb_res = WDBC_ERROR;
+                }
+                else if (!data_out) {
+                    data_out = cves;
+                }
+                else {
+                    cJSON *cve = NULL;
+                    cJSON_ArrayForEach(cve, cves) {
+                        cJSON_AddItemToArray(data_out, cJSON_Duplicate(cve, true));
+                    }
+                    cJSON_Delete(cves);
+                }
+            }
+        }
+        else {
+            wdb_res = WDBC_ERROR;
+        }
+    }
+
+    if (WDBC_ERROR == wdb_res) {
+        mdebug1("Error removing vulnerabilities from the agent database.");
+        cJSON_Delete(data_out);
+    }
+
+    if (!sock) {
+        wdbc_close(&aux_sock);
+    }
+
+    cJSON_Delete(data_in);
+    os_free(data_in_str);
+    os_free(wdbquery);
+    os_free(wdboutput);
+
+    return data_out;
+}
+
+int wdb_agents_vuln_cves_clear(int id,
+                              int *sock) {
+    int result = 0;
+    char *wdbquery = NULL;
+    char *wdboutput = NULL;
+    char *payload = NULL;
+    int aux_sock = -1;
+
+    os_malloc(WDBQUERY_SIZE, wdbquery);
+    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVES_CLEAR], id);
+
+    os_malloc(WDBOUTPUT_SIZE, wdboutput);
+    result = wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);
+
+    switch (result) {
+        case OS_SUCCESS:
+            if (WDBC_OK != wdbc_parse_result(wdboutput, &payload)) {
+                mdebug1("Agents DB (%d) Error reported in the result of the query", id);
+                result = OS_INVALID;
+            }
+            break;
+        case OS_INVALID:
+            mdebug1("Agents DB (%d) Error in the response from socket", id);
+            mdebug2("Agents DB (%d) SQL query: %s", id, wdbquery);
+            result = OS_INVALID;
+            break;
+        default:
+            mdebug1("Agents DB (%d) Cannot execute SQL query", id);
+            mdebug2("Agents DB (%d) SQL query: %s", id, wdbquery);
+            result = OS_INVALID;
+    }
+
+    if (!sock) {
+        wdbc_close(&aux_sock);
+    }
+
     os_free(wdbquery);
     os_free(wdboutput);
 

--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -13,12 +13,12 @@
 #include "wazuhdb_op.h"
 
 static const char *agents_db_commands[] = {
-    [WDB_AGENTS_VULN_CVE_INSERT] = "agent %d vuln_cve insert %s",
-    [WDB_AGENTS_VULN_CVE_CLEAR] = "agent %d vuln_cve clear",
-    [WDB_AGENTS_VULN_CVE_UPDATE_STATUS] = "agent %d vuln_cve update_status %s"
+    [WDB_AGENTS_VULN_CVES_INSERT] = "agent %d vuln_cves insert %s",
+    [WDB_AGENTS_VULN_CVES_CLEAR] = "agent %d vuln_cves clear",
+    [WDB_AGENTS_VULN_CVES_UPDATE_STATUS] = "agent %d vuln_cves update_status %s"
 };
 
-int wdb_agents_vuln_cve_insert(int id,
+int wdb_agents_vuln_cves_insert(int id,
                                const char *name,
                                const char *version,
                                const char *architecture,
@@ -46,7 +46,7 @@ int wdb_agents_vuln_cve_insert(int id,
 
     data_in_str = cJSON_PrintUnformatted(data_in);
     os_malloc(WDBQUERY_SIZE, wdbquery);
-    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVE_INSERT], id, data_in_str);
+    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVES_INSERT], id, data_in_str);
 
     os_malloc(WDBOUTPUT_SIZE, wdboutput);
     result = wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);
@@ -81,7 +81,7 @@ int wdb_agents_vuln_cve_insert(int id,
     return result;
 }
 
-int wdb_agents_vuln_cve_clear(int id,
+int wdb_agents_vuln_cves_clear(int id,
                               int *sock) {
     int result = 0;
     char *wdbquery = NULL;
@@ -90,7 +90,7 @@ int wdb_agents_vuln_cve_clear(int id,
     int aux_sock = -1;
 
     os_malloc(WDBQUERY_SIZE, wdbquery);
-    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVE_CLEAR], id);
+    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVES_CLEAR], id);
 
     os_malloc(WDBOUTPUT_SIZE, wdboutput);
     result = wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);
@@ -123,7 +123,7 @@ int wdb_agents_vuln_cve_clear(int id,
     return result;
 }
 
-int wdb_agents_vuln_cve_update_status(int id,
+int wdb_agents_vuln_cves_update_status(int id,
                                const char *old_status,
                                const char *new_status,
                                int *sock) {
@@ -147,7 +147,7 @@ int wdb_agents_vuln_cve_update_status(int id,
 
     data_in_str = cJSON_PrintUnformatted(data_in);
     os_malloc(WDBQUERY_SIZE, wdbquery);
-    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVE_UPDATE_STATUS], id, data_in_str);
+    snprintf(wdbquery, WDBQUERY_SIZE, agents_db_commands[WDB_AGENTS_VULN_CVES_UPDATE_STATUS], id, data_in_str);
 
     os_malloc(WDBOUTPUT_SIZE, wdboutput);
     result = wdbc_query_ex(sock?sock:&aux_sock, wdbquery, wdboutput, WDBOUTPUT_SIZE);

--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -141,7 +141,7 @@ int wdb_agents_vuln_cves_update_status(int id,
     return result;
 }
 
-int wdb_agents_vuln_cve_remove_entry(int id,
+int wdb_agents_vuln_cves_remove_entry(int id,
                                      const char *cve,
                                      const char *reference,
                                      int *sock) {
@@ -240,15 +240,20 @@ cJSON* wdb_agents_vuln_cves_remove_by_status(int id,
                     mdebug2("JSON error near: %s", error);
                     wdb_res = WDBC_ERROR;
                 }
-                else if (!data_out) {
-                    data_out = cves;
-                }
                 else {
-                    cJSON *cve = NULL;
-                    cJSON_ArrayForEach(cve, cves) {
-                        cJSON_AddItemToArray(data_out, cJSON_Duplicate(cve, true));
+                    if (!data_out) {
+                        // The first call to Wazuh DB, we consider the query response as the response of the method.
+                        data_out = cves;
                     }
-                    cJSON_Delete(cves);
+                    else {
+                        // In case of having vulnerabilities returned by chunks, from the second call, all the subsequent calls
+                        // we will add the JSON response of the query to the JSON response of the query obtained in the first call.
+                        cJSON *cve = NULL;
+                        cJSON_ArrayForEach(cve, cves) {
+                            cJSON_AddItemToArray(data_out, cJSON_Duplicate(cve, true));
+                        }
+                        cJSON_Delete(cves);
+                    }
                 }
             }
             else {

--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -142,8 +142,8 @@ int wdb_agents_vuln_cves_update_status(int id,
 }
 
 int wdb_agents_vuln_cve_remove_entry(int id,
-                                     char *cve,
-                                     char *reference,
+                                     const char *cve,
+                                     const char *reference,
                                      int *sock) {
     int result = 0;
     cJSON *data_in = NULL;
@@ -201,7 +201,7 @@ int wdb_agents_vuln_cve_remove_entry(int id,
 }
 
 cJSON* wdb_agents_vuln_cves_remove_by_status(int id,
-                                            char *status,
+                                            const char *status,
                                             int *sock) {
     cJSON *data_in = NULL;
     char *data_in_str = NULL;
@@ -251,14 +251,17 @@ cJSON* wdb_agents_vuln_cves_remove_by_status(int id,
                     cJSON_Delete(cves);
                 }
             }
+            else {
+                mdebug1("Agents DB (%d) Error reported in the result of the query", id);
+            }
         }
         else {
+            mdebug1("Error removing vulnerabilities from the agent database.");
             wdb_res = WDBC_ERROR;
         }
     }
 
     if (WDBC_ERROR == wdb_res) {
-        mdebug1("Error removing vulnerabilities from the agent database.");
         cJSON_Delete(data_out);
     }
 

--- a/src/wazuh_db/helpers/wdb_agents_helpers.h
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.h
@@ -17,6 +17,7 @@
 typedef enum agents_db_access {
     WDB_AGENTS_VULN_CVES_INSERT,
     WDB_AGENTS_VULN_CVES_CLEAR,
+    WDB_AGENTS_VULN_CVES_REMOVE,
     WDB_AGENTS_VULN_CVES_UPDATE_STATUS
 } agents_db_access;
 
@@ -47,6 +48,32 @@ int wdb_agents_vuln_cves_insert(int id,
  */
 int wdb_agents_vuln_cves_clear(int id,
                               int *sock);
+
+/**
+ * @brief Removes an entry from the vuln_cve table in the agent's database.
+ *
+ * @param[in] id The agent ID.
+ * @param[in] cve The cve of the vulnerability entry that should be removed.
+ * @param[in] reference The reference of the vulnerability entry that should be removed.
+ * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
+ * @return Returns 0 on success or -1 on error.
+ */
+int wdb_agents_vuln_cve_remove_entry(int id,
+                                     char *cve,
+                                     char *reference,
+                                     int *sock);
+
+/**
+ * @brief Removes all the entries from the vuln_cve table in the agent's database that have the specified status.
+ *
+ * @param[in] id The agent ID.
+ * @param[in] status The status of the vulnerabilities that should be removed.
+ * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
+ * @return Returns a pointer to a cJSON object that contains the information of all the vulnerabilities removed.
+ */
+cJSON* wdb_agents_vuln_cve_remove_by_status(int id,
+                                            char *status,
+                                            int *sock);
 
 /**
  * @brief Updates all or a specific status from the vuln_cves table in the agents database.

--- a/src/wazuh_db/helpers/wdb_agents_helpers.h
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.h
@@ -50,7 +50,7 @@ int wdb_agents_vuln_cves_clear(int id,
                               int *sock);
 
 /**
- * @brief Removes an entry from the vuln_cve table in the agent's database.
+ * @brief Removes an entry from the vuln_cves table in the agent's database.
  *
  * @param[in] id The agent ID.
  * @param[in] cve The cve of the vulnerability entry that should be removed.
@@ -58,13 +58,13 @@ int wdb_agents_vuln_cves_clear(int id,
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_agents_vuln_cve_remove_entry(int id,
+int wdb_agents_vuln_cves_remove_entry(int id,
                                      const char *cve,
                                      const char *reference,
                                      int *sock);
 
 /**
- * @brief Removes all the entries from the vuln_cve table in the agent's database that have the specified status.
+ * @brief Removes all the entries from the vuln_cves table in the agent's database that have the specified status.
  *
  * @param[in] id The agent ID.
  * @param[in] status The status of the vulnerabilities that should be removed.

--- a/src/wazuh_db/helpers/wdb_agents_helpers.h
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.h
@@ -15,13 +15,13 @@
 #include "../wdb.h"
 
 typedef enum agents_db_access {
-    WDB_AGENTS_VULN_CVE_INSERT,
-    WDB_AGENTS_VULN_CVE_CLEAR,
-    WDB_AGENTS_VULN_CVE_UPDATE_STATUS
+    WDB_AGENTS_VULN_CVES_INSERT,
+    WDB_AGENTS_VULN_CVES_CLEAR,
+    WDB_AGENTS_VULN_CVES_UPDATE_STATUS
 } agents_db_access;
 
 /**
- * @brief Insert a CVE to the vuln_cve table in the agents database.
+ * @brief Insert a CVE to the vuln_cves table in the agents database.
  *
  * @param[in] id The agent ID.
  * @param[in] name The affected package name.
@@ -31,7 +31,7 @@ typedef enum agents_db_access {
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_agents_vuln_cve_insert(int id,
+int wdb_agents_vuln_cves_insert(int id,
                                const char *name,
                                const char *version,
                                const char *architecture,
@@ -39,25 +39,25 @@ int wdb_agents_vuln_cve_insert(int id,
                                int *sock);
 
 /**
- * @brief Removes all the entries from the vuln_cve table in the agents database.
+ * @brief Removes all the entries from the vuln_cves table in the agents database.
  *
  * @param[in] id The agent ID.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_agents_vuln_cve_clear(int id,
+int wdb_agents_vuln_cves_clear(int id,
                               int *sock);
 
-/** 
- * @brief Updates all or a specific status from the vuln_cve table in the agents database. 
- *  
+/**
+ * @brief Updates all or a specific status from the vuln_cves table in the agents database.
+ *
  * @param[in] id The agent ID.
  * @param[in] old_status The status that is going to be updated. The '*' option changes all statuses.
  * @param[in] new_status The new status.
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_agents_vuln_cve_update_status(int id,
+int wdb_agents_vuln_cves_update_status(int id,
                                       const char *old_status,
                                       const char *new_status,
                                       int *sock);

--- a/src/wazuh_db/helpers/wdb_agents_helpers.h
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.h
@@ -59,8 +59,8 @@ int wdb_agents_vuln_cves_clear(int id,
  * @return Returns 0 on success or -1 on error.
  */
 int wdb_agents_vuln_cve_remove_entry(int id,
-                                     char *cve,
-                                     char *reference,
+                                     const char *cve,
+                                     const char *reference,
                                      int *sock);
 
 /**
@@ -71,8 +71,8 @@ int wdb_agents_vuln_cve_remove_entry(int id,
  * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
  * @return Returns a pointer to a cJSON object that contains the information of all the vulnerabilities removed.
  */
-cJSON* wdb_agents_vuln_cve_remove_by_status(int id,
-                                            char *status,
+cJSON* wdb_agents_vuln_cves_remove_by_status(int id,
+                                            const char *status,
                                             int *sock);
 
 /**

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -1082,7 +1082,7 @@ int wdb_reset_agents_connection(const char *sync_status, int *sock) {
     return result;
 }
 
-int* wdb_get_agents_by_connection_status (const char* connection_status, int *sock) {
+int* wdb_get_agents_by_connection_status(const char* connection_status, int *sock) {
     char wdbquery[WDBQUERY_SIZE] = "";
     char wdboutput[WDBOUTPUT_SIZE] = "";
     int last_id = 0;

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -206,12 +206,12 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_AROUND] = "DELETE FROM sys_osinfo WHERE os_name < ? OR os_name > ? OR checksum = 'legacy' OR checksum = '';",
     [WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_RANGE] = "DELETE FROM sys_osinfo WHERE os_name > ? AND os_name < ?;",
     [WDB_STMT_SYSCOLLECTOR_OSINFO_CLEAR] = "DELETE FROM sys_osinfo;",
-    [WDB_STMT_VULN_CVE_INSERT] = "INSERT OR IGNORE INTO vuln_cves (name, version, architecture, cve) VALUES(?,?,?,?);",
-    [WDB_STMT_VULN_CVE_CLEAR] = "DELETE FROM vuln_cves;",
-    [WDB_STMT_VULN_CVE_UPDATE] = "UPDATE vuln_cves SET status = ? WHERE status = ?;",
-    [WDB_STMT_VULN_CVE_UPDATE_ALL] = "UPDATE vuln_cves SET status = ?",
-    [WDB_STMT_VULN_CVE_SELECT_BY_STATUS] = "SELECT * FROM vuln_cves WHERE status = ? LIMIT 1;",
-    [WDB_STMT_VULN_CVE_DELETE_ENTRY] = "DELETE FROM vuln_cves WHERE cve = ? AND reference = ?;"
+    [WDB_STMT_VULN_CVES_INSERT] = "INSERT OR IGNORE INTO vuln_cves (name, version, architecture, cve) VALUES(?,?,?,?);",
+    [WDB_STMT_VULN_CVES_CLEAR] = "DELETE FROM vuln_cves;",
+    [WDB_STMT_VULN_CVES_UPDATE] = "UPDATE vuln_cves SET status = ? WHERE status = ?;",
+    [WDB_STMT_VULN_CVES_UPDATE_ALL] = "UPDATE vuln_cves SET status = ?",
+    [WDB_STMT_VULN_CVES_SELECT_BY_STATUS] = "SELECT * FROM vuln_cves WHERE status = ? LIMIT 1;",
+    [WDB_STMT_VULN_CVES_DELETE_ENTRY] = "DELETE FROM vuln_cves WHERE cve = ? AND reference = ?;"
 };
 
 wdb_config wconfig;

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -210,7 +210,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_VULN_CVES_CLEAR] = "DELETE FROM vuln_cves;",
     [WDB_STMT_VULN_CVES_UPDATE] = "UPDATE vuln_cves SET status = ? WHERE status = ?;",
     [WDB_STMT_VULN_CVES_UPDATE_ALL] = "UPDATE vuln_cves SET status = ?",
-    [WDB_STMT_VULN_CVES_SELECT_BY_STATUS] = "SELECT * FROM vuln_cves WHERE status = ? LIMIT 1;",
+    [WDB_STMT_VULN_CVES_SELECT_BY_STATUS] = "SELECT * FROM vuln_cves WHERE status = ?;",
     [WDB_STMT_VULN_CVES_DELETE_ENTRY] = "DELETE FROM vuln_cves WHERE cve = ? AND reference = ?;"
 };
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -209,7 +209,9 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_VULN_CVE_INSERT] = "INSERT OR IGNORE INTO vuln_cves (name, version, architecture, cve) VALUES(?,?,?,?);",
     [WDB_STMT_VULN_CVE_CLEAR] = "DELETE FROM vuln_cves;",
     [WDB_STMT_VULN_CVE_UPDATE] = "UPDATE vuln_cves SET status = ? WHERE status = ?;",
-    [WDB_STMT_VULN_CVE_UPDATE_ALL] = "UPDATE vuln_cves SET status = ?"
+    [WDB_STMT_VULN_CVE_UPDATE_ALL] = "UPDATE vuln_cves SET status = ?",
+    [WDB_STMT_VULN_CVE_SELECT_BY_STATUS] = "SELECT * FROM vuln_cves WHERE status = ? LIMIT 1;",
+    [WDB_STMT_VULN_CVE_DELETE_ENTRY] = "DELETE FROM vuln_cves WHERE cve = ? AND reference = ?;"
 };
 
 wdb_config wconfig;

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1785,7 +1785,7 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
  * @param [in] wdb The global struct database.
  * @param [in] input String with the the data in json format.
  * @param [out] output Response of the query.
- *  * @return 0 Success: response contains "ok".
+ * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.
  */
  int wdb_parse_agents_vuln_cves_update_status(wdb_t* wdb, char* input, char* output);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -1796,7 +1796,8 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
  * @param [in] wdb The global struct database.
  * @param [in] input String with the the data in json format. It could receive a status to remove all the vulnerabilities
  *                   whith that status, or the CVE and reference to remove a particular entry. Examples:
- *                   TOTATODO
+ *                   - To remove by status: {"status":"OBSOLETE"}
+ *                   - To remove a specific entry: {"cve":"cve-xxxx-xxxx","reference":"refxxx"}
  * @param [out] output Response of the query.
  * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -227,12 +227,12 @@ typedef enum wdb_stmt {
     WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_AROUND,
     WDB_STMT_SYSCOLLECTOR_OSINFO_DELETE_RANGE,
     WDB_STMT_SYSCOLLECTOR_OSINFO_CLEAR,
-    WDB_STMT_VULN_CVE_INSERT,
-    WDB_STMT_VULN_CVE_CLEAR,
-    WDB_STMT_VULN_CVE_UPDATE,
-    WDB_STMT_VULN_CVE_UPDATE_ALL,
-    WDB_STMT_VULN_CVE_SELECT_BY_STATUS,
-    WDB_STMT_VULN_CVE_DELETE_ENTRY,
+    WDB_STMT_VULN_CVES_INSERT,
+    WDB_STMT_VULN_CVES_CLEAR,
+    WDB_STMT_VULN_CVES_UPDATE,
+    WDB_STMT_VULN_CVES_UPDATE_ALL,
+    WDB_STMT_VULN_CVES_SELECT_BY_STATUS,
+    WDB_STMT_VULN_CVES_DELETE_ENTRY,
     WDB_STMT_SIZE // This must be the last constant
 } wdb_stmt;
 
@@ -1758,7 +1758,7 @@ int wdb_parse_task_set_timeout(wdb_t* wdb, const cJSON *parameters, char* output
 int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output);
 
 /**
- * @brief Function to parse the vuln_cve requests.
+ * @brief Function to parse the vuln_cves requests.
  *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the action and the data if needed.
@@ -1766,10 +1766,10 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
  * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.
  */
- int wdb_parse_vuln_cve(wdb_t* wdb, char* input, char* output);
+ int wdb_parse_vuln_cves(wdb_t* wdb, char* input, char* output);
 
  /**
- * @brief Function to parse the vuln_cve insert action.
+ * @brief Function to parse the vuln_cves insert action.
  *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the the data in json format.
@@ -1777,10 +1777,10 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
  * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.
  */
- int wdb_parse_agents_insert_vuln_cve(wdb_t* wdb, char* input, char* output);
+ int wdb_parse_agents_insert_vuln_cves(wdb_t* wdb, char* input, char* output);
 
 /**
- * @brief Function to parse the vuln_cve update status action.
+ * @brief Function to parse the vuln_cves update status action.
  *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the the data in json format.
@@ -1788,10 +1788,10 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
  *  * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.
  */
- int wdb_parse_agents_vuln_cve_update_status(wdb_t* wdb, char* input, char* output);
+ int wdb_parse_agents_vuln_cves_update_status(wdb_t* wdb, char* input, char* output);
 
  /**
- * @brief Function to parse the vuln_cve remove action.
+ * @brief Function to parse the vuln_cves remove action.
  *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the the data in json format. It could receive a status to remove all the vulnerabilities
@@ -1801,17 +1801,17 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
  * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.
  */
- int wdb_parse_agents_remove_vuln_cve(wdb_t* wdb, char* input, char* output);
+ int wdb_parse_agents_remove_vuln_cves(wdb_t* wdb, char* input, char* output);
 
  /**
- * @brief Function to parse the vuln_cve clear action.
+ * @brief Function to parse the vuln_cves clear action.
  *
  * @param [in] wdb The global struct database.
  * @param [out] output Response of the query.
  * @return 0 Success: response contains "ok".
  *        -1 On error: response contains "err" and an error description.
  */
- int wdb_parse_agents_clear_vuln_cve(wdb_t* wdb, char* output);
+ int wdb_parse_agents_clear_vuln_cves(wdb_t* wdb, char* output);
 
 /**
  * Update old tasks with status in progress to status timeout

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -51,6 +51,10 @@
 #define AGENT_CS_ACTIVE          "active"
 #define AGENT_CS_DISCONNECTED    "disconnected"
 
+#define VULN_CVES_STATUS_VALID    "VALID"
+#define VULN_CVES_STATUS_PENDING  "PENDING"
+#define VULN_CVES_STATUS_OBSOLETE "OBSOLETE"
+
 typedef enum wdb_stmt {
     WDB_STMT_FIM_LOAD,
     WDB_STMT_FIM_FIND_ENTRY,
@@ -227,6 +231,8 @@ typedef enum wdb_stmt {
     WDB_STMT_VULN_CVE_CLEAR,
     WDB_STMT_VULN_CVE_UPDATE,
     WDB_STMT_VULN_CVE_UPDATE_ALL,
+    WDB_STMT_VULN_CVE_SELECT_BY_STATUS,
+    WDB_STMT_VULN_CVE_DELETE_ENTRY,
     WDB_STMT_SIZE // This must be the last constant
 } wdb_stmt;
 
@@ -1774,17 +1780,7 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
  int wdb_parse_agents_insert_vuln_cve(wdb_t* wdb, char* input, char* output);
 
 /**
- * @brief Function to parse the vuln_cve clear action.
- *
- * @param [in] wdb The global struct database.
- * @param [out] output Response of the query.
- * @return 0 Success: response contains "ok".
- *        -1 On error: response contains "err" and an error description.
- */
- int wdb_parse_agents_clear_vuln_cve(wdb_t* wdb, char* output);
-
-/**
- * @brief Function to parse the vuln_cve update action.
+ * @brief Function to parse the vuln_cve update status action.
  *
  * @param [in] wdb The global struct database.
  * @param [in] input String with the the data in json format.
@@ -1793,6 +1789,29 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
  *        -1 On error: response contains "err" and an error description.
  */
  int wdb_parse_agents_vuln_cve_update_status(wdb_t* wdb, char* input, char* output);
+
+ /**
+ * @brief Function to parse the vuln_cve remove action.
+ *
+ * @param [in] wdb The global struct database.
+ * @param [in] input String with the the data in json format. It could receive a status to remove all the vulnerabilities
+ *                   whith that status, or the CVE and reference to remove a particular entry. Examples:
+ *                   TOTATODO
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+ int wdb_parse_agents_remove_vuln_cve(wdb_t* wdb, char* input, char* output);
+
+ /**
+ * @brief Function to parse the vuln_cve clear action.
+ *
+ * @param [in] wdb The global struct database.
+ * @param [out] output Response of the query.
+ * @return 0 Success: response contains "ok".
+ *        -1 On error: response contains "err" and an error description.
+ */
+ int wdb_parse_agents_clear_vuln_cve(wdb_t* wdb, char* output);
 
 /**
  * Update old tasks with status in progress to status timeout

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -15,22 +15,12 @@ int wdb_agents_insert_vuln_cve(wdb_t *wdb, const char* name, const char* version
     return wdb_exec_stmt_silent(stmt);
 }
 
-int wdb_agents_clear_vuln_cve(wdb_t *wdb) {
-
-    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVE_CLEAR);
-    if (stmt == NULL) {
-        return OS_INVALID;
-    }
-
-    return wdb_exec_stmt_silent(stmt);
-}
-
 int wdb_agents_update_status_vuln_cve(wdb_t *wdb, const char* old_status, const char* new_status) {
-    
+
     bool update_all = (strcmp(old_status, "*") == 0);
 
     sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, update_all ? WDB_STMT_VULN_CVE_UPDATE_ALL : WDB_STMT_VULN_CVE_UPDATE);
-    
+
     if (stmt == NULL) {
         return OS_INVALID;
     }
@@ -40,6 +30,113 @@ int wdb_agents_update_status_vuln_cve(wdb_t *wdb, const char* old_status, const 
     } else {
         sqlite3_bind_text(stmt, 1, new_status, -1, NULL);
         sqlite3_bind_text(stmt, 2, old_status, -1, NULL);
+    }
+
+    return wdb_exec_stmt_silent(stmt);
+}
+
+int wdb_agents_remove_vuln_cve(wdb_t *wdb, const char* cve, const char* reference) {
+    if (!cve || !reference) {
+        mdebug1("Invalid data provided");
+        return OS_INVALID;
+    }
+
+    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVE_DELETE_ENTRY);
+
+    if (stmt == NULL) {
+        return OS_INVALID;
+    }
+
+    sqlite3_bind_text(stmt, 1, cve, -1, NULL);
+    sqlite3_bind_text(stmt, 2, reference, -1, NULL);
+
+    return wdb_exec_stmt_silent(stmt);
+}
+
+wdbc_result wdb_agents_remove_by_status_vuln_cve(wdb_t *wdb, const char* status, char **output) {
+    sqlite3_stmt* stmt = NULL;
+    unsigned response_size = 2; //Starts with "[]" size
+    wdbc_result wdb_res = WDBC_UNKNOWN;
+
+    os_calloc(WDB_MAX_RESPONSE_SIZE, sizeof(char), *output);
+    char *response_aux = *output;
+
+    //Prepare SQL query
+    if (stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVE_SELECT_BY_STATUS), !stmt) {
+        mdebug1("Cannot cache statement");
+        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot cache statement");
+        return WDBC_ERROR;
+    }
+    if (sqlite3_bind_text(stmt, 1, status, -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
+        return WDBC_ERROR;
+    }
+
+    //Add array start
+    *response_aux++ = '[';
+
+    while (wdb_res == WDBC_UNKNOWN) {
+        //Get vulnerabilities info
+        cJSON* sql_vulns_response = wdb_exec_stmt(stmt);
+
+        if (sql_vulns_response && sql_vulns_response->child) {
+            cJSON* json_vuln = sql_vulns_response->child;
+            cJSON* json_cve = cJSON_GetObjectItem(json_vuln,"cve");
+            cJSON* json_reference = cJSON_GetObjectItem(json_vuln,"reference");
+
+            if (cJSON_IsString(json_cve) && cJSON_IsString(json_reference)) {
+                //Print vulnerability info
+                char *vuln_str = cJSON_PrintUnformatted(json_vuln);
+                unsigned vuln_len = strlen(vuln_str);
+
+                //Check if new vulnerability fits in response
+                if (response_size+vuln_len+1 < WDB_MAX_RESPONSE_SIZE) {
+                    //Delete the vulnerability
+                    if (OS_SUCCESS != wdb_agents_remove_vuln_cve(wdb, json_cve->valuestring, json_reference->valuestring)) {
+                        merror("Error removing vulnerability from the inventory database: %s", json_cve->valuestring);
+                        wdb_res = WDBC_ERROR;
+                    }
+                    else {
+                        //Add new vulnerability
+                        memcpy(response_aux, vuln_str, vuln_len);
+                        response_aux+=vuln_len;
+                        //Add separator
+                        *response_aux++ = ',';
+                        //Save size
+                        response_size += vuln_len+1;
+                    }
+                }
+                else {
+                    //Pending vulnerabilities but buffer is full
+                    wdb_res = WDBC_DUE;
+                }
+                os_free(vuln_str);
+            }
+        }
+        else {
+            //All vulnerabilities have been obtained
+            wdb_res = WDBC_OK;
+        }
+        cJSON_Delete(sql_vulns_response);
+    }
+
+    if (wdb_res != WDBC_ERROR) {
+        if (response_size > 2) {
+            //Remove last ','
+            response_aux--;
+        }
+        //Add array end
+        *response_aux = ']';
+    }
+    return wdb_res;
+}
+
+int wdb_agents_clear_vuln_cve(wdb_t *wdb) {
+
+    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVE_CLEAR);
+    if (stmt == NULL) {
+        return OS_INVALID;
     }
 
     return wdb_exec_stmt_silent(stmt);

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -54,82 +54,50 @@ int wdb_agents_remove_vuln_cves(wdb_t *wdb, const char* cve, const char* referen
 }
 
 wdbc_result wdb_agents_remove_by_status_vuln_cves(wdb_t *wdb, const char* status, char **output) {
-    sqlite3_stmt* stmt = NULL;
-    unsigned response_size = 2; //Starts with "[]" size
-    wdbc_result wdb_res = WDBC_UNKNOWN;
+    wdbc_result wdb_res = WDBC_ERROR;
 
-    os_calloc(WDB_MAX_RESPONSE_SIZE, sizeof(char), *output);
-    char *response_aux = *output;
+    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+
+    if (stmt == NULL) {
+        return wdb_res;
+    }
 
     //Prepare SQL query
-    if (stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVES_SELECT_BY_STATUS), !stmt) {
-        mdebug1("Cannot cache statement");
-        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot cache statement");
-        return WDBC_ERROR;
-    }
     if (sqlite3_bind_text(stmt, 1, status, -1, NULL) != SQLITE_OK) {
         merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot bind sql statement");
-        return WDBC_ERROR;
+        return wdb_res;
     }
 
-    //Add array start
-    *response_aux++ = '[';
+    //Execute SQL query limited by size
+    int sql_status = SQLITE_ERROR;
+    cJSON* cves = wdb_exec_stmt_sized(stmt, WDB_MAX_RESPONSE_SIZE, &sql_status);
 
-    while (wdb_res == WDBC_UNKNOWN) {
-        //Get vulnerabilities info
-        cJSON* sql_vulns_response = wdb_exec_stmt(stmt);
+    if (SQLITE_DONE == sql_status) wdb_res = WDBC_OK;
+    else if (SQLITE_ROW == sql_status) wdb_res = WDBC_DUE;
+    else {
+        merror("Failed to retrieve vulnerabilities with status %s from the database", status);
+        return wdb_res;
+    }
 
-        if (sql_vulns_response && sql_vulns_response->child) {
-            cJSON* json_vuln = sql_vulns_response->child;
-            cJSON* json_cve = cJSON_GetObjectItem(json_vuln,"cve");
-            cJSON* json_reference = cJSON_GetObjectItem(json_vuln,"reference");
+    cJSON *cve = NULL;
+    cJSON_ArrayForEach(cve, cves) {
+        cJSON* json_cve_id = cJSON_GetObjectItem(cve,"cve");
+        cJSON* json_reference = cJSON_GetObjectItem(cve,"reference");
 
-            if (cJSON_IsString(json_cve) && cJSON_IsString(json_reference)) {
-                //Print vulnerability info
-                char *vuln_str = cJSON_PrintUnformatted(json_vuln);
-                unsigned vuln_len = strlen(vuln_str);
-
-                //Check if new vulnerability fits in response
-                if (response_size+vuln_len+1 < WDB_MAX_RESPONSE_SIZE) {
-                    //Delete the vulnerability
-                    if (OS_SUCCESS != wdb_agents_remove_vuln_cves(wdb, json_cve->valuestring, json_reference->valuestring)) {
-                        merror("Error removing vulnerability from the inventory database: %s", json_cve->valuestring);
-                        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s %s", "Error removing vulnerability from the inventory database: ", json_cve->valuestring);
-                        wdb_res = WDBC_ERROR;
-                    }
-                    else {
-                        //Add new vulnerability
-                        memcpy(response_aux, vuln_str, vuln_len);
-                        response_aux+=vuln_len;
-                        //Add separator
-                        *response_aux++ = ',';
-                        //Save size
-                        response_size += vuln_len+1;
-                    }
-                }
-                else {
-                    //Pending vulnerabilities but buffer is full
-                    wdb_res = WDBC_DUE;
-                }
-                os_free(vuln_str);
+        if (cJSON_IsString(json_cve_id) && cJSON_IsString(json_reference)) {
+            //Delete the vulnerability
+            if (OS_SUCCESS != wdb_agents_remove_vuln_cves(wdb, json_cve_id->valuestring, json_reference->valuestring)) {
+                merror("Error removing vulnerability from the inventory database: %s", json_cve_id->valuestring);
+                cJSON_Delete(cves);
+                return WDBC_ERROR;
             }
         }
-        else {
-            //All vulnerabilities have been obtained
-            wdb_res = WDBC_OK;
-        }
-        cJSON_Delete(sql_vulns_response);
     }
 
-    if (wdb_res != WDBC_ERROR) {
-        if (response_size > 2) {
-            //Remove last ','
-            response_aux--;
-        }
-        //Add array end
-        *response_aux = ']';
-    }
+    //Printing the results
+    *output = cJSON_PrintUnformatted(cves);
+    cJSON_Delete(cves);
+
     return wdb_res;
 }
 

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -95,6 +95,7 @@ wdbc_result wdb_agents_remove_by_status_vuln_cves(wdb_t *wdb, const char* status
                     //Delete the vulnerability
                     if (OS_SUCCESS != wdb_agents_remove_vuln_cves(wdb, json_cve->valuestring, json_reference->valuestring)) {
                         merror("Error removing vulnerability from the inventory database: %s", json_cve->valuestring);
+                        snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s %s", "Error removing vulnerability from the inventory database: ", json_cve->valuestring);
                         wdb_res = WDBC_ERROR;
                     }
                     else {

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -1,8 +1,8 @@
 #include "wdb_agents.h"
 
-int wdb_agents_insert_vuln_cve(wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve) {
+int wdb_agents_insert_vuln_cves(wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve) {
 
-    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVE_INSERT);
+    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVES_INSERT);
     if (stmt == NULL) {
         return OS_INVALID;
     }
@@ -15,11 +15,11 @@ int wdb_agents_insert_vuln_cve(wdb_t *wdb, const char* name, const char* version
     return wdb_exec_stmt_silent(stmt);
 }
 
-int wdb_agents_update_status_vuln_cve(wdb_t *wdb, const char* old_status, const char* new_status) {
+int wdb_agents_update_status_vuln_cves(wdb_t *wdb, const char* old_status, const char* new_status) {
 
     bool update_all = (strcmp(old_status, "*") == 0);
 
-    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, update_all ? WDB_STMT_VULN_CVE_UPDATE_ALL : WDB_STMT_VULN_CVE_UPDATE);
+    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, update_all ? WDB_STMT_VULN_CVES_UPDATE_ALL : WDB_STMT_VULN_CVES_UPDATE);
 
     if (stmt == NULL) {
         return OS_INVALID;
@@ -35,13 +35,13 @@ int wdb_agents_update_status_vuln_cve(wdb_t *wdb, const char* old_status, const 
     return wdb_exec_stmt_silent(stmt);
 }
 
-int wdb_agents_remove_vuln_cve(wdb_t *wdb, const char* cve, const char* reference) {
+int wdb_agents_remove_vuln_cves(wdb_t *wdb, const char* cve, const char* reference) {
     if (!cve || !reference) {
         mdebug1("Invalid data provided");
         return OS_INVALID;
     }
 
-    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVE_DELETE_ENTRY);
+    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVES_DELETE_ENTRY);
 
     if (stmt == NULL) {
         return OS_INVALID;
@@ -53,7 +53,7 @@ int wdb_agents_remove_vuln_cve(wdb_t *wdb, const char* cve, const char* referenc
     return wdb_exec_stmt_silent(stmt);
 }
 
-wdbc_result wdb_agents_remove_by_status_vuln_cve(wdb_t *wdb, const char* status, char **output) {
+wdbc_result wdb_agents_remove_by_status_vuln_cves(wdb_t *wdb, const char* status, char **output) {
     sqlite3_stmt* stmt = NULL;
     unsigned response_size = 2; //Starts with "[]" size
     wdbc_result wdb_res = WDBC_UNKNOWN;
@@ -62,7 +62,7 @@ wdbc_result wdb_agents_remove_by_status_vuln_cve(wdb_t *wdb, const char* status,
     char *response_aux = *output;
 
     //Prepare SQL query
-    if (stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVE_SELECT_BY_STATUS), !stmt) {
+    if (stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVES_SELECT_BY_STATUS), !stmt) {
         mdebug1("Cannot cache statement");
         snprintf(*output, WDB_MAX_RESPONSE_SIZE, "%s", "Cannot cache statement");
         return WDBC_ERROR;
@@ -93,7 +93,7 @@ wdbc_result wdb_agents_remove_by_status_vuln_cve(wdb_t *wdb, const char* status,
                 //Check if new vulnerability fits in response
                 if (response_size+vuln_len+1 < WDB_MAX_RESPONSE_SIZE) {
                     //Delete the vulnerability
-                    if (OS_SUCCESS != wdb_agents_remove_vuln_cve(wdb, json_cve->valuestring, json_reference->valuestring)) {
+                    if (OS_SUCCESS != wdb_agents_remove_vuln_cves(wdb, json_cve->valuestring, json_reference->valuestring)) {
                         merror("Error removing vulnerability from the inventory database: %s", json_cve->valuestring);
                         wdb_res = WDBC_ERROR;
                     }
@@ -132,9 +132,9 @@ wdbc_result wdb_agents_remove_by_status_vuln_cve(wdb_t *wdb, const char* status,
     return wdb_res;
 }
 
-int wdb_agents_clear_vuln_cve(wdb_t *wdb) {
+int wdb_agents_clear_vuln_cves(wdb_t *wdb) {
 
-    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVE_CLEAR);
+    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVES_CLEAR);
     if (stmt == NULL) {
         return OS_INVALID;
     }

--- a/src/wazuh_db/wdb_agents.h
+++ b/src/wazuh_db/wdb_agents.h
@@ -15,7 +15,7 @@
 #include "wdb.h"
 
 /**
- * @brief Function to insert a new entry into the agent vuln_cve table.
+ * @brief Function to insert a new entry into the agent vuln_cves table.
  *
  * @param [in] wdb The 'agents' struct database.
  * @param [in] name The vulnerable package name.
@@ -24,44 +24,44 @@
  * @param [in] cve The CVE id of the vulnerability.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_agents_insert_vuln_cve(wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve);
+int wdb_agents_insert_vuln_cves(wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve);
 
 /**
- * @brief Function to update the status field in agent database vuln_cve table.
+ * @brief Function to update the status field in agent database vuln_cves table.
  *
  * @param [in] wdb The 'agents' struct database.
  * @param [in] old_status The status that is going to be updated. The '*' option changes all statuses.
  * @param [in] new_status The new status.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_agents_update_status_vuln_cve(wdb_t *wdb, const char* old_status, const char* new_status);
+int wdb_agents_update_status_vuln_cves(wdb_t *wdb, const char* old_status, const char* new_status);
 
 /**
- * @brief Function to remove vulnerabilities from the vuln_cve table by specifying the PK of the entry.
+ * @brief Function to remove vulnerabilities from the vuln_cves table by specifying the PK of the entry.
  *
  * @param [in] wdb The 'agents' struct database.
  * @param [in] cve The cve of the entry that should be removed.
  * @param [in] reference The reference of the entry that should be removed.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_agents_remove_vuln_cve(wdb_t *wdb, const char* cve, const char* reference);
+int wdb_agents_remove_vuln_cves(wdb_t *wdb, const char* cve, const char* reference);
 
 /**
- * @brief Function to remove vulnerabilities from the vuln_cve table filtering by the status.
+ * @brief Function to remove vulnerabilities from the vuln_cves table filtering by the status.
  *
  * @param [in] wdb The 'agents' struct database.
  * @param [in] status The status that is going to be updated. The '*' option changes all statuses.
  * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
  * @return wdbc_result to represent if all the vulnerabilities have been removed.
  */
-wdbc_result wdb_agents_remove_by_status_vuln_cve(wdb_t *wdb, const char* status, char **output);
+wdbc_result wdb_agents_remove_by_status_vuln_cves(wdb_t *wdb, const char* status, char **output);
 
 /**
- * @brief Function to clear whole data from agent vuln_cve table.
+ * @brief Function to clear whole data from agent vuln_cves table.
  *
  * @param [in] wdb The 'agents' struct database.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_agents_clear_vuln_cve(wdb_t *wdb);
+int wdb_agents_clear_vuln_cves(wdb_t *wdb);
 
 #endif

--- a/src/wazuh_db/wdb_agents.h
+++ b/src/wazuh_db/wdb_agents.h
@@ -15,14 +15,6 @@
 #include "wdb.h"
 
 /**
- * @brief Function to clear whole data from agent vuln_cve table.
- *
- * @param [in] wdb The 'agents' struct database.
- * @return Returns 0 on success or -1 on error.
- */
-int wdb_agents_clear_vuln_cve(wdb_t *wdb);
-
-/**
  * @brief Function to insert a new entry into the agent vuln_cve table.
  *
  * @param [in] wdb The 'agents' struct database.
@@ -36,12 +28,40 @@ int wdb_agents_insert_vuln_cve(wdb_t *wdb, const char* name, const char* version
 
 /**
  * @brief Function to update the status field in agent database vuln_cve table.
- * 
+ *
  * @param [in] wdb The 'agents' struct database.
  * @param [in] old_status The status that is going to be updated. The '*' option changes all statuses.
  * @param [in] new_status The new status.
  * @return Returns 0 on success or -1 on error.
  */
 int wdb_agents_update_status_vuln_cve(wdb_t *wdb, const char* old_status, const char* new_status);
+
+/**
+ * @brief Function to remove vulnerabilities from the vuln_cve table by specifying the PK of the entry.
+ *
+ * @param [in] wdb The 'agents' struct database.
+ * @param [in] cve The cve of the entry that should be removed.
+ * @param [in] reference The reference of the entry that should be removed.
+ * @return Returns 0 on success or -1 on error.
+ */
+int wdb_agents_remove_vuln_cve(wdb_t *wdb, const char* cve, const char* reference);
+
+/**
+ * @brief Function to remove vulnerabilities from the vuln_cve table filtering by the status.
+ *
+ * @param [in] wdb The 'agents' struct database.
+ * @param [in] status The status that is going to be updated. The '*' option changes all statuses.
+ * @param [out] output A buffer where the response is written. Must be de-allocated by the caller.
+ * @return wdbc_result to represent if all the vulnerabilities have been removed.
+ */
+wdbc_result wdb_agents_remove_by_status_vuln_cve(wdb_t *wdb, const char* status, char **output);
+
+/**
+ * @brief Function to clear whole data from agent vuln_cve table.
+ *
+ * @param [in] wdb The 'agents' struct database.
+ * @return Returns 0 on success or -1 on error.
+ */
+int wdb_agents_clear_vuln_cve(wdb_t *wdb);
 
 #endif

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -444,14 +444,14 @@ int wdb_parse(char * input, char * output) {
             } else {
                 result = wdb_parse_rootcheck(wdb, next, output);
             }
-        } else if (strcmp(query, "vuln_cve") == 0) {
+        } else if (strcmp(query, "vuln_cves") == 0) {
             if (!next) {
-                mdebug1("DB(%s) Invalid vuln_cve query syntax.", sagent_id);
-                mdebug2("DB(%s) vuln_cve query error near: %s", sagent_id, query);
-                snprintf(output, OS_MAXSTR + 1, "err Invalid vuln_cve query syntax, near '%.32s'", query);
+                mdebug1("DB(%s) Invalid vuln_cves query syntax.", sagent_id);
+                mdebug2("DB(%s) vuln_cves query error near: %s", sagent_id, query);
+                snprintf(output, OS_MAXSTR + 1, "err Invalid vuln_cves query syntax, near '%.32s'", query);
                 result = -1;
             } else {
-                result = wdb_parse_vuln_cve(wdb, next, output);
+                result = wdb_parse_vuln_cves(wdb, next, output);
             }
         } else if (strcmp(query, "sql") == 0) {
             if (!next) {
@@ -6056,7 +6056,7 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
 
 // 'agents' DB command parsing
 
-int wdb_parse_vuln_cve(wdb_t* wdb, char* input, char* output) {
+int wdb_parse_vuln_cves(wdb_t* wdb, char* input, char* output) {
     int result = OS_INVALID;
     char * next;
     const char delim[] = " ";
@@ -6065,35 +6065,35 @@ int wdb_parse_vuln_cve(wdb_t* wdb, char* input, char* output) {
     next = strtok_r(input, delim, &tail);
 
     if (!next){
-        snprintf(output, OS_MAXSTR + 1, "err Missing vuln_cve action");
+        snprintf(output, OS_MAXSTR + 1, "err Missing vuln_cves action");
     }
     else if (strcmp(next, "insert") == 0) {
-        result = wdb_parse_agents_insert_vuln_cve(wdb, tail, output);
+        result = wdb_parse_agents_insert_vuln_cves(wdb, tail, output);
     }
     else if (strcmp(next, "update_status") == 0) {
-        result = wdb_parse_agents_vuln_cve_update_status(wdb, tail, output);
+        result = wdb_parse_agents_vuln_cves_update_status(wdb, tail, output);
     }
     else if (strcmp(next, "remove") == 0) {
-        result = wdb_parse_agents_remove_vuln_cve(wdb, tail, output);
+        result = wdb_parse_agents_remove_vuln_cves(wdb, tail, output);
     }
     else if (strcmp(next, "clear") == 0) {
-        result = wdb_parse_agents_clear_vuln_cve(wdb, output);
+        result = wdb_parse_agents_clear_vuln_cves(wdb, output);
     }
     else {
-        snprintf(output, OS_MAXSTR + 1, "err Invalid vuln_cve action: %s", next);
+        snprintf(output, OS_MAXSTR + 1, "err Invalid vuln_cves action: %s", next);
     }
 
     return result;
 }
 
-int wdb_parse_agents_insert_vuln_cve(wdb_t* wdb, char* input, char* output) {
+int wdb_parse_agents_insert_vuln_cves(wdb_t* wdb, char* input, char* output) {
     cJSON *data = NULL;
     const char *error = NULL;
     int ret = OS_INVALID;
 
     data = cJSON_ParseWithOpts(input, &error, TRUE);
     if (!data) {
-        mdebug1("Invalid vuln_cve JSON syntax when inserting vulnerable package.");
+        mdebug1("Invalid vuln_cves JSON syntax when inserting vulnerable package.");
         mdebug2("JSON error near: %s", error);
         snprintf(output, OS_MAXSTR + 1, "err Invalid JSON syntax, near '%.32s'", input);
     }
@@ -6104,15 +6104,15 @@ int wdb_parse_agents_insert_vuln_cve(wdb_t* wdb, char* input, char* output) {
         cJSON* j_cve = cJSON_GetObjectItem(data, "cve");
         // Required fields
         if (!cJSON_IsString(j_name) || !cJSON_IsString(j_version) || !cJSON_IsString(j_architecture) ||!cJSON_IsString(j_cve)) {
-            mdebug1("Invalid vuln_cve JSON data when inserting vulnerable package. Not compliant with constraints defined in the database.");
+            mdebug1("Invalid vuln_cves JSON data when inserting vulnerable package. Not compliant with constraints defined in the database.");
             snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, missing required fields");
         }
 
         else {
-            ret = wdb_agents_insert_vuln_cve(wdb, j_name->valuestring, j_version->valuestring, j_architecture->valuestring, j_cve->valuestring);
+            ret = wdb_agents_insert_vuln_cves(wdb, j_name->valuestring, j_version->valuestring, j_architecture->valuestring, j_cve->valuestring);
             if (OS_SUCCESS != ret) {
-                mdebug1("DB(%s) Cannot execute vuln_cve insert command; SQL err: %s", wdb->id, sqlite3_errmsg(wdb->db));
-                snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cve insert command; SQL err: %s", sqlite3_errmsg(wdb->db));
+                mdebug1("DB(%s) Cannot execute vuln_cves insert command; SQL err: %s", wdb->id, sqlite3_errmsg(wdb->db));
+                snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cves insert command; SQL err: %s", sqlite3_errmsg(wdb->db));
             }
             else {
                 snprintf(output, OS_MAXSTR + 1, "ok");
@@ -6124,7 +6124,7 @@ int wdb_parse_agents_insert_vuln_cve(wdb_t* wdb, char* input, char* output) {
     return ret;
 }
 
-int wdb_parse_agents_vuln_cve_update_status(wdb_t* wdb, char* input, char* output) {
+int wdb_parse_agents_vuln_cves_update_status(wdb_t* wdb, char* input, char* output) {
     cJSON *data = NULL;
     const char *error = NULL;
     int ret = OS_INVALID;
@@ -6132,7 +6132,7 @@ int wdb_parse_agents_vuln_cve_update_status(wdb_t* wdb, char* input, char* outpu
     data = cJSON_ParseWithOpts(input, &error, TRUE);
 
     if (!data) {
-        mdebug1("Invalid vuln_cve JSON syntax when updating status value.");
+        mdebug1("Invalid vuln_cves JSON syntax when updating status value.");
         mdebug2("JSON error near: %s", error);
         snprintf(output, OS_MAXSTR + 1, "err Invalid JSON syntax, near '%.32s'", input);
     }
@@ -6141,15 +6141,15 @@ int wdb_parse_agents_vuln_cve_update_status(wdb_t* wdb, char* input, char* outpu
         cJSON* new_status = cJSON_GetObjectItem(data, "new_status");
         // Required fields
         if (!cJSON_IsString(old_status) || !cJSON_IsString(new_status)) {
-            mdebug1("Invalid vuln_cve JSON data when updating status value. Not compliant with constraints defined in the database.");
+            mdebug1("Invalid vuln_cves JSON data when updating status value. Not compliant with constraints defined in the database.");
             snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, missing required fields");
         }
 
         else {
-            ret = wdb_agents_update_status_vuln_cve(wdb, old_status->valuestring, new_status->valuestring);
+            ret = wdb_agents_update_status_vuln_cves(wdb, old_status->valuestring, new_status->valuestring);
             if (OS_SUCCESS != ret) {
-                mdebug1("DB(%s) Cannot execute vuln_cve update_status command; SQL err: %s", wdb->id, sqlite3_errmsg(wdb->db));
-                snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cve update_status command; SQL err: %s", sqlite3_errmsg(wdb->db));
+                mdebug1("DB(%s) Cannot execute vuln_cves update_status command; SQL err: %s", wdb->id, sqlite3_errmsg(wdb->db));
+                snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cves update_status command; SQL err: %s", sqlite3_errmsg(wdb->db));
             }
             else {
                 snprintf(output, OS_MAXSTR + 1, "ok");
@@ -6161,7 +6161,7 @@ int wdb_parse_agents_vuln_cve_update_status(wdb_t* wdb, char* input, char* outpu
     return ret;
 }
 
-int wdb_parse_agents_remove_vuln_cve(wdb_t* wdb, char* input, char* output) {
+int wdb_parse_agents_remove_vuln_cves(wdb_t* wdb, char* input, char* output) {
     cJSON *data = NULL;
     const char *error = NULL;
     int ret = OS_INVALID;
@@ -6169,7 +6169,7 @@ int wdb_parse_agents_remove_vuln_cve(wdb_t* wdb, char* input, char* output) {
     data = cJSON_ParseWithOpts(input, &error, TRUE);
 
     if (!data) {
-        mdebug1("Invalid vuln_cve JSON syntax when removing vulnerabilities.");
+        mdebug1("Invalid vuln_cves JSON syntax when removing vulnerabilities.");
         mdebug2("JSON error near: %s", error);
         snprintf(output, OS_MAXSTR + 1, "err Invalid JSON syntax, near '%.32s'", input);
     }
@@ -6182,24 +6182,24 @@ int wdb_parse_agents_remove_vuln_cve(wdb_t* wdb, char* input, char* output) {
         if (cJSON_IsString(status)) {
             char* removed_cves = NULL;
 
-            wdbc_result wdb_res = wdb_agents_remove_by_status_vuln_cve(wdb, status->valuestring, &removed_cves);
+            wdbc_result wdb_res = wdb_agents_remove_by_status_vuln_cves(wdb, status->valuestring, &removed_cves);
             snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[wdb_res], removed_cves);
             os_free(removed_cves)
             ret = OS_SUCCESS;
         }
         // Checking whether we should remove a specific entry
         else if (cJSON_IsString(cve) && cJSON_IsString(reference)) {
-            ret = wdb_agents_remove_vuln_cve(wdb, cve->valuestring, reference->valuestring);
+            ret = wdb_agents_remove_vuln_cves(wdb, cve->valuestring, reference->valuestring);
             if (OS_SUCCESS != ret) {
-                mdebug1("DB(%s) Cannot execute vuln_cve remove command; SQL err: %s", wdb->id, sqlite3_errmsg(wdb->db));
-                snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cve remove command; SQL err: %s", sqlite3_errmsg(wdb->db));
+                mdebug1("DB(%s) Cannot execute vuln_cves remove command; SQL err: %s", wdb->id, sqlite3_errmsg(wdb->db));
+                snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cves remove command; SQL err: %s", sqlite3_errmsg(wdb->db));
             }
             else {
                 snprintf(output, OS_MAXSTR + 1, "ok");
             }
         }
         else {
-            mdebug1("Invalid vuln_cve JSON data to remove vulnerabilities.");
+            mdebug1("Invalid vuln_cves JSON data to remove vulnerabilities.");
             snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data");
         }
     }
@@ -6208,11 +6208,11 @@ int wdb_parse_agents_remove_vuln_cve(wdb_t* wdb, char* input, char* output) {
     return ret;
 }
 
-int wdb_parse_agents_clear_vuln_cve(wdb_t* wdb, char* output) {
-    int ret = wdb_agents_clear_vuln_cve(wdb);
+int wdb_parse_agents_clear_vuln_cves(wdb_t* wdb, char* output) {
+    int ret = wdb_agents_clear_vuln_cves(wdb);
     if (OS_SUCCESS != ret) {
-        mdebug1("DB(%s) Cannot execute vuln_cve clear command; SQL err: %s",  wdb->id, sqlite3_errmsg(wdb->db));
-        snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cve clear command; SQL err: %s", sqlite3_errmsg(wdb->db));
+        mdebug1("DB(%s) Cannot execute vuln_cves clear command; SQL err: %s",  wdb->id, sqlite3_errmsg(wdb->db));
+        snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cves clear command; SQL err: %s", sqlite3_errmsg(wdb->db));
     }
     else {
         snprintf(output, OS_MAXSTR + 1, "ok");

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -6180,11 +6180,11 @@ int wdb_parse_agents_remove_vuln_cves(wdb_t* wdb, char* input, char* output) {
 
         // Checking whether we should remove by status
         if (cJSON_IsString(status)) {
-            char* removed_cves = NULL;
+            char* remove_out_str = NULL;
 
-            wdbc_result wdb_res = wdb_agents_remove_by_status_vuln_cves(wdb, status->valuestring, &removed_cves);
-            snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[wdb_res], removed_cves);
-            os_free(removed_cves)
+            wdbc_result wdb_res = wdb_agents_remove_by_status_vuln_cves(wdb, status->valuestring, &remove_out_str);
+            snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[wdb_res], remove_out_str);
+            os_free(remove_out_str)
             ret = OS_SUCCESS;
         }
         // Checking whether we should remove a specific entry

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -6070,11 +6070,14 @@ int wdb_parse_vuln_cve(wdb_t* wdb, char* input, char* output) {
     else if (strcmp(next, "insert") == 0) {
         result = wdb_parse_agents_insert_vuln_cve(wdb, tail, output);
     }
-    else if (strcmp(next, "clear") == 0) {
-        result = wdb_parse_agents_clear_vuln_cve(wdb, output);
-    }
     else if (strcmp(next, "update_status") == 0) {
         result = wdb_parse_agents_vuln_cve_update_status(wdb, tail, output);
+    }
+    else if (strcmp(next, "remove") == 0) {
+        result = wdb_parse_agents_remove_vuln_cve(wdb, tail, output);
+    }
+    else if (strcmp(next, "clear") == 0) {
+        result = wdb_parse_agents_clear_vuln_cve(wdb, output);
     }
     else {
         snprintf(output, OS_MAXSTR + 1, "err Invalid vuln_cve action: %s", next);
@@ -6121,18 +6124,6 @@ int wdb_parse_agents_insert_vuln_cve(wdb_t* wdb, char* input, char* output) {
     return ret;
 }
 
-int wdb_parse_agents_clear_vuln_cve(wdb_t* wdb, char* output) {
-    int ret = wdb_agents_clear_vuln_cve(wdb);
-    if (OS_SUCCESS != ret) {
-        mdebug1("DB(%s) Cannot execute vuln_cve clear command; SQL err: %s",  wdb->id, sqlite3_errmsg(wdb->db));
-        snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cve clear command; SQL err: %s", sqlite3_errmsg(wdb->db));
-    }
-    else {
-        snprintf(output, OS_MAXSTR + 1, "ok");
-    }
-    return ret;
-}
-
 int wdb_parse_agents_vuln_cve_update_status(wdb_t* wdb, char* input, char* output) {
     cJSON *data = NULL;
     const char *error = NULL;
@@ -6167,5 +6158,64 @@ int wdb_parse_agents_vuln_cve_update_status(wdb_t* wdb, char* input, char* outpu
     }
 
     cJSON_Delete(data);
+    return ret;
+}
+
+int wdb_parse_agents_remove_vuln_cve(wdb_t* wdb, char* input, char* output) {
+    cJSON *data = NULL;
+    const char *error = NULL;
+    int ret = OS_INVALID;
+
+    data = cJSON_ParseWithOpts(input, &error, TRUE);
+
+    if (!data) {
+        mdebug1("Invalid vuln_cve JSON syntax when removing vulnerabilities.");
+        mdebug2("JSON error near: %s", error);
+        snprintf(output, OS_MAXSTR + 1, "err Invalid JSON syntax, near '%.32s'", input);
+    }
+    else {
+        cJSON* status = cJSON_GetObjectItem(data, "status");
+        cJSON* cve = cJSON_GetObjectItem(data, "cve");
+        cJSON* reference = cJSON_GetObjectItem(data, "reference");
+
+        // Checking whether we should remove by status
+        if (cJSON_IsString(status)) {
+            char* removed_cves = NULL;
+
+            wdbc_result wdb_res = wdb_agents_remove_by_status_vuln_cve(wdb, status->valuestring, &removed_cves);
+            snprintf(output, OS_MAXSTR + 1, "%s %s",  WDBC_RESULT[wdb_res], removed_cves);
+            os_free(removed_cves)
+            ret = OS_SUCCESS;
+        }
+        // Checking whether we should remove a specific entry
+        else if (cJSON_IsString(cve) && cJSON_IsString(reference)) {
+            ret = wdb_agents_remove_vuln_cve(wdb, cve->valuestring, reference->valuestring);
+            if (OS_SUCCESS != ret) {
+                mdebug1("DB(%s) Cannot execute vuln_cve remove command; SQL err: %s", wdb->id, sqlite3_errmsg(wdb->db));
+                snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cve remove command; SQL err: %s", sqlite3_errmsg(wdb->db));
+            }
+            else {
+                snprintf(output, OS_MAXSTR + 1, "ok");
+            }
+        }
+        else {
+            mdebug1("Invalid vuln_cve JSON data to remove vulnerabilities.");
+            snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data");
+        }
+    }
+
+    cJSON_Delete(data);
+    return ret;
+}
+
+int wdb_parse_agents_clear_vuln_cve(wdb_t* wdb, char* output) {
+    int ret = wdb_agents_clear_vuln_cve(wdb);
+    if (OS_SUCCESS != ret) {
+        mdebug1("DB(%s) Cannot execute vuln_cve clear command; SQL err: %s",  wdb->id, sqlite3_errmsg(wdb->db));
+        snprintf(output, OS_MAXSTR + 1, "err Cannot execute vuln_cve clear command; SQL err: %s", sqlite3_errmsg(wdb->db));
+    }
+    else {
+        snprintf(output, OS_MAXSTR + 1, "ok");
+    }
     return ret;
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -301,9 +301,9 @@ STATIC int wm_vuldet_compare_vendors(char * vendor);
 STATIC void wm_vuldel_truncate_revision(char * revision);
 
 /**
- * @brief Clean every agent vuln_cve DB.
+ * @brief Clean every agent vuln_cves DB.
  */
-STATIC void wm_vuldet_clean_vuln_cve_db(void);
+STATIC void wm_vuldet_clean_vuln_cves_db(void);
 
 int wdb_vuldet_sock = -1;
 int *vu_queue;
@@ -1322,7 +1322,7 @@ int wm_vuldet_send_agent_report(sqlite3 *db, OSHash *cve_table, agent_software *
             }
 
             //Save the vulnerability in the agent database
-            if (OS_INVALID == wdb_agents_vuln_cve_insert(atoi(agents_it->agent_id), report->software, report->version, report->arch, report->cve, &sock)) {
+            if (OS_INVALID == wdb_agents_vuln_cves_insert(atoi(agents_it->agent_id), report->software, report->version, report->arch, report->cve, &sock)) {
                 mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to insert %s for package %s in the agent %.3d database",
                          report->cve ? report->cve : "null", report->software ? report->software : "null", atoi(agents_it->agent_id));
                 cve_insert_result = OS_INVALID;
@@ -2146,7 +2146,7 @@ int wm_vuldet_check_agent_vulnerabilities(agent_software *agents, wm_vuldet_flag
             if (VU_SOFTWARE_FULL_REQ == request) {
                 //Clean the vulnerabilities in the agent database
                 int sock = wm_vuldet_get_wdb_socket();
-                if (OS_INVALID == wdb_agents_vuln_cve_clear(atoi(agents_it->agent_id), &sock)) {
+                if (OS_INVALID == wdb_agents_vuln_cves_clear(atoi(agents_it->agent_id), &sock)) {
                     mtwarn(WM_VULNDETECTOR_LOGTAG, "Failed to clear vulnerabilities from the agent %s database", agents_it->agent_id);
                 }
             }
@@ -7151,7 +7151,7 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
 
     if (!flags->enabled) {
         // If vuldet is disabled we must clean the vulnerable software tables
-        wm_vuldet_clean_vuln_cve_db();
+        wm_vuldet_clean_vuln_cves_db();
 
         mtdebug1(WM_VULNDETECTOR_LOGTAG, "Module disabled. Exiting...");
         pthread_exit(NULL);
@@ -7661,16 +7661,16 @@ void wm_vuldel_truncate_revision(char * revision) {
     return;
 }
 
-void wm_vuldet_clean_vuln_cve_db(void) {
+void wm_vuldet_clean_vuln_cves_db(void) {
     int sock = wm_vuldet_get_wdb_socket();
     int *id_array = wdb_get_all_agents(TRUE, &sock);
     if (!id_array) {
-        mtwarn(WM_VULNDETECTOR_LOGTAG, "Unable to get agent's ID array to clear vuln_cve table");
+        mtwarn(WM_VULNDETECTOR_LOGTAG, "Unable to get agent's ID array to clear vuln_cves table");
         return;
     }
     for (size_t i = 0; id_array[i] != OS_INVALID; i++) {
-        if (OS_SUCCESS != wdb_agents_vuln_cve_clear(id_array[i], &sock)) {
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Error clearing vuln_cve table for agent %d", id_array[i]);
+        if (OS_SUCCESS != wdb_agents_vuln_cves_clear(id_array[i], &sock)) {
+            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Error clearing vuln_cves table for agent %d", id_array[i]);
         }
     }
     os_free(id_array);

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector_nvd.c
@@ -2224,7 +2224,7 @@ int wm_vuldet_report_nvd_vulnerabilities(sqlite3 *db, vu_nvd_report **nvd_report
         snprintf(report->title, OS_SIZE_512, "%s affects %s", report->cve, report->software);
 
         //Save the vulnerability in the agent database
-        if (OS_INVALID == wdb_agents_vuln_cve_insert(atoi(agent->agent_id), report->software, report->version, report->arch, report->cve, &sock)) {
+        if (OS_INVALID == wdb_agents_vuln_cves_insert(atoi(agent->agent_id), report->software, report->version, report->arch, report->cve, &sock)) {
             mtdebug1(WM_VULNDETECTOR_LOGTAG, "Failed to insert %s for package %s in the agent %s database",
                      report->cve ? report->cve : "null",
                      report->software ? report->software : "null",


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7918 |

## Description

This pull request implements all the necessary changes to have a new Wazuh DB command that allows the caller to remove vulnerabilities from the `vuln_cves` table of the agents' databases. The command accepts two criteria for removing the vulnerabilities:

1. Remove vulnerabilities by specifying the status. This will remove all the vulnerabilities in the database with the status specified.
2. Remove a specific vulnerability from the database by specifying its `cve` id and the `reference`.

## Testing done

To validate the right behavior it was created a python script that sends the command to the Wazuh DB socket. Here are some examples of the execution:

```
// Inserting CVEs for testing
[root@localhost ~]# python3 wdb-query.py 000 "SELECT * FROM vuln_cves"
[]
[root@localhost ~]# python3 wdb-query.py 000 "INSERT INTO vuln_cves (name,version,architecture,cve,reference,type,status) VALUES (\"aaa\",\"1\",\"x64\",\"aaacve\",\"aaaref\",\"OS\",\"VALID\")"
[]
[root@localhost ~]# python3 wdb-query.py 000 "INSERT INTO vuln_cves (name,version,architecture,cve,reference,type,status) VALUES (\"bbb\",\"1\",\"x64\",\"bbbcve\",\"bbbref\",\"OS\",\"VALID\")"
[]
[root@localhost ~]# python3 wdb-query.py 000 "INSERT INTO vuln_cves (name,version,architecture,cve,reference,type,status) VALUES (\"ccc\",\"1\",\"x64\",\"ccccve\",\"cccref\",\"OS\",\"VALID\")"
[]
[root@localhost ~]# python3 wdb-query.py 000 "INSERT INTO vuln_cves (name,version,architecture,cve,reference,type,status) VALUES (\"ddd\",\"1\",\"x64\",\"dddcve\",\"dddref\",\"OS\",\"OBSOLETE\")"
[]
[root@localhost ~]# python3 wdb-query.py 000 "INSERT INTO vuln_cves (name,version,architecture,cve,reference,type,status) VALUES (\"eee\",\"1\",\"x64\",\"eeecve\",\"eeeref\",\"OS\",\"OBSOLETE\")"
[]
[root@localhost ~]# python3 wdb-query.py 000 "INSERT INTO vuln_cves (name,version,architecture,cve,reference,type,status) VALUES (\"fff\",\"1\",\"x64\",\"fffcve\",\"fffref\",\"OS\",\"VALID\")"
[]

// Verifying the insertion
[root@localhost ~]# python3 wdb-query.py 000 "SELECT * FROM vuln_cves"
[
    {
        "name": "aaa",
        "version": "1",
        "architecture": "x64",
        "cve": "aaacve",
        "reference": "aaaref",
        "type": "OS",
        "status": "VALID"
    },
    {
        "name": "bbb",
        "version": "1",
        "architecture": "x64",
        "cve": "bbbcve",
        "reference": "bbbref",
        "type": "OS",
        "status": "VALID"
    },
    {
        "name": "ccc",
        "version": "1",
        "architecture": "x64",
        "cve": "ccccve",
        "reference": "cccref",
        "type": "OS",
        "status": "VALID"
    },
    {
        "name": "ddd",
        "version": "1",
        "architecture": "x64",
        "cve": "dddcve",
        "reference": "dddref",
        "type": "OS",
        "status": "OBSOLETE"
    },
    {
        "name": "eee",
        "version": "1",
        "architecture": "x64",
        "cve": "eeecve",
        "reference": "eeeref",
        "type": "OS",
        "status": "OBSOLETE"
    },
    {
        "name": "fff",
        "version": "1",
        "architecture": "x64",
        "cve": "fffcve",
        "reference": "fffref",
        "type": "OS",
        "status": "VALID"
    }
]

// Removing vulnerabilities by status OBSOLETE. This returns the vulnerabilities removed.
[root@localhost ~]# python3 wdb-query.py 000 "vuln_cve remove {\"status\":\"OBSOLETE\"}"
[
    {
        "name": "ddd",
        "version": "1",
        "architecture": "x64",
        "cve": "dddcve",
        "reference": "dddref",
        "type": "OS",
        "status": "OBSOLETE"
    },
    {
        "name": "eee",
        "version": "1",
        "architecture": "x64",
        "cve": "eeecve",
        "reference": "eeeref",
        "type": "OS",
        "status": "OBSOLETE"
    }
]

// Removing a specific vulnerability. This do not returns the vulnerability removed.
[root@localhost ~]# python3 wdb-query.py 000 "vuln_cve remove {\"cve\":\"bbbcve\",\"reference\":\"bbbref\"}"
ok
[root@localhost ~]# python3 wdb-query.py 000 "sql SELECT * FROM vuln_cves"
[
    {
        "name": "aaa",
        "version": "1",
        "architecture": "x64",
        "cve": "aaacve",
        "reference": "aaaref",
        "type": "OS",
        "status": "VALID"
    },
    {
        "name": "ccc",
        "version": "1",
        "architecture": "x64",
        "cve": "ccccve",
        "reference": "cccref",
        "type": "OS",
        "status": "VALID"
    },
    {
        "name": "fff",
        "version": "1",
        "architecture": "x64",
        "cve": "fffcve",
        "reference": "fffref",
        "type": "OS",
        "status": "VALID"
    }
]

```

## Static analysis

An execution of `scan-build` was performed over the implementation and it didn't report any issue.

## Dynamic analysis

Valgrind was executed over Wazuh DB and it didn't report any memory leak.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)