### PR TITLE
Create execd socket when AR is disabled.

### DIFF
--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -216,14 +216,8 @@ int main(int argc, char **argv)
     /* Start up message */
     minfo(STARTUP_MSG, (int)getpid());
 
-    /* If AR is disabled, do not continue */
-    if (c == 1) {
-        pthread_join(wcom_thread, NULL);
-        exit(EXIT_SUCCESS);
-    }
-
     /* Start exec queue */
-    if ((m_queue = StartMQ(EXECQUEUE, READ, 0)) < 0) {
+    if ((m_queue = StartMQ(EXECQUEUE, READ, INFINITE_OPENQ_ATTEMPTS)) < 0) {
         merror_exit(QUEUE_ERROR, EXECQUEUE, strerror(errno));
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|#7968|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
As described in #7968, the `execq` socket wasn't created if AR was disabled. This PR aims to move the creation of the socket before ending `execd`.

Closes #7968 


## Configuration options
```xml
  <active-response>
    <disabled>yes</disabled>
    <command>host-deny</command>
    <location>local</location>
  </active-response>

  <active-response>
    <disabled>yes</disabled>
    <command>firewall-drop</command>
    <location>local</location>
  </active-response>

```
## Logs/Alerts example

I have created this simple python script just to check if the socket is available: 
```python
import socket
execq_socket_path = '/var/ossec/queue/alerts/execq'
execq_socket = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
execq_socket.connect(execq_socket_path)
```

## Tests
If this configuration is used in a manager without the changes, the following error will appear:
```
{"statusCode":500,"error":"Internal Server Error","message":"3013 - Unable to connect with socket: Socket: WAZUH_PATH/queue/alerts/execq. Error Connection refused"}
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] Source installation
- [X] Source upgrade


<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)

