### PR TITLE
Revised UTs of wdb insert command

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -20,7 +20,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                         -Wl,--wrap,sqlite3_changes -Wl,--wrap,sqlite3_bind_int -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,sqlite3_last_insert_rowid \
                         -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_open_agent2 -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_agents_insert_vuln_cves \
                         -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cves -Wl,--wrap,wdb_agents_update_status_vuln_cves \
-                        -Wl,--wrap,wdb_agents_remove_vuln_cves -Wl,--wrap,wdb_agents_remove_by_status_vuln_cves")
+                        -Wl,--wrap,wdb_agents_remove_vuln_cves -Wl,--wrap,wdb_agents_remove_by_status_vuln_cves -Wl,--wrap,cJSON_PrintUnformatted")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \
@@ -69,7 +69,8 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                              -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_AddNumberToObject \
                              -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_GetObjectItem \
                              -Wl,--wrap,cJSON_ParseWithOpts -Wl,--wrap,cJSON_Delete -Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_parse_result \
-                             -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_Duplicate -Wl,--wrap,wdbc_query_parse_json -Wl,--wrap,wdbc_query_parse")
+                             -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,cJSON_Duplicate -Wl,--wrap,wdbc_query_parse_json -Wl,--wrap,wdbc_query_parse \
+                             -Wl,--wrap,cJSON_AddBoolToObject")
 
 list(APPEND wdb_tests_names "test_wdb")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,pthread_mutex_lock \

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -49,38 +49,326 @@ static int test_teardown(void **state){
     return 0;
 }
 
-/* Tests wdb_agents_insert_vuln_cves */
+/* Tests wdb_agents_find_package */
 
-void test_wdb_agents_insert_vuln_cves_statement_init_fail(void **state)
-{
-    int ret = -1;
+void test_wdb_agents_find_package_statement_init_fail(void **state){
+    bool ret = FALSE;
     test_struct_t *data  = (test_struct_t *)*state;
-    const char* name = "package";
-    const char* version = "4.0";
-    const char* architecture = "x86";
-    const char* cve = "CVE-2021-1200";
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
 
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_PROGRAM_FIND);
     will_return(__wrap_wdb_init_stmt_in_cache, NULL);
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_INSERT);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve);
+    ret = wdb_agents_find_package(data->wdb, reference);
 
-    assert_int_equal(ret, OS_INVALID);
+    assert_false(ret);
 }
 
-void test_wdb_agents_insert_vuln_cves_success(void **state)
+void test_wdb_agents_find_package_success_row(void **state){
+    bool ret = FALSE;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_PROGRAM_FIND);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_ROW);
+
+    ret = wdb_agents_find_package(data->wdb, reference);
+
+    assert_true(ret);
+}
+
+void test_wdb_agents_find_package_success_done(void **state){
+    bool ret = FALSE;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_PROGRAM_FIND);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    ret = wdb_agents_find_package(data->wdb, reference);
+
+    assert_false(ret);
+}
+
+void test_wdb_agents_find_package_error(void **state){
+    bool ret = FALSE;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_PROGRAM_FIND);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_ERROR);
+    
+    will_return(__wrap_sqlite3_errmsg, "test_sql_no_done");
+    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) sqlite3_step(): test_sql_no_done");
+
+    ret = wdb_agents_find_package(data->wdb, reference);
+
+    assert_false(ret);
+}
+
+/* Tests wdb_agents_find_cve */
+
+void test_wdb_agents_find_cve_statement_init_fail(void **state){
+    bool ret = FALSE;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* cve = "CVE-2021-1200";
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+
+    ret = wdb_agents_find_cve(data->wdb, cve, reference);
+
+    assert_false(ret);
+}
+
+void test_wdb_agents_find_cve_success_row(void **state){
+    bool ret = FALSE;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* cve = "CVE-2021-1200";
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_ROW);
+
+    ret = wdb_agents_find_cve(data->wdb, cve, reference);
+
+    assert_true(ret);
+}
+
+void test_wdb_agents_find_cve_success_done(void **state){
+    bool ret = FALSE;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* cve = "CVE-2021-1200";
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    ret = wdb_agents_find_cve(data->wdb, cve, reference);
+
+    assert_false(ret);
+}
+
+void test_wdb_agents_find_cve_error(void **state){
+    bool ret = FALSE;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* cve = "CVE-2021-1200";
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_ERROR);
+
+    will_return(__wrap_sqlite3_errmsg, "test_sql_no_done");
+    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) sqlite3_step(): test_sql_no_done");
+
+    ret = wdb_agents_find_cve(data->wdb, cve, reference);
+
+    assert_false(ret);
+}
+
+/* Tests wdb_agents_insert_vuln_cves */
+
+void test_wdb_agents_insert_vuln_cves_error_json(void **state)
 {
-    int ret = -1;
+    cJSON *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* name = "package";
     const char* version = "4.0";
     const char* architecture = "x86";
     const char* cve = "CVE-2021-1200";
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+    const char* type = "PACKAGE";
+    const char* status = "VALID";
+    bool check_pkg_existance = true;
 
+    will_return(__wrap_cJSON_CreateObject, NULL);
+
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existance);
+
+    assert_null(ret);
+}
+
+void test_wdb_agents_insert_vuln_cves_success_pkg_not_found(void **state)
+{
+    cJSON *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* name = "package";
+    const char* version = "4.0";
+    const char* architecture = "x86";
+    const char* cve = "CVE-2021-1200";
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+    const char* type = "PACKAGE";
+    const char* status = "VALID";
+    bool check_pkg_existance = true;
+
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
+    
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
-    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_INSERT);
-
+    
     will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_ROW);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "action");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "UPDATE");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_PROGRAM_FIND);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "PKG_NOT_FOUND");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existance);
+
+    assert_ptr_equal(1, ret);
+}
+
+void test_wdb_agents_insert_vuln_cves_success_statement_init_fail(void **state)
+{
+    cJSON *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* name = "package";
+    const char* version = "4.0";
+    const char* architecture = "x86";
+    const char* cve = "CVE-2021-1200";
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+    const char* type = "PACKAGE";
+    const char* status = "VALID";
+    bool check_pkg_existance = true;
+
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
+    
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "action");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "INSERT");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_PROGRAM_FIND);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_ROW);
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_INSERT);
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "ERROR");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existance);
+
+    assert_ptr_equal(1, ret);
+}
+
+void test_wdb_agents_insert_vuln_cves_success_statement_exec_fail(void **state)
+{
+    cJSON *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* name = "package";
+    const char* version = "4.0";
+    const char* architecture = "x86";
+    const char* cve = "CVE-2021-1200";
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+    const char* type = "PACKAGE";
+    const char* status = "VALID";
+    bool check_pkg_existance = true;
+
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
+    
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "action");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "INSERT");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_PROGRAM_FIND);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_ROW);
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_INSERT);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, name);
     expect_value(__wrap_sqlite3_bind_text, pos, 2);
@@ -89,12 +377,93 @@ void test_wdb_agents_insert_vuln_cves_success(void **state)
     expect_string(__wrap_sqlite3_bind_text, buffer, architecture);
     expect_value(__wrap_sqlite3_bind_text, pos, 4);
     expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, type);
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_string(__wrap_sqlite3_bind_text, buffer, status);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_INVALID);
+
+    will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
+    expect_string(__wrap__mdebug1, formatted_msg, "Exec statement error ERROR MESSAGE");
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "ERROR");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existance);
+
+    assert_ptr_equal(1, ret);
+}
+
+
+void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state)
+{
+    cJSON *ret = NULL;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* name = "package";
+    const char* version = "4.0";
+    const char* architecture = "x86";
+    const char* cve = "CVE-2021-1200";
+    const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
+    const char* type = "PACKAGE";
+    const char* status = "VALID";
+    bool check_pkg_existance = true;
+
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
+    
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_DONE);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "action");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "INSERT");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_PROGRAM_FIND);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+
+    expect_sqlite3_step_call(SQLITE_ROW);
+
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_INSERT);
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, name);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, version);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_string(__wrap_sqlite3_bind_text, buffer, architecture);
+    expect_value(__wrap_sqlite3_bind_text, pos, 4);
+    expect_string(__wrap_sqlite3_bind_text, buffer, cve);
+    expect_value(__wrap_sqlite3_bind_text, pos, 5);
+    expect_string(__wrap_sqlite3_bind_text, buffer, reference);
+    expect_value(__wrap_sqlite3_bind_text, pos, 6);
+    expect_string(__wrap_sqlite3_bind_text, buffer, type);
+    expect_value(__wrap_sqlite3_bind_text, pos, 7);
+    expect_string(__wrap_sqlite3_bind_text, buffer, status);
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 
-    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve);
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "SUCCESS");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    assert_int_equal(ret, OS_SUCCESS);
+    ret = wdb_agents_insert_vuln_cves(data->wdb, name, version, architecture, cve, reference, type, status, check_pkg_existance);
+
+    assert_ptr_equal(1, ret);
 }
 
 /* Tests wdb_agents_update_status_vuln_cves*/
@@ -408,9 +777,22 @@ void test_wdb_agents_clear_vuln_cves_success(void **state)
 int main()
 {
     const struct CMUnitTest tests[] = {
+        /* Tests wdb_agents_find_package */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_find_package_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_find_package_success_row, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_find_package_success_done, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_find_package_error, test_setup, test_teardown),
+        /* Tests wdb_agents_find_cve */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_find_cve_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_find_cve_success_row, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_find_cve_success_done, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_find_cve_error, test_setup, test_teardown),
         /* Tests wdb_agents_insert_vuln_cves */
-        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_statement_init_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_error_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success_pkg_not_found, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success_statement_exec_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success_pkg_found, test_setup, test_teardown),
         /* Tests wdb_agents_update_status_vuln_cves */
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_success, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -42,80 +42,41 @@ int teardown_wdb_agents_helpers(void **state) {
 
 void test_wdb_agents_vuln_cves_insert_error_json(void **state)
 {
-    int ret = 0;
+    cJSON *ret = NULL;
     int id = 1;
     const char *name = "test_package";
     const char *version = "1.0";
     const char *architecture = "x86";
     const char *cve = "CVE-2021-1001";
+    const char *reference = "69ac04fa9b4a0dcfccd7c2237b366e501b678cc7";
+    const char *type = "PACKAGE";
+    const char *status = "VALID";
+    bool check_pkg_existance = true;
 
     will_return(__wrap_cJSON_CreateObject, NULL);
 
     expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
 
-    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, NULL);
+    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, reference, type, status, check_pkg_existance, NULL);
 
-    assert_int_equal(OS_INVALID, ret);
-}
-
-void test_wdb_agents_vuln_cves_insert_error_socket(void **state)
-{
-    int ret = 0;
-    int id = 1;
-    const char *name = "test_package";
-    const char *version = "1.0";
-    const char *architecture = "x86";
-    const char *cve = "CVE-2021-1001";
-
-    const char *json_str = strdup("{\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
-    const char *query_str = "agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
-    const char *response = "err";
-
-    will_return(__wrap_cJSON_CreateObject, 1);
-    will_return_always(__wrap_cJSON_AddStringToObject, 1);
-
-    // Adding data to JSON
-    expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "test_package");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "version");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "1.0");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "x86");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2021-1001");
-
-    // Printing JSON
-    will_return(__wrap_cJSON_PrintUnformatted, json_str);
-    expect_function_call(__wrap_cJSON_Delete);
-
-    // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, OS_INVALID);
-
-    // Handling result
-    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error in the response from socket");
-    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
-
-    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, NULL);
-
-    assert_int_equal(OS_INVALID, ret);
+    assert_null(ret);
 }
 
 void test_wdb_agents_vuln_cves_insert_error_sql_execution(void **state)
 {
-    int ret = 0;
+    cJSON *ret = NULL;
     int id = 1;
     const char *name = "test_package";
     const char *version = "1.0";
     const char *architecture = "x86";
     const char *cve = "CVE-2021-1001";
+    const char *reference = "69ac04fa9b4a0dcfccd7c2237b366e501b678cc7";
+    const char *type = "PACKAGE";
+    const char *status = "VALID";
+    bool check_pkg_existance = true;
 
-    const char *json_str = strdup("{\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
-    const char *query_str = "agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
-    const char *response = "err";
+    const char *json_str = NULL; 
+    os_strdup("{\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\",\"reference\":\"69ac04fa9b4a0dcfccd7c2237b366e501b678cc7\",\"type\":\"PACKAGE\",\"status\":\"VALID\",\"check_pkg_existance\":true}", json_str);
 
     will_return(__wrap_cJSON_CreateObject, 1);
     will_return_always(__wrap_cJSON_AddStringToObject, 1);
@@ -129,86 +90,47 @@ void test_wdb_agents_vuln_cves_insert_error_sql_execution(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "x86");
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
     expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2021-1001");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "69ac04fa9b4a0dcfccd7c2237b366e501b678cc7");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "PACKAGE");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "VALID");
+    will_return(__wrap_cJSON_AddBoolToObject, (cJSON *)1);
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
-    expect_function_call(__wrap_cJSON_Delete);
 
     // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, -100); // Returning any error
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, NULL);
+
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
 
     // Handling result
-    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");
-    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
+    expect_string(__wrap__merror, formatted_msg, "Agents DB (1) Error querying Wazuh DB to insert vuln_cves");
 
-    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, NULL);
+    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, reference, type, status, check_pkg_existance, NULL);
 
-    assert_int_equal(OS_INVALID, ret);
-}
-
-void test_wdb_agents_vuln_cves_insert_error_result(void **state)
-{
-    int ret = 0;
-    int id = 1;
-    const char *name = "test_package";
-    const char *version = "1.0";
-    const char *architecture = "x86";
-    const char *cve = "CVE-2021-1001";
-
-    const char *json_str = strdup("{\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
-    const char *query_str = "agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
-    const char *response = "err";
-
-    will_return(__wrap_cJSON_CreateObject, 1);
-    will_return_always(__wrap_cJSON_AddStringToObject, 1);
-
-    // Adding data to JSON
-    expect_string(__wrap_cJSON_AddStringToObject, name, "name");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "test_package");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "version");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "1.0");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "architecture");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "x86");
-    expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
-    expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2021-1001");
-
-    // Printing JSON
-    will_return(__wrap_cJSON_PrintUnformatted, json_str);
-    expect_function_call(__wrap_cJSON_Delete);
-
-    // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
-
-    // Parsing Wazuh DB result
-    expect_any(__wrap_wdbc_parse_result, result);
-    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
-    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
-
-    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, NULL);
-
-    assert_int_equal(OS_INVALID, ret);
+    assert_null(ret);
 }
 
 void test_wdb_agents_vuln_cves_insert_success(void **state)
 {
-    int ret = 0;
+    cJSON *ret = NULL;
     int id = 1;
     const char *name = "test_package";
     const char *version = "1.0";
     const char *architecture = "x86";
     const char *cve = "CVE-2021-1001";
+    const char *reference = "69ac04fa9b4a0dcfccd7c2237b366e501b678cc7";
+    const char *type = "PACKAGE";
+    const char *status = "VALID";
+    bool check_pkg_existance = true;
 
-    const char *json_str = strdup("{\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}");
-    const char *query_str = "agent 1 vuln_cves insert {\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\"}";
-    const char *response = "ok";
+    const char *json_str = NULL; 
+    os_strdup("{\"name\":\"test_package\",\"version\":\"1.0\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1001\",\"reference\":\"69ac04fa9b4a0dcfccd7c2237b366e501b678cc7\",\"type\":\"PACKAGE\",\"status\":\"VALID\",\"check_pkg_existance\":true}", json_str);
 
     will_return(__wrap_cJSON_CreateObject, 1);
     will_return_always(__wrap_cJSON_AddStringToObject, 1);
@@ -222,25 +144,27 @@ void test_wdb_agents_vuln_cves_insert_success(void **state)
     expect_string(__wrap_cJSON_AddStringToObject, string, "x86");
     expect_string(__wrap_cJSON_AddStringToObject, name, "cve");
     expect_string(__wrap_cJSON_AddStringToObject, string, "CVE-2021-1001");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "reference");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "69ac04fa9b4a0dcfccd7c2237b366e501b678cc7");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "PACKAGE");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "VALID");
+    will_return(__wrap_cJSON_AddBoolToObject, (cJSON *)1);
 
     // Printing JSON
     will_return(__wrap_cJSON_PrintUnformatted, json_str);
-    expect_function_call(__wrap_cJSON_Delete);
 
     // Calling Wazuh DB
-    expect_any(__wrap_wdbc_query_ex, *sock);
-    expect_string(__wrap_wdbc_query_ex, query, query_str);
-    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
-    will_return(__wrap_wdbc_query_ex, response);
-    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, (cJSON *)1);
 
-    // Parsing Wazuh DB result
-    expect_any(__wrap_wdbc_parse_result, result);
-    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+    //Cleaning  memory
+    expect_function_call(__wrap_cJSON_Delete);
 
-    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, NULL);
+    ret = wdb_agents_vuln_cves_insert(id, name, version, architecture, cve, reference, type, status, check_pkg_existance, NULL);
 
-    assert_int_equal(OS_SUCCESS, ret);
+    assert_ptr_equal(1, ret);
 }
 
 /* Tests wdb_agents_vuln_cves_update_status */
@@ -980,9 +904,7 @@ int main()
     {
         /* Tests wdb_agents_vuln_cves_insert*/
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
-        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_insert_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         /* Tests wdb_agents_vuln_cves_update_status*/
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -853,9 +853,7 @@ void test_vuln_cves_insert_command_error(void **state) {
     expect_value(__wrap_wdb_agents_insert_vuln_cves, check_pkg_existance, true);
     will_return(__wrap_wdb_agents_insert_vuln_cves, NULL);
 
-    //will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Error inserting vulnerability in vuln_cves.");
-    //expect_string(__wrap__mdebug1, formatted_msg, "Invalid vuln_cves JSON data when inserting vulnerable package. Not compliant with constraints defined in the database.");
 
     ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -869,10 +869,11 @@ void test_vuln_cves_insert_command_success(void **state) {
     int ret = OS_INVALID;
     test_struct_t *data  = (test_struct_t *)*state;
     char *query = NULL;
-    cJSON *test = NULL;
-
     os_strdup("insert {\"name\":\"package\",\"version\":\"2.2\",\"architecture\":\"x86\",\"cve\":\"CVE-2021-1500\",\"reference\":\"8549fd9faf9b124635298e9311ccf672c2ad05d1\",\"type\":\"PACKAGE\",\"status\":\"VALID\",\"check_pkg_existance\":true}", query);
-    test = cJSON_CreateObject();
+    char *result = NULL;
+    os_strdup("[{\"test\":\"TEST\"}]", result);
+
+    cJSON *test =  cJSON_CreateObject();
 
     // wdb_parse_agents_insert_vuln_cves
     expect_string(__wrap_wdb_agents_insert_vuln_cves, name, "package");
@@ -884,13 +885,14 @@ void test_vuln_cves_insert_command_success(void **state) {
     expect_string(__wrap_wdb_agents_insert_vuln_cves, status, "VALID");
     expect_value(__wrap_wdb_agents_insert_vuln_cves, check_pkg_existance, true);
     will_return(__wrap_wdb_agents_insert_vuln_cves, test);
-
-    will_return(__wrap_cJSON_PrintUnformatted, query);
+    will_return(__wrap_cJSON_PrintUnformatted, result);
 
     ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
-    assert_string_equal(data->output, "ok insert");
+    assert_string_equal(data->output, "ok [{\"test\":\"TEST\"}]");
     assert_int_equal(ret, OS_SUCCESS);
+
+    os_free(query);
 }
 
 void test_vuln_cves_update_status_syntax_error(void **state){

--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -4972,7 +4972,11 @@ void test_wm_vuldet_send_agent_report_vuln_cves_insert_error(void **state)
     expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
-    will_return(__wrap_wdb_agents_vuln_cves_insert, OS_INVALID);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "UNDEFINED");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "OS");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, status, "VALID");
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existance, TRUE);
+    will_return(__wrap_wdb_agents_vuln_cves_insert, NULL);
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
     expect_string(__wrap__mtdebug1, formatted_msg, "Failed to insert CVE-2016-6489 for package libhogweed4 in the agent 000 database");
     // Sending CVE report
@@ -5141,7 +5145,12 @@ void test_wm_vuldet_send_agent_report_send_cve_report_error(void **state)
     expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
-    will_return(__wrap_wdb_agents_vuln_cves_insert, OS_SUCCESS);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "UNDEFINED");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "OS");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, status, "VALID");
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existance, TRUE);
+    will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON *)1);
+    expect_function_call(__wrap_cJSON_Delete); 
     // Sending CVE report
     will_return(__wrap_cJSON_CreateObject, NULL);
 
@@ -5309,7 +5318,12 @@ void test_wm_vuldet_send_agent_report_send_cve_report_negative_version(void **st
     expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
-    will_return(__wrap_wdb_agents_vuln_cves_insert, OS_SUCCESS);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "UNDEFINED");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "OS");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, status, "VALID");
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existance, TRUE);
+    will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON *)1);    
+    expect_function_call(__wrap_cJSON_Delete); 
     // Sending CVE report
     will_return(__wrap_cJSON_CreateObject, NULL);
 
@@ -5634,7 +5648,12 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_OVAL(void *
     expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
-    will_return(__wrap_wdb_agents_vuln_cves_insert, OS_SUCCESS);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "UNDEFINED");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "OS");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, status, "VALID");
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existance, TRUE);
+    will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON *)1);
+    expect_function_call(__wrap_cJSON_Delete); 
 
     // Sending the CVE report
     cJSON* alert = (cJSON *)1;
@@ -5976,7 +5995,12 @@ void test_wm_vuldet_send_agent_report_send_cve_report_without_errors_NVD(void **
     expect_string(__wrap_wdb_agents_vuln_cves_insert, version, "5.3.4");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, architecture, "x86_64");
     expect_string(__wrap_wdb_agents_vuln_cves_insert, cve, "CVE-2016-6489");
-    will_return(__wrap_wdb_agents_vuln_cves_insert, OS_SUCCESS);
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, reference, "UNDEFINED");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, type, "OS");
+    expect_string(__wrap_wdb_agents_vuln_cves_insert, status, "VALID");
+    expect_value(__wrap_wdb_agents_vuln_cves_insert, check_pkg_existance, TRUE);
+    will_return(__wrap_wdb_agents_vuln_cves_insert, (cJSON *)1);
+    expect_function_call(__wrap_cJSON_Delete); 
 
     // Sending the CVE report
     cJSON* alert = (cJSON *)1;

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.c
@@ -19,12 +19,20 @@ int __wrap_wdb_agents_vuln_cves_insert(int id,
                                       const char *version,
                                       const char *architecture,
                                       const char *cve,
+                                      const char *reference,
+                                      const char *type,
+                                      const char *status,
+                                      bool check_pkg_existance,
                                       __attribute__((unused)) int *sock) {
     check_expected(id);
     check_expected(name);
     check_expected(version);
     check_expected(architecture);
     check_expected(cve);
+    check_expected(reference);
+    check_expected(type);
+    check_expected(status);
+    check_expected(check_pkg_existance);
     return mock_type(int);
 }
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
@@ -18,6 +18,10 @@ int __wrap_wdb_agents_vuln_cves_insert(int id,
                                       const char *version,
                                       const char *architecture,
                                       const char *cve,
+                                      const char *reference,
+                                      const char *type,
+                                      const char *status,
+                                      bool check_pkg_existance,
                                       __attribute__((unused)) int *sock);
 
 int __wrap_wdb_agents_vuln_cves_clear(int id,

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
@@ -13,10 +13,10 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-cJSON* __wrap_wdb_agents_insert_vuln_cves(__attribute__((unused)) wdb_t *wdb, 
-                                          const char* name, 
-                                          const char* version, 
-                                          const char* architecture, 
+cJSON* __wrap_wdb_agents_insert_vuln_cves(__attribute__((unused)) wdb_t *wdb,
+                                          const char* name,
+                                          const char* version,
+                                          const char* architecture,
                                           const char* cve,
                                           const char* reference,
                                           const char* type,

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
@@ -13,12 +13,24 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-int __wrap_wdb_agents_insert_vuln_cves(__attribute__((unused)) wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve) {
+cJSON* __wrap_wdb_agents_insert_vuln_cves(__attribute__((unused)) wdb_t *wdb, 
+                                          const char* name, 
+                                          const char* version, 
+                                          const char* architecture, 
+                                          const char* cve,
+                                          const char* reference,
+                                          const char* type,
+                                          const char* status,
+                                          bool check_pkg_existance) {
     check_expected(name);
     check_expected(version);
     check_expected(architecture);
     check_expected(cve);
-    return mock();
+    check_expected(reference);
+    check_expected(type);
+    check_expected(status);
+    check_expected(check_pkg_existance);
+    return mock_ptr_type(cJSON*);
 }
 
 int __wrap_wdb_agents_update_status_vuln_cves(__attribute__((unused)) wdb_t *wdb, const char* old_status, const char* new_status) {
@@ -40,5 +52,16 @@ wdbc_result __wrap_wdb_agents_remove_by_status_vuln_cves(__attribute__((unused))
 }
 
 int __wrap_wdb_agents_clear_vuln_cves(__attribute__((unused)) wdb_t *wdb) {
+    return mock();
+}
+
+bool __wrap_wdb_agents_find_package(__attribute__((unused)) wdb_t *wdb, const char* reference){
+    check_expected(reference);
+    return mock();
+}
+
+bool __wrap_wdb_agents_find_cve(__attribute__((unused)) wdb_t *wdb, const char* cve, const char* reference){
+    check_expected(cve);
+    check_expected(reference);
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
@@ -13,10 +13,19 @@
 
 #include "wazuh_db/wdb.h"
 
-int __wrap_wdb_agents_insert_vuln_cves(wdb_t *wdb, const char* name, const char* version, const char* architecture, const char* cve);
+cJSON* __wrap_wdb_agents_insert_vuln_cves(wdb_t *wdb, 
+                                          const char* name, 
+                                          const char* version, 
+                                          const char* architecture, 
+                                          const char* cve,
+                                          const char* reference,
+                                          const char* type,
+                                          const char* status,
+                                          bool check_pkg_existance);
 int __wrap_wdb_agents_update_status_vuln_cves(wdb_t *wdb, const char* old_status, const char* new_status);
 int __wrap_wdb_agents_remove_vuln_cves(wdb_t *wdb, const char* cve, const char* reference);
 wdbc_result __wrap_wdb_agents_remove_by_status_vuln_cves(wdb_t *wdb, const char* status, char **output);
 int __wrap_wdb_agents_clear_vuln_cves(wdb_t *wdb);
-
+bool __wrap_wdb_agents_find_package(wdb_t *wdb, const char* reference);
+bool __wrap_wdb_agents_find_cve(wdb_t *wdb, const char* cve, const char* reference);
 #endif

--- a/src/wazuh_db/helpers/wdb_agents_helpers.c
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.c
@@ -35,7 +35,6 @@ cJSON* wdb_agents_vuln_cves_insert(int id,
     char *wdboutput = NULL;
     int aux_sock = -1;
 
-
     data_in = cJSON_CreateObject();
     if (!data_in) {
         mdebug1("Error creating data JSON for Wazuh DB.");
@@ -75,9 +74,9 @@ cJSON* wdb_agents_vuln_cves_insert(int id,
 }
 
 int wdb_agents_vuln_cves_update_status(int id,
-                               const char *old_status,
-                               const char *new_status,
-                               int *sock) {
+                                       const char *old_status,
+                                       const char *new_status,
+                                       int *sock) {
     int result = 0;
     cJSON *data_in = NULL;
     char *data_in_str = NULL;
@@ -134,9 +133,9 @@ int wdb_agents_vuln_cves_update_status(int id,
 }
 
 int wdb_agents_vuln_cves_remove_entry(int id,
-                                     const char *cve,
-                                     const char *reference,
-                                     int *sock) {
+                                      const char *cve,
+                                      const char *reference,
+                                      int *sock) {
     int result = 0;
     cJSON *data_in = NULL;
     char *data_in_str = NULL;
@@ -193,8 +192,8 @@ int wdb_agents_vuln_cves_remove_entry(int id,
 }
 
 cJSON* wdb_agents_vuln_cves_remove_by_status(int id,
-                                            const char *status,
-                                            int *sock) {
+                                             const char *status,
+                                             int *sock) {
     cJSON *data_in = NULL;
     char *data_in_str = NULL;
     char *wdbquery = NULL;
@@ -275,7 +274,7 @@ cJSON* wdb_agents_vuln_cves_remove_by_status(int id,
 }
 
 int wdb_agents_vuln_cves_clear(int id,
-                              int *sock) {
+                               int *sock) {
     int result = 0;
     char *wdbquery = NULL;
     char *wdboutput = NULL;

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -4,7 +4,7 @@ bool wdb_agents_find_package(wdb_t *wdb, const char* reference){
     sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_PROGRAM_FIND);
 
     if (stmt == NULL) {
-        return OS_INVALID;
+        return FALSE;
     }
 
     sqlite3_bind_text(stmt, 1, reference, -1, NULL);
@@ -24,7 +24,7 @@ bool wdb_agents_find_cve(wdb_t *wdb, const char* cve, const char* reference){
     sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_VULN_CVES_FIND_CVE);
 
     if (stmt == NULL) {
-        return OS_INVALID;
+        return FALSE;
     }
 
     sqlite3_bind_text(stmt, 1, cve, -1, NULL);
@@ -87,7 +87,6 @@ cJSON* wdb_agents_insert_vuln_cves(wdb_t *wdb,
             }
         }
         else {
-            mdebug1("Cannot cache statement");
             cJSON_AddStringToObject(result, "status", "ERROR");
         }
     }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -6109,7 +6109,7 @@ int wdb_parse_agents_insert_vuln_cves(wdb_t* wdb, char* input, char* output) {
         // Required fields
         if (!cJSON_IsString(j_name) || !cJSON_IsString(j_version) || !cJSON_IsString(j_architecture) ||!cJSON_IsString(j_cve) ||
             !cJSON_IsString(j_reference) || !cJSON_IsString(j_type) || !cJSON_IsString(j_status) ||!cJSON_IsBool(j_check_pkg_existance)) {
-            mdebug1("Invalid vuln_cve JSON data when inserting vulnerable package. Not compliant with constraints defined in the database.");
+            mdebug1("Invalid vuln_cves JSON data when inserting vulnerable package. Not compliant with constraints defined in the database.");
             snprintf(output, OS_MAXSTR + 1, "err Invalid JSON data, missing required fields");
         }
         else {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -866,6 +866,9 @@ void wm_vuldet_free_report(vu_report *report) {
     }
 
     os_free(report->cve);
+    os_free(report->reference);
+    os_free(report->type);
+    os_free(report->status);
     os_free(report->title);
     os_free(report->rationale);
     os_free(report->published);


### PR DESCRIPTION
|Related issue|
|---|
|#7926|
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.
Please fill the table above. Feel free to extend it at your convenience.
-->
## Description
Adding and fixing UTs for the changes introduced in #7915 respect to the wazuh-db insert command. 
## Dod
Valgrind results. 
[valgrind.txt](https://github.com/wazuh/wazuh/files/6238046/valgrind.txt)
### Coverage
#### wm_vuldet_send_agent_report()
![1-vuldet](https://user-images.githubusercontent.com/13010397/113179266-d2063700-9225-11eb-878a-c99bfd300f54.png)
#### wdb_agents_vuln_cves_insert()
![2-helper](https://user-images.githubusercontent.com/13010397/113179268-d3376400-9225-11eb-9ce8-7a2f1004065f.png)
#### wdb_parse_agents_insert_vuln_cves()
![3-parser](https://user-images.githubusercontent.com/13010397/113179269-d3cffa80-9225-11eb-9434-501fe00ed0fd.png)
#### wdb_agents_find_package() & wdb_agents_find_cve()
![4-agents-aux](https://user-images.githubusercontent.com/13010397/113179272-d4689100-9225-11eb-86f8-71b3e919bd83.png)
#### wdb_agents_insert_vuln_cves()
![5-insert](https://user-images.githubusercontent.com/13010397/113179275-d4689100-9225-11eb-8eb1-3eecf70f971d.png)
## Tests
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Review logs syntax and correct language
- Memory tests for Linux
  - [X] Valgrind (memcheck and descriptor leaks check)
<!-- Checks for huge PRs that affect the product more generally -->
- [X] Added unit tests (for new features)