### PR TITLE
Update PUT /agents/group/{group}/restart response for groups with no agents

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -18,6 +18,7 @@ from wazuh import agent, stats
 from wazuh.core.cluster.control import get_system_nodes
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.common import database_limit
+from wazuh.core.results import AffectedItemsWazuhResult
 
 logger = logging.getLogger('wazuh-api')
 
@@ -958,7 +959,25 @@ async def restart_agents_by_group(request, group_id, pretty=False, wait_for_comp
     :param group_id: Group ID.
     :return: AllItemsResponseAgents
     """
-    f_kwargs = {'group_id': group_id}
+    f_kwargs = {'group_list': [group_id], 'select': ['id']}
+
+    dapi = DistributedAPI(f=agent.get_agents_in_group,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='local_master',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          logger=logger,
+                          rbac_permissions=request['token_info']['rbac_policies']
+                          )
+
+    agents = raise_if_exc(await dapi.distribute_function())
+    agent_list = [a['id'] for a in agents.affected_items]
+
+    if not agent_list:
+        data = AffectedItemsWazuhResult(none_msg='Restart command was not sent to any agent')
+        return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
+
+    f_kwargs = {'agent_list': agent_list}
 
     dapi = DistributedAPI(f=agent.restart_agents,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6357,8 +6357,16 @@ paths:
                       data:
                         $ref: '#/components/schemas/AllItemsResponseAgentIDs'
                 example:
-                  message: "Restart command sent to all agents"
-                  error: 0
+                  data:
+                    affected_items:
+                      - '002'
+                      - '003'
+                      - '005'
+                    total_affected_items: 3
+                    total_failed_items: 0
+                    failed_items: []
+                    message: "Restart command sent to all agents"
+                    error: 0
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -64,7 +64,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -90,7 +90,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -119,7 +119,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -145,7 +145,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 2
         data:
           affected_items:
             - "003"
@@ -172,7 +172,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - "001"
@@ -197,7 +197,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - "001"
@@ -322,7 +322,7 @@ stages:
           expected_field: "query"
           expected_value: " <QueryList> <Query Id='0' Path='System'> <Select Path='System'>*[System[(Level&lt;=3)]]</Select> </Query> </QueryList> "
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - filters: !anything
@@ -344,9 +344,14 @@ stages:
         Authorization: "Bearer {test_login_token}"
         content-type: "application/xml"
     response:
-      status_code: 400
+      status_code: 200
       json:
-        error: 1755
+        error: 0
+        data:
+          affected_items: []
+          total_affected_items: 0
+          failed_items: []
+          total_failed_items: 0
 
     # PUT /agents/group/group2/restart (Agents 009 and 010 are disconnected)
   - name: Restart all agents from group2
@@ -360,7 +365,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 2
         data:
           affected_items:
             - "001"
@@ -423,7 +428,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -444,7 +449,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -469,7 +474,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 2
         data:
           affected_items:
             - "001"
@@ -494,7 +499,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 2
         data:
           affected_items:
             - "001"
@@ -526,7 +531,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - "001"
@@ -557,7 +562,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -581,7 +586,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - "001"
@@ -604,7 +609,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -626,7 +631,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:
@@ -661,7 +666,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
             - "002"
@@ -700,7 +705,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 0
       verify_response_with:
         - function: tavern_utils:test_validate_restart_by_node
           extra_kwargs:
@@ -717,7 +722,7 @@ stages:
     response:
       status_code: 200
       json:
-        error: !anyint
+        error: 1
         data:
           affected_items: []
           failed_items:

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -541,18 +541,6 @@ class DistributedAPI:
             requested_nodes = self.f_kwargs.get('node_list', None) or [self.f_kwargs['node_id']]
             return {node_id: [] for node_id in requested_nodes}
 
-        elif 'group_id' in self.f_kwargs:
-            common.rbac.set(self.rbac_permissions)
-            agents = agent.get_agents_in_group(group_list=[self.f_kwargs['group_id']], select=select_node,
-                                               sort={'fields': ['node_name'], 'order': 'desc'}).affected_items
-            if len(agents) == 0:
-                raise WazuhError(1755)
-            del self.f_kwargs['group_id']
-            node_name = {k: list(map(operator.itemgetter('id'), g)) for k, g in
-                         itertools.groupby(agents, key=operator.itemgetter('node_name'))}
-
-            return node_name
-
         else:
             if self.broadcasting:
                 node_name = {}

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -50,6 +50,8 @@ def raise_if_exc_routine(dapi_kwargs, expected_error=None):
     dapi = DistributedAPI(**dapi_kwargs)
     try:
         raise_if_exc(loop.run_until_complete(dapi.distribute_function()))
+        if expected_error:
+            assert False, f'Expected exception not generated: {expected_error}'
     except ProblemException as e:
         if expected_error:
             assert e.ext['code'] == expected_error
@@ -326,17 +328,17 @@ def test_DistributedAPI_get_solver_node(mock_cluster_status, mock_agents_overvie
             with patch('wazuh.agent.get_agents_in_group', return_value=expected):
                 dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'distributed_master',
                                'f_kwargs': {'group_id': 'default'}, 'nodes': ['master']}
-                raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=1755)
+                raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
 
             expected.affected_items = []
             with patch('wazuh.agent.get_agents_in_group', return_value=expected):
                 dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'distributed_master',
                                'f_kwargs': {'group_id': 'noexist'}, 'nodes': ['master']}
-                raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=1755)
+                raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
 
             dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'distributed_master',
                            'f_kwargs': {'node_list': '*'}, 'broadcasting': True, 'nodes': ['master']}
-            raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=1755)
+            raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
 
 
 @pytest.mark.parametrize('api_request', [

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -336,8 +336,6 @@ class WazuhException(Exception):
                'remediation': 'Please select another agent or connect your agent before assigning groups'},
         1754: {'message': 'Agent does not exist or you do not have permissions to access it',
                'remediation': 'Try listing all agents with GET /agents endpoint'},
-        1755: {'message': 'The group does not have any agent assigned',
-               'remediation': 'Please select another group or assign any agent to it'},
         1756: {'message': 'Upgrade procedure could not start. Agent already upgrading',
                'remediation': 'You can check the status of this task with the /agents/:agent_id/upgrade_result endpoint'
                },


### PR DESCRIPTION
|Related issue|
|---|
| #8001 |

Hi team,

This PR closes #8001.

We are raising the `1755` error code and message before calling the `restart_agents` function from the SDK, in the `dapi.py`. 

When we try to do the distributed master call (in `distribute_function`), we call the function `forward_request`. This function uses `get_solver_node` to get the nodes the agents belonging to the specific group are reporting to.

If `len(agents) == 0`, we raise the error mentioned above:

https://github.com/wazuh/wazuh/blob/fd4ac51bf994703e85a913ae22b1897f0d5ae686/framework/wazuh/core/cluster/dapi/dapi.py#L544-L554

In this PR, I have removed the `group_id` check in `get_solver_node` (in dapi.py) used to indicate if the API call was `PUT /agents/group/default/restart`.

Now the agent controller function `restart_agents_by_group` gets the agents that belong to the specific group. If the agent list size is 0, we return a json response with status 200 and 0 failed and affected items.

I have also updated unittest and API integration tests.

### Manual tests:

_**default: group with 1 agent assigned
group1: unexistant group
group2: group with no agents assigned**_

**Group with agents:**

`2021/04/06 10:45:59 INFO: wazuh 172.20.0.1 "PUT /agents/group/default/restart" with parameters {"pretty": "true", "wait_for_complete": "true"} and body {} done in 1.594s: 200`

```
{
  "data": {
    "affected_items": [
      "001"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Restart command was sent to all agents",
  "error": 0
}
```

**Group without agents:**

`2021/04/06 10:44:42 INFO: wazuh 172.20.0.1 "PUT /agents/group/group2/restart" with parameters {"pretty": "true", "wait_for_complete": "true"} and body {} done in 38.726s: 200`

```
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Restart command was not sent to any agent",
  "error": 0
}
```

**Unexistant group:**

`2021/04/06 12:26:32 INFO: wazuh 172.20.0.1 "PUT /agents/group/group1/restart" with parameters {"pretty": "true", "wait_for_complete": "true"} and body {} done in 2.475s: 404`

```
{
  "title": "Resource Not Found",
  "detail": "The group does not exist",
  "remediation": "Please, use `GET /agents/groups` to find all available groups",
  "dapi_errors": {
    "master-node": {
      "error": "The group does not exist"
    }
  },
  "error": 1710
}
```

**With both `group:read` and `agent:read `denied (SAME FOR group:read denied and agent:read allowed):**

```
2021/04/06 12:34:04 INFO: manuel 172.20.0.1 "PUT /agents/group/default/restart" with parameters {"pretty": "true", "wait_for_complete": "true"} and body {} done in 0.025s: 403
2021/04/06 12:34:08 INFO: manuel 172.20.0.1 "PUT /agents/group/group1/restart" with parameters {"pretty": "true", "wait_for_complete": "true"} and body {} done in 0.026s: 403
2021/04/06 12:34:12 INFO: manuel 172.20.0.1 "PUT /agents/group/group2/restart" with parameters {"pretty": "true", "wait_for_complete": "true"} and body {} done in 0.024s: 403
```

The 3 responses were:

```
{
  "title": "Permission Denied",
  "detail": "Permission denied: Resource type: group:id",
  "remediation": "Please, make sure you have permissions to execute the current request. For more information on how to set up permissions, please visit https://documentation.wazuh.com/4.3/user-manual/api/rbac/configuration.html",
  "dapi_errors": {
    "unknown-node": {
      "error": "Permission denied: Resource type: group:id"
    }
  },
  "error": 4000
}
```

**With `group:read` allowed and `agent:read` denied:**


```
"roles": [
          {
            "id": 100,
            "name": "read_group",
            "policies": [
              {
                "id": 5,
                "name": "agents_read_groups",
                "policy": {
                  "actions": [
                    "group:read"
                  ],
                  "resources": [
                    "group:id:*"
                  ],
                  "effect": "allow"
                }
              }
            ],
            ...
```
        
**Groups with agents:**
    
`2021/04/06 13:22:38 INFO: manuel 172.20.0.1 "PUT /agents/group/default/restart" with parameters {"pretty": "true", "wait_for_complete": "true"} and body {} done in 0.039s: 200`

```
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Restart command was not sent to any agent",
  "error": 0
}
```

**Unexistant group:**

`2021/04/06 13:23:10 INFO: manuel 172.20.0.1 "PUT /agents/group/group1/restart" with parameters {"pretty": "true", "wait_for_complete": "true"} and body {} done in 0.036s: 404`

```
{
  "title": "Resource Not Found",
  "detail": "The group does not exist",
  "remediation": "Please, use `GET /agents/groups` to find all available groups",
  "dapi_errors": {
    "unknown-node": {
      "error": "The group does not exist"
    }
  },
  "error": 1710
}
```

**Group with no agents:**

`2021/04/06 13:23:47 INFO: manuel 172.20.0.1 "PUT /agents/group/group2/restart" with parameters {"pretty": "true", "wait_for_complete": "true"} and body {} done in 0.042s: 200`

```
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Restart command was not sent to any agent",
  "error": 0
}
```

### Unittest results:

```
pytest framework/wazuh/core/cluster/dapi/tests/
======================== 23 passed, 9 warnings in 0.57s ========================
```

Rest of unittests passing.

### API integration test results:

```
test_agent_PUT_endpoints.tavern.yaml 
	 9 passed, 11 warnings
	 
test_rbac_white_agent_endpoints.tavern.yaml 
	 40 passed, 42 warnings

test_rbac_black_agent_endpoints.tavern.yaml 
	 40 passed, 42 warnings
```

Regards,
Manuel.
