### PR TITLE
Added configuration  for ULS logs collection

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -137,17 +137,17 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         } else if (strcmp(node[i]->element, xml_localfile_query) == 0) {
 //ifdef Darwin
             const char * type_attr = w_get_attr_val_by_name(node[i], xml_localfile_query_type_attr);
-            if(type_attr) {
+            if (type_attr) {
                 logf[pl].query_type = w_logcollector_get_oslog_type(type_attr);
             }
 
             const char * level_attr = w_get_attr_val_by_name(node[i], xml_localfile_query_level_attr);
-            if(level_attr) {
+            if (level_attr) {
                 if ((strcmp(node[i]->content, OSLOG_LEVEL_DEFAULT_STR) != 0) &&
                     (strcmp(node[i]->content, OSLOG_LEVEL_INFO_STR) != 0) &&
                     (strcmp(node[i]->content, OSLOG_LEVEL_DEBUG_STR) != 0)) {
                     /* Invalid level query */
-                        mwarn(LOGCOLLECTOR_INV_VALUE_DEFAULT, level_attr, \
+                    mwarn(LOGCOLLECTOR_INV_VALUE_IGNORE, level_attr,
                         xml_localfile_query_level_attr, xml_localfile_query);
                 } else {
                     os_strdup(node[i]->content, logf[pl].query_level);
@@ -475,9 +475,9 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     }
 
     if (strcmp(logf[pl].logformat, OSLOG) == 0 && strcmp(logf[pl].file, OSLOG) != 0) {
-            /* Invalid oslog */
-            merror(INV_OSLOG);
-            return (OS_INVALID);
+        /* Invalid oslog */
+        merror(INV_OSLOG);
+        return (OS_INVALID);
     }
 //endif Darwin
     /* Verify Multiline Regex Config */
@@ -874,17 +874,21 @@ STATIC int w_logcollector_get_oslog_type(const char * content) {
 
     if (type_arr) {
         while (type_arr[current]) {
-            char * word = &(type_arr[current])[strspn(type_arr[current], " ")];
-            word[strcspn(word, " ")] = '\0';
+            char * config_str = &(type_arr[current])[strspn(type_arr[current], " ")];
+            int num_words = w_word_counter(config_str);
 
-            if (strcasecmp(word, OSLOG_TYPE_ACTIVITY_STR) == 0) {
+            if (num_words == 1) {
+                config_str[strcspn(config_str, " ")] = '\0';
+            }
+
+            if (strcasecmp(config_str, OSLOG_TYPE_ACTIVITY_STR) == 0) {
                 retval |= OSLOG_TYPE_ACTIVITY;
-            } else if (strcasecmp(word, OSLOG_TYPE_LOG_STR) == 0) {
+            } else if (strcasecmp(config_str, OSLOG_TYPE_LOG_STR) == 0) {
                 retval |= OSLOG_TYPE_LOG;
-            } else if (strcasecmp(word, OSLOG_TYPE_TRACE_STR) == 0) {
+            } else if (strcasecmp(config_str, OSLOG_TYPE_TRACE_STR) == 0) {
                 retval |= OSLOG_TYPE_TRACE;
-            } else if (strcasecmp(word, "") != 0) {
-                mwarn(LOGCOLLECTOR_INV_VALUE_DEFAULT, word, XML_LOCALFILE_QUERY_TYPE_ATTR, XML_LOCALFILE_QUERY);
+            } else if (strcasecmp(config_str, "") != 0) {
+                mwarn(LOGCOLLECTOR_INV_VALUE_IGNORE, config_str, XML_LOCALFILE_QUERY_TYPE_ATTR, XML_LOCALFILE_QUERY);
             }
 
             os_free(type_arr[current]);

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -132,8 +132,9 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                     /* Invalid type query */
                         mwarn(LOGCOLLECTOR_INV_VALUE_DEFAULT, type_attr, \
                         xml_localfile_query_type_attr, xml_localfile_query);
-                }
+                } else {
                 os_strdup(node[i]->content, logf[pl].query_type);
+                }
             }
 
             const char * level_attr = w_get_attr_val_by_name(node[i], xml_localfile_query_level_attr);
@@ -144,8 +145,9 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                     /* Invalid level query */
                         mwarn(LOGCOLLECTOR_INV_VALUE_DEFAULT, level_attr, \
                         xml_localfile_query_level_attr, xml_localfile_query);
+                } else {
+                    os_strdup(node[i]->content, logf[pl].query_level);
                 }
-                os_strdup(node[i]->content, logf[pl].query_type);
             }
 //endif Darwin
             os_strdup(node[i]->content, logf[pl].query);
@@ -302,14 +304,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 }
             }
 #endif
-//ifdef Darwin
-            if (strcmp(node[i]->content, OSLOG) == 0) {
-                if (++log_config->oslog_count > 1) {
-                    merror(DUP_OSLOG);
-                    return (OS_INVALID);
-                }
-            }
-//endif Darwin
             os_strdup(node[i]->content, logf[pl].file);
         } else if (strcasecmp(node[i]->element, xml_localfile_logformat) == 0) {
             os_strdup(node[i]->content, logf[pl].logformat);
@@ -359,6 +353,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             } else if (strcmp(logf[pl].logformat, EVENTCHANNEL) == 0) {
 //ifdef Darwin
             } else if (strcmp(logf[pl].logformat, OSLOG) == 0) {
+                log_config->oslog_count++;
                 os_calloc(1, sizeof(w_oslog_config_t), logf[pl].oslog);
 //endif Darwin
             } else {
@@ -470,12 +465,15 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     }
 //ifdef Darwin
     /* Verify oslog config*/
-    if (strcmp(logf[pl].logformat, OSLOG) == 0) {
-        if (strcmp(logf[pl].file, OSLOG) != 0) {
+    if (log_config->oslog_count > 1) {
+        merror(DUP_OSLOG);
+        return (OS_INVALID);
+    }
+
+    if (strcmp(logf[pl].logformat, OSLOG) == 0 && strcmp(logf[pl].file, OSLOG) != 0) {
             /* Invalid oslog */
             merror(INV_OSLOG);
             return (OS_INVALID);
-        }
     }
 //endif Darwin
     /* Verify Multiline Regex Config */

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -359,6 +359,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             } else if (strcmp(logf[pl].logformat, EVENTCHANNEL) == 0) {
 //ifdef Darwin
             } else if (strcmp(logf[pl].logformat, OSLOG) == 0) {
+                os_calloc(1, sizeof(w_oslog_config_t), logf[pl].oslog);
 //endif Darwin
             } else {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -29,6 +29,7 @@
 #include "labels_op.h"
 #include "expression.h"
 #include "os_xml/os_xml.h"
+#include "exec_op.h"
 
 extern int maximum_files;
 extern int total_files;
@@ -99,6 +100,18 @@ typedef struct {
     int64_t offset_last_read;  ///< absolut file offset of last complete multiline log processed
 } w_multiline_config_t;
 
+/**
+ * @brief An instance of w_oslog_config_t represents a OSlog (ULS) and its state
+ */
+typedef struct {
+    char * ctxt_buffer;         ///< store current read when os log is in process
+    int64_t offset_last_read;   ///< absolut stream offset of last complete log processed
+    char * last_timestamp_read; ///< timestamp of last log queued (Used for only feature event)
+    wfd_t * log_wfd;            ///< `log stream` IPC connector
+    /** Indicates if `log stream` is currently running. if not running, localfiles with oslog format will be ignored */
+    bool oslog_running;
+} w_oslog_config_t;
+
 /* Logreader config */
 typedef struct _logreader {
     off_t size;
@@ -119,7 +132,8 @@ typedef struct _logreader {
     char *ffile;
     char *file;
     char *logformat;
-    w_multiline_config_t * multiline;
+    w_multiline_config_t * multiline; ///< Multiline regex config & state
+    w_oslog_config_t * oslog;         ///< oslog config & state
     long linecount;
     char *djb_program_name;
     char *command;

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -13,6 +13,7 @@
 
 #define EVENTLOG     "eventlog"
 #define EVENTCHANNEL "eventchannel"
+#define OSLOG        "oslog"
 #define MULTI_LINE_REGEX              "multi-line-regex"
 #define MULTI_LINE_REGEX_TIMEOUT      5
 #define MULTI_LINE_REGEX_MAX_TIMEOUT  120
@@ -127,6 +128,8 @@ typedef struct _logreader {
     char future;
     long diff_max_size;
     char *query;
+    char *query_type;   ///< Filtering by type in oslog
+    char *query_level;  ///< Filtering by level in oslog
     int filter_binary;
     int ucs2;
     outformat ** out_format;
@@ -156,6 +159,7 @@ typedef struct _logreader_glob {
 typedef struct _logreader_config {
     int agent_cfg;
     int accept_remote;
+    unsigned int oslog_count;
     logreader_glob *globs;
     logreader *config;
     logsocket *socket_list;

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -142,8 +142,8 @@ typedef struct _logreader {
     char future;
     long diff_max_size;
     char *query;
-    char *query_type;   ///< Filtering by type in oslog
-    char *query_level;  ///< Filtering by level in oslog
+    char * query_type;   ///< Filtering by type in oslog
+    char * query_level;  ///< Filtering by level in oslog
     int filter_binary;
     int ucs2;
     outformat ** out_format;

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -117,7 +117,7 @@ typedef struct {
 typedef struct {
     char * ctxt_buffer;         ///< store current read when os log is in process
     int64_t last_read_offset;   ///< absolut stream offset of last complete log processed
-    char * last_read_timestamp; ///< timestamp of last log queued (Used for only feature event)
+    char * last_read_timestamp; ///< timestamp of last log queued (Used for only future event)
     wfd_t * log_wfd;            ///< `log stream` IPC connector
     /** Indicates if `log stream` is currently running. if not running, localfiles with oslog format will be ignored */
     bool is_oslog_running;

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -22,6 +22,17 @@
 #define DIFF_DEFAULT_SIZE 10 * 1024 * 1024
 #define DIFF_MAX_SIZE (2 * 1024 * 1024 * 1024LL)
 
+/* oslog configurations */
+#define OSLOG_LEVEL_DEFAULT_STR "default"  ///< Represents the lowest loggin level in oslog
+#define OSLOG_LEVEL_INFO_STR    "info"     ///< Represents the intermediate loggin level in oslog
+#define OSLOG_LEVEL_DEBUG_STR   "debug"    ///< Represents the highest loggin level in oslog
+#define OSLOG_TYPE_ACTIVITY_STR "activity" ///< Is used to filter by `activity` logs
+#define OSLOG_TYPE_LOG_STR      "log"      ///< Is used to filter by `log` logs
+#define OSLOG_TYPE_TRACE_STR    "trace"    ///< Is used to filter by `trace` logs
+#define OSLOG_TYPE_ACTIVITY     (0x1 << 0) ///< Flag used to filter by `activity` logs
+#define OSLOG_TYPE_LOG          (0x1 << 1) ///< Flag used to filter by `log` logs
+#define OSLOG_TYPE_TRACE        (0x1 << 2) ///< Flag used to filter by `trace` logs
+
 #include <pthread.h>
 
 /* For ino_t */
@@ -105,11 +116,11 @@ typedef struct {
  */
 typedef struct {
     char * ctxt_buffer;         ///< store current read when os log is in process
-    int64_t offset_last_read;   ///< absolut stream offset of last complete log processed
-    char * last_timestamp_read; ///< timestamp of last log queued (Used for only feature event)
+    int64_t last_read_offset;   ///< absolut stream offset of last complete log processed
+    char * last_read_timestamp; ///< timestamp of last log queued (Used for only feature event)
     wfd_t * log_wfd;            ///< `log stream` IPC connector
     /** Indicates if `log stream` is currently running. if not running, localfiles with oslog format will be ignored */
-    bool oslog_running;
+    bool is_oslog_running;
 } w_oslog_config_t;
 
 /* Logreader config */
@@ -142,7 +153,7 @@ typedef struct _logreader {
     char future;
     long diff_max_size;
     char *query;
-    char * query_type;   ///< Filtering by type in oslog
+    int query_type;      ///< Filtering by type in oslog
     char * query_level;  ///< Filtering by level in oslog
     int filter_binary;
     int ucs2;

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -215,7 +215,7 @@
 #define LOCALFILE_REGEX "(1967): Syntax error on multiline_regex: '%s'"
 #define MISS_MULT_REGEX "(1968): Missing 'multiline_regex' element."
 #define DUP_OSLOG       "(1969): Can't add more than one oslog block."
-#define INV_OSLOG       "(1970): Invalid Oslog configuration. 'location' and 'log_format' must be both set to 'oslog'."
+#define INV_OSLOG       "(1970): Invalid Oslog configuration. Attributes 'location' and 'log_format' must be both set to 'oslog'."
 
 /* Encryption/auth errors */
 #define INVALID_KEY     "(1401): Error reading authentication key: '%s'."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -214,6 +214,8 @@
 #define DUP_FILE_INODE  "(1966): Inode for file '%s' already found. Skipping it."
 #define LOCALFILE_REGEX "(1967): Syntax error on multiline_regex: '%s'"
 #define MISS_MULT_REGEX "(1968): Missing 'multiline_regex' element."
+#define DUP_OSLOG       "(1969): Can't add more than one oslog block."
+#define INV_OSLOG       "(1970): Invalid Oslog configuration. 'location' and 'log_format' must be both set to 'oslog'."
 
 /* Encryption/auth errors */
 #define INVALID_KEY     "(1401): Error reading authentication key: '%s'."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -91,6 +91,8 @@
                                                 " Will be ignored."
 #define LOGCOLLECTOR_MULTILINE_AGE_TIMEOUT      "(8002): 'age' cannot be less than 'timeout' in multiline_regex option."\
                                                 " 'age' will be ignored."
+#define LOGCOLLECTOR_INV_VALUE_IGNORE           "(8003): Invalid value '%s' for attribute '%s' in '%s' option. " \
+                                                "Attribute will be ignored."
 
 /* Remoted */
 #define REMOTED_NET_PROTOCOL_ERROR              "(9000): Error getting protocol. Default value (%s) will be used."

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -35,6 +35,7 @@ int LogCollectorConfig(const char *cfgfile)
     log_config.globs = NULL;
     log_config.socket_list = NULL;
     log_config.agent_cfg = 0;
+    log_config.oslog_count = 0;
     accept_remote = getDefine_Int("logcollector", "remote_commands", 0, 1);
     log_config.accept_remote = accept_remote;
 

--- a/src/unit_tests/logcollector/test_localfile-config.c
+++ b/src/unit_tests/logcollector/test_localfile-config.c
@@ -363,11 +363,11 @@ void test_w_logcollector_get_oslog_type_content_empty(void ** state) {
 void test_w_logcollector_get_oslog_type_content_ignore_values(void ** state) {
     const char * content = "  hello, ,world  ";
 
-    expect_string(__wrap__mwarn, formatted_msg, "(8000): Invalid value 'hello' for attribute 'type' in 'query' option."\
-                  " Default value will be used.");
+    expect_string(__wrap__mwarn, formatted_msg, "(8003): Invalid value 'hello' for attribute 'type' in 'query' option."\
+                  " Attribute will be ignored.");
 
-    expect_string(__wrap__mwarn, formatted_msg, "(8000): Invalid value 'world' for attribute 'type' in 'query' option."\
-                  " Default value will be used.");
+    expect_string(__wrap__mwarn, formatted_msg, "(8003): Invalid value 'world' for attribute 'type' in 'query' option."\
+                  " Attribute will be ignored.");
 
     int ret = w_logcollector_get_oslog_type(content);
     assert_int_equal(ret, 0);
@@ -406,6 +406,17 @@ void test_w_logcollector_get_oslog_type_content_trace_log_activity(void ** state
 
     int ret = w_logcollector_get_oslog_type(content);
     assert_int_equal(ret, OSLOG_TYPE_TRACE | OSLOG_TYPE_ACTIVITY | OSLOG_TYPE_LOG);
+}
+
+void test_w_logcollector_get_oslog_type_content_log_multiword_invalid(void ** state) {
+    const char * content = "log, trace  activity";
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(8003): Invalid value 'trace  activity' for attribute 'type' in 'query' option."
+                  " Attribute will be ignored.");
+
+    int ret = w_logcollector_get_oslog_type(content);
+    assert_int_equal(ret, OSLOG_TYPE_LOG);
 }
 
 int main(void) {
@@ -449,6 +460,7 @@ int main(void) {
         cmocka_unit_test(test_w_logcollector_get_oslog_type_content_trace),
         cmocka_unit_test(test_w_logcollector_get_oslog_type_content_trace_activity),
         cmocka_unit_test(test_w_logcollector_get_oslog_type_content_trace_log_activity),
+        cmocka_unit_test(test_w_logcollector_get_oslog_type_content_log_multiword_invalid),
 
     };
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #8135|
|Closes #8136|


## Description

Hi team !

This PR aims to add parsing support for `localfile` configuration block for [Unified Logging System (ULS)](https://developer.apple.com/documentation/os/logging), that consists of adding the following features 

- Add `oslog` as `log_format` value.
- Only one `localfile` block with `oslog` as `log_format` is supported
- Use `query` option to specify [NSPredicate](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/Predicates/AdditionalChapters/Introduction.html) (filter) when `log_format` is set to `oslog`.
- The `query` option will support `type` (activity|log|trace) and `level` (default|info|debug) attributes when `log_format` is set to `oslog`.
- `location` value will be mandatory and with `oslog` value when `log_format` is set to `oslog`.
- Related options that should be handled: `out_format`, `only-future-events`, `target`.

### UPDATE

Also, this PR  add configuration load support for localfile configuration block for Unified Logging System (ULS), creating the appropriate data structures to store and handle this new log format.

## Configuration options

An example of the new configuration:
```xml
<localfile>
  <log_format>oslog</log_format>
  <location>oslog</location>
  <query type="trace" level="debug">processImagePath CONTAINS[c] "com.apple.geod"</query>
</localfile>
```

## Logs/Alerts example
With the following configuration:
```xml
<localfile>
    <log_format>oslog</log_format>
    <location>EXAMPLE</location>
    <only-future-events>no</only-future-events>
  </localfile>
```
Output:
```
2021/04/08 17:29:27 wazuh-logcollector: ERROR: (1970): Invalid Oslog configuration. 'location' and 'log_format' must be both set to 'oslog'.
2021/04/08 17:29:27 wazuh-logcollector: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
2021/04/08 17:29:27 wazuh-logcollector: CRITICAL: (1202): Configuration error at 'etc/ossec.conf'.
wazuh-logcollector: Configuration error. Exiting
```
With this configuration:
```xml
<localfile>
    <log_format>oslog</log_format>
    <location>EXAMPLE</location>
    <only-future-events>no</only-future-events>
  </localfile>
```
Output:
```
2021/04/08 17:29:43 wazuh-logcollector: ERROR: (1969): Can't add more than one oslog block.
2021/04/08 17:29:43 wazuh-logcollector: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
2021/04/08 17:29:43 wazuh-logcollector: CRITICAL: (1202): Configuration error at 'etc/ossec.conf'.
```
## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
