### PR TITLE
Fix a crash in winagents during sync of registries

### DIFF
--- a/src/syscheckd/db/fim_db.c
+++ b/src/syscheckd/db/fim_db.c
@@ -328,6 +328,13 @@ fim_entry *fim_db_get_entry_from_sync_msg(fdb_t *fim_sql, fim_type type, const c
     entry->type = FIM_TYPE_REGISTRY;
     entry->registry_entry.key = fim_db_get_registry_key(fim_sql, key_path, arch);
 
+    if (entry->registry_entry.key == NULL) {
+        free(key_path);
+        free(full_path);
+        fim_registry_free_entry(entry);
+        return NULL;
+    }
+
     if (value_name == NULL || *value_name == '\0') {
         free(key_path);
         free(full_path);

--- a/src/unit_tests/syscheckd/db/test_fim_db.c
+++ b/src/unit_tests/syscheckd/db/test_fim_db.c
@@ -2182,6 +2182,21 @@ void test_fim_db_get_entry_from_sync_msg_get_registry_key(void **state) {
     assert_null(entry->registry_entry.value);
 }
 
+void test_fim_db_get_entry_from_sync_msg_get_registry_key_fail_to_get_key(void **state) {
+    fdb_t fim_sql;
+    fim_registry_key data = DEFAULT_REGISTRY_KEY;
+    fim_entry *entry;
+
+    expect_fim_db_get_registry_key_fail(&data);
+
+    entry =
+    fim_db_get_entry_from_sync_msg(&fim_sql, FIM_TYPE_REGISTRY, "[x64] HKEY_LOCAL_MACHINE\\software\\some::\\key:value");
+
+    *state = entry;
+
+    assert_null(entry);
+}
+
 void test_fim_db_get_entry_from_sync_msg_get_registry_value_fail_to_get_data(void **state) {
     fdb_t fim_sql;
     fim_registry_key key_data = DEFAULT_REGISTRY_KEY;
@@ -2362,6 +2377,7 @@ int main(void) {
         // fim_db_get_entry_from_sync_msg
         cmocka_unit_test_teardown(test_fim_db_get_entry_from_sync_msg_get_file, teardown_fim_entry),
         cmocka_unit_test_teardown(test_fim_db_get_entry_from_sync_msg_get_registry_key, teardown_fim_entry),
+        cmocka_unit_test_teardown(test_fim_db_get_entry_from_sync_msg_get_registry_key_fail_to_get_key, teardown_fim_entry),
         cmocka_unit_test_teardown(test_fim_db_get_entry_from_sync_msg_get_registry_value_fail_to_get_data, teardown_fim_entry),
         cmocka_unit_test_teardown(test_fim_db_get_entry_from_sync_msg_get_registry_value_success, teardown_fim_entry),
 #endif


### PR DESCRIPTION
Prevents the Windows agent from crashing when a registry key is not found during synchronization.

|Related issue|
|---|
|#7836|

## Description
Hi team. 

As described in #7836, users reported that the agent in windows crashed when a registry key has values starting with `:`, this provokes a segmentation fault. 
This PR fixes the crash by checking if the query to the DB has returned a valid value, and if it not, the allocated memory is freed and the function ends, avoiding the crash.

This PR WON'T close the issue, as some changes in the synchronization mechanism have to be done to handle this kind of value correctly.


## Configuration options
```xml
 <disabled>no</disabled>
    <frequency>10</frequency>
    <windows_registry>HKEY_LOCAL_MACHINE\SOFTWARE\ramdon_key</windows_registry>
```
The configured key has the following values:
- `:arandomvalue`
- `::this_is_a_test`
- `othervalue`

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example
```
2021/04/05 09:40:13 wazuh-agent[1560] receiver-win.c:128 at receiver_thread(): DEBUG: Received message: '#!-fim_registry dbsync no_data {"id":1617612013,"begin":"[x64] HKEY_LOCAL_MACHINE\\SOFTWARE\\random_key:","end":"[x64] HKEY_LOCAL_MACHINE\\SOFTWARE\\random_key:othervalue"}'
2021/04/05 09:40:13 wazuh-agent[1560] run_check.c:82 at fim_send_sync_msg(): DEBUG: (6317): Sending integrity control message: {"component":"fim_registry","type":"state","data":{"path":"HKEY_LOCAL_MACHINE\\SOFTWARE\\random_key","arch":"[x64]","timestamp":1617612013,"attributes":{"type":"registry_key","perm":"Usuarios (allowed): read_control|read_data|read_ea|write_ea, Usuarios (allowed): generic_read, Administradores (allowed): delete|read_control|write_dac|write_owner|read_data|write_data|append_data|read_ea|write_ea|execute, Administradores (allowed): generic_all, SYSTEM (allowed): delete|read_control|write_dac|write_owner|read_data|write_data|append_data|read_ea|write_ea|execute, SYSTEM (allowed): generic_all, CREATOR OWNER (allowed): generic_all","uid":"S-1-5-32-544","user_name":"Administradores","gid":"S-1-5-21-3527455827-79240758-596275861-513","group_name":"","mtime":1617611975,"checksum":"9f3499dac54e5b98d286562d47dd5f361a1545ba"}}}
2021/04/05 09:40:13 wazuh-agent[1560] fim_sync.c:354 at fim_sync_send_list(): ERROR: (6704): Couldn't get path of '[x64] HKEY_LOCAL_MACHINE\SOFTWARE\random_key:::::this_is_a_test'
2021/04/05 09:40:13 wazuh-agent[1560] fim_sync.c:354 at fim_sync_send_list(): ERROR: (6704): Couldn't get path of '[x64] HKEY_LOCAL_MACHINE\SOFTWARE\random_key:::arandomvalue'
2021/04/05 09:40:13 wazuh-agent[1560] run_check.c:82 at fim_send_sync_msg(): DEBUG: (6317): Sending integrity control message: {"component":"fim_registry","type":"state","data":{"timestamp":1617612013,"path":"HKEY_LOCAL_MACHINE\\SOFTWARE\\random_key","arch":"[x64]","value_name":"othervalue","attributes":{"type":"registry_value","value_type":"REG_SZ","size":1,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"4ca7b88b201728c31afb691707c41d35a984317d"}}}
2021/04/05 09:40:16 wazuh-agent[1560] create_db.c:128 at fim_scan(): INFO: (6008): File integrity monitoring scan started.
```

These logs prove that the agent won't crash if a value is starting with `:`, but as I mentioned earlier, some changes need to be done in the synchronization mechanism in order to handle properly this values.


<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Windows
 
- [X] Source installation
- [X] Source upgrade

- Memory tests for Windows
  - [X] Scan-build report
