### PR TITLE
Let CURL downloading function take the default values

### DIFF
--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -86,8 +86,6 @@ int wurl_get(const char * url, const char * dest, const char * header, const cha
 
         // Enable SSL check if url is HTTPS
         if (!strncmp(url,"https",5)) {
-            res += curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
-            res += curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 1L);
             if (NULL != cert) {
                 res += curl_easy_setopt(curl, CURLOPT_CAINFO, cert);
             }
@@ -321,8 +319,6 @@ char * wurl_http_get(const char * url) {
 
         // Enable SSL check if url is HTTPS
         if(!strncmp(url,"https",5)){
-            res += curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
-            res += curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 1L);
             if (NULL != cert) {
                 res += curl_easy_setopt(curl, CURLOPT_CAINFO, cert);
             }


### PR DESCRIPTION
|Related issue|
|---|
|#8103|

This PR lets the CURL helper library take the default values for the parameters `CURLOPT_SSL_VERIFYPEER` and `CURLOPT_PROXY_SSL_VERIFYHOST`. That prevents `wurl_get()` from returning an error code as setting `CURLOPT_PROXY_SSL_VERIFYHOST` to `1` produces.

## Tests

- [X] Compile manager on Linux.
- [X] Download NVD feed for Vuln Detector.