### PR TITLE
Add the capability to disable the max_request_per_minute option

### DIFF
--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -108,7 +108,8 @@ async def prevent_denial_of_service(request, max_requests=300):
 @web.middleware
 async def security_middleware(request, handler):
     access_conf = api_conf['access']
-    await prevent_denial_of_service(request, max_requests=access_conf['max_request_per_minute'])
+    if access_conf['max_request_per_minute'] > 0:
+        await prevent_denial_of_service(request, max_requests=access_conf['max_request_per_minute'])
     await unlock_ip(request=request, block_time=access_conf['block_time'])
 
     return await handler(request)


### PR DESCRIPTION
|Related issue|
|---|
|#8110|

Hi team,

This PR closes #8110. In this PR we have added the capability to disable the API's max_request_per_minute option. To disable this feature it is necessary to set its value to 0.

```yaml
# Access parameters
 access:
  max_login_attempts: 50
  block_time: 300
  max_request_per_minute: 0
```

Regards