### PR TITLE
Update reconnect delay for the API integration tests

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -17,7 +17,7 @@ variables:
   login_endpoint: security/user/authenticate
 
   # delays
-  reconnect_delay: 15
+  reconnect_delay: 30
   restart_delay: 30
   restart_delay_cluster: 120
   upgrade_delay: 45


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/8067 |

This pull request and https://github.com/wazuh/wazuh/pull/8079 close #8067.

This PR updates the delay used for the reconnect endpoint tests.

This delay is now higher to avoid random test fails due to race conditions. This is detailed in section 3 of the PR 8079 or issue 8067.

Regards,
Manuel.