### PR TITLE
Add reconnection functionality to active response

### DIFF
--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -341,14 +341,14 @@ void get_exec_msg(const active_response *ar, char *agent_id, const char *msg, ch
 }
 
 /**
- * @brief Send the message to the socket, if it fails, try reconnecting
+ * @brief Send the message to the socket. Tries to reconnect one time if the socket is not valid.
  *
  * @param socket Socket where the message will be sent.
  * @param queue_path Queue in case it is necessary to reconnect the socket
  * @param exec_msg Complete massage to be sent.
  * @return void.
  */
-void send_exec_msg(int *socket, char *queue_path, char *exec_msg) {
+void send_exec_msg(int *socket, const char *queue_path, const char *exec_msg) {
     if (*socket < 0) {
         if ((*socket = StartMQ(queue_path, WRITE, 1)) < 0) {
             merror(QUEUE_ERROR, queue_path, strerror(errno));

--- a/src/analysisd/alerts/exec.h
+++ b/src/analysisd/alerts/exec.h
@@ -14,15 +14,15 @@
 #include "eventinfo.h"
 #include "active-response.h"
 
-void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar);
+void OS_Exec(int *execq, int *arq, const Eventinfo *lf, const active_response *ar);
 void getActiveResponseInString(const Eventinfo *lf,
-                                const active_response *ar,
-                                const char *ip,
-                                const char *user,
-                                char *filename,
-                                char *extra_args,
-                                char *temp_msg);
+                               const active_response *ar,
+                               const char *ip,
+                               const char *user,
+                               char *filename,
+                               char *extra_args,
+                               char *temp_msg);
 void get_exec_msg(const active_response *ar, char *agent_id, const char *temp_msg, char *exec_msg);
-
+void send_exec_msg(int *socket, char *queue_path, char *exec_msg);
 
 #endif /* EXEC_H */

--- a/src/analysisd/alerts/exec.h
+++ b/src/analysisd/alerts/exec.h
@@ -23,6 +23,6 @@ void getActiveResponseInString(const Eventinfo *lf,
                                char *extra_args,
                                char *temp_msg);
 void get_exec_msg(const active_response *ar, char *agent_id, const char *temp_msg, char *exec_msg);
-void send_exec_msg(int *socket, char *queue_path, char *exec_msg);
+void send_exec_msg(int *socket, const char *queue_path, const char *exec_msg);
 
 #endif /* EXEC_H */

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -2118,7 +2118,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
                     }
 
                     if (do_ar && execdq >= 0) {
-                        OS_Exec(execdq, &arq, lf, *rule_ar);
+                        OS_Exec(&execdq, &arq, lf, *rule_ar);
                     }
                     rule_ar++;
                 }

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -874,26 +874,8 @@ void OS_ReadMSG_analysisd(int m_queue)
         if (Config.ar & REMOTE_AR) {
             if ((arq = StartMQ(ARQUEUE, WRITE, 1)) < 0) {
                 merror(ARQ_ERROR);
-
-                /* If LOCAL_AR is set, keep it there */
-                if (Config.ar & LOCAL_AR) {
-                    Config.ar = 0;
-                    Config.ar |= LOCAL_AR;
-                } else {
-                    Config.ar = 0;
-                }
             } else {
                 minfo(CONN_TO, ARQUEUE, "active-response");
-            }
-        }
-#else
-        /* Only for LOCAL_ONLY installs */
-        if (Config.ar & REMOTE_AR) {
-            if (Config.ar & LOCAL_AR) {
-                Config.ar = 0;
-                Config.ar |= LOCAL_AR;
-            } else {
-                Config.ar = 0;
             }
         }
 #endif
@@ -901,14 +883,6 @@ void OS_ReadMSG_analysisd(int m_queue)
         if (Config.ar & LOCAL_AR) {
             if ((execdq = StartMQ(EXECQUEUE, WRITE, 1)) < 0) {
                 merror(ARQ_ERROR);
-
-                /* If REMOTE_AR is set, keep it there */
-                if (Config.ar & REMOTE_AR) {
-                    Config.ar = 0;
-                    Config.ar |= REMOTE_AR;
-                } else {
-                    Config.ar = 0;
-                }
             } else {
                 minfo(CONN_TO, EXECQUEUE, "exec");
             }
@@ -2117,7 +2091,7 @@ void * w_process_event_thread(__attribute__((unused)) void * id){
                         do_ar = 0;
                     }
 
-                    if (do_ar && execdq >= 0) {
+                    if (do_ar) {
                         OS_Exec(&execdq, &arq, lf, *rule_ar);
                     }
                     rule_ar++;

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -168,7 +168,9 @@
 #define EXEC_INV_CMD    "(1316): Invalid AR command: '%s'"
 #define EXEC_CMD_FAIL   "(1317): Could not launch command %s (%d)"
 
-#define AR_NOAGENT_ERROR    "(1320): Agent '%s' not found."
+#define AR_NOAGENT_ERROR                "(1320): Agent '%s' not found."
+#define EXEC_QUEUE_CONNECTION_ERROR     "(1321): Error communicating with queue '%s'."
+#define EXEC_QUEUE_BUSY                 "(1322): Socket busy."
 
 /* List operations */
 #define LIST_ERROR      "(1290): Unable to create a new list (calloc)."

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -40,7 +40,6 @@ int StartMQ(const char *path, short int type, short int n_attempts)
         }
 
         if (rc < 0) {
-            merror(QUEUE_ERROR, path, strerror(errno));
             return OS_INVALID;
         }
 

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -42,7 +42,7 @@ list(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,OS_ConnectUnixDomain 
 
 list(APPEND analysisd_names "test_exec")
 list(APPEND analysisd_flags "-Wl,--wrap,_merror -Wl,--wrap,OS_SendUnix -Wl,--wrap,wdb_get_agent_info -Wl,--wrap,Eventinfo_to_jsonstr \
-                             -Wl,--wrap,OS_ReadXML -Wl,--wrap,OS_GetOneContentforElement -Wl,--wrap,OS_ClearXML \
+                             -Wl,--wrap,OS_ReadXML -Wl,--wrap,OS_GetOneContentforElement -Wl,--wrap,OS_ClearXML -Wl,--wrap,StartMQ \
                              -Wl,--wrap,wdb_get_agents_by_connection_status -Wl,--wrap,labels_find -Wl,--wrap,labels_get -Wl,--wrap,labels_free")
 
 list(APPEND analysisd_names "test_labels")

--- a/src/unit_tests/analysisd/test_exec.c
+++ b/src/unit_tests/analysisd/test_exec.c
@@ -133,7 +133,7 @@ void test_server_success_json(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_all_agents_success_json_string(void **state)
@@ -211,7 +211,7 @@ void test_all_agents_success_json_string(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_all_agents_success_json_string_wdb(void **state)
@@ -299,7 +299,7 @@ void test_all_agents_success_json_string_wdb(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_all_agents_success_fail_agt_info1(void **state)
@@ -354,7 +354,7 @@ void test_all_agents_success_fail_agt_info1(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Failed to get agent '5' information from Wazuh DB.");
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_specific_agent_success_json(void **state)
@@ -398,7 +398,7 @@ void test_specific_agent_success_json(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_specific_agent_success_json_wdb(void **state)
@@ -447,7 +447,7 @@ void test_specific_agent_success_json_wdb(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_specific_agent_success_string(void **state)
@@ -482,7 +482,7 @@ void test_specific_agent_success_string(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_specific_agent_success_string_wdb(void **state)
@@ -522,7 +522,7 @@ void test_specific_agent_success_string_wdb(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_specific_agent_success_fail_agt_info1(void **state)
@@ -550,7 +550,7 @@ void test_specific_agent_success_fail_agt_info1(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Failed to get agent '2' information from Wazuh DB.");
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_remote_agent_success_json(void **state)
@@ -594,7 +594,7 @@ void test_remote_agent_success_json(void **state)
 
     will_return(__wrap_OS_GetOneContentforElement, node);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_remote_agent_success_json_wdb(void **state)
@@ -643,7 +643,7 @@ void test_remote_agent_success_json_wdb(void **state)
 
     will_return(__wrap_OS_GetOneContentforElement, node);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_remote_agent_success_string(void **state)
@@ -678,7 +678,7 @@ void test_remote_agent_success_string(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_remote_agent_success_string_wdb(void **state)
@@ -718,7 +718,7 @@ void test_remote_agent_success_string_wdb(void **state)
     expect_value(__wrap_OS_SendUnix, size, 0);
     will_return(__wrap_OS_SendUnix, 1);
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_remote_agent_success_fail_agt_info1(void **state)
@@ -746,7 +746,7 @@ void test_remote_agent_success_fail_agt_info1(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Failed to get agent '1' information from Wazuh DB.");
 
-    OS_Exec(execq, &arq, data->lf, data->ar);
+    OS_Exec(&execq, &arq, data->lf, data->ar);
 }
 
 void test_getActiveResponseInJSON_extra_args(void **state){

--- a/src/unit_tests/shared/test_mq_op.c
+++ b/src/unit_tests/shared/test_mq_op.c
@@ -131,14 +131,10 @@ void test_start_mq_write_simple_fail(void ** state){
     char * path = "/test";
 
     int ret = 0;
-    char expected_str[OS_SIZE_64];
     errno = ERRNO;
 
     will_return(__wrap_OS_ConnectUnixDomain, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Can't connect to '/test': Socket operation on non-socket (88). Attempt: 1");
-
-    snprintf(expected_str, OS_SIZE_64, "(1210): Queue '%s' not accessible: '%s'", path,strerror(errno));
-    expect_string(__wrap__merror, formatted_msg, expected_str);
 
     ret = StartMQ(path, type, n_attempts);
     assert_int_equal(ret, -1);
@@ -184,16 +180,12 @@ void test_start_mq_write_multiple_fail(void ** state){
 
     int ret = 0;
     char messages[n_attempts][OS_SIZE_1024];
-    char expected_str[OS_SIZE_64];
 
     for (int i = 0; i <= n_attempts - 1; i++) {
         will_return(__wrap_OS_ConnectUnixDomain, -1);
         snprintf(messages[i], OS_SIZE_1024, "Can't connect to '/test': Socket operation on non-socket (88). Attempt: %d", i + 1);
         expect_string(__wrap__mdebug1, formatted_msg, messages[i]);
     }
-
-    snprintf(expected_str, OS_SIZE_64, "(1210): Queue '%s' not accessible: '%s'", path,strerror(errno));
-    expect_string(__wrap__merror, formatted_msg, expected_str);
 
     ret = StartMQ(path, type, n_attempts);
     assert_int_equal(ret, -1);
@@ -247,7 +239,7 @@ void test_start_mq_write_inf_fail(void ** state){
     will_return(__wrap_OS_ConnectUnixDomain, 0);
     /* Ignoring output */
     expect_any_count(__wrap__mdebug1, formatted_msg, -1);
-    
+
     ret = StartMQ(path, type, n_attempts);
 }
 

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
@@ -53,6 +53,13 @@ int __wrap_OS_SendUnix(int socket, const char *msg, int size) {
     return mock();
 }
 
+void expect_OS_SendUnix_call(int socket, const char *msg, int size, int ret) {
+    expect_value(__wrap_OS_SendUnix, socket, socket);
+    expect_string(__wrap_OS_SendUnix, msg, msg);
+    expect_value(__wrap_OS_SendUnix, size, size);
+    will_return(__wrap_OS_SendUnix, ret);
+}
+
 int __wrap_OS_RecvSecureTCP(int sock, char * ret, uint32_t size) {
     check_expected(sock);
     check_expected(size);

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.h
@@ -29,6 +29,8 @@ int __wrap_OS_SendSecureTCP(int sock, uint32_t size, const void * msg);
 
 int __wrap_OS_SendUnix(int socket, const char *msg, int size);
 
+void expect_OS_SendUnix_call(int socket, const char *msg, int size, int ret);
+
 int __wrap_OS_RecvSecureTCP(int sock, char * ret, uint32_t size);
 
 int __wrap_OS_RecvUnix(int socket, int sizet, char *ret);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/7625|


## Description

This PR adds to active-response the functionality to reconnect to analysisd if for some reason the socket is disconnected.
I've created a function that takes care of sending the message, trying to find a socket if it doesn't have one.
## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)

