### PR TITLE
Fix race conditions and optimize garbage collection in Wazuh DB

### DIFF
--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -414,7 +414,7 @@ void * run_up(__attribute__((unused)) void * args) {
         return NULL;
     }
 
-    while ((db = readdir(fd)) != NULL) {
+    while ((db = readdir(fd)) != NULL && running) {
         if ((strcmp(db->d_name, ".") == 0) ||
             (strcmp(db->d_name, "..") == 0) ||
             (strcmp(db->d_name, ".template.db") == 0) ||
@@ -438,6 +438,8 @@ void * run_up(__attribute__((unused)) void * args) {
         wdb = wdb_open_agent2(atoi(entry));
         wdb_leave(wdb);
         free(entry);
+
+        sleep(1);
     }
 
     os_free(db_folder);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -712,6 +712,16 @@ void wdb_pool_append(wdb_t * wdb);
 
 void wdb_pool_remove(wdb_t * wdb);
 
+/**
+ * @brief Duplicate the database pool
+ *
+ * Gets a copy of the database pool. This function fills the member "id" and
+ * creates the mutex only.
+ *
+ * @return Pointer to a database list.
+ */
+wdb_t * wdb_pool_copy();
+
 void wdb_close_all();
 
 void wdb_commit_old();


### PR DESCRIPTION
|Related issue|
|---|
|#8146|

This PR applies the following changes into Wazuh DB:

- Protect each database node reference count with the node mutex.
- Prevent the database update thread from stalling the exit procedure.
- Slow down the database update procedure to one agent per second.
- Unlock the global database pool mutex in the garbage collector while closing or committing databases.

## Tests

- [X] Compile manager for Linux.
- [X] Run Wazuh DB with Thread Sanitizer.
- [X] Run a bunch of `vuln_cve clean` queries on 10.000 databases.