### PR TITLE
Add new cluster integrity preprocessor

### DIFF
--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -188,10 +188,15 @@ def walk_dir(dirname, recursive, files, excluded_files, excluded_extensions, get
     except OSError as e:
         raise WazuhError(3015, str(e))
 
+    # Get the information collected in the previous integration process.
+    previous_status = common.cluster_integrity_mtime.get()
+
     for entry in entries:
+        # Relative path to listed file.
+        full_path = path.join(dirname, entry)
 
         # If file is inside 'excluded_files' or file extension is inside 'excluded_extensions', skip over.
-        if entry in excluded_files or reduce(add, map(lambda x: entry[-(len(x)):] == x, excluded_extensions)):
+        if entry in excluded_files or any([entry.endswith(v) for v in excluded_extensions]):
             continue
 
         try:
@@ -199,25 +204,32 @@ def walk_dir(dirname, recursive, files, excluded_files, excluded_extensions, get
             full_path = path.join(dirname, entry)
 
             # If 'all' files have been requested or entry is in the specified files list.
-            if entry in files or files == ["all"]:
+            current_path = os.path.join(common.wazuh_path, full_path)
+            if entry in files or files == ["all"] and not path.isdir(current_path):
+                file_mod_time = os.path.getmtime(current_path)
 
-                if not path.isdir(os.path.join(common.wazuh_path, full_path)):
-                    file_mod_time = datetime.utcfromtimestamp(stat(os.path.join(common.wazuh_path, full_path)).st_mtime)
+                try:
+                    if file_mod_time == previous_status[full_path]['mod_time']:
+                        # The current file has not changed its mtime since the last integrity process
+                        walk_files[full_path] = previous_status[full_path]
+                        continue
+                except KeyError:
+                    pass
 
-                    # Create dict with metadata of 'full_path' file.
-                    entry_metadata = {"mod_time": str(file_mod_time), 'cluster_item_key': get_cluster_item_key}
-                    if '.merged' in entry:
-                        entry_metadata['merged'] = True
-                        entry_metadata['merge_type'] = 'agent-groups'
-                        entry_metadata['merge_name'] = os.path.join(dirname, entry)
-                    else:
-                        entry_metadata['merged'] = False
+                # Create dict with metadata of 'full_path' file.
+                entry_metadata = {"mod_time": file_mod_time, 'cluster_item_key': get_cluster_item_key}
+                if '.merged' in entry:
+                    entry_metadata['merged'] = True
+                    entry_metadata['merge_type'] = 'agent-groups'
+                    entry_metadata['merge_name'] = os.path.join(dirname, entry)
+                else:
+                    entry_metadata['merged'] = False
 
-                    if get_md5:
-                        entry_metadata['md5'] = md5(os.path.join(common.wazuh_path, full_path))
+                if get_md5:
+                    entry_metadata['md5'] = md5(os.path.join(common.wazuh_path, full_path))
 
-                    # Use the relative file path as a key to save its metadata dictionary.
-                    walk_files[full_path] = entry_metadata
+                # Use the relative file path as a key to save its metadata dictionary.
+                walk_files[full_path] = entry_metadata
 
             if recursive and path.isdir(os.path.join(common.wazuh_path, full_path)):
                 walk_files.update(walk_dir(full_path, recursive, files, excluded_files, excluded_extensions,
@@ -255,6 +267,9 @@ def get_files_status(get_md5=True):
                          cluster_items['files']['excluded_extensions'], file_path, get_md5))
         except Exception as e:
             logger.warning(f"Error getting file status: {e}.")
+
+    # Save the information collected in the current integration process.
+    common.cluster_integrity_mtime.set(final_items)
 
     return final_items
 

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -209,6 +209,7 @@ rbac: ContextVar[Dict] = ContextVar('rbac', default={'rbac_mode': 'black'})
 current_user: ContextVar[str] = ContextVar('current_user', default='')
 broadcast: ContextVar[bool] = ContextVar('broadcast', default=False)
 cluster_nodes: ContextVar[list] = ContextVar('cluster_nodes', default=list())
+cluster_integrity_mtime: ContextVar[Dict] = ContextVar('cluster_integrity_mtime', default={})
 
 _context_cache = dict()
 


### PR DESCRIPTION
|Related issue|
|---|
|#7861|

Hi team,

This PR closes #7861. In this PR we have improved the `wazuh-clusterd` integrity process. In the current version, the checksum of all files to be synchronized is calculated every 9 seconds (default value). However, between two integrity processes, usually not many files are changed and in some cases there is no change at all, so the checksum calculation is not necessary.

To solve this we have created a new variable that contains the information of the integrity process before the integrity process that queries it. This way, if the m_time of the file has not changed, the checksum calculation is skipped.

Best regards,

Adrián Peña
