### PR TITLE
Unit testing for Wazuh DB command to remove vulnerabilities from the vuln_cves table of the agents' databases

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -48,7 +48,7 @@ list(APPEND wdb_tests_names "test_wdb_agents")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step \
                              -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,cJSON_Delete \
                              -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_AddItemToObject \
-                             -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_GetObjectItem")
+                             -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,wdb_exec_stmt_sized")
 
 
 list(APPEND wdb_tests_names "test_wdb_global_helpers")

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -19,7 +19,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                         -Wl,--wrap,wdbi_query_checksum -Wl,--wrap,wdbi_query_clear -Wl,--wrap,wdb_stmt_cache -Wl,--wrap,wdb_step \
                         -Wl,--wrap,sqlite3_changes -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_last_insert_rowid \
                         -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_open_agent2 -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_agents_insert_vuln_cves \
-                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cves -Wl,--wrap,wdb_agents_update_status_vuln_cves")
+                        -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cves -Wl,--wrap,wdb_agents_update_status_vuln_cves \
+                        -Wl,--wrap,wdb_agents_remove_vuln_cves -Wl,--wrap,wdb_agents_remove_by_status_vuln_cves")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
@@ -44,7 +45,10 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                             -Wl,--wrap,sqlite3_bind_parameter_index -Wl,--wrap,cJSON_Delete -Wl,--wrap,sqlite3_step -Wl,--wrap,sqlite3_column_int")
 
 list(APPEND wdb_tests_names "test_wdb_agents")
-list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step")
+list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step \
+                             -Wl,--wrap,wdb_exec_stmt -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,cJSON_Delete \
+                             -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_AddItemToObject \
+                             -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_GetObjectItem")
 
 
 list(APPEND wdb_tests_names "test_wdb_global_helpers")
@@ -64,8 +68,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_CreateArray -Wl,--wrap,cJSON_CreateString -Wl,--wrap,cJSON_Parse \
                              -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddNumberToObject \
                              -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_GetObjectItem \
-                             -Wl,--wrap,cJSON_Delete -Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result -Wl,--wrap,wdbc_query_parse_json \
-                             -Wl,--wrap,wdbc_query_parse")
+                             -Wl,--wrap,cJSON_ParseWithOpts -Wl,--wrap,cJSON_Delete -Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result \
+                             -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_Duplicate -Wl,--wrap,wdbc_query_parse_json -Wl,--wrap,wdbc_query_parse")
 
 list(APPEND wdb_tests_names "test_wdb")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,pthread_mutex_lock \

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -19,6 +19,7 @@
 #include "wazuh_db/wdb.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/externals/sqlite/sqlite3_wrappers.h"
+#include "../wrappers/externals/cJSON/cJSON_wrappers.h"
 #include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
 #include "wazuhdb_op.h"
 #include "wazuh_db/wdb_agents.h"
@@ -33,7 +34,6 @@ static int test_setup(void **state) {
     os_calloc(1,sizeof(test_struct_t),init_data);
     os_calloc(1,sizeof(wdb_t),init_data->wdb);
     os_strdup("000",init_data->wdb->id);
-    os_calloc(256,sizeof(char),init_data->output);
     os_calloc(1,sizeof(sqlite3 *),init_data->wdb->db);
     *state = init_data;
     return 0;
@@ -97,36 +97,6 @@ void test_wdb_agents_insert_vuln_cves_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-/* Tests wdb_agents_clear_vuln_cves */
-
-void test_wdb_agents_clear_vuln_cves_statement_init_fail(void **state)
-{
-    int ret = -1;
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_CLEAR);
-
-    ret = wdb_agents_clear_vuln_cves(data->wdb);
-
-    assert_int_equal(ret, OS_INVALID);
-}
-
-void test_wdb_agents_clear_vuln_cves_success(void **state)
-{
-    int ret = -1;
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_CLEAR);
-
-    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
-
-    ret = wdb_agents_clear_vuln_cves(data->wdb);
-
-    assert_int_equal(ret, OS_SUCCESS);
-}
-
 /* Tests wdb_agents_update_status_vuln_cves*/
 
 void test_wdb_agents_update_status_vuln_cves_statement_init_fail(void **state){
@@ -183,19 +153,343 @@ void test_wdb_agents_update_status_vuln_cves_success_all(void **state){
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_agents_remove_vuln_cves */
+
+void test_wdb_agents_remove_vuln_cves_invalid_data(void **state)
+{
+    int ret = -1;
+    const char *cve = NULL;
+    const char *reference = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid data provided");
+
+    ret = wdb_agents_remove_vuln_cves(data->wdb, cve, reference);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_agents_remove_vuln_cves_statement_init_fail(void **state)
+{
+    int ret = -1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "ref-cve-xxxx-yyyy";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_DELETE_ENTRY);
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+
+    ret = wdb_agents_remove_vuln_cves(data->wdb, cve, reference);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_agents_remove_vuln_cves_success(void **state)
+{
+    int ret = -1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "ref-cve-xxxx-yyyy";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_DELETE_ENTRY);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    ret = wdb_agents_remove_vuln_cves(data->wdb, cve, reference);
+
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+/* Tests wdb_agents_remove_by_status_vuln_cves */
+
+void test_wdb_agents_remove_by_status_vuln_cves_statement_init_fail(void **state)
+{
+    int ret = -1;
+    const char *status = "OBSOLETE";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // Preparing statement
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
+
+    ret = wdb_agents_remove_by_status_vuln_cves(data->wdb, status, &data->output);
+
+    assert_string_equal(data->output, "Cannot cache statement");
+    assert_int_equal(ret, WDBC_ERROR);
+}
+
+void test_wdb_agents_remove_by_status_vuln_cves_statement_bind_fail(void **state)
+{
+    int ret = -1;
+    const char *status = "OBSOLETE";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // Preparing statement
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, SQLITE_ERROR, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, status);
+
+    will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
+    expect_string(__wrap__merror, formatted_msg, "DB(000) sqlite3_bind_text(): ERROR MESSAGE");
+
+    ret = wdb_agents_remove_by_status_vuln_cves(data->wdb, status, &data->output);
+
+    assert_string_equal(data->output, "Cannot bind sql statement");
+    assert_int_equal(ret, WDBC_ERROR);
+}
+
+void test_wdb_agents_remove_by_status_vuln_cves_no_cves_for_detele(void **state)
+{
+    int ret = -1;
+    const char *status = "OBSOLETE";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    // Preparing statement
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, status);
+
+    // Executing statement
+    will_return(__wrap_wdb_exec_stmt, NULL);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_remove_by_status_vuln_cves(data->wdb, status, &data->output);
+
+    assert_string_equal(data->output, "[]");
+    assert_int_equal(ret, WDBC_OK);
+}
+
+void test_wdb_agents_remove_by_status_vuln_cves_error_removing_cve(void **state)
+{
+    int ret = -1;
+    cJSON *root = NULL;
+    cJSON *row = NULL;
+    cJSON *str1 = NULL;
+    cJSON *str2 = NULL;
+    const char *status = "OBSOLETE";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    root = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str1 = __real_cJSON_CreateString("cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "cve", str1);
+    str2 = __real_cJSON_CreateString("ref-cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "reference", str2);
+    __real_cJSON_AddItemToArray(root, row);
+
+    // Preparing statement
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, status);
+
+    // Executing statement
+    will_return(__wrap_wdb_exec_stmt, root);
+    will_return(__wrap_cJSON_GetObjectItem, str1);
+    will_return(__wrap_cJSON_GetObjectItem, str2);
+
+    // Removing vulnerability
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_DELETE_ENTRY);
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+    expect_string(__wrap__merror, formatted_msg, "Error removing vulnerability from the inventory database: cve-xxxx-yyyy");
+
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_remove_by_status_vuln_cves(data->wdb, status, &data->output);
+
+    assert_string_equal(data->output, "Error removing vulnerability from the inventory database:  cve-xxxx-yyyy");
+    assert_int_equal(ret, WDBC_ERROR);
+
+    __real_cJSON_Delete(root);
+}
+
+void test_wdb_agents_remove_by_status_vuln_cves_success(void **state)
+{
+    int ret = -1;
+    cJSON *root = NULL;
+    cJSON *row = NULL;
+    cJSON *str1 = NULL;
+    cJSON *str2 = NULL;
+    const char *status = "OBSOLETE";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    root = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str1 = __real_cJSON_CreateString("cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "cve", str1);
+    str2 = __real_cJSON_CreateString("ref-cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "reference", str2);
+    __real_cJSON_AddItemToArray(root, row);
+
+    // Preparing statement
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, status);
+
+    // Executing statement first time
+    will_return(__wrap_wdb_exec_stmt, root);
+    will_return(__wrap_cJSON_GetObjectItem, str1);
+    will_return(__wrap_cJSON_GetObjectItem, str2);
+
+    // Removing vulnerability
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_DELETE_ENTRY);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "cve-xxxx-yyyy");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "ref-cve-xxxx-yyyy");
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Executing statement second time
+    will_return(__wrap_wdb_exec_stmt, root);
+    will_return(__wrap_cJSON_GetObjectItem, str1);
+    will_return(__wrap_cJSON_GetObjectItem, str2);
+
+    // Removing vulnerability
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_DELETE_ENTRY);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "cve-xxxx-yyyy");
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, "ref-cve-xxxx-yyyy");
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Executing statement third time
+    will_return(__wrap_wdb_exec_stmt, NULL);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_remove_by_status_vuln_cves(data->wdb, status, &data->output);
+
+    assert_string_equal(data->output, "[{\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"ref-cve-xxxx-yyyy\"},{\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"ref-cve-xxxx-yyyy\"}]");
+    assert_int_equal(ret, WDBC_OK);
+
+    __real_cJSON_Delete(root);
+}
+
+void test_wdb_agents_remove_by_status_vuln_cves_full(void **state)
+{
+    int ret = -1;
+    cJSON *root = NULL;
+    cJSON *row = NULL;
+    cJSON *str1 = NULL;
+    cJSON *str2 = NULL;
+    const char *status = "OBSOLETE";
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    root = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str1 = __real_cJSON_CreateString("cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "cve", str1);
+    str2 = __real_cJSON_CreateString("ref-cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "reference", str2);
+    __real_cJSON_AddItemToArray(root, row);
+    // Creating a cJSON array bigger than WDB_MAX_RESPONSE_SIZE
+    for(int i = 0; i < 2500; i++){
+        __real_cJSON_AddStringToObject(row,"test_field", "test_value");
+    }
+
+    // Preparing statement
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_SELECT_BY_STATUS);
+    will_return(__wrap_wdb_init_stmt_in_cache, 1);
+
+    will_return_count(__wrap_sqlite3_bind_text, SQLITE_OK, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, status);
+
+    // Executing statement first time
+    will_return(__wrap_wdb_exec_stmt, root);
+    will_return(__wrap_cJSON_GetObjectItem, str1);
+    will_return(__wrap_cJSON_GetObjectItem, str2);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_remove_by_status_vuln_cves(data->wdb, status, &data->output);
+
+    assert_string_equal(data->output, "[]");
+    assert_int_equal(ret, WDBC_DUE);
+
+    __real_cJSON_Delete(root);
+}
+
+/* Tests wdb_agents_clear_vuln_cves */
+
+void test_wdb_agents_clear_vuln_cves_statement_init_fail(void **state)
+{
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_CLEAR);
+
+    ret = wdb_agents_clear_vuln_cves(data->wdb);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_agents_clear_vuln_cves_success(void **state)
+{
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_CLEAR);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    ret = wdb_agents_clear_vuln_cves(data->wdb);
+
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] = {
         /* Tests wdb_agents_insert_vuln_cves */
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success, test_setup, test_teardown),
-        /* Tests wdb_agents_clear_vuln_cves */
-        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_statement_init_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_success, test_setup, test_teardown),
         /* Tests wdb_agents_update_status_vuln_cves */
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_success_all, test_setup, test_teardown),
+        /* Tests wdb_agents_remove_vuln_cves */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_vuln_cves_invalid_data, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_vuln_cves_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_vuln_cves_success, test_setup, test_teardown),
+        /* Tests wdb_agents_remove_by_status_vuln_cves */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_by_status_vuln_cves_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_by_status_vuln_cves_statement_bind_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_by_status_vuln_cves_no_cves_for_detele, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_by_status_vuln_cves_error_removing_cve, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_by_status_vuln_cves_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_remove_by_status_vuln_cves_full, test_setup, test_teardown),
+        /* Tests wdb_agents_clear_vuln_cves */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_success, test_setup, test_teardown),
       };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -421,9 +421,9 @@ void test_wdb_agents_vuln_cves_update_status_success(void **state){
     assert_int_equal(OS_SUCCESS, ret);
 }
 
-/* Tests wdb_agents_vuln_cve_remove_entry */
+/* Tests wdb_agents_vuln_cves_remove_entry */
 
-void test_wdb_agents_vuln_cve_remove_entry_error_json(void **state)
+void test_wdb_agents_vuln_cves_remove_entry_error_json(void **state)
 {
     int ret = 0;
     int id = 1;
@@ -434,12 +434,12 @@ void test_wdb_agents_vuln_cve_remove_entry_error_json(void **state)
     will_return(__wrap_cJSON_CreateObject, NULL);
     expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
 
-    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+    ret = wdb_agents_vuln_cves_remove_entry(id, cve, reference, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_remove_entry_error_socket(void **state){
+void test_wdb_agents_vuln_cves_remove_entry_error_socket(void **state){
     int ret = 0;
     int id = 1;
     const char *cve = "cve-xxxx-yyyy";
@@ -476,12 +476,12 @@ void test_wdb_agents_vuln_cve_remove_entry_error_socket(void **state){
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);
 
-    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+    ret = wdb_agents_vuln_cves_remove_entry(id, cve, reference, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_remove_entry_error_sql_execution(void **state){
+void test_wdb_agents_vuln_cves_remove_entry_error_sql_execution(void **state){
     int ret = 0;
     int id = 1;
     const char *cve = "cve-xxxx-yyyy";
@@ -518,12 +518,12 @@ void test_wdb_agents_vuln_cve_remove_entry_error_sql_execution(void **state){
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);
 
-    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+    ret = wdb_agents_vuln_cves_remove_entry(id, cve, reference, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_remove_entry_error_result(void **state){
+void test_wdb_agents_vuln_cves_remove_entry_error_result(void **state){
     int ret = 0;
     int id = 1;
     const char *cve = "cve-xxxx-yyyy";
@@ -561,12 +561,12 @@ void test_wdb_agents_vuln_cve_remove_entry_error_result(void **state){
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);
 
-    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+    ret = wdb_agents_vuln_cves_remove_entry(id, cve, reference, NULL);
 
     assert_int_equal(OS_INVALID, ret);
 }
 
-void test_wdb_agents_vuln_cve_remove_entry_success(void **state){
+void test_wdb_agents_vuln_cves_remove_entry_success(void **state){
     int ret = 0;
     int id = 1;
     const char *cve = "cve-xxxx-yyyy";
@@ -603,7 +603,7 @@ void test_wdb_agents_vuln_cve_remove_entry_success(void **state){
     //Cleaning  memory
     expect_function_call(__wrap_cJSON_Delete);
 
-    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+    ret = wdb_agents_vuln_cves_remove_entry(id, cve, reference, NULL);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
@@ -990,12 +990,12 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        /* Tests wdb_agents_vuln_cve_remove_entry */
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cves_remove_entry */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_entry_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_entry_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_entry_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_entry_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_entry_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         /* Tests wdb_agents_vuln_cves_remove_by_status */
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_error_wdb_query, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -19,6 +19,9 @@
 #include "wazuh_db/helpers/wdb_agents_helpers.h"
 #include "wazuhdb_op.h"
 
+#include "../wrappers/externals/cJSON/cJSON_wrappers.h"
+#include "../wrappers/wazuh/wazuh_db/wdb_wrappers.h"
+
 extern int test_mode;
 
 /* setup/teardown */
@@ -205,7 +208,7 @@ void test_wdb_agents_vuln_cves_insert_success(void **state)
 
     const char *json_str = strdup("{\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
     const char *query_str = "agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
-    const char *response = "err";
+    const char *response = "ok";
 
     will_return(__wrap_cJSON_CreateObject, 1);
     will_return_always(__wrap_cJSON_AddStringToObject, 1);
@@ -236,105 +239,6 @@ void test_wdb_agents_vuln_cves_insert_success(void **state)
     will_return(__wrap_wdbc_parse_result, WDBC_OK);
 
     ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, NULL);
-
-    assert_int_equal(OS_SUCCESS, ret);
-}
-
-/* Tests wdb_agents_vuln_cves_clear */
-
-void test_wdb_agents_vuln_cves_clear_error_socket(void **state)
-{
-    int ret = 0;
-    int id = 1;
-
-    const char *query_str = "agent 1 vuln_cves clear";
-    const char *response = "err";
-
-    // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, OS_INVALID);
-
-    // Handling result
-    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error in the response from socket");
-    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves clear");
-
-    ret = wdb_agents_vuln_cves_clear(id, NULL);
-
-    assert_int_equal(OS_INVALID, ret);
-}
-
-void test_wdb_agents_vuln_cves_clear_error_sql_execution(void **state)
-{
-    int ret = 0;
-    int id = 1;
-
-    const char *query_str = "agent 1 vuln_cves clear";
-    const char *response = "err";
-
-    // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, -100); // Returning any error
-
-    // Handling result
-    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");
-    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves clear");
-
-    ret = wdb_agents_vuln_cves_clear(id, NULL);
-
-    assert_int_equal(OS_INVALID, ret);
-}
-
-void test_wdb_agents_vuln_cves_clear_error_result(void **state)
-{
-    int ret = 0;
-    int id = 1;
-
-    const char *query_str = "agent 1 vuln_cves clear";
-    const char *response = "err";
-
-    // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
-
-    // Parsing Wazuh DB result
-    expect_any(__wrap_wdbc_parse_result, result);
-    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
-    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
-
-    ret = wdb_agents_vuln_cves_clear(id, NULL);
-
-    assert_int_equal(OS_INVALID, ret);
-}
-
-void test_wdb_agents_vuln_cves_clear_success(void **state)
-{
-    int ret = 0;
-    int id = 1;
-
-    const char *query_str = "agent 1 vuln_cves clear";
-    const char *response = "err";
-
-    // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
-
-    // Parsing Wazuh DB result
-    expect_any(__wrap_wdbc_parse_result, result);
-    will_return(__wrap_wdbc_parse_result, WDBC_OK);
-
-    ret = wdb_agents_vuln_cves_clear(id, NULL);
 
     assert_int_equal(OS_SUCCESS, ret);
 }
@@ -486,7 +390,7 @@ void test_wdb_agents_vuln_cves_update_status_success(void **state){
 
     os_strdup("{\"old_status\":\"valid\",\"new_status\":\"obsolete\"}", json_str);
     const char *query_str = "agent 1 vuln_cves update_status {\"old_status\":\"valid\",\"new_status\":\"obsolete\"}";
-    const char *response = "err";
+    const char *response = "ok";
 
     will_return(__wrap_cJSON_CreateObject, 1);
     will_return_always(__wrap_cJSON_AddStringToObject, 1);
@@ -517,6 +421,559 @@ void test_wdb_agents_vuln_cves_update_status_success(void **state){
     assert_int_equal(OS_SUCCESS, ret);
 }
 
+/* Tests wdb_agents_vuln_cve_remove_entry */
+
+void test_wdb_agents_vuln_cve_remove_entry_error_json(void **state)
+{
+    int ret = 0;
+    int id = 1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "reference-cve-xxxx-yyyy";
+
+    // Creating JSON data_in
+    will_return(__wrap_cJSON_CreateObject, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
+
+    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cve_remove_entry_error_socket(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "reference-cve-xxxx-yyyy";
+    const char *json_str = NULL;
+
+    os_strdup("{\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "cve-xxxx-yyyy");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "reference-cve-xxxx-yyyy");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_INVALID);
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error in the response from socket");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves remove {\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}");
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cve_remove_entry_error_sql_execution(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "reference-cve-xxxx-yyyy";
+    const char *json_str = NULL;
+
+    os_strdup("{\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "cve-xxxx-yyyy");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "reference-cve-xxxx-yyyy");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, -100); // Returning any error
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves remove {\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}");
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cve_remove_entry_error_result(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "reference-cve-xxxx-yyyy";
+    const char *json_str = NULL;
+
+    os_strdup("{\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "cve-xxxx-yyyy");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "reference-cve-xxxx-yyyy");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cve_remove_entry_success(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *cve = "cve-xxxx-yyyy";
+    const char *reference = "reference-cve-xxxx-yyyy";
+    const char *json_str = NULL;
+
+    os_strdup("{\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"cve\":\"cve-xxxx-yyyy\",\"reference\":\"reference-cve-xxxx-yyyy\"}";
+    const char *response = "ok";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "cve-xxxx-yyyy");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "reference-cve-xxxx-yyyy");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret = wdb_agents_vuln_cve_remove_entry(id, cve, reference, NULL);
+
+    assert_int_equal(OS_SUCCESS, ret);
+}
+
+/* Tests wdb_agents_vuln_cves_remove_by_status */
+
+void test_wdb_agents_vuln_cves_remove_by_status_error_json(void **state)
+{
+    cJSON *ret_cves = NULL;
+    int id = 1;
+    const char *status = "OBSOLETE";
+
+    // Creating JSON data_in
+    will_return(__wrap_cJSON_CreateObject, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
+
+    ret_cves = wdb_agents_vuln_cves_remove_by_status(id, status, NULL);
+
+    assert_null(ret_cves);
+}
+
+void test_wdb_agents_vuln_cves_remove_by_status_error_wdb_query(void **state)
+{
+    cJSON *ret_cves = NULL;
+    int id = 1;
+    const char *status = "OBSOLETE";
+    const char *json_str = NULL;
+
+    os_strdup("{\"status\":\"OBSOLETE\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"status\":\"OBSOLETE\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OBSOLETE");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_INVALID);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error removing vulnerabilities from the agent database.");
+    expect_function_call(__wrap_cJSON_Delete);
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret_cves = wdb_agents_vuln_cves_remove_by_status(id, status, NULL);
+
+    assert_null(ret_cves);
+}
+
+void test_wdb_agents_vuln_cves_remove_by_status_error_result(void **state)
+{
+    cJSON *ret_cves = NULL;
+    int id = 1;
+    const char *status = "OBSOLETE";
+    const char *json_str = NULL;
+
+    os_strdup("{\"status\":\"OBSOLETE\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"status\":\"OBSOLETE\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OBSOLETE");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret_cves = wdb_agents_vuln_cves_remove_by_status(id, status, NULL);
+
+    assert_null(ret_cves);
+}
+
+void test_wdb_agents_vuln_cves_remove_by_status_error_json_result(void **state)
+{
+    cJSON *ret_cves = NULL;
+    int id = 1;
+    const char *status = "OBSOLETE";
+    const char *json_str = NULL;
+
+    os_strdup("{\"status\":\"OBSOLETE\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"status\":\"OBSOLETE\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OBSOLETE");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    // Parsing JSON result
+    will_return(__wrap_cJSON_ParseWithOpts, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid vuln_cves JSON results syntax after removing vulnerabilities.");
+    expect_string(__wrap__mdebug2, formatted_msg, "JSON error near: (null)");
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret_cves = wdb_agents_vuln_cves_remove_by_status(id, status, NULL);
+
+    assert_null(ret_cves);
+}
+
+void test_wdb_agents_vuln_cves_remove_by_status_success_ok(void **state)
+{
+    cJSON *ret_cves = NULL;
+    int id = 1;
+    const char *status = "OBSOLETE";
+    const char *json_str = NULL;
+
+    os_strdup("{\"status\":\"OBSOLETE\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"status\":\"OBSOLETE\"}";
+    const char *response = "err";
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OBSOLETE");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    // Parsing JSON result
+    will_return(__wrap_cJSON_ParseWithOpts, 1);
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret_cves = wdb_agents_vuln_cves_remove_by_status(id, status, NULL);
+
+    assert_ptr_equal(1, ret_cves);
+}
+
+void test_wdb_agents_vuln_cves_remove_by_status_success_due(void **state)
+{
+    cJSON *ret_cves = NULL;
+    cJSON *root1 = NULL;
+    cJSON *root2 = NULL;
+    cJSON *row = NULL;
+    cJSON *str = NULL;
+    int id = 1;
+    const char *status = "OBSOLETE";
+    const char *json_str = NULL;
+
+    os_strdup("{\"status\":\"OBSOLETE\"}", json_str);
+    const char *query_str = "agent 1 vuln_cves remove {\"status\":\"OBSOLETE\"}";
+    const char *response = "ok";
+
+    root1 = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str = __real_cJSON_CreateString("cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "cve", str);
+    __real_cJSON_AddItemToArray(root1, row);
+    root2 = __real_cJSON_CreateArray();
+    row = __real_cJSON_CreateObject();
+    str = __real_cJSON_CreateString("cve-xxxx-yyyy");
+    __real_cJSON_AddItemToObject(row, "cve", str);
+    __real_cJSON_AddItemToArray(root2, row);
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OBSOLETE");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+
+    //// First call to Wazuh DB
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_DUE);
+
+    // Parsing JSON result
+    will_return(__wrap_cJSON_ParseWithOpts, root1);
+
+    //// Second call to Wazuh DB
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    // Parsing JSON result
+    will_return(__wrap_cJSON_ParseWithOpts, root2);
+    will_return(__wrap_cJSON_Duplicate, row);
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
+
+    ret_cves = wdb_agents_vuln_cves_remove_by_status(id, status, NULL);
+
+    assert_ptr_equal(root1, ret_cves);
+    __real_cJSON_Delete(root1);
+    __real_cJSON_Delete(root2);
+}
+
+/* Tests wdb_agents_vuln_cves_clear */
+
+void test_wdb_agents_vuln_cves_clear_error_socket(void **state)
+{
+    int ret = 0;
+    int id = 1;
+
+    const char *query_str = "agent 1 vuln_cves clear";
+    const char *response = "err";
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_INVALID);
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error in the response from socket");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves clear");
+
+    ret = wdb_agents_vuln_cves_clear(id, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cves_clear_error_sql_execution(void **state)
+{
+    int ret = 0;
+    int id = 1;
+
+    const char *query_str = "agent 1 vuln_cves clear";
+    const char *response = "err";
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, -100); // Returning any error
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves clear");
+
+    ret = wdb_agents_vuln_cves_clear(id, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cves_clear_error_result(void **state)
+{
+    int ret = 0;
+    int id = 1;
+
+    const char *query_str = "agent 1 vuln_cves clear";
+    const char *response = "err";
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
+
+    ret = wdb_agents_vuln_cves_clear(id, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cves_clear_success(void **state)
+{
+    int ret = 0;
+    int id = 1;
+
+    const char *query_str = "agent 1 vuln_cves clear";
+    const char *response = "ok";
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    ret = wdb_agents_vuln_cves_clear(id, NULL);
+
+    assert_int_equal(OS_SUCCESS, ret);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] =
@@ -527,17 +984,30 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        /* Tests wdb_agents_vuln_cves_clear*/
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         /* Tests wdb_agents_vuln_cves_update_status*/
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cve_remove_entry */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cve_remove_entry_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cves_remove_by_status */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_error_wdb_query, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_error_json_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_success_ok, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_by_status_success_due, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cves_clear*/
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_clear_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.c
@@ -125,6 +125,13 @@ cJSON * __wrap_cJSON_Parse(__attribute__ ((__unused__)) const char *value) {
     return mock_type(cJSON *);
 }
 
+cJSON * __wrap_cJSON_ParseWithOpts(__attribute__ ((__unused__)) const char *value,
+                                   const char **return_parse_end,
+                                   __attribute__ ((__unused__)) cJSON_bool require_null_terminated) {
+    *return_parse_end = NULL;
+    return mock_type(cJSON *);
+}
+
 char * __wrap_cJSON_PrintUnformatted(__attribute__ ((__unused__)) const cJSON *item) {
     return mock_type(char *);
 }
@@ -145,8 +152,8 @@ cJSON* __wrap_cJSON_Duplicate(__attribute__ ((__unused__)) const cJSON *item, __
     return mock_type(cJSON*);
 }
 
-cJSON* __wrap_cJSON_AddBoolToObject(__attribute__ ((__unused__)) cJSON * const object, 
-                                    __attribute__ ((__unused__))const char * const name, 
+cJSON* __wrap_cJSON_AddBoolToObject(__attribute__ ((__unused__)) cJSON * const object,
+                                    __attribute__ ((__unused__))const char * const name,
                                     __attribute__ ((__unused__))const cJSON_bool boolean) {
     return mock_type(cJSON *);
 }

--- a/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.h
+++ b/src/unit_tests/wrappers/externals/cJSON/cJSON_wrappers.h
@@ -83,6 +83,8 @@ void expect_cJSON_IsObject_call(int ret);
 
 cJSON * __wrap_cJSON_Parse(const char *value);
 
+cJSON * __wrap_cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated);
+
 extern cJSON * __real_cJSON_Parse(const char *value);
 
 char * __wrap_cJSON_PrintUnformatted(const cJSON *item);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
@@ -13,7 +13,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-int __wrap_wdb_agents_insert_vuln_cves( __attribute__((unused)) wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve) {
+int __wrap_wdb_agents_insert_vuln_cves(__attribute__((unused)) wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve) {
     check_expected(name);
     check_expected(version);
     check_expected(architecture);
@@ -21,12 +21,24 @@ int __wrap_wdb_agents_insert_vuln_cves( __attribute__((unused)) wdb_t *wdb, cons
     return mock();
 }
 
-int __wrap_wdb_agents_clear_vuln_cves( __attribute__((unused)) wdb_t *wdb) {
+int __wrap_wdb_agents_update_status_vuln_cves(__attribute__((unused)) wdb_t *wdb, const char* old_status, const char* new_status) {
+    check_expected(old_status);
+    check_expected(new_status);
     return mock();
 }
 
-int __wrap_wdb_agents_update_status_vuln_cves( __attribute__((unused)) wdb_t *wdb, const char* old_status, const char* new_status) {
-    check_expected(old_status);
-    check_expected(new_status);
+int __wrap_wdb_agents_remove_vuln_cves(__attribute__((unused)) wdb_t *wdb, const char* cve, const char* reference) {
+    check_expected(cve);
+    check_expected(reference);
+    return mock();
+}
+
+wdbc_result __wrap_wdb_agents_remove_by_status_vuln_cves(__attribute__((unused)) wdb_t *wdb, const char* status, char **output) {
+    check_expected(status);
+    os_strdup(mock_ptr_type(char*), *output);
+    return mock();
+}
+
+int __wrap_wdb_agents_clear_vuln_cves(__attribute__((unused)) wdb_t *wdb) {
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
@@ -14,6 +14,9 @@
 #include "wazuh_db/wdb.h"
 
 int __wrap_wdb_agents_insert_vuln_cves(wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve);
+int __wrap_wdb_agents_update_status_vuln_cves(wdb_t *wdb, const char* old_status, const char* new_status);
+int __wrap_wdb_agents_remove_vuln_cves(wdb_t *wdb, const char* cve, const char* reference);
+wdbc_result __wrap_wdb_agents_remove_by_status_vuln_cves(wdb_t *wdb, const char* status, char **output);
 int __wrap_wdb_agents_clear_vuln_cves(wdb_t *wdb);
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7918 |

## Description

This pull request implements all the necessary unit test cases to cover 100% of the code related to the new `vuln_cves remove` Wazuh DB command implemented as part of the issue in reference.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade