### PR TITLE
Adding new rule for removed vulnerabilities

### DIFF
--- a/ruleset/rules/0520-vulnerability-detector_rules.xml
+++ b/ruleset/rules/0520-vulnerability-detector_rules.xml
@@ -17,7 +17,7 @@
       <if_sid>23501</if_sid>
       <options>no_full_log</options>
       <field name="vulnerability.status">Removed</field>
-      <description>The $(vulnerability.cve) that affected $(vulnerability.package.name) was eliminated due a package removal/update or a system upgrade</description>
+      <description>The $(vulnerability.cve) that affected $(vulnerability.package.name) was eliminated due to a package removal/update or a system upgrade</description>
   </rule>
 
   <rule id="23503" level="5">

--- a/ruleset/rules/0520-vulnerability-detector_rules.xml
+++ b/ruleset/rules/0520-vulnerability-detector_rules.xml
@@ -1,7 +1,7 @@
 <!--
   -  Vulnerability detector module rules
   -  Created by Wazuh, Inc.
-  -  Copyright (C) 2015-2020, Wazuh Inc.
+  -  Copyright (C) 2015-2021, Wazuh Inc.
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
@@ -13,6 +13,12 @@
     <description>$(vulnerability.cve) affects $(vulnerability.package.name)</description>
   </rule>
 
+  <rule id="23502" level="3">
+      <if_sid>23501</if_sid>
+      <options>no_full_log</options>
+      <field name="vulnerability.status">Removed</field>
+      <description>The $(vulnerability.cve) that affected $(vulnerability.package.name) was eliminated due a package removal/update or a system upgrade</description>
+  </rule>
 
   <rule id="23503" level="5">
       <if_sid>23501</if_sid>

--- a/ruleset/testing/tests/vuln_detector.ini
+++ b/ruleset/testing/tests/vuln_detector.ini
@@ -1,0 +1,6 @@
+[cve: removed ]
+log 1 pass = {"vulnerability":{"package":{"name":"ncurses","version":"5.9-14.20130511.el7_4","architecture":"x86_64"},"cve":"CVE-2019-17594", "status":"Removed", "reference":"fb783b1c771a643f81259a93248e7f61e9a4a597"}}
+log 2 fail = {"vulnerability":{"package":{"name":"ncurses","version":"5.9-14.20130511.el7_4","architecture":"x86_64"},"cve":"", "status":"Removed", "reference":"fb783b1c771a643f81259a93248e7f61e9a4a597"}}
+rule = 23502
+alert = 3
+decoder = json


### PR DESCRIPTION
|Related issue|
|---|
|#7920|

## Description

This PR adds a new rule to alert the user of a vulnerability removed, due an upgrade or a package removal.
Also, some unit tests for the rule were added.

## Logs/Alerts example

The rule requieres a `vulnerability.status` field with the value **Removed** in order to trigger.
Also, the field `vulnerability.cve` must have a value, because this rule depends on **23501**. Here, an example for `wazuh-logtest`

```
{"vulnerability":{"package":{"name":"ncurses","version":"5.9-14.20130511.el7_4","architecture":"x86_64"},"cve":"CVE-2019-17594", "status":"Removed", "reference":"fb783b1c771a643f81259a93248e7f61e9a4a597"}}
```
![cve](https://user-images.githubusercontent.com/65046601/113889415-988b7980-9799-11eb-8850-777084a966e9.png)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)