### PR TITLE
Delete ossec.log and ossec.json files and rotated ossec-*.log and ossec-*.json files in Wazuh upgrades

### DIFF
--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -115,7 +115,7 @@ getPreinstalledDirByType()
     # Checking for Darwin
     if [ "X${NUNAME}" = "XDarwin" ]; then
         if [ -f /Library/StartupItems/WAZUH/WAZUH ]; then
-            PREINSTALLEDDIR=`sed -n 's/^\s*\(.*\)\/bin\/wazuh-control start$/\1/p' /Library/StartupItems/WAZUH/WAZUH`
+            PREINSTALLEDDIR=`sed -n 's/^ *//; s/^\s*\(.*\)\/bin\/wazuh-control start$/\1/p' /Library/StartupItems/WAZUH/WAZUH`
             if [ -d "$PREINSTALLEDDIR" ]; then
                 return 0;
             else

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -115,7 +115,7 @@ getPreinstalledDirByType()
     # Checking for Darwin
     if [ "X${NUNAME}" = "XDarwin" ]; then
         if [ -f /Library/StartupItems/WAZUH/WAZUH ]; then
-            PREINSTALLEDDIR=`sed -n 's/^ *//; s/^\s*\(.*\)\/bin\/wazuh-control start$/\1/p' /Library/StartupItems/WAZUH/WAZUH`
+            PREINSTALLEDDIR=`sed -n 's/^\s*\(.*\)\/bin\/wazuh-control start$/\1/p' /Library/StartupItems/WAZUH/WAZUH`
             if [ -d "$PREINSTALLEDDIR" ]; then
                 return 0;
             else
@@ -423,11 +423,23 @@ UpdateOldVersions()
     # Update versions previous to Wazuh 5.0.0, which is a breaking change
     if [ "X$1" = "Xyes" ]; then
 
-        OSSEC_CONF_FILE="$PREINSTALLEDDIR/etc/ossec.conf"
-        OSSEC_CONF_FILE_BACKUP="$PREINSTALLEDDIR/etc/ossec.conf.backup"
+        echo "Renaming and deleting old files..."
+
+        CONF_FILE="$PREINSTALLEDDIR/etc/ossec.conf"
+        CONF_FILE_BACKUP="$PREINSTALLEDDIR/etc/ossec.conf.backup"
+        LOG_FILE="$PREINSTALLEDDIR/logs/ossec.log"
+        JSON_FILE="$PREINSTALLEDDIR/logs/ossec.json"
+        LOG_WAZUH_FOLDER="$PREINSTALLEDDIR/logs/wazuh/*"
 
         # rename ossec.conf to ossec.conf.backup
-        mv $OSSEC_CONF_FILE $OSSEC_CONF_FILE_BACKUP
+        mv $CONF_FILE $CONF_FILE_BACKUP
+
+        # remove ossec.log and ossec.json
+        rm -v $LOG_FILE
+        rm -v $JSON_FILE
+
+        # remove all files folders from /logs/wazuh/*
+        rm -rfv $LOG_WAZUH_FOLDER
 
         # If it is Wazuh 2.0 or newer, exit
         if [ "X$USER_OLD_NAME" = "XWazuh" ]; then

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -430,6 +430,7 @@ UpdateOldVersions()
         LOG_FILE="$PREINSTALLEDDIR/logs/ossec.log"
         JSON_FILE="$PREINSTALLEDDIR/logs/ossec.json"
         LOG_WAZUH_FOLDER="$PREINSTALLEDDIR/logs/wazuh/*"
+        LOG_OSSEC_FOLDER="$PREINSTALLEDDIR/logs/ossec/*"
 
         # rename ossec.conf to ossec.conf.backup
         mv $CONF_FILE $CONF_FILE_BACKUP
@@ -438,8 +439,13 @@ UpdateOldVersions()
         rm -v $LOG_FILE
         rm -v $JSON_FILE
 
-        # remove all files folders from /logs/wazuh/*
-        rm -rfv $LOG_WAZUH_FOLDER
+        # remove all files and folders from /logs/wazuh/* or /logs/ossec/*
+        if [ -f $LOG_WAZUH_FOLDER ]; then
+            rm -rfv $LOG_WAZUH_FOLDER
+        fi
+        if [ -f $LOG_OSSEC_FOLDER ]; then
+            rm -rfv $LOG_OSSEC_FOLDER
+        fi
 
         # If it is Wazuh 2.0 or newer, exit
         if [ "X$USER_OLD_NAME" = "XWazuh" ]; then

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -79,13 +79,12 @@ If objFSO.fileExists(home_dir & "ossec.conf") Then
         objSFO.DeleteFile(home_dir & "ossec.log")
     End If
 
-    ' remove all files and folders from /logs/wazuh/* or /logs/ossec/*
-    If objFSO.folderExists(home_dir & "logs\wazuh") Then
-        objSFO.DeleteFile(home_dir & "logs\wazuh\*"), TRUE
+    ' remove all files and folders from /logs/*
+    If objFSO.folderExists(home_dir & "logs\") Then
+        objSFO.DeleteFolder(home_dir & "logs")
+        objSFO.CreateFolder(home_dir & "logs")
     End If
-    If objFSO.folderExists(home_dir & "logs\ossec") Then
-        objSFO.DeleteFile(home_dir & "logs\ossec\*"), TRUE
-    End If
+
 End If
 
 If objFSO.fileExists(home_dir & "agent.conf") Then

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -68,9 +68,23 @@ If Not objFSO.fileExists(home_dir & "client.keys") Then
 
 End If
 
+' rename ossec.conf to ossec.conf.backup
 If objFSO.fileExists(home_dir & "ossec.conf") Then
     objFSO.MoveFile home_dir & "ossec.conf" , home_dir & "ossec.conf.backup"
 End If
+
+' remove ossec.log and ossec.json
+If objFSO.fileExists(home_dir & "logs\ossec.log") Then
+    objSFO.DeleteFile(home_dir & "logs\ossec.log")
+End If
+If objFSO.fileExists(home_dir & "logs\ossec.json") Then
+    objSFO.DeleteFile(home_dir & "logs\ossec.json")
+End If
+
+' remove all files folders from /logs/wazuh/*
+objSFO.DeleteFile(home_dir & "logs\wazuh\*"), TRUE
+
+' rm -rfv $LOG_WAZUH_FOLDER
 
 If objFSO.fileExists(home_dir & "agent.conf") Then
     ' Reading agent.conf file

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -68,23 +68,25 @@ If Not objFSO.fileExists(home_dir & "client.keys") Then
 
 End If
 
-' rename ossec.conf to ossec.conf.backup
+' If ossec.conf exists, it means Wazuh version < 5.0.0
 If objFSO.fileExists(home_dir & "ossec.conf") Then
+
+    ' rename ossec.conf to ossec.conf.backup
     objFSO.MoveFile home_dir & "ossec.conf" , home_dir & "ossec.conf.backup"
-End If
 
-' remove ossec.log and ossec.json
-If objFSO.fileExists(home_dir & "logs\ossec.log") Then
-    objSFO.DeleteFile(home_dir & "logs\ossec.log")
-End If
-If objFSO.fileExists(home_dir & "logs\ossec.json") Then
-    objSFO.DeleteFile(home_dir & "logs\ossec.json")
-End If
+    ' remove ossec.log
+    If objFSO.fileExists(home_dir & "ossec.log") Then
+        objSFO.DeleteFile(home_dir & "ossec.log")
+    End If
 
-' remove all files folders from /logs/wazuh/*
-objSFO.DeleteFile(home_dir & "logs\wazuh\*"), TRUE
-
-' rm -rfv $LOG_WAZUH_FOLDER
+    ' remove all files and folders from /logs/wazuh/* or /logs/ossec/*
+    If objFSO.folderExists(home_dir & "logs\wazuh") Then
+        objSFO.DeleteFile(home_dir & "logs\wazuh\*"), TRUE
+    End If
+    If objFSO.folderExists(home_dir & "logs\ossec") Then
+        objSFO.DeleteFile(home_dir & "logs\ossec\*"), TRUE
+    End If
+End If
 
 If objFSO.fileExists(home_dir & "agent.conf") Then
     ' Reading agent.conf file


### PR DESCRIPTION
|Related issue|
|---|
|#8088|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The purpose of this issue is to delete ossec.log and ossec.json files in Wazuh upgrades.

Also, old rotated log files located at /var/ossec/logs/wazuh/ have to be deleted.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
- [ ] Manager RPM: Upgrade from 4.x to 5.0.
- [x] Manager DEB: Upgrade from 4.x to 5.0.
- [ ] Agent RPM: Upgrade from 4.x to 5.0.
- [x] Agent DEB: Upgrade from 4.x to 5.0.
- [ ] Agent MacOS: Upgrade from 4.x to 5.0.
- [x] Agent Windows: Upgrade from 4.x to 5.0.
- [ ] Other agent OS: Upgrade from 4.x to 5.0.
