### PR TITLE
Obscure agent keys when registering agents

### DIFF
--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -27,7 +27,8 @@ class AccessLogger(AbstractAccessLogger):
             query['password'] = '****'
         if 'password' in body:
             body['password'] = '****'
-
+        if 'key' in body and '/agents' in request.path:
+            body['key'] = '****'
         # With permanent redirect, not found responses or any response with no token information,
         # decode the JWT token to get the username
         user = request.get('user', '')


### PR DESCRIPTION
Hello team,

This PR adds a fix to obscure agent keys in the API log when registering agents through the Wazuh API.

Before:
```
2021/04/02 09:14:38 INFO: wazuh 172.19.0.1 "POST /agents/insert" with parameters {} and body {"name": "David", "ip": "any", "key": "1abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi64"} done in 0.047s: 200
```

After:
```
2021/04/02 09:17:27 INFO: wazuh 172.19.0.1 "POST /agents/insert" with parameters {} and body {"name": "David2", "ip": "any", "key": "****"} done in 0.058s: 200
```

Regards,

David J. Iglesias