### PR TITLE
Delete ossec.log and ossec.json files and rotated ossec-*.log and ossec-*.json files in Wazuh upgrades

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -145,8 +145,8 @@ Install()
     # If update, start Wazuh
     if [ "X${update_only}" = "Xyes" ]; then
         WazuhUpgrade
-        # Update versions previous to Wazuh 1.2
-        UpdateOldVersions
+        # Update versions previous to Wazuh 5.0.0
+        UpdateOldVersions $breaking_upgrade
         echo "Starting Wazuh..."
         UpdateStartOSSEC
     fi
@@ -894,6 +894,13 @@ main()
             esac
         done
 
+        # Only if the update is for a version lower than 5.0.0
+        USER_OLD_VERSION=`getPreinstalledVersion`
+        VERSIONv5="v5.0.0"
+
+        if [ "$USER_OLD_VERSION" \< "$VERSIONv5" ]; then
+            breaking_upgrade="yes"
+        fi
 
         # Do some of the update steps.
         if [ "X${update_only}" = "Xyes" ]; then

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -420,82 +420,103 @@ UpdateOldVersions()
         done
     fi
 
-    # If it is Wazuh 2.0 or newer, exit
-    if [ "X$USER_OLD_NAME" = "XWazuh" ]; then
-        return
-    fi
+    # Update versions previous to Wazuh 5.0.0, which is a breaking change
+    if [ "X$1" = "Xyes" ]; then
 
-    if [ "X$PREINSTALLEDDIR" != "X" ]; then
-        getPreinstalledDir
-    fi
+        echo "Renaming and deleting old files..."
 
-    OSSEC_CONF_FILE="$PREINSTALLEDDIR/etc/ossec.conf"
-    OSSEC_CONF_FILE_ORIG="$PREINSTALLEDDIR/etc/ossec.conf.orig"
+        OSSEC_LOG_FILE="$PREINSTALLEDDIR/logs/ossec.log"
+        OSSEC_JSON_FILE="$PREINSTALLEDDIR/logs/ossec.json"
+        LOG_WAZUH_FOLDER="$PREINSTALLEDDIR/logs/wazuh/*"
+        LOG_OSSEC_FOLDER="$PREINSTALLEDDIR/logs/ossec/*"
 
-    # ossec.conf -> ossec.conf.orig
-    cp -pr $OSSEC_CONF_FILE $OSSEC_CONF_FILE_ORIG
+        # remove ossec.log and ossec.json
+        rm -v $OSSEC_LOG_FILE
+        rm -v $OSSEC_JSON_FILE
 
-    # Delete old service
-    if [ -f /etc/init.d/ossec ]; then
-        rm /etc/init.d/ossec
-    fi
-
-    if [ ! "$INSTYPE" = "agent" ]; then
-
-        # Delete old update ruleset
-        if [ -d "$PREINSTALLEDDIR/update" ]; then
-            rm -rf "$PREINSTALLEDDIR/update"
+        # remove all files and folders from /logs/wazuh/* or /logs/ossec/*
+        if [ -f $LOG_WAZUH_FOLDER ]; then
+            rm -rfv $LOG_WAZUH_FOLDER
+        fi
+        if [ -f $LOG_OSSEC_FOLDER ]; then
+            rm -rfv $LOG_OSSEC_FOLDER
         fi
 
-        ETC_DECODERS="$PREINSTALLEDDIR/etc/decoders"
-        ETC_RULES="$PREINSTALLEDDIR/etc/rules"
+        # If it is Wazuh 2.0 or newer, exit
+        if [ "X$USER_OLD_NAME" = "XWazuh" ]; then
+            return
+        fi
 
-        # Moving local_decoder
-        if [ -f "$PREINSTALLEDDIR/etc/local_decoder.xml" ]; then
-            if [ -s "$PREINSTALLEDDIR/etc/local_decoder.xml" ]; then
-                mv "$PREINSTALLEDDIR/etc/local_decoder.xml" $ETC_DECODERS
-            else
-                # it is empty
-                rm -f "$PREINSTALLEDDIR/etc/local_decoder.xml"
+        if [ "X$PREINSTALLEDDIR" != "X" ]; then
+            getPreinstalledDir
+        fi
+        OSSEC_CONF_FILE="$PREINSTALLEDDIR/etc/ossec.conf"
+        OSSEC_CONF_FILE_ORIG="$PREINSTALLEDDIR/etc/ossec.conf.orig"
+
+        # ossec.conf -> ossec.conf.orig
+        cp -pr $OSSEC_CONF_FILE $OSSEC_CONF_FILE_ORIG
+        # Delete old service
+        if [ -f /etc/init.d/ossec ]; then
+            rm /etc/init.d/ossec
+        fi
+
+        if [ ! "$INSTYPE" = "agent" ]; then
+
+            # Delete old update ruleset
+            if [ -d "$PREINSTALLEDDIR/update" ]; then
+                rm -rf "$PREINSTALLEDDIR/update"
             fi
-        fi
 
-        # Moving local_rules
-        if [ -f "$PREINSTALLEDDIR/rules/local_rules.xml" ]; then
-            mv "$PREINSTALLEDDIR/rules/local_rules.xml" $ETC_RULES
-        fi
+            ETC_DECODERS="$PREINSTALLEDDIR/etc/decoders"
+            ETC_RULES="$PREINSTALLEDDIR/etc/rules"
 
-        # Creating backup directory
-        BACKUP_RULESET="$PREINSTALLEDDIR/etc/backup_ruleset"
-        mkdir $BACKUP_RULESET > /dev/null 2>&1
-        chmod 750 $BACKUP_RULESET > /dev/null 2>&1
-        chown root:ossec $BACKUP_RULESET > /dev/null 2>&1
-
-        # Backup decoders: Wazuh v1.0.1 to v1.1.1
-        old_decoders="ossec_decoders wazuh_decoders"
-        for old_decoder in $old_decoders
-        do
-            if [ -d "$PREINSTALLEDDIR/etc/$old_decoder" ]; then
-                mv "$PREINSTALLEDDIR/etc/$old_decoder" $BACKUP_RULESET
+            # Moving local_decoder
+            if [ -f "$PREINSTALLEDDIR/etc/local_decoder.xml" ]; then
+                if [ -s "$PREINSTALLEDDIR/etc/local_decoder.xml" ]; then
+                    mv "$PREINSTALLEDDIR/etc/local_decoder.xml" $ETC_DECODERS
+                else
+                    # it is empty
+                    rm -f "$PREINSTALLEDDIR/etc/local_decoder.xml"
+                fi
             fi
-        done
 
-        # Backup decoders: Wazuh v1.0 and OSSEC
-        if [ -f "$PREINSTALLEDDIR/etc/decoder.xml" ]; then
-            mv "$PREINSTALLEDDIR/etc/decoder.xml" $BACKUP_RULESET
+            # Moving local_rules
+            if [ -f "$PREINSTALLEDDIR/rules/local_rules.xml" ]; then
+                mv "$PREINSTALLEDDIR/rules/local_rules.xml" $ETC_RULES
+            fi
+
+            # Creating backup directory
+            BACKUP_RULESET="$PREINSTALLEDDIR/etc/backup_ruleset"
+            mkdir $BACKUP_RULESET > /dev/null 2>&1
+            chmod 750 $BACKUP_RULESET > /dev/null 2>&1
+            chown root:ossec $BACKUP_RULESET > /dev/null 2>&1
+
+            # Backup decoders: Wazuh v1.0.1 to v1.1.1
+            old_decoders="ossec_decoders wazuh_decoders"
+            for old_decoder in $old_decoders
+            do
+                if [ -d "$PREINSTALLEDDIR/etc/$old_decoder" ]; then
+                    mv "$PREINSTALLEDDIR/etc/$old_decoder" $BACKUP_RULESET
+                fi
+            done
+
+            # Backup decoders: Wazuh v1.0 and OSSEC
+            if [ -f "$PREINSTALLEDDIR/etc/decoder.xml" ]; then
+                mv "$PREINSTALLEDDIR/etc/decoder.xml" $BACKUP_RULESET
+            fi
+
+            # Backup rules: All versions
+            mv "$PREINSTALLEDDIR/rules" $BACKUP_RULESET
+
+            # New ossec.conf by default
+            ./gen_ossec.sh conf "manager" $DIST_NAME $DIST_VER > $OSSEC_CONF_FILE
+            ./add_localfiles.sh $PREINSTALLEDDIR >> $OSSEC_CONF_FILE
+        else
+            # New ossec.conf by default
+            ./gen_ossec.sh conf "agent" $DIST_NAME $DIST_VER > $OSSEC_CONF_FILE
+            # Replace IP
+            ./src/init/replace_manager_ip.sh $OSSEC_CONF_FILE_ORIG $OSSEC_CONF_FILE
+            ./add_localfiles.sh $PREINSTALLEDDIR >> $OSSEC_CONF_FILE
         fi
-
-        # Backup rules: All versions
-        mv "$PREINSTALLEDDIR/rules" $BACKUP_RULESET
-
-        # New ossec.conf by default
-        ./gen_ossec.sh conf "manager" $DIST_NAME $DIST_VER > $OSSEC_CONF_FILE
-        ./add_localfiles.sh $PREINSTALLEDDIR >> $OSSEC_CONF_FILE
-    else
-        # New ossec.conf by default
-        ./gen_ossec.sh conf "agent" $DIST_NAME $DIST_VER > $OSSEC_CONF_FILE
-        # Replace IP
-        ./src/init/replace_manager_ip.sh $OSSEC_CONF_FILE_ORIG $OSSEC_CONF_FILE
-        ./add_localfiles.sh $PREINSTALLEDDIR >> $OSSEC_CONF_FILE
     fi
 }

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -67,6 +67,22 @@ If Not objFSO.fileExists(home_dir & "client.keys") Then
     objFSO.CreateTextFile(home_dir & "client.keys")
 End If
 
+' If ossec.conf exists, it means Wazuh version < 5.0.0
+If objFSO.fileExists(home_dir & "ossec.conf") Then
+
+    ' remove ossec.log
+    If objFSO.fileExists(home_dir & "ossec.log") Then
+        objSFO.DeleteFile(home_dir & "ossec.log")
+    End If
+
+    ' remove all files and folders from /logs/*
+    If objFSO.folderExists(home_dir & "logs\") Then
+        objSFO.DeleteFolder(home_dir & "logs")
+        objSFO.CreateFolder(home_dir & "logs")
+    End If
+
+End If
+
 If objFSO.fileExists(home_dir & "ossec.conf") Then
     ' Reading ossec.conf file
     Const ForReading = 1

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -75,6 +75,11 @@ If objFSO.fileExists(home_dir & "ossec.conf") Then
         objSFO.DeleteFile(home_dir & "ossec.log")
     End If
 
+    ' remove ossec.json
+    If objFSO.fileExists(home_dir & "ossec.json") Then
+        objSFO.DeleteFile(home_dir & "ossec.json")
+    End If
+
     ' remove all files and folders from /logs/*
     If objFSO.folderExists(home_dir & "logs\") Then
         objSFO.DeleteFolder(home_dir & "logs")


### PR DESCRIPTION
|Related issue|
|---|
|#8088|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The purpose of this issue is to delete ossec.log and ossec.json files in Wazuh upgrades.

Also, old rotated log files located at /var/ossec/logs/wazuh/ have to be deleted.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
- [ ] Manager RPM: Upgrade from 4.x to 5.0.
- [x] Manager DEB: Upgrade from 4.x to 5.0.
- [ ] Agent RPM: Upgrade from 4.x to 5.0.
- [x] Agent DEB: Upgrade from 4.x to 5.0.
- [ ] Agent MacOS: Upgrade from 4.x to 5.0.
- [ ] Agent Windows: Upgrade from 4.x to 5.0.
- [ ] Other agent OS: Upgrade from 4.x to 5.0.