### PR TITLE
Fix the working of the overwrite option of the rules

### DIFF
--- a/ruleset/testing/ruleset/test_decoders.xml
+++ b/ruleset/testing/ruleset/test_decoders.xml
@@ -2,6 +2,12 @@
   <program_name>^ow_test$</program_name>
 </decoder>
 
+<decoder name="test_overwrite">
+  <program_name>^test_overwrite_field$</program_name>
+  <regex>Test example '(\w+)' field</regex>
+  <order>example</order>
+</decoder>
+
 <decoder name="test_same">
   <program_name>^test_same_fields$</program_name>
   <regex>User '(\w+)' logged from '(\d+.\d+.\d+.\d+)' (\d+) this is</regex>

--- a/ruleset/testing/ruleset/test_rules.xml
+++ b/ruleset/testing/ruleset/test_rules.xml
@@ -13,6 +13,16 @@
     <description>Successfully</description>
   </rule>
 
+<!-- testing overwrite and field -->
+  <rule id="99901" level="3">
+    <field name="example">TEST1</field>
+    <description>Testing overwrite and field</description>
+  </rule>
+
+  <rule id="99901" level="6" overwrite="yes">
+    <field name="example">TEST2</field>
+    <description>Successfully</description>
+  </rule>
 
 <!-- Trigger alerts which depend on same_fields . Also it tests if_matched_sid -->
 <!-- Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test -->

--- a/ruleset/testing/ruleset/test_static_filters_decoders.xml
+++ b/ruleset/testing/ruleset/test_static_filters_decoders.xml
@@ -2,6 +2,12 @@
   <program_name>^ow_test$</program_name>
 </decoder>
 
+<decoder name="test_overwrite">
+  <program_name>^test_overwrite_field$</program_name>
+  <regex>Test example '(\w+)' field</regex>
+  <order>example</order>
+</decoder>
+
 <decoder name="test_same">
   <program_name>^test_same_fields$</program_name>
   <regex>User '(\w+)' logged from '(\d+.\d+.\d+.\d+)' (\d+) this is</regex>

--- a/ruleset/testing/ruleset/test_static_filters_rules.xml
+++ b/ruleset/testing/ruleset/test_static_filters_rules.xml
@@ -13,6 +13,16 @@
     <description>Successfully</description>
   </rule>
 
+<!-- testing overwrite and field -->
+  <rule id="99901" level="3">
+    <field name="example">TEST1</field>
+    <description>Testing overwrite and field</description>
+  </rule>
+
+  <rule id="99901" level="6" overwrite="yes">
+    <field name="example">TEST2</field>
+    <description>Successfully</description>
+  </rule>
 
 <!-- Trigger alerts which depend on same_fields . Also it tests if_matched_sid -->
 <!-- Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test -->

--- a/ruleset/testing/tests/test_features.ini
+++ b/ruleset/testing/tests/test_features.ini
@@ -5,6 +5,13 @@ rule = 99900
 alert = 7
 decoder = ow_test
 
+[overwrite & field]
+log 1 pass =  Apr 14 13:38:51 testUser test_overwrite_field[13244]: Test example 'TEST2' field
+
+rule = 99901
+alert = 6
+decoder = test_overwrite
+
 [same fields]
 log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test
 log 1 pass = Dec 25 20:45:02 MyHost test_same_fields[12345]: User 'admin' logged from '192.168.1.100' 5 this is the same_fields test

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -92,7 +92,7 @@ void Rules_OP_CreateRules() {
 
 }
 
-int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node, 
+int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_node,
                        EventList **last_event_list, OSStore **decoder_list, OSList* log_msg)
 {
     OS_XML xml;
@@ -313,8 +313,8 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                 goto cleanup;
             }
             if ((!node[i]->attributes) || (!node[i]->values)
-                || (!node[i]->values[0]) || (!node[i]->attributes[0]) 
-                || (strcasecmp(node[i]->attributes[0], "name") != 0) 
+                || (!node[i]->values[0]) || (!node[i]->attributes[0])
+                || (strcasecmp(node[i]->attributes[0], "name") != 0)
                 || (node[i]->attributes[1])) {
                 smerror(log_msg, "rules_op: Invalid root element '%s'."
                        "Only the group name is allowed", node[i]->element);
@@ -589,7 +589,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                     } else if (strcasecmp(rule_opt[k]->element, xml_group) == 0) {
                         config_ruleinfo->group = loadmemory(config_ruleinfo->group, rule_opt[k]->content, log_msg);
- 
+
                     } else if (strcasecmp(rule_opt[k]->element, xml_comment) == 0) {
 
                         char *newline;
@@ -823,7 +823,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                         lookup_type = LR_ADDRESS_MATCH_VALUE;
                                     } else {
                                         smerror(log_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
-                                        smerror(log_msg, "List match lookup=\"%s\" is not valid.", 
+                                        smerror(log_msg, "List match lookup=\"%s\" is not valid.",
                                                 rule_opt[k]->values[list_att_num]);
                                         goto cleanup;
                                     }
@@ -870,7 +870,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                                     os_calloc(1, sizeof(OSMatch), matcher);
                                     if (!OSMatch_Compile(rule_opt[k]->values[list_att_num], matcher, 0)) {
                                         smerror(log_msg, INVALID_CONFIG, rule_opt[k]->element, rule_opt[k]->content);
-                                        smerror(log_msg, REGEX_COMPILE, rule_opt[k]->values[list_att_num], 
+                                        smerror(log_msg, REGEX_COMPILE, rule_opt[k]->values[list_att_num],
                                             matcher->error);
                                         goto cleanup;
                                     }
@@ -1501,9 +1501,17 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
                     goto cleanup;
                 }
 
+                /* Check for valid overwrite */
+                if ((config_ruleinfo->if_sid || config_ruleinfo->if_group || config_ruleinfo->if_level)
+                    && (config_ruleinfo->alert_opts & DO_OVERWRITE)) {
+                    smerror(log_msg, "Invalid use of overwrite option. "
+                            "Could not overwrite parent rule at rule '%d'.", config_ruleinfo->sigid);
+                    goto cleanup;
+                }
+
                 /* Check for valid use of frequency */
-                if ((config_ruleinfo->context_opts || config_ruleinfo->same_field 
-                    || config_ruleinfo->different_field || config_ruleinfo->frequency) 
+                if ((config_ruleinfo->context_opts || config_ruleinfo->same_field
+                    || config_ruleinfo->different_field || config_ruleinfo->frequency)
                     && !config_ruleinfo->context) {
                     smerror(log_msg, "Invalid use of frequency/context options. "
                            "Missing if_matched on rule '%d'.", config_ruleinfo->sigid);
@@ -1721,7 +1729,7 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                     os_free(location);
                 }
-                
+
                 /* Add location */
                 if (action) {
                     w_calloc_expression_t(&config_ruleinfo->action, action_type);
@@ -1904,7 +1912,7 @@ cleanup:
     os_free(action)
     OS_ClearNode(rule);
     OS_ClearNode(rule_opt);
-    
+
     if (config_ruleinfo != NULL) {
         os_remove_ruleinfo(config_ruleinfo);
     }
@@ -3090,7 +3098,7 @@ w_exp_type_t w_check_attr_type(xml_node * node, w_exp_type_t default_type, int r
     const char * xml_type = "type";
     const char * str_type = w_get_attr_val_by_name(node, xml_type);
 
-    if (!str_type) { 
+    if (!str_type) {
         return default_type;
     }
 

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -277,13 +277,16 @@ int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid)
             r_node->ruleinfo->maxsize = newrule->maxsize;
             r_node->ruleinfo->frequency = newrule->frequency;
             r_node->ruleinfo->timeframe = newrule->timeframe;
+
             r_node->ruleinfo->ignore_time = newrule->ignore_time;
 
             r_node->ruleinfo->group = newrule->group;
             r_node->ruleinfo->match = newrule->match;
             r_node->ruleinfo->regex = newrule->regex;
+
             r_node->ruleinfo->day_time = newrule->day_time;
             r_node->ruleinfo->week_day = newrule->week_day;
+
             r_node->ruleinfo->srcip = newrule->srcip;
             r_node->ruleinfo->dstip = newrule->dstip;
             r_node->ruleinfo->srcport = newrule->srcport;
@@ -294,27 +297,41 @@ int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid)
             r_node->ruleinfo->status = newrule->status;
             r_node->ruleinfo->hostname = newrule->hostname;
             r_node->ruleinfo->program_name = newrule->program_name;
+            r_node->ruleinfo->data = newrule->data;
             r_node->ruleinfo->extra_data = newrule->extra_data;
+            r_node->ruleinfo->location = newrule->location;
+            r_node->ruleinfo->system_name = newrule->system_name;
+            r_node->ruleinfo->protocol = newrule->protocol;
+            r_node->ruleinfo->fields = newrule->fields;
             r_node->ruleinfo->action = newrule->action;
+
             r_node->ruleinfo->comment = newrule->comment;
             r_node->ruleinfo->info = newrule->info;
             r_node->ruleinfo->cve = newrule->cve;
             r_node->ruleinfo->info_details = newrule->info_details;
+            r_node->ruleinfo->lists = newrule->lists;
+
             r_node->ruleinfo->if_matched_regex = newrule->if_matched_regex;
             r_node->ruleinfo->if_matched_group = newrule->if_matched_group;
             r_node->ruleinfo->if_matched_sid = newrule->if_matched_sid;
+
             r_node->ruleinfo->alert_opts = newrule->alert_opts;
             r_node->ruleinfo->context_opts = newrule->context_opts;
             r_node->ruleinfo->context = newrule->context;
+
             r_node->ruleinfo->decoded_as = newrule->decoded_as;
+
             r_node->ruleinfo->ar = newrule->ar;
             r_node->ruleinfo->compiled_rule = newrule->compiled_rule;
 
-            r_node->ruleinfo->location = newrule->location;
-            r_node->ruleinfo->lists = newrule->lists;
+            r_node->ruleinfo->file = newrule->file;
+
             r_node->ruleinfo->prev_rule = newrule->prev_rule;
+
             r_node->ruleinfo->same_fields = newrule->same_fields;
             r_node->ruleinfo->not_same_fields = newrule->not_same_fields;
+
+            r_node->ruleinfo->mitre_id = newrule->mitre_id;
 
 #ifdef LIBGEOIP_ENABLED
             r_node->ruleinfo->srcgeoip = newrule->srcgeoip;

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -273,74 +273,10 @@ int OS_AddRuleInfo(RuleNode *r_node, RuleInfo *newrule, int sid)
     while (r_node) {
         /* Check if the sigid matches */
         if (r_node->ruleinfo->sigid == sid) {
-            r_node->ruleinfo->level = newrule->level;
-            r_node->ruleinfo->maxsize = newrule->maxsize;
-            r_node->ruleinfo->frequency = newrule->frequency;
-            r_node->ruleinfo->timeframe = newrule->timeframe;
-
-            r_node->ruleinfo->ignore_time = newrule->ignore_time;
-
-            r_node->ruleinfo->group = newrule->group;
-            r_node->ruleinfo->match = newrule->match;
-            r_node->ruleinfo->regex = newrule->regex;
-
-            r_node->ruleinfo->day_time = newrule->day_time;
-            r_node->ruleinfo->week_day = newrule->week_day;
-
-            r_node->ruleinfo->srcip = newrule->srcip;
-            r_node->ruleinfo->dstip = newrule->dstip;
-            r_node->ruleinfo->srcport = newrule->srcport;
-            r_node->ruleinfo->dstport = newrule->dstport;
-            r_node->ruleinfo->user = newrule->user;
-            r_node->ruleinfo->url = newrule->url;
-            r_node->ruleinfo->id = newrule->id;
-            r_node->ruleinfo->status = newrule->status;
-            r_node->ruleinfo->hostname = newrule->hostname;
-            r_node->ruleinfo->program_name = newrule->program_name;
-            r_node->ruleinfo->data = newrule->data;
-            r_node->ruleinfo->extra_data = newrule->extra_data;
-            r_node->ruleinfo->location = newrule->location;
-            r_node->ruleinfo->system_name = newrule->system_name;
-            r_node->ruleinfo->protocol = newrule->protocol;
-            r_node->ruleinfo->fields = newrule->fields;
-            r_node->ruleinfo->action = newrule->action;
-
-            r_node->ruleinfo->comment = newrule->comment;
-            r_node->ruleinfo->info = newrule->info;
-            r_node->ruleinfo->cve = newrule->cve;
-            r_node->ruleinfo->info_details = newrule->info_details;
-            r_node->ruleinfo->lists = newrule->lists;
-
-            r_node->ruleinfo->if_matched_regex = newrule->if_matched_regex;
-            r_node->ruleinfo->if_matched_group = newrule->if_matched_group;
-            r_node->ruleinfo->if_matched_sid = newrule->if_matched_sid;
-
-            r_node->ruleinfo->alert_opts = newrule->alert_opts;
-            r_node->ruleinfo->context_opts = newrule->context_opts;
-            r_node->ruleinfo->context = newrule->context;
-
-            r_node->ruleinfo->decoded_as = newrule->decoded_as;
-
-            r_node->ruleinfo->ar = newrule->ar;
-            r_node->ruleinfo->compiled_rule = newrule->compiled_rule;
-
-            r_node->ruleinfo->file = newrule->file;
-
-            r_node->ruleinfo->prev_rule = newrule->prev_rule;
-
-            r_node->ruleinfo->same_fields = newrule->same_fields;
-            r_node->ruleinfo->not_same_fields = newrule->not_same_fields;
-
-            r_node->ruleinfo->mitre_id = newrule->mitre_id;
-
-#ifdef LIBGEOIP_ENABLED
-            r_node->ruleinfo->srcgeoip = newrule->srcgeoip;
-            r_node->ruleinfo->dstgeoip = newrule->dstgeoip;
-#endif
-
+            os_remove_ruleinfo(r_node->ruleinfo);
+            r_node->ruleinfo = newrule;
             return (1);
         }
-
 
         /* Check if the child has a rule */
         if (r_node->child) {

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -709,7 +709,7 @@ int OS_ReadXMLRules(const char *rulefile,
                     if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                         config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                     }
-                } else if (strcmp(rule_opt[k]->element, xml_different_id) == 0 || 
+                } else if (strcmp(rule_opt[k]->element, xml_different_id) == 0 ||
                            strcmp(rule_opt[k]->element, xml_notsame_id) == 0) {
                     config_ruleinfo->different_field |= FIELD_ID;
 
@@ -777,7 +777,7 @@ int OS_ReadXMLRules(const char *rulefile,
                     }
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_different_user) == 0 ||
-                           strcasecmp(rule_opt[k]->element, 
+                           strcasecmp(rule_opt[k]->element,
                                       xml_notsame_user) == 0) {
                     config_ruleinfo->different_field |= FIELD_USER;
 
@@ -793,7 +793,7 @@ int OS_ReadXMLRules(const char *rulefile,
 
                     if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                         config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
-                    } 
+                    }
                 } else if (strcasecmp(rule_opt[k]->element,
                                       xml_global_frequency) == 0) {
                     config_ruleinfo->context_opts |= FIELD_GFREQUENCY;
@@ -1006,8 +1006,16 @@ int OS_ReadXMLRules(const char *rulefile,
                 k++;
             }
 
+            /* Check for valid overwrite */
+            if ((config_ruleinfo->if_sid || config_ruleinfo->if_group || config_ruleinfo->if_level)
+                && (config_ruleinfo->alert_opts & DO_OVERWRITE)) {
+                merror("Invalid use of overwrite option. "
+                       "Could not overwrite parent rule at rule '%d'.", config_ruleinfo->sigid);
+                goto cleanup;
+            }
+
             /* Check for a valid use of frequency */
-            if ((config_ruleinfo->context_opts || config_ruleinfo->same_field || 
+            if ((config_ruleinfo->context_opts || config_ruleinfo->same_field ||
                     config_ruleinfo->different_field ||
                     config_ruleinfo->frequency) &&
                     !config_ruleinfo->context) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/7948|

## Description

This PR fixes the option `overwrite` of rules:

- Now, a rule with `overwrite` tag doesn't allow options `if_sid`, `if_group` or `if_level`.
- Now, all the fields of a rule with `overwrite` tag replace the old ones.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
