### PR TITLE
Change in the severity of SCA module log message when queue is not available

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -148,7 +148,7 @@ end:
 static int ConnectToSecurityConfigurationAssessmentSocket() {
 
     if ((cfga_socket = StartMQ(CFGAQUEUE, WRITE, 1)) < 0) {
-        merror(QUEUE_ERROR, CFGAQUEUE, strerror(errno));
+        mwarn(QUEUE_ERROR, CFGAQUEUE, strerror(errno));
         return -1;
     }
 
@@ -158,7 +158,7 @@ static int ConnectToSecurityConfigurationAssessmentSocket() {
 static int ConnectToSecurityConfigurationAssessmentSocketRemoted() {
 
     if ((cfgar_socket = StartMQ(CFGARQUEUE, WRITE, 1)) < 0) {
-        merror(QUEUE_ERROR, CFGARQUEUE, strerror(errno));
+        mwarn(QUEUE_ERROR, CFGARQUEUE, strerror(errno));
         return -1;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|#6944|

## Description

If the agent is not able to connect to the SCA queue, an error message is printed.
But sometimes a normal restarts generates a race condition that produces this message, so it was decided to change it to a warning message.

This situation was also reported in #6232, and after an upgrade in Debian ARM32 (4.0.1-> 4.2.0) by @DFolchA.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Review logs syntax and correct language
