### PR TITLE
Add os_info triaged command

### DIFF
--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -21,7 +21,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,
                         -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_open_agent2 -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_agents_insert_vuln_cves \
                         -Wl,--wrap,sqlite3_errmsg -Wl,--wrap,wdb_agents_clear_vuln_cves -Wl,--wrap,wdb_agents_update_status_vuln_cves \
                         -Wl,--wrap,wdb_agents_remove_vuln_cves -Wl,--wrap,wdb_agents_remove_by_status_vuln_cves -Wl,--wrap,cJSON_PrintUnformatted \
-                        -Wl,--wrap,wdb_agents_get_sys_osinfo -Wl,--wrap,wdb_osinfo_save")
+                        -Wl,--wrap,wdb_agents_get_sys_osinfo -Wl,--wrap,wdb_agents_set_sys_osinfo_triaged -Wl,--wrap,wdb_osinfo_save")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,_merror -Wl,--wrap,_mwarn \

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -850,6 +850,34 @@ void test_wdb_agents_clear_vuln_cves_success(void **state) {
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_agents_set_sys_osinfo_triaged */
+
+void test_wdb_agents_set_sys_osinfo_triaged_statement_init_fail(void **state) {
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_init_stmt_in_cache, NULL);
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_OSINFO_SET_TRIAGED);
+
+    ret = wdb_agents_set_sys_osinfo_triaged(data->wdb);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_agents_set_sys_osinfo_triaged_success(void **state) {
+    int ret = -1;
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    will_return(__wrap_wdb_init_stmt_in_cache, (sqlite3_stmt*)1); //Returning any value
+    expect_value(__wrap_wdb_init_stmt_in_cache, statement_index, WDB_STMT_OSINFO_SET_TRIAGED);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    ret = wdb_agents_set_sys_osinfo_triaged(data->wdb);
+
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] = {
@@ -893,6 +921,9 @@ int main()
         /* Tests wdb_agents_clear_vuln_cves */
         cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_success, test_setup, test_teardown),
+        /* Tests wdb_agents_clear_vuln_cves */
+        cmocka_unit_test_setup_teardown(test_wdb_agents_set_sys_osinfo_triaged_statement_init_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_agents_set_sys_osinfo_triaged_success, test_setup, test_teardown),
       };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wazuh_db/test_wdb_agents.c
+++ b/src/unit_tests/wazuh_db/test_wdb_agents.c
@@ -921,7 +921,7 @@ int main()
         /* Tests wdb_agents_clear_vuln_cves */
         cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_clear_vuln_cves_success, test_setup, test_teardown),
-        /* Tests wdb_agents_clear_vuln_cves */
+        /* Tests wdb_agents_set_sys_osinfo_triaged */
         cmocka_unit_test_setup_teardown(test_wdb_agents_set_sys_osinfo_triaged_statement_init_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_agents_set_sys_osinfo_triaged_success, test_setup, test_teardown),
       };

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
@@ -8,26 +8,23 @@
  */
 
 
-#ifndef WDB_AGENTS_WRAPPERS_H
-#define WDB_AGENTS_WRAPPERS_H
+#ifndef WDB_AGENTS_HELPERS_WRAPPERS_H
+#define WDB_AGENTS_HELPERS_WRAPPERS_H
 
 #include "wazuh_db/wdb.h"
 
-cJSON* __wrap_wdb_agents_get_sys_osinfo(wdb_t *wdb);
-int __wrap_wdb_agents_set_sys_osinfo_triaged(wdb_t *wdb);
-cJSON* __wrap_wdb_agents_insert_vuln_cves(wdb_t *wdb,
-                                          const char* name,
-                                          const char* version,
-                                          const char* architecture,
-                                          const char* cve,
-                                          const char* reference,
-                                          const char* type,
-                                          const char* status,
-                                          bool check_pkg_existence);
-int __wrap_wdb_agents_update_status_vuln_cves(wdb_t *wdb, const char* old_status, const char* new_status, const char* type);
-int __wrap_wdb_agents_remove_vuln_cves(wdb_t *wdb, const char* cve, const char* reference);
-wdbc_result __wrap_wdb_agents_remove_by_status_vuln_cves(wdb_t *wdb, const char* status, char **output);
-int __wrap_wdb_agents_clear_vuln_cves(wdb_t *wdb);
-bool __wrap_wdb_agents_find_package(wdb_t *wdb, const char* reference);
-bool __wrap_wdb_agents_find_cve(wdb_t *wdb, const char* cve, const char* reference);
+int __wrap_wdb_agents_vuln_cves_insert(int id,
+                                      const char *name,
+                                      const char *version,
+                                      const char *architecture,
+                                      const char *cve,
+                                      const char *reference,
+                                      const char *type,
+                                      const char *status,
+                                      bool check_pkg_existence,
+                                      __attribute__((unused)) int *sock);
+
+int __wrap_wdb_agents_vuln_cves_clear(int id,
+                                     __attribute__((unused)) int *sock);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_helpers_wrappers.h
@@ -8,23 +8,26 @@
  */
 
 
-#ifndef WDB_AGENTS_HELPERS_WRAPPERS_H
-#define WDB_AGENTS_HELPERS_WRAPPERS_H
+#ifndef WDB_AGENTS_WRAPPERS_H
+#define WDB_AGENTS_WRAPPERS_H
 
 #include "wazuh_db/wdb.h"
 
-int __wrap_wdb_agents_vuln_cves_insert(int id,
-                                      const char *name,
-                                      const char *version,
-                                      const char *architecture,
-                                      const char *cve,
-                                      const char *reference,
-                                      const char *type,
-                                      const char *status,
-                                      bool check_pkg_existence,
-                                      __attribute__((unused)) int *sock);
-
-int __wrap_wdb_agents_vuln_cves_clear(int id,
-                                     __attribute__((unused)) int *sock);
-
+cJSON* __wrap_wdb_agents_get_sys_osinfo(wdb_t *wdb);
+int __wrap_wdb_agents_set_sys_osinfo_triaged(wdb_t *wdb);
+cJSON* __wrap_wdb_agents_insert_vuln_cves(wdb_t *wdb,
+                                          const char* name,
+                                          const char* version,
+                                          const char* architecture,
+                                          const char* cve,
+                                          const char* reference,
+                                          const char* type,
+                                          const char* status,
+                                          bool check_pkg_existence);
+int __wrap_wdb_agents_update_status_vuln_cves(wdb_t *wdb, const char* old_status, const char* new_status, const char* type);
+int __wrap_wdb_agents_remove_vuln_cves(wdb_t *wdb, const char* cve, const char* reference);
+wdbc_result __wrap_wdb_agents_remove_by_status_vuln_cves(wdb_t *wdb, const char* status, char **output);
+int __wrap_wdb_agents_clear_vuln_cves(wdb_t *wdb);
+bool __wrap_wdb_agents_find_package(wdb_t *wdb, const char* reference);
+bool __wrap_wdb_agents_find_cve(wdb_t *wdb, const char* cve, const char* reference);
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.c
@@ -17,6 +17,10 @@ cJSON* __wrap_wdb_agents_get_sys_osinfo(__attribute__((unused)) wdb_t *wdb) {
     return mock_ptr_type(cJSON*);
 }
 
+int __wrap_wdb_agents_set_sys_osinfo_triaged(__attribute__((unused)) wdb_t *wdb) {
+    return mock();
+}
+
 cJSON* __wrap_wdb_agents_insert_vuln_cves(__attribute__((unused)) wdb_t *wdb,
                                           const char* name,
                                           const char* version,

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_agents_wrappers.h
@@ -14,6 +14,7 @@
 #include "wazuh_db/wdb.h"
 
 cJSON* __wrap_wdb_agents_get_sys_osinfo(wdb_t *wdb);
+int __wrap_wdb_agents_set_sys_osinfo_triaged(wdb_t *wdb);
 cJSON* __wrap_wdb_agents_insert_vuln_cves(wdb_t *wdb,
                                           const char* name,
                                           const char* version,

--- a/src/wazuh_db/helpers/wdb_agents_helpers.h
+++ b/src/wazuh_db/helpers/wdb_agents_helpers.h
@@ -16,6 +16,7 @@
 
 typedef enum agents_db_access {
     WDB_AGENTS_SYS_OSINFO_GET,
+    WDB_AGENTS_SYS_OSINFO_SET_TRIAGGED,
     WDB_AGENTS_VULN_CVES_INSERT,
     WDB_AGENTS_VULN_CVES_CLEAR,
     WDB_AGENTS_VULN_CVES_REMOVE,
@@ -31,6 +32,16 @@ typedef enum agents_db_access {
  */
 int wdb_agents_sys_osinfo_check_triaged(int id,
                                         int *sock);
+
+/**
+ * @brief Sets the triaged status in the sys_osinfo table of the specified agent's database.
+ *
+ * @param[in] id The agent ID.
+ * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
+ * @return Returns 0 on success or -1 on error.
+ */
+int wdb_agents_sys_osinfo_set_triaged(int id,
+                                      int *sock);
 
 /**
  * @brief Insert or update a vulnerability to the vuln_cves table in the agents database.

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -49,6 +49,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_OSINFO_INSERT2] = "INSERT OR REPLACE INTO sys_osinfo (scan_id, scan_time, hostname, architecture, os_name, os_version, os_codename, os_major, os_minor,  os_patch, os_build, os_platform, sysname, release, version, os_release, checksum, reference, triaged) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
     [WDB_STMT_OSINFO_DEL] = "DELETE FROM sys_osinfo;",
     [WDB_STMT_OSINFO_GET] = "SELECT * FROM sys_osinfo;",
+    [WDB_STMT_OSINFO_SET_TRIAGED] = "UPDATE sys_osinfo SET TRIAGED = 1;",
     [WDB_STMT_PROGRAM_INSERT] = "INSERT INTO sys_programs (scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, architecture, multiarch, source, description, location, triaged, checksum, item_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
     [WDB_STMT_PROGRAM_INSERT2] = "INSERT OR REPLACE INTO sys_programs (scan_id, scan_time, format, name, priority, section, size, vendor, install_time, version, architecture, multiarch, source, description, location, triaged, checksum, item_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
     [WDB_STMT_PROGRAM_DEL] = "DELETE FROM sys_programs WHERE scan_id != ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -73,6 +73,7 @@ typedef enum wdb_stmt {
     WDB_STMT_OSINFO_INSERT2,
     WDB_STMT_OSINFO_DEL,
     WDB_STMT_OSINFO_GET,
+    WDB_STMT_OSINFO_SET_TRIAGED,
     WDB_STMT_PROGRAM_INSERT,
     WDB_STMT_PROGRAM_INSERT2,
     WDB_STMT_PROGRAM_DEL,
@@ -860,6 +861,18 @@ int wdb_parse_agents_get_sys_osinfo(wdb_t* wdb, char* output);
  * @return -1 on error, and 0 on success.
  */
 int wdb_parse_agents_set_sys_osinfo(wdb_t * wdb, char * input, char * output);
+
+
+/**
+ * @brief Function to parse set triaged over the sys_osinfo database table.
+ *
+ * @param wdb The Global struct database.
+ * @param output Buffer output, on success responses are:
+ *        "ok" -> If sql statement was processed.
+ *        "err <error_message>" -> If sql statement wasn't processed.
+ * @return -1 on error, and 0 on success.
+ */
+int wdb_parse_agents_set_sys_osinfo_triaged(wdb_t* wdb, char* output);
 
 
 /**

--- a/src/wazuh_db/wdb_agents.c
+++ b/src/wazuh_db/wdb_agents.c
@@ -27,6 +27,16 @@ cJSON* wdb_agents_get_sys_osinfo(wdb_t *wdb){
     return result;
 }
 
+int wdb_agents_set_sys_osinfo_triaged(wdb_t *wdb){
+    sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_OSINFO_SET_TRIAGED);
+
+    if (stmt == NULL) {
+        return OS_INVALID;
+    }
+
+    return wdb_exec_stmt_silent(stmt);
+}
+
 bool wdb_agents_find_package(wdb_t *wdb, const char* reference){
     sqlite3_stmt* stmt = wdb_init_stmt_in_cache(wdb, WDB_STMT_PROGRAM_FIND);
 

--- a/src/wazuh_db/wdb_agents.h
+++ b/src/wazuh_db/wdb_agents.h
@@ -24,6 +24,14 @@
 cJSON* wdb_agents_get_sys_osinfo(wdb_t *wdb);
 
 /**
+ * @brief Function to set the triaged column from the sys_osinfo table.
+ *
+ * @param [in] wdb The 'agents' struct database.
+ * @return Returns 0 on success or -1 on error.
+ */
+int wdb_agents_set_sys_osinfo_triaged(wdb_t *wdb);
+
+/**
  * @brief Function to check if a certain package exists.
  *
  * @param [in] wdb The 'agents' struct database.

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -2935,11 +2935,26 @@ int wdb_parse_osinfo(wdb_t* wdb, char* input, char* output) {
     }
     else if (strcmp(next, "set") == 0) {
         result = wdb_parse_agents_set_sys_osinfo(wdb, tail, output);
-    } else {
+    }
+    else if (strcmp(next, "set_triaged") == 0) {
+        result = wdb_parse_agents_set_sys_osinfo_triaged(wdb, output);
+    }
+    else {
         snprintf(output, OS_MAXSTR + 1, "err Invalid osinfo action: %s", next);
     }
 
     return result;
+}
+
+int wdb_parse_agents_set_sys_osinfo_triaged(wdb_t* wdb, char* output) {
+    int ret = wdb_agents_set_sys_osinfo_triaged(wdb);
+    if (OS_SUCCESS != ret) {
+        snprintf(output, OS_MAXSTR + 1, "err Cannot set sys_osinfo as triaged; SQL err: %s", sqlite3_errmsg(wdb->db));
+    }
+    else {
+        snprintf(output, OS_MAXSTR + 1, "ok");
+    }
+    return ret;
 }
 
 int wdb_parse_agents_get_sys_osinfo(wdb_t* wdb, char* output) {

--- a/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
+++ b/src/wazuh_modules/vulnerability_detector/wm_vuln_detector.c
@@ -4645,6 +4645,8 @@ int wm_vuldet_collect_agent_software(scan_agent *agent, sqlite3 *db, scan_ctx_t*
                     goto end;
                 }
                 scan_ctx->os_scan = TRUE;
+                // Avoid checking the Operating System again
+                wdb_agents_sys_osinfo_set_triaged(scan_ctx->agent_id, &sock);
             }
         }
         else {
@@ -4658,6 +4660,8 @@ int wm_vuldet_collect_agent_software(scan_agent *agent, sqlite3 *db, scan_ctx_t*
                 goto end;
             }
             scan_ctx->os_scan = TRUE;
+            // Avoid checking the Operating System again
+            wdb_agents_sys_osinfo_set_triaged(scan_ctx->agent_id, &sock);
         }
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|#8165|

## Description
This PR adds a WazuhDB command to set **os_info** table from **agents** DB to **triaged**.
It includes the UT for the new methods.
And also implements the usage of this command during the scan to avoid checking again the scanned Operating System.

## Tests
<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Package installation
- [X] Source upgrade
- [X] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [X] Scan-build report
  - [X] Valgrind (memcheck and descriptor leaks check)
