### PR TITLE
Change AR log from error to debug2

### DIFF
--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -124,7 +124,7 @@ void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar
                     if(cJSON_IsString(json_agt_version) && json_agt_version->valuestring != NULL) {
                         agt_version = json_agt_version->valuestring;
                     } else {
-                        merror("Failed to get agent '%d' version.", id_array[i]);
+                        mdebug2("Failed to get agent '%d' version.", id_array[i]);
                         labels_free(agt_labels);
                         cJSON_Delete(json_agt_info);
                         continue;
@@ -203,7 +203,7 @@ void OS_Exec(int execq, int *arq, const Eventinfo *lf, const active_response *ar
                 if(cJSON_IsString(json_agt_version) && json_agt_version->valuestring != NULL) {
                     agt_version = json_agt_version->valuestring;
                 } else {
-                    merror("Failed to get agent '%d' version.", agt_id);
+                    mdebug2("Failed to get agent '%d' version.", agt_id);
                     labels_free(agt_labels);
                     cJSON_Delete(json_agt_info);
                     goto cleanup;

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -959,7 +959,7 @@ int send_msg_to_agent(int msocket, const char *msg, const char *agt_id, const ch
             if(cJSON_IsString(json_agt_version) && json_agt_version->valuestring != NULL) {
                 agt_version = json_agt_version->valuestring;
             } else {
-                merror("Failed to get agent '%d' version.", id_array[i]);
+                mdebug2("Failed to get agent '%d' version.", id_array[i]);
                 cJSON_Delete(json_agt_info);
                 continue;
             }


### PR DESCRIPTION
## Description

This PR attempts to change a log from `error` to `debug2`.

This log is related to agents that don't have a version in the DB. It was very verbose so it was changed to `debug2`.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
