### PR TITLE
Adding new unit tests for update vulnerability status Wazuh-DB command 

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -468,6 +468,17 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state)
 
 /* Tests wdb_agents_update_status_vuln_cves*/
 
+void test_wdb_agents_update_status_vuln_cves_statement_parameter_fail(void **state){
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* old_status = "pending";
+    const char* type = "OS";
+
+    ret = wdb_agents_update_status_vuln_cves(data->wdb, old_status, NULL, type);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
 void test_wdb_agents_update_status_vuln_cves_statement_init_fail(void **state){
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
@@ -519,6 +530,42 @@ void test_wdb_agents_update_status_vuln_cves_success_all(void **state){
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 
     ret = wdb_agents_update_status_vuln_cves(data->wdb, old_status, new_status, NULL);
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_agents_update_status_vuln_cves_by_type_statement_init_fail(void **state){
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* type = "OS";
+    const char* new_status = "pending";
+
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_UPDATE_BY_TYPE);
+
+    ret = wdb_agents_update_status_vuln_cves(data->wdb, NULL, new_status, type);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_agents_update_status_vuln_cves_by_type_success(void **state){
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    const char* type = "OS";
+    const char* new_status = "pending";
+
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_UPDATE_BY_TYPE);
+
+    will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
+    expect_value(__wrap_sqlite3_bind_text, pos, 1);
+    expect_string(__wrap_sqlite3_bind_text, buffer, new_status);
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_string(__wrap_sqlite3_bind_text, buffer, type);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    ret = wdb_agents_update_status_vuln_cves(data->wdb, NULL, new_status, type);
+
     assert_int_equal(ret, OS_SUCCESS);
 }
 
@@ -794,9 +841,12 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success_statement_exec_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_insert_vuln_cves_success_pkg_found, test_setup, test_teardown),
         /* Tests wdb_agents_update_status_vuln_cves */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_statement_parameter_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_success_all, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_by_type_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_update_status_vuln_cves_by_type_success, test_setup, test_teardown),
         /* Tests wdb_agents_remove_vuln_cves */
         cmocka_unit_test_setup_teardown(test_wdb_agents_remove_vuln_cves_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_remove_vuln_cves_statement_init_fail, test_setup, test_teardown),

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -39,7 +39,7 @@ static int test_setup(void **state) {
     return 0;
 }
 
-static int test_teardown(void **state){
+static int test_teardown(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     os_free(data->output);
     os_free(data->wdb->id);
@@ -51,7 +51,7 @@ static int test_teardown(void **state){
 
 /* Tests wdb_agents_find_package */
 
-void test_wdb_agents_find_package_statement_init_fail(void **state){
+void test_wdb_agents_find_package_statement_init_fail(void **state) {
     bool ret = FALSE;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
@@ -64,7 +64,7 @@ void test_wdb_agents_find_package_statement_init_fail(void **state){
     assert_false(ret);
 }
 
-void test_wdb_agents_find_package_success_row(void **state){
+void test_wdb_agents_find_package_success_row(void **state) {
     bool ret = FALSE;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
@@ -83,7 +83,7 @@ void test_wdb_agents_find_package_success_row(void **state){
     assert_true(ret);
 }
 
-void test_wdb_agents_find_package_success_done(void **state){
+void test_wdb_agents_find_package_success_done(void **state) {
     bool ret = FALSE;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
@@ -102,7 +102,7 @@ void test_wdb_agents_find_package_success_done(void **state){
     assert_false(ret);
 }
 
-void test_wdb_agents_find_package_error(void **state){
+void test_wdb_agents_find_package_error(void **state) {
     bool ret = FALSE;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* reference = "1c979289c63e6225fea818ff9ca83d9d0d25c46a";
@@ -115,7 +115,7 @@ void test_wdb_agents_find_package_error(void **state){
     expect_string(__wrap_sqlite3_bind_text, buffer, reference);
 
     expect_sqlite3_step_call(SQLITE_ERROR);
-    
+
     will_return(__wrap_sqlite3_errmsg, "test_sql_no_done");
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) sqlite3_step(): test_sql_no_done");
 
@@ -126,7 +126,7 @@ void test_wdb_agents_find_package_error(void **state){
 
 /* Tests wdb_agents_find_cve */
 
-void test_wdb_agents_find_cve_statement_init_fail(void **state){
+void test_wdb_agents_find_cve_statement_init_fail(void **state) {
     bool ret = FALSE;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* cve = "CVE-2021-1200";
@@ -140,7 +140,7 @@ void test_wdb_agents_find_cve_statement_init_fail(void **state){
     assert_false(ret);
 }
 
-void test_wdb_agents_find_cve_success_row(void **state){
+void test_wdb_agents_find_cve_success_row(void **state) {
     bool ret = FALSE;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* cve = "CVE-2021-1200";
@@ -162,7 +162,7 @@ void test_wdb_agents_find_cve_success_row(void **state){
     assert_true(ret);
 }
 
-void test_wdb_agents_find_cve_success_done(void **state){
+void test_wdb_agents_find_cve_success_done(void **state) {
     bool ret = FALSE;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* cve = "CVE-2021-1200";
@@ -184,7 +184,7 @@ void test_wdb_agents_find_cve_success_done(void **state){
     assert_false(ret);
 }
 
-void test_wdb_agents_find_cve_error(void **state){
+void test_wdb_agents_find_cve_error(void **state) {
     bool ret = FALSE;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* cve = "CVE-2021-1200";
@@ -211,8 +211,7 @@ void test_wdb_agents_find_cve_error(void **state){
 
 /* Tests wdb_agents_insert_vuln_cves */
 
-void test_wdb_agents_insert_vuln_cves_error_json(void **state)
-{
+void test_wdb_agents_insert_vuln_cves_error_json(void **state) {
     cJSON *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* name = "package";
@@ -231,8 +230,7 @@ void test_wdb_agents_insert_vuln_cves_error_json(void **state)
     assert_null(ret);
 }
 
-void test_wdb_agents_insert_vuln_cves_success_pkg_not_found(void **state)
-{
+void test_wdb_agents_insert_vuln_cves_success_pkg_not_found(void **state) {
     cJSON *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* name = "package";
@@ -245,10 +243,10 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_not_found(void **state)
     bool check_pkg_existance = true;
 
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-    
+
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
-    
+
     will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, cve);
@@ -278,8 +276,7 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_not_found(void **state)
     assert_ptr_equal(1, ret);
 }
 
-void test_wdb_agents_insert_vuln_cves_success_statement_init_fail(void **state)
-{
+void test_wdb_agents_insert_vuln_cves_success_statement_init_fail(void **state) {
     cJSON *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* name = "package";
@@ -292,10 +289,10 @@ void test_wdb_agents_insert_vuln_cves_success_statement_init_fail(void **state)
     bool check_pkg_existance = true;
 
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-    
+
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
-    
+
     will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, cve);
@@ -328,8 +325,7 @@ void test_wdb_agents_insert_vuln_cves_success_statement_init_fail(void **state)
     assert_ptr_equal(1, ret);
 }
 
-void test_wdb_agents_insert_vuln_cves_success_statement_exec_fail(void **state)
-{
+void test_wdb_agents_insert_vuln_cves_success_statement_exec_fail(void **state) {
     cJSON *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* name = "package";
@@ -342,10 +338,10 @@ void test_wdb_agents_insert_vuln_cves_success_statement_exec_fail(void **state)
     bool check_pkg_existance = true;
 
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-    
+
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
-    
+
     will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, cve);
@@ -399,8 +395,7 @@ void test_wdb_agents_insert_vuln_cves_success_statement_exec_fail(void **state)
 }
 
 
-void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state)
-{
+void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state) {
     cJSON *ret = NULL;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* name = "package";
@@ -413,10 +408,10 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state)
     bool check_pkg_existance = true;
 
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-    
+
     expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_VULN_CVES_FIND_CVE);
     will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
-    
+
     will_return_count(__wrap_sqlite3_bind_text, OS_SUCCESS, -1);
     expect_value(__wrap_sqlite3_bind_text, pos, 1);
     expect_string(__wrap_sqlite3_bind_text, buffer, cve);
@@ -468,7 +463,7 @@ void test_wdb_agents_insert_vuln_cves_success_pkg_found(void **state)
 
 /* Tests wdb_agents_update_status_vuln_cves*/
 
-void test_wdb_agents_update_status_vuln_cves_statement_parameter_fail(void **state){
+void test_wdb_agents_update_status_vuln_cves_statement_parameter_fail(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* old_status = "pending";
@@ -479,7 +474,7 @@ void test_wdb_agents_update_status_vuln_cves_statement_parameter_fail(void **sta
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_agents_update_status_vuln_cves_statement_init_fail(void **state){
+void test_wdb_agents_update_status_vuln_cves_statement_init_fail(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* old_status = "valid";
@@ -493,7 +488,7 @@ void test_wdb_agents_update_status_vuln_cves_statement_init_fail(void **state){
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_agents_update_status_vuln_cves_success(void **state){
+void test_wdb_agents_update_status_vuln_cves_success(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* old_status = "valid";
@@ -514,7 +509,7 @@ void test_wdb_agents_update_status_vuln_cves_success(void **state){
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-void test_wdb_agents_update_status_vuln_cves_success_all(void **state){
+void test_wdb_agents_update_status_vuln_cves_success_all(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* old_status = "*";
@@ -533,7 +528,7 @@ void test_wdb_agents_update_status_vuln_cves_success_all(void **state){
     assert_int_equal(ret, OS_SUCCESS);
 }
 
-void test_wdb_agents_update_status_vuln_cves_by_type_statement_init_fail(void **state){
+void test_wdb_agents_update_status_vuln_cves_by_type_statement_init_fail(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* type = "OS";
@@ -547,7 +542,7 @@ void test_wdb_agents_update_status_vuln_cves_by_type_statement_init_fail(void **
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_agents_update_status_vuln_cves_by_type_success(void **state){
+void test_wdb_agents_update_status_vuln_cves_by_type_success(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
     const char* type = "OS";
@@ -571,8 +566,7 @@ void test_wdb_agents_update_status_vuln_cves_by_type_success(void **state){
 
 /* Tests wdb_agents_remove_vuln_cves */
 
-void test_wdb_agents_remove_vuln_cves_invalid_data(void **state)
-{
+void test_wdb_agents_remove_vuln_cves_invalid_data(void **state) {
     int ret = -1;
     const char *cve = NULL;
     const char *reference = NULL;
@@ -585,8 +579,7 @@ void test_wdb_agents_remove_vuln_cves_invalid_data(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_agents_remove_vuln_cves_statement_init_fail(void **state)
-{
+void test_wdb_agents_remove_vuln_cves_statement_init_fail(void **state) {
     int ret = -1;
     const char *cve = "cve-xxxx-yyyy";
     const char *reference = "ref-cve-xxxx-yyyy";
@@ -600,8 +593,7 @@ void test_wdb_agents_remove_vuln_cves_statement_init_fail(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_agents_remove_vuln_cves_success(void **state)
-{
+void test_wdb_agents_remove_vuln_cves_success(void **state) {
     int ret = -1;
     const char *cve = "cve-xxxx-yyyy";
     const char *reference = "ref-cve-xxxx-yyyy";
@@ -625,8 +617,7 @@ void test_wdb_agents_remove_vuln_cves_success(void **state)
 
 /* Tests wdb_agents_remove_by_status_vuln_cves */
 
-void test_wdb_agents_remove_by_status_vuln_cves_statement_init_fail(void **state)
-{
+void test_wdb_agents_remove_by_status_vuln_cves_statement_init_fail(void **state) {
     int ret = -1;
     const char *status = "OBSOLETE";
     test_struct_t *data  = (test_struct_t *)*state;
@@ -641,8 +632,7 @@ void test_wdb_agents_remove_by_status_vuln_cves_statement_init_fail(void **state
     assert_int_equal(ret, WDBC_ERROR);
 }
 
-void test_wdb_agents_remove_by_status_vuln_cves_statement_bind_fail(void **state)
-{
+void test_wdb_agents_remove_by_status_vuln_cves_statement_bind_fail(void **state) {
     int ret = -1;
     const char *status = "OBSOLETE";
     test_struct_t *data  = (test_struct_t *)*state;
@@ -664,8 +654,7 @@ void test_wdb_agents_remove_by_status_vuln_cves_statement_bind_fail(void **state
     assert_int_equal(ret, WDBC_ERROR);
 }
 
-void test_wdb_agents_remove_by_status_vuln_cves_error_exec_stmt_sized(void **state)
-{
+void test_wdb_agents_remove_by_status_vuln_cves_error_exec_stmt_sized(void **state) {
     int ret = -1;
     const char *status = "OBSOLETE";
     test_struct_t *data  = (test_struct_t *)*state;
@@ -690,8 +679,7 @@ void test_wdb_agents_remove_by_status_vuln_cves_error_exec_stmt_sized(void **sta
     assert_int_equal(ret, WDBC_ERROR);
 }
 
-void test_wdb_agents_remove_by_status_vuln_cves_error_removing_cve(void **state)
-{
+void test_wdb_agents_remove_by_status_vuln_cves_error_removing_cve(void **state) {
     int ret = -1;
     cJSON *root = NULL;
     cJSON *row = NULL;
@@ -738,8 +726,7 @@ void test_wdb_agents_remove_by_status_vuln_cves_error_removing_cve(void **state)
     __real_cJSON_Delete(root);
 }
 
-void test_wdb_agents_remove_by_status_vuln_cves_success(void **state)
-{
+void test_wdb_agents_remove_by_status_vuln_cves_success(void **state) {
     int ret = -1;
     cJSON *root = NULL;
     cJSON *row = NULL;
@@ -793,8 +780,7 @@ void test_wdb_agents_remove_by_status_vuln_cves_success(void **state)
 
 /* Tests wdb_agents_clear_vuln_cves */
 
-void test_wdb_agents_clear_vuln_cves_statement_init_fail(void **state)
-{
+void test_wdb_agents_clear_vuln_cves_statement_init_fail(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
 
@@ -806,8 +792,7 @@ void test_wdb_agents_clear_vuln_cves_statement_init_fail(void **state)
     assert_int_equal(ret, OS_INVALID);
 }
 
-void test_wdb_agents_clear_vuln_cves_success(void **state)
-{
+void test_wdb_agents_clear_vuln_cves_success(void **state) {
     int ret = -1;
     test_struct_t *data  = (test_struct_t *)*state;
 

--- a/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
@@ -345,6 +345,188 @@ void test_wdb_agents_vuln_cves_update_status_success(void **state){
     assert_int_equal(OS_SUCCESS, ret);
 }
 
+/* Tests wdb_agents_vuln_cves_update_status_by_type */
+
+void test_wdb_agents_vuln_cves_update_status_by_type_error_json(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *type = "OS";
+    const char *new_status = "PENDING";
+
+    will_return(__wrap_cJSON_CreateObject, NULL);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Error creating data JSON for Wazuh DB.");
+
+    ret = wdb_agents_vuln_cves_update_status_by_type(id, type, new_status, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cves_update_status_by_type_error_socket(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *type = "OS";
+    const char *new_status = "PENDING";
+    const char *json_str = NULL;
+    const char *response = "err";
+    char query_str[OS_SIZE_256];
+
+    os_strdup("{\"type\":\"OS\",\"new_status\":\"PENDING\"}", json_str);
+    snprintf(query_str, OS_SIZE_256, "agent 1 vuln_cves update_status %s", json_str);
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OS");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "new_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "PENDING");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_INVALID);
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error in the response from socket");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves update_status {\"type\":\"OS\",\"new_status\":\"PENDING\"}");
+
+    ret = wdb_agents_vuln_cves_update_status_by_type(id, type, new_status, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cves_update_status_by_type_error_sql_execution(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *type = "OS";
+    const char *new_status = "PENDING";
+    const char *json_str = NULL;
+    const char *response = "err";
+    char query_str[OS_SIZE_256];
+
+    os_strdup("{\"type\":\"OS\",\"new_status\":\"PENDING\"}", json_str);
+    snprintf(query_str, OS_SIZE_256, "agent 1 vuln_cves update_status %s", json_str);
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OS");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "new_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "PENDING");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, -100); // Returning any error
+
+    // Handling result
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Cannot execute SQL query");
+    expect_string(__wrap__mdebug2, formatted_msg, "Agents DB (1) SQL query: agent 1 vuln_cves update_status {\"type\":\"OS\",\"new_status\":\"PENDING\"}");
+
+    ret = wdb_agents_vuln_cves_update_status_by_type(id, type, new_status, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cves_update_status_by_type_error_result(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *type = "OS";
+    const char *new_status = "PENDING";
+    const char *json_str = NULL;
+    const char *response = "err";
+    char query_str[OS_SIZE_256];
+
+    os_strdup("{\"type\":\"OS\",\"new_status\":\"PENDING\"}", json_str);
+    snprintf(query_str, OS_SIZE_256, "agent 1 vuln_cves update_status %s", json_str);
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OS");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "new_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "PENDING");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_ERROR);
+    expect_string(__wrap__mdebug1, formatted_msg, "Agents DB (1) Error reported in the result of the query");
+
+    ret = wdb_agents_vuln_cves_update_status_by_type(id, type, new_status, NULL);
+
+    assert_int_equal(OS_INVALID, ret);
+}
+
+void test_wdb_agents_vuln_cves_update_status_by_type_success(void **state){
+    int ret = 0;
+    int id = 1;
+    const char *type = "OS";
+    const char *new_status = "PENDING";
+    const char *json_str = NULL;
+    char query_str[OS_SIZE_256];
+    const char *response = "ok";
+
+    os_strdup("{\"type\":\"OS\",\"new_status\":\"PENDING\"}", json_str);
+    snprintf(query_str, OS_SIZE_256, "agent 1 vuln_cves update_status %s", json_str);
+
+    will_return(__wrap_cJSON_CreateObject, 1);
+    will_return_always(__wrap_cJSON_AddStringToObject, 1);
+
+    // Adding data to JSON
+    expect_string(__wrap_cJSON_AddStringToObject, name, "type");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "OS");
+    expect_string(__wrap_cJSON_AddStringToObject, name, "new_status");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "PENDING");
+
+    // Printing JSON
+    will_return(__wrap_cJSON_PrintUnformatted, json_str);
+    expect_function_call(__wrap_cJSON_Delete);
+
+    // Calling Wazuh DB
+    expect_any(__wrap_wdbc_query_ex, *sock);
+    expect_string(__wrap_wdbc_query_ex, query, query_str);
+    expect_value(__wrap_wdbc_query_ex, len, WDBOUTPUT_SIZE);
+    will_return(__wrap_wdbc_query_ex, response);
+    will_return(__wrap_wdbc_query_ex, OS_SUCCESS);
+
+    // Parsing Wazuh DB result
+    expect_any(__wrap_wdbc_parse_result, result);
+    will_return(__wrap_wdbc_parse_result, WDBC_OK);
+
+    ret = wdb_agents_vuln_cves_update_status_by_type(id, type, new_status, NULL);
+
+    assert_int_equal(OS_SUCCESS, ret);
+}
+
 /* Tests wdb_agents_vuln_cves_remove_entry */
 
 void test_wdb_agents_vuln_cves_remove_entry_error_json(void **state)
@@ -912,6 +1094,12 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        /* Tests wdb_agents_vuln_cves_update_status_by_type*/
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_by_type_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_by_type_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_by_type_error_sql_execution, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_by_type_error_result, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_update_status_by_type_success, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         /* Tests wdb_agents_vuln_cves_remove_entry */
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_entry_error_json, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),
         cmocka_unit_test_setup_teardown(test_wdb_agents_vuln_cves_remove_entry_error_socket, setup_wdb_agents_helpers, teardown_wdb_agents_helpers),

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -941,6 +941,7 @@ void test_vuln_cves_update_status_command_error(void **state){
     will_return(__wrap_wdb_agents_update_status_vuln_cves, OS_INVALID);
     expect_string(__wrap_wdb_agents_update_status_vuln_cves, old_status, "valid");
     expect_string(__wrap_wdb_agents_update_status_vuln_cves, new_status, "obsolete");
+    expect_value(__wrap_wdb_agents_update_status_vuln_cves, type, NULL);
     will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
     expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot execute vuln_cves update_status command; SQL err: ERROR MESSAGE");
 
@@ -963,6 +964,51 @@ void test_vuln_cves_update_status_command_success(void **state){
     will_return(__wrap_wdb_agents_update_status_vuln_cves, OS_SUCCESS);
     expect_string(__wrap_wdb_agents_update_status_vuln_cves, old_status, "valid");
     expect_string(__wrap_wdb_agents_update_status_vuln_cves, new_status, "obsolete");
+    expect_value(__wrap_wdb_agents_update_status_vuln_cves, type, NULL);
+
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(ret, OS_SUCCESS);
+
+    os_free(query);
+}
+
+void test_vuln_cves_update_status_by_type_command_error(void **state){
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char *query = NULL;
+
+    os_strdup("update_status {\"type\":\"PACKAGES\",\"new_status\":\"VALID\"}", query);
+
+    // wdb_parse_agents_update_status_vuln_cves
+    will_return(__wrap_wdb_agents_update_status_vuln_cves, OS_INVALID);
+    expect_string(__wrap_wdb_agents_update_status_vuln_cves, type, "PACKAGES");
+    expect_string(__wrap_wdb_agents_update_status_vuln_cves, new_status, "VALID");
+    expect_value(__wrap_wdb_agents_update_status_vuln_cves, old_status, NULL);
+    will_return_count(__wrap_sqlite3_errmsg, "ERROR MESSAGE", -1);
+    expect_string(__wrap__mdebug1, formatted_msg, "DB(000) Cannot execute vuln_cves update_status command; SQL err: ERROR MESSAGE");
+
+    ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
+
+    assert_string_equal(data->output, "err Cannot execute vuln_cves update_status command; SQL err: ERROR MESSAGE");
+    assert_int_equal(ret, OS_INVALID);
+
+    os_free(query);
+}
+
+void test_vuln_cves_update_status_by_type_command_success(void **state){
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char *query = NULL;
+
+    os_strdup("update_status {\"type\":\"PACKAGES\",\"new_status\":\"VALID\"}", query);
+
+    // wdb_parse_agents_update_status_vuln_cves
+    will_return(__wrap_wdb_agents_update_status_vuln_cves, OS_SUCCESS);
+    expect_string(__wrap_wdb_agents_update_status_vuln_cves, type, "PACKAGES");
+    expect_string(__wrap_wdb_agents_update_status_vuln_cves, new_status, "VALID");
+    expect_value(__wrap_wdb_agents_update_status_vuln_cves, old_status, NULL);
 
     ret = wdb_parse_vuln_cves(data->wdb, query, data->output);
 
@@ -1170,6 +1216,9 @@ int main()
         cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_constraint_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_command_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_command_success, test_setup, test_teardown),
+        // wdb_parse_agents_vuln_cves_update_status_by_type
+        cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_by_type_command_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_vuln_cves_update_status_by_type_command_success, test_setup, test_teardown),
         // wdb_parse_agents_remove_vuln_cves
         cmocka_unit_test_setup_teardown(test_vuln_cves_remove_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_vuln_cves_remove_json_data_error, test_setup, test_teardown),

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
@@ -33,9 +33,10 @@ cJSON* __wrap_wdb_agents_insert_vuln_cves(__attribute__((unused)) wdb_t *wdb,
     return mock_ptr_type(cJSON*);
 }
 
-int __wrap_wdb_agents_update_status_vuln_cves(__attribute__((unused)) wdb_t *wdb, const char* old_status, const char* new_status) {
+int __wrap_wdb_agents_update_status_vuln_cves(__attribute__((unused)) wdb_t *wdb, const char* old_status, const char* new_status, const char* type) {
     check_expected(old_status);
     check_expected(new_status);
+    check_expected(type);
     return mock();
 }
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
@@ -13,16 +13,16 @@
 
 #include "wazuh_db/wdb.h"
 
-cJSON* __wrap_wdb_agents_insert_vuln_cves(wdb_t *wdb, 
-                                          const char* name, 
-                                          const char* version, 
-                                          const char* architecture, 
+cJSON* __wrap_wdb_agents_insert_vuln_cves(wdb_t *wdb,
+                                          const char* name,
+                                          const char* version,
+                                          const char* architecture,
                                           const char* cve,
                                           const char* reference,
                                           const char* type,
                                           const char* status,
                                           bool check_pkg_existance);
-int __wrap_wdb_agents_update_status_vuln_cves(wdb_t *wdb, const char* old_status, const char* new_status);
+int __wrap_wdb_agents_update_status_vuln_cves(wdb_t *wdb, const char* old_status, const char* new_status, const char* type);
 int __wrap_wdb_agents_remove_vuln_cves(wdb_t *wdb, const char* cve, const char* reference);
 wdbc_result __wrap_wdb_agents_remove_by_status_vuln_cves(wdb_t *wdb, const char* status, char **output);
 int __wrap_wdb_agents_clear_vuln_cves(wdb_t *wdb);


### PR DESCRIPTION
|Related issue|
|---|
|#7989|

## Description

This PR adds more unit tests to completely cover the methods related to the vulnerabilities status update.
The tests were added to:
- src/unit_tests/wazuh_db/test_wdb_agents.c
- src/unit_tests/wazuh_db/test_wdb_agents_helpers.c
- src/unit_tests/wazuh_db/test_wdb_parser.c

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
<!-- Depending on the affected OS -->
- Memory tests for Linux
   - [x] Valgrind (memcheck and descriptor leaks check)
 
<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
