### PR TITLE
Change ossec_path to wazuh_path in azure-logs script

### DIFF
--- a/wodles/azure/azure-logs.py
+++ b/wodles/azure/azure-logs.py
@@ -46,7 +46,7 @@ except Exception as e:
 	print("Azure Storage SDK for Python is missing: '{}', try 'pip install azure-storage-blob'.".format(e))
 	sys.exit(1)
 
-ADDR = '{}/queue/sockets/queue'.format(common.ossec_path)
+ADDR = '{}/queue/sockets/queue'.format(common.wazuh_path)
 BLEN = 212992
 
 utc = pytz.UTC
@@ -111,7 +111,7 @@ def set_logger():
 	if args.verbose:
 		logging.basicConfig(level = logging.DEBUG, format = '%(asctime)s %(levelname)s: AZURE %(message)s', datefmt = '%m/%d/%Y %I:%M:%S %p')
 	else:
-		log_path = "{}/logs/azure_logs.log".format(common.ossec_path)
+		log_path = "{}/logs/azure_logs.log".format(common.wazuh_path)
 		logging.basicConfig(filename=log_path, level = logging.DEBUG, format = '%(asctime)s %(levelname)s: AZURE %(message)s', datefmt = '%m/%d/%Y %I:%M:%S %p')
 
 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7700 |

In this issue: https://github.com/wazuh/wazuh/issues/7700, all the `ossec` words used in the Framework and API were changed to Wazuh.

There were missing ossec words in our wodles folder. I have changed these ossec words to wazuh.