### PR TITLE
Fix Framework and API Makefiles to support installing in a custom path

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -5,7 +5,7 @@
 # Syntax: make [ all | backup | install | restore | service ]
 
 OSSEC_GROUP       = ossec
-INSTALLDIR        = /var/ossec
+INSTALLDIR       ?= /var/ossec
 
 RM_FILE        = rm -f
 INSTALL_DIR    = install -o root -g ${OSSEC_GROUP} -m 0750 -d

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -5,7 +5,7 @@
 # Syntax: make [ all | build | install | examples | clean ]
 
 OSSEC_GROUP       = ossec
-INSTALLDIR        = /var/ossec
+INSTALLDIR       ?= /var/ossec
 
 CC           = gcc
 CFLAGS       = -pipe -Wall -Wextra


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh-documentation/issues/3584 |

Hi team,

This PR is related to https://github.com/wazuh/wazuh-documentation/issues/3584.

I have updated the api and framework Makefiles to support installing Wazuh in a custom path.

There was a problem when indicating a path different to `/var/ossec` when executing `install.sh`.

Python was being installed in `/var/ossec` anyway as we were hardcoding the path in the framework Makefile. I have updated the framework and api makefiles to assign `PREFIX=/var/ossec` only if `PREFIX` wasn't assigned before. This can be done adding `?` to the statement.

More information here: https://github.com/wazuh/wazuh-documentation/issues/3584#issuecomment-807132334

Regards,
Manuel