### PR TITLE
Fix high impact defects detected by Coverity

### DIFF
--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -58,23 +58,6 @@ int bzip2_compress(const char *file, const char *filebz2) {
         }
     }
 
-    unsigned int nbytes_in_lo32;
-    unsigned int nbytes_in_hi32;
-    unsigned int nbytes_out_lo32;
-    unsigned int nbytes_out_hi32;
-    BZ2_bzWriteClose64(&bzerror, compressfile, 0,
-                       &nbytes_in_lo32, &nbytes_in_hi32,
-                       &nbytes_out_lo32, &nbytes_out_hi32);
-
-    if (bzerror != BZ_OK) {
-        mdebug2("BZ2_bzWriteClose64(%d)'%s': (%d)-%s",
-                bzerror, filebz2, errno, strerror(errno));
-        fclose(input);
-        fclose(output);
-        BZ2_bzReadClose(&bzerror, compressfile);
-        return -1;
-    }
-
     fclose(input);
     fclose(output);
     BZ2_bzReadClose(&bzerror, compressfile);

--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -51,16 +51,16 @@ int bzip2_compress(const char *file, const char *filebz2) {
         if (bzerror != BZ_OK) {
             mdebug2("Could not write bz2 file (%d)'%s': (%d)-%s",
                     bzerror, filebz2, errno, strerror(errno));
+            BZ2_bzWriteClose(&bzerror, compressfile, 0, NULL, NULL);
             fclose(input);
             fclose(output);
-            BZ2_bzReadClose(&bzerror, compressfile);
             return -1;
         }
     }
 
+    BZ2_bzWriteClose(&bzerror, compressfile, 0, NULL, NULL);
     fclose(input);
     fclose(output);
-    BZ2_bzReadClose(&bzerror, compressfile);
     return 0;
 }
 
@@ -107,15 +107,15 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
         } else {
             mdebug2("BZ2_bzRead(%d)'%s': (%d)-%s",
                     bzerror, filebz2, errno, strerror(errno));
+            BZ2_bzReadClose(&bzerror, compressfile);
             fclose(input);
             fclose(output);
-            BZ2_bzReadClose(&bzerror, compressfile);
             return -1;
         }
     } while (bzerror == BZ_OK);
 
+    BZ2_bzReadClose(&bzerror, compressfile);
     fclose(input);
     fclose(output);
-    BZ2_bzReadClose(&bzerror, compressfile);
     return 0;
 }

--- a/src/shared/bzip2_op.c
+++ b/src/shared/bzip2_op.c
@@ -38,6 +38,10 @@ int bzip2_compress(const char *file, const char *filebz2) {
     if (bzerror != BZ_OK) {
         mdebug2("Could not open to write bz2 file (%d)'%s': (%d)-%s",
                 bzerror, filebz2, errno, strerror(errno));
+
+        // compressfile is null at this point.
+        BZ2_bzWriteClose(&bzerror, compressfile, 0, NULL, NULL);
+
         fclose(input);
         fclose(output);
         return -1;
@@ -93,6 +97,10 @@ int bzip2_uncompress(const char *filebz2, const char *file) {
     if (compressfile == NULL || bzerror != BZ_OK) {
         mdebug2("BZ2_bzReadOpen(%d)'%s': (%d)-%s",
                 bzerror, filebz2, errno, strerror(errno));
+
+        // compressfile is null at this point.
+        BZ2_bzReadClose(&bzerror, compressfile);
+
         fclose(input);
         fclose(output);
         return -1;

--- a/src/shared/json-queue.c
+++ b/src/shared/json-queue.c
@@ -139,7 +139,9 @@ cJSON * jqueue_parse_json(file_queue * queue) {
 
         if (queue->read_attempts < MAX_READ_ATTEMPTS) {
             if (current_pos >= 0) {
-                fseek(queue->fp, current_pos, SEEK_SET);
+                if (fseek(queue->fp, current_pos, SEEK_SET) != 0) {
+                    queue->flags = CRALERT_READ_FAILED;
+                }
             }
         } else {
             queue->read_attempts = 0;

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -81,7 +81,7 @@ list(APPEND shared_tests_flags " ")
 if(${TARGET} STREQUAL "server")
 list(APPEND shared_tests_names "test_bzip2_op")
 list(APPEND shared_tests_flags "-Wl,--wrap=fopen,--wrap=fread,--wrap=fclose,--wrap=fwrite,--wrap=BZ2_bzWriteOpen \
-                                -Wl,--wrap=BZ2_bzWriteClose64 -Wl,--wrap=BZ2_bzReadClose,--wrap=BZ2_bzReadOpen \
+                                -Wl,--wrap=BZ2_bzReadClose,--wrap=BZ2_bzReadOpen \
                                 -Wl,--wrap=BZ2_bzRead,--wrap=BZ2_bzWrite,--wrap=_mdebug2,--wrap=fflush \
                                 -Wl,--wrap=fgets,--wrap=fprintf,--wrap=fseek,--wrap=remove -Wl,--wrap,fgetpos \
                                 -Wl,--wrap=fgetc")

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -81,7 +81,7 @@ list(APPEND shared_tests_flags " ")
 if(${TARGET} STREQUAL "server")
 list(APPEND shared_tests_names "test_bzip2_op")
 list(APPEND shared_tests_flags "-Wl,--wrap=fopen,--wrap=fread,--wrap=fclose,--wrap=fwrite,--wrap=BZ2_bzWriteOpen \
-                                -Wl,--wrap=BZ2_bzReadClose,--wrap=BZ2_bzReadOpen \
+                                -Wl,--wrap=BZ2_bzWriteClose -Wl,--wrap=BZ2_bzReadClose,--wrap=BZ2_bzReadOpen \
                                 -Wl,--wrap=BZ2_bzRead,--wrap=BZ2_bzWrite,--wrap=_mdebug2,--wrap=fflush \
                                 -Wl,--wrap=fgets,--wrap=fprintf,--wrap=fseek,--wrap=remove -Wl,--wrap,fgetpos \
                                 -Wl,--wrap=fgetc")

--- a/src/unit_tests/shared/test_bzip2_op.c
+++ b/src/unit_tests/shared/test_bzip2_op.c
@@ -102,6 +102,8 @@ void test_bzip2_compress_bzWriteOpen(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg,
                   "Could not open to write bz2 file (-3)'testfile2': (0)-Success");
 
+    expect_value(__wrap_BZ2_bzWriteClose, f, NULL);
+
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 1);
     expect_value(__wrap_fclose, _File, 2);
@@ -258,6 +260,8 @@ void test_bzip2_uncompress_bzReadOpen(void **state) {
     will_return(__wrap_BZ2_bzReadOpen, NULL);
     expect_string(__wrap__mdebug2, formatted_msg,
                   "BZ2_bzReadOpen(-3)'testfile': (0)-Success");
+
+    expect_value(__wrap_BZ2_bzReadClose, f, NULL);
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 1);

--- a/src/unit_tests/shared/test_bzip2_op.c
+++ b/src/unit_tests/shared/test_bzip2_op.c
@@ -78,7 +78,7 @@ void test_bzip2_compress_secondfopenfail(void **state) {
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 1);
-    
+
     ret = bzip2_compress(file1, file2);
     assert_int_equal(ret, -1);
 }
@@ -106,7 +106,7 @@ void test_bzip2_compress_bzWriteOpen(void **state) {
     will_return(__wrap_fclose, 1);
     expect_value(__wrap_fclose, _File, 2);
     will_return(__wrap_fclose, 1);
-    
+
     ret = bzip2_compress(file1, file2);
     assert_int_equal(ret, -1);
 }
@@ -147,48 +147,6 @@ void test_bzip2_compress_BZ2_bzWrite(void **state) {
     assert_int_equal(ret, -1);
 }
 
-void test_bzip2_compress_bzWriteClose64(void **state) {
-    int ret;
-    char *file1 = "testfile";
-    char *file2 = "testfile2";
-
-    expect_value(__wrap_fopen, path, file1);
-    expect_string(__wrap_fopen, mode, "rb");
-    will_return(__wrap_fopen, 1);
-
-    expect_value(__wrap_fopen, path, file2);
-    expect_string(__wrap_fopen, mode, "wb");
-    will_return(__wrap_fopen, 2);
-
-    expect_value(__wrap_BZ2_bzWriteOpen, f, 2);
-    will_return(__wrap_BZ2_bzWriteOpen, BZ_OK);
-    will_return(__wrap_BZ2_bzWriteOpen, 3);
-
-    will_return(__wrap_fread, "teststring");
-    will_return(__wrap_fread, 10);
-
-    expect_value(__wrap_BZ2_bzWrite, f, 3);
-    expect_string(__wrap_BZ2_bzWrite, buf, "teststring");
-    expect_value(__wrap_BZ2_bzWrite, len, 10);
-    will_return(__wrap_BZ2_bzWrite, BZ_OK);
-
-    will_return(__wrap_fread, "");
-    will_return(__wrap_fread, 0);
-
-    expect_value(__wrap_BZ2_bzWriteClose64, f, 3);
-    will_return(__wrap_BZ2_bzWriteClose64, BZ_MEM_ERROR);
-    expect_string(__wrap__mdebug2, formatted_msg,
-                  "BZ2_bzWriteClose64(-3)'testfile2': (0)-Success");
-
-    expect_value(__wrap_fclose, _File, 1);
-    will_return(__wrap_fclose, 1);
-    expect_value(__wrap_fclose, _File, 2);
-    will_return(__wrap_fclose, 1);
-
-    ret = bzip2_compress(file1, file2);
-    assert_int_equal(ret, -1);
-}
-
 void test_bzip2_compress_success(void **state) {
     int ret;
     char *file1 = "testfile";
@@ -216,9 +174,6 @@ void test_bzip2_compress_success(void **state) {
 
     will_return(__wrap_fread, "");
     will_return(__wrap_fread, 0);
-
-    expect_value(__wrap_BZ2_bzWriteClose64, f, 3);
-    will_return(__wrap_BZ2_bzWriteClose64, BZ_OK);
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 1);
@@ -397,7 +352,6 @@ int main(void) {
         cmocka_unit_test(test_bzip2_compress_secondfopenfail),
         cmocka_unit_test(test_bzip2_compress_bzWriteOpen),
         cmocka_unit_test(test_bzip2_compress_BZ2_bzWrite),
-        cmocka_unit_test(test_bzip2_compress_bzWriteClose64),
         cmocka_unit_test(test_bzip2_compress_success),
         cmocka_unit_test(test_bzip2_uncompress_nullfile),
         cmocka_unit_test(test_bzip2_uncompress_nullfilebz2),

--- a/src/unit_tests/shared/test_bzip2_op.c
+++ b/src/unit_tests/shared/test_bzip2_op.c
@@ -138,6 +138,8 @@ void test_bzip2_compress_BZ2_bzWrite(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg,
                   "Could not write bz2 file (-3)'testfile2': (0)-Success");
 
+    expect_value(__wrap_BZ2_bzWriteClose, f, 3);
+
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 1);
     expect_value(__wrap_fclose, _File, 2);
@@ -174,6 +176,8 @@ void test_bzip2_compress_success(void **state) {
 
     will_return(__wrap_fread, "");
     will_return(__wrap_fread, 0);
+
+    expect_value(__wrap_BZ2_bzWriteClose, f, 3);
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 1);
@@ -295,6 +299,8 @@ void test_bzip2_uncompress_bzReadsuccess(void **state) {
 
     will_return(__wrap_fwrite, 0);
 
+    expect_value(__wrap_BZ2_bzReadClose, f, 3);
+
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 1);
     expect_value(__wrap_fclose, _File, 2);
@@ -334,6 +340,8 @@ void test_bzip2_uncompress_bzReadfail(void **state) {
     will_return(__wrap_BZ2_bzRead, "");
     expect_string(__wrap__mdebug2, formatted_msg,
                   "BZ2_bzRead(-3)'testfile': (0)-Success");
+
+    expect_value(__wrap_BZ2_bzReadClose, f, 3);
 
     expect_value(__wrap_fclose, _File, 1);
     will_return(__wrap_fclose, 1);

--- a/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.c
+++ b/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.c
@@ -55,17 +55,6 @@ void __wrap_BZ2_bzWrite(int* bzerror,
     *bzerror = mock();
 }
 
-void __wrap_BZ2_bzWriteClose64(int* bzerror,
-                               BZFILE* f,
-                               __attribute__ ((__unused__)) int abandon,
-                               __attribute__ ((__unused__)) unsigned int* nbytes_in_lo32,
-                               __attribute__ ((__unused__)) unsigned int* nbytes_in_hi32,
-                               __attribute__ ((__unused__)) unsigned int* nbytes_out_lo32,
-                               __attribute__ ((__unused__)) unsigned int* nbytes_out_hi32) {
-    check_expected_ptr(f);
-    *bzerror = mock();
-}
-
 BZFILE* __wrap_BZ2_bzWriteOpen(int* bzerror,
                                FILE* f,
                                __attribute__ ((__unused__)) int blockSize100k,

--- a/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.c
+++ b/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.c
@@ -29,8 +29,8 @@ int __wrap_BZ2_bzRead(int* bzerror,
 }
 
 void __wrap_BZ2_bzReadClose(__attribute__ ((__unused__)) int* bzerror,
-                            __attribute__ ((__unused__)) BZFILE* f) {
-    return;
+                            BZFILE* f) {
+    check_expected_ptr(f);
 }
 
 BZFILE* __wrap_BZ2_bzReadOpen(int* bzerror,
@@ -53,6 +53,14 @@ void __wrap_BZ2_bzWrite(int* bzerror,
     check_expected(buf);
     check_expected(len);
     *bzerror = mock();
+}
+
+void __wrap_BZ2_bzWriteClose(__attribute__ ((__unused__)) int* bzerror,
+                               BZFILE* f,
+                               __attribute__ ((__unused__)) int abandon,
+                               __attribute__ ((__unused__)) unsigned int* nbytes_in,
+                               __attribute__ ((__unused__)) unsigned int* nbytes_out) {
+    check_expected_ptr(f);
 }
 
 BZFILE* __wrap_BZ2_bzWriteOpen(int* bzerror,

--- a/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.h
+++ b/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.h
@@ -33,14 +33,6 @@ void __wrap_BZ2_bzWrite(int* bzerror,
                        void* buf,
                        int len);
 
-void __wrap_BZ2_bzWriteClose64(int* bzerror,
-                               BZFILE* f,
-                               int abandon,
-                               unsigned int* nbytes_in_lo32,
-                               unsigned int* nbytes_in_hi32,
-                               unsigned int* nbytes_out_lo32,
-                               unsigned int* nbytes_out_hi32);
-
 BZFILE* __wrap_BZ2_bzWriteOpen(int* bzerror,
                                FILE* f,
                                int blockSize100k,

--- a/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.h
+++ b/src/unit_tests/wrappers/externals/bzip2/bzlib_wrappers.h
@@ -33,6 +33,12 @@ void __wrap_BZ2_bzWrite(int* bzerror,
                        void* buf,
                        int len);
 
+void __wrap_BZ2_bzWriteClose(int* bzerror,
+                               BZFILE* f,
+                               int abandon,
+                               unsigned int* nbytes_in,
+                               unsigned int* nbytes_out);
+
 BZFILE* __wrap_BZ2_bzWriteOpen(int* bzerror,
                                FILE* f,
                                int blockSize100k,


### PR DESCRIPTION
This PR aims to fix the following defects:

- **CID 1503042**: Resource leak in `bzip2_compress()`. This is false positive, but the fix will silence it.
- **CID 1503038**: Resource leak in `bzip2_uncompress()`. Same as above, in another function.
- **CID 1503037**: Unchecked return value of `curl_easy_opt()` in `wurl_http_get()`.
- **CID 1503033**:  Use after free in `bzip2_compress()`. This also seems a false positive as the return value of `bzWriteClose` was checked, but we would call `bzWriteClose()` again.
- **CID 1503030**: Unchecked return value of `fseek()` in`jqueue_parse_json()`.
- **CID 1503029**: Unchecked return value of `curl_easy_opt()` in `wurl_get()`.

### Dismissed defects

- **CID 1503041**: Wleep in `local_add()`. We assume Authd may sleep if Wazuh DB stops.
- **CID 1503036**:  Buffer overrun in `realtime_process()`. The buffer offset is given by the kernel, we can trust it.
- **CID 1503035**:  Uninitialized variable `key` in `OS_BF_Str()`. We just call `BF_set_key()` to set the value of `key`.

## Tests

- [X] Compile manager for Linux.
- [X] Run unit tests for the manager.
- [ ] Update the Vuln Detector feeds to check the bzip2 and curl helper libraries.