### PR TITLE
Adapt registry synchronization mechanism

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1715,7 +1715,7 @@ syscheck_o := $(syschecklib_o:.c=.o) $(syscheck_c:.c=.o) $(syscheck_sql:.sql=.o)
 syscheck_eventchannel_o := $(syscheck_c:.c=-event.o) $(syscheck_sql:.sql=.o)
 
 syscheckd/db/schema_fim_db.o: syscheckd/db/schema_fim_db.sql
-	${QUIET_CC}echo 'const char *schema_fim_sql = "'"`cat $< | tr -d \\\n | sed s/\\\\\\\/\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/g`"'";' | ${MING_BASE}${CC} ${OSSEC_CFLAGS} -xc -c -o $@ -
+	${QUIET_CC}echo 'const char *schema_fim_sql = "'"`cat $< | sed s/\\\\\\\/\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/g | tr -d \\\n`"'";' | ${MING_BASE}${CC} ${OSSEC_CFLAGS} -xc -c -o $@ -
 
 syscheckd/%.o: syscheckd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"wazuh-syscheckd\" -c $^ -o $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -1715,7 +1715,7 @@ syscheck_o := $(syschecklib_o:.c=.o) $(syscheck_c:.c=.o) $(syscheck_sql:.sql=.o)
 syscheck_eventchannel_o := $(syscheck_c:.c=-event.o) $(syscheck_sql:.sql=.o)
 
 syscheckd/db/schema_fim_db.o: syscheckd/db/schema_fim_db.sql
-	${QUIET_CC}echo 'const char *schema_fim_sql = "'"`cat $< | tr -d \"\n\"`"'";' | ${MING_BASE}${CC} ${OSSEC_CFLAGS} -xc -c -o $@ -
+	${QUIET_CC}echo 'const char *schema_fim_sql = "'"`cat $< | tr -d \\\n | sed s/\\\\\\\/\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/g`"'";' | ${MING_BASE}${CC} ${OSSEC_CFLAGS} -xc -c -o $@ -
 
 syscheckd/%.o: syscheckd/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"wazuh-syscheckd\" -c $^ -o $@

--- a/src/shared/integrity_op.c
+++ b/src/shared/integrity_op.c
@@ -69,7 +69,6 @@ char * dbsync_state_msg(const char * component, cJSON * data) {
     cJSON * root = cJSON_CreateObject();
     cJSON_AddStringToObject(root, "component", component);
     cJSON_AddStringToObject(root, "type", "state");
-    cJSON_AddStringToObject(data, "version", "2.0");
     cJSON_AddItemToObject(root, "data", data);
 
     char * msg = cJSON_PrintUnformatted(root);

--- a/src/shared/integrity_op.c
+++ b/src/shared/integrity_op.c
@@ -40,7 +40,7 @@ char * dbsync_check_msg(const char * component, dbsync_msg msg, long id, const c
     cJSON * data = cJSON_CreateObject();
     cJSON_AddItemToObject(root, "data", data);
     cJSON_AddNumberToObject(data, "id", id);
-    cJSON_AddStringToObject(data, "version", "2.0");
+    cJSON_AddNumberToObject(data, "version", 2.0);
 
     if (msg != INTEGRITY_CLEAR) {
         assert(start != NULL);

--- a/src/shared/integrity_op.c
+++ b/src/shared/integrity_op.c
@@ -40,6 +40,7 @@ char * dbsync_check_msg(const char * component, dbsync_msg msg, long id, const c
     cJSON * data = cJSON_CreateObject();
     cJSON_AddItemToObject(root, "data", data);
     cJSON_AddNumberToObject(data, "id", id);
+    cJSON_AddStringToObject(data, "version", "2.0");
 
     if (msg != INTEGRITY_CLEAR) {
         assert(start != NULL);
@@ -68,6 +69,7 @@ char * dbsync_state_msg(const char * component, cJSON * data) {
     cJSON * root = cJSON_CreateObject();
     cJSON_AddStringToObject(root, "component", component);
     cJSON_AddStringToObject(root, "type", "state");
+    cJSON_AddStringToObject(data, "version", "2.0");
     cJSON_AddItemToObject(root, "data", data);
 
     char * msg = cJSON_PrintUnformatted(root);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -1259,7 +1259,7 @@ cJSON *fim_json_event(const char *file_name,
     cJSON_AddItemToObject(json_event, "data", data);
 
     cJSON_AddStringToObject(data, "path", file_name);
-    cJSON_AddStringToObject(data, "version", "2.0");
+    cJSON_AddNumberToObject(data, "version", 2.0);
 
     cJSON_AddStringToObject(data, "mode", FIM_EVENT_MODE[mode]);
     cJSON_AddStringToObject(data, "type", FIM_EVENT_TYPE[type]);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -1259,6 +1259,8 @@ cJSON *fim_json_event(const char *file_name,
     cJSON_AddItemToObject(json_event, "data", data);
 
     cJSON_AddStringToObject(data, "path", file_name);
+    cJSON_AddStringToObject(data, "version", "2.0");
+
     cJSON_AddStringToObject(data, "mode", FIM_EVENT_MODE[mode]);
     cJSON_AddStringToObject(data, "type", FIM_EVENT_TYPE[type]);
     cJSON_AddNumberToObject(data, "timestamp", new_data->last_event);

--- a/src/syscheckd/db/schema_fim_db.sql
+++ b/src/syscheckd/db/schema_fim_db.sql
@@ -76,6 +76,6 @@ CREATE TABLE IF NOT EXISTS registry_data (
 CREATE INDEX IF NOT EXISTS key_name_index ON registry_data (key_id, name);
 
 CREATE VIEW IF NOT EXISTS registry_view (path, checksum) AS
-    SELECT arch || ' ' || replace(path, ':', '::') || ':', checksum FROM registry_key
+    SELECT arch || ' ' || replace(replace(path, '\', '\\'), ':', '\:') || ':', checksum FROM registry_key
     UNION ALL
-    SELECT arch || ' ' || replace(path, ':', '::') || ':' || replace(name, ':', '::'), registry_data.checksum FROM registry_key INNER JOIN registry_data ON registry_key.id=registry_data.key_id;
+    SELECT arch || ' ' || replace(replace(path, '\', '\\'), ':', '\:') || ':' || replace(replace(name, '\', '\\'), ':', '\:'), registry_data.checksum FROM registry_key INNER JOIN registry_data ON registry_key.id=registry_data.key_id;

--- a/src/syscheckd/fim_sync.c
+++ b/src/syscheckd/fim_sync.c
@@ -148,8 +148,7 @@ cJSON *fim_entry_json(const char *key, fim_entry *entry) {
         attributes = fim_registry_value_attributes_json(entry->registry_entry.value, configuration);
     }
 #endif
-    cJSON_AddStringToObject(root, "version", "2.0");
-
+    cJSON_AddNumberToObject(root, "version", 2.0);
     cJSON_AddItemToObject(root, "attributes", attributes);
 
     return root;

--- a/src/syscheckd/fim_sync.c
+++ b/src/syscheckd/fim_sync.c
@@ -148,6 +148,7 @@ cJSON *fim_entry_json(const char *key, fim_entry *entry) {
         attributes = fim_registry_value_attributes_json(entry->registry_entry.value, configuration);
     }
 #endif
+    cJSON_AddStringToObject(root, "version", "2.0");
 
     cJSON_AddItemToObject(root, "attributes", attributes);
 

--- a/src/syscheckd/registry/events.c
+++ b/src/syscheckd/registry/events.c
@@ -138,6 +138,7 @@ cJSON *fim_registry_value_json_event(const fim_entry *new_data,
     cJSON_AddItemToObject(json_event, "data", data);
 
     cJSON_AddStringToObject(data, "path", new_data->registry_entry.key->path);
+    cJSON_AddStringToObject(data, "version", "2.0");
     cJSON_AddStringToObject(data, "mode", FIM_EVENT_MODE[mode]);
     cJSON_AddStringToObject(data, "type", FIM_EVENT_TYPE[type]);
     cJSON_AddStringToObject(data, "arch", new_data->registry_entry.key->arch == ARCH_32BIT ? "[x32]" : "[x64]");
@@ -289,6 +290,7 @@ cJSON *fim_registry_key_json_event(const fim_registry_key *new_data,
     cJSON_AddItemToObject(json_event, "data", data);
 
     cJSON_AddStringToObject(data, "path", new_data->path);
+    cJSON_AddStringToObject(data, "version", "2.0");
     cJSON_AddStringToObject(data, "mode", FIM_EVENT_MODE[mode]);
     cJSON_AddStringToObject(data, "type", FIM_EVENT_TYPE[type]);
     cJSON_AddStringToObject(data, "arch", new_data->arch == ARCH_32BIT ? "[x32]" : "[x64]");

--- a/src/syscheckd/registry/events.c
+++ b/src/syscheckd/registry/events.c
@@ -138,7 +138,7 @@ cJSON *fim_registry_value_json_event(const fim_entry *new_data,
     cJSON_AddItemToObject(json_event, "data", data);
 
     cJSON_AddStringToObject(data, "path", new_data->registry_entry.key->path);
-    cJSON_AddStringToObject(data, "version", "2.0");
+    cJSON_AddNumberToObject(data, "version", 2.0);
     cJSON_AddStringToObject(data, "mode", FIM_EVENT_MODE[mode]);
     cJSON_AddStringToObject(data, "type", FIM_EVENT_TYPE[type]);
     cJSON_AddStringToObject(data, "arch", new_data->registry_entry.key->arch == ARCH_32BIT ? "[x32]" : "[x64]");
@@ -290,7 +290,7 @@ cJSON *fim_registry_key_json_event(const fim_registry_key *new_data,
     cJSON_AddItemToObject(json_event, "data", data);
 
     cJSON_AddStringToObject(data, "path", new_data->path);
-    cJSON_AddStringToObject(data, "version", "2.0");
+    cJSON_AddNumberToObject(data, "version", 2.0);
     cJSON_AddStringToObject(data, "mode", FIM_EVENT_MODE[mode]);
     cJSON_AddStringToObject(data, "type", FIM_EVENT_TYPE[type]);
     cJSON_AddStringToObject(data, "arch", new_data->arch == ARCH_32BIT ? "[x32]" : "[x64]");

--- a/src/unit_tests/shared/test_integrity_op.c
+++ b/src/unit_tests/shared/test_integrity_op.c
@@ -29,7 +29,7 @@ void test_dbsync_check_msg_left(void **state)
 {
     (void) state; /* unused */
     char *ret;
-    char json[256] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_check_left\",\"data\":{\"id\":1569926892,\"version\":\"2.0\",\"begin\":\"start\",\"end\":\"top\",\"tail\":\"tail\",\"checksum\":\"51ABB9636078DEFBF888D8457A7C76F85C8F114C\"}}";
+    char json[256] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_check_left\",\"data\":{\"id\":1569926892,\"version\":2,\"begin\":\"start\",\"end\":\"top\",\"tail\":\"tail\",\"checksum\":\"51ABB9636078DEFBF888D8457A7C76F85C8F114C\"}}";
 
     ret = dbsync_check_msg("wazuh-testing", INTEGRITY_CHECK_LEFT, 1569926892, "start", "top", "tail", "51ABB9636078DEFBF888D8457A7C76F85C8F114C");
     *state = ret;
@@ -40,7 +40,7 @@ void test_dbsync_check_msg_right(void **state)
 {
     (void) state; /* unused */
     char *ret;
-    char json[256] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_check_right\",\"data\":{\"id\":1569926892,\"version\":\"2.0\",\"begin\":\"start\",\"end\":\"top\",\"checksum\":\"51ABB9636078DEFBF888D8457A7C76F85C8F114C\"}}";
+    char json[256] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_check_right\",\"data\":{\"id\":1569926892,\"version\":2,\"begin\":\"start\",\"end\":\"top\",\"checksum\":\"51ABB9636078DEFBF888D8457A7C76F85C8F114C\"}}";
 
     ret = dbsync_check_msg("wazuh-testing", INTEGRITY_CHECK_RIGHT, 1569926892, "start", "top", "tail", "51ABB9636078DEFBF888D8457A7C76F85C8F114C");
     *state = ret;
@@ -51,7 +51,7 @@ void test_dbsync_check_msg_global(void **state)
 {
     (void) state; /* unused */
     char *ret;
-    char json[256] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_check_global\",\"data\":{\"id\":1569926892,\"version\":\"2.0\",\"begin\":\"start\",\"end\":\"top\",\"checksum\":\"51ABB9636078DEFBF888D8457A7C76F85C8F114C\"}}";
+    char json[256] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_check_global\",\"data\":{\"id\":1569926892,\"version\":2,\"begin\":\"start\",\"end\":\"top\",\"checksum\":\"51ABB9636078DEFBF888D8457A7C76F85C8F114C\"}}";
 
     ret = dbsync_check_msg("wazuh-testing", INTEGRITY_CHECK_GLOBAL, 1569926892, "start", "top", "tail", "51ABB9636078DEFBF888D8457A7C76F85C8F114C");
     *state = ret;
@@ -62,7 +62,7 @@ void test_dbsync_check_msg_clear(void **state)
 {
     (void) state; /* unused */
     char *ret;
-    char json[128] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_clear\",\"data\":{\"id\":1569926892,\"version\":\"2.0\"}}";
+    char json[128] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_clear\",\"data\":{\"id\":1569926892,\"version\":2}}";
 
     ret = dbsync_check_msg("wazuh-testing", INTEGRITY_CLEAR, 1569926892, "start", "top", "tail", "51ABB9636078DEFBF888D8457A7C76F85C8F114C");
     *state = ret;

--- a/src/unit_tests/shared/test_integrity_op.c
+++ b/src/unit_tests/shared/test_integrity_op.c
@@ -85,7 +85,7 @@ void test_dbsync_state_msg(void **state)
     char *ret;
     cJSON *data = cJSON_CreateObject();
     cJSON_AddStringToObject(data, "test", "test");
-    char json[128] = "{\"component\":\"wazuh-testing\",\"type\":\"state\",\"data\":{\"test\":\"test\",\"version\":\"2.0\"}}";
+    char json[128] = "{\"component\":\"wazuh-testing\",\"type\":\"state\",\"data\":{\"test\":\"test\"}}";
 
     ret = dbsync_state_msg("wazuh-testing", data);
     *state = ret;

--- a/src/unit_tests/shared/test_integrity_op.c
+++ b/src/unit_tests/shared/test_integrity_op.c
@@ -29,7 +29,7 @@ void test_dbsync_check_msg_left(void **state)
 {
     (void) state; /* unused */
     char *ret;
-    char json[256] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_check_left\",\"data\":{\"id\":1569926892,\"begin\":\"start\",\"end\":\"top\",\"tail\":\"tail\",\"checksum\":\"51ABB9636078DEFBF888D8457A7C76F85C8F114C\"}}";
+    char json[256] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_check_left\",\"data\":{\"id\":1569926892,\"version\":\"2.0\",\"begin\":\"start\",\"end\":\"top\",\"tail\":\"tail\",\"checksum\":\"51ABB9636078DEFBF888D8457A7C76F85C8F114C\"}}";
 
     ret = dbsync_check_msg("wazuh-testing", INTEGRITY_CHECK_LEFT, 1569926892, "start", "top", "tail", "51ABB9636078DEFBF888D8457A7C76F85C8F114C");
     *state = ret;
@@ -40,7 +40,7 @@ void test_dbsync_check_msg_right(void **state)
 {
     (void) state; /* unused */
     char *ret;
-    char json[256] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_check_right\",\"data\":{\"id\":1569926892,\"begin\":\"start\",\"end\":\"top\",\"checksum\":\"51ABB9636078DEFBF888D8457A7C76F85C8F114C\"}}";
+    char json[256] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_check_right\",\"data\":{\"id\":1569926892,\"version\":\"2.0\",\"begin\":\"start\",\"end\":\"top\",\"checksum\":\"51ABB9636078DEFBF888D8457A7C76F85C8F114C\"}}";
 
     ret = dbsync_check_msg("wazuh-testing", INTEGRITY_CHECK_RIGHT, 1569926892, "start", "top", "tail", "51ABB9636078DEFBF888D8457A7C76F85C8F114C");
     *state = ret;
@@ -51,7 +51,7 @@ void test_dbsync_check_msg_global(void **state)
 {
     (void) state; /* unused */
     char *ret;
-    char json[256] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_check_global\",\"data\":{\"id\":1569926892,\"begin\":\"start\",\"end\":\"top\",\"checksum\":\"51ABB9636078DEFBF888D8457A7C76F85C8F114C\"}}";
+    char json[256] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_check_global\",\"data\":{\"id\":1569926892,\"version\":\"2.0\",\"begin\":\"start\",\"end\":\"top\",\"checksum\":\"51ABB9636078DEFBF888D8457A7C76F85C8F114C\"}}";
 
     ret = dbsync_check_msg("wazuh-testing", INTEGRITY_CHECK_GLOBAL, 1569926892, "start", "top", "tail", "51ABB9636078DEFBF888D8457A7C76F85C8F114C");
     *state = ret;
@@ -62,7 +62,7 @@ void test_dbsync_check_msg_clear(void **state)
 {
     (void) state; /* unused */
     char *ret;
-    char json[128] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_clear\",\"data\":{\"id\":1569926892}}";
+    char json[128] = "{\"component\":\"wazuh-testing\",\"type\":\"integrity_clear\",\"data\":{\"id\":1569926892,\"version\":\"2.0\"}}";
 
     ret = dbsync_check_msg("wazuh-testing", INTEGRITY_CLEAR, 1569926892, "start", "top", "tail", "51ABB9636078DEFBF888D8457A7C76F85C8F114C");
     *state = ret;
@@ -85,7 +85,7 @@ void test_dbsync_state_msg(void **state)
     char *ret;
     cJSON *data = cJSON_CreateObject();
     cJSON_AddStringToObject(data, "test", "test");
-    char json[128] = "{\"component\":\"wazuh-testing\",\"type\":\"state\",\"data\":{\"test\":\"test\"}}";
+    char json[128] = "{\"component\":\"wazuh-testing\",\"type\":\"state\",\"data\":{\"test\":\"test\",\"version\":\"2.0\"}}";
 
     ret = dbsync_state_msg("wazuh-testing", data);
     *state = ret;

--- a/src/unit_tests/syscheckd/db/test_fim_db.c
+++ b/src/unit_tests/syscheckd/db/test_fim_db.c
@@ -2170,7 +2170,7 @@ void test_fim_db_get_entry_from_sync_msg_get_registry_key(void **state) {
     expect_fim_db_get_registry_key(&data);
 
     entry =
-    fim_db_get_entry_from_sync_msg(&fim_sql, FIM_TYPE_REGISTRY, "[x64] HKEY_LOCAL_MACHINE\\software\\some::\\key");
+    fim_db_get_entry_from_sync_msg(&fim_sql, FIM_TYPE_REGISTRY, "[x64] HKEY_LOCAL_MACHINE\\\\software\\\\some\\:\\\\key:");
 
     *state = entry;
 
@@ -2190,7 +2190,7 @@ void test_fim_db_get_entry_from_sync_msg_get_registry_key_fail_to_get_key(void *
     expect_fim_db_get_registry_key_fail(&data);
 
     entry =
-    fim_db_get_entry_from_sync_msg(&fim_sql, FIM_TYPE_REGISTRY, "[x64] HKEY_LOCAL_MACHINE\\software\\some::\\key:value");
+    fim_db_get_entry_from_sync_msg(&fim_sql, FIM_TYPE_REGISTRY, "[x64] HKEY_LOCAL_MACHINE\\\\software\\\\some\\:\\\\key:value");
 
     *state = entry;
 
@@ -2206,7 +2206,7 @@ void test_fim_db_get_entry_from_sync_msg_get_registry_value_fail_to_get_data(voi
     expect_fim_db_get_registry_data_fail("some:value", key_data.id);
 
     entry = fim_db_get_entry_from_sync_msg(&fim_sql, FIM_TYPE_REGISTRY,
-                                           "[x64] HKEY_LOCAL_MACHINE\\software\\some::\\key:some::value");
+                                           "[x64] HKEY_LOCAL_MACHINE\\\\software\\\\some\\:\\\\key:some\\:value");
 
     *state = entry;
 
@@ -2223,7 +2223,7 @@ void test_fim_db_get_entry_from_sync_msg_get_registry_value_success(void **state
     expect_fim_db_get_registry_data("some:value", key_data.id, &value_data);
 
     entry = fim_db_get_entry_from_sync_msg(&fim_sql, FIM_TYPE_REGISTRY,
-                                           "[x64] HKEY_LOCAL_MACHINE\\software\\some::\\key:some::value");
+                                           "[x64] HKEY_LOCAL_MACHINE\\\\software\\\\some\\:\\\\key:some\\:value");
 
     *state = entry;
 

--- a/src/unit_tests/wazuh_db/test_wdb_fim.c
+++ b/src/unit_tests/wazuh_db/test_wdb_fim.c
@@ -59,7 +59,7 @@ void expect_wdb_fim_insert_entry2_success(sqlite3_int64 inode) {
     expect_cJSON_GetStringValue_call("/test");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
-    expect_cJSON_GetStringValue_call("version");
+    expect_cJSON_IsNumber_call(true);
     expect_cJSON_GetStringValue_call("file");
 
     expect_wdb_stmt_cache_call(1);
@@ -267,10 +267,11 @@ static void test_wdb_fim_insert_entry2_attributes_null(void **state) {
     cJSON* data = cJSON_Parse(VALID_ENTRY);
     wdb_t * wdb = *state;
 
-    will_return(__wrap_cJSON_GetStringValue, "version");
     will_return(__wrap_cJSON_GetStringValue, "/test");
 
     will_return(__wrap_cJSON_IsNumber, true);
+    will_return(__wrap_cJSON_IsNumber, true);
+
     will_return(__wrap_cJSON_IsObject, false);
 
     cJSON_ReplaceItemInObject(data, "attributes", cJSON_CreateString(""));
@@ -288,8 +289,9 @@ static void test_wdb_fim_insert_entry2_fail_cache(void **state) {
     wdb_t * wdb = *state;
     cJSON *data = cJSON_Parse(VALID_ENTRY);
 
-    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_GetStringValue_call("/test");
+    expect_cJSON_IsNumber_call(true);
+
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("file");
@@ -315,8 +317,9 @@ static void test_wdb_fim_insert_entry2_fail_element_null(void **state) {
     data->child->next->next->child->string = NULL;
 
     expect_cJSON_GetStringValue_call("/test");
-    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_IsNumber_call(true);
+    expect_cJSON_IsNumber_call(true);
+
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("file");
 
@@ -345,7 +348,7 @@ static void test_wdb_fim_insert_entry2_fail_element_string(void **state) {
     cJSON_ReplaceItemInObject(data, "attributes", array);
 
     expect_cJSON_GetStringValue_call("/test");
-    expect_cJSON_GetStringValue_call("version");
+    expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("file");
@@ -377,7 +380,7 @@ static void test_wdb_fim_insert_entry2_fail_element_number(void **state) {
     cJSON_ReplaceItemInObject(data, "attributes", array);
 
     expect_cJSON_GetStringValue_call("/test");
-    expect_cJSON_GetStringValue_call("version");
+    expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("file");
@@ -405,7 +408,7 @@ static void test_wdb_fim_insert_entry2_fail_sqlite3_stmt(void **state) {
     cJSON* data = cJSON_Parse(VALID_ENTRY);
 
     expect_cJSON_GetStringValue_call("/test");
-    expect_cJSON_GetStringValue_call("version");
+    expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("file");
@@ -437,7 +440,7 @@ static void test_wdb_fim_insert_entry2_registry_arch_null(void **state) {
     cJSON_ReplaceItemInObject(data, "path", cJSON_CreateString("HKEY_LOCAL_MACHINE\\System\\TEST\\clave"));
     cJSON_AddItemToObject(data, "arch", cJSON_CreateObject());
 
-    expect_cJSON_GetStringValue_call("version");
+    expect_cJSON_IsNumber_call(true);
     expect_cJSON_GetStringValue_call("HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
@@ -461,7 +464,7 @@ static void test_wdb_fim_insert_entry2_registry_value_name_null(void **state) {
     cJSON_AddItemToObject(data, "arch", cJSON_CreateString("[x32]"));
     cJSON_AddItemToObject(data, "value_name", cJSON_CreateObject());
 
-    expect_cJSON_GetStringValue_call("version");
+    expect_cJSON_IsNumber_call(true);
     expect_cJSON_GetStringValue_call("HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
@@ -487,7 +490,7 @@ static void test_wdb_fim_insert_entry2_registry_item_type_null(void **state) {
     cJSON_ReplaceItemInObject(data, "path", cJSON_CreateString("HKEY_LOCAL_MACHINE\\System\\TEST\\clave"));
     cJSON_ReplaceItemInObject(data, "type", cJSON_CreateObject());
 
-    expect_cJSON_GetStringValue_call("version");
+    expect_cJSON_IsNumber_call(true);
     expect_cJSON_GetStringValue_call("HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
@@ -512,7 +515,7 @@ static void test_wdb_fim_insert_entry2_invalid_item_type(void **state) {
 
     cJSON_ReplaceItemInObject(data, "path", cJSON_CreateString("[x32] HKEY_LOCAL_MACHINE\\System\\TEST\\clave"));
 
-    expect_cJSON_GetStringValue_call("version");
+    expect_cJSON_IsNumber_call(true);
     expect_cJSON_GetStringValue_call("[x32] HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
@@ -539,7 +542,7 @@ static void test_wdb_fim_insert_entry2_registry_invalid_item_type(void **state) 
     cJSON_AddItemToObject(data, "arch", cJSON_CreateString("[x32]"));
 
     expect_cJSON_GetStringValue_call("HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
-    expect_cJSON_GetStringValue_call("version");
+    expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("registry_invalid");
@@ -568,7 +571,7 @@ static void test_wdb_fim_insert_entry2_registry_succesful(void **state) {
     expect_wdb_stmt_cache_call(1);
 
     expect_cJSON_GetStringValue_call("[x32] HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
-    expect_cJSON_GetStringValue_call("version");
+    expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("registry");
@@ -603,7 +606,7 @@ static void test_wdb_fim_insert_entry2_registry_key_succesful(void **state) {
     expect_wdb_stmt_cache_call(1);
 
     expect_cJSON_GetStringValue_call("HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
-    expect_cJSON_GetStringValue_call("version");
+    expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("registry_key");
@@ -648,7 +651,7 @@ static void test_wdb_fim_insert_entry2_registry_value_succesful(void **state) {
     expect_wdb_stmt_cache_call(1);
 
     expect_cJSON_GetStringValue_call("HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
-    expect_cJSON_GetStringValue_call("version");
+    expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("registry_value");

--- a/src/unit_tests/wazuh_db/test_wdb_fim.c
+++ b/src/unit_tests/wazuh_db/test_wdb_fim.c
@@ -59,6 +59,7 @@ void expect_wdb_fim_insert_entry2_success(sqlite3_int64 inode) {
     expect_cJSON_GetStringValue_call("/test");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_GetStringValue_call("file");
 
     expect_wdb_stmt_cache_call(1);
@@ -266,7 +267,9 @@ static void test_wdb_fim_insert_entry2_attributes_null(void **state) {
     cJSON* data = cJSON_Parse(VALID_ENTRY);
     wdb_t * wdb = *state;
 
+    will_return(__wrap_cJSON_GetStringValue, "version");
     will_return(__wrap_cJSON_GetStringValue, "/test");
+
     will_return(__wrap_cJSON_IsNumber, true);
     will_return(__wrap_cJSON_IsObject, false);
 
@@ -285,6 +288,7 @@ static void test_wdb_fim_insert_entry2_fail_cache(void **state) {
     wdb_t * wdb = *state;
     cJSON *data = cJSON_Parse(VALID_ENTRY);
 
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_GetStringValue_call("/test");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
@@ -311,6 +315,7 @@ static void test_wdb_fim_insert_entry2_fail_element_null(void **state) {
     data->child->next->next->child->string = NULL;
 
     expect_cJSON_GetStringValue_call("/test");
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("file");
@@ -340,6 +345,7 @@ static void test_wdb_fim_insert_entry2_fail_element_string(void **state) {
     cJSON_ReplaceItemInObject(data, "attributes", array);
 
     expect_cJSON_GetStringValue_call("/test");
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("file");
@@ -371,6 +377,7 @@ static void test_wdb_fim_insert_entry2_fail_element_number(void **state) {
     cJSON_ReplaceItemInObject(data, "attributes", array);
 
     expect_cJSON_GetStringValue_call("/test");
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("file");
@@ -398,6 +405,7 @@ static void test_wdb_fim_insert_entry2_fail_sqlite3_stmt(void **state) {
     cJSON* data = cJSON_Parse(VALID_ENTRY);
 
     expect_cJSON_GetStringValue_call("/test");
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("file");
@@ -429,6 +437,7 @@ static void test_wdb_fim_insert_entry2_registry_arch_null(void **state) {
     cJSON_ReplaceItemInObject(data, "path", cJSON_CreateString("HKEY_LOCAL_MACHINE\\System\\TEST\\clave"));
     cJSON_AddItemToObject(data, "arch", cJSON_CreateObject());
 
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_GetStringValue_call("HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
@@ -452,6 +461,7 @@ static void test_wdb_fim_insert_entry2_registry_value_name_null(void **state) {
     cJSON_AddItemToObject(data, "arch", cJSON_CreateString("[x32]"));
     cJSON_AddItemToObject(data, "value_name", cJSON_CreateObject());
 
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_GetStringValue_call("HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
@@ -477,6 +487,7 @@ static void test_wdb_fim_insert_entry2_registry_item_type_null(void **state) {
     cJSON_ReplaceItemInObject(data, "path", cJSON_CreateString("HKEY_LOCAL_MACHINE\\System\\TEST\\clave"));
     cJSON_ReplaceItemInObject(data, "type", cJSON_CreateObject());
 
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_GetStringValue_call("HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
@@ -501,6 +512,7 @@ static void test_wdb_fim_insert_entry2_invalid_item_type(void **state) {
 
     cJSON_ReplaceItemInObject(data, "path", cJSON_CreateString("[x32] HKEY_LOCAL_MACHINE\\System\\TEST\\clave"));
 
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_GetStringValue_call("[x32] HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
@@ -527,6 +539,7 @@ static void test_wdb_fim_insert_entry2_registry_invalid_item_type(void **state) 
     cJSON_AddItemToObject(data, "arch", cJSON_CreateString("[x32]"));
 
     expect_cJSON_GetStringValue_call("HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("registry_invalid");
@@ -555,6 +568,7 @@ static void test_wdb_fim_insert_entry2_registry_succesful(void **state) {
     expect_wdb_stmt_cache_call(1);
 
     expect_cJSON_GetStringValue_call("[x32] HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("registry");
@@ -589,6 +603,7 @@ static void test_wdb_fim_insert_entry2_registry_key_succesful(void **state) {
     expect_wdb_stmt_cache_call(1);
 
     expect_cJSON_GetStringValue_call("HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("registry_key");
@@ -633,6 +648,7 @@ static void test_wdb_fim_insert_entry2_registry_value_succesful(void **state) {
     expect_wdb_stmt_cache_call(1);
 
     expect_cJSON_GetStringValue_call("HKEY_LOCAL_MACHINE\\System\\TEST\\clave");
+    expect_cJSON_GetStringValue_call("version");
     expect_cJSON_IsNumber_call(true);
     expect_cJSON_IsObject_call(true);
     expect_cJSON_GetStringValue_call("registry_value");

--- a/src/wazuh_db/wdb_fim.c
+++ b/src/wazuh_db/wdb_fim.c
@@ -494,7 +494,7 @@ int wdb_fim_insert_entry(wdb_t * wdb, const char * file, int ftype, const sk_sum
 
 int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
     cJSON *json_path;
-    char *path, *arch, *value_name, *full_path, *item_type, *item_version;
+    char *path, *arch, *value_name, *full_path, *item_type;
     if (!wdb) {
         merror("WDB object cannot be null.");
         return -1;
@@ -515,11 +515,11 @@ int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
         return -1;
     }
 
-    item_version = cJSON_GetStringValue(cJSON_GetObjectItem(data, "version"));
+    cJSON * version = cJSON_GetObjectItem(data, "version");
 
-    if (item_version == NULL) {
-        merror("DB(%s) fim/save request with no version attribute.", wdb->id);
-        return -1;
+    if (!cJSON_IsNumber(version)) {
+        // Synchronization messages without the "version" attribute are ignored, but won't trigger any error message.
+        return 0;
     }
 
     cJSON * attributes = cJSON_GetObjectItem(data, "attributes");

--- a/src/wazuh_db/wdb_fim.c
+++ b/src/wazuh_db/wdb_fim.c
@@ -494,7 +494,7 @@ int wdb_fim_insert_entry(wdb_t * wdb, const char * file, int ftype, const sk_sum
 
 int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
     cJSON *json_path;
-    char *path, *arch, *value_name, *full_path, *item_type;
+    char *path, *arch, *value_name, *full_path, *item_type, *item_version;
     if (!wdb) {
         merror("WDB object cannot be null.");
         return -1;
@@ -512,6 +512,13 @@ int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
 
     if (!cJSON_IsNumber(timestamp)) {
         merror("DB(%s) fim/save request with no timestamp path argument.", wdb->id);
+        return -1;
+    }
+
+    item_version = cJSON_GetStringValue(cJSON_GetObjectItem(data, "version"));
+
+    if (item_version == NULL) {
+        merror("DB(%s) fim/save request with no version attribute.", wdb->id);
         return -1;
     }
 
@@ -538,7 +545,7 @@ int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
         item_type = "registry_key";
     } else if (strncmp(item_type, "registry_", 9) == 0) {
         int full_path_length;
-        char *path_escaped = wstr_replace(path, ":", "::");
+        char *path_escaped = wstr_replace(path, ":", "\\:");
 
         arch = cJSON_GetStringValue(cJSON_GetObjectItem(data, "arch"));
 
@@ -565,7 +572,7 @@ int wdb_fim_insert_entry2(wdb_t * wdb, const cJSON * data) {
                 return -1;
             }
 
-            value_name_escaped = wstr_replace(value_name, ":", "::");
+            value_name_escaped = wstr_replace(value_name, ":", "\\:");
 
             full_path_length = snprintf(NULL, 0, "%s %s:%s", arch, path_escaped, value_name_escaped);
 


### PR DESCRIPTION
|Related issue|
|---|
|#7836|

This PR aims to fix the sync mechanism between the windows agent and the manager when the values contained in a key start with `:`.  Now when a key or value contains a `:`, it's scaped and when the synchronization is performed, these values are unescaped again.

Closes #7836

## Configuration options
```xml
 <syscheck>

    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>2</frequency>
    <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\random_key</windows_registry>

    <!-- Database synchronization settings -->
    <synchronization>
      <enabled>yes</enabled>
      <interval>1m</interval>
      <max_interval>1h</max_interval>
      <max_eps>10</max_eps>
    </synchronization>
  </syscheck>

```

## Logs/Alerts example
The synchronization messages now are correctly decoded: 

```
2021/04/07 13:44:22 wazuh-agent[848] run_check.c:82 at fim_send_sync_msg(): DEBUG: (6317): Sending integrity control message: {"component":"fim_registry","type":"state","data":{"path":"HKEY_LOCAL_MACHINE\\Software\\random_key","arch":"[x64]","timestamp":1617799462,"attributes":{"type":"registry_key","perm":"Usuarios (allowed): read_control|read_data|read_ea|write_ea, Usuarios (allowed): generic_read, Administradores (allowed): delete|read_control|write_dac|write_owner|read_data|write_data|append_data|read_ea|write_ea|execute, Administradores (allowed): generic_all, SYSTEM (allowed): delete|read_control|write_dac|write_owner|read_data|write_data|append_data|read_ea|write_ea|execute, SYSTEM (allowed): generic_all, CREATOR OWNER (allowed): generic_all","uid":"S-1-5-32-544","user_name":"Administradores","gid":"S-1-5-21-3527455827-79240758-596275861-513","group_name":"","mtime":1617722229,"checksum":"b31b92d3ab7006c014dd562b228f5859932c1027"},"version":"2.0"}}
2021/04/07 13:44:22 wazuh-agent[848] run_check.c:82 at fim_send_sync_msg(): DEBUG: (6317): Sending integrity control message: {"component":"fim_registry","type":"state","data":{"timestamp":1617799462,"path":"HKEY_LOCAL_MACHINE\\Software\\random_key","arch":"[x64]","value_name":":thisisatest","attributes":{"type":"registry_value","value_type":"REG_SZ","size":1,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"4ca7b88b201728c31afb691707c41d35a984317d"},"version":"2.0"}}
2021/04/07 13:44:22 wazuh-agent[848] run_check.c:82 at fim_send_sync_msg(): DEBUG: (6317): Sending integrity control message: {"component":"fim_registry","type":"state","data":{"path":"HKEY_LOCAL_MACHINE\\Software\\random_key\\:newkey:","arch":"[x64]","timestamp":1617799462,"attributes":{"type":"registry_key","perm":"Usuarios (allowed): read_control|read_data|read_ea|write_ea, Usuarios (allowed): generic_read, Administradores (allowed): delete|read_control|write_dac|write_owner|read_data|write_data|append_data|read_ea|write_ea|execute, Administradores (allowed): generic_all, SYSTEM (allowed): delete|read_control|write_dac|write_owner|read_data|write_data|append_data|read_ea|write_ea|execute, SYSTEM (allowed): generic_all, CREATOR OWNER (allowed): generic_all","uid":"S-1-5-32-544","user_name":"Administradores","gid":"S-1-5-21-3527455827-79240758-596275861-513","group_name":"","mtime":1617797960,"checksum":"99db959b54481ab4ec2f0b5906edb703254c6958"},"version":"2.0"}}
2021/04/07 13:44:22 wazuh-agent[848] run_check.c:82 at fim_send_sync_msg(): DEBUG: (6317): Sending integrity control message: {"component":"fim_registry","type":"state","data":{"timestamp":1617799462,"path":"HKEY_LOCAL_MACHINE\\Software\\random_key\\:newkey:","arch":"[x64]","value_name":":sdaf","attributes":{"type":"registry_value","value_type":"REG_SZ","size":12,"hash_md5":"c31e41940cd12cf9b24b0e528ab955bc","hash_sha1":"2b487009fe43ee00158ba4c05b201d2702f30881","hash_sha256":"b897e454e5dac59345d6b879207383d6e196d01df9d09cb711671f7680a8b8c9","checksum":"85c2868e366cdd87bbb67daa95ad10f75a6f7e19"},"version":"2.0"}}
2021/04/07 13:44:22 wazuh-agent[848] run_check.c:82 at fim_send_sync_msg(): DEBUG: (6317): Sending integrity control message: {"component":"fim_registry","type":"state","data":{"timestamp":1617799462,"path":"HKEY_LOCAL_MACHINE\\Software\\random_key\\:newkey:","arch":"[x64]","value_name":"asdfasdfads","attributes":{"type":"registry_value","value_type":"REG_SZ","size":1,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"4ca7b88b201728c31afb691707c41d35a984317d"},"version":"2.0"}}
2021/04/07 13:44:25 wazuh-agent[848] create_db.c:128 at fim_scan(): INFO: (6008): File integrity monitoring scan started.
```

And the manager database is updated correctly: 
```
root@ubuntumanager:/var/ossec/queue/db# sqlite3 015.db "select full_path from fim_entry"
[x64] HKEY_LOCAL_MACHINE\Software\random_key:
[x64] HKEY_LOCAL_MACHINE\Software\random_key:\:thisisatest
[x64] HKEY_LOCAL_MACHINE\Software\random_key\\:newkey\::
[x64] HKEY_LOCAL_MACHINE\Software\random_key\\:newkey\::\:sdaf
[x64] HKEY_LOCAL_MACHINE\Software\random_key\\:newkey\::asdfasdfads
root@ubuntumanager:/var/ossec/queue/db# 
```
<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [X] Source installation
- [X] Source upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory