### PR TITLE
Extended ip_update_interval functionality to windows agent

### DIFF
--- a/src/unit_tests/win32/CMakeLists.txt
+++ b/src/unit_tests/win32/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Generate win32 library
+file(GLOB win32_files
+    ${SRC_FOLDER}/win32/*.o)
+
+list(REMOVE_ITEM win32_files ${SRC_FOLDER}/win32/main.o)
+
+#${SRC_FOLDER}/monitord/*.o
+
+add_library(WIN32 STATIC ${win32_files})
+
+set_source_files_properties(
+    ${win32_files}
+    PROPERTIES
+    EXTERNAL_OBJECT true
+    GENERATED true
+)
+
+set_target_properties(
+    WIN32
+    PROPERTIES
+    LINKER_LANGUAGE C
+)
+
+target_link_libraries(WIN32 ${WAZUHLIB} ${WAZUHEXT} -lpthread)
+
+# Generate win32 tests
+list(APPEND win32_names "test_win_utils")
+list(APPEND win32_flags "-Wl,--wrap,__merror -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,cJSON_GetArraySize \
+                        -Wl,--wrap,cJSON_GetArrayItem -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,time")
+
+list(LENGTH win32_names count)
+math(EXPR count "${count} - 1")
+foreach(counter RANGE ${count})
+    list(GET win32_names ${counter} win32_test_name)
+    list(GET win32_flags ${counter} win32_test_flags)
+
+    add_executable(${win32_test_name} ${win32_test_name}.c)
+
+    target_link_libraries(
+        ${win32_test_name}
+        ${WAZUHLIB}
+        ${WAZUHEXT}
+        WIN32
+        ${TEST_DEPS}
+    )
+
+    if(NOT win32_test_flags STREQUAL " ")
+        target_link_libraries(
+            ${win32_test_name}
+            ${win32_test_flags}
+        )
+    endif()
+    add_test(NAME ${win32_test_name} COMMAND ${win32_test_name})
+endforeach()

--- a/src/unit_tests/win32/CMakeLists.txt
+++ b/src/unit_tests/win32/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(WIN32 ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 
 # Generate win32 tests
 list(APPEND win32_names "test_win_utils")
-list(APPEND win32_flags "-Wl,--wrap,__merror -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,cJSON_GetArraySize \
+list(APPEND win32_flags "-Wl,--wrap,_merror -Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,cJSON_GetArraySize \
                         -Wl,--wrap,cJSON_GetArrayItem -Wl,--wrap,cJSON_GetStringValue -Wl,--wrap,time")
 
 list(LENGTH win32_names count)

--- a/src/unit_tests/win32/test_win_utils.c
+++ b/src/unit_tests/win32/test_win_utils.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2015-2021, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "../../client-agent/agentd.h"
+#include "../wrappers/externals/cJSON/cJSON_wrappers.h"
+#include "../wrappers/common.h"
+#include "../../data_provider/include/sysInfo.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+
+#ifdef TEST_WINAGENT
+
+#define TIME_INCREMENT ((time_t)(60))
+
+extern sysinfo_networks_func sysinfo_network_ptr;
+extern sysinfo_free_result_func sysinfo_free_result_ptr;
+
+static agent global_config = { .main_ip_update_interval = (int)TIME_INCREMENT };
+static int test_case_selector = 0;
+static int error_code_sysinfo_network = 0;
+
+int mock_sysinfo_networks_func(cJSON** object) {
+
+    char* ip_update_success = {"{ \"iface\": [ { \"gateway\":\"mock_gateway\", \"IPv4\": { \"address\":\"111.222.333.444\" } } ] }"};
+    char* iface_bad_name = {"{\"iface_fail\":[]}"};
+    char* iface_no_elements = {"{\"iface\":[]"};
+    char* gateway_unknown = {"{ \"iface\": [ { \"gateway\":\"unknown\" } ] }"};
+    char* json_string = 0;
+
+    switch(test_case_selector){
+        case 1:
+            json_string = ip_update_success;
+            break;
+        case 2:
+            json_string = iface_bad_name;
+            break;
+        case 3:
+            json_string = iface_no_elements;
+            break;
+        case 4:
+            json_string = gateway_unknown;
+            break;
+    }
+
+    *object = cJSON_Parse(json_string);
+
+    return error_code_sysinfo_network;
+}
+
+void mock_sysinfo_free_result_func(cJSON** object){
+    cJSON_free(object);
+    return;
+}
+
+static int setup_group(void **state) {
+    agt = &global_config;
+    time_mock_value = 0;
+    sysinfo_network_ptr = mock_sysinfo_networks_func;
+    sysinfo_free_result_ptr = mock_sysinfo_free_result_func;
+
+    return 0;
+}
+
+static void test_get_agent_ip_update_ip_success(void** state){
+
+    char* agent_ip = {"\0"};
+    time_mock_value += TIME_INCREMENT+1;
+    char* address = {"111.222.333.444"};
+    error_code_sysinfo_network = 0;
+    test_case_selector = 1;
+
+    agent_ip = get_agent_ip();
+
+    assert_string_equal(agent_ip,address);
+
+}
+
+static void test_get_agent_ip_sysinfo_error(void** state){
+
+    char* agent_ip = {"\0"};
+    char* address = {"\0"};
+    time_mock_value += TIME_INCREMENT+1;
+    error_code_sysinfo_network = 2;
+    test_case_selector = 1;
+    expect_string(__wrap__merror,formatted_msg,"Unable to get system network information. Error code: 2.");
+    agent_ip = get_agent_ip();
+
+    assert_string_equal(agent_ip,address);
+}
+
+static void test_get_agent_ip_iface_bad_name(void** state){
+
+    char* agent_ip = {"\0"};
+    char* address = {"\0"};
+    time_mock_value += TIME_INCREMENT+1;
+    error_code_sysinfo_network = 0;
+    test_case_selector = 2;
+
+    agent_ip = get_agent_ip();
+
+    assert_string_equal(agent_ip,address);
+}
+
+static void test_get_agent_ip_iface_no_elements(void** state){
+
+    char* agent_ip = {"\0"};
+    char* address = {"\0"};
+    time_mock_value += TIME_INCREMENT+1;
+    error_code_sysinfo_network = 0;
+    test_case_selector = 3;
+
+    agent_ip = get_agent_ip();
+
+    assert_string_equal(agent_ip,address);
+}
+
+static void test_get_agent_ip_gateway_unknown(void** state){
+
+    char* agent_ip = {"\0"};
+    char* address = {"\0"};
+    time_mock_value += TIME_INCREMENT+1;
+    error_code_sysinfo_network = 0;
+    test_case_selector = 4;
+
+    agent_ip = get_agent_ip();
+
+    assert_string_equal(agent_ip,address);
+}
+
+static void test_get_agent_ip_no_update(void** state){
+
+    char* agent_ip = {"\0"};
+    char* address = {"\0"};
+    time_mock_value += TIME_INCREMENT;
+
+    agent_ip = get_agent_ip();
+
+    assert_string_equal(agent_ip,address);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_get_agent_ip_update_ip_success),
+        cmocka_unit_test(test_get_agent_ip_sysinfo_error),
+        cmocka_unit_test(test_get_agent_ip_iface_bad_name),
+        cmocka_unit_test(test_get_agent_ip_iface_no_elements),
+        cmocka_unit_test(test_get_agent_ip_gateway_unknown),
+        cmocka_unit_test(test_get_agent_ip_no_update),
+    };
+
+    return cmocka_run_group_tests(tests, setup_group, NULL);
+}
+
+#endif

--- a/src/unit_tests/win32/test_win_utils.c
+++ b/src/unit_tests/win32/test_win_utils.c
@@ -29,27 +29,28 @@ static agent global_config = { .main_ip_update_interval = (int)TIME_INCREMENT };
 static int test_case_selector = 0;
 static int error_code_sysinfo_network = 0;
 
-int mock_sysinfo_networks_func(cJSON** object) {
+int mock_sysinfo_networks_func(cJSON **object) {
 
-    char* ip_update_success = {"{ \"iface\": [ { \"gateway\":\"mock_gateway\", \"IPv4\": { \"address\":\"111.222.333.444\" } } ] }"};
-    char* iface_bad_name = {"{\"iface_fail\":[]}"};
-    char* iface_no_elements = {"{\"iface\":[]"};
-    char* gateway_unknown = {"{ \"iface\": [ { \"gateway\":\"unknown\" } ] }"};
-    char* json_string = 0;
+    static const char *ip_update_success =
+    "{ \"iface\": [ { \"gateway\":\"mock_gateway\", \"IPv4\": { \"address\":\"111.222.333.444\" } } ] }";
+    static const char *iface_bad_name = "{\"iface_fail\":[]}";
+    static const char *iface_no_elements = "{\"iface\":[]";
+    static const char *gateway_unknown = "{ \"iface\": [ { \"gateway\":\"unknown\" } ] }";
+    char *json_string = NULL;
 
-    switch(test_case_selector){
-        case 1:
-            json_string = ip_update_success;
-            break;
-        case 2:
-            json_string = iface_bad_name;
-            break;
-        case 3:
-            json_string = iface_no_elements;
-            break;
-        case 4:
-            json_string = gateway_unknown;
-            break;
+    switch (test_case_selector) {
+    case 1:
+        json_string = ip_update_success;
+        break;
+    case 2:
+        json_string = iface_bad_name;
+        break;
+    case 3:
+        json_string = iface_no_elements;
+        break;
+    case 4:
+        json_string = gateway_unknown;
+        break;
     }
 
     *object = cJSON_Parse(json_string);
@@ -57,8 +58,8 @@ int mock_sysinfo_networks_func(cJSON** object) {
     return error_code_sysinfo_network;
 }
 
-void mock_sysinfo_free_result_func(cJSON** object){
-    cJSON_free(object);
+void mock_sysinfo_free_result_func(cJSON **object) {
+    cJSON_free(*object);
     return;
 }
 
@@ -71,91 +72,87 @@ static int setup_group(void **state) {
     return 0;
 }
 
-static void test_get_agent_ip_update_ip_success(void** state){
+static void test_get_agent_ip_update_ip_success(void **state) {
 
-    char* agent_ip = {"\0"};
-    time_mock_value += TIME_INCREMENT+1;
-    char* address = {"111.222.333.444"};
+    char *agent_ip = { "\0" };
+    char *address = { "111.222.333.444" };
+    time_mock_value += TIME_INCREMENT + 1;
     error_code_sysinfo_network = 0;
     test_case_selector = 1;
 
     agent_ip = get_agent_ip();
 
-    assert_string_equal(agent_ip,address);
-
+    assert_string_equal(agent_ip, address);
 }
 
-static void test_get_agent_ip_sysinfo_error(void** state){
+static void test_get_agent_ip_sysinfo_error(void **state) {
 
-    char* agent_ip = {"\0"};
-    char* address = {"\0"};
-    time_mock_value += TIME_INCREMENT+1;
+    char *agent_ip = { "\0" };
+    char *address = { "\0" };
+    time_mock_value += TIME_INCREMENT + 1;
     error_code_sysinfo_network = 2;
     test_case_selector = 1;
-    expect_string(__wrap__merror,formatted_msg,"Unable to get system network information. Error code: 2.");
+    expect_string(__wrap__merror, formatted_msg, "Unable to get system network information. Error code: 2.");
     agent_ip = get_agent_ip();
 
-    assert_string_equal(agent_ip,address);
+    assert_string_equal(agent_ip, address);
 }
 
-static void test_get_agent_ip_iface_bad_name(void** state){
+static void test_get_agent_ip_iface_bad_name(void **state) {
 
-    char* agent_ip = {"\0"};
-    char* address = {"\0"};
-    time_mock_value += TIME_INCREMENT+1;
+    char *agent_ip = { "\0" };
+    char *address = { "\0" };
+    time_mock_value += TIME_INCREMENT + 1;
     error_code_sysinfo_network = 0;
     test_case_selector = 2;
 
     agent_ip = get_agent_ip();
 
-    assert_string_equal(agent_ip,address);
+    assert_string_equal(agent_ip, address);
 }
 
-static void test_get_agent_ip_iface_no_elements(void** state){
+static void test_get_agent_ip_iface_no_elements(void **state) {
 
-    char* agent_ip = {"\0"};
-    char* address = {"\0"};
-    time_mock_value += TIME_INCREMENT+1;
+    char *agent_ip = { "\0" };
+    char *address = { "\0" };
+    time_mock_value += TIME_INCREMENT + 1;
     error_code_sysinfo_network = 0;
     test_case_selector = 3;
 
     agent_ip = get_agent_ip();
 
-    assert_string_equal(agent_ip,address);
+    assert_string_equal(agent_ip, address);
 }
 
-static void test_get_agent_ip_gateway_unknown(void** state){
+static void test_get_agent_ip_gateway_unknown(void **state) {
 
-    char* agent_ip = {"\0"};
-    char* address = {"\0"};
-    time_mock_value += TIME_INCREMENT+1;
+    char *agent_ip = { "\0" };
+    char *address = { "\0" };
+    time_mock_value += TIME_INCREMENT + 1;
     error_code_sysinfo_network = 0;
     test_case_selector = 4;
 
     agent_ip = get_agent_ip();
 
-    assert_string_equal(agent_ip,address);
+    assert_string_equal(agent_ip, address);
 }
 
-static void test_get_agent_ip_no_update(void** state){
+static void test_get_agent_ip_no_update(void **state) {
 
-    char* agent_ip = {"\0"};
-    char* address = {"\0"};
+    char *agent_ip = { "\0" };
+    char *address = { "\0" };
     time_mock_value += TIME_INCREMENT;
 
     agent_ip = get_agent_ip();
 
-    assert_string_equal(agent_ip,address);
+    assert_string_equal(agent_ip, address);
 }
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_get_agent_ip_update_ip_success),
-        cmocka_unit_test(test_get_agent_ip_sysinfo_error),
-        cmocka_unit_test(test_get_agent_ip_iface_bad_name),
-        cmocka_unit_test(test_get_agent_ip_iface_no_elements),
-        cmocka_unit_test(test_get_agent_ip_gateway_unknown),
-        cmocka_unit_test(test_get_agent_ip_no_update),
+        cmocka_unit_test(test_get_agent_ip_update_ip_success), cmocka_unit_test(test_get_agent_ip_sysinfo_error),
+        cmocka_unit_test(test_get_agent_ip_iface_bad_name),    cmocka_unit_test(test_get_agent_ip_iface_no_elements),
+        cmocka_unit_test(test_get_agent_ip_gateway_unknown),   cmocka_unit_test(test_get_agent_ip_no_update),
     };
 
     return cmocka_run_group_tests(tests, setup_group, NULL);

--- a/src/unit_tests/winagent.cmake
+++ b/src/unit_tests/winagent.cmake
@@ -79,3 +79,4 @@ set(TEST_EVENT_DEPS -Wl,--start-group ${WAZUHLIB} ${WAZUHEXT} DEPENDENCIES_O -Wl
 add_subdirectory(client-agent)
 add_subdirectory(wazuh_modules)
 add_subdirectory(os_execd)
+add_subdirectory(win32)

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -357,9 +357,18 @@ int StartMQ(__attribute__((unused)) const char *path, __attribute__((unused)) sh
 
 char *get_agent_ip()
 {
-    char *agent_ip = NULL;
-
+    static char agent_ip[IPSIZE + 1] = { '\0' };
+    static time_t last_update = 0;
+    time_t now = time(NULL);
     cJSON *object;
+
+    if ((now - last_update) < agt->main_ip_update_interval) {
+        return strdup(agent_ip);
+    }
+
+    last_update = now;
+    agent_ip[0] = '\0';
+
     if (sysinfo_network_ptr && sysinfo_free_result_ptr) {
         const int error_code = sysinfo_network_ptr(&object);
         if (error_code == 0) {
@@ -381,7 +390,7 @@ char *get_agent_ip()
                             cJSON *address = cJSON_GetObjectItem(ipv4, "address");
                             if (address && cJSON_GetStringValue(address))
                             {
-                                os_strdup(address->valuestring, agent_ip);
+                                strncpy(agent_ip, address->valuestring, IPSIZE);
                                 break;
                             }
                         }
@@ -394,7 +403,12 @@ char *get_agent_ip()
             merror("Unable to get system network information. Error code: %d.", error_code);
         }
     }
-    return agent_ip;
+
+    if(agent_ip[0]=='\0'){
+        last_update = 0;
+    }
+
+    return strdup(agent_ip);
 }
 
 #endif

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -404,7 +404,7 @@ char *get_agent_ip()
         }
     }
 
-    if(agent_ip[0]=='\0'){
+    if (agent_ip[0] == '\0') {
         last_update = 0;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|#7775|


## Description

Added the check of ip_update_interval tag for windows agents in win_utils.c

Note: agentd integration tests fails equally in this branch and master (windows platform), in both local and jenkins. After reviewing the report, the failures do not seem to be problem of this PR. Jenkins (current): 
[windows_agent_tests_agentd.zip](https://github.com/wazuh/wazuh/files/6316494/windows_agent_tests_agentd.zip)
, Local (current): [agentd_win_report.zip](https://github.com/wazuh/wazuh/files/6229186/agentd_win_report.zip) , Local (master): [agentd_win_report_master.zip](https://github.com/wazuh/wazuh/files/6237256/agentd_win_report_master.zip)

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [X] Windows
  - [ ] MAC OS X


<!-- Depending on the affected OS -->
- Memory tests for Windows
  - [X] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory

