### PR TITLE
Add new endpoint to get the MITRE's database metadata

### DIFF
--- a/api/api/controllers/mitre_controller.py
+++ b/api/api/controllers/mitre_controller.py
@@ -31,7 +31,7 @@ async def get_metadata(request, pretty=False, wait_for_complete=False):
 
     dapi = DistributedAPI(f=mitre_metadata,
                           f_kwargs={},
-                          request_type='local_master',
+                          request_type='local_any',
                           is_async=False,
                           wait_for_complete=wait_for_complete,
                           logger=logger,

--- a/api/api/controllers/mitre_controller.py
+++ b/api/api/controllers/mitre_controller.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2020, Wazuh Inc.
+# Copyright (C) 2015-2021, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
@@ -7,17 +7,39 @@ import logging
 from aiohttp import web
 
 from api.encoder import dumps, prettify
-from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
-from wazuh.core.common import database_limit
+from api.util import raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
+from wazuh.mitre import get_metadata
 
 logger = logging.getLogger('wazuh-api')
 
 
-async def get_metadata():
-    """TODO
+async def get_mitre_metadata(request, pretty=False, wait_for_complete=False):
+    """Return the metadata of the MITRE's database
+
+    Parameters
+    ----------
+    pretty : bool, optional
+        Show results in human-readable format
+    wait_for_complete : bool, optional
+        Disable timeout response
+
+    Returns
+    -------
+    Metadata of MITRE's db
     """
-    # TODO
+
+    dapi = DistributedAPI(f=get_metadata,
+                          f_kwargs={},
+                          request_type='local_master',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          logger=logger,
+                          rbac_permissions=request['token_info']['rbac_policies']
+                          )
+    data = raise_if_exc(await dapi.distribute_function())
+
+    return web.json_response(data=data, status=200, dumps=prettify if pretty else dumps)
 
 
 async def get_tactics():

--- a/api/api/controllers/mitre_controller.py
+++ b/api/api/controllers/mitre_controller.py
@@ -9,12 +9,12 @@ from aiohttp import web
 from api.encoder import dumps, prettify
 from api.util import raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
-from wazuh.mitre import get_metadata
+from wazuh.mitre import mitre_metadata
 
 logger = logging.getLogger('wazuh-api')
 
 
-async def get_mitre_metadata(request, pretty=False, wait_for_complete=False):
+async def get_metadata(request, pretty=False, wait_for_complete=False):
     """Return the metadata of the MITRE's database
 
     Parameters
@@ -29,7 +29,7 @@ async def get_mitre_metadata(request, pretty=False, wait_for_complete=False):
     Metadata of MITRE's db
     """
 
-    dapi = DistributedAPI(f=get_metadata,
+    dapi = DistributedAPI(f=mitre_metadata,
                           f_kwargs={},
                           request_type='local_master',
                           is_async=False,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3504,13 +3504,6 @@ components:
       x-bearerInfoFunc: api.authentication.decode_token
 
   parameters:
-    technique_id:
-      in: query
-      name: id
-      description: "MITRE technique ID"
-      schema:
-        type: string
-        format: alphanumeric
     agent_id:
       in: path
       name: agent_id
@@ -10502,13 +10495,13 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
-  /mitre:
+  /mitre/metadata:
     get:
       tags:
         - Mitre
       summary: "Get MITRE metadata"
       description: "Return the metadata from MITRE database"
-      operationId: api.controllers.mitre_controller.get_metadata
+      operationId: api.controllers.mitre_controller.get_mitre_metadata
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/mitre:read'
       parameters:
@@ -10516,7 +10509,7 @@ paths:
         - $ref: '#/components/parameters/wait_for_complete'
       responses:
         '200':
-          description: "Clear rootcheck database for all agents or a list of them"
+          description: "Get MITRE metadata information"
           content:
             application/json:
               schema:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -10501,7 +10501,7 @@ paths:
         - Mitre
       summary: "Get MITRE metadata"
       description: "Return the metadata from MITRE database"
-      operationId: api.controllers.mitre_controller.get_mitre_metadata
+      operationId: api.controllers.mitre_controller.get_metadata
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/mitre:read'
       parameters:

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -1,0 +1,29 @@
+---
+test_name: GET /mitre/metadata
+
+marks:
+  - base_tests
+
+stages:
+
+  # GET /mitre/metadata
+  - name: Request MITRE metadata
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/mitre/metadata"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - key: db_version
+              value: !anystr
+            - key: mitre_version
+              value: !anystr
+          total_affected_items: 2
+          total_failed_items: 0
+          failed_items: [ ]

--- a/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ marks:
 stages:
 
   # GET /mitre/metadata
-  - name: Request MITRE metadata
+  - name: Request MITRE metadata (Denied)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/metadata"

--- a/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
@@ -1,0 +1,20 @@
+---
+test_name: GET /mitre/metadata
+
+marks:
+  - base_tests
+
+stages:
+
+  # GET /mitre/metadata
+  - name: Request MITRE metadata
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/mitre/metadata"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response: &permission_denied
+      status_code: 403
+      json:
+        error: 4000

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -1742,13 +1742,13 @@ stages:
       <<: *permission_denied
 
 ---
-test_name: GET /mitre
+test_name: GET /mitre/metadata
 
 stages:
-  - name: Try to get MITRE techniques
+  - name: Try to get MITRE metadata
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre"
+      url: "{protocol:s}://{host:s}:{port:d}/mitre/metadata"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ marks:
 stages:
 
   # GET /mitre/metadata
-  - name: Request MITRE metadata
+  - name: Request MITRE metadata (Allowed)
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/mitre/metadata"

--- a/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
@@ -1,0 +1,23 @@
+---
+test_name: GET /mitre/metadata
+
+marks:
+  - base_tests
+
+stages:
+
+  # GET /mitre/metadata
+  - name: Request MITRE metadata
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/mitre/metadata"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response: &permission_allowed
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items: !anything
+          total_failed_items: 0

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -7,24 +7,35 @@ from wazuh.core.utils import WazuhDBQuery, WazuhDBBackend
 
 
 class WazuhDBQueryMitre(WazuhDBQuery):
-    metadata_fields = {'key': 'key', 'value': 'value'}
 
     def __init__(self, offset: int = 0, limit: int = common.database_limit, query: str = '', count: bool = True,
                  get_data: bool = True, table: str = 'technique', sort: dict = None, default_sort_field: str = 'key',
-                 fields=None, search: dict = None, select: dict = None, min_select_fields=None, filters=None):
+                 default_sort_order='ASC', fields=None, search: dict = None, select: dict = None,
+                 min_select_fields=None, filters=None):
         """Create an instance of WazuhDBQueryMitre query."""
 
         if filters is None:
             filters = {}
-        if min_select_fields is None:
-            min_select_fields = {'key', 'value'}
-        if fields is None:
-            fields = self.metadata_fields
 
         WazuhDBQuery.__init__(self, offset=offset, limit=limit, table=table, sort=sort, search=search, select=select,
-                              fields=fields, default_sort_field=default_sort_field, default_sort_order='ASC',
-                              filters=filters, query=query, count=count, get_data=get_data,
-                              min_select_fields=min_select_fields, backend=WazuhDBBackend(query_format='mitre'))
+                              fields=fields, default_sort_field=default_sort_field,
+                              default_sort_order=default_sort_order, filters=filters, query=query, count=count,
+                              get_data=get_data, min_select_fields=min_select_fields,
+                              backend=WazuhDBBackend(query_format='mitre'))
+
+    def _filter_status(self, status_filter):
+        pass
+
+
+class WazuhDBQueryMitreMetadata(WazuhDBQueryMitre):
+
+    def __init__(self):
+        """Create an instance of WazuhDBQueryMitreMetadata query."""
+
+        min_select_fields = {'key', 'value'}
+        fields = {'key': 'key', 'value': 'value'}
+
+        WazuhDBQueryMitre.__init__(self, table='metadata', min_select_fields=min_select_fields, fields=fields)
 
     def _filter_status(self, status_filter):
         pass

--- a/framework/wazuh/core/mitre.py
+++ b/framework/wazuh/core/mitre.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GP
+
+from wazuh.core import common
+from wazuh.core.utils import WazuhDBQuery, WazuhDBBackend
+
+
+class WazuhDBQueryMitre(WazuhDBQuery):
+    metadata_fields = {'key': 'key', 'value': 'value'}
+
+    def __init__(self, offset: int = 0, limit: int = common.database_limit, query: str = '', count: bool = True,
+                 get_data: bool = True, table: str = 'technique', sort: dict = None, default_sort_field: str = 'key',
+                 fields=None, search: dict = None, select: dict = None, min_select_fields=None, filters=None):
+        """Create an instance of WazuhDBQueryMitre query."""
+
+        if filters is None:
+            filters = {}
+        if min_select_fields is None:
+            min_select_fields = {'key', 'value'}
+        if fields is None:
+            fields = self.metadata_fields
+
+        WazuhDBQuery.__init__(self, offset=offset, limit=limit, table=table, sort=sort, search=search, select=select,
+                              fields=fields, default_sort_field=default_sort_field, default_sort_order='ASC',
+                              filters=filters, query=query, count=count, get_data=get_data,
+                              min_select_fields=min_select_fields, backend=WazuhDBBackend(query_format='mitre'))
+
+    def _filter_status(self, status_filter):
+        pass

--- a/framework/wazuh/core/tests/test_mitre.py
+++ b/framework/wazuh/core/tests/test_mitre.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# Copyright (C) 2015-2021, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from unittest.mock import patch
+
+from wazuh.tests.util import InitWDBSocketMock
+
+with patch('wazuh.core.common.ossec_uid'):
+    with patch('wazuh.core.common.ossec_gid'):
+        from wazuh.core.mitre import *
+
+
+# Tests
+
+def test_WazuhDBQueryMitre_metadata():
+    """Verify that the method connects correctly to the database and returns the correct type."""
+    with patch('wazuh.core.utils.WazuhDBConnection') as mock_wdb:
+        mock_wdb.return_value = InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql')
+        db_query = WazuhDBQueryMitre(table="metadata")
+        data = db_query.run()
+
+        assert isinstance(db_query, WazuhDBQueryMitre) and isinstance(data, dict)

--- a/framework/wazuh/core/tests/test_mitre.py
+++ b/framework/wazuh/core/tests/test_mitre.py
@@ -18,7 +18,7 @@ def test_WazuhDBQueryMitre_metadata():
     """Verify that the method connects correctly to the database and returns the correct type."""
     with patch('wazuh.core.utils.WazuhDBConnection') as mock_wdb:
         mock_wdb.return_value = InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql')
-        db_query = WazuhDBQueryMitre(table="metadata")
+        db_query = WazuhDBQueryMitreMetadata()
         data = db_query.run()
 
         assert isinstance(db_query, WazuhDBQueryMitre) and isinstance(data, dict)

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -46,8 +46,12 @@ class WazuhDBConnection:
         sql_first_index = 2 if query_elements[0] == 'agent' else 1
 
         if query_elements[0] == 'mitre':
-            # TODO
-            pass
+            input_val_errors = [
+                (query_elements[sql_first_index] == 'sql',
+                 'Incorrect WDB request type'),
+                (query_elements[2] == 'select',
+                 'Wrong SQL query for Mitre database')
+            ]
         elif query_elements[sql_first_index] == 'rootcheck':
             input_val_errors = [
                 (query_elements[sql_first_index+1] == 'delete' or query_elements[sql_first_index+1] == 'save',

--- a/framework/wazuh/mitre.py
+++ b/framework/wazuh/mitre.py
@@ -5,17 +5,15 @@
 import logging
 from typing import Dict
 
-from wazuh.core.common import database_limit
+from wazuh.core.mitre import WazuhDBQueryMitreMetadata
 from wazuh.core.results import AffectedItemsWazuhResult
-from wazuh.core.mitre import WazuhDBQueryMitre
-from wazuh.core.utils import sort_array
 from wazuh.rbac.decorators import expose_resources
 
 logger = logging.getLogger('wazuh')
 
 
 @expose_resources(actions=["mitre:read"], resources=["*:*:*"])
-def get_metadata() -> Dict:
+def mitre_metadata() -> Dict:
     """Return the metadata of the MITRE's database
 
     Returns
@@ -25,7 +23,7 @@ def get_metadata() -> Dict:
     result = AffectedItemsWazuhResult(none_msg='No metadata information was returned',
                                       all_msg='Metadata information was returned')
 
-    db_query = WazuhDBQueryMitre(table="metadata")
+    db_query = WazuhDBQueryMitreMetadata()
     data = db_query.run()
 
     result.affected_items.extend(data['items'])

--- a/framework/wazuh/mitre.py
+++ b/framework/wazuh/mitre.py
@@ -23,8 +23,7 @@ def get_metadata() -> Dict:
     Metadata of MITRE's db
     """
     result = AffectedItemsWazuhResult(none_msg='No metadata information was returned',
-                                      some_msg='Some metadata information was not returned',
-                                      all_msg='All specified metadata information was returned')
+                                      all_msg='Metadata information was returned')
 
     db_query = WazuhDBQueryMitre(table="metadata")
     data = db_query.run()

--- a/framework/wazuh/mitre.py
+++ b/framework/wazuh/mitre.py
@@ -1,3 +1,35 @@
-# Copyright (C) 2015-2020, Wazuh Inc.
+# Copyright (C) 2015-2021, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import logging
+from typing import Dict
+
+from wazuh.core.common import database_limit
+from wazuh.core.results import AffectedItemsWazuhResult
+from wazuh.core.mitre import WazuhDBQueryMitre
+from wazuh.core.utils import sort_array
+from wazuh.rbac.decorators import expose_resources
+
+logger = logging.getLogger('wazuh')
+
+
+@expose_resources(actions=["mitre:read"], resources=["*:*:*"])
+def get_metadata() -> Dict:
+    """Return the metadata of the MITRE's database
+
+    Returns
+    -------
+    Metadata of MITRE's db
+    """
+    result = AffectedItemsWazuhResult(none_msg='No metadata information was returned',
+                                      some_msg='Some metadata information was not returned',
+                                      all_msg='All specified metadata information was returned')
+
+    db_query = WazuhDBQueryMitre(table="metadata")
+    data = db_query.run()
+
+    result.affected_items.extend(data['items'])
+    result.total_affected_items = data['totalItems']
+
+    return result

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -459,7 +459,7 @@ get_rbac_actions:
             - "*:*:*"
           effect: allow
         related_endpoints:
-          - GET /mitre
+          - GET /mitre/metadata
       rootcheck:clear:
         description: Clear the agents rootcheck database
         resources:

--- a/framework/wazuh/tests/test_mitre.py
+++ b/framework/wazuh/tests/test_mitre.py
@@ -1,9 +1,35 @@
 #!/usr/bin/env python
-# -*- coding: UTF-8 -*-
-#
-# Copyright (C) 2015-2019, Wazuh Inc.
+# Copyright (C) 2015-2021, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is a free software; you can redistribute
-# it and/or modify it under the terms of GPLv2
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-"""Framework tests for Mitre module."""
+import os
+from unittest.mock import patch
+
+with patch('wazuh.common.ossec_uid'):
+    with patch('wazuh.common.ossec_gid'):
+        import wazuh.rbac.decorators
+
+        from wazuh.tests.util import get_fake_database_data, RBAC_bypasser, InitWDBSocketMock
+
+        wazuh.rbac.decorators.expose_resources = RBAC_bypasser
+        from wazuh import mitre
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+
+
+# Tests
+
+@patch('wazuh.core.utils.WazuhDBConnection', return_value=InitWDBSocketMock(sql_schema_file='schema_mitre_test.sql'))
+def test_get_mitre_metadata(mock_mitre_db):
+    """Check MITRE metadata
+    """
+    result = mitre.get_metadata()
+    cur = get_fake_database_data('schema_mitre_test.sql').cursor()
+    cur.execute("SELECT * FROM metadata")
+    rows = cur.fetchall()
+
+    assert result.affected_items[0]['key'] == rows[0][0]
+    assert result.affected_items[1]['key'] == rows[1][0]
+    assert result.affected_items[0]['value'] == rows[0][1]
+    assert result.affected_items[1]['value'] == rows[1][1]

--- a/framework/wazuh/tests/test_mitre.py
+++ b/framework/wazuh/tests/test_mitre.py
@@ -24,7 +24,7 @@ test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data
 def test_get_mitre_metadata(mock_mitre_db):
     """Check MITRE metadata
     """
-    result = mitre.get_metadata()
+    result = mitre.mitre_metadata()
     cur = get_fake_database_data('schema_mitre_test.sql').cursor()
     cur.execute("SELECT * FROM metadata")
     rows = cur.fetchall()


### PR DESCRIPTION
|Related issue|
|---|
|#7822|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

This PR closes #7822. In this PR we have added a new WazuhDBQueryMitre class. This class will be the base for all the development of the new MITRE endpoints. On the other hand, we have added all the parts of the framework and the api needed to make requests to the db and get the metadata from it.

Finally, we have added the unit and integrated tests needed to test these new functions.

## Test results

### Integration tests
```
adriiiprodri@wazuh python3 run_tests.py -rbac both -k mitre
Collected tests [3]:
test_mitre_endpoints.tavern.yaml, test_rbac_black_mitre_endpoints.tavern.yaml, test_rbac_white_mitre_endpoints.tavern.yaml


test_mitre_endpoints.tavern.yaml 
	 1 passed, 3 warnings

test_rbac_black_mitre_endpoints.tavern.yaml 
	 1 passed, 3 warnings

test_rbac_white_mitre_endpoints.tavern.yaml 
	 1 passed, 3 warnings
```

### Framework unittests
```
adriiiprodri@wazuh pytest -x framework/wazuh/tests
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/git/wazuh/framework
plugins: tavern-1.14.0, metadata-1.11.0, html-3.1.1
collected 577 items                                                                                                                                                                                                  

framework/wazuh/tests/test_active_response.py ............                                                                                                                                                     [  2%]
framework/wazuh/tests/test_agent.py ................................................................................................                                                                           [ 18%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                                   [ 27%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                         [ 33%]
framework/wazuh/tests/test_cluster.py .....ss                                                                                                                                                                  [ 34%]
framework/wazuh/tests/test_decoder.py ...................................                                                                                                                                      [ 40%]
framework/wazuh/tests/test_group.py ........                                                                                                                                                                   [ 42%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                                   [ 43%]
framework/wazuh/tests/test_manager.py .................................                                                                                                                                        [ 49%]
framework/wazuh/tests/test_mitre.py .                                                                                                                                                                          [ 49%]
framework/wazuh/tests/test_rootcheck.py .................................................                                                                                                                      [ 57%]
framework/wazuh/tests/test_rule.py ........................................................                                                                                                                    [ 67%]
framework/wazuh/tests/test_sca.py .......                                                                                                                                                                      [ 68%]
framework/wazuh/tests/test_security.py ...........................................................................                                                                                             [ 81%]
framework/wazuh/tests/test_stats.py ................                                                                                                                                                           [ 84%]
framework/wazuh/tests/test_syscheck.py ........................                                                                                                                                                [ 88%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                                        [ 90%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                                [ 95%]
framework/wazuh/tests/test_vulnerability.py ..........................                                                                                                                                         [100%]

=================================================================================== 575 passed, 2 skipped, 916 warnings in 48.43s ====================================================================================
```

### Core unittests
```
{
  "data": {
    "affected_items": [
      {
        "value": "1",
        "key": "db_version"
      },
      {
        "value": "2.0",
        "key": "mitre_version"
      }
    ],
    "total_affected_items": 2,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All specified metadata information was returned",
  "error": 0
}




## Core

adriiiprodri@wazuh pytest -x framework/wazuh/core/tests
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/adriiiprodri/git/wazuh/framework
plugins: tavern-1.14.0, metadata-1.11.0, html-3.1.1
collected 653 items                                                                                                                                                                                                  

framework/wazuh/core/tests/test_active_response.py ..............                                                                                                                                              [  2%]
framework/wazuh/core/tests/test_agent.py ..........................................................................................................................................................            [ 25%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                             [ 31%]
framework/wazuh/core/tests/test_common.py .......                                                                                                                                                              [ 32%]
framework/wazuh/core/tests/test_configuration.py ....................................                                                                                                                          [ 38%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                                    [ 40%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                         [ 41%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                                                                                  [ 41%]
framework/wazuh/core/tests/test_manager.py .................                                                                                                                                                   [ 43%]
framework/wazuh/core/tests/test_mitre.py .                                                                                                                                                                     [ 44%]
framework/wazuh/core/tests/test_pyDaemonModule.py ......                                                                                                                                                       [ 45%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                            [ 51%]
framework/wazuh/core/tests/test_rootcheck.py ..........                                                                                                                                                        [ 52%]
framework/wazuh/core/tests/test_rule.py ......................                                                                                                                                                 [ 56%]
framework/wazuh/core/tests/test_stats.py ....                                                                                                                                                                  [ 56%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                            [ 57%]
framework/wazuh/core/tests/test_utils.py ..................................................................................................................................................................... [ 82%]
......................................................                                                                                                                                                         [ 90%]
framework/wazuh/core/tests/test_vulnerability.py .                                                                                                                                                             [ 90%]
framework/wazuh/core/tests/test_wazuh_queue.py ...................                                                                                                                                             [ 93%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                           [ 96%]
framework/wazuh/core/tests/test_wdb.py .....................                                                                                                                                                   [100%]

========================================================================================== 653 passed, 12 warnings in 2.93s ==========================================================================================
```

Best regards,

Adrián Peña