### PR TITLE
Fix build with ZeroMQ flag

### DIFF
--- a/src/analysisd/output/zeromq.c
+++ b/src/analysisd/output/zeromq.c
@@ -112,7 +112,7 @@ void zeromq_output_end()
 #if CZMQ_VERSION_MAJOR == 2
 void zeromq_output_event(const Eventinfo *lf)
 {
-    char *json_alert = Eventinfo_to_jsonstr(lf);
+    char *json_alert = Eventinfo_to_jsonstr(lf, false);
 
     zmsg_t *msg = zmsg_new();
     zmsg_addstr(msg, "ossec.alerts");
@@ -123,7 +123,7 @@ void zeromq_output_event(const Eventinfo *lf)
 #elif ZMQ_VERSION_MAJOR >= 3
 void zeromq_output_event(const Eventinfo *lf)
 {
-    char *json_alert = Eventinfo_to_jsonstr(lf);
+    char *json_alert = Eventinfo_to_jsonstr(lf, false);
 
     zmsg_t *msg = zmsg_new();
     zmsg_addstr(msg, "ossec.alerts");


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8141|


## Description

Hi team!,

This PR solves the Wazuh-Analysisd compilation problem with the `USE_ZEROMQ=yes` flag. This small bug was introduced by PR #4906 where the prototype of the `Eventinfo_to_jsonstr()` function was changed and has no additional complexity.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [ ] Coverity
  - [X] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [X] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
