### PR TITLE
Fixing log message during service start/stop

### DIFF
--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -129,7 +129,7 @@ testconfig()
 # Start function
 start_service()
 {
-    echo "Starting $NAME $VERSION..."
+    echo "Starting Wazuh $VERSION..."
     checkpid;
 
     # Delete all files in temporary folder
@@ -246,7 +246,7 @@ stop_service()
         rm -f ${DIR}/var/run/${i}*.pid
      done
 
-    echo "$NAME $VERSION Stopped"
+    echo "Wazuh $VERSION Stopped"
 }
 
 info()

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -217,7 +217,7 @@ testconfig()
 
 start_service()
 {
-    echo "Starting $NAME $VERSION..."
+    echo "Starting Wazuh $VERSION..."
     TEST=$(${DIR}/bin/wazuh-logtest-legacy -t  2>&1)
     echo $TEST
 
@@ -346,7 +346,7 @@ stop_service()
         echo "Stopping sub agent directory (for hybrid mode)"
         ${DIR}/ossec-agent/bin/wazuh-control stop
     fi
-    echo "$NAME $VERSION Stopped"
+    echo "Wazuh $VERSION Stopped"
 }
 
 info()

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -259,7 +259,7 @@ start_service()
 {
 
     if [ $USE_JSON = false ]; then
-        echo "Starting $NAME $VERSION..."
+        echo "Starting Wazuh $VERSION..."
     fi
 
     TEST=$(${DIR}/bin/wazuh-logtest-legacy -t  2>&1 | grep "ERROR")
@@ -505,7 +505,7 @@ stop_service()
     if [ $USE_JSON = true ]; then
         echo -n ']}'
     else
-        echo "$NAME $VERSION Stopped"
+        echo "Wazuh $VERSION Stopped"
     fi
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#8040|

## Description

This PR updates the `wazuh-control` start/stop log message to properly print the product name.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language