### PR TITLE
Fix buffer overflow in Analysisd when sending an AR request to Remoted

### DIFF
--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -24,16 +24,12 @@ static const char* get_ip(const Eventinfo *lf);
 
 void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar)
 {
-    char exec_msg[OS_SIZE_8192 + 1];
-    char msg[OS_SIZE_8192 + 1];
+    char * exec_msg = NULL;
+    char * msg = NULL;
     const char *ip;
     const char *user;
     char *filename = NULL;
     char *extra_args = NULL;
-
-    memset(exec_msg, 0, OS_SIZE_8192 + 1);
-    memset(msg, 0, OS_SIZE_8192 + 1);
-
     /* Clean the IP */
     ip = "-";
     if (lf->srcip) {
@@ -42,6 +38,9 @@ void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar
             return;
         }
     }
+
+    os_calloc(OS_MAXSTR + 1, sizeof(char), exec_msg);
+    os_calloc(OS_MAXSTR + 1, sizeof(char), msg);
 
     /* Get username */
     user = "-";
@@ -103,8 +102,8 @@ void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar
                 wlabel_t *agt_labels = NULL;
                 char *agt_version = NULL;
 
-                memset(exec_msg, 0, OS_SIZE_8192 + 1);
-                memset(msg, 0, OS_SIZE_8192 + 1);
+                memset(exec_msg, 0, OS_MAXSTR + 1);
+                memset(msg, 0, OS_MAXSTR + 1);
 
                 snprintf(c_agent_id, OS_SIZE_16, "%.3d", id_array[i]);
 
@@ -244,6 +243,8 @@ void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar
     /* Clean up Memory */
     os_free(filename);
     os_free(extra_args);
+    os_free(exec_msg);
+    os_free(msg);
 
     return;
 }
@@ -329,6 +330,7 @@ void getActiveResponseInString( const Eventinfo *lf,
  * @param[in] agent_id Agent ID to identify where the AR will be executed.
  * @param[in] msg Message that can be in JSON or string format
  * @param[out] exec_msg Complete massage containing the message and the header.
+ * @pre exec_msg is OS_MAXSTR + 1 or more bytes long.
  * @return void.
  */
 void get_exec_msg(const active_response *ar, char *agent_id, const char *msg, char *exec_msg)
@@ -345,7 +347,5 @@ void get_exec_msg(const active_response *ar, char *agent_id, const char *msg, ch
             (ar->location & SPECIFIC_AGENT || ar->location & ALL_AGENTS) ? SPECIFIC_AGENT_C : NONE_C,
             agent_id);
 
-    strcpy(exec_msg, temp_msg);
-    strcat(exec_msg, " ");
-    strcat(exec_msg, msg);
+    os_snprintf(exec_msg, OS_MAXSTR + 1, "%s %s", temp_msg, msg);
 }

--- a/src/analysisd/ar_json.c
+++ b/src/analysisd/ar_json.c
@@ -23,6 +23,7 @@
  * @param[in] ar Active Response information.
  * @param[in] extra_args Extra arguments escaped.
  * @param[out] temp_msg Message in JSON format.
+ * @pre temp_msg is OS_MAXSTR + 1 or more bytes long.
  */
 void getActiveResponseInJSON(const Eventinfo *lf, const active_response *ar, char *extra_args, char *temp_msg)
 {
@@ -73,7 +74,8 @@ void getActiveResponseInJSON(const Eventinfo *lf, const active_response *ar, cha
     cJSON_AddItemToObject(_object, "alert", json_alert);
 
     msg = cJSON_PrintUnformatted(message);
-    strcpy(temp_msg, msg);
+    strncpy(temp_msg, msg, OS_MAXSTR);
+    temp_msg[OS_MAXSTR] = '\0';
     os_free(msg);
 
     // Clean up Memory

--- a/src/unit_tests/analysisd/test_exec.c
+++ b/src/unit_tests/analysisd/test_exec.c
@@ -753,13 +753,14 @@ void test_getActiveResponseInJSON_extra_args(void **state){
     test_struct_t *data  = (test_struct_t *)*state;
     cJSON *json_msj = NULL;
 
-    char msg[OS_SIZE_8192 + 1];
+    char * msg;
     char *c_device = NULL;
     const char *alert_info = "[{\"test\":\"test\"}]";
     char *extra_args = "-arg1 --arg2 arg3 ; cat /etc/passwd";
     char *result = "[\"-arg1\",\"--arg2\",\"arg3\",\";\",\"cat\",\"/etc/passwd\"]";
     char *node = NULL;
 
+    os_malloc(OS_MAXSTR + 1, msg);
     os_strdup("node01", node);
 
     will_return(__wrap_Eventinfo_to_jsonstr, strdup(alert_info));
@@ -783,6 +784,7 @@ void test_getActiveResponseInJSON_extra_args(void **state){
     assert_string_equal(c_device, result);
 
     os_free(c_device);
+    os_free(msg);
 }
 
 int main(void)


### PR DESCRIPTION
|Related issue|
|---|
|#8104|

This PR aims to fix a buffer overflow hazard in Analysisd due to handling strings with no limit control.

- `strcpy` on an 8 KiB long string from an undefined length string.
- `strcat` from a 1 KiB and another 8 KiB long string on an 8 KiB long string.

## Tests

- [X] Try to reproduce the case described in #8104.
- [X] Send a 65408 bytes long string: we have a warning in Analysisd.
- [X] Send a 65409 bytes long string: we have a warning in Agentd.
- [x] Run Analysisd on Address Sanitizer.