### PR TITLE
Fixed ignore_time property not found during upgrade

### DIFF
--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -77,6 +77,7 @@ static const char *XML_END = "end";
 static const char *XML_FEED = "feed";
 static const char *XML_UPDATE_UBUNTU_OVAL = "update_ubuntu_oval";
 static const char *XML_UPDATE_REDHAT_OVAL = "update_redhat_oval";
+static const char *XML_IGNORE_TIME = "ignore_time";
 
 int format_os_version(char *OS, char **os_name, char **os_ver) {
     char OS_cpy[OS_SIZE_1024] = {'\0'};
@@ -416,6 +417,8 @@ int Read_Vuln(const OS_XML *xml, xml_node **nodes, void *d1, char d2) {
                 merror("Invalid content for tag '%s' at module '%s'", XML_RUN_ON_START, WM_VULNDETECTOR_CONTEXT.name);
                 return OS_INVALID;
             }
+        } else if (!strcmp(nodes[i]->element, XML_IGNORE_TIME)){
+            mwarn("Detected deprecated tag <%s> at module '%s'.", nodes[i]->element, WM_VULNDETECTOR_CONTEXT.name);
         } else if (!strcmp(nodes[i]->element, XML_MIN_FULL_SCAN_INTERVAL)) {
             if (wm_vuldet_get_interval(nodes[i]->content, &vuldet->min_full_scan_interval)) {
                 merror("Invalid min_full_scan_interval at module '%s'", WM_VULNDETECTOR_CONTEXT.name);

--- a/src/config/wmodules-vuln-detector.c
+++ b/src/config/wmodules-vuln-detector.c
@@ -418,7 +418,7 @@ int Read_Vuln(const OS_XML *xml, xml_node **nodes, void *d1, char d2) {
                 return OS_INVALID;
             }
         } else if (!strcmp(nodes[i]->element, XML_IGNORE_TIME)){
-            mwarn("Detected deprecated tag <%s> at module '%s'.", nodes[i]->element, WM_VULNDETECTOR_CONTEXT.name);
+            mwarn("The <%s> tag at module '%s' is deprecated for version newer than 4.3.", nodes[i]->element, WM_VULNDETECTOR_CONTEXT.name);
         } else if (!strcmp(nodes[i]->element, XML_MIN_FULL_SCAN_INTERVAL)) {
             if (wm_vuldet_get_interval(nodes[i]->content, &vuldet->min_full_scan_interval)) {
                 merror("Invalid min_full_scan_interval at module '%s'", WM_VULNDETECTOR_CONTEXT.name);


### PR DESCRIPTION
|Related issue|
|---|
|#8062|
## Description
As consequence of the change introduced in #7892, after an upgrade Wazuh was no able to start, due to the `ignore_time` property in the ossec.conf file is not found in vuln_det module. 
<!--
Add a clear description of how the problem has been solved.
-->
## DoD
Warning that shows that the property is deprecated. 

![image](https://user-images.githubusercontent.com/13010397/113767299-e5694480-96f4-11eb-8408-9240bb6c672a.png)
## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Source upgrade
- [X] Review logs syntax and correct language