### PR TITLE
Update delays, fix and improve API integration tests

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -17,12 +17,11 @@ variables:
   login_endpoint: security/user/authenticate
 
   # delays
-  reconnect_delay: 15
-  restart_delay: 30
-  restart_delay_cluster: 120
-  upgrade_delay: 45
+  reconnect_delay: 30
+  restart_delay: 45
+  restart_delay_cluster: 150
+  upgrade_delay: 60
   global_db_delay: 20
-  active_reponse_delay: 5
 
   custom_wpk_path: "/var/ossec/test_custom_upgrade_3.12.2.wpk"
 

--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -21,7 +21,7 @@ variables:
   restart_delay: 45
   restart_delay_cluster: 150
   upgrade_delay: 60
-  global_db_delay: 20
+  global_db_delay: 30
 
   custom_wpk_path: "/var/ossec/test_custom_upgrade_3.12.2.wpk"
 

--- a/api/test/integration/env/base/agent/new.Dockerfile
+++ b/api/test/integration/env/base/agent/new.Dockerfile
@@ -9,4 +9,4 @@ RUN /wazuh/install.sh
 
 COPY base/agent/entrypoint.sh /scripts/entrypoint.sh
 
-HEALTHCHECK --retries=30 --interval=10s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1
+HEALTHCHECK --retries=300 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1

--- a/api/test/integration/env/base/agent/old.Dockerfile
+++ b/api/test/integration/env/base/agent/old.Dockerfile
@@ -2,4 +2,4 @@ FROM public.ecr.aws/o5x5t0j3/amd64/api_development:integration_test_wazuh-agent_
 
 COPY base/agent/entrypoint.sh /scripts/entrypoint.sh
 
-HEALTHCHECK --retries=30 --interval=10s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1
+HEALTHCHECK --retries=300 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1

--- a/api/test/integration/env/base/manager/manager.Dockerfile
+++ b/api/test/integration/env/base/manager/manager.Dockerfile
@@ -12,4 +12,4 @@ RUN /wazuh/install.sh
 COPY base/manager/entrypoint.sh /scripts/entrypoint.sh
 
 # HEALTHCHECK
-HEALTHCHECK --retries=30 --interval=10s --timeout=30s --start-period=30s CMD /var/ossec/framework/python/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1
+HEALTHCHECK --retries=300 --interval=1s --timeout=30s --start-period=30s CMD /var/ossec/framework/python/bin/python3 /tmp/healthcheck/healthcheck.py || exit 1

--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import socket
+import time
 from datetime import datetime
 
 
@@ -38,7 +39,14 @@ def get_agent_health_base():
         t1 = get_timestamp(output_agent_restart[-2])
         t2 = get_timestamp(output_agent_connection[-2])
 
-        return 0 if t2 > t1 else 1
+        if t2 > t1:
+            # Wait to avoid the worst case:
+            # +10 seconds for the agent to report the worker
+            # +10 seconds for the worker to report master
+            # After this time, the agent appears as active in the master node
+            time.sleep(20)
+            return 0
+
     return 1
 
 

--- a/api/test/integration/test_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_active_response_endpoints.tavern.yaml
@@ -202,7 +202,6 @@ stages:
 
     # PUT /active-response
   - name: Runs an Active Response command on all agents
-    delay_before: !float "{active_reponse_delay}"
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/active-response"

--- a/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
@@ -662,14 +662,14 @@ stages:
       json:
         <<: *error_spec
 
-    # DELETE /agents?agents_list=007&older_than=1h
+    # DELETE /agents?agents_list=007&older_than=10d
   - name: Try to delete agent with older_than param older than agent life
     request:
       verify: False
       <<: *delete_agents
       params:
         agents_list: '007'
-        older_than: '1h'
+        older_than: '10d'
         status: 'all'
     response:
       status_code: 200
@@ -686,14 +686,14 @@ stages:
           total_failed_items: 1
     delay_after: !float "{global_db_delay}"
 
-    # DELETE /agents?agents_list=009&older_than=1s
-  - name: Delete agent older_than 1s
+    # DELETE /agents?agents_list=009&older_than=0s
+  - name: Delete agent older_than 0s
     request:
       verify: False
       <<: *delete_agents
       params:
         agents_list: '009'
-        older_than: '1s'
+        older_than: '0s'
         status: 'all'
     response:
       status_code: 200
@@ -705,7 +705,7 @@ stages:
           total_affected_items: 1
     delay_after: !float "{global_db_delay}"
 
-    # DELETE /agents?agents_list=001,011&older_than=1s
+    # DELETE /agents?agents_list=001,011&older_than=0s
   - name: Delete several agents
     request:
       verify: False
@@ -725,14 +725,14 @@ stages:
           total_affected_items: 2
     delay_after: !float "{global_db_delay}"
 
-    # DELETE /agents?agents_list=012&older_than=1s&purge=True
-  - name: Delete agent older_than 1s with purge
+    # DELETE /agents?agents_list=005&older_than=0s&purge=True
+  - name: Delete agent older_than 0s with purge
     request:
       verify: False
       <<: *delete_agents
       params:
         agents_list: '005'
-        older_than: '1s'
+        older_than: '0s'
         purge: True
         status: 'all'
     response:

--- a/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
@@ -429,7 +429,6 @@ stages:
           affected_items:
             - 'group3'
           total_affected_items: 1
-    delay_after: !float "{global_db_delay}"
 
   # DELETE /groups (invalid groups_list)
   - name: Delete group3
@@ -500,6 +499,7 @@ stages:
                 - 'default'
           total_affected_items: 1
           total_failed_items: 1
+    delay_after: !float "{global_db_delay}"
 
     # DELETE /groups
   - name: Delete all groups (group2)
@@ -732,6 +732,7 @@ stages:
           affected_items:
             - '005'
           total_affected_items: 1
+    delay_after: !float "{global_db_delay}"
 
   # DELETE /agents
   - name: Delete agents ip=any and q=id<11
@@ -798,6 +799,7 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
+    delay_after: !float "{global_db_delay}"
 
     # DELETE /agents
   - name: Delete all agents (006,007,008)

--- a/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
@@ -97,7 +97,6 @@ stages:
       status_code: 200
       json:
         message: "Agent '001' removed from 'group1'."
-    delay_after: !float "{global_db_delay}"
 
     # DELETE /agents/002/group/default
   - name: Remove agent 002 from default
@@ -186,10 +185,9 @@ stages:
             - "group1"
             - "group2"
           total_affected_items: 2
-    delay_after: !float "{global_db_delay}"
 
     # DELETE /agents/008/group?groups_list=group1,group3
-  - name: Remove agent 008 from group1 and group2
+  - name: Remove agent 008 from group1 and group3
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/008/group"
@@ -207,7 +205,6 @@ stages:
             - "group1"
             - "group3"
           total_affected_items: 2
-    delay_after: !float "{global_db_delay}"
 
 ---
 test_name: DELETE /agents/group
@@ -327,7 +324,6 @@ stages:
           affected_items:
             - '008'
           total_affected_items: 1
-    delay_after: !float "{global_db_delay}"
 
   # DELETE /agents/group?group_id=group2
   - name: Remove all agents from group2 (invalid agents_list)
@@ -385,7 +381,6 @@ stages:
                 - 'wrong_group'
           total_affected_items: 0
           total_failed_items: 1
-    delay_after: !float "{global_db_delay}"
 
     # DELETE /groups?groups_list=default
   - name: Try to delete default group
@@ -505,7 +500,6 @@ stages:
                 - 'default'
           total_affected_items: 1
           total_failed_items: 1
-    delay_after: !float "{global_db_delay}"
 
     # DELETE /groups
   - name: Delete all groups (group2)
@@ -522,11 +516,10 @@ stages:
       json:
         error: 0
         data:
-          affected_agents: []
+          affected_agents: !anything
           affected_items:
             - 'group2'
           total_affected_items: 1
-    delay_after: !float "{global_db_delay}"
 
 ---
 test_name: DELETE /agents
@@ -646,7 +639,6 @@ stages:
           affected_items:
             - '004'
           total_affected_items: 1
-    delay_after: !float "{global_db_delay}"
 
     # DELETE /agents?agents_list=007&older_than=wrong
   - name: Try to delete agent with a wrong older_than param
@@ -684,7 +676,6 @@ stages:
                 - '007'
           total_affected_items: 0
           total_failed_items: 1
-    delay_after: !float "{global_db_delay}"
 
     # DELETE /agents?agents_list=009&older_than=0s
   - name: Delete agent older_than 0s
@@ -703,7 +694,6 @@ stages:
           affected_items:
             - '009'
           total_affected_items: 1
-    delay_after: !float "{global_db_delay}"
 
     # DELETE /agents?agents_list=001,011&older_than=0s
   - name: Delete several agents
@@ -723,7 +713,6 @@ stages:
             - "001"
             - "011"
           total_affected_items: 2
-    delay_after: !float "{global_db_delay}"
 
     # DELETE /agents?agents_list=005&older_than=0s&purge=True
   - name: Delete agent older_than 0s with purge
@@ -743,7 +732,6 @@ stages:
           affected_items:
             - '005'
           total_affected_items: 1
-    delay_after: !float "{global_db_delay}"
 
   # DELETE /agents
   - name: Delete agents ip=any and q=id<11

--- a/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
@@ -429,9 +429,34 @@ stages:
           affected_items:
             - 'group3'
           total_affected_items: 1
+    delay_after: !float "{global_db_delay}"
+
+  # DELETE /groups?groups_list=group3 (already deleted group)
+  - name: Delete group3
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      method: DELETE
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        groups_list: group3
+    response:
+      status_code: 200
+      json:
+        error: 1
+        data:
+          affected_items: []
+          total_affected_items: 0
+          failed_items:
+            - error:
+                code: 1710
+              id:
+                - 'group3'
+          total_failed_items: 1
 
   # DELETE /groups (invalid groups_list)
-  - name: Delete group3
+  - name: Delete groups with no groups_list
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/groups"
@@ -440,6 +465,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 400
+      json:
+        <<: *error_spec
 
 ---
 test_name: DELETE /groups (several groups)
@@ -516,7 +543,7 @@ stages:
       json:
         error: 0
         data:
-          affected_agents: !anything
+          affected_agents: []
           affected_items:
             - 'group2'
           total_affected_items: 1

--- a/api/test/integration/test_agent_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_POST_endpoints.tavern.yaml
@@ -88,7 +88,6 @@ stages:
       status_code: 200
       json:
         <<: *agent_create_response
-    delay_after: !float "{global_db_delay}"
 
     # POST /agents
   - name: Create agent with an specific IP
@@ -159,7 +158,6 @@ stages:
       status_code: 200
       json:
         <<: *agent_create_response
-    delay_after: !float "{global_db_delay}"
 
 ---
 test_name: POST /agents (no IP)
@@ -220,7 +218,6 @@ stages:
       status_code: 200
       json:
         message: !anystr
-    delay_after: !float "{global_db_delay}"
 
     # POST /groups
   - name: Try to create a group that already exists
@@ -361,7 +358,6 @@ stages:
       status_code: 200
       json:
         <<: *agent_create_response
-    delay_after: !float "{global_db_delay}"
 
     # POST /agents/insert
   - name: Create a new agent using a manual IP
@@ -437,7 +433,6 @@ stages:
       status_code: 200
       json:
         <<: *agent_create_response
-    delay_after: !float "{global_db_delay}"
 
 ---
 test_name: POST /agents/insert/quick

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -634,7 +634,7 @@ test_name: PUT /agents/{agent_id}/group/{group_id}
 
 stages:
 
-  # PUT /agents/001/group/group2
+  # PUT /agents/001/group/group1
   - name: Assign agent 001 to group1
     request:
       verify: False
@@ -650,7 +650,6 @@ stages:
           affected_items:
             - "001"
           total_affected_items: 1
-    delay_after: !float "{restart_delay}"
 
     # PUT /agents/wrong_id/group/group1
   - name: Try to assign an agent with an invalid id
@@ -687,11 +686,11 @@ stages:
           total_affected_items: 0
           total_failed_items: 1
 
-    # PUT /agents/001/group/group3?force_single_group=true
-  - name: Assign agent 001 to group3 with force_single_group
+    # PUT /agents/002/group/group3?force_single_group=true
+  - name: Assign agent 002 to group3 with force_single_group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group3?force_single_group=true"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/002/group/group3?force_single_group=true"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -703,9 +702,8 @@ stages:
         error: 0
         data:
           affected_items:
-            - "001"
+            - "002"
           total_affected_items: 1
-    delay_after: !float "{restart_delay}"
 
 ---
 test_name: PUT /agents/{agent_id}/restart
@@ -769,11 +767,11 @@ stages:
       json:
         <<: *error_spec
 
-    # PUT /agents/002/restart
+    # PUT /agents/003/restart
   - name: Restart an agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/002/restart"
+      url: "{protocol:s}://{host:s}:{port:d}/agents/003/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -783,7 +781,7 @@ stages:
         error: 0
         data:
           affected_items:
-            - "002"
+            - "003"
           total_affected_items: 1
     delay_after: !float "{restart_delay}"
 

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -342,7 +342,6 @@ stages:
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
-        content-type: "application/xml"
     response:
       status_code: 200
       json:
@@ -361,7 +360,6 @@ stages:
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
-        content-type: "application/xml"
     response:
       status_code: 200
       json:
@@ -394,7 +392,6 @@ stages:
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
-        content-type: "application/xml"
     response:
       <<: *resource_not_found_group
 

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -761,7 +761,7 @@ stages:
     response:
       <<: *permission_denied
 
-  - name: Remove agent 009 from all groups Partially allowed, user agnostic)
+  - name: Remove agent 009 from all groups (Partially allowed, user agnostic)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/009/group"
@@ -807,7 +807,6 @@ stages:
                 - 'group3'
           total_affected_items: 0
           total_failed_items: 3
-    delay_after: !float "{global_db_delay}"
 
 ---
 test_name: DELETE /agents/group?group_id=group_id
@@ -846,7 +845,6 @@ stages:
           failed_items: []
           total_affected_items: 0
           total_failed_items: 0
-    delay_after: !float "{global_db_delay}"
 
   - name: Remove a list of agents from group1 (Partially allowed, user aware)
     request:
@@ -878,7 +876,6 @@ stages:
                 - '999'
           total_affected_items: 0
           total_failed_items: 5
-    delay_after: !float "{global_db_delay}"
 
 ---
 test_name: DELETE groups?groups_list=group_id
@@ -973,7 +970,6 @@ stages:
                 - 'group2'
           total_affected_items: 0
           total_failed_items: 1
-    delay_after: !float "{global_db_delay}"
 
   - name: Try to delete a list of groups (Partially allowed, indirectly denied to delete group2, user aware)
     request:
@@ -1119,7 +1115,6 @@ stages:
                 - '006'
           total_affected_items: 1
           total_failed_items: 1
-    delay_after: !float "{global_db_delay}"
 
   - name: Try to delete a list of agents (Partially allowed, user aware)
     request:
@@ -1680,7 +1675,6 @@ stages:
         - function: tavern_utils:test_validate_restart_by_node_rbac
           extra_kwargs:
             permitted_agents: ['003','005','007'] # Agents '003', '005' and '007' can be restarted
-    delay_after: !float "{global_db_delay}"
 
   - name: Restart all agents belonging to worker1 (Allow node_id - Could deny agent_id)
     request:
@@ -1697,7 +1691,6 @@ stages:
         - function: tavern_utils:test_validate_restart_by_node_rbac
           extra_kwargs:
             permitted_agents: ['003','005','007'] # Agents '003', '005' and '007' can be restarted
-    delay_after: !float "{global_db_delay}"
 
   - name: Restart all agents belonging to worker2 (Allow node_id - Could deny agent_id)
     request:
@@ -1714,4 +1707,3 @@ stages:
         - function: tavern_utils:test_validate_restart_by_node_rbac
           extra_kwargs:
             permitted_agents: ['003','005','007'] # Agents '003', '005' and '007' can be restarted
-    delay_after: !float "{global_db_delay}"

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -133,7 +133,7 @@ test_name: GET /agents/{agent_id}/config/{component}/{configuration}
 
 stages:
 
-  - name: Try tp get Request-Agent-Client for agent 004 (Denied)
+  - name: Try to get Request-Agent-Client for agent 004 (Denied)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/004/config/agent/client"
@@ -144,7 +144,6 @@ stages:
       <<: *permission_denied
 
   - name: Get Request-Agent-Client for agent 003 (Allowed)
-    delay_before: !float "{active_reponse_delay}"
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/003/config/agent/client"
@@ -1304,7 +1303,6 @@ stages:
                 - '002'
           total_affected_items: 1
           total_failed_items: 2
-    delay_after: !float "{restart_delay}"
 
   - name: Try to assign all agents to group1 (Partially allowed, user agnostic)
     request:
@@ -1344,7 +1342,6 @@ stages:
         "{file_xml:s}"
     response:
       status_code: 200
-    delay_after: !float "{restart_delay}"
 
   - name: Try to update group3 configuration (Denied)
     request:

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -1372,7 +1372,6 @@ stages:
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
-        content-type: "application/xml"
     response:
       status_code: 403
       json:
@@ -1386,7 +1385,6 @@ stages:
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
-        content-type: "application/xml"
     response:
       status_code: 200
       json:

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -1675,6 +1675,7 @@ stages:
         - function: tavern_utils:test_validate_restart_by_node_rbac
           extra_kwargs:
             permitted_agents: ['003','005','007'] # Agents '003', '005' and '007' can be restarted
+    delay_after: !float "{global_db_delay}"
 
   - name: Restart all agents belonging to worker1 (Allow node_id - Could deny agent_id)
     request:
@@ -1691,6 +1692,7 @@ stages:
         - function: tavern_utils:test_validate_restart_by_node_rbac
           extra_kwargs:
             permitted_agents: ['003','005','007'] # Agents '003', '005' and '007' can be restarted
+    delay_after: !float "{global_db_delay}"
 
   - name: Restart all agents belonging to worker2 (Allow node_id - Could deny agent_id)
     request:

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -137,7 +137,7 @@ test_name: GET /agents/{agent_id}/config/{component}/{configuration}
 
 stages:
 
-  - name: Try tp get Request-Agent-Client for agent 003 (Denied)
+  - name: Try to get Request-Agent-Client for agent 003 (Denied)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/003/config/agent/client"
@@ -148,7 +148,6 @@ stages:
       <<: *permission_denied
 
   - name: Get Request-Agent-Client for agent 002 (Allowed)
-    delay_before: !float "{active_reponse_delay}"
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents/002/config/agent/client"

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -744,7 +744,6 @@ stages:
       status_code: 200
       json:
         message: !anystr
-    delay_after: !float "{global_db_delay}"
 
 ---
 test_name: DELETE /agents/{agent_id}/group
@@ -791,7 +790,6 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
-    delay_after: !float "{global_db_delay}"
 
   - name: Try to remove agent 005 from all groups (Partially allowed, user agnostic)
     request:
@@ -810,7 +808,6 @@ stages:
             - 'group2'
           total_affected_items: 2
           total_failed_items: 0
-    delay_after: !float "{global_db_delay}"
 
   - name: Try to remove agent 007 from a list of groups (Partially allowed, user aware)
     request:
@@ -894,7 +891,6 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
-    delay_after: !float "{global_db_delay}"
 
   - name: Remove a list of agents from group3 (Partially allowed, user aware)
     request:
@@ -929,7 +925,6 @@ stages:
                 - '998'
           total_affected_items: 1
           total_failed_items: 4
-    delay_after: !float "{global_db_delay}"
 
   - name: Remove a list of agents from group default (Allowed)
     request:
@@ -1046,7 +1041,6 @@ stages:
                 - group1
           total_affected_items: 0
           total_failed_items: 1
-    delay_after: !float "{global_db_delay}"
 
   - name: Try to delete a list of groups (Partially allowed, indirectly denied to delete group1, user aware)
     request:
@@ -1167,7 +1161,6 @@ stages:
           failed_items: []
           total_affected_items: 2
           total_failed_items: 0
-    delay_after: !float "{global_db_delay}"
 
   - name: Try to delete a list of agents (Partially allowed, user aware)
     request:

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -1430,7 +1430,6 @@ stages:
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
-        content-type: "application/xml"
     response:
       status_code: 200
       json:


### PR DESCRIPTION
|Related issue|
|---|
| #8067 |

Hi team,

This PR closes #8067.

In this pull request, I have changed some API integration test to avoid errors caused by race conditions. I have improved other tests not failing.

**1.-** Used `older_than: 0s` when we were using 1s.

**2.-** Removed `content-type: "application/xml"` from restart tests and other tests that don't need it.

**3.-** More delay time to avoid possible race conditions:

**restart_delay**
used  4 times in `rbac_white_agent`
7 times in `rbac_black_agent`
1 time  in `rbac_black_manager`
12 times in `agent_PUT`

I have changed test cases in agent_PUT and deleted 2 restart_delays.
I have deleted 2 restart_delays in rbac_blac_agent.
Its actual value is 30 and the test takes 8 minutes. Updating it to 40 and deleting 2 delays will make the test take 100 seconds - 60 seconds (2 delays less) = 40 seconds more -> test will take 8:40 minutes. 
I will update the delay to 45 as I see we can wait 50 seconds more in total. Total test aprox: 9:30 minutes

```
test_agent_PUT_endpoints.tavern.yaml [1/3]
  9 passed, 11 warnings

test_agent_PUT_endpoints.tavern.yaml [2/3]
  9 passed, 11 warnings

test_agent_PUT_endpoints.tavern.yaml [3/3]
  9 passed, 11 warnings
```


**restart_delay_cluster**
used 2 times in `cluster`
2 times in `rbac_white_cluster`

Its actual value is 120, I will update it to 150 and therefore 1 minute per test is added.


**upgrade_delay**
used 1 time in `agent_PUT`

Its actual value is 45, I will update it to 60.


**global_db_delay**
used 11 times in `agent_POST`
16 times in `agent_DELETE`
14 times in `rbac_black_agent`
15 times in `rbac_white_agent`

I have removed a lot of delays from those tests. 10 removed from agent_DELETE, 5 removed from agent_POST, 7 removed from rbac_white_agent and 8 removed from rbac_black_agent.
Updated from 20 to 30.

```
test_agent_DELETE_endpoints.tavern.yaml [1/3]
  6 passed, 8 warnings

test_agent_DELETE_endpoints.tavern.yaml [2/3]
  6 passed, 8 warnings

test_agent_DELETE_endpoints.tavern.yaml [3/3]
  6 passed, 8 warnings
```

```
test_agent_POST_endpoints.tavern.yaml [1/3]
  5 passed, 7 warnings

test_agent_POST_endpoints.tavern.yaml [2/3]
  5 passed, 7 warnings

test_agent_POST_endpoints.tavern.yaml [3/3]
  5 passed, 7 warnings
```

**active_response_delay**
used  1 time in `active_response`
1 time in `rbac_black_agent`
1 time in `rbac_white_agent`

Used with delay_before, I have updated this case.
I have removed the active response delay.

```
test_active_response_endpoints.tavern.yaml 
  2 passed, 4 warnings

test_rbac_white_agent_endpoints.tavern.yaml 
  40 passed, 42 warnings

test_rbac_black_agent_endpoints.tavern.yaml 
  40 passed, 42 warnings
```

**force_reconnect_delay**
I have also updated force_reconnect delay in a different pull request.
	

**4.-** Changed docker healthchecks to 300 retries and interval 1 sec.

**5.-** Added delay to `get_agent_health_base` to avoid a known race condition. This way we ensure agent is active in the master node.

Regards,
Manuel