### PR TITLE
Fix 8144 remove vuln cve clean action

### DIFF
--- a/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
+++ b/src/unit_tests/wazuh_modules/vulnerability_detector/test_wm_vuln_detector.c
@@ -17280,56 +17280,6 @@ void test_wm_vuldet_init_success(void **state)
     os_free(vuldet);
 }
 
-// Tests wm_vuldet_clean_vuln_cve_db
-
-void test_wm_vuldet_clean_vuln_cve_db_success(void **state)
-{
-    int *array = NULL;
-    os_malloc(sizeof(int)*3, array);
-    array[0] = 0;
-    array[1] = 1;
-    array[2] = OS_INVALID;
-
-    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
-    will_return(__wrap_wdb_get_all_agents, array);
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 1);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
-
-    wm_vuldet_clean_vuln_cve_db();
-}
-
-void test_wm_vuldet_clean_vuln_cve_db_get_agents_error(void **state)
-{
-    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
-    will_return(__wrap_wdb_get_all_agents, NULL);
-    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtwarn, formatted_msg, "Unable to get agent's ID array to clear vuln_cve table");
-
-    wm_vuldet_clean_vuln_cve_db();
-}
-
-void test_wm_vuldet_clean_vuln_cve_db_clear_table_error(void **state)
-{
-    int *array = NULL;
-    os_malloc(sizeof(int)*3, array);
-    array[0] = 0;
-    array[1] = 1;
-    array[2] = OS_INVALID;
-
-    expect_value(__wrap_wdb_get_all_agents, include_manager, TRUE);
-    will_return(__wrap_wdb_get_all_agents, array);
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 0);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_SUCCESS);
-    expect_value(__wrap_wdb_agents_vuln_cve_clear, id, 1);
-    will_return(__wrap_wdb_agents_vuln_cve_clear, OS_INVALID);
-    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:vulnerability-detector");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Error clearing vuln_cve table for agent 1");
-
-    wm_vuldet_clean_vuln_cve_db();
-}
-
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -17779,10 +17729,6 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_wm_vuldet_fetch_MSU_max_attempts, setup_group, teardown_group),
         // Tests wm_vuldet_init
         cmocka_unit_test_setup_teardown(test_wm_vuldet_init_success, setup_group, teardown_group),
-        // Tests wm_vuldet_clean_vuln_cve_db
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_success, setup_group, teardown_group),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_get_agents_error, setup_group, teardown_group),
-        cmocka_unit_test_setup_teardown(test_wm_vuldet_clean_vuln_cve_db_clear_table_error, setup_group, teardown_group),
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -300,11 +300,6 @@ STATIC int wm_vuldet_compare_vendors(char * vendor);
  */
 STATIC void wm_vuldel_truncate_revision(char * revision);
 
-/**
- * @brief Clean every agent vuln_cve DB.
- */
-STATIC void wm_vuldet_clean_vuln_cve_db(void);
-
 int wdb_vuldet_sock = -1;
 int *vu_queue;
 // Define time to sleep between messages sent
@@ -7150,9 +7145,6 @@ void wm_vuldet_init(wm_vuldet_t * vuldet) {
     int i;
 
     if (!flags->enabled) {
-        // If vuldet is disabled we must clean the vulnerable software tables
-        wm_vuldet_clean_vuln_cve_db();
-
         mtdebug1(WM_VULNDETECTOR_LOGTAG, "Module disabled. Exiting...");
         pthread_exit(NULL);
     }
@@ -7659,21 +7651,6 @@ void wm_vuldel_truncate_revision(char * revision) {
         }
     }
     return;
-}
-
-void wm_vuldet_clean_vuln_cve_db(void) {
-    int sock = wm_vuldet_get_wdb_socket();
-    int *id_array = wdb_get_all_agents(TRUE, &sock);
-    if (!id_array) {
-        mtwarn(WM_VULNDETECTOR_LOGTAG, "Unable to get agent's ID array to clear vuln_cve table");
-        return;
-    }
-    for (size_t i = 0; id_array[i] != OS_INVALID; i++) {
-        if (OS_SUCCESS != wdb_agents_vuln_cve_clear(id_array[i], &sock)) {
-            mtdebug1(WM_VULNDETECTOR_LOGTAG, "Error clearing vuln_cve table for agent %d", id_array[i]);
-        }
-    }
-    os_free(id_array);
 }
 
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|#8144|

## Description
This PR implements the removal of the clean for every agent vuln_cve table when Vulnerability Detector is disabled.
It also updates the UT for these changes.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Package installation
- [X] Source upgrade
- [X] Package upgrade
