### PR TITLE
Fix agent add manual race condition and thread lock

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -3,10 +3,10 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 import copy
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor
 from secrets import token_urlsafe
 from shutil import chown
 from time import time

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -3,7 +3,7 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import asyncio
-import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor
 import copy
 import logging
 import os
@@ -23,7 +23,7 @@ from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.rbac.orm import AuthenticationManager, TokenManager, UserRolesManager, Roles
 from wazuh.rbac.preprocessor import optimize_resources
 
-pool = concurrent.futures.ThreadPoolExecutor()
+pool = ThreadPoolExecutor()
 
 
 def check_user_master(user, password):
@@ -66,7 +66,7 @@ def check_user(user, password, required_scopes=None):
                           f_kwargs={'user': user, 'password': password},
                           request_type='local_master',
                           is_async=False,
-                          wait_for_complete=True,
+                          wait_for_complete=False,
                           logger=logging.getLogger('wazuh-api')
                           )
     data = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result())
@@ -136,7 +136,7 @@ def generate_token(user_id=None, data=None, run_as=False):
     dapi = DistributedAPI(f=get_security_conf,
                           request_type='local_master',
                           is_async=False,
-                          wait_for_complete=True,
+                          wait_for_complete=False,
                           logger=logging.getLogger('wazuh-api')
                           )
     result = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result()).dikt
@@ -219,7 +219,7 @@ def decode_token(token):
                                         'run_as': payload['run_as']},
                               request_type='local_master',
                               is_async=False,
-                              wait_for_complete=True,
+                              wait_for_complete=False,
                               logger=logging.getLogger('wazuh-api')
                               )
         data = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result()).to_dict()
@@ -233,7 +233,7 @@ def decode_token(token):
         dapi = DistributedAPI(f=get_security_conf,
                               request_type='local_master',
                               is_async=False,
-                              wait_for_complete=True,
+                              wait_for_complete=False,
                               logger=logging.getLogger('wazuh-api')
                               )
         result = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result())

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -66,7 +66,7 @@ def test_check_user(mock_raise_if_exc, mock_submit, mock_distribute_function, mo
 
     assert result == {'sub': 'test_user', 'active': True}, 'Result is not as expected'
     mock_dapi.assert_called_once_with(f=ANY, f_kwargs={'user': 'test_user', 'password': 'test_pass'},
-                                      request_type='local_master', is_async=False, wait_for_complete=True, logger=ANY)
+                                      request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY)
     mock_distribute_function.assert_called_once_with()
     mock_raise_if_exc.assert_called_once()
 
@@ -132,7 +132,7 @@ def test_generate_token(mock_raise_if_exc, mock_submit, mock_distribute_function
     assert result == 'test_token', 'Result is not as expected'
 
     # Check all functions are called with expected params
-    mock_dapi.assert_called_once_with(f=ANY, request_type='local_master', is_async=False, wait_for_complete=True,
+    mock_dapi.assert_called_once_with(f=ANY, request_type='local_master', is_async=False, wait_for_complete=False,
                                       logger=ANY)
     mock_distribute_function.assert_called_once_with()
     mock_raise_if_exc.assert_called_once()
@@ -164,8 +164,8 @@ def test_decode_token(mock_raise_if_exc, mock_submit, mock_distribute_function, 
     # Check all functions are called with expected params
     calls = [call(f=ANY, f_kwargs={'username': original_payload['sub'], 'token_nbf_time': original_payload['nbf'],
                                    'run_as': False, 'roles': original_payload['rbac_roles']},
-                  request_type='local_master', is_async=False, wait_for_complete=True, logger=ANY),
-             call(f=ANY, request_type='local_master', is_async=False, wait_for_complete=True, logger=ANY)]
+                  request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY),
+             call(f=ANY, request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY)]
     mock_dapi.assert_has_calls(calls)
     mock_generate_secret.assert_called_once()
     mock_decode.assert_called_once_with('test_token', 'test_secret_token', algorithms=['HS256'],

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -3,23 +3,20 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import hashlib
-import logging
 import operator
 from os import chmod, path, listdir
 from shutil import copyfile
 
 from wazuh.core import common, configuration
 from wazuh.core.InputValidator import InputValidator
-from wazuh.core.agent import WazuhDBQueryAgents, WazuhDBQueryGroupByAgents, WazuhDBQueryMultigroups, expand_group, \
-    Agent, WazuhDBQueryGroup, get_agents_info, get_groups, core_upgrade_agents, get_rbac_filters, agents_padding
+from wazuh.core.agent import WazuhDBQueryAgents, WazuhDBQueryGroupByAgents, WazuhDBQueryMultigroups, Agent, \
+    WazuhDBQueryGroup, get_agents_info, get_groups, core_upgrade_agents, get_rbac_filters, agents_padding
 from wazuh.core.cluster.cluster import get_node
 from wazuh.core.cluster.utils import read_cluster_config
 from wazuh.core.exception import WazuhError, WazuhInternalError, WazuhException, WazuhResourceNotFound
 from wazuh.core.results import WazuhResult, AffectedItemsWazuhResult
 from wazuh.core.utils import chmod_r, chown_r, get_hash, mkdir_with_mode, md5, process_array
 from wazuh.rbac.decorators import expose_resources
-
-logger = logging.getLogger('wazuh')
 
 cluster_enabled = not read_cluster_config()['disabled']
 node_id = get_node().get('node') if cluster_enabled else None

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -476,15 +476,15 @@ class Agent:
         manager_status = get_manager_status()
         is_authd_running = 'wazuh-authd' in manager_status and manager_status['wazuh-authd'] == 'running'
 
-        try:
-            if use_only_authd:
-                if not is_authd_running:
-                    raise WazuhInternalError(1726)
+        if use_only_authd and not is_authd_running:
+            raise WazuhInternalError(1726)
 
+        try:
             if not is_authd_running:
                 data = self._remove_manual(backup, purge)
             else:
                 data = self._remove_authd(purge)
+
             return data
         except WazuhException as e:
             raise e
@@ -681,9 +681,8 @@ class Agent:
         manager_status = get_manager_status()
         is_authd_running = 'wazuh-authd' in manager_status and manager_status['wazuh-authd'] == 'running'
 
-        if use_only_authd:
-            if not is_authd_running:
-                raise WazuhInternalError(1726)
+        if use_only_authd and not is_authd_running:
+            raise WazuhInternalError(1726)
 
         try:
             if not is_authd_running:

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -339,6 +339,9 @@ class WazuhException(Exception):
         1756: {'message': 'Upgrade procedure could not start. Agent already upgrading',
                'remediation': 'You can check the status of this task with the /agents/:agent_id/upgrade_result endpoint'
                },
+        1757: {'message': 'Error deleting an agent',
+               'remediation': 'Please check all data fields and try again'
+               },
 
         # CDB List: 1800 - 1899
         1800: {'message': 'Bad format in CDB list {path}'},

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -272,8 +272,8 @@ class WazuhException(Exception):
         1725: {'message': 'Error registering a new agent',
                'remediation': 'Please check all data fields and try again'
                },
-        1726: {'message': 'Ossec authd is not running',
-               'remediation': f'Please, visit our documentation to get more information: https://documentation.wazuh.com/{WAZUH_VERSION}/user-manual/registering/index.html#registering-the-wazuh-agent-using-simple-registration-service'
+        1726: {'message': 'Ossec authd is not running and API use_only_authd is enabled',
+               'remediation': f'Please enable authd or change the API use_only_authd configuration'
                },
         1727: {'message': 'Error listing group files',
                'remediation': 'Please, use `GET /agents/groups/:group_id/files` to get all available group files'
@@ -341,6 +341,10 @@ class WazuhException(Exception):
                },
         1757: {'message': 'Error deleting an agent',
                'remediation': 'Please check all data fields and try again'
+               },
+        1758: {'message': 'Tried to release an already unlocked client.keys thread lock',
+               },
+        1759: {'message': 'Timeout acquiring client.keys lock, another thread or process might be blocking it',
                },
 
         # CDB List: 1800 - 1899

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -623,7 +623,7 @@ def test_agent_remove(mock_remove_manual, mock_remove_authd, status):
 @patch('wazuh.core.agent.Agent._remove_manual', return_value='Agent was successfully deleted')
 def test_agent_remove_ko(mock_remove_manual, mock_remove_authd):
     """Tests if method remove() raises expected exception"""
-    with pytest.raises(WazuhInternalError, match='.* 1726 .*'):
+    with pytest.raises(WazuhError, match='.* 1726 .*'):
         agent = Agent(0)
         agent.remove(use_only_authd=True)
 
@@ -644,6 +644,7 @@ def test_agent_remove_authd(mock_wazuh_socket):
     (True, False),
     (True, True),
 ])
+@patch('wazuh.core.agent.tempfile.mkstemp', return_value=['mock_handle', 'mock_tmp_file'])
 @patch('wazuh.core.agent.fcntl.lockf')
 @patch('wazuh.core.wdb.WazuhDBConnection.delete_agents_db')
 @patch('wazuh.core.agent.remove')
@@ -665,7 +666,8 @@ def test_agent_remove_authd(mock_wazuh_socket):
 @patch('socket.socket.connect')
 def test_agent_remove_manual(socket_mock, run_wdb_mock, send_mock, grp_mock, pwd_mock, chmod_r_mock, makedirs_mock,
                              safe_move_mock, isdir_mock, isfile_mock, exists_mock, stat_mock, chmod_mock,
-                             rmtree_mock, remove_mock, mock_delete_agents, lockf_mock, backup, exists_backup_dir):
+                             rmtree_mock, remove_mock, mock_delete_agents, lockf_mock, mkstemp_mock,  backup,
+                             exists_backup_dir):
     """Test the _remove_manual function
 
     Parameters
@@ -685,15 +687,15 @@ def test_agent_remove_manual(socket_mock, run_wdb_mock, send_mock, grp_mock, pwd
         Agent('001')._remove_manual(backup=backup)
 
         m.assert_any_call(common.client_keys)
-        m.assert_any_call(common.client_keys + '.tmp', 'a')
         stat_mock.assert_called_once_with(common.client_keys)
         mock_delete_agents.assert_called_once_with(['001'])
         run_wdb_mock.assert_called_once_with('global sql DELETE FROM belongs WHERE id_agent = 001')
         remove_mock.assert_any_call(os.path.join(common.wazuh_path, 'queue/rids/001'))
+        mkstemp_mock.assert_called_once_with(prefix=common.client_keys, suffix=".tmp")
 
         # make sure the mock is called with a string according to a non-backup path
-        exists_mock.assert_any_call('{0}/queue/agent-info/agent-1-any'.format(test_data_path))
-        safe_move_mock.assert_called_with(common.client_keys + '.tmp', common.client_keys,
+        exists_mock.assert_any_call('{0}/queue/agent-groups/001'.format(test_data_path))
+        safe_move_mock.assert_called_with('mock_tmp_file', common.client_keys,
                                           permissions=stat_mock().st_mode)
         if backup:
             if exists_backup_dir:
@@ -754,7 +756,7 @@ def test_agent_add_ko(mock_maganer_status):
     with pytest.raises(WazuhError, match='.* 1706 .*'):
         agent._add('test_name', '1111', use_only_authd=True)
 
-    with pytest.raises(WazuhInternalError, match='.* 1726 .*'):
+    with pytest.raises(WazuhError, match='.* 1726 .*'):
         agent._add('test_name', '192.168.0.0', use_only_authd=True)
 
 
@@ -818,15 +820,16 @@ def test_agent_add_authd_ko(mock_wazuh_socket, mocked_exception, expected_except
     ('any', None, 'WMPlw93l2PnwQMN', -1),
     ('any', '003', 'WMPlw93l2PnwQMN', 1),
 ])
+@patch('wazuh.core.agent.tempfile.mkstemp', return_value=['mock_handle', 'mock_tmp_file'])
 @patch('wazuh.core.agent.safe_move')
 @patch('wazuh.core.common.ossec_uid')
 @patch('wazuh.core.common.ossec_gid')
 @patch('wazuh.core.agent.stat')
 @patch('wazuh.core.agent.fcntl.lockf')
-@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('wazuh.core.agent.get_manager_name')
 @patch('socket.socket.connect')
-def test_agent_add_manual(socket_mock, mock_send, mock_lockf, mock_stat, mock_ossec_gid,
-                          mosck_ossec_uid, mock_safe_move, ip, id, key, force):
+def test_agent_add_manual(socket_mock, mock_get_manager_name, mock_lockf, mock_stat, mock_ossec_gid,
+                          mosck_ossec_uid, mock_safe_move, mkstemp_mock, ip, id, key, force):
     """Tests if method _add_manual() works as expected"""
     key = 'MDAyIHdpbmRvd3MtYWdlbnQyIGFueSAzNDA2MjgyMjEwYmUwOWVlMWViNDAyZTYyODZmNWQ2OTE5' \
           'MjBkODNjNTVjZDE5N2YyMzk3NzA0YWRhNjg1YzQz'
@@ -838,21 +841,32 @@ def test_agent_add_manual(socket_mock, mock_send, mock_lockf, mock_stat, mock_os
         agent._add_manual('test_agent', ip=ip, id=id, key=key, force=force)
 
         assert agent.id == id if id is not None else agent.id == '002', 'ID should has been updated.'
-        calls = [call('global sql select count(*) from agent where (id = 0)'),
-                 call('global sql select name from agent where (id = 0) limit 1 offset 0')]
 
-        mock_send.assert_has_calls(calls)
-        mock_safe_move.assert_called_once_with('{0}.tmp'.format(common.client_keys), common.client_keys,
+        mock_get_manager_name.assert_called_once()
+        mkstemp_mock.assert_called_once_with(prefix=common.client_keys, suffix=".tmp")
+        mock_safe_move.assert_called_once_with('mock_tmp_file', common.client_keys,
                                                permissions=ANY)
 
 
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_get_manager_name(mock_connect, mock_send):
+    get_manager_name()
+    calls = [call('global sql select count(*) from agent where (id = 0)'),
+             call('global sql select name from agent where (id = 0) limit 1 offset 0')]
+
+    mock_send.assert_has_calls(calls)
+
+
+@patch('wazuh.core.agent.tempfile.mkstemp', return_value=['mock_handle', 'mock_tmp_file'])
 @patch('wazuh.core.common.ossec_uid')
 @patch('wazuh.core.common.ossec_gid')
 @patch('wazuh.core.agent.chown')
 @patch('wazuh.core.agent.chmod')
 @patch('wazuh.core.agent.stat')
 @patch('wazuh.core.agent.fcntl.lockf')
-def test_agent_add_manual_ko(mock_lockf, mock_stat, mock_chmod, mock_chown, mock_ossec_gid, mosck_ossec_uid):
+def test_agent_add_manual_ko(mock_lockf, mock_stat, mock_chmod, mock_chown, mock_ossec_gid, mosck_ossec_uid,
+                             mock_mkstemp):
     """Tests if method _add_manual() raises expected exceptions"""
     key = 'MDAyIHdpbmRvd3MtYWdlbnQyIGFueSAzNDA2MjgyMjEwYmUwOWVlMWViNDAyZTYyODZmNWQ2OTE5' \
           'MjBkODNjNTVjZDE5N2YyMzk3NzA0YWRhNjg1YzQz'
@@ -891,12 +905,12 @@ def test_agent_add_manual_ko(mock_lockf, mock_stat, mock_chmod, mock_chown, mock
                         agent._add_manual('test_agent', '172.19.0.100')
 
                     # It used to raise 1725, now FileNotFoundError is captured at a higher level and then raises 1725
-                    with patch('wazuh.core.agent.Agent._remove_manual') as mock_remove:
+                    with patch('wazuh.core.agent.Agent.delete_agent_files') as mock_delete_files:
                         # IP already exists and force
                         with pytest.raises(FileNotFoundError):
                             agent = Agent(1)
                             agent._add_manual('test_agent', '192.168.0.1', force=0)
-                        mock_remove.assert_called_once_with(backup=True)
+                        mock_delete_files.assert_called_once_with('001', 'windows-agent', '192.168.0.1', backup=True)
 
                     with patch('wazuh.core.agent.Agent.check_if_delete_agent', return_value=False):
                         # IP already exists and force
@@ -1567,7 +1581,6 @@ def test_expand_group(group, expected_agents):
     ('001', 1747),
     ('001', 1748),
 ])
-@patch('wazuh.core.agent.Agent._acquire_client_keys_lock')
 @patch('wazuh.core.agent.safe_move')
 @patch('wazuh.core.agent.fcntl.lockf')
 @patch('wazuh.core.wdb.WazuhDBConnection.delete_agents_db')
@@ -1587,7 +1600,7 @@ def test_expand_group(group, expected_agents):
 @patch('socket.socket.connect')
 def test_agent_remove_manual_ko(socket_mock, send_mock, grp_mock, pwd_mock, chmod_r_mock, makedirs_mock, isdir_mock,
                                 stat_mock, chmod_mock, chown_mock, rmtree_mock, remove_mock, delete_mock, lockf_mock,
-                                mock_safe_move, acquire_mock, agent_id, expected_exception):
+                                mock_safe_move, agent_id, expected_exception):
     """Test the _remove_manual function error cases.
 
     Parameters
@@ -1620,10 +1633,6 @@ def test_agent_remove_manual_ko(socket_mock, send_mock, grp_mock, pwd_mock, chmo
     if expected_exception == 1701:
         with patch('wazuh.core.wdb.WazuhDBConnection.run_wdb_command'):
             check_exception(client_keys_text)
-
-    if expected_exception == 1746:
-        with patch('wazuh.core.wdb.WazuhDBConnection.run_wdb_command'):
-            check_exception(Exception("Boom!"))
 
 
 @pytest.mark.parametrize('system_resources, permitted_resources, filters, expected_result', [

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -34,6 +34,12 @@ class WazuhDBConnection:
         except OSError as e:
             raise WazuhInternalError(2005, e)
 
+    def close(self):
+        self.__conn.close()
+
+    def __del__(self):
+        self.close()
+
     def __query_input_validation(self, query):
         """
         Checks input queries have the correct format


### PR DESCRIPTION
Hello team,

This PR closes #8122. It adds several fixes to improve `add_manual` and `remove_manual` framework functions to avoid race conditions among threads. It also uses a better approach to `client.keys.tmp` handling. Lastly, an unique `ThreadpoolExecutor` is used for the wazuh-apid process.

Regards,

David J. Iglesias
